### PR TITLE
RUM-401 Introduce new FeatureBaggage

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -556,6 +556,10 @@
 		D21C26C628A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
 		D21C26D128A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
 		D21C26D228A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
+		D2216EC02A94DE2900ADAEC8 /* NewFeatureBaggage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2216EBF2A94DE2800ADAEC8 /* NewFeatureBaggage.swift */; };
+		D2216EC12A94DE2900ADAEC8 /* NewFeatureBaggage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2216EBF2A94DE2800ADAEC8 /* NewFeatureBaggage.swift */; };
+		D2216EC32A96649500ADAEC8 /* NewFeatureBaggageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2216EC22A96632F00ADAEC8 /* NewFeatureBaggageTests.swift */; };
+		D2216EC42A96649700ADAEC8 /* NewFeatureBaggageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2216EC22A96632F00ADAEC8 /* NewFeatureBaggageTests.swift */; };
 		D224430429E9588100274EC7 /* TelemetryReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */; };
 		D224430529E9588500274EC7 /* TelemetryReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */; };
 		D224430629E95C2C00274EC7 /* MessageBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA429E072D7004D0AE8 /* MessageBus.swift */; };
@@ -2396,6 +2400,8 @@
 		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
 		D21C26EA28AFA11E005DD405 /* LogMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageReceiverTests.swift; sourceTree = "<group>"; };
+		D2216EBF2A94DE2800ADAEC8 /* NewFeatureBaggage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureBaggage.swift; sourceTree = "<group>"; };
+		D2216EC22A96632F00ADAEC8 /* NewFeatureBaggageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureBaggageTests.swift; sourceTree = "<group>"; };
 		D224430C29E95D6600274EC7 /* CrashReportReceiverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportReceiverTests.swift; sourceTree = "<group>"; };
 		D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
@@ -5137,6 +5143,7 @@
 			isa = PBXGroup;
 			children = (
 				D23039C0298D5235001A1FA3 /* FeatureBaggage.swift */,
+				D2216EBF2A94DE2800ADAEC8 /* NewFeatureBaggage.swift */,
 				D23039C1298D5235001A1FA3 /* FeatureMessageReceiver.swift */,
 				D23039C2298D5235001A1FA3 /* FeatureMessage.swift */,
 			);
@@ -5559,6 +5566,7 @@
 			isa = PBXGroup;
 			children = (
 				D2DA239F298D58F300C6C7E6 /* FeatureBaggageTests.swift */,
+				D2216EC22A96632F00ADAEC8 /* NewFeatureBaggageTests.swift */,
 				D2DA23A0298D58F400C6C7E6 /* FeatureMessageReceiverTests.swift */,
 			);
 			path = MessageBus;
@@ -7830,6 +7838,7 @@
 				D2EBEE2329BA160F00B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D23039F8298D5236001A1FA3 /* InternalLogger.swift in Sources */,
 				D2303A01298D5236001A1FA3 /* DateFormatting.swift in Sources */,
+				D2216EC02A94DE2900ADAEC8 /* NewFeatureBaggage.swift in Sources */,
 				D23039F1298D5236001A1FA3 /* AnyDecodable.swift in Sources */,
 				D2160CC529C0DED100FAA9A5 /* URLSessionTaskInterception.swift in Sources */,
 				D23039DD298D5235001A1FA3 /* DD.swift in Sources */,
@@ -8609,6 +8618,7 @@
 				D2EBEE3129BA161100B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D2DA236E298D57AA00C6C7E6 /* InternalLogger.swift in Sources */,
 				D2DA236F298D57AA00C6C7E6 /* DateFormatting.swift in Sources */,
+				D2216EC12A94DE2900ADAEC8 /* NewFeatureBaggage.swift in Sources */,
 				D2DA2370298D57AA00C6C7E6 /* AnyDecodable.swift in Sources */,
 				D2160CC629C0DED100FAA9A5 /* URLSessionTaskInterception.swift in Sources */,
 				D2DA2372298D57AA00C6C7E6 /* DD.swift in Sources */,
@@ -8666,6 +8676,7 @@
 				D2DA23A6298D58F400C6C7E6 /* AnyCoderTests.swift in Sources */,
 				D2EBEE3E29BA163E00B15732 /* W3CHTTPHeadersReaderTests.swift in Sources */,
 				D2160CE929C0E00200FAA9A5 /* MethodSwizzlerTests.swift in Sources */,
+				D2216EC32A96649500ADAEC8 /* NewFeatureBaggageTests.swift in Sources */,
 				D2160CDC29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
 				D2F44FB8299AA1DA0074B0D9 /* DataCompressionTests.swift in Sources */,
 				D2160CE029C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,
@@ -8703,6 +8714,7 @@
 				D2160CEA29C0E00200FAA9A5 /* MethodSwizzlerTests.swift in Sources */,
 				D2DA23B6298D59DC00C6C7E6 /* AnyCoderTests.swift in Sources */,
 				D2EBEE4229BA163F00B15732 /* W3CHTTPHeadersReaderTests.swift in Sources */,
+				D2216EC42A96649700ADAEC8 /* NewFeatureBaggageTests.swift in Sources */,
 				D2160CDD29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
 				D2F44FB9299AA1DB0074B0D9 /* DataCompressionTests.swift in Sources */,
 				D2160CE129C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -54,7 +54,7 @@ class CrashContextProviderTests: XCTestCase {
 
     // MARK: - `RUMViewEvent` Integration
 
-    func testWhenNewRUMView_thenItNotifiesNewCrashContext() {
+    func testWhenNewRUMView_thenItNotifiesNewCrashContext() throws {
         let expectation = self.expectation(description: "Notify new crash context")
 
         // Given
@@ -69,13 +69,13 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewEvent: viewEvent]))
+        try core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
-    func testWhenRUMViewReset_thenItNotifiesNewCrashContext() {
+    func testWhenRUMViewReset_thenItNotifiesNewCrashContext() throws {
         let expectation = self.expectation(description: "Notify new crash context")
         expectation.expectedFulfillmentCount = 2
 
@@ -91,8 +91,8 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewEvent: viewEvent]))
-        core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewReset: true]))
+        try core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
+        try core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -101,7 +101,7 @@ class CrashContextProviderTests: XCTestCase {
 
     // MARK: - RUM Session State Integration
 
-    func testWhenNewRUMSessionStateIsSentThroughMessageBus_thenItNotifiesNewCrashContext() {
+    func testWhenNewRUMSessionStateIsSentThroughMessageBus_thenItNotifiesNewCrashContext() throws {
         let expectation = self.expectation(description: "Notify new crash context")
 
         // Given
@@ -116,7 +116,7 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.sessionState: sessionState]))
+        try core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -135,9 +135,9 @@ class CrashContextProviderTests: XCTestCase {
             closures: [
                 { _ = provider.currentCrashContext },
                 { core.send(message: .context(.mockRandom())) },
-                { core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewReset: true])) },
-                { core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewEvent: viewEvent])) },
-                { core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.sessionState: sessionState])) },
+                { try? core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true)) },
+                { try? core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent)) },
+                { try? core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState)) },
             ],
             iterations: 50
         )

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -69,7 +69,7 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        try core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
+        core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -91,8 +91,8 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        try core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
-        try core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
+        core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
+        core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -116,7 +116,7 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        try core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState))
+        core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -135,9 +135,9 @@ class CrashContextProviderTests: XCTestCase {
             closures: [
                 { _ = provider.currentCrashContext },
                 { core.send(message: .context(.mockRandom())) },
-                { try? core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true)) },
-                { try? core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent)) },
-                { try? core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState)) },
+                { core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true)) },
+                { core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent)) },
+                { core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState)) },
             ],
             iterations: 50
         )

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -141,6 +141,10 @@ class CrashContextProviderTests: XCTestCase {
             ],
             iterations: 50
         )
+
+        // provider retains the core in its queue:
+        // flush to release the core.
+        provider.flush()
         // swiftlint:enable opening_brace
     }
 }

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -80,7 +80,7 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        XCTAssert(!rumCrashReceiver.receivedBaggage.isEmpty, "RUM baggage must not be empty")
+        XCTAssertNotNil(rumCrashReceiver.receivedBaggage, "RUM baggage must not be empty")
     }
 
     func testWhenPendingCrashReportIsFound_itIsSentToLogsFeature() throws {
@@ -112,7 +112,7 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        XCTAssert(!logsCrashReceiver.receivedBaggage.isEmpty, "Logs baggage must not be empty")
+        XCTAssertNotNil(logsCrashReceiver.receivedBaggage, "Logs baggage must not be empty")
     }
 
     func testWhenPendingCrashReportIsNotFound_itDoesNothing() {

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -340,8 +340,8 @@ class CrashReporterTests: XCTestCase {
 
         XCTAssert(logs.contains(where: { $0.message == """
             In order to use Crash Reporting, RUM or Logging feature must be enabled.
-            Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
-            when initializing Datadog SDK.
-            """ }))
+            Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
+            """
+        }))
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
@@ -35,7 +35,7 @@ class MessageBusTests: XCTestCase {
         bus.connect(receiver, forKey: "receiver 2")
 
         // When
-        try bus.send(message: .baggage(key: "test", value: "value"))
+        bus.send(message: .baggage(key: "test", value: "value"))
 
         // Then
         wait(for: [expectation], timeout: 0.5)

--- a/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
@@ -20,14 +20,10 @@ class MessageBusTests: XCTestCase {
 
         let receiver = FeatureMessageReceiverMock(expectation: expectation) { message in
             // Then
-            switch message {
-            case .custom(let key, let attributes):
-                XCTAssertEqual(key, "test")
-                XCTAssertEqual(attributes["key"], "value")
+            if let value: String = try? message.baggage(forKey: "test") {
+                XCTAssertEqual(value, "value")
                 expectation.fulfill()
-            case .context:
-                break
-            default:
+            } else {
                 XCTFail("wrong message case")
             }
         }
@@ -39,7 +35,7 @@ class MessageBusTests: XCTestCase {
         bus.connect(receiver, forKey: "receiver 2")
 
         // When
-        bus.send(message: .custom(key: "test", baggage: ["key": "value"]))
+        try bus.send(message: .baggage(key: "test", value: "value"))
 
         // Then
         wait(for: [expectation], timeout: 0.5)

--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -21,7 +21,7 @@ class CrashLogReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(

--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -21,19 +21,14 @@ class CrashLogReceiverTests: XCTestCase {
         )
 
         // When
-        let sent: LogEvent = .mockRandom()
-
-        core.send(
-            message: .custom(key: LoggingMessageKeys.crash, baggage: [
-                "report": DDCrashReport.mockAny(),
-                "context": CrashContext.mockWith(lastRUMViewEvent: nil)
-            ])
-        )
-
-        core.send(
-            message: .custom(key: LoggingMessageKeys.crash, baggage: [
-                "log": sent
-            ])
+        try core.send(
+            message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(
+                    report: DDCrashReport.mockAny(),
+                    context: CrashContext.mockWith(lastRUMViewEvent: nil)
+                )
+            )
         )
 
         // Then

--- a/DatadogCore/Tests/Datadog/Logs/WebViewLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/WebViewLogReceiverTests.swift
@@ -23,8 +23,8 @@ class WebViewLogReceiverTests: XCTestCase {
         // When
         let value: String = .mockRandom()
 
-        core.send(
-            message: .custom(key: LoggingMessageKeys.browserLog, baggage: .init([
+        try core.send(
+            message: .baggage(key: LoggingMessageKeys.browserLog, value: AnyEncodable([
                 "test": value
             ]))
         )
@@ -84,10 +84,10 @@ class WebViewLogReceiverTests: XCTestCase {
             "view": ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"]
         ]
 
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: LoggingMessageKeys.browserLog,
-                baggage: .init(webLogEvent)
+                value: AnyCodable(webLogEvent)
             )
         )
 
@@ -119,10 +119,10 @@ class WebViewLogReceiverTests: XCTestCase {
         var expectedWebLogEvent: JSON = webLogEvent
         expectedWebLogEvent["ddtags"] = "version:\(applicationVersion),env:\(environment)"
 
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: LoggingMessageKeys.browserLog,
-                baggage: .init(webLogEvent)
+                value: AnyEncodable(webLogEvent)
             )
         )
 

--- a/DatadogCore/Tests/Datadog/Logs/WebViewLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/WebViewLogReceiverTests.swift
@@ -23,7 +23,7 @@ class WebViewLogReceiverTests: XCTestCase {
         // When
         let value: String = .mockRandom()
 
-        try core.send(
+        core.send(
             message: .baggage(key: LoggingMessageKeys.browserLog, value: AnyEncodable([
                 "test": value
             ]))
@@ -84,7 +84,7 @@ class WebViewLogReceiverTests: XCTestCase {
             "view": ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"]
         ]
 
-        try core.send(
+        core.send(
             message: .baggage(
                 key: LoggingMessageKeys.browserLog,
                 value: AnyCodable(webLogEvent)
@@ -119,7 +119,7 @@ class WebViewLogReceiverTests: XCTestCase {
         var expectedWebLogEvent: JSON = webLogEvent
         expectedWebLogEvent["ddtags"] = "version:\(applicationVersion),env:\(environment)"
 
-        try core.send(
+        core.send(
             message: .baggage(
                 key: LoggingMessageKeys.browserLog,
                 value: AnyEncodable(webLogEvent)

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -96,12 +96,12 @@ class CrashReportSenderMock: CrashReportSender {
 }
 
 class RUMCrashReceiverMock: FeatureMessageReceiver {
-    var receivedBaggage: FeatureBaggage = [:]
+    var receivedBaggage: NewFeatureBaggage?
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         switch message {
-        case .custom(let key, let attributes) where key == CrashReportReceiver.MessageKeys.crash:
-            receivedBaggage = attributes
+        case .baggage(let label, let baggage) where label == CrashReportReceiver.MessageKeys.crash:
+            receivedBaggage = baggage
             return true
         default:
             return false
@@ -110,12 +110,12 @@ class RUMCrashReceiverMock: FeatureMessageReceiver {
 }
 
 class LogsCrashReceiverMock: FeatureMessageReceiver {
-    var receivedBaggage: FeatureBaggage = [:]
+    var receivedBaggage: NewFeatureBaggage?
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         switch message {
-        case .custom(let key, let attributes) where key == LoggingMessageKeys.crash:
-            receivedBaggage = attributes
+        case .baggage(let label, let baggage) where label == LoggingMessageKeys.crash:
+            receivedBaggage = baggage
             return true
         default:
             return false

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -32,7 +32,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: CrashReportReceiver.MessageKeys.crash,
                 value: MessageBusSender.Crash(
@@ -57,7 +57,7 @@ class CrashReportReceiverTests: XCTestCase {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: CrashReportReceiver.MessageKeys.crash,
                 value: MessageBusSender.Crash(
@@ -99,7 +99,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -133,7 +133,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -165,7 +165,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -198,7 +198,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -232,7 +232,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -264,7 +264,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -294,7 +294,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -332,7 +332,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -365,7 +365,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -462,7 +462,7 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            try receiver.receive(message: .baggage(
+            receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
@@ -572,7 +572,7 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                try receiver.receive(message: .baggage(
+                receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
                 ), from: core)
@@ -713,7 +713,7 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                try receiver.receive(message: .baggage(
+                receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
                 ), from: core)

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -32,11 +32,14 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        core.send(
-            message: .custom(key: CrashReportReceiver.MessageKeys.crash, baggage: [
-                "report": DDCrashReport.mockAny(),
-                "context": CrashContext.mockWith(lastRUMViewEvent: nil)
-            ])
+        try core.send(
+            message: .baggage(
+                key: CrashReportReceiver.MessageKeys.crash,
+                value: MessageBusSender.Crash(
+                    report: DDCrashReport.mockAny(),
+                    context: CrashContext.mockWith(lastRUMViewEvent: nil)
+                )
+            )
         )
 
         // Then
@@ -54,13 +57,16 @@ class CrashReportReceiverTests: XCTestCase {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // When
-        core.send(
-            message: .custom(key: CrashReportReceiver.MessageKeys.crash, baggage: [
-                "report": DDCrashReport.mockWith(date: Date()),
-                "context": CrashContext.mockWith(
-                    lastRUMViewEvent: AnyCodable(lastRUMViewEvent)
+        try core.send(
+            message: .baggage(
+                key: CrashReportReceiver.MessageKeys.crash,
+                value: MessageBusSender.Crash(
+                    report: DDCrashReport.mockWith(date: Date()),
+                    context: CrashContext.mockWith(
+                        lastRUMViewEvent: AnyCodable(lastRUMViewEvent)
+                    )
                 )
-            ])
+            )
         )
 
         // Then
@@ -93,12 +99,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -130,12 +133,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -165,12 +165,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -201,12 +198,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -238,12 +232,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -273,12 +264,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -306,12 +294,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -347,12 +332,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -383,12 +365,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -483,12 +462,9 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .custom(
-                key: CrashReportReceiver.MessageKeys.crash,
-                baggage: [
-                    "report": crashReport,
-                    "context": crashContext
-                ]
+            try receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
             ), from: core)
         )
 
@@ -596,12 +572,9 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .custom(
-                    key: CrashReportReceiver.MessageKeys.crash,
-                    baggage: [
-                        "report": crashReport,
-                        "context": crashContext
-                    ]
+                try receiver.receive(message: .baggage(
+                    key: MessageBusSender.MessageKeys.crash,
+                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
                 ), from: core)
             )
 
@@ -740,12 +713,9 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .custom(
-                    key: CrashReportReceiver.MessageKeys.crash,
-                    baggage: [
-                        "report": crashReport,
-                        "context": crashContext
-                    ]
+                try receiver.receive(message: .baggage(
+                    key: MessageBusSender.MessageKeys.crash,
+                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
                 ), from: core)
             )
 

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
@@ -135,3 +135,12 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
         }
     }
 }
+
+extension CrashContextCoreProvider: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
@@ -71,11 +71,11 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
         case .context(let context):
             update(context: context)
         case .baggage(let label, let baggage) where label == RUMBaggageKeys.viewEvent:
-            rumView(baggage: baggage, to: core)
+            updateRUMView(with: baggage, to: core)
         case .baggage(let label, let baggage) where label == RUMBaggageKeys.viewReset:
-            rumReset(baggage: baggage, to: core)
+            resetRUMView(with: baggage, to: core)
         case .baggage(let label, let baggage) where label == RUMBaggageKeys.sessionState:
-            rumSessionState(baggage: baggage, to: core)
+            updateSessionState(with: baggage, to: core)
         default:
             return false
         }
@@ -100,7 +100,7 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
         }
     }
 
-    private func rumView(baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
+    private func updateRUMView(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
         queue.async {
             do {
                 self.viewEvent = try baggage.decode(type: AnyCodable.self)
@@ -111,7 +111,7 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
         }
     }
 
-    private func rumReset(baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
+    private func resetRUMView(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
         queue.async {
             do {
                 if try baggage.decode(type: Bool.self) {
@@ -124,7 +124,7 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
         }
     }
 
-    private func rumSessionState(baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
+    private func updateSessionState(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
         queue.async {
             do {
                 self.sessionState = try baggage.decode(type: AnyCodable.self)

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -59,8 +59,7 @@ internal struct MessageBusSender: CrashReportSender {
                 DD.logger.warn(
                     """
                     In order to use Crash Reporting, RUM or Logging feature must be enabled.
-                    Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
-                    when initializing Datadog SDK.
+                    Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
                     """
                 )
             }

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -50,25 +50,20 @@ internal struct MessageBusSender: CrashReportSender {
             return
         }
 
-        do {
-            try core.send(
-                message: .baggage(
-                    key: MessageKeys.crash,
-                    value: Crash(report: report, context: context)
-                ),
-                else: {
-                    DD.logger.warn(
-                """
-                In order to use Crash Reporting, RUM or Logging feature must be enabled.
-                Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
-                when initializing Datadog SDK.
-                """
+        core.send(
+            message: .baggage(
+                key: MessageKeys.crash,
+                value: Crash(report: report, context: context)
+            ),
+            else: {
+                DD.logger.warn(
+                    """
+                    In order to use Crash Reporting, RUM or Logging feature must be enabled.
+                    Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
+                    when initializing Datadog SDK.
+                    """
                 )
-                }
-            )
-        } catch {
-            core.telemetry
-                .error("Fails to encode crash", error: error)
-        }
+            }
+        )
     }
 }

--- a/DatadogInternal/Sources/Codable/AnyEncoder.swift
+++ b/DatadogInternal/Sources/Codable/AnyEncoder.swift
@@ -650,7 +650,7 @@ private class _AnyEncoder: Encoder {
         ///
         /// - parameter value: The value to encode.
         func encode<T>(_ value: T) throws where T: Encodable {
-            if value is DictionaryEncodable {
+            if value is PassthroughAnyCodable {
                 store(value)
             } else {
                 let encoder = _AnyEncoder(path: codingPath)
@@ -661,13 +661,18 @@ private class _AnyEncoder: Encoder {
     }
 }
 
-/// A shared encodable object will skip encoding when using the `AnyEncoder`.
+/// A passthrough  object will skip encoding when using the ``AnyEncoder``.
+/// The object will be stored as-is in the returned `Any?` container.
 ///
-/// Making an `Encodable` as shared allow to bypass encoding when the type is
+/// Making an `Encodable` as passthrough allow to bypass encoding when the type is
 /// known by multiple parties.
-public protocol DictionaryEncodable { }
+///
+/// When decoding an object using the ``AnyDecoder``, the decoder will
+/// attempt to cast the object to the expected type, a `DecodingError.typeMismatch`
+/// error is raised in case of failure.
+public protocol PassthroughAnyCodable { }
 
-extension URL: DictionaryEncodable { }
-extension Date: DictionaryEncodable { }
-extension UUID: DictionaryEncodable { }
-extension Data: DictionaryEncodable { }
+extension URL: PassthroughAnyCodable { }
+extension Date: PassthroughAnyCodable { }
+extension UUID: PassthroughAnyCodable { }
+extension Data: PassthroughAnyCodable { }

--- a/DatadogInternal/Sources/Context/AppState.swift
+++ b/DatadogInternal/Sources/Context/AppState.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Application state.
-public enum AppState: Codable, DictionaryEncodable {
+public enum AppState: Codable, PassthroughAnyCodable {
     /// The app is running in the foreground and currently receiving events.
     case active
     /// The app is running in the foreground but is not receiving events.
@@ -28,7 +28,7 @@ public enum AppState: Codable, DictionaryEncodable {
 }
 
 /// A data structure to represent recorded app states in a given period of time
-public struct AppStateHistory: Codable, Equatable, DictionaryEncodable {
+public struct AppStateHistory: Codable, Equatable, PassthroughAnyCodable {
     /// Snapshot of the app state at `date`
     public struct Snapshot: Codable, Equatable {
         /// The app state at this `date`.

--- a/DatadogInternal/Sources/Context/BatteryStatus.swift
+++ b/DatadogInternal/Sources/Context/BatteryStatus.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Describe the battery state for mobile devices.
-public struct BatteryStatus: Codable, Equatable, DictionaryEncodable {
+public struct BatteryStatus: Codable, Equatable, PassthroughAnyCodable {
     public enum State: Codable {
         case unknown
         case unplugged

--- a/DatadogInternal/Sources/Context/CarrierInfo.swift
+++ b/DatadogInternal/Sources/Context/CarrierInfo.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Carrier details specific to cellular radio access.
-public struct CarrierInfo: Codable, Equatable, DictionaryEncodable {
+public struct CarrierInfo: Codable, Equatable, PassthroughAnyCodable {
     // swiftlint:disable identifier_name
     public enum RadioAccessTechnology: String, Codable, CaseIterable {
         case GPRS

--- a/DatadogInternal/Sources/Context/DeviceInfo.swift
+++ b/DatadogInternal/Sources/Context/DeviceInfo.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Describes current device information.
-public struct DeviceInfo: Codable, Equatable, DictionaryEncodable {
+public struct DeviceInfo: Codable, Equatable, PassthroughAnyCodable {
     // MARK: - Info
 
     /// Device manufacturer name. Always'Apple'

--- a/DatadogInternal/Sources/Context/LaunchTime.swift
+++ b/DatadogInternal/Sources/Context/LaunchTime.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Provides the application launch time.
-public struct LaunchTime: Codable, Equatable, DictionaryEncodable {
+public struct LaunchTime: Codable, Equatable, PassthroughAnyCodable {
     /// The app process launch duration (in seconds) measured as the time from process start time
     /// to receiving `UIApplication.didBecomeActiveNotification` notification.
     ///

--- a/DatadogInternal/Sources/Context/NetworkConnectionInfo.swift
+++ b/DatadogInternal/Sources/Context/NetworkConnectionInfo.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Network connection details.
-public struct NetworkConnectionInfo: Codable, Equatable, DictionaryEncodable {
+public struct NetworkConnectionInfo: Codable, Equatable, PassthroughAnyCodable {
     /// Tells if network is reachable.
     public enum Reachability: String, Codable, CaseIterable {
         /// The network is reachable.

--- a/DatadogInternal/Sources/Context/TrackingConsent.swift
+++ b/DatadogInternal/Sources/Context/TrackingConsent.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// This value should be used to grant the permission for Datadog SDK to store data collected in
 /// Logging, Tracing or RUM and upload it to Datadog servers.
-public enum TrackingConsent: Codable, DictionaryEncodable {
+public enum TrackingConsent: Codable, PassthroughAnyCodable {
     /// The permission to persist and send data to the Datadog servers was granted.
     /// Any previously stored pending data will be marked as ready for sent.
     case granted

--- a/DatadogInternal/Sources/Context/UserInfo.swift
+++ b/DatadogInternal/Sources/Context/UserInfo.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct UserInfo: Codable, DictionaryEncodable {
+public struct UserInfo: Codable, PassthroughAnyCodable {
     /// User ID, if any.
     public let id: String?
     /// Name representing the user, if any.

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -31,11 +31,11 @@ extension FeatureMessage {
     /// Creates a `.baggage` message with thegiven label and `Encodable` type.
     ///
     /// - Parameters:
-    ///   - label: The baggage label.
+    ///   - key: The baggage key.
     ///   - baggage: The baggage value.
     /// - Returns: a `.baggage` case.
-    public static func baggage<Value>(key: String, value: Value) throws -> FeatureMessage where Value: Encodable {
-        try .baggage(key: key, baggage: .init(value))
+    public static func baggage<Value>(key: String, value: Value) -> FeatureMessage where Value: Encodable {
+        .baggage(key: key, baggage: .init(value))
     }
 
     /// Decodes the value of a baggage if the label matches.

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -8,24 +8,11 @@ import Foundation
 
 /// The set of messages that can be transimtted on the Features message bus.
 public enum FeatureMessage {
-    /// An error message.
-    case error(
-        message: String,
-        baggage: FeatureBaggage
-    )
-
-    /// An encodable event that will be transmitted
-    /// as-is through a Feature.
-    case event(
-        target: String,
-        event: AnyEncodable
-    )
-
     /// A custom message with generic encodable
     /// attributes.
-    case custom(
+    case baggage(
         key: String,
-        baggage: FeatureBaggage
+        baggage: NewFeatureBaggage
     )
 
     /// A core context message.
@@ -38,4 +25,31 @@ public enum FeatureMessage {
     ///
     /// The core can send telemtry data coming from all Features.
     case telemetry(TelemetryMessage)
+}
+
+extension FeatureMessage {
+    /// Creates a `.baggage` message with thegiven label and `Encodable` type.
+    ///
+    /// - Parameters:
+    ///   - label: The baggage label.
+    ///   - baggage: The baggage value.
+    /// - Returns: a `.baggage` case.
+    public static func baggage<Value>(key: String, value: Value) throws -> FeatureMessage where Value: Encodable {
+        try .baggage(key: key, baggage: .init(value))
+    }
+
+    /// Decodes the value of a baggage if the label matches.
+    ///
+    /// - Parameters:
+    ///   - label: The requested baggage label.
+    ///   - type: The expected type of the baggage value.
+    /// - Returns: The decoded baggage value, or nil if the label doesn't match.
+    /// - Throws: A `DecodingError` if decoding fails.
+    public func baggage<Value>(forKey key: String, type: Value.Type = Value.self) throws -> Value? where Value: Decodable {
+        guard case let .baggage(messageKey, baggage) = self, messageKey == key else {
+            return nil
+        }
+
+        return try baggage.decode(type: type)
+    }
 }

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -28,7 +28,7 @@ public enum FeatureMessage {
 }
 
 extension FeatureMessage {
-    /// Creates a `.baggage` message with thegiven label and `Encodable` type.
+    /// Creates a `.baggage` message with the given key and `Encodable` value.
     ///
     /// - Parameters:
     ///   - key: The baggage key.
@@ -38,7 +38,7 @@ extension FeatureMessage {
         .baggage(key: key, baggage: .init(value))
     }
 
-    /// Decodes the value of a baggage if the label matches.
+    /// Returns the baggage if the key matches the message.
     ///
     /// - Parameters:
     ///   - label: The requested baggage label.

--- a/DatadogInternal/Sources/MessageBus/NewFeatureBaggage.swift
+++ b/DatadogInternal/Sources/MessageBus/NewFeatureBaggage.swift
@@ -49,6 +49,7 @@ import Foundation
 /// sure that any value can be accessibe from any thread.
 public final class NewFeatureBaggage {
     /// The raw value contained in the baggage.
+    @ReadWriteLock
     private var rawValue: Any?
 
     /// The underlying encoding process.
@@ -66,10 +67,11 @@ public final class NewFeatureBaggage {
     public func encode() throws -> Any? {
         // lazily encode to save from encoding
         // if the value is never decoded.
-        if let rawValue = rawValue {
+        if let rawValue = self.rawValue {
             return rawValue
         }
-        rawValue = try _encode()
+        let rawValue = try _encode()
+        self.rawValue = rawValue
         return rawValue
     }
 

--- a/DatadogInternal/Sources/MessageBus/NewFeatureBaggage.swift
+++ b/DatadogInternal/Sources/MessageBus/NewFeatureBaggage.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A `FeatureBaggage` holds any codable value.
+///
+/// Values are uniquely identified by key as `String`, the value type is validated on `get`
+/// either explicity, when specified, or inferred.
+///
+/// ## Creates a Feature Baggage
+/// Create a baggage by providing an `Encodable` value.
+///
+/// The example below shows how to create a baggage from an instance of a simple `GroceryProduct`:
+///
+///     struct GroceryProduct: Encodable {
+///         var name: String
+///         var points: Int
+///         var description: String?
+///     }
+///
+///     let pear = GroceryProduct(name: "Pear", points: 250, description: "A ripe pear.")
+///     let baggage = try FeatureBaggage(pear)
+///
+/// The `pear` is stored as a dictionary within the baggage:
+///
+///     print(baggage.rawValue)
+///     // ["description": Optional("A ripe pear."), "points": Optional(250), "name": Optional("Pear")]
+///
+/// ## Accessing Value
+/// The baggage value can then be decoded to any type that follow the same schema.
+///
+/// The following example decodes the baggage into a new data type:
+///
+///     struct CartItem: Decodable {
+///         var name: String
+///         var points: Int
+///     }
+///
+///     let item: CartItem = try baggage.decode()
+///
+///     print(item)
+///     // CartItem(name: "Pear", points: 250)
+///
+/// A Feature Baggage does not ensure thread-safety of values that holds references, make
+/// sure that any value can be accessibe from any thread.
+public struct NewFeatureBaggage {
+    /// The raw value contained in the baggage.
+    public let rawValue: Any?
+
+    /// Creates an instance initialized with the given encodable.
+    public init<Value>(_ value: Value) throws where Value: Encodable {
+        let encoder = AnyEncoder()
+        self.rawValue = try encoder.encode(value)
+    }
+
+    /// Decodes the value stored in the baggage.
+    ///
+    /// - Parameters:
+    ///   - type: The expected value type.
+    /// - Returns: The decoded baggage.
+    public func decode<Value>(type: Value.Type = Value.self) throws -> Value where Value: Decodable {
+        let decoder = AnyDecoder()
+        return try decoder.decode(from: rawValue)
+    }
+}

--- a/DatadogInternal/Sources/Utils/DDError.swift
+++ b/DatadogInternal/Sources/Utils/DDError.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Common representation of Swift `Error` used by different features.
-public struct DDError: Equatable, Codable {
+public struct DDError: Equatable, Codable, PassthroughAnyCodable {
     /// Common error key encoding threads information in Crash Reporting.
     /// See "RFC - iOS Crash Reports Minimization" for more context.
     public static let threads = "error.threads"

--- a/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
@@ -29,19 +29,19 @@ class FeatureMessageReceiverTests: XCTestCase {
         }
     }
 
-    func testNOPReceiver_returnsFalse() {
+    func testNOPReceiver_returnsFalse() throws {
         let receiver = NOPFeatureMessageReceiver()
-        XCTAssertFalse(receiver.receive(message: .custom(key: .mockAny(), baggage: [:]), from: core))
+        XCTAssertFalse(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
-    func testEmptyCombinedReceiver_returnsFalse() {
+    func testEmptyCombinedReceiver_returnsFalse() throws {
         let receiver = CombinedFeatureMessageReceiver([])
-        XCTAssertFalse(receiver.receive(message: .custom(key: .mockAny(), baggage: [:]), from: core))
+        XCTAssertFalse(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
-    func testCombinedReceiver_withValidReceiver_returnsTrue() {
+    func testCombinedReceiver_withValidReceiver_returnsTrue() throws {
         let expectation = expectation(description: "receive 2 messages")
         expectation.expectedFulfillmentCount = 2
 
@@ -50,12 +50,12 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: expectation)
         )
 
-        XCTAssertTrue(receiver.receive(message: .custom(key: .mockAny(), baggage: [:]), from: core))
+        XCTAssertTrue(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertTrue(receiver.receive(message: .context(.mockRandom()), from: core))
         waitForExpectations(timeout: 0)
     }
 
-    func testCombinedReceiver_withMultiValidReceiver_itSendsToFirstOnly() {
+    func testCombinedReceiver_withMultiValidReceiver_itSendsToFirstOnly() throws {
         let expectation = self.expectation(description: "receive message")
         let noExpectation = self.expectation(description: "do not receive message")
         noExpectation.isInverted = true
@@ -65,7 +65,7 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: noExpectation)
         )
 
-        XCTAssertTrue(receiver.receive(message: .custom(key: .mockAny(), baggage: [:]), from: core))
+        XCTAssertTrue(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         waitForExpectations(timeout: 0)
     }
 }

--- a/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
@@ -31,13 +31,13 @@ class FeatureMessageReceiverTests: XCTestCase {
 
     func testNOPReceiver_returnsFalse() throws {
         let receiver = NOPFeatureMessageReceiver()
-        XCTAssertFalse(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertFalse(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
     func testEmptyCombinedReceiver_returnsFalse() throws {
         let receiver = CombinedFeatureMessageReceiver([])
-        XCTAssertFalse(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertFalse(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
@@ -50,7 +50,7 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: expectation)
         )
 
-        XCTAssertTrue(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertTrue(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         XCTAssertTrue(receiver.receive(message: .context(.mockRandom()), from: core))
         waitForExpectations(timeout: 0)
     }
@@ -65,7 +65,7 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: noExpectation)
         )
 
-        XCTAssertTrue(try receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertTrue(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
         waitForExpectations(timeout: 0)
     }
 }

--- a/DatadogInternal/Tests/MessageBus/NewFeatureBaggageTests.swift
+++ b/DatadogInternal/Tests/MessageBus/NewFeatureBaggageTests.swift
@@ -21,7 +21,7 @@ class NewFeatureBaggageTests: XCTestCase {
 
     func testEncodeDecode() throws {
         let pear = GroceryProduct(name: .mockRandom(), points: .mockRandom(), description: .mockRandom())
-        let baggage = try NewFeatureBaggage(pear)
+        let baggage = NewFeatureBaggage(pear)
         let item: CartItem = try baggage.decode()
 
         XCTAssertEqual(pear.name, item.name)

--- a/DatadogInternal/Tests/MessageBus/NewFeatureBaggageTests.swift
+++ b/DatadogInternal/Tests/MessageBus/NewFeatureBaggageTests.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogInternal
+
+class NewFeatureBaggageTests: XCTestCase {
+    struct GroceryProduct: Encodable {
+        var name: String
+        var points: Int
+        var description: String?
+    }
+
+    struct CartItem: Decodable {
+        var name: String
+        var points: Int
+    }
+
+    func testEncodeDecode() throws {
+        let pear = GroceryProduct(name: .mockRandom(), points: .mockRandom(), description: .mockRandom())
+        let baggage = try NewFeatureBaggage(pear)
+        let item: CartItem = try baggage.decode()
+
+        XCTAssertEqual(pear.name, item.name)
+        XCTAssertEqual(pear.points, item.points)
+    }
+}

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -248,7 +248,7 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
                 return false
             }
 
-            guard var event = baggage.rawValue as? [String: Any?] else {
+            guard var event = try baggage.encode() as? [String: Any?] else {
                 throw InternalError(description: "event is not a dictionary")
             }
 

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -21,6 +21,29 @@ internal enum LoggingMessageKeys {
 
 /// Receiver to consume a Log message
 internal struct LogMessageReceiver: FeatureMessageReceiver {
+    struct LogMessage: Decodable {
+        /// The Logger name
+        let logger: String
+        /// The Logger service
+        let service: String?
+        /// The Log date
+        let date: Date
+        /// The Log message
+        let message: String
+        /// The Log error
+        let error: DDError?
+        /// The Log level
+        let level: LogLevel
+        /// The thread name
+        let thread: String
+        /// The thread name
+        let networkInfoEnabled: Bool?
+        /// The Log user custom attributes
+        let userAttributes: [String: AnyCodable]?
+        /// The Log internal attributes
+        let internalAttributes: [String: AnyCodable]?
+    }
+
     /// The log event mapper
     let logEventMapper: LogEventMapper?
 
@@ -30,50 +53,54 @@ internal struct LogMessageReceiver: FeatureMessageReceiver {
     ///   - message: The Feature message
     ///   - core: The core from which the message is transmitted.
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard
-            case let .custom(key, attributes) = message, key == LoggingMessageKeys.log,
-            let loggerName: String = attributes["loggerName"],
-            let date: Date = attributes["date"],
-            let message: String = attributes["message"],
-            let level: LogLevel = attributes["level"],
-            let threadName: String = attributes["threadName"]
-        else {
-            return false
+        do {
+            guard let log: LogMessage = try message.baggage(forKey: LoggingMessageKeys.log) else {
+                return false
+            }
+
+            core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+                let builder = LogEventBuilder(
+                    service: log.service ?? context.service,
+                    loggerName: log.logger,
+                    networkInfoEnabled: log.networkInfoEnabled ?? false,
+                    eventMapper: logEventMapper
+                )
+
+                builder.createLogEvent(
+                    date: log.date,
+                    level: log.level,
+                    message: log.message,
+                    error: log.error,
+                    attributes: .init(
+                        userAttributes: log.userAttributes ?? [:],
+                        internalAttributes: log.internalAttributes
+                    ),
+                    tags: [],
+                    context: context,
+                    threadName: log.thread,
+                    callback: writer.write
+                )
+            }
+
+            return true
+        } catch {
+            core.telemetry
+                .error("Fails to decode crash from Logs", error: error)
         }
 
-        let userAttributes: [String: AnyCodable] = attributes["userAttributes"] ?? [:]
-        let internalAttributes: [String: AnyCodable]? = attributes["internalAttributes"]
-
-        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: false) { context, writer in
-            let builder = LogEventBuilder(
-                service: attributes["service"] ?? context.service,
-                loggerName: loggerName,
-                networkInfoEnabled: attributes["networkInfoEnabled"] ?? false,
-                eventMapper: logEventMapper
-            )
-
-            builder.createLogEvent(
-                date: date,
-                level: level,
-                message: message,
-                error: attributes["error"],
-                attributes: .init(
-                    userAttributes: userAttributes,
-                    internalAttributes: internalAttributes
-                ),
-                tags: [],
-                context: context,
-                threadName: threadName,
-                callback: writer.write
-            )
-        }
-
-        return true
+        return false
     }
 }
 
 /// Receiver to consume a Crash Log message as Log.
 internal struct CrashLogReceiver: FeatureMessageReceiver {
+    private struct Crash: Decodable {
+        /// The crash report.
+        let report: CrashReport
+        /// The crash context
+        let context: CrashContext
+    }
+
     private struct CrashReport: Decodable {
         /// The date of the crash occurrence.
         let date: Date?
@@ -134,14 +161,20 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
     ///   - message: The Feature message
     ///   - core: The core from which the message is transmitted.
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard
-            case let .custom(key, attributes) = message, key == LoggingMessageKeys.crash,
-            let report = attributes["report", type: CrashReport.self],
-            let context = attributes["context", type: CrashContext.self]
-        else {
-            return false
-        }
+        do {
+            guard let crash: Crash = try message.baggage(forKey: LoggingMessageKeys.crash) else {
+                return false
+            }
 
+            return send(report: crash.report, with: crash.context, to: core)
+        } catch {
+            core.telemetry
+                .error("Fails to decode crash from RUM", error: error)
+        }
+        return false
+    }
+
+    private func send(report: CrashReport, with context: CrashContext, to core: DatadogCoreProtocol) -> Bool {
         // The `report.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
         // to the server time before processing. Following use of the current correction is not ideal, but this is the best
         // approximation we can get.
@@ -210,40 +243,49 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
     ///   - message: The Feature message
     ///   - core: The core from which the message is transmitted.
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .custom(key, baggage) = message, key == LoggingMessageKeys.browserLog else {
-            return false
+        do {
+            guard case let .baggage(label, baggage) = message, label == LoggingMessageKeys.browserLog else {
+                return false
+            }
+
+            guard var event = baggage.rawValue as? [String: Any?] else {
+                throw InternalError(description: "event is not a dictionary")
+            }
+
+            let versionKey = LogEventEncoder.StaticCodingKeys.applicationVersion.rawValue
+            let envKey = LogEventEncoder.StaticCodingKeys.environment.rawValue
+            let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
+            let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
+
+            core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+                let ddTags = "\(versionKey):\(context.version),\(envKey):\(context.env)"
+
+                if let tags = event[tagsKey] as? String, !tags.isEmpty {
+                    event[tagsKey] = "\(ddTags),\(tags)"
+                } else {
+                    event[tagsKey] = ddTags
+                }
+
+                if let timestampInMs = event[dateKey] as? Int64 {
+                    let serverTimeOffsetInMs = context.serverTimeOffset.toInt64Milliseconds
+                    let correctedTimestamp = Int64(timestampInMs) + serverTimeOffsetInMs
+                    event[dateKey] = correctedTimestamp
+                }
+
+                if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
+                    let mappedBaggage = Dictionary(uniqueKeysWithValues: baggage.map { key, value in (mapRUMContextAttributeKeyToLogAttributeKey(key), value) })
+                    event.merge(mappedBaggage as [String: Any]) { $1 }
+                }
+
+                writer.write(value: AnyEncodable(event))
+            }
+
+            return true
+        } catch {
+            core.telemetry
+                .error("Fails to decode browser log", error: error)
         }
 
-        var event = baggage.attributes
-
-        let versionKey = LogEventEncoder.StaticCodingKeys.applicationVersion.rawValue
-        let envKey = LogEventEncoder.StaticCodingKeys.environment.rawValue
-        let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
-        let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
-
-        core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
-            let ddTags = "\(versionKey):\(context.version),\(envKey):\(context.env)"
-
-            if let tags = event[tagsKey] as? String, !tags.isEmpty {
-                event[tagsKey] = "\(ddTags),\(tags)"
-            } else {
-                event[tagsKey] = ddTags
-            }
-
-            if let timestampInMs = event[dateKey] as? Int64 {
-                let serverTimeOffsetInMs = context.serverTimeOffset.toInt64Milliseconds
-                let correctedTimestamp = timestampInMs + serverTimeOffsetInMs
-                event[dateKey] = correctedTimestamp
-            }
-
-            if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
-                let mappedBaggage = Dictionary(uniqueKeysWithValues: baggage.map { key, value in (mapRUMContextAttributeKeyToLogAttributeKey(key), value) })
-                event.merge(mappedBaggage as [String: Any]) { $1 }
-            }
-
-            writer.write(value: AnyEncodable(event))
-        }
-
-        return true
+        return false
     }
 }

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -25,6 +25,20 @@ internal final class RemoteLogger: LoggerProtocol {
         let sampler: Sampler
     }
 
+    struct ErrorMessage: Encodable {
+        static let key = "error"
+        /// The Log error message
+        let message: String
+        /// The Log error type
+        let type: String?
+        /// The Log error stack
+        let stack: String?
+        /// The Log error stack
+        let source: String = "logger"
+        /// The Log attributes
+        let attributes: AnyEncodable
+    }
+
     /// `DatadogCore` instance managing this logger.
     internal let core: DatadogCoreProtocol
     /// Configuration specific to this logger.
@@ -154,17 +168,22 @@ internal final class RemoteLogger: LoggerProtocol {
                     return
                 }
 
-                self.core.send(
-                    message: .error(
-                        message: log.error?.message ?? log.message,
-                        baggage: [
-                            "type": log.error?.kind,
-                            "stack": log.error?.stack,
-                            "source": "logger",
-                            "attributes": userAttributes
-                        ]
+                do {
+                    try self.core.send(
+                        message: .baggage(
+                            key: ErrorMessage.key,
+                            value: ErrorMessage(
+                                message: log.error?.message ?? log.message,
+                                type: log.error?.kind,
+                                stack: log.error?.stack,
+                                attributes: .init(userAttributes)
+                            )
+                        )
                     )
-                )
+                } catch {
+                    self.core.telemetry
+                        .error("Fails to encore error message", error: error)
+                }
             }
         }
     }

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -168,22 +168,17 @@ internal final class RemoteLogger: LoggerProtocol {
                     return
                 }
 
-                do {
-                    try self.core.send(
-                        message: .baggage(
-                            key: ErrorMessage.key,
-                            value: ErrorMessage(
-                                message: log.error?.message ?? log.message,
-                                type: log.error?.kind,
-                                stack: log.error?.stack,
-                                attributes: .init(userAttributes)
-                            )
+                self.core.send(
+                    message: .baggage(
+                        key: ErrorMessage.key,
+                        value: ErrorMessage(
+                            message: log.error?.message ?? log.message,
+                            type: log.error?.kind,
+                            stack: log.error?.stack,
+                            attributes: .init(userAttributes)
                         )
                     )
-                } catch {
-                    self.core.telemetry
-                        .error("Fails to encore error message", error: error)
-                }
+                )
             }
         }
     }

--- a/DatadogLogs/Tests/LogMessageReceiverTests.swift
+++ b/DatadogLogs/Tests/LogMessageReceiverTests.swift
@@ -10,6 +10,19 @@ import DatadogInternal
 @testable import DatadogLogs
 
 class LogMessageReceiverTests: XCTestCase {
+    struct LogMessage: Encodable {
+        let logger: String
+        let service: String?
+        let date: Date
+        let message: String
+        let level: LogLevel
+        let thread: String
+        let error: DDError?
+        let networkInfoEnabled: Bool?
+        let userAttributes: [String: String]?
+        let internalAttributes: [String: String]?
+    }
+
     func testReceiveIncompleteLogMessage() throws {
         let expectation = expectation(description: "Don't send log fallback")
 
@@ -20,13 +33,10 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: "log",
-                baggage: [
-                    "date": Date.mockDecember15th2019At10AMUTC(),
-                    "message": "message-test",
-                ]
+                value: "wrong-type"
             ),
             else: { expectation.fulfill() }
         )
@@ -45,16 +55,21 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: "log",
-                baggage: [
-                    "date": Date.mockDecember15th2019At10AMUTC(),
-                    "loggerName": "logger-test",
-                    "threadName": "thread-test",
-                    "message": "message-test",
-                    "level": LogLevel.info
-                ]
+                value: LogMessage(
+                    logger: "logger-test",
+                    service: nil,
+                    date: .mockDecember15th2019At10AMUTC(),
+                    message: "message-test",
+                    level: .info,
+                    thread: "thread-test",
+                    error: nil,
+                    networkInfoEnabled: nil,
+                    userAttributes: nil,
+                    internalAttributes: nil
+                )
             )
         )
 
@@ -83,21 +98,21 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: "log",
-                baggage: [
-                    "date": Date.mockDecember15th2019At10AMUTC(),
-                    "loggerName": "logger-test",
-                    "service": "service-test",
-                    "threadName": "thread-test",
-                    "message": "message-test",
-                    "level": LogLevel.info,
-                    "error": DDError.mockAny(),
-                    "userAttributes": ["user": "attribute"],
-                    "internalAttributes": ["internal": "attribute"],
-                    "networkInfoEnabled": true
-                ]
+                value: LogMessage(
+                    logger: "logger-test",
+                    service: "service-test",
+                    date: .mockDecember15th2019At10AMUTC(),
+                    message: "message-test",
+                    level: .info,
+                    thread: "thread-test",
+                    error: .mockAny(),
+                    networkInfoEnabled: true,
+                    userAttributes: ["user": "attribute"],
+                    internalAttributes: ["internal": "attribute"]
+                )
             )
         )
 
@@ -134,16 +149,21 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        core.send(
-            message: .custom(
+        try core.send(
+            message: .baggage(
                 key: "log",
-                baggage: [
-                    "date": Date.mockDecember15th2019At10AMUTC(),
-                    "loggerName": "logger-test",
-                    "threadName": "thread-test",
-                    "message": "message-test",
-                    "level": LogLevel.info
-                ]
+                value: LogMessage(
+                    logger: "logger-test",
+                    service: nil,
+                    date: .mockDecember15th2019At10AMUTC(),
+                    message: "message-test",
+                    level: .info,
+                    thread: "thread-test",
+                    error: nil,
+                    networkInfoEnabled: nil,
+                    userAttributes: nil,
+                    internalAttributes: nil
+                )
             )
         )
 

--- a/DatadogLogs/Tests/LogMessageReceiverTests.swift
+++ b/DatadogLogs/Tests/LogMessageReceiverTests.swift
@@ -33,7 +33,7 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: "log",
                 value: "wrong-type"
@@ -55,7 +55,7 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: "log",
                 value: LogMessage(
@@ -98,7 +98,7 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: "log",
                 value: LogMessage(
@@ -149,7 +149,7 @@ class LogMessageReceiverTests: XCTestCase {
         )
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(
                 key: "log",
                 value: LogMessage(

--- a/DatadogRUM/Sources/Feature/RUMBaggageKeys.swift
+++ b/DatadogRUM/Sources/Feature/RUMBaggageKeys.swift
@@ -10,12 +10,12 @@ import Foundation
 internal enum RUMBaggageKeys {
     /// The key references RUM view event.
     /// The view event associated with the key conforms to `Codable`.
-    static let viewEvent = "view-event"
+    static let viewEvent = "rum-view-event"
 
     /// The key references a `true` value if the RUM view is reset.
-    static let viewReset = "view-reset"
+    static let viewReset = "rum-view-reset"
 
     /// The key references RUM session state.
     /// The state associated with the key conforms to `Codable`.
-    static let sessionState = "session-state"
+    static let sessionState = "rum-session-state"
 }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -25,7 +25,14 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         static let viewEventAvailabilityThreshold: TimeInterval = 14_400 // 4 hours
     }
 
-    private struct CrashReport: Decodable {
+    struct Crash: Decodable {
+        /// The crash report.
+        let report: CrashReport
+        /// The crash context
+        let context: CrashContext
+    }
+
+    struct CrashReport: Decodable {
         /// The date of the crash occurrence.
         let date: Date?
         /// Crash report type - used to group similar crash reports.
@@ -47,7 +54,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         let wasTruncated: Bool
     }
 
-    private struct CrashContext: Decodable {
+    struct CrashContext: Decodable {
         /// Interval between device and server time.
         let serverTimeOffset: TimeInterval
         /// The name of the service that data is generated from.
@@ -120,22 +127,18 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
     }
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        if case let .custom(key, baggage) = message, key == MessageKeys.crash {
-            return write(crash: baggage, to: core)
+        do {
+            guard let crash: Crash = try message.baggage(forKey: MessageKeys.crash) else {
+                return false
+            }
+
+            return send(report: crash.report, with: crash.context, to: core)
+        } catch {
+            core.telemetry
+                .error("Fails to decode crash from RUM", error: error)
         }
 
         return false
-    }
-
-    private func write(crash attributes: FeatureBaggage, to core: DatadogCoreProtocol) -> Bool {
-        guard
-            let report = attributes["report", type: CrashReport.self],
-            let context = attributes["context", type: CrashContext.self]
-        else {
-            return false
-        }
-
-        return send(report: report, with: context, to: core)
     }
 
     private func send(report: CrashReport, with context: CrashContext, to core: DatadogCoreProtocol) -> Bool {

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -42,7 +42,7 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                 return false
             }
 
-            guard let event = baggage.rawValue as? JSON else {
+            guard let event = try baggage.encode() as? JSON else {
                 throw InternalError(description: "Event is not a dictionary")
             }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -34,7 +34,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// Information about this session state, shared with `CrashContext`.
     private var state: RUMSessionState {
         didSet {
-            try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+            dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
         }
     }
 
@@ -102,7 +102,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
 
         // Update `CrashContext` with recent RUM session state:
-        try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+        dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
     }
 
     /// Creates a new Session upon expiration of the previous one.
@@ -191,7 +191,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             // We also want to send this as a session is being stopped.
             // It means that with Background Events Tracking disabled, eventual off-view crashes will be dropped
             // similar to how we drop other events.
-            try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
+            dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
         }
 
         return isActive || !viewScopes.isEmpty

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -34,7 +34,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// Information about this session state, shared with `CrashContext`.
     private var state: RUMSessionState {
         didSet {
-            dependencies.core?.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.sessionState: state]))
+            try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
         }
     }
 
@@ -102,7 +102,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
 
         // Update `CrashContext` with recent RUM session state:
-        dependencies.core?.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.sessionState: state]))
+        try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
     }
 
     /// Creates a new Session upon expiration of the previous one.
@@ -191,7 +191,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             // We also want to send this as a session is being stopped.
             // It means that with Background Events Tracking disabled, eventual off-view crashes will be dropped
             // similar to how we drop other events.
-            dependencies.core?.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.viewReset: true]))
+            try? dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
         }
 
         return isActive || !viewScopes.isEmpty

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -520,10 +520,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
             // Update `CrashContext` with recent RUM view (no matter sampling - we want to always
             // have recent information if process is interrupted by crash):
-            dependencies.core?.send(
-                message: .custom(
-                    key: "rum",
-                    baggage: [RUMBaggageKeys.viewEvent: event]
+            try? dependencies.core?.send(
+                message: .baggage(
+                    key: RUMBaggageKeys.viewEvent,
+                    value: event
                 )
             )
         } else { // if event was dropped by mapper

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -520,7 +520,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
             // Update `CrashContext` with recent RUM view (no matter sampling - we want to always
             // have recent information if process is interrupted by crash):
-            try? dependencies.core?.send(
+            dependencies.core?.send(
                 message: .baggage(
                     key: RUMBaggageKeys.viewEvent,
                     value: event

--- a/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
@@ -35,11 +35,8 @@ class ErrorMessageReceiverTests: XCTestCase {
         let expectation = expectation(description: "Don't send error fallback")
 
         // When
-        core.send(
-            message: .error(
-                message: "message-test",
-                baggage: [:]
-            ),
+        try core.send(
+            message: .baggage(key: "error", value: ["message": "message-test"]),
             else: { expectation.fulfill() }
         )
 
@@ -54,13 +51,11 @@ class ErrorMessageReceiverTests: XCTestCase {
         core.expectation = expectation(description: "Send Error")
 
         // When
-        core.send(
-            message: .error(
-                message: "message-test",
-                baggage: [
-                    "source": "custom"
-                ]
-            )
+        try core.send(
+            message: .baggage(key: "error", value: [
+                "message": "message-test",
+                "source": "custom"
+            ])
         )
 
         // Then
@@ -76,18 +71,17 @@ class ErrorMessageReceiverTests: XCTestCase {
 
         // When
         let mockAttribute: String = .mockRandom()
-        core.send(
-            message: .error(
-                message: "message-test",
-                baggage: [
-                    "type": "type-test",
-                    "stack": "stack-test",
-                    "source": "logger",
-                    "attributes": [
-                        "any-key": mockAttribute
-                    ]
-                ]
-            )
+        let baggage: [String: Any] = [
+            "message": "message-test",
+            "type": "type-test",
+            "stack": "stack-test",
+            "source": "logger",
+            "attributes": [
+                "any-key": mockAttribute
+            ]
+        ]
+        try core.send(
+            message: .baggage(key: "error", value: AnyEncodable(baggage))
         )
 
         // Then

--- a/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
@@ -35,7 +35,7 @@ class ErrorMessageReceiverTests: XCTestCase {
         let expectation = expectation(description: "Don't send error fallback")
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(key: "error", value: ["message": "message-test"]),
             else: { expectation.fulfill() }
         )
@@ -51,7 +51,7 @@ class ErrorMessageReceiverTests: XCTestCase {
         core.expectation = expectation(description: "Send Error")
 
         // When
-        try core.send(
+        core.send(
             message: .baggage(key: "error", value: [
                 "message": "message-test",
                 "source": "custom"
@@ -80,7 +80,7 @@ class ErrorMessageReceiverTests: XCTestCase {
                 "any-key": mockAttribute
             ]
         ]
-        try core.send(
+        core.send(
             message: .baggage(key: "error", value: AnyEncodable(baggage))
         )
 

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -53,8 +53,8 @@ class WebViewEventReceiverTests: XCTestCase {
             "test": String.mockRandom()
         ]
 
-        core.send(
-            message: .custom(key: WebViewEventReceiver.MessageKeys.browserEvent, baggage: .init(sent))
+        try core.send(
+            message: .baggage(key: WebViewEventReceiver.MessageKeys.browserEvent, value: AnyEncodable(sent))
         )
 
         // Then

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -53,7 +53,7 @@ class WebViewEventReceiverTests: XCTestCase {
             "test": String.mockRandom()
         ]
 
-        try core.send(
+        core.send(
             message: .baggage(key: WebViewEventReceiver.MessageKeys.browserEvent, value: AnyEncodable(sent))
         )
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2032,8 +2032,8 @@ class RUMViewScopeTests: XCTestCase {
     func testWhenViewIsStarted_thenItUpdatesLastRUMViewEventInCrashContext() throws {
         var viewEvent: RUMViewEvent? = nil
         let messageReciever = FeatureMessageReceiverMock { message in
-            if case let .custom(_, baggage) = message {
-                viewEvent = baggage[RUMBaggageKeys.viewEvent]
+            if case let .baggage(label, baggage) = message, label == RUMBaggageKeys.viewEvent {
+                viewEvent = try? baggage.decode()
             }
         }
 

--- a/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
+++ b/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
@@ -97,27 +97,22 @@ internal struct TracingWithLoggingIntegration {
             )
         }
 
-        do {
-            try core.send(
-                message: .baggage(
-                    key: LogMessage.key,
-                    value: LogMessage(
-                        service: service,
-                        date: date,
-                        message: message,
-                        error: extractedError,
-                        level: level,
-                        thread: Thread.current.dd.name,
-                        networkInfoEnabled: networkInfoEnabled,
-                        userAttributes: AnyEncodable(userAttributes),
-                        internalAttributes: internalAttributes
-                    )
-                ),
-                else: fallback
-            )
-        } catch {
-            core.telemetry
-                .error("Fails to encode a span log", error: error)
-        }
+        core.send(
+            message: .baggage(
+                key: LogMessage.key,
+                value: LogMessage(
+                    service: service,
+                    date: date,
+                    message: message,
+                    error: extractedError,
+                    level: level,
+                    thread: Thread.current.dd.name,
+                    networkInfoEnabled: networkInfoEnabled,
+                    userAttributes: AnyEncodable(userAttributes),
+                    internalAttributes: internalAttributes
+                )
+            ),
+            else: fallback
+        )
     }
 }

--- a/DatadogWebViewTracking/Sources/MessageEmitter.swift
+++ b/DatadogWebViewTracking/Sources/MessageEmitter.swift
@@ -33,20 +33,15 @@ internal final class MessageEmitter: InternalExtension<WebViewTracking>.Abstract
             return DD.logger.debug("Core must not be nil when using WebViewTracking")
         }
 
-        do {
-            switch message {
-            case let .log(event):
-                try core.send(message: .baggage(key: MessageKeys.browserLog, value: AnyEncodable(event)), else: {
-                    DD.logger.warn("A WebView log is lost because Logging is disabled in the SDK")
-                })
-            case let .rum(event):
-                try core.send(message: .baggage(key: MessageKeys.browserRUMEvent, value: AnyEncodable(event)), else: {
-                    DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
-                })
-            }
-        } catch {
-            core.telemetry
-                .error("Fails to encode a browser event", error: error)
+        switch message {
+        case let .log(event):
+            core.send(message: .baggage(key: MessageKeys.browserLog, value: AnyEncodable(event)), else: {
+                DD.logger.warn("A WebView log is lost because Logging is disabled in the SDK")
+            })
+        case let .rum(event):
+            core.send(message: .baggage(key: MessageKeys.browserRUMEvent, value: AnyEncodable(event)), else: {
+                DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
+            })
         }
     }
 }

--- a/DatadogWebViewTracking/Sources/MessageEmitter.swift
+++ b/DatadogWebViewTracking/Sources/MessageEmitter.swift
@@ -29,18 +29,24 @@ internal final class MessageEmitter: InternalExtension<WebViewTracking>.Abstract
     /// Sends a message to the message bus
     /// - Parameter message: The message to send
     func send(message: WebViewMessage) throws {
-        if core == nil {
-            DD.logger.debug("Core must not be nil when using WebViewTracking")
+        guard let core = core else {
+            return DD.logger.debug("Core must not be nil when using WebViewTracking")
         }
-        switch message {
-        case let .log(event):
-            core?.send(message: .custom(key: MessageKeys.browserLog, baggage: .init(event)), else: {
-                DD.logger.warn("A WebView log is lost because Logging is disabled in the SDK")
-            })
-        case let .rum(event):
-            core?.send(message: .custom(key: MessageKeys.browserRUMEvent, baggage: .init(event)), else: {
-                DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
-            })
+
+        do {
+            switch message {
+            case let .log(event):
+                try core.send(message: .baggage(key: MessageKeys.browserLog, value: AnyEncodable(event)), else: {
+                    DD.logger.warn("A WebView log is lost because Logging is disabled in the SDK")
+                })
+            case let .rum(event):
+                try core.send(message: .baggage(key: MessageKeys.browserRUMEvent, value: AnyEncodable(event)), else: {
+                    DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
+                })
+            }
+        } catch {
+            core.telemetry
+                .error("Fails to encode a browser event", error: error)
         }
     }
 }

--- a/DatadogWebViewTracking/Tests/MessageEmitterCoreTests.swift
+++ b/DatadogWebViewTracking/Tests/MessageEmitterCoreTests.swift
@@ -58,7 +58,7 @@ class MessageEmitterCoreTests: XCTestCase {
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
                 case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserLog:
-                    let event = baggage.rawValue as? JSON
+                    let event = try? baggage.encode() as? JSON
                     XCTAssertEqual(event?["date"] as? Int64, 1_635_932_927_012)
                     XCTAssertEqual(event?["message"] as? String, "console error: error")
                     XCTAssertEqual(event?["status"] as? String, "error")
@@ -109,7 +109,7 @@ class MessageEmitterCoreTests: XCTestCase {
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
                 case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserRUMEvent:
-                    let event = baggage.rawValue as? JSON
+                    let event = try? baggage.encode() as? JSON
                     XCTAssertEqual((event?["session"] as? JSON)?["id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
                     XCTAssertEqual((event?["view"] as? JSON)?["url"] as? String, "http://localhost:8080/test.html")
                     expectation.fulfill()

--- a/DatadogWebViewTracking/Tests/MessageEmitterCoreTests.swift
+++ b/DatadogWebViewTracking/Tests/MessageEmitterCoreTests.swift
@@ -57,20 +57,17 @@ class MessageEmitterCoreTests: XCTestCase {
         let core = PassthroughCoreMock(
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
-                case .custom(let key, let baggage):
-                    switch key {
-                    case "browser-log":
-                        let event = baggage.attributes as JSON
-                        XCTAssertEqual(event["date"] as? Int64, 1_635_932_927_012)
-                        XCTAssertEqual(event["message"] as? String, "console error: error")
-                        XCTAssertEqual(event["status"] as? String, "error")
-                        XCTAssertEqual(event["view"] as? [String: String], ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
-                        XCTAssertEqual(event["error"] as? [String: String], ["origin": "console"])
-                        XCTAssertEqual(event["session_id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
-                        expectation.fulfill()
-                    default:
-                        XCTFail("Unexpected custom message received: key: \(key), baggage: \(baggage)")
-                    }
+                case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserLog:
+                    let event = baggage.rawValue as? JSON
+                    XCTAssertEqual(event?["date"] as? Int64, 1_635_932_927_012)
+                    XCTAssertEqual(event?["message"] as? String, "console error: error")
+                    XCTAssertEqual(event?["status"] as? String, "error")
+                    XCTAssertEqual(event?["view"] as? [String: String], ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
+                    XCTAssertEqual(event?["error"] as? [String: String], ["origin": "console"])
+                    XCTAssertEqual(event?["session_id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
+                    expectation.fulfill()
+                case .baggage(let label, let baggage):
+                    XCTFail("Unexpected custom message received: label: \(label), baggage: \(baggage)")
                 case .context:
                     break
                 default:
@@ -111,16 +108,17 @@ class MessageEmitterCoreTests: XCTestCase {
         let core = PassthroughCoreMock(
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
-                case .custom(let key, let baggage):
-                    XCTAssertEqual(key, "browser-rum-event")
-                    let event = baggage.attributes as JSON
-                    XCTAssertEqual((event["session"] as? JSON)?["id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
-                    XCTAssertEqual((event["view"] as? JSON)?["url"] as? String, "http://localhost:8080/test.html")
+                case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserRUMEvent:
+                    let event = baggage.rawValue as? JSON
+                    XCTAssertEqual((event?["session"] as? JSON)?["id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
+                    XCTAssertEqual((event?["view"] as? JSON)?["url"] as? String, "http://localhost:8080/test.html")
                     expectation.fulfill()
+                case .baggage(let label, let baggage):
+                    XCTFail("Unexpected custom message received: label: \(label), baggage: \(baggage)")
                 case .context:
                     break
                 default:
-                    XCTFail("Unexpected message type")
+                    XCTFail("Unexpected message received: \(message)")
                 }
             }
         )

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -156,24 +156,21 @@ class WebViewTrackingTests: XCTestCase {
         let core = PassthroughCoreMock(
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
-                case .custom(key: let key, baggage: let baggage):
-                    switch key {
-                    case "browser-log":
-                        let event = baggage.attributes as JSON
-                        XCTAssertEqual(event["date"] as? Int64, 1_635_932_927_012)
-                        XCTAssertEqual(event["message"] as? String, "console error: error")
-                        XCTAssertEqual(event["status"] as? String, "error")
-                        XCTAssertEqual(event["view"] as? [String: String], ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
-                        XCTAssertEqual(event["error"] as? [String: String], ["origin": "console"])
-                        XCTAssertEqual(event["session_id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
-                        logMessageExpectation.fulfill()
-                    case "browser-rum-event":
-                        let event = baggage.attributes as JSON
-                        XCTAssertEqual((event["view"] as? JSON)?["id"] as? String, "64308fd4-83f9-48cb-b3e1-1e91f6721230")
-                        rumMessageExpectation.fulfill()
-                    default:
-                        XCTFail("Unexpected custom message received: key: \(key), baggage: \(baggage)")
-                    }
+                case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserLog:
+                    let event = baggage.rawValue as? JSON
+                    XCTAssertEqual(event?["date"] as? Int64, 1_635_932_927_012)
+                    XCTAssertEqual(event?["message"] as? String, "console error: error")
+                    XCTAssertEqual(event?["status"] as? String, "error")
+                    XCTAssertEqual(event?["view"] as? [String: String], ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
+                    XCTAssertEqual(event?["error"] as? [String: String], ["origin": "console"])
+                    XCTAssertEqual(event?["session_id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
+                    logMessageExpectation.fulfill()
+                case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserRUMEvent:
+                    let event = baggage.rawValue as? JSON
+                    XCTAssertEqual((event?["view"] as? JSON)?["id"] as? String, "64308fd4-83f9-48cb-b3e1-1e91f6721230")
+                    rumMessageExpectation.fulfill()
+                case .baggage(let label, let baggage):
+                    XCTFail("Unexpected custom message received: label: \(label), baggage: \(baggage)")
                 case .context:
                     break
                 default:

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -157,7 +157,7 @@ class WebViewTrackingTests: XCTestCase {
             messageReceiver: FeatureMessageReceiverMock { message in
                 switch message {
                 case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserLog:
-                    let event = baggage.rawValue as? JSON
+                    let event = try? baggage.encode() as? JSON
                     XCTAssertEqual(event?["date"] as? Int64, 1_635_932_927_012)
                     XCTAssertEqual(event?["message"] as? String, "console error: error")
                     XCTAssertEqual(event?["status"] as? String, "error")
@@ -166,7 +166,7 @@ class WebViewTrackingTests: XCTestCase {
                     XCTAssertEqual(event?["session_id"] as? String, "0110cab4-7471-480e-aa4e-7ce039ced355")
                     logMessageExpectation.fulfill()
                 case .baggage(let label, let baggage) where label == MessageEmitter.MessageKeys.browserRUMEvent:
-                    let event = baggage.rawValue as? JSON
+                    let event = try? baggage.encode() as? JSON
                     XCTAssertEqual((event?["view"] as? JSON)?["id"] as? String, "64308fd4-83f9-48cb-b3e1-1e91f6721230")
                     rumMessageExpectation.fulfill()
                 case .baggage(let label, let baggage):


### PR DESCRIPTION
### What and why?

Only allow single data types to be shared on the message-bus and prevent accessing values by keys. This solution enforces defining `Encodable` end-to-end.

### How?

Here a usage example:

From a sender:
```swift

struct MyBaggage: Encodable {
  let value: String
}

let baggage = MyBaggage(value: "test")
try core.send(message: .baggage(key: "test", value: baggage)) 
```

From a receiver:
```swift

struct MyReceiver: FeatureMessageReceiver {
  struct TheirBaggage: Decodable {
    let value: String
  }

  func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
    guard let baggage: TheirBaggage = try? message.baggage(forKey: "test") else {
      return false
    }

    // do something with baggage
  }
}
```

The proposed implementation makes the message-bus throwable in case of encoding/decoding failures allowing reporting telemetry errors with more context.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
