### PR TITLE
Make pending crash report completion escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [IMPROVEMENT] Allow readPendingCrashReport completion closure to escape.
 
 # 2.1.1 / 22-08-2023
 

--- a/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
@@ -181,7 +181,7 @@ internal protocol CrashReportingPlugin: AnyObject {
     ///
     /// The SDK calls this method on a background thread. The implementation is free to choice any thread
     /// for executing the  `completion`.
-    func readPendingCrashReport(completion: (DDCrashReport?) -> Bool)
+    func readPendingCrashReport(completion: @escaping (DDCrashReport?) -> Bool)
 
     /// Injects custom data for describing the application state in the crash report.
     /// This data will be attached to produced crash report and will be available in `DDCrashReport`.


### PR DESCRIPTION
This enables the completion closure to be called asynchronously

### What and why?

This closure is currently non-escaping, which means it must be called before the method returns, it cannot be called asynchronously. However, the documentation states that "any thread (can be used) for executing the  `completion`."

### How?

Added an escaping annotation.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
