### PR TITLE
use enum for namespacing

### DIFF
--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 
 /// An entry point to Datadog Trace feature.
-public struct Trace {
+public enum Trace {
     /// Enables Datadog Trace feature.
     ///
     /// After Trace is enabled, use `Tracer.shared(in:)` to collect spans.


### PR DESCRIPTION
### What and why?

changed struct Trace into enum Trace.
In Swift practice way, when it comes to making namespace, it's better off using enum.
because struct can be an instance with `Trace()`, enum can not be.


### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
