### PR TITLE
RUM-951 Allow application version override in additionalConfig

### DIFF
--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -340,7 +340,8 @@ public struct Datadog {
             Datadog.verbosityLevel = .debug
         }
 
-        let applicationVersion = configuration.bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let applicationVersion = configuration.additionalConfiguration[CrossPlatformAttributes.version] as? String
+            ?? configuration.bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
             ?? configuration.bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
             ?? "0.0.0"
 

--- a/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
@@ -327,4 +327,17 @@ class DatadogConfigurationTests: XCTestCase {
         verify(invalidEnv: "*^@!&#\nsome_env")
         verify(invalidEnv: String(repeating: "a", count: 197))
     }
+
+    func testApplicationVersionOverride() throws {
+        var configuration = defaultConfig
+        configuration.additionalConfiguration[CrossPlatformAttributes.version] = "5.23.2"
+
+        Datadog.initialize(with: configuration, trackingConsent: .mockRandom())
+        defer { Datadog.flushAndDeinitialize() }
+
+        let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
+        let context = core.contextProvider.read()
+
+        XCTAssertEqual(context.version, "5.23.2")
+    }
 }


### PR DESCRIPTION
### What and why?

This fixes a regression from 1.x to 2.x to allow cross platform SDKs to override the application version string

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
