### PR TITLE
RUM-917 Fix unnecessary type mismatch fix

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -19,6 +19,7 @@ internal typealias NodeID = Int64
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
 internal final class NodeIDGenerator {
+    /// Dictionary of generated node IDs for given `UIView` /  `NodeRecorder` pairs.
     private var ids = [String: [NodeID]]()
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
@@ -36,7 +37,7 @@ internal final class NodeIDGenerator {
     /// - Parameter nodeRecorder: the `NodeRecorder` object
     /// - Returns: the `NodeID` of queried instance
     func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
-        let key = nodeRecorder.identifier.uuidString + "-\(view.hash)"
+        let key = nodeRecorder.identifier.uuidString + String(view.hash)
         if let nodeID = ids[key]?.first {
             return nodeID
         } else {
@@ -52,7 +53,7 @@ internal final class NodeIDGenerator {
     /// - Parameter nodeRecorder: the `NodeRecorder` object
     /// - Returns: an array with given number of `NodeID` values
     func nodeIDs(_ size: Int, view: UIView, nodeRecorder: NodeRecorder) -> [NodeID] {
-        let key = nodeRecorder.identifier.uuidString + "-\(view.hash)-\(size)"
+        let key = nodeRecorder.identifier.uuidString + String(view.hash) + String(size)
         if let nodeIDs = ids[key] {
             return nodeIDs
         } else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -53,19 +53,14 @@ internal final class NodeIDGenerator {
     /// - Parameter nodeRecorder: the `NodeRecorder` object
     /// - Returns: an array with given number of `NodeID` values
     func nodeIDs(_ size: Int, view: UIView, nodeRecorder: NodeRecorder) -> [NodeID] {
-        var result = [NodeID]()
-        let key = nodeRecorder.identifier.uuidString + "-\(view.hash)"
+        let key = nodeRecorder.identifier.uuidString + "-\(view.hash)-\(size)"
         if let nodeIDs = ids[key] {
-            result += nodeIDs
+            return nodeIDs
+        } else {
+            let nodeIDs = (0..<size).map { _ in getNextID() }
+            ids[key] = nodeIDs
+            return nodeIDs
         }
-        if result.count < size {
-            for _ in 0..<(size - result.count) {
-                let nodeID = getNextID()
-                result.append(nodeID)
-            }
-            ids[key] = result
-        }
-        return result
     }
 
     private func getNextID() -> NodeID {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -19,8 +19,8 @@ internal typealias NodeID = Int64
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
 internal final class NodeIDGenerator {
-    /// Dictionary of generated node IDs for given `UIView` /  `NodeRecorder` pairs.
-    private var ids = [String: [NodeID]]()
+    /// Cache of generated node IDs for given `UIView` /  `NodeRecorder` pairs.
+    private var ids = Cache<String, [NodeID]>(maximumEntryCount: 10_000)
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -31,7 +31,6 @@ internal final class NodeIDGenerator {
         self.maxID = maxID
     }
 
-
     /// Returns single `NodeID` for given instance of `UIView`.
     /// - Parameter view: the `UIView` object
     /// - Parameter nodeRecorder: the `NodeRecorder` object

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -32,6 +32,7 @@ internal final class NodeIDGenerator {
 
     /// Returns single `NodeID` for given instance of `UIView`.
     /// - Parameter view: the `UIView` object
+    /// - Parameter nodeRecorder: the `NodeRecorder` responsible for recording `UIView`
     /// - Returns: the `NodeID` of queried instance
     func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
         if let currentID = view.nodeID?[nodeRecorder.identifier] {
@@ -50,6 +51,7 @@ internal final class NodeIDGenerator {
     /// Returns multiple `NodeIDs` for given instance of `UIView`.
     /// - Parameter size: the number of IDs
     /// - Parameter view: the `UIView` object
+    /// - Parameter nodeRecorder: the `NodeRecorder` responsible for recording `UIView`
     /// - Returns: an array with given number of `NodeID` values
     func nodeIDs(_ size: Int, view: UIView, nodeRecorder: NodeRecorder) -> [NodeID] {
         if let currentIDs = view.nodeIDs?[nodeRecorder.identifier], currentIDs.count == size {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -19,6 +19,9 @@ internal protocol NodeRecorder {
     ///   - context: the context of recording current view-tree
     /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics?
+
+    /// Unique identifier of the node recorder.
+    var identifier: UUID { get }
 }
 
 /// A type producing SR wireframes.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 internal struct UIDatePickerRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     private let wheelsStyleRecorder = WheelsStyleDatePickerRecorder()
     private let compactStyleRecorder = CompactStyleDatePickerRecorder()
     private let inlineStyleRecorder = InlineStyleDatePickerRecorder()
@@ -55,7 +56,7 @@ internal struct UIDatePickerRecorder: NodeRecorder {
         let builder = UIDatePickerWireframesBuilder(
             wireframeRect: attributes.frame,
             attributes: attributes,
-            backgroundWireframeID: context.ids.nodeID(for: datePicker),
+            backgroundWireframeID: context.ids.nodeID(view: datePicker, nodeRecorder: self),
             isDisplayedInPopover: isDisplayedInPopover
         )
         let backgroundNode = Node(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UIDatePickerRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     private let wheelsStyleRecorder = WheelsStyleDatePickerRecorder()
     private let compactStyleRecorder = CompactStyleDatePickerRecorder()
     private let inlineStyleRecorder = InlineStyleDatePickerRecorder()

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UIImageViewRecorder: NodeRecorder {
-    internal let identifier: UUID = UUID()
+    internal let identifier = UUID()
 
     private let tintColorProvider: (UIImageView) -> UIColor?
     private let shouldRecordImagePredicate: (UIImageView) -> Bool

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UIImageViewRecorder: NodeRecorder {
+    internal let identifier: UUID = UUID()
+
     private let tintColorProvider: (UIImageView) -> UIColor?
     private let shouldRecordImagePredicate: (UIImageView) -> Bool
     /// An option for overriding default semantics from parent recorder.
@@ -50,7 +52,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let ids = context.ids.nodeIDs(2, for: imageView)
+        let ids = context.ids.nodeIDs(2, view: imageView, nodeRecorder: self)
         let contentFrame: CGRect?
         if let image = imageView.image {
             contentFrame = attributes.frame.contentFrame(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal class UILabelRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
 
     /// An option for customizing wireframes builder created by this recorder.
     var builderOverride: (UILabelWireframesBuilder) -> UILabelWireframesBuilder

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal class UILabelRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+
     /// An option for customizing wireframes builder created by this recorder.
     var builderOverride: (UILabelWireframesBuilder) -> UILabelWireframesBuilder
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating
@@ -34,7 +36,7 @@ internal class UILabelRecorder: NodeRecorder {
         }
 
         let builder = UILabelWireframesBuilder(
-            wireframeID: context.ids.nodeID(for: label),
+            wireframeID: context.ids.nodeID(view: label, nodeRecorder: self),
             attributes: attributes,
             text: label.text ?? "",
             textColor: label.textColor?.cgColor,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 internal struct UINavigationBarRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
-    
+    let identifier = UUID()
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let navigationBar = view as? UINavigationBar else {
             return nil

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UINavigationBarRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+    
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let navigationBar = view as? UINavigationBar else {
             return nil
@@ -15,7 +17,7 @@ internal struct UINavigationBarRecorder: NodeRecorder {
 
         let builder = UINavigationBarWireframesBuilder(
             wireframeRect: inferOccupiedFrame(of: navigationBar, in: context),
-            wireframeID: context.ids.nodeID(for: navigationBar),
+            wireframeID: context.ids.nodeID(view: navigationBar, nodeRecorder: self),
             attributes: attributes,
             color: inferColor(of: navigationBar)
         )

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -17,7 +17,7 @@ import UIKit
 /// - Instead, we infer the value by traversing picker's subtree and finding texts that have no "3D wheel" effect applied.
 /// - If privacy mode is elevated, we don't replace individual characters with "x" letter - instead we change whole options to fixed-width mask value.
 internal struct UIPickerViewRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     /// Records all shapes in picker's subtree.
     /// It is used to capture the background of selected option.
     private let selectionRecorder: ViewTreeRecorder

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -17,6 +17,7 @@ import UIKit
 /// - Instead, we infer the value by traversing picker's subtree and finding texts that have no "3D wheel" effect applied.
 /// - If privacy mode is elevated, we don't replace individual characters with "x" letter - instead we change whole options to fixed-width mask value.
 internal struct UIPickerViewRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     /// Records all shapes in picker's subtree.
     /// It is used to capture the background of selected option.
     private let selectionRecorder: ViewTreeRecorder
@@ -83,7 +84,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         let builder = UIPickerViewWireframesBuilder(
             wireframeRect: attributes.frame,
             attributes: attributes,
-            backgroundWireframeID: context.ids.nodeID(for: picker)
+            backgroundWireframeID: context.ids.nodeID(view: picker, nodeRecorder: self)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node] + backgroundNodes + titleNodes)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
         return context.recorder.privacy.inputAndOptionTextObfuscator
     }
@@ -21,7 +22,7 @@ internal struct UISegmentRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let ids = context.ids.nodeIDs(1 + segment.numberOfSegments, for: segment)
+        let ids = context.ids.nodeIDs(1 + segment.numberOfSegments, view: segment, nodeRecorder: self)
 
         let builder = UISegmentWireframesBuilder(
             wireframeRect: attributes.frame,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
         return context.recorder.privacy.inputAndOptionTextObfuscator
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UISliderRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let slider = view as? UISlider else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UISliderRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let slider = view as? UISlider else {
             return nil
@@ -17,7 +19,7 @@ internal struct UISliderRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let ids = context.ids.nodeIDs(4, for: slider)
+        let ids = context.ids.nodeIDs(4, view: slider, nodeRecorder: self)
 
         let builder = UISliderWireframesBuilder(
             wireframeRect: attributes.frame,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UIStepperRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+    
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let stepper = view as? UIStepper else {
             return nil
@@ -17,7 +19,7 @@ internal struct UIStepperRecorder: NodeRecorder {
         }
 
         let stepperFrame = CGRect(origin: attributes.frame.origin, size: stepper.intrinsicContentSize)
-        let ids = context.ids.nodeIDs(5, for: stepper)
+        let ids = context.ids.nodeIDs(5, view: stepper, nodeRecorder: self)
         let isMasked = context.recorder.privacy.shouldMaskInputElements
 
         let builder = UIStepperWireframesBuilder(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 internal struct UIStepperRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
-    
+    let identifier = UUID()
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let stepper = view as? UIStepper else {
             return nil

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 internal struct UISwitchRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
-    
+    let identifier = UUID()
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let `switch` = view as? UISwitch else {
             return nil

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UISwitchRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+    
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let `switch` = view as? UISwitch else {
             return nil
@@ -19,7 +21,7 @@ internal struct UISwitchRecorder: NodeRecorder {
 
         // The actual frame of the switch. It might be different than `view.frame` if displayed in stack view:
         let switchFrame = CGRect(origin: attributes.frame.origin, size: view.intrinsicContentSize)
-        let ids = context.ids.nodeIDs(3, for: `switch`)
+        let ids = context.ids.nodeIDs(3, view: `switch`, nodeRecorder: self)
 
         let builder = UISwitchWireframesBuilder(
             wireframeRect: switchFrame,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UITabBarRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let tabBar = view as? UITabBar else {
             return nil

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 internal struct UITabBarRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let tabBar = view as? UITabBar else {
             return nil
@@ -15,7 +16,7 @@ internal struct UITabBarRecorder: NodeRecorder {
 
         let builder = UITabBarWireframesBuilder(
             wireframeRect: inferOccupiedFrame(of: tabBar, in: context),
-            wireframeID: context.ids.nodeID(for: tabBar),
+            wireframeID: context.ids.nodeID(view: tabBar, nodeRecorder: self),
             attributes: attributes,
             color: inferColor(of: tabBar)
         )

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UITextFieldRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     /// `UIViewRecorder` for recording appearance of the text field.
     private let backgroundViewRecorder: UIViewRecorder
     /// `UIImageViewRecorder` for recording icons that are displayed in text field.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 internal struct UITextFieldRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     /// `UIViewRecorder` for recording appearance of the text field.
     private let backgroundViewRecorder: UIViewRecorder
     /// `UIImageViewRecorder` for recording icons that are displayed in text field.
@@ -85,7 +86,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
         let builder = UITextFieldWireframesBuilder(
             wireframeRect: textFrame,
             attributes: attributes,
-            wireframeID: context.ids.nodeID(for: textField),
+            wireframeID: context.ids.nodeID(view: textField, nodeRecorder: self),
             text: text,
             textColor: textField.textColor?.cgColor,
             textAlignment: textField.textAlignment,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal struct UITextViewRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
         if isSensitive {
             return context.recorder.privacy.sensitiveTextObfuscator
@@ -29,7 +31,7 @@ internal struct UITextViewRecorder: NodeRecorder {
         }
 
         let builder = UITextViewWireframesBuilder(
-            wireframeID: context.ids.nodeID(for: textView),
+            wireframeID: context.ids.nodeID(view: textView, nodeRecorder: self),
             attributes: attributes,
             text: textView.text,
             textAlignment: textView.textAlignment,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UITextViewRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
 
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
         if isSensitive {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal class UIViewRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
 
     /// An option for overriding default semantics from parent recorder.
     var semanticsOverride: (UIView, ViewAttributes) -> NodeSemantics?

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 internal class UIViewRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
+
     /// An option for overriding default semantics from parent recorder.
     var semanticsOverride: (UIView, ViewAttributes) -> NodeSemantics?
 
@@ -44,7 +46,7 @@ internal class UIViewRecorder: NodeRecorder {
         }
 
         let builder = UIViewWireframesBuilder(
-            wireframeID: context.ids.nodeID(for: view),
+            wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
             attributes: attributes
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -10,7 +10,7 @@ import WebKit
 import SwiftUI
 
 internal struct UnsupportedViewRecorder: NodeRecorder {
-    let identifier: UUID = UUID()
+    let identifier = UUID()
     // swiftlint:disable opening_brace
     private let unsupportedViewsPredicates: [(UIView, ViewTreeRecordingContext) -> Bool] = [
         { _, context in context.viewControllerContext.isRootView(of: .safari) },

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -10,6 +10,7 @@ import WebKit
 import SwiftUI
 
 internal struct UnsupportedViewRecorder: NodeRecorder {
+    let identifier: UUID = UUID()
     // swiftlint:disable opening_brace
     private let unsupportedViewsPredicates: [(UIView, ViewTreeRecordingContext) -> Bool] = [
         { _, context in context.viewControllerContext.isRootView(of: .safari) },
@@ -30,7 +31,7 @@ internal struct UnsupportedViewRecorder: NodeRecorder {
         }
         let builder = UnsupportedViewWireframesBuilder(
             wireframeRect: view.frame,
-            wireframeID: context.ids.nodeID(for: view),
+            wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
             unsupportedClassName: context.viewControllerContext.name ?? String(reflecting: type(of: view)),
             attributes: attributes
         )

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -315,7 +315,7 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
 }
 
 class NodeRecorderMock: NodeRecorder {
-    var identifier: UUID = UUID()
+    var identifier = UUID()
     var queriedViews: Set<UIView> = []
     var queryContexts: [ViewTreeRecordingContext] = []
     var queryContextsByView: [UIView: ViewTreeRecordingContext] = [:]

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -315,12 +315,13 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
 }
 
 class NodeRecorderMock: NodeRecorder {
+    var identifier: UUID = UUID()
     var queriedViews: Set<UIView> = []
     var queryContexts: [ViewTreeRecordingContext] = []
     var queryContextsByView: [UIView: ViewTreeRecordingContext] = [:]
-    var resultForView: (UIView) -> NodeSemantics?
+    var resultForView: ((UIView) -> NodeSemantics?)?
 
-    init(resultForView: @escaping (UIView) -> NodeSemantics?) {
+    init(resultForView: ((UIView) -> NodeSemantics?)? = nil) {
         self.resultForView = resultForView
     }
 
@@ -328,7 +329,7 @@ class NodeRecorderMock: NodeRecorder {
         queriedViews.insert(view)
         queryContexts.append(context)
         queryContextsByView[view] = context
-        return resultForView(view)
+        return resultForView?(view)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -50,15 +50,14 @@ class NodeIDGeneratorTests: XCTestCase {
         // Given
         let maxID: NodeID = .mockRandom(min: 1)
         let currentID: NodeID = maxID - 1
-        let views: [UIView] = [.mockRandom(), .mockRandom(), .mockRandom()]
 
         // When
         let generator = NodeIDGenerator(currentID: currentID, maxID: maxID)
 
         // Then
-        XCTAssertEqual(generator.nodeID(view: views[0], nodeRecorder: nodeRecorder), currentID)
-        XCTAssertEqual(generator.nodeID(view: views[1], nodeRecorder: nodeRecorder), maxID)
-        XCTAssertEqual(generator.nodeID(view: views[2], nodeRecorder: nodeRecorder), 0)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), currentID)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), maxID)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), 0)
     }
 
     func testGivenIDsRetrievedFirstTime_whenQueryingForDifferentSize_itReturnsDistinctIDs() {
@@ -85,8 +84,7 @@ class NodeIDGeneratorTests: XCTestCase {
         let id = generator.nodeID(view: view, nodeRecorder: nodeRecorder)
 
         // When
-        let newRecorder = NodeRecorderMock()
-        let newID = generator.nodeID(view: view, nodeRecorder: newRecorder)
+        let newID = generator.nodeID(view: view, nodeRecorder: NodeRecorderMock())
 
         // Then
         XCTAssertNotEqual(id, newID)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -50,14 +50,15 @@ class NodeIDGeneratorTests: XCTestCase {
         // Given
         let maxID: NodeID = .mockRandom(min: 1)
         let currentID: NodeID = maxID - 1
+        let views: [UIView] = [.mockRandom(), .mockRandom(), .mockRandom()]
 
         // When
         let generator = NodeIDGenerator(currentID: currentID, maxID: maxID)
 
         // Then
-        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), currentID)
-        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), maxID)
-        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), 0)
+        XCTAssertEqual(generator.nodeID(view: views[0], nodeRecorder: nodeRecorder), currentID)
+        XCTAssertEqual(generator.nodeID(view: views[1], nodeRecorder: nodeRecorder), maxID)
+        XCTAssertEqual(generator.nodeID(view: views[2], nodeRecorder: nodeRecorder), 0)
     }
 
     func testGivenIDsRetrievedFirstTime_whenQueryingForDifferentSize_itReturnsDistinctIDs() {
@@ -75,5 +76,33 @@ class NodeIDGeneratorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(Set(ids1).intersection(Set(ids2)), [])
+    }
+    
+    func testIDisDifferentWhenRecorderChanges() {
+        // Given
+        let view: UIView = .mockRandom()
+        let generator = NodeIDGenerator()
+        let id = generator.nodeID(view: view, nodeRecorder: nodeRecorder)
+
+        // When
+        let newRecorder = NodeRecorderMock()
+        let newID = generator.nodeID(view: view, nodeRecorder: newRecorder)
+
+        // Then
+        XCTAssertNotEqual(id, newID)
+    }
+
+    func testIDchangesWhenViewChanges() {
+        // Given
+        let view1: UIView = .mockRandom()
+        let view2: UIView = .mockRandom()
+        let generator = NodeIDGenerator()
+        let id = generator.nodeID(view: view1, nodeRecorder: nodeRecorder)
+
+        // When
+        let newID = generator.nodeID(view: view2, nodeRecorder: nodeRecorder)
+
+        // Then
+        XCTAssertNotEqual(id, newID)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -77,7 +77,7 @@ class NodeIDGeneratorTests: XCTestCase {
         // Then
         XCTAssertEqual(Set(ids1).intersection(Set(ids2)), [])
     }
-    
+
     func testIDisDifferentWhenRecorderChanges() {
         // Given
         let view: UIView = .mockRandom()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -11,6 +11,7 @@ import UIKit
 
 class NodeIDGeneratorTests: XCTestCase {
     private let n: Int = .mockRandom(min: 1, max: 100)
+    private let nodeRecorder = NodeRecorderMock()
 
     func testAfterIDisRetrievedFirstTime_itAlwaysReturnsTheSameIDForUIViewInstance() {
         // Given
@@ -19,12 +20,12 @@ class NodeIDGeneratorTests: XCTestCase {
 
         // When
         let generator = NodeIDGenerator()
-        let id = generator.nodeID(for: view1)
-        let ids = generator.nodeIDs(n, for: view2)
+        let id = generator.nodeID(view: view1, nodeRecorder: nodeRecorder)
+        let ids = generator.nodeIDs(n, view: view2, nodeRecorder: nodeRecorder)
 
         // Then
-        XCTAssertEqual(id, generator.nodeID(for: view1))
-        XCTAssertEqual(ids, generator.nodeIDs(n, for: view2))
+        XCTAssertEqual(id, generator.nodeID(view: view1, nodeRecorder: nodeRecorder))
+        XCTAssertEqual(ids, generator.nodeIDs(n, view: view2, nodeRecorder: nodeRecorder))
     }
 
     func testAllIDsAreUnique() {
@@ -34,8 +35,8 @@ class NodeIDGeneratorTests: XCTestCase {
 
         // When
         let generator = NodeIDGenerator(currentID: .mockRandom())
-        let ids = viewsWithID.map { generator.nodeID(for: $0) }
-        let idNs = viewsWithIDs.map { generator.nodeIDs(n, for: $0) }
+        let ids = viewsWithID.map { generator.nodeID(view: $0, nodeRecorder: nodeRecorder) }
+        let idNs = viewsWithIDs.map { generator.nodeIDs(n, view: $0, nodeRecorder: nodeRecorder) }
 
         // Then
         let singleIDs: Set<NodeID> = ids.reduce(into: []) { result, id in result.insert(id) }
@@ -54,19 +55,23 @@ class NodeIDGeneratorTests: XCTestCase {
         let generator = NodeIDGenerator(currentID: currentID, maxID: maxID)
 
         // Then
-        XCTAssertEqual(generator.nodeID(for: .mockRandom()), currentID)
-        XCTAssertEqual(generator.nodeID(for: .mockRandom()), maxID)
-        XCTAssertEqual(generator.nodeID(for: .mockRandom()), 0)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), currentID)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), maxID)
+        XCTAssertEqual(generator.nodeID(view: .mockRandom(), nodeRecorder: nodeRecorder), 0)
     }
 
     func testGivenIDsRetrievedFirstTime_whenQueryingForDifferentSize_itReturnsDistinctIDs() {
         // Given
         let view: UIView = .mockRandom()
         let generator = NodeIDGenerator()
-        let ids1 = generator.nodeIDs(n, for: view)
+        let ids1 = generator.nodeIDs(n, view: view, nodeRecorder: nodeRecorder)
 
         // When
-        let ids2 = generator.nodeIDs(.mockRandom(min: 1, max: 100, otherThan: [n]), for: view)
+        let ids2 = generator.nodeIDs(
+            .mockRandom(min: 1, max: 100, otherThan: [n]),
+            view: view,
+            nodeRecorder: nodeRecorder
+        )
 
         // Then
         XCTAssertEqual(Set(ids1).intersection(Set(ids2)), [])


### PR DESCRIPTION
### What and why?

Refactors id generation for views in session replay. It prevents from reaching type mismatch for the same view but recorded by different recorders and forcing full snapshot change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
