### PR TITLE
Add default objc rum predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 2.2.1 / 13-09-2023
+
+- [BUGFIX] Add default RUM views and actions predicates to DatadogObjc . See [#1464][].
+
 # 2.2.0 / 12-09-2023
 
 - [IMPROVEMENT] Enable cross-platform SDKs to change app `version`. See [#1447][]
@@ -518,6 +522,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1419]: https://github.com/DataDog/dd-sdk-ios/pull/1419
 [#1428]: https://github.com/DataDog/dd-sdk-ios/pull/1428
 [#1444]: https://github.com/DataDog/dd-sdk-ios/pull/1444
+[#1464]: https://github.com/DataDog/dd-sdk-ios/pull/1464
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -458,6 +458,10 @@
 		A79B0F65292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */; };
 		A79B0F66292BD7CA008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
 		A79B0F67292BD7CC008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
+		A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
+		A7DA18052AB0C91300F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
+		A7DA18072AB0CA5E00F76337 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
+		A7EA11622AB0CE6C00C73970 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A4287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A6287476230047275C /* ServerOffsetPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A5287476230047275C /* ServerOffsetPublisher.swift */; };
@@ -2332,6 +2336,8 @@
 		A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "B3HTTPHeadersWriter+objc.swift"; sourceTree = "<group>"; };
 		A79B0F60292BB071008742B3 /* B3HTTPHeadersReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReaderTests.swift; sourceTree = "<group>"; };
 		A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDB3HTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
+		A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
+		A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
 		A7F773D32924EA2D00AC1A62 /* B3HTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeaders.swift; sourceTree = "<group>"; };
 		A7F773DB29253F8B00AC1A62 /* B3HTTPHeadersWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersWriter.swift; sourceTree = "<group>"; };
 		A7F773DC29253F8B00AC1A62 /* B3HTTPHeadersReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReader.swift; sourceTree = "<group>"; };
@@ -3777,6 +3783,8 @@
 				616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */,
 				61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */,
 				61A2CC232A44454D0000FF25 /* DDRUMTests.swift */,
+				A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */,
+				A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */,
 				9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */,
 				D2A434AD2A8E426C0028E329 /* DDSessionReplayTests.swift */,
 				61D03BDE273404BB00367DE0 /* RUM */,
@@ -7367,6 +7375,7 @@
 				61F2723F25C86DA400D54BF8 /* CrashReportingFeatureMocks.swift in Sources */,
 				61DA20F026C40121004AFE6D /* DataUploadStatusTests.swift in Sources */,
 				61112F8E2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */,
+				A7DA18072AB0CA5E00F76337 /* DDUIKitRUMActionsPredicateTests.swift in Sources */,
 				6139CD772589FEE3007E8BB7 /* RetryingTests.swift in Sources */,
 				D29A9FC429DDB710005C54A4 /* RUMInternalProxyTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
@@ -7403,6 +7412,7 @@
 				D25CFAA329C8644E00E3A43D /* Casting+Tracing.swift in Sources */,
 				61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */,
 				61B5E42726DFB145000B0A5F /* DDDatadog+apiTests.m in Sources */,
+				A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* TracingWithLoggingIntegrationTests.swift in Sources */,
 				D2A1EE3E2885D7EC00D28DFB /* LaunchTimePublisherTests.swift in Sources */,
 				61B5E42926DFB60A000B0A5F /* DDConfiguration+apiTests.m in Sources */,
@@ -8367,6 +8377,7 @@
 				61112F8F2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */,
 				D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */,
 				D2CB6EE427C520D400A62B57 /* FeatureTests.swift in Sources */,
+				A7EA11622AB0CE6C00C73970 /* DDUIKitRUMActionsPredicateTests.swift in Sources */,
 				D2CB6EE527C520D400A62B57 /* DataUploadConditionsTests.swift in Sources */,
 				D2CB6EE627C520D400A62B57 /* DateFormattingTests.swift in Sources */,
 				D2CB6EE727C520D400A62B57 /* FileTests.swift in Sources */,
@@ -8435,6 +8446,7 @@
 				61A2CC222A443D330000FF25 /* DDRUMConfigurationTests.swift in Sources */,
 				6176991C2A86121B0030022B /* HTTPClientMock.swift in Sources */,
 				D29294E4291D652D00F8EFF9 /* ApplicationVersionPublisherTests.swift in Sources */,
+				A7DA18052AB0C91300F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */,
 				A79B0F65292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */,
 				D2CB6F4327C520D400A62B57 /* DDLogsTests.swift in Sources */,
 				D2CB6F4527C520D400A62B57 /* TracerTests.swift in Sources */,

--- a/DatadogCore/Tests/DatadogObjc/DDUIKitRUMActionsPredicateTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDUIKitRUMActionsPredicateTests.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogObjc
+import DatadogRUM
+
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+class DDUIKitRUMActionsPredicateTests: XCTestCase {
+    func testGivenDefaultPredicate_whenAskingForCustomView_itNamesTheActionByItsClassName() {
+        // Given
+        let predicate = DDDefaultUIKitRUMActionsPredicate()
+
+        // When
+        #if os(tvOS)
+        let rumAction = predicate.rumAction(press: .select, targetView: UIButton())
+        #else
+        let rumAction = predicate.rumAction(targetView: UIButton())
+        #endif
+        // Then
+        XCTAssertEqual(rumAction?.name, "UIButton")
+        XCTAssertTrue(rumAction!.attributes.isEmpty)
+    }
+
+    func testGivenDefaultPredicate_whenAskingForViewWithAccesiblityIdentifier_itNamesTheActionWithIt() {
+        // Given
+        let predicate = DDDefaultUIKitRUMActionsPredicate()
+        let targetView = UIButton()
+        targetView.accessibilityIdentifier = "Identifier"
+
+        // When
+        #if os(tvOS)
+        let rumAction = predicate.rumAction(press: .select, targetView: targetView)
+        #else
+        let rumAction = predicate.rumAction(targetView: targetView)
+        #endif
+
+        // Then
+        XCTAssertEqual(rumAction?.name, "UIButton(Identifier)")
+        XCTAssertTrue(rumAction!.attributes.isEmpty)
+    }
+
+#if canImport(SwiftUI)
+    func testGivenDefaultPredicate_whenAskingSwiftUIView_itReturnsAction() {
+        guard #available(iOS 13, tvOS 13, *) else {
+            return
+        }
+        // Given
+        let predicate = DDDefaultUIKitRUMActionsPredicate()
+
+        // When
+        let swiftUIView = UIHostingController(rootView: EmptyView()).view!
+        #if os(tvOS)
+        let rumAction = predicate.rumAction(press: .select, targetView: swiftUIView)
+        #else
+        let rumAction = predicate.rumAction(targetView: swiftUIView)
+        #endif
+
+        // Then
+        XCTAssertNotNil(rumAction)
+    }
+#endif
+}

--- a/DatadogCore/Tests/DatadogObjc/DDUIKitRUMViewsPredicateTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDUIKitRUMViewsPredicateTests.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogObjc
+
+@testable import DatadogRUM
+
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+class DDUIKitRUMViewsPredicateTests: XCTestCase {
+    func testGivenDefaultPredicate_whenAskingForCustomSwiftViewController_itNamesTheViewByItsClassName() {
+        // Given
+        let predicate = DDDefaultUIKitRUMViewsPredicate()
+
+        // When
+        let customViewController = createMockView(viewControllerClassName: "CustomSwiftViewController")
+        let rumView = predicate.rumView(for: customViewController)
+
+        // Then
+        XCTAssertEqual(rumView?.name, "CustomSwiftViewController")
+        XCTAssertTrue(rumView!.attributes.isEmpty)
+    }
+
+    func testGivenDefaultPredicate_whenAskingForCustomObjcViewController_itNamesTheViewByItsClassName() {
+        // Given
+        let predicate = DDDefaultUIKitRUMViewsPredicate()
+
+        // When
+        let customViewController = CustomObjcViewController()
+        let rumView = predicate.rumView(for: customViewController)
+
+        // Then
+        XCTAssertEqual(rumView?.name, "CustomObjcViewController")
+        XCTAssertTrue(rumView!.attributes.isEmpty)
+    }
+
+    func testGivenDefaultPredicate_whenAskingUIKitViewController_itReturnsNoView() {
+        // Given
+        let predicate = DDDefaultUIKitRUMViewsPredicate()
+
+        // When
+        let uiKitViewController = UIViewController()
+        let rumView = predicate.rumView(for: uiKitViewController)
+
+        // Then
+        XCTAssertNil(rumView)
+    }
+
+#if canImport(SwiftUI)
+    func testGivenDefaultPredicate_whenAskingSwiftUIViewController_itReturnsNoView() {
+        guard #available(iOS 13, tvOS 13, *) else {
+            return
+        }
+        // Given
+        let predicate = DDDefaultUIKitRUMViewsPredicate()
+
+        // When
+        let swiftUIHostingController = UIHostingController<EmptyView>(rootView: EmptyView())
+        let rumView = predicate.rumView(for: swiftUIHostingController)
+
+        // Then
+        XCTAssertNil(rumView)
+    }
+#endif
+}

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -45,6 +45,35 @@ public protocol DDUIKitRUMViewsPredicate: AnyObject {
     func rumView(for viewController: UIViewController) -> DDRUMView?
 }
 
+@objc
+public class DDDefaultUIKitRUMViewsPredicate: NSObject, DDUIKitRUMViewsPredicate {
+    private let swiftPredicate = DefaultUIKitRUMViewsPredicate()
+
+    public func rumView(for viewController: UIViewController) -> DDRUMView? {
+        return swiftPredicate.rumView(for: viewController).map {
+            DDRUMView(name: $0.name, attributes: castAttributesToObjectiveC($0.attributes))
+        }
+    }
+}
+
+@objc
+public class DDDefaultUIKitRUMActionsPredicate: NSObject, DDUIKitRUMActionsPredicate {
+    let swiftPredicate = DefaultUIKitRUMActionsPredicate()
+    #if os(tvOS)
+    public func rumAction(press type: UIPress.PressType, targetView: UIView) -> DDRUMAction? {
+        swiftPredicate.rumAction(press: type, targetView: targetView).map {
+            DDRUMAction(name: $0.name, attributes: castAttributesToObjectiveC($0.attributes))
+        }
+    }
+    #else
+    public func rumAction(targetView: UIView) -> DDRUMAction? {
+        swiftPredicate.rumAction(targetView: targetView).map {
+            DDRUMAction(name: $0.name, attributes: castAttributesToObjectiveC($0.attributes))
+        }
+    }
+    #endif
+}
+
 internal struct UIKitRUMActionsPredicateBridge: UITouchRUMActionsPredicate & UIPressRUMActionsPredicate {
     let objcPredicate: AnyObject?
 


### PR DESCRIPTION
### What and why?

Adds missing default objective-c predicates, which are part of official documentation:
https://docs.datadoghq.com/real_user_monitoring/ios/?tab=objectivec#initialize-the-rum-monitor-and-ddurlsessiondelegate

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
