### PR TITLE
RUM-1033 Enable graphql attributes from cross platform SDKs

### DIFF
--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -125,6 +125,26 @@ public struct CrossPlatformAttributes {
     /// The goal of RUMM-3289 is to create an RFC to get rid of this mechanism.
     /// Expects `Bool` value.
     public static let errorLogIsCrash = "_dd.error_log.is_crash"
+
+    /// Custom attribute passed when starting GraphQL RUM resources from a cross platform SDK.
+    /// It sets the GraphQL operation name if it was defined by the developer.
+    /// Expects `String` value.
+    public static let graphqlOperationName = "_dd.graphql.operation_name"
+
+    /// Custom attribute passed when starting GraphQL RUM resources from a cross platform SDK.
+    /// It sets the GraphQL operation type.
+    /// Expects `String` value of either `query`, `mutation` or `subscription`.
+    public static let graphqlOperationType = "_dd.graphql.operation_type"
+
+    /// Custom attribute passed when starting GraphQL RUM resources from a cross platform SDK.
+    /// It sets the GraphQL payload as a JSON string when it is specified.
+    /// Expects `String` value.
+    public static let graphqlPayload = "_dd.graphql.payload"
+
+    /// Custom attribute passed when starting GraphQL RUM resources resources from a cross platform SDK.
+    /// It sets the GraphQL varibles as a JSON string if they were defined by the developer.
+    /// Expects `String` value.
+    public static let graphqlVariables = "_dd.graphql.variables"
 }
 
 public struct LaunchArguments {

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -2988,6 +2988,10 @@ public class DDRUMResourceEventResource: NSObject {
         root.swiftModel.resource.firstByte != nil ? DDRUMResourceEventResourceFirstByte(root: root) : nil
     }
 
+    @objc public var graphql: DDRUMResourceEventResourceGraphql? {
+        root.swiftModel.resource.graphql != nil ? DDRUMResourceEventResourceGraphql(root: root) : nil
+    }
+
     @objc public var id: String? {
         root.swiftModel.resource.id
     }
@@ -3092,6 +3096,56 @@ public class DDRUMResourceEventResourceFirstByte: NSObject {
     @objc public var start: NSNumber {
         root.swiftModel.resource.firstByte!.start as NSNumber
     }
+}
+
+@objc
+public class DDRUMResourceEventResourceGraphql: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var operationName: String? {
+        root.swiftModel.resource.graphql!.operationName
+    }
+
+    @objc public var operationType: DDRUMResourceEventResourceGraphqlOperationType {
+        .init(swift: root.swiftModel.resource.graphql!.operationType)
+    }
+
+    @objc public var payload: String? {
+        set { root.swiftModel.resource.graphql!.payload = newValue }
+        get { root.swiftModel.resource.graphql!.payload }
+    }
+
+    @objc public var variables: String? {
+        set { root.swiftModel.resource.graphql!.variables = newValue }
+        get { root.swiftModel.resource.graphql!.variables }
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceGraphqlOperationType: Int {
+    internal init(swift: RUMResourceEvent.Resource.Graphql.OperationType) {
+        switch swift {
+        case .query: self = .query
+        case .mutation: self = .mutation
+        case .subscription: self = .subscription
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Resource.Graphql.OperationType {
+        switch self {
+        case .query: return .query
+        case .mutation: return .mutation
+        case .subscription: return .subscription
+        }
+    }
+
+    case query
+    case mutation
+    case subscription
 }
 
 @objc
@@ -5490,4 +5544,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/221e41f0b9dc24312731e22dff34d276a378d11d
+// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -1389,6 +1389,9 @@ public struct RUMResourceEvent: RUMDataModel {
         /// First Byte phase properties
         public let firstByte: FirstByte?
 
+        /// GraphQL requests parameters
+        public var graphql: Graphql?
+
         /// UUID of the resource
         public let id: String?
 
@@ -1422,6 +1425,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case download = "download"
             case duration = "duration"
             case firstByte = "first_byte"
+            case graphql = "graphql"
             case id = "id"
             case method = "method"
             case provider = "provider"
@@ -1486,6 +1490,35 @@ public struct RUMResourceEvent: RUMDataModel {
             enum CodingKeys: String, CodingKey {
                 case duration = "duration"
                 case start = "start"
+            }
+        }
+
+        /// GraphQL requests parameters
+        public struct Graphql: Codable {
+            /// Name of the GraphQL operation
+            public let operationName: String?
+
+            /// Type of the GraphQL operation
+            public let operationType: OperationType
+
+            /// Content of the GraphQL operation
+            public var payload: String?
+
+            /// String representation of the operation variables
+            public var variables: String?
+
+            enum CodingKeys: String, CodingKey {
+                case operationName = "operationName"
+                case operationType = "operationType"
+                case payload = "payload"
+                case variables = "variables"
+            }
+
+            /// Type of the GraphQL operation
+            public enum OperationType: String, Codable {
+                case query = "query"
+                case mutation = "mutation"
+                case subscription = "subscription"
             }
         }
 
@@ -3365,4 +3398,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/221e41f0b9dc24312731e22dff34d276a378d11d
+// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -181,6 +181,7 @@ internal class RUMResourceScope: RUMScope {
                         start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
                 },
+                graphql: nil,
                 id: resourceUUID.toRUMDataFormat,
                 method: resourceHTTPMethod,
                 provider: resourceEventProvider,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -121,6 +121,22 @@ internal class RUMResourceScope: RUMScope {
         let spanId = (attributes.removeValue(forKey: CrossPlatformAttributes.spanID) as? String) ?? spanContext?.spanID
         let traceSamplingRate = (attributes.removeValue(forKey: CrossPlatformAttributes.rulePSR) as? Double) ?? spanContext?.samplingRate
 
+        // Check GraphQL attributes
+        var graphql: RUMResourceEvent.Resource.Graphql? = nil
+        let graphqlOperationName = (attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationName) as? String)
+        let graphqlPayload = (attributes.removeValue(forKey: CrossPlatformAttributes.graphqlPayload) as? String)
+        let graphqlVariables = (attributes.removeValue(forKey: CrossPlatformAttributes.graphqlVariables) as? String)
+        if let rawGraphqlOperationType = (attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationType) as? String) {
+            if let graphqlOperationType = RUMResourceEvent.Resource.Graphql.OperationType(rawValue: rawGraphqlOperationType) {
+                graphql = .init(
+                    operationName: graphqlOperationName,
+                    operationType: graphqlOperationType,
+                    payload: graphqlPayload,
+                    variables: graphqlVariables
+                )
+            }
+        }
+
         /// Metrics values take precedence over other values.
         if let metrics = resourceMetrics {
             resourceStartTime = metrics.fetch.start
@@ -181,7 +197,7 @@ internal class RUMResourceScope: RUMScope {
                         start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
                 },
-                graphql: nil,
+                graphql: graphql,
                 id: resourceUUID.toRUMDataFormat,
                 method: resourceHTTPMethod,
                 provider: resourceEventProvider,

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -1145,5 +1145,5 @@ internal enum SRRecord: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/e3d941c30622ff8624051604584ebd3f9fff2b25
+// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
 #endif


### PR DESCRIPTION
### What and why?

Enable cross platform SDKs to specify GraphQL attributes.

### How?

We remove all cross-platform attributes first, and only add the graphql struct if the operation type is present.
The implementation might change in the future when we support GraphQL requests monitoring for iOS, but it should not be hard to migrate the cross platform SDKs then.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
