### PR TITLE
fix(internal): Lower constraints when retrieving `_internal`

### DIFF
--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -12,7 +12,7 @@ public extension RUMMonitorProtocol {
     /// Grants access to an internal interface utilized only by Datadog cross-platform SDKs.
     /// **It is not meant for public use** and it might change without prior notice.
     var _internal: DatadogInternalInterface? {
-        guard let monitor = self as? Monitor else {
+        guard let monitor = self as? RUMCommandSubscriber else {
             return nil
         }
         return DatadogInternalInterface(monitor: monitor)


### PR DESCRIPTION
### What and why?

`RUMMonitorProtocol._internal` required that self be the type `Monitor` before creating the DatadogInternalInterface. This was overspecialization and made it hard to mock internal calls. By casting only to `RUMCommandSubscriber` we can more easily create mocks for testing.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
