### PR TITLE
Fix Xcode 13.4 Nightly Tests

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -204,7 +204,7 @@ class DataUploadWorkerTests: XCTestCase {
                 delay.current > initialUploadDelay
             }
         }, andThenFulfill: delayChangeExpectation)
-        wait(for: [delayChangeExpectation])
+        wait(for: [delayChangeExpectation], timeout: 0.5)
         worker.cancelSynchronously()
     }
 
@@ -240,7 +240,7 @@ class DataUploadWorkerTests: XCTestCase {
                 delay.current > initialUploadDelay
             }
         }, andThenFulfill: delayChangeExpectation)
-        wait(for: [delayChangeExpectation])
+        wait(for: [delayChangeExpectation], timeout: 0.5)
         worker.cancelSynchronously()
     }
 
@@ -275,7 +275,7 @@ class DataUploadWorkerTests: XCTestCase {
                 delay.current < initialUploadDelay
             }
         }, andThenFulfill: delayChangeExpectation)
-        wait(for: [delayChangeExpectation])
+        wait(for: [delayChangeExpectation], timeout: 0.5)
         worker.cancelSynchronously()
     }
 
@@ -558,7 +558,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         // Then
         withExtendedLifetime(worker) {
-            wait(for: [expectTaskRegistered, expectTaskEnded])
+            wait(for: [expectTaskRegistered, expectTaskEnded], timeout: 0.5)
         }
     }
 
@@ -587,7 +587,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         // Then
         withExtendedLifetime(worker) {
-            wait(for: [expectTaskRegistered, expectTaskEnded])
+            wait(for: [expectTaskRegistered, expectTaskEnded], timeout: 0.5)
         }
     }
 
@@ -613,7 +613,7 @@ class DataUploadWorkerTests: XCTestCase {
         )
         // Then
         withExtendedLifetime(worker) {
-            wait(for: [expectTaskEnded])
+            wait(for: [expectTaskEnded], timeout: 0.5)
         }
     }
 }


### PR DESCRIPTION
### What and why?

Fixes compilation issues on Xcode 13.4.x nightly tests.

### How?

Older wait() signature requires timeout parameter. This PR adds that.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
