### PR TITLE
fix: Fix CI Visibility setup and maximise tests observability

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@ A brief description of implementation details of this PR.
 - [ ] Add CHANGELOG entry for user facing changes
 
 ### Custom CI job configuration (optional)
-- [ ] Run unit tests
+- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
+- [ ] Run unit tests for Session Replay
 - [ ] Run integration tests
 - [ ] Run smoke tests
+- [ ] Run tests for `tools/`

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1816,7 +1816,7 @@
 		3C85D41429F7C59C00AFF894 /* WebViewTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewTracking.swift; sourceTree = "<group>"; };
 		3C85D42B29F7C87D00AFF894 /* HostsSanitizerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostsSanitizerMock.swift; sourceTree = "<group>"; };
 		3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogWebViewTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogWebViewTrackingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
@@ -1965,7 +1965,7 @@
 		61133B82242393DE00786299 /* DatadogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* DatadogCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DatadogCore.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		61133B8B242393DE00786299 /* DatadogCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61133B8B242393DE00786299 /* DatadogCoreTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCoreTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B92242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61133BA72423979B00786299 /* FileWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileWriter.swift; sourceTree = "<group>"; };
 		61133BA92423979B00786299 /* FilesOrchestrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilesOrchestrator.swift; sourceTree = "<group>"; };
@@ -2555,7 +2555,7 @@
 		D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisherTests.swift; sourceTree = "<group>"; };
 		D2C7E3AD28FEBDA10023B2CC /* LaunchTimePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTimePublisher.swift; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* DatadogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2CB6F8F27C520D400A62B57 /* DatadogCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2CB6F8F27C520D400A62B57 /* DatadogCoreTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCoreTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCrashReportingTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3581,7 +3581,7 @@
 			isa = PBXGroup;
 			children = (
 				61133B82242393DE00786299 /* DatadogCore.framework */,
-				61133B8B242393DE00786299 /* DatadogCoreTests.xctest */,
+				61133B8B242393DE00786299 /* DatadogCoreTests iOS.xctest */,
 				61133BF0242397DA00786299 /* DatadogObjc.framework */,
 				61441C0224616DE9003D8BB8 /* Example iOS.app */,
 				61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */,
@@ -3591,7 +3591,7 @@
 				61993665265BBEDC009D7EA8 /* E2ETests.xctest */,
 				618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */,
 				D2CB6ED127C50EAE00A62B57 /* DatadogCore.framework */,
-				D2CB6F8F27C520D400A62B57 /* DatadogCoreTests.xctest */,
+				D2CB6F8F27C520D400A62B57 /* DatadogCoreTests tvOS.xctest */,
 				D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */,
 				D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */,
 				D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests tvOS.xctest */,
@@ -3615,7 +3615,7 @@
 				D23F8E9929DDCD28001CFAE8 /* DatadogRUM.framework */,
 				D23F8ECD29DDCD38001CFAE8 /* DatadogRUMTests tvOS.xctest */,
 				3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */,
-				3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests.xctest */,
+				3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */,
 				6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */,
 				6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests iOS.xctest */,
 			);
@@ -5890,7 +5890,7 @@
 			);
 			name = "DatadogWebViewTrackingTests iOS";
 			productName = "DatadogWebViewTracking iOSTests";
-			productReference = 3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests.xctest */;
+			productReference = 3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		61133B81242393DE00786299 /* DatadogCore iOS */ = {
@@ -5930,7 +5930,7 @@
 			);
 			name = "DatadogCoreTests iOS";
 			productName = DatadogTests;
-			productReference = 61133B8B242393DE00786299 /* DatadogCoreTests.xctest */;
+			productReference = 61133B8B242393DE00786299 /* DatadogCoreTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		61133BEF242397DA00786299 /* DatadogObjc iOS */ = {
@@ -6472,7 +6472,7 @@
 			);
 			name = "DatadogCoreTests tvOS";
 			productName = DatadogTests;
-			productReference = D2CB6F8F27C520D400A62B57 /* DatadogCoreTests.xctest */;
+			productReference = D2CB6F8F27C520D400A62B57 /* DatadogCoreTests tvOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		D2CB6F9227C5217A00A62B57 /* DatadogObjc tvOS */ = {
@@ -9157,7 +9157,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogWebViewTrackingTests;
-				PRODUCT_NAME = DatadogWebViewTrackingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -9187,7 +9187,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogWebViewTrackingTests;
-				PRODUCT_NAME = DatadogWebViewTrackingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -9216,7 +9216,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogWebViewTrackingTests;
-				PRODUCT_NAME = DatadogWebViewTrackingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -9418,7 +9418,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -9444,7 +9444,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -10362,7 +10362,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -11922,7 +11922,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
@@ -11946,7 +11946,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
@@ -11969,7 +11969,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -460,12 +460,12 @@
 		A79B0F65292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */; };
 		A79B0F66292BD7CA008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
 		A79B0F67292BD7CC008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
+		A7C816AB2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
+		A7C816AC2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
 		A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
 		A7DA18052AB0C91300F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
 		A7DA18072AB0CA5E00F76337 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
 		A7EA11622AB0CE6C00C73970 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
-		A7C816AB2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
-		A7C816AC2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A4287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A6287476230047275C /* ServerOffsetPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A5287476230047275C /* ServerOffsetPublisher.swift */; };
@@ -1500,6 +1500,13 @@
 			remoteGlobalIDString = 61441C0124616DE9003D8BB8;
 			remoteInfo = Example;
 		};
+		6158155A2AB4534F002C60D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61441C0124616DE9003D8BB8;
+			remoteInfo = "Example iOS";
+		};
 		618F9845265BC486009959F8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -2028,7 +2035,7 @@
 		6132BF4B24A49C8F00D7BD17 /* HTTPHeadersWriter+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPHeadersWriter+objc.swift"; sourceTree = "<group>"; };
 		6132BF5024A49F7400D7BD17 /* Casting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Casting.swift; sourceTree = "<group>"; };
 		6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogSessionReplay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogSessionReplayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogSessionReplayTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61345612244756E300E7DA6B /* PerformancePresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePresetTests.swift; sourceTree = "<group>"; };
 		6134CDB02A691E850061CCD9 /* CoreMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMetricsTests.swift; sourceTree = "<group>"; };
 		61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorTests.swift; sourceTree = "<group>"; };
@@ -2195,7 +2202,7 @@
 		61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61B7885625C180CB002675B5 /* DatadogCrashReporting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DatadogCrashReporting.h; sourceTree = "<group>"; };
 		61B7885725C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCrashReportingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61B7885C25C180CB002675B5 /* DatadogCrashReportingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCrashReportingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61B7886125C180CB002675B5 /* CrashReportingPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingPluginTests.swift; sourceTree = "<group>"; };
 		61B7886325C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61B8BA90281812F60068AFF4 /* KronosInternetAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KronosInternetAddressTests.swift; sourceTree = "<group>"; };
@@ -2341,9 +2348,9 @@
 		A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "B3HTTPHeadersWriter+objc.swift"; sourceTree = "<group>"; };
 		A79B0F60292BB071008742B3 /* B3HTTPHeadersReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReaderTests.swift; sourceTree = "<group>"; };
 		A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDB3HTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
+		A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBackgroundTaskCoordinatorTests.swift; sourceTree = "<group>"; };
 		A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
-		A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBackgroundTaskCoordinatorTests.swift; sourceTree = "<group>"; };
 		A7F773D32924EA2D00AC1A62 /* B3HTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeaders.swift; sourceTree = "<group>"; };
 		A7F773DB29253F8B00AC1A62 /* B3HTTPHeadersWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersWriter.swift; sourceTree = "<group>"; };
 		A7F773DC29253F8B00AC1A62 /* B3HTTPHeadersReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReader.swift; sourceTree = "<group>"; };
@@ -2551,7 +2558,7 @@
 		D2CB6F8F27C520D400A62B57 /* DatadogCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCrashReportingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCrashReportingTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CBC26A294383F200134409 /* WebViewEventReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewEventReceiver.swift; sourceTree = "<group>"; };
 		D2CBC26D294395A300134409 /* RUMContextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContextAttributes.swift; sourceTree = "<group>"; };
 		D2D30E5A2A40BF540020C553 /* Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logs.swift; sourceTree = "<group>"; };
@@ -3579,7 +3586,7 @@
 				61441C0224616DE9003D8BB8 /* Example iOS.app */,
 				61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */,
 				61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */,
-				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */,
+				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests iOS.xctest */,
 				6199362B265BA958009D7EA8 /* E2E.app */,
 				61993665265BBEDC009D7EA8 /* E2ETests.xctest */,
 				618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */,
@@ -3587,7 +3594,7 @@
 				D2CB6F8F27C520D400A62B57 /* DatadogCoreTests.xctest */,
 				D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */,
 				D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */,
-				D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests.xctest */,
+				D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests tvOS.xctest */,
 				D240684D27CE6C9E00C04F44 /* Example tvOS.app */,
 				D257953E298ABA65008A1BE5 /* TestUtilities.framework */,
 				D257958B298ABB83008A1BE5 /* TestUtilities.framework */,
@@ -3610,7 +3617,7 @@
 				3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */,
 				3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests.xctest */,
 				6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */,
-				6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests.xctest */,
+				6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5981,10 +5988,11 @@
 				6133D1F72A6EDB7700384BEF /* PBXTargetDependency */,
 				6133D1F92A6EDB7700384BEF /* PBXTargetDependency */,
 				6133D20A2A6EDBAE00384BEF /* PBXTargetDependency */,
+				6158155B2AB4534F002C60D7 /* PBXTargetDependency */,
 			);
 			name = "DatadogSessionReplayTests iOS";
 			productName = "DatadogWebViewTracking iOSTests";
-			productReference = 6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests.xctest */;
+			productReference = 6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		61441C0124616DE9003D8BB8 /* Example iOS */ = {
@@ -6124,7 +6132,7 @@
 			);
 			name = "DatadogCrashReportingTests iOS";
 			productName = DatadogCrashReportingTests;
-			productReference = 61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */;
+			productReference = 61B7885C25C180CB002675B5 /* DatadogCrashReportingTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		D207317B29A5226A00ECBF94 /* DatadogLogs iOS */ = {
@@ -6524,7 +6532,7 @@
 			);
 			name = "DatadogCrashReportingTests tvOS";
 			productName = DatadogCrashReportingTests;
-			productReference = D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests.xctest */;
+			productReference = D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests tvOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		D2DA2355298D57AA00C6C7E6 /* DatadogInternal tvOS */ = {
@@ -6614,6 +6622,7 @@
 					};
 					6133D1F62A6EDB7700384BEF = {
 						LastSwiftMigration = 1430;
+						TestTargetID = 61441C0124616DE9003D8BB8;
 					};
 					61441C0124616DE9003D8BB8 = {
 						CreatedOnToolsVersion = 11.4;
@@ -8805,6 +8814,11 @@
 			target = 61441C0124616DE9003D8BB8 /* Example iOS */;
 			targetProxy = 61441C7424619FED003D8BB8 /* PBXContainerItemProxy */;
 		};
+		6158155B2AB4534F002C60D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61441C0124616DE9003D8BB8 /* Example iOS */;
+			targetProxy = 6158155A2AB4534F002C60D7 /* PBXContainerItemProxy */;
+		};
 		618F9846265BC486009959F8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 6199362A265BA958009D7EA8 /* E2E */;
@@ -9125,6 +9139,7 @@
 		};
 		3CE11A1629F7BE0B00202522 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -9606,6 +9621,7 @@
 		};
 		6133D2052A6EDB7700384BEF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -9623,7 +9639,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSessionReplayTests;
-				PRODUCT_NAME = DatadogSessionReplayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -9631,6 +9647,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example iOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example iOS";
 			};
 			name = Debug;
 		};
@@ -9653,13 +9670,14 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSessionReplayTests;
-				PRODUCT_NAME = DatadogSessionReplayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example iOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example iOS";
 			};
 			name = Release;
 		};
@@ -9682,13 +9700,14 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSessionReplayTests;
-				PRODUCT_NAME = DatadogSessionReplayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example iOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example iOS";
 			};
 			name = Integration;
 		};
@@ -10160,7 +10179,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -10182,7 +10201,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -10204,7 +10223,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -10464,6 +10483,7 @@
 		};
 		D207318E29A5226B00ECBF94 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -10843,6 +10863,7 @@
 		};
 		D23F8ECA29DDCD38001CFAE8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -11315,6 +11336,7 @@
 		};
 		D25EE94629C4C3C400CE3839 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -11489,6 +11511,7 @@
 		};
 		D29A9F4629DD84AB005C54A4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -11558,6 +11581,7 @@
 		};
 		D2A783FE29A534F9003B03BB /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -11729,6 +11753,7 @@
 		};
 		D2C1A57029C4F2E800946C31 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -12151,7 +12176,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 			};
@@ -12170,7 +12195,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 			};
@@ -12189,7 +12214,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 			};
@@ -12306,6 +12331,7 @@
 		};
 		D2DA2392298D588A00C6C7E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
@@ -12391,6 +12417,7 @@
 		};
 		D2DA23C0298D59DC00C6C7E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
@@ -48,20 +48,6 @@
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "61B7885B25C180CB002675B5"
-               BuildableName = "DatadogCrashReportingTests.xctest"
-               BlueprintName = "DatadogCrashReportingTests iOS"
-               ReferencedContainer = "container:Datadog.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -72,6 +58,15 @@
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61133B8A242393DE00786299"
+            BuildableName = "DatadogCoreTests.xctest"
+            BlueprintName = "DatadogCoreTests iOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "IS_RUNNING_UNIT_TESTS"
@@ -166,7 +161,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_CIVISIBILITY_ITR_ENABLED"
-            value = "1"
+            value = "0"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -239,16 +234,6 @@
                BlueprintIdentifier = "D29A9F3A29DD84AB005C54A4"
                BuildableName = "DatadogRUMTests iOS.xctest"
                BlueprintName = "DatadogRUMTests iOS"
-               ReferencedContainer = "container:Datadog.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "61B7885B25C180CB002675B5"
-               BuildableName = "DatadogCrashReportingTests.xctest"
-               BlueprintName = "DatadogCrashReportingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests iOS.xctest"
                BlueprintName = "DatadogCoreTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3CE11A0429F7BE0300202522"
-               BuildableName = "DatadogWebViewTrackingTests.xctest"
+               BuildableName = "DatadogWebViewTrackingTests iOS.xctest"
                BlueprintName = "DatadogWebViewTrackingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B8A242393DE00786299"
-            BuildableName = "DatadogCoreTests.xctest"
+            BuildableName = "DatadogCoreTests iOS.xctest"
             BlueprintName = "DatadogCoreTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -192,7 +192,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests iOS.xctest"
                BlueprintName = "DatadogCoreTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -242,7 +242,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3CE11A0429F7BE0300202522"
-               BuildableName = "DatadogWebViewTrackingTests.xctest"
+               BuildableName = "DatadogWebViewTrackingTests iOS.xctest"
                BlueprintName = "DatadogWebViewTrackingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
@@ -44,6 +44,15 @@
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D24067F827CE6C9E00C04F44"
+            BuildableName = "Example tvOS.app"
+            BlueprintName = "Example tvOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "IS_RUNNING_UNIT_TESTS"
@@ -211,16 +220,6 @@
                BlueprintIdentifier = "D23F8E9A29DDCD38001CFAE8"
                BuildableName = "DatadogRUMTests tvOS.xctest"
                BlueprintName = "DatadogRUMTests tvOS"
-               ReferencedContainer = "container:Datadog.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2CB6FD327C5352300A62B57"
-               BuildableName = "DatadogCrashReportingTests.xctest"
-               BlueprintName = "DatadogCrashReportingTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D2CB6FD327C5352300A62B57"
-               BuildableName = "DatadogCrashReportingTests.xctest"
+               BuildableName = "DatadogCrashReportingTests tvOS.xctest"
                BlueprintName = "DatadogCrashReportingTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -47,9 +47,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D24067F827CE6C9E00C04F44"
-            BuildableName = "Example tvOS.app"
-            BlueprintName = "Example tvOS"
+            BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
+            BuildableName = "DatadogCoreTests tvOS.xctest"
+            BlueprintName = "DatadogCoreTests tvOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -147,7 +147,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_CIVISIBILITY_ITR_ENABLED"
-            value = "1"
+            value = "0"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -178,7 +178,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests tvOS.xctest"
                BlueprintName = "DatadogCoreTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
@@ -77,18 +77,28 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "GIT_REPOSITORY_URL"
-            value = "$(GIT_REPOSITORY_URL)"
+            key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
+            value = "$(DD_DISABLE_NETWORK_INSTRUMENTATION)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "BITRISE_GIT_COMMIT"
-            value = "$(BITRISE_GIT_COMMIT)"
+            key = "SRCROOT"
+            value = "$(SRCROOT)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BITRISE_SOURCE_DIR"
             value = "$(BITRISE_SOURCE_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
+            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -99,71 +109,6 @@
          <EnvironmentVariable
             key = "BITRISE_BUILD_URL"
             value = "$(BITRISE_BUILD_URL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_BRANCH"
-            value = "$(BITRISE_GIT_BRANCH)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISEIO_GIT_BRANCH_DEST"
-            value = "$(BITRISEIO_GIT_BRANCH_DEST)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_TAG"
-            value = "$(BITRISE_GIT_TAG)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_HASH"
-            value = "$(GIT_CLONE_COMMIT_HASH)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_APP_TITLE"
-            value = "$(BITRISE_APP_TITLE)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_BUILD_SLUG"
-            value = "$(BITRISE_BUILD_SLUG)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_MESSAGE"
-            value = "$(BITRISE_GIT_MESSAGE)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_MESSAGE_SUBJECT"
-            value = "$(GIT_CLONE_COMMIT_MESSAGE_SUBJECT)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_MESSAGE_BODY"
-            value = "$(GIT_CLONE_COMMIT_MESSAGE_BODY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_AUTHOR_NAME"
-            value = "$(GIT_CLONE_COMMIT_AUTHOR_NAME)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_AUTHOR_EMAIL"
-            value = "$(GIT_CLONE_COMMIT_AUTHOR_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_COMMITER_NAME"
-            value = "$(GIT_CLONE_COMMIT_COMMITER_NAME)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_COMMITER_EMAIL"
-            value = "$(GIT_CLONE_COMMIT_COMMITER_EMAIL)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -188,7 +133,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_CIVISIBILITY_ITR_ENABLED"
-            value = "1"
+            value = "0"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
@@ -34,7 +34,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61B7885B25C180CB002675B5"
-            BuildableName = "DatadogCrashReportingTests.xctest"
+            BuildableName = "DatadogCrashReportingTests iOS.xctest"
             BlueprintName = "DatadogCrashReportingTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -157,7 +157,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61B7885B25C180CB002675B5"
-               BuildableName = "DatadogCrashReportingTests.xctest"
+               BuildableName = "DatadogCrashReportingTests iOS.xctest"
                BlueprintName = "DatadogCrashReportingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
@@ -34,7 +34,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D2CB6FD327C5352300A62B57"
-            BuildableName = "DatadogCrashReportingTests.xctest"
+            BuildableName = "DatadogCrashReportingTests tvOS.xctest"
             BlueprintName = "DatadogCrashReportingTests tvOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -157,7 +157,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D2CB6FD327C5352300A62B57"
-               BuildableName = "DatadogCrashReportingTests.xctest"
+               BuildableName = "DatadogCrashReportingTests tvOS.xctest"
                BlueprintName = "DatadogCrashReportingTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
@@ -77,18 +77,28 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "GIT_REPOSITORY_URL"
-            value = "$(GIT_REPOSITORY_URL)"
+            key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
+            value = "$(DD_DISABLE_NETWORK_INSTRUMENTATION)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "BITRISE_GIT_COMMIT"
-            value = "$(BITRISE_GIT_COMMIT)"
+            key = "SRCROOT"
+            value = "$(SRCROOT)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BITRISE_SOURCE_DIR"
             value = "$(BITRISE_SOURCE_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
+            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -99,71 +109,6 @@
          <EnvironmentVariable
             key = "BITRISE_BUILD_URL"
             value = "$(BITRISE_BUILD_URL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_BRANCH"
-            value = "$(BITRISE_GIT_BRANCH)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISEIO_GIT_BRANCH_DEST"
-            value = "$(BITRISEIO_GIT_BRANCH_DEST)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_TAG"
-            value = "$(BITRISE_GIT_TAG)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_HASH"
-            value = "$(GIT_CLONE_COMMIT_HASH)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_APP_TITLE"
-            value = "$(BITRISE_APP_TITLE)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_BUILD_SLUG"
-            value = "$(BITRISE_BUILD_SLUG)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_GIT_MESSAGE"
-            value = "$(BITRISE_GIT_MESSAGE)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_MESSAGE_SUBJECT"
-            value = "$(GIT_CLONE_COMMIT_MESSAGE_SUBJECT)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_MESSAGE_BODY"
-            value = "$(GIT_CLONE_COMMIT_MESSAGE_BODY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_AUTHOR_NAME"
-            value = "$(GIT_CLONE_COMMIT_AUTHOR_NAME)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_AUTHOR_EMAIL"
-            value = "$(GIT_CLONE_COMMIT_AUTHOR_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_COMMITER_NAME"
-            value = "$(GIT_CLONE_COMMIT_COMMITER_NAME)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GIT_CLONE_COMMIT_COMMITER_EMAIL"
-            value = "$(GIT_CLONE_COMMIT_COMMITER_EMAIL)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -188,7 +133,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_CIVISIBILITY_ITR_ENABLED"
-            value = "1"
+            value = "0"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
@@ -33,7 +33,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B8A242393DE00786299"
-            BuildableName = "DatadogCoreTests.xctest"
+            BuildableName = "DatadogCoreTests iOS.xctest"
             BlueprintName = "DatadogCoreTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -158,7 +158,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests iOS.xctest"
                BlueprintName = "DatadogCoreTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests tvOS.xctest"
                BlueprintName = "DatadogCoreTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
-            BuildableName = "DatadogCoreTests.xctest"
+            BuildableName = "DatadogCoreTests tvOS.xctest"
             BlueprintName = "DatadogCoreTests tvOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -172,7 +172,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
-               BuildableName = "DatadogCoreTests.xctest"
+               BuildableName = "DatadogCoreTests tvOS.xctest"
                BlueprintName = "DatadogCoreTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6133D1F62A6EDB7700384BEF"
-            BuildableName = "DatadogSessionReplayTests.xctest"
+            BuildableName = "DatadogSessionReplayTests iOS.xctest"
             BlueprintName = "DatadogSessionReplayTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
@@ -145,7 +145,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6133D1F62A6EDB7700384BEF"
-               BuildableName = "DatadogSessionReplayTests.xctest"
+               BuildableName = "DatadogSessionReplayTests iOS.xctest"
                BlueprintName = "DatadogSessionReplayTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
@@ -26,7 +26,119 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6133D1F62A6EDB7700384BEF"
+            BuildableName = "DatadogSessionReplayTests.xctest"
+            BlueprintName = "DatadogSessionReplayTests iOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "IS_RUNNING_UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DD_TEST_RUNNER"
+            value = "$(DD_TEST_RUNNER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENV"
+            value = "$(DD_SDK_SWIFT_TESTING_ENV)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_SERVICE"
+            value = "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_SDKIOS_INTEGRATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_HEADERS_INJECTION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
+            value = "$(DD_DISABLE_NETWORK_INSTRUMENTATION)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SRCROOT"
+            value = "$(SRCROOT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_SOURCE_DIR"
+            value = "$(BITRISE_SOURCE_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
+            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_NUMBER"
+            value = "$(BITRISE_BUILD_NUMBER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_URL"
+            value = "$(BITRISE_BUILD_URL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_APPLICATION_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APPLICATION_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_ITR_ENABLED"
+            value = "0"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_EXCLUDED_BRANCHES"
+            value = "develop,release/*,hotfix/*"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,6 +169,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6133D1E52A6ED9E100384BEF"
+            BuildableName = "DatadogSessionReplay.framework"
+            BlueprintName = "DatadogSessionReplay iOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogWebViewTracking iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogWebViewTracking iOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3CE11A0429F7BE0300202522"
-               BuildableName = "DatadogWebViewTrackingTests.xctest"
+               BuildableName = "DatadogWebViewTrackingTests iOS.xctest"
                BlueprintName = "DatadogWebViewTrackingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3CE11A0429F7BE0300202522"
-               BuildableName = "DatadogWebViewTrackingTests.xctest"
+               BuildableName = "DatadogWebViewTrackingTests iOS.xctest"
                BlueprintName = "DatadogWebViewTrackingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>

--- a/DatadogCore/Tests/Datadog/OpenTracing/OTSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/OpenTracing/OTSpanTests.swift
@@ -44,6 +44,12 @@ private extension Dictionary where Key == String, Value == Encodable {
 }
 
 class OTSpanTests: XCTestCase {
+    #if os(iOS)
+    private let testModuleName = "DatadogCoreTests_iOS"
+    #elseif os(tvOS)
+    private let testModuleName = "DatadogCoreTests_tvOS"
+    #endif
+
     // MARK: - Test Error Conveniences
 
     func testWhenSettingErrorFromSwiftError_itLogsErrorFields() throws {
@@ -65,7 +71,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            DatadogCoreTests/File.swift:42
+            \(testModuleName)/File.swift:42
             swift error description
             """
         )
@@ -117,7 +123,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            DatadogCoreTests/File.swift:42
+            \(testModuleName)/File.swift:42
             Error Domain=DDSpan Code=1 "ns error description" UserInfo={NSLocalizedDescription=ns error description}
             """
         )
@@ -141,7 +147,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            DatadogCoreTests/File.swift:42
+            \(testModuleName)/File.swift:42
             """
         )
     }
@@ -156,7 +162,9 @@ class OTSpanTests: XCTestCase {
         0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
         1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
         """
+        #sourceLocation(file: "File.swift", line: 42)
         span.setError(kind: "custom kind", message: "custom message", stack: stack)
+        #sourceLocation()
 
         // Then
         XCTAssertEqual(span.logs.count, 1)
@@ -167,7 +175,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            DatadogCoreTests/OTSpanTests.swift:159
+            \(testModuleName)/File.swift:42
             Thread 0 Crashed:
             0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
             1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620

--- a/DatadogCore/Tests/Datadog/Utils/UIKitExtensionsTests.swift
+++ b/DatadogCore/Tests/Datadog/Utils/UIKitExtensionsTests.swift
@@ -15,7 +15,11 @@ class UIKitExtensionsTests: XCTestCase {
         let swiftViewController = CustomSwiftViewController()
         let objcViewController = CustomObjcViewController()
 
-        XCTAssertEqual(swiftViewController.canonicalClassName, "DatadogCoreTests.CustomSwiftViewController")
+        #if os(iOS)
+        XCTAssertEqual(swiftViewController.canonicalClassName, "DatadogCoreTests_iOS.CustomSwiftViewController")
+        #elseif os(tvOS)
+        XCTAssertEqual(swiftViewController.canonicalClassName, "DatadogCoreTests_tvOS.CustomSwiftViewController")
+        #endif
         XCTAssertEqual(objcViewController.canonicalClassName, "CustomObjcViewController")
     }
 

--- a/DatadogCore/Tests/TestsObserver/DatadogTestsObserverLoader.m
+++ b/DatadogCore/Tests/TestsObserver/DatadogTestsObserverLoader.m
@@ -6,7 +6,12 @@
 
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
-#import "DatadogCoreTests-Swift.h"
+
+#if TARGET_OS_IOS
+#import "DatadogCoreTests_iOS-Swift.h"
+#elif TARGET_OS_TV
+#import "DatadogCoreTests_tvOS-Swift.h"
+#endif
 
 /// This code runs when the `DatadogTests` bundle is loaded into memory and tests start.
 /// Reference: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load

--- a/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportBuilderTests.swift
+++ b/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportBuilderTests.swift
@@ -38,10 +38,17 @@ class DDCrashReportBuilderTests: XCTestCase {
             ddCrashReport.stack.contains("XCTest"),
             "`DDCrashReport's` stack should include at least one frame from `XCTest` image"
         )
+        #if os(iOS)
         XCTAssertTrue(
-            ddCrashReport.binaryImages.contains(where: { $0.libraryName == "DatadogCrashReportingTests" }),
-            "`DDCrashReport` should include the image for `DatadogCrashReportingTests`"
+            ddCrashReport.binaryImages.contains(where: { $0.libraryName == "DatadogCrashReportingTests iOS" }),
+            "`DDCrashReport` should include the image for `DatadogCrashReportingTests iOS`"
         )
+        #elseif os(tvOS)
+        XCTAssertTrue(
+            ddCrashReport.binaryImages.contains(where: { $0.libraryName == "DatadogCrashReportingTests tvOS" }),
+            "`DDCrashReport` should include the image for `DatadogCrashReportingTests tvOS`"
+        )
+        #endif
         XCTAssertTrue(
             // Assert on prefix as it's `XCTestCore` on iOS 15+ and `XCTest` earlier:
             ddCrashReport.binaryImages.contains(where: { $0.libraryName.hasPrefix("XCTest") }),

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcconfig
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcconfig
@@ -1,2 +1,6 @@
 // Add common settings from Datadog.xcconfig
 #include "../../xcconfigs/Datadog.xcconfig"
+
+// Add DatadogSDKTesting instrumentation (if available in current environment)
+DD_SDK_TESTING_OVERRIDE_PATH=$(SRCROOT)/../../instrumented-tests/
+#include? "../../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/xcshareddata/xcschemes/SRSnapshotTests.xcscheme
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/xcshareddata/xcschemes/SRSnapshotTests.xcscheme
@@ -26,11 +26,117 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       language = "en"
       region = "US"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61B3BC612993BEAF0032C78A"
+            BuildableName = "SRSnapshotTests.xctest"
+            BlueprintName = "SRSnapshotTests"
+            ReferencedContainer = "container:SRSnapshotTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DD_TEST_RUNNER"
+            value = "$(DD_TEST_RUNNER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENV"
+            value = "$(DD_SDK_SWIFT_TESTING_ENV)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_SERVICE"
+            value = "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_SDKIOS_INTEGRATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_HEADERS_INJECTION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
+            value = "$(DD_DISABLE_NETWORK_INSTRUMENTATION)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SRCROOT"
+            value = "$(SRCROOT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_SOURCE_DIR"
+            value = "$(BITRISE_SOURCE_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
+            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_NUMBER"
+            value = "$(BITRISE_BUILD_NUMBER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_URL"
+            value = "$(BITRISE_BUILD_URL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_APPLICATION_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APPLICATION_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_ITR_ENABLED"
+            value = "0"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_CIVISIBILITY_EXCLUDED_BRANCHES"
+            value = "develop,release/*,hotfix/*"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/DatadogTrace/Tests/ContextMessageReceiverTests.swift
+++ b/DatadogTrace/Tests/ContextMessageReceiverTests.swift
@@ -42,10 +42,11 @@ class ContextMessageReceiverTests: XCTestCase {
             messageReceiver: receiver
         )
 
-        XCTAssertEqual(receiver.context.rum!["_dd.application.id"] as? String?, "app-id")
-        XCTAssertEqual(receiver.context.rum!["_dd.session.id"] as? String?, "session-id")
-        XCTAssertEqual(receiver.context.rum!["_dd.view.id"] as? String?, "view-id")
-        XCTAssertEqual(receiver.context.rum!["_dd.action.id"] as? String?, "action-id")
+        var rumContext = try XCTUnwrap(receiver.context.rum)
+        XCTAssertEqual(rumContext["_dd.application.id"] as? String, "app-id")
+        XCTAssertEqual(rumContext["_dd.session.id"] as? String, "session-id")
+        XCTAssertEqual(rumContext["_dd.view.id"] as? String, "view-id")
+        XCTAssertEqual(rumContext["_dd.action.id"] as? String, "action-id")
 
         // When
         ids = [
@@ -57,10 +58,11 @@ class ContextMessageReceiverTests: XCTestCase {
         core.set(feature: "rum", attributes: { ["ids": ids] })
 
         // Then
-        XCTAssertEqual(receiver.context.rum!["_dd.application.id"] as? String?, "app-id")
-        XCTAssertEqual(receiver.context.rum!["_dd.session.id"] as? String?, "session-id")
-        XCTAssertNil(receiver.context.rum!["_dd.view.id"])
-        XCTAssertNil(receiver.context.rum!["_dd.action.id"])
+        rumContext = try XCTUnwrap(receiver.context.rum)
+        XCTAssertEqual(rumContext["_dd.application.id"] as? String, "app-id")
+        XCTAssertEqual(rumContext["_dd.session.id"] as? String, "session-id")
+        XCTAssertNil(rumContext["_dd.view.id"] as Any?)
+        XCTAssertNil(rumContext["_dd.action.id"] as Any?)
     }
 
     func testItIngnoresRUMContext() throws {

--- a/IntegrationTests/xctestplans/DatadogCrashReportingIntegrationTests.xctestplan
+++ b/IntegrationTests/xctestplans/DatadogCrashReportingIntegrationTests.xctestplan
@@ -92,7 +92,7 @@
       },
       {
         "key" : "DD_CIVISIBILITY_ITR_ENABLED",
-        "value" : "1"
+        "value" : "0"
       },
       {
         "key" : "DD_CIVISIBILITY_EXCLUDED_BRANCHES",

--- a/IntegrationTests/xctestplans/DatadogIntegrationTests.xctestplan
+++ b/IntegrationTests/xctestplans/DatadogIntegrationTests.xctestplan
@@ -148,7 +148,7 @@
       },
       {
         "key" : "DD_CIVISIBILITY_ITR_ENABLED",
-        "value" : "1"
+        "value" : "0"
       },
       {
         "key" : "DD_CIVISIBILITY_EXCLUDED_BRANCHES",

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ all: dependencies templates
 DD_SDK_SWIFT_TESTING_VERSION = 2.3.0
 
 define DD_SDK_TESTING_XCCONFIG_CI
-FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+DD_SDK_TESTING_PATH=$$(DD_SDK_TESTING_OVERRIDE_PATH:default=$$(SRCROOT)/../instrumented-tests/)\n
+FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 OTHER_LDFLAGS[sdk=iphonesimulator*]=$$(inherited) -framework DatadogSDKTesting\n
 OTHER_LDFLAGS[sdk=appletvsimulator*]=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -204,8 +204,6 @@ workflows:
         - scheme: DatadogCore iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
         - is_clean_build: 'yes'
-        - test_repetition_mode: 'retry_on_failure'
-        - maximum_test_repetitions: 2
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-ios-unit-tests.html"
@@ -225,8 +223,6 @@ workflows:
         - scheme: DatadogCore tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
         - is_clean_build: 'yes'
-        - test_repetition_mode: 'retry_on_failure'
-        - maximum_test_repetitions: 2
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-tvos-unit-tests.html"

--- a/tools/ci/choose_workflows.py
+++ b/tools/ci/choose_workflows.py
@@ -88,7 +88,7 @@ def should_run_tools_tests(ctx: CIContext) -> bool:
         ctx=ctx,
         trigger_env=context.trigger_env.DD_RUN_TOOLS_TESTS,
         build_env=context.build_env.DD_OVERRIDE_RUN_TOOLS_TESTS,
-        pr_keyword=None,
+        pr_keyword='[x] Run tests for `tools/`',
         pr_path_prefixes=[
             'instrumented-tests/',
             'tools/',


### PR DESCRIPTION
### What and why?

🔭 Fixing CI Visibility setup for V2 modules, to gain observability into test runs.
* `Datadog.xcworkspace` - it was partially broken 💔, now works for all modules on both iOS and tvOS;
* `IntegrationTests/IntegrationTests.xcworkspace` - no change, was fine 👍;
* `DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace` - added 🎁.

<p align="center">
<img width="70%" alt="Screenshot 2023-09-15 at 17 04 35" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/f02b7b2f-3b40-4ff3-9678-e46f44eebcd3">
</p>

### How?

Following [CI Visibility docs](https://docs.datadoghq.com/continuous_integration/tests/swift/?tab=swiftpackagemanager#installing-the-swift-testing-sdk):
* Fixed ENV setup in `DatadogCore` and `DatadogCrashReporting` test schemes.
* Added ENV setup in `DatadogSessionReplay` scheme.
* Enabled CI Visibility for `SRSnapshotTests` project.

Also:
* 🧽 I removed redundant run of `DatadogCrashReporting` tests (they are run [directly from `bitrise.yml`](https://github.com/DataDog/dd-sdk-ios/blob/438280f7da19e369b0cb76a9e308980a1423d57d/bitrise.yml#L212-L220) and extra run was made indirectly from `DatadogCore` scheme).
* ❄️ Temporarily disabled [ITR](https://docs.datadoghq.com/continuous_integration/intelligent_test_runner/swift/) for all schemes - rationale: it doesn't help solving the flakiness we currently observe.
* ❗ Removed "retry on failure" for unit tests - rationale: added a long time ago to mitigate flakiness, doesn't prevent from getting new flakiness - makes things worse long term.
* 🎁 ✏️ Updated PR template with options to selectively run SR and `tools/` tests.


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
