### PR TITLE
Revert in background telemetry

### DIFF
--- a/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -36,7 +36,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        self.writer = storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: false)
+        self.writer = storage.writer(for: .granted, forceNewBatch: false)
         self.reader = storage.reader
 
         XCTAssertTrue(try directory.files().isEmpty)
@@ -71,13 +71,13 @@ class LoggingStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch(context: .mockAny())
+            let batch = reader.readNextBatch()
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch, reason: .flushed, context: .mockAny())
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -36,7 +36,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        self.writer = storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: false)
+        self.writer = storage.writer(for: .granted, forceNewBatch: false)
         self.reader = storage.reader
 
         XCTAssertTrue(try directory.files().isEmpty)
@@ -71,13 +71,13 @@ class RUMStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch(context: .mockAny())
+            let batch = reader.readNextBatch()
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch, reason: .flushed, context: .mockAny())
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -36,7 +36,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        self.writer = storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: false)
+        self.writer = storage.writer(for: .granted, forceNewBatch: false)
         self.reader = storage.reader
 
         XCTAssertTrue(try directory.files().isEmpty)
@@ -71,13 +71,13 @@ class TracingStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch(context: .mockAny())
+            let batch = reader.readNextBatch()
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch, reason: .flushed, context: .mockAny())
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -318,7 +318,10 @@ internal struct DatadogCoreFeatureScope: FeatureScope {
         // On user thread: request SDK context.
         contextProvider.read { context in
             // On context thread: request writer for current tracking consent.
-            let writer = storage.writer(for: context, bypassConsent: bypassConsent, forceNewBatch: forceNewBatch)
+            let writer = storage.writer(
+                for: bypassConsent ? .granted : context.trackingConsent,
+                forceNewBatch: forceNewBatch
+            )
 
             // Still on context thread: send `Writer` to EWC caller. The writer implements `AsyncWriter`, so
             // the implementation of `writer.write(value:)` will run asynchronously without blocking the context thread.

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -23,20 +23,15 @@ internal struct FeatureStorage {
     /// Telemetry interface.
     let telemetry: Telemetry
 
-    func writer(
-        for context: DatadogContext,
-        bypassConsent: Bool = false,
-        forceNewBatch: Bool = false
-    ) -> Writer {
-        switch bypassConsent ? .granted : context.trackingConsent {
+    func writer(for trackingConsent: TrackingConsent, forceNewBatch: Bool) -> Writer {
+        switch trackingConsent {
         case .granted:
             return AsyncWriter(
                 execute: FileWriter(
                     orchestrator: authorizedFilesOrchestrator,
                     forceNewFile: forceNewBatch,
                     encryption: encryption,
-                    telemetry: telemetry,
-                    context: context
+                    telemetry: telemetry
                 ),
                 on: queue
             )
@@ -48,8 +43,7 @@ internal struct FeatureStorage {
                     orchestrator: unauthorizedFilesOrchestrator,
                     forceNewFile: forceNewBatch,
                     encryption: encryption,
-                    telemetry: telemetry,
-                    context: context
+                    telemetry: telemetry
                 ),
                 on: queue
             )

--- a/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
@@ -5,7 +5,6 @@
  */
 
 import Foundation
-import DatadogInternal
 
 /// Synchronizes the work of `FileReader` on given read/write queue.
 internal final class DataReader: Reader {
@@ -18,15 +17,15 @@ internal final class DataReader: Reader {
         self.fileReader = fileReader
     }
 
-    func readNextBatch(context: DatadogContext) -> Batch? {
+    func readNextBatch() -> Batch? {
         queue.sync {
-            self.fileReader.readNextBatch(context: context)
+            self.fileReader.readNextBatch()
         }
     }
 
-    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason, context: DatadogContext) {
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {
         queue.sync {
-            self.fileReader.markBatchAsRead(batch, reason: reason, context: context)
+            self.fileReader.markBatchAsRead(batch, reason: reason)
         }
     }
 }

--- a/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
@@ -30,8 +30,8 @@ internal final class FileReader: Reader {
 
     // MARK: - Reading batches
 
-    func readNextBatch(context: DatadogContext) -> Batch? {
-        guard let file = orchestrator.getReadableFile(excludingFilesNamed: filesRead, context: context) else {
+    func readNextBatch() -> Batch? {
+        guard let file = orchestrator.getReadableFile(excludingFilesNamed: filesRead) else {
             return nil
         }
 
@@ -95,8 +95,8 @@ internal final class FileReader: Reader {
 
     // MARK: - Accepting batches
 
-    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason, context: DatadogContext) {
-        orchestrator.delete(readableFile: batch.file, deletionReason: reason, context: context)
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {
+        orchestrator.delete(readableFile: batch.file, deletionReason: reason)
         filesRead.insert(batch.file.name)
     }
 }

--- a/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
@@ -24,6 +24,6 @@ extension Batch {
 
 /// A type, reading batched data.
 internal protocol Reader {
-    func readNextBatch(context: DatadogContext) -> Batch?
-    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason, context: DatadogContext)
+    func readNextBatch() -> Batch?
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason)
 }

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -20,21 +20,17 @@ internal struct FileWriter: Writer {
     let forceNewFile: Bool
     /// Telemetry interface.
     let telemetry: Telemetry
-    /// Current context of the SDK.
-    let context: DatadogContext
 
     init(
         orchestrator: FilesOrchestratorType,
         forceNewFile: Bool,
         encryption: DataEncryption?,
-        telemetry: Telemetry,
-        context: DatadogContext
+        telemetry: Telemetry
     ) {
         self.orchestrator = orchestrator
         self.encryption = encryption
         self.forceNewFile = forceNewFile
         self.telemetry = telemetry
-        self.context = context
     }
 
     // MARK: - Writing data
@@ -59,9 +55,7 @@ internal struct FileWriter: Writer {
             // This is to avoid a situation where event is written to one file and event metadata to another.
             // If this happens, the reader will not be able to match event with its metadata.
             let writeSize = UInt64(encoded.count)
-            let file = try forceNewFile
-                ? orchestrator.getNewWritableFile(writeSize: writeSize, context: context)
-                : orchestrator.getWritableFile(writeSize: writeSize, context: context)
+            let file = try forceNewFile ? orchestrator.getNewWritableFile(writeSize: writeSize) : orchestrator.getWritableFile(writeSize: writeSize)
             try file.append(data: encoded)
         } catch {
             DD.logger.error("Failed to write data", error: error)

--- a/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
@@ -38,67 +38,67 @@ class FeatureStorageTests: XCTestCase {
 
     func testWhenWritingEventsWithoutForcingNewBatch_itShouldWriteAllEventsToTheSameBatch() throws {
         // When
-        storage.writer(for: .mockWith(trackingConsent: .granted)).write(value: ["event1": "1"])
-        storage.writer(for: .mockWith(trackingConsent: .granted)).write(value: ["event2": "2"])
-        storage.writer(for: .mockWith(trackingConsent: .granted)).write(value: ["event3": "3"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event1": "1"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event2": "2"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event3": "3"])
 
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        let batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.count, 3, "All 3 events should be written to the same batch")
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batche")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batche")
     }
 
     func testWhenWritingEventsWithForcingNewBatch_itShouldWriteEachEventToSeparateBatch() throws {
         // When
-        storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: true).write(value: ["event1": "1"])
-        storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: true).write(value: ["event2": "2"])
-        storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: true).write(value: ["event3": "3"])
+        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event1": "1"])
+        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event2": "2"])
+        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event3": "3"])
 
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        var batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        var batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batches")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
     }
 
     // MARK: - Behaviours on tracking consent
 
     func testWhenWritingEventsInDifferentConsents_itOnlyReadsGrantedEvents() throws {
         // When
-        storage.writer(for: .mockWith(trackingConsent: .granted)).write(value: ["event.consent": "granted"])
-        storage.writer(for: .mockWith(trackingConsent: .pending)).write(value: ["event.consent": "pending"])
-        storage.writer(for: .mockWith(trackingConsent: .notGranted)).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
 
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        let batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batches")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
     }
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToGranted_itMakesPendingEventsReadable() throws {
         // Given
-        storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: false).write(value: ["event.consent": "granted"])
-        storage.writer(for: .mockWith(trackingConsent: .pending), forceNewBatch: false).write(value: ["event.consent": "pending"])
-        storage.writer(for: .mockWith(trackingConsent: .notGranted), forceNewBatch: false).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
 
         // When
         storage.migrateUnauthorizedData(toConsent: .granted)
@@ -106,22 +106,22 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        var batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        var batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"pending"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batches")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
     }
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToNotGranted_itDeletesPendingEvents() throws {
         // Given
-        storage.writer(for: .mockWith(trackingConsent: .granted), forceNewBatch: false).write(value: ["event.consent": "granted"])
-        storage.writer(for: .mockWith(trackingConsent: .pending), forceNewBatch: false).write(value: ["event.consent": "pending"])
-        storage.writer(for: .mockWith(trackingConsent: .notGranted), forceNewBatch: false).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
 
         // When
         storage.migrateUnauthorizedData(toConsent: .notGranted)
@@ -129,14 +129,14 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch(context: .mockAny()))
+        let batch = try XCTUnwrap(storage.reader.readNextBatch())
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batches")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
 
         storage.migrateUnauthorizedData(toConsent: .granted)
-        XCTAssertNil(storage.reader.readNextBatch(context: .mockAny()), "There must be no other batches, because pending events were deleted")
+        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches, because pending events were deleted")
     }
 
     // MARK: - Data migration

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -44,13 +44,13 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
     func testWhenReadableFileIsDeleted_itSendsBatchDeletedMetric() throws {
         // Given
         let orchestrator = createOrchestrator()
-        let file = try XCTUnwrap(orchestrator.getWritableFile(writeSize: 1, context: .mockAny()) as? ReadableFile)
+        let file = try XCTUnwrap(orchestrator.getWritableFile(writeSize: 1) as? ReadableFile)
         let expectedBatchAge = storage.minFileAgeForRead + 1
 
         // When:
         // - wait and delete the file
         dateProvider.advance(bySeconds: expectedBatchAge)
-        orchestrator.delete(readableFile: file, deletionReason: .intakeCode(responseCode: 202), context: .mockAny())
+        orchestrator.delete(readableFile: file, deletionReason: .intakeCode(responseCode: 202))
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
@@ -72,13 +72,13 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         // Given:
         // - request some batch to be created
         let orchestrator = createOrchestrator()
-        _ = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator.getWritableFile(writeSize: 1)
 
         // When:
         // - wait more than batch obsolescence limit
         // - then request readable file, which should trigger obsolete files deletion
         dateProvider.advance(bySeconds: storage.maxFileAgeForRead + 1)
-        _ = orchestrator.getReadableFile(context: .mockAny())
+        _ = orchestrator.getReadableFile()
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
@@ -102,14 +102,14 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         // - write more data than allowed directory size limit
         storage.maxDirectorySize = 10 // 10 bytes
         let orchestrator = createOrchestrator()
-        let file = try orchestrator.getWritableFile(writeSize: storage.maxDirectorySize + 1, context: .mockAny())
+        let file = try orchestrator.getWritableFile(writeSize: storage.maxDirectorySize + 1)
         try file.append(data: .mockRandom(ofSize: storage.maxDirectorySize + 1))
         let expectedBatchAge = storage.minFileAgeForRead + 1
 
         // When:
         // - then request new batch, which triggers directory purging
         dateProvider.advance(bySeconds: expectedBatchAge)
-        _ = try orchestrator.getNewWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator.getNewWritableFile(writeSize: 1)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
@@ -127,21 +127,6 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         ])
     }
 
-    func testWhenAppIsInBackground_itSendsBatchInBackgroundMetric() throws {
-        // Given
-        let orchestrator = createOrchestrator()
-        let context: DatadogContext = .mockWith(applicationStateHistory: .mockAppInBackground())
-        let file = try XCTUnwrap(orchestrator.getWritableFile(writeSize: 1, context: context) as? ReadableFile)
-
-        // When:
-        orchestrator.delete(readableFile: file, deletionReason: .intakeCode(responseCode: 202), context: context)
-
-        // Then
-        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
-        let inBackground = try XCTUnwrap(metric.attributes["in_background"] as? Bool)
-        XCTAssertTrue(inBackground)
-    }
-
     // MARK: - "Batch Closed" Metric
 
     func testWhenNewBatchIsStarted_itSendsBatchClosedMetric() throws {
@@ -151,14 +136,14 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         let orchestrator = createOrchestrator()
         let expectedWrites: [UInt64] = [10, 5, 2]
         try expectedWrites.forEach { writeSize in
-            _ = try orchestrator.getWritableFile(writeSize: writeSize, context: .mockAny())
+            _ = try orchestrator.getWritableFile(writeSize: writeSize)
         }
 
         // When
         // - wait more than allowed batch age for writes, so next batch request will create another batch
         // - then request another batch, which will close the previous one
         dateProvider.advance(bySeconds: (storage.maxFileAgeForWrite + 1))
-        _ = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator.getWritableFile(writeSize: 1)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Closed"))
@@ -180,7 +165,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         let orchestrator = createOrchestrator()
         let expectedWrites: [UInt64] = [10, 5, 2]
         try expectedWrites.forEach { writeSize in
-            _ = try orchestrator.getWritableFile(writeSize: writeSize, context: .mockAny())
+            _ = try orchestrator.getWritableFile(writeSize: writeSize)
         }
         let expectedBatchDuration = storage.maxFileAgeForWrite - 1
 
@@ -188,7 +173,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         // - wait less than allowed batch age for writes
         // - then request new batch, which closes the previous one
         dateProvider.advance(bySeconds: expectedBatchDuration)
-        _ = try orchestrator.getNewWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator.getNewWritableFile(writeSize: 1)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Closed"))

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -38,7 +38,7 @@ class FilesOrchestratorTests: XCTestCase {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
 
-        _ = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator.getWritableFile(writeSize: 1)
 
         XCTAssertEqual(try orchestrator.directory.files().count, 1)
         XCTAssertNotNil(try orchestrator.directory.file(named: dateProvider.now.toFileName))
@@ -46,9 +46,9 @@ class FilesOrchestratorTests: XCTestCase {
 
     func testWhenWritableFileIsObtainedAnotherTime_itReusesSameFile() throws {
         let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
-        let file1 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file1 = try orchestrator.getWritableFile(writeSize: 1)
 
-        let file2 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file2 = try orchestrator.getWritableFile(writeSize: 1)
 
         XCTAssertEqual(try orchestrator.directory.files().count, 1)
         XCTAssertEqual(file1.name, file2.name)
@@ -56,17 +56,17 @@ class FilesOrchestratorTests: XCTestCase {
 
     func testWhenSameWritableFileWasUsedMaxNumberOfTimes_itCreatesNewFile() throws {
         let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
-        var previousFile: WritableFile = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny()) // first use of a new file
+        var previousFile: WritableFile = try orchestrator.getWritableFile(writeSize: 1) // first use of a new file
         var nextFile: WritableFile
 
         for _ in (0..<5) {
             for _ in (0 ..< performance.maxObjectsInFile).dropLast() { // skip first use
-                nextFile = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+                nextFile = try orchestrator.getWritableFile(writeSize: 1)
                 XCTAssertEqual(nextFile.name, previousFile.name, "It should reuse the file \(performance.maxObjectsInFile) times")
                 previousFile = nextFile
             }
 
-            nextFile = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny()) // first use of a new file
+            nextFile = try orchestrator.getWritableFile(writeSize: 1) // first use of a new file
             XCTAssertNotEqual(nextFile.name, previousFile.name, "It should create a new file when previous one is used \(performance.maxObjectsInFile) times")
             previousFile = nextFile
         }
@@ -79,31 +79,31 @@ class FilesOrchestratorTests: XCTestCase {
             maxChunkSize: performance.maxObjectSize
         )
 
-        let file1 = try orchestrator.getWritableFile(writeSize: performance.maxObjectSize, context: .mockAny())
+        let file1 = try orchestrator.getWritableFile(writeSize: performance.maxObjectSize)
         try chunkedData.forEach { chunk in try file1.append(data: chunk) }
 
-        let file2 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file2 = try orchestrator.getWritableFile(writeSize: 1)
         XCTAssertNotEqual(file1.name, file2.name)
     }
 
     func testWhenWritableFileIsTooOld_itCreatesNewFile() throws {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
-        let file1 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file1 = try orchestrator.getWritableFile(writeSize: 1)
 
         dateProvider.advance(bySeconds: 1 + performance.maxFileAgeForWrite)
 
-        let file2 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file2 = try orchestrator.getWritableFile(writeSize: 1)
         XCTAssertNotEqual(file1.name, file2.name)
     }
 
     func testWhenWritableFileWasDeleted_itCreatesNewFile() throws {
         let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
-        let file1 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file1 = try orchestrator.getWritableFile(writeSize: 1)
 
         try orchestrator.directory.files().forEach { try $0.delete() }
 
-        let file2 = try orchestrator.getWritableFile(writeSize: 1, context: .mockAny())
+        let file2 = try orchestrator.getWritableFile(writeSize: 1)
         XCTAssertNotEqual(file1.name, file2.name)
     }
 
@@ -115,10 +115,10 @@ class FilesOrchestratorTests: XCTestCase {
             using: RelativeDateProvider(startingFrom: Date().secondsAgo(0.01)) // simulate time difference
         )
 
-        _ = try orchestrator1.getWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator1.getWritableFile(writeSize: 1)
         XCTAssertEqual(try orchestrator1.directory.files().count, 1)
 
-        _ = try orchestrator2.getWritableFile(writeSize: 1, context: .mockAny())
+        _ = try orchestrator2.getWritableFile(writeSize: 1)
         XCTAssertEqual(try orchestrator2.directory.files().count, 2)
     }
 
@@ -141,27 +141,27 @@ class FilesOrchestratorTests: XCTestCase {
         )
 
         // write 1MB to first file (1MB of directory size in total)
-        let file1 = try orchestrator.getWritableFile(writeSize: oneMB, context: .mockAny())
+        let file1 = try orchestrator.getWritableFile(writeSize: oneMB)
         try file1.append(data: .mock(ofSize: oneMB))
 
         // write 1MB to second file (2MB of directory size in total)
-        let file2 = try orchestrator.getWritableFile(writeSize: oneMB, context: .mockAny())
+        let file2 = try orchestrator.getWritableFile(writeSize: oneMB)
         try file2.append(data: .mock(ofSize: oneMB))
 
         // write 1MB to third file (3MB of directory size in total)
-        let file3 = try orchestrator.getWritableFile(writeSize: oneMB + 1, context: .mockAny()) // +1 byte to exceed the limit
+        let file3 = try orchestrator.getWritableFile(writeSize: oneMB + 1) // +1 byte to exceed the limit
         try file3.append(data: .mock(ofSize: oneMB + 1))
 
         XCTAssertEqual(try orchestrator.directory.files().count, 3)
 
         // At this point, directory reached its maximum size.
         // Asking for the next file should purge the oldest one.
-        let file4 = try orchestrator.getWritableFile(writeSize: oneMB, context: .mockAny())
+        let file4 = try orchestrator.getWritableFile(writeSize: oneMB)
         XCTAssertEqual(try orchestrator.directory.files().count, 3)
         XCTAssertNil(try? orchestrator.directory.file(named: file1.name))
         try file4.append(data: .mock(ofSize: oneMB + 1))
 
-        _ = try orchestrator.getWritableFile(writeSize: oneMB, context: .mockAny())
+        _ = try orchestrator.getWritableFile(writeSize: oneMB)
         XCTAssertEqual(try orchestrator.directory.files().count, 3)
         XCTAssertNil(try? orchestrator.directory.file(named: file2.name))
     }
@@ -169,9 +169,9 @@ class FilesOrchestratorTests: XCTestCase {
     func testWhenNewWritableFileIsObtained_itAlwaysCreatesNewFile() throws {
         let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
 
-        let file1 = try orchestrator.getNewWritableFile(writeSize: 1, context: .mockAny())
-        let file2 = try orchestrator.getNewWritableFile(writeSize: 1, context: .mockAny())
-        let file3 = try orchestrator.getNewWritableFile(writeSize: 1, context: .mockAny())
+        let file1 = try orchestrator.getNewWritableFile(writeSize: 1)
+        let file2 = try orchestrator.getNewWritableFile(writeSize: 1)
+        let file3 = try orchestrator.getNewWritableFile(writeSize: 1)
 
         XCTAssertEqual(try orchestrator.directory.files().count, 3)
         XCTAssertNotEqual(file1.name, file2.name)
@@ -187,7 +187,7 @@ class FilesOrchestratorTests: XCTestCase {
         let orchestrator = configureOrchestrator(using: dateProvider)
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile(context: .mockAny()))
+        XCTAssertNil(orchestrator.getReadableFile())
     }
 
     func testWhenReadableFileIsOldEnough_itReturnsFile() throws {
@@ -197,7 +197,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertEqual(orchestrator.getReadableFile(context: .mockAny())?.name, file.name)
+        XCTAssertEqual(orchestrator.getReadableFile()?.name, file.name)
     }
 
     func testWhenReadableFileIsNotOldEnough_itReturnsNil() throws {
@@ -207,7 +207,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 0.5 * performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile(context: .mockAny()))
+        XCTAssertNil(orchestrator.getReadableFile())
     }
 
     func testWhenThereAreMultipleReadableFiles_itReturnsOldestFile() throws {
@@ -218,15 +218,15 @@ class FilesOrchestratorTests: XCTestCase {
         try fileNames.forEach { fileName in _ = try orchestrator.directory.createFile(named: fileName) }
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
-        XCTAssertEqual(orchestrator.getReadableFile(context: .mockAny())?.name, fileNames[0])
+        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[0])
         try orchestrator.directory.file(named: fileNames[0]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile(context: .mockAny())?.name, fileNames[1])
+        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[1])
         try orchestrator.directory.file(named: fileNames[1]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile(context: .mockAny())?.name, fileNames[2])
+        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[2])
         try orchestrator.directory.file(named: fileNames[2]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile(context: .mockAny())?.name, fileNames[3])
+        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[3])
         try orchestrator.directory.file(named: fileNames[3]).delete()
-        XCTAssertNil(orchestrator.getReadableFile(context: .mockAny()))
+        XCTAssertNil(orchestrator.getReadableFile())
     }
 
     func testsWhenThereAreMultipleReadableFiles_itReturnsFileByExcludingCertainNames() throws {
@@ -238,7 +238,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
         XCTAssertEqual(
-            orchestrator.getReadableFile(excludingFilesNamed: Set(fileNames[0...2]), context: .mockAny())?.name,
+            orchestrator.getReadableFile(excludingFilesNamed: Set(fileNames[0...2]))?.name,
             fileNames[3]
         )
     }
@@ -250,7 +250,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 2 * performance.maxFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile(context: .mockAny()))
+        XCTAssertNil(orchestrator.getReadableFile())
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
     }
 
@@ -263,7 +263,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        let readableFile = try orchestrator.getReadableFile(context: .mockAny()).unwrapOrThrow()
+        let readableFile = try orchestrator.getReadableFile().unwrapOrThrow()
         XCTAssertEqual(try orchestrator.directory.files().count, 1)
         orchestrator.delete(readableFile: readableFile)
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
@@ -309,6 +309,6 @@ extension FilesOrchestrator {
     func getReadableFile(
         context: DatadogContext
     ) -> ReadableFile? {
-        getReadableFile(excludingFilesNamed: [], context: context)
+        getReadableFile(excludingFilesNamed: [])
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -45,7 +45,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(try directory.files().count, 1)
-        let batch = reader.readNextBatch(context: .mockAny())
+        let batch = reader.readNextBatch()
 
         let expected = [
             Event(data: "ABCD".utf8Data, metadata: "EFGH".utf8Data)
@@ -84,7 +84,7 @@ class FileReaderTests: XCTestCase {
         )
 
         // When
-        let batch = reader.readNextBatch(context: .mockAny())
+        let batch = reader.readNextBatch()
 
         // Then
         let expected = [
@@ -125,19 +125,19 @@ class FileReaderTests: XCTestCase {
         ]
 
         var batch: Batch
-        batch = try reader.readNextBatch(context: .mockAny()).unwrapOrThrow()
+        batch = try reader.readNextBatch().unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[0])
         reader.markBatchAsRead(batch)
 
-        batch = try reader.readNextBatch(context: .mockAny()).unwrapOrThrow()
+        batch = try reader.readNextBatch().unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[1])
         reader.markBatchAsRead(batch)
 
-        batch = try reader.readNextBatch(context: .mockAny()).unwrapOrThrow()
+        batch = try reader.readNextBatch().unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[2])
         reader.markBatchAsRead(batch)
 
-        XCTAssertNil(reader.readNextBatch(context: .mockAny()))
+        XCTAssertNil(reader.readNextBatch())
         XCTAssertEqual(try directory.files().count, 0)
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -33,8 +33,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["key1": "value1"], metadata: ["meta1": "metaValue1"])
@@ -76,8 +75,7 @@ class FileWriterTests: XCTestCase {
                     "encrypted".utf8Data + data + "encrypted".utf8Data
                 }
             ),
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["key1": "value1"], metadata: ["meta1": "metaValue1"])
@@ -115,8 +113,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["key1": "value1"])
@@ -148,8 +145,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: true,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["key1": "value1"])
@@ -196,8 +192,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["key1": "value1"]) // will be written
@@ -230,8 +225,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: FailingEncodableMock(errorMessage: "failed to encode `FailingEncodable`."))
@@ -253,8 +247,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         writer.write(value: ["ok"]) // will create the file
@@ -285,8 +278,7 @@ class FileWriterTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         let ioInterruptionQueue = DispatchQueue(label: "com.datadohq.file-writer-random-io")
@@ -351,8 +343,7 @@ class FileWriterTests: XCTestCase {
             encryption: DataEncryptionMock(
                 encrypt: { _ in "foo".utf8Data }
             ),
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         // When

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -23,8 +23,7 @@ class DataUploadWorkerTests: XCTestCase {
         orchestrator: orchestrator,
         forceNewFile: false,
         encryption: nil,
-        telemetry: NOPTelemetry(),
-        context: .mockAny()
+        telemetry: NOPTelemetry()
     )
     lazy var reader = FileReader(
         orchestrator: orchestrator,

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -247,20 +247,20 @@ extension FeatureUpload {
 extension Reader {
     func markBatchAsRead(_ batch: Batch) {
         // We can ignore `reason` in most tests (used for sending metric), so we provide this convenience variant.
-        markBatchAsRead(batch, reason: .flushed, context: .mockAny())
+        markBatchAsRead(batch, reason: .flushed)
     }
 }
 
 extension FilesOrchestratorType {
     func delete(readableFile: ReadableFile) {
         // We can ignore `deletionReason` in most tests (used for sending metric), so we provide this convenience variant.
-        delete(readableFile: readableFile, deletionReason: .flushed, context: .mockAny())
+        delete(readableFile: readableFile, deletionReason: .flushed)
     }
 }
 
 class NOPReader: Reader {
-    func readNextBatch(context: DatadogContext) -> Batch? { nil }
-    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason, context: DatadogContext) {}
+    func readNextBatch() -> Batch? { nil }
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {}
 }
 
 internal class NOPFilesOrchestrator: FilesOrchestratorType {
@@ -274,10 +274,10 @@ internal class NOPFilesOrchestrator: FilesOrchestratorType {
 
     var performance: StoragePerformancePreset { StoragePerformanceMock.noOp }
 
-    func getNewWritableFile(writeSize: UInt64, context: DatadogContext) throws -> WritableFile { NOPFile() }
-    func getWritableFile(writeSize: UInt64, context: DatadogContext) throws -> WritableFile { NOPFile() }
-    func getReadableFile(excludingFilesNamed excludedFileNames: Set<String>, context: DatadogContext) -> ReadableFile? { NOPFile() }
-    func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason, context: DatadogContext) { }
+    func getNewWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
+    func getWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
+    func getReadableFile(excludingFilesNamed excludedFileNames: Set<String>) -> ReadableFile? { NOPFile() }
+    func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) { }
 
     var ignoreFilesAgeWhenReading = false
 }

--- a/DatadogCore/Tests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -39,8 +39,7 @@ class RUMEventFileOutputTests: XCTestCase {
             ),
             forceNewFile: false,
             encryption: nil,
-            telemetry: NOPTelemetry(),
-            context: .mockAny()
+            telemetry: NOPTelemetry()
         )
 
         let dataModel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": "value"]))

--- a/DatadogCore/Tests/TestsObserver/DatadogTestsObserver.swift
+++ b/DatadogCore/Tests/TestsObserver/DatadogTestsObserver.swift
@@ -113,6 +113,35 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             ```
             """
         ),
+        .init(
+            assert: { DatadogCoreProxy.referenceCount == 0 },
+            problem: "Leaking reference to `DatadogCoreProtocol`",
+            solution: """
+            There should be no remaining reference to `DatadogCoreProtocol` upon each test completion
+            but some instances of `DatadogCoreProxy` are still alive.
+
+            Make sure the instance of `DatadogCoreProxy` is properly managed in test:
+            - it must be allocated on each test start (e.g. in `setUp()` or directly in test)
+            - it must be flushed and deinitialized before test ends with `.flushAndTearDown()`
+            - it must be deallocated before test ends (e.g. in `tearDown()`)
+
+            If all above conditions are met, this failure might indicate a memory leak in the implementation.
+            """
+        ),
+        .init(
+            assert: { PassthroughCoreMock.referenceCount == 0 },
+            problem: "Leaking reference to `DatadogCoreProtocol`",
+            solution: """
+            There should be no remaining reference to `DatadogCoreProtocol` upon each test completion
+            but some instances of `PassthroughCoreMock` are still alive.
+
+            Make sure the instance of `PassthroughCoreMock` is properly managed in test:
+            - it must be allocated on each test test start (e.g. in `setUp()` or directly in test)
+            - it must be deallocated before test ends (e.g. in `tearDown()`)
+
+            If all above conditions are met, this failure might indicate a memory leak in the implementation.
+            """
+        )
     ]
 
     func testCaseDidFinish(_ testCase: XCTestCase) {


### PR DESCRIPTION
### What and why?

Reverts in background telemetry changes as they're likely to cause integrity checks flakyness.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
