### PR TITLE
Fix flakiness in `CrashContextProvider`

### DIFF
--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -50,6 +50,7 @@ class CrashContextProviderTests: XCTestCase {
         core.send(message: .context(context))
 
         // Then
+        crashContextProvider.flush()
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
@@ -73,6 +74,7 @@ class CrashContextProviderTests: XCTestCase {
         core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
 
         // Then
+        crashContextProvider.flush()
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
@@ -96,6 +98,7 @@ class CrashContextProviderTests: XCTestCase {
         core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
 
         // Then
+        crashContextProvider.flush()
         waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertNil(viewEvent)
     }
@@ -120,6 +123,7 @@ class CrashContextProviderTests: XCTestCase {
         core.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: sessionState))
 
         // Then
+        crashContextProvider.flush()
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
@@ -101,35 +101,35 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func updateRUMView(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async {
+        queue.async { [weak core] in
             do {
                 self.viewEvent = try baggage.decode(type: AnyCodable.self)
             } catch {
-                core.telemetry
+                core?.telemetry
                     .error("Fails to decode RUM view event from Crash Reporting", error: error)
             }
         }
     }
 
     private func resetRUMView(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async {
+        queue.async { [weak core] in
             do {
                 if try baggage.decode(type: Bool.self) {
                     self.viewEvent = nil
                 }
             } catch {
-                core.telemetry
+                core?.telemetry
                     .error("Fails to decode RUM view reset from Crash Reporting", error: error)
             }
         }
     }
 
     private func updateSessionState(with baggage: NewFeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async {
+        queue.async { [weak core] in
             do {
                 self.sessionState = try baggage.decode(type: AnyCodable.self)
             } catch {
-                core.telemetry
+                core?.telemetry
                     .error("Fails to decode RUM session state from Crash Reporting", error: error)
             }
         }


### PR DESCRIPTION
### What and why?

`CrashContextProviderTests` were flaky due to missing `flush`.

Additionally, we stop retaining the `core` by using `[weak core]` in the crash-context provider's queue.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
