### PR TITLE
RUM-966 fix: wrong `view.name` reported in RUM crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [IMPROVEMENT] Add UIBackgroundTask for uploading jobs. See [#1412][]
 - [IMPROVEMENT] Report Build Number in Logs and RUM. See [#1465][]
+- [BUGFIX] Fix wrong `view.name` reported in RUM crashes. See [#1488][]
 
 # 2.2.1 / 13-09-2023
 
@@ -528,6 +529,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1444]: https://github.com/DataDog/dd-sdk-ios/pull/1444
 [#1464]: https://github.com/DataDog/dd-sdk-ios/pull/1464
 [#1412]: https://github.com/DataDog/dd-sdk-ios/pull/1412
+[#1488]: https://github.com/DataDog/dd-sdk-ios/pull/1488
 [#1465]: https://github.com/DataDog/dd-sdk-ios/pull/1465
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -482,6 +482,10 @@ class CrashReportReceiverTests: XCTestCase {
             "The `RUMErrorEvent` sent must be linked to the same RUM Session as the last `RUMViewEvent`."
         )
 
+        XCTAssertEqual(sendRUMErrorEvent.model.view.name, lastRUMViewEvent.view.name, "It must include view attributes")
+        XCTAssertEqual(sendRUMErrorEvent.model.view.referrer, lastRUMViewEvent.view.referrer, "It must include view attributes")
+        XCTAssertEqual(sendRUMErrorEvent.model.view.url, lastRUMViewEvent.view.url, "It must include view attributes")
+
         XCTAssertNotNil(sendRUMErrorEvent.context, "It must contain context details")
         XCTAssertNotNil(lastRUMViewEvent.context, "It must contain context details")
 

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -372,6 +372,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             view: .init(
                 id: lastRUMView.view.id,
                 inForeground: nil,
+                name: lastRUMView.view.name,
                 referrer: lastRUMView.view.referrer,
                 url: lastRUMView.view.url
             )


### PR DESCRIPTION
### What and why?

📦 Fixes wrong `error.view.name` being reported in some RUM crashes.

| before | after |
|--------|-------|
| <img width="440" alt="before" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/5edada16-9420-4310-b46f-a6e3b696de5d"> | <img width="437" alt="after" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/316c8409-48c1-4e6b-8d71-50d96c65fd76"> |

### How?

The `view.name` information was not forwarded from the "previous RUM view (before crash)".

In case of `error.view.name` being empty, RUM BE fallbacks to other `view` properties, notably `view.url`, which may cause the wrong name being displayed.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
