### PR TITLE
chore: Fix build compatibility Xcode 13.4.1 (for nightly tests)

### DIFF
--- a/DatadogCore/Tests/Matchers/SRRequestMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SRRequestMatcher.swift
@@ -237,6 +237,6 @@ private extension String {
     var utf8Bytes: [UInt8] { [UInt8](utf8Data) }
 }
 
-private extension ArraySlice<UInt8> {
+private extension ArraySlice where Element == UInt8 {
     var utf8String: String { Data(Array(self)).utf8String }
 }


### PR DESCRIPTION
### What and why?

🧰 Fixing build compatibility for Xcode 13.4.1. We use that version for running nightly unit tests.

### How?

Fixed Swift syntax.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
