### PR TITLE
Change swift version to 5.7.1

### DIFF
--- a/DatadogAlamofireExtension.podspec
+++ b/DatadogAlamofireExtension.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogObjc.podspec
+++ b/DatadogObjc.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.deprecated_in_favor_of = "DatadogAlamofireExtension"
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version = '5.8.0'
+  s.swift_version = '5.7.1'
   s.ios.deployment_target = '11.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 import Foundation

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version      = '5.8.0'
+  s.swift_version      = '5.7.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/TestUtilities/Package.swift
+++ b/TestUtilities/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 

--- a/tools/api-surface/Fixtures/Package.swift
+++ b/tools/api-surface/Fixtures/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 

--- a/tools/api-surface/Package.swift
+++ b/tools/api-surface/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 

--- a/tools/rum-models-generator/Package.swift
+++ b/tools/rum-models-generator/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 

--- a/tools/sr-snapshots/Package.swift
+++ b/tools/sr-snapshots/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.0
+// swift-tools-version: 5.7.1
 
 import PackageDescription
 


### PR DESCRIPTION
### What and why?

Changes the swift version back to 5.7.1 to maintain compatibility with older Xcodes.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [x] Run tests for `tools/`
