### PR TITLE
RUM-1096 Fix os name in log events

### DIFF
--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -103,7 +103,7 @@ class CrashLogReceiverTests: XCTestCase {
             version: .mockRandom(),
             buildNumber: .mockRandom(),
             device: .mockWith(
-                name: mockOSName,
+                osName: mockOSName,
                 osVersion: mockOSVersion,
                 osBuildNumber: mockOSBuild,
                 architecture: mockArchitecture

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -212,7 +212,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
                 device: .init(architecture: deviceInfo.architecture)
             ),
             os: .init(
-                name: context.device.name,
+                name: context.device.osName,
                 version: context.device.osVersion,
                 build: context.device.osBuildNumber
             ),

--- a/DatadogLogs/Sources/Log/LogEventBuilder.swift
+++ b/DatadogLogs/Sources/Log/LogEventBuilder.swift
@@ -75,7 +75,7 @@ internal struct LogEventBuilder {
                 device: LogEvent.DeviceInfo(architecture: context.device.architecture)
             ),
             os: .init(
-                name: context.device.name,
+                name: context.device.osName,
                 version: context.device.osVersion,
                 build: context.device.osBuildNumber
             ),

--- a/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
@@ -22,6 +22,9 @@ class LogEventBuilderTests: XCTestCase {
         let randomService: String = .mockRandom()
         let randomLoggerName: String = .mockRandom()
         let randomThreadName: String = .mockRandom()
+        let randomOsName: String = .mockRandom()
+        let randomOsVersion: String = .mockRandom()
+        let randomOsBuildNumber: String = .mockRandom()
         let randomArchitecture: String = .mockRandom()
 
         // Given
@@ -43,6 +46,9 @@ class LogEventBuilderTests: XCTestCase {
             context: .mockWith(
                 serverTimeOffset: 0,
                 device: .mockWith(
+                    osName: randomOsName,
+                    osVersion: randomOsVersion,
+                    osBuildNumber: randomOsBuildNumber,
                     architecture: randomArchitecture
                 )
             ),
@@ -61,6 +67,9 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.loggerName, randomLoggerName)
             XCTAssertEqual(log.threadName, randomThreadName)
             XCTAssertEqual(log.dd.device.architecture, randomArchitecture)
+            XCTAssertEqual(log.os.name, randomOsName)
+            XCTAssertEqual(log.os.version, randomOsVersion)
+            XCTAssertEqual(log.os.build, randomOsBuildNumber)
 
             expectation.fulfill()
         }


### PR DESCRIPTION
### What and why?

Fixes OS name for log events.

**Before fix:**
<img width="319" alt="Screenshot 2023-09-26 at 16 19 33" src="https://github.com/DataDog/dd-sdk-ios/assets/6953112/691f18ea-f3f1-4467-960d-c20140a160d3">

**After fix:**
<img width="151" alt="Screenshot 2023-09-26 at 16 18 05" src="https://github.com/DataDog/dd-sdk-ios/assets/6953112/e0449c30-7775-4a32-b6ae-ceee5d27da46">

### How?

Change was quite simple. We should use osName instead of name from context.device.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
