### PR TITLE
RUM-1098 ci: update stack to Xcode 14.3

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -163,16 +163,16 @@ class DataBlockTests: XCTestCase {
         let stream = InputStream(url: url)!
         let reader = DataBlockReader(input: stream)
 
-        do {
-            _ = try reader.next()
-            XCTFail("Expected error to be thrown")
-        } catch DataBlockError.readOperationFailed(_, let error) {
-            XCTAssertEqual(
-                (error as? NSError)?.localizedDescription,
-                "The operation couldn’t be completed. No such file or directory"
-            )
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try reader.next()) { error in
+            guard case DataBlockError.readOperationFailed(streamStatus: _, streamError: let streamError) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+
+            guard let streamError = streamError else {
+                return XCTFail("Expected stream error")
+            }
+
+            XCTAssertTrue(streamError.localizedDescription.contains("No such file or directory"))
         }
     }
 }

--- a/tools/nightly-unit-tests/bitrise-nightly-unit-tests.yml
+++ b/tools/nightly-unit-tests/bitrise-nightly-unit-tests.yml
@@ -16,7 +16,7 @@ project_type: other
 #   This logic is implemented in Python (`generate_bitrise_yml.py`). It creates randomized Test Plan,
 #   installs missing simulators and generates another YML file: `bitrise.yml`, to execute the plan.
 # * The second part, defined in generated `bitrise.yml`, executes the Test Plan by running tests for given
-#   device and OS version. All is followed by sending Slack notification on the build status. 
+#   device and OS version. All is followed by sending Slack notification on the build status.
 #
 # The content of generated `bitrise.yml` file can be previewed in `bitrise.yml.src` template used by Python
 # script. The generated version is also attached to build artifacts.
@@ -42,12 +42,12 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            gem install xcode-install
+            brew install xcodesorg/made/xcodes
 
             # Record env logs before installing new simulators
             mkdir -p tools/nightly-unit-tests/env-logs
             xcrun simctl list --json > tools/nightly-unit-tests/env-logs/xcrun-simctl-list-before.json
-            xcversion simulators > tools/nightly-unit-tests/env-logs/xcversion-simulators-before
+            xcodes runtimes > tools/nightly-unit-tests/env-logs/xcodes-simulators-before
 
             # Read OS name or default to 'iOS'
             DD_OS_NAME="${DD_SIMULATOR_OS_NAME:-iOS}"
@@ -70,7 +70,7 @@ workflows:
 
             # Record env logs after installing new simulators
             xcrun simctl list --json > tools/nightly-unit-tests/env-logs/xcrun-simctl-list-after.json
-            xcversion simulators > tools/nightly-unit-tests/env-logs/xcversion-simulators-after
+            xcodes runtimes > tools/nightly-unit-tests/env-logs/xcodes-simulators-after
     - deploy-to-bitrise-io:
         inputs:
         - deploy_path: tools/nightly-unit-tests/bitrise.yml

--- a/tools/nightly-unit-tests/generate_bitrise_yml.py
+++ b/tools/nightly-unit-tests/generate_bitrise_yml.py
@@ -25,11 +25,11 @@ from src.semver import Version
 
 def get_environment() -> (Simulators, Runtimes, Devices):
     """
-    Uses `xcversion simulators` and `xcrun simctl` CLIs to load available
+    Uses `xcodes runtimes` and `xcrun simctl` CLIs to load available
     simulators, runtimes and devices.
     """
     simulators = Simulators(
-        xcversion_simulators_output=shell_output('xcversion simulators')
+        xcodes_runtimes_output=shell_output('xcodes runtimes')
     )
     runtimes = Runtimes(
         xcrun_simctl_list_runtimes_json_output=shell_output('xcrun simctl list runtimes --json')
@@ -76,9 +76,8 @@ def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
     else:
         for simulator in missing_simulators:
             start = time.time()
-            print(f' → xcversion simulators --install="{simulator.os_name} {simulator.os_version}"')
             if not dry_run:
-                print(shell_output(f'xcversion simulators --install="{simulator.os_name} {simulator.os_version}"'))
+                print(shell_output(f'sudo xcodes runtimes install "{simulator.os_name} {simulator.os_version}"'))
             else:
                 print(f' → skipping installation (dry-run mode enabled 🐞)')
             minutes_elapsed = datetime.timedelta(seconds=(time.time() - start))
@@ -128,7 +127,7 @@ def create_random_test_plan(os_name: str) -> TestPlan:
     simulators and running tests does not exceed Bitrise build limit.
     """
     supported_simulators = Simulators(
-        xcversion_simulators_output=shell_output('xcversion simulators')
+        xcodes_runtimes_output=shell_output('xcodes runtimes')
     )
     return TestPlan.create_randomized_plan(
         simulators=supported_simulators.get_all_simulators(os_name=os_name)
@@ -141,7 +140,7 @@ def create_test_plan(os_name: str, os_versions: [Version]) -> TestPlan:
     Missing simulators will be installed.
     """
     supported_simulators = Simulators(
-        xcversion_simulators_output=shell_output('xcversion simulators')
+        xcodes_runtimes_output=shell_output('xcodes runtimes')
     )
 
     simulators: [Simulator] = []

--- a/tools/nightly-unit-tests/src/utils.py
+++ b/tools/nightly-unit-tests/src/utils.py
@@ -16,22 +16,24 @@ def shell_output(command: str):
     :param command: shell command
     :return: command's STDOUT
     """
+    print(f'{command}')
     process = subprocess.run(
         args=[command],
         capture_output=True,
         shell=True,
         text=True  # capture STDOUT as text
     )
-    if process.returncode == 0:
-        return process.stdout
-    else:
-        raise Exception(
-            f'''
+    output = f'''
             Command {command} exited with status code {process.returncode}
             - STDOUT: {process.stdout if process.stdout != '' else '""'}
             - STDERR: {process.stderr if process.stderr != '' else '""'}
             '''
-        )
+    print(output)
+
+    if process.returncode == 0:
+        return process.stdout
+    else:
+        raise Exception(output)
 
 
 def shell(command: str):

--- a/tools/nightly-unit-tests/tests/test_simulators_parser.py
+++ b/tools/nightly-unit-tests/tests/test_simulators_parser.py
@@ -8,59 +8,87 @@ from src.semver import Version
 from src.simulators_parser import Simulators, Simulator
 
 
-mock_xcversion_simulators_output = """
-iOS 12.4 Simulator (installed)
-iOS 13.0 Simulator (not installed)
-watchOS 7.1 Simulator (installed)
-tvOS 13.3 Simulator (not installed)
-iOS 14.2 Simulator (not installed)
-iOS 15.0 Simulator (installed)
-watchOS 8.3 Simulator (not installed)
+mock_xcodes_runtimes_output = """
+-- iOS --
+iOS 13.2.2
+iOS 14.0.1 (Installed)
+iOS 16.1 (Bundled with selected Xcode)
+iOS 16.4 (Installed)
+iOS 17.0 (Installed)
+-- watchOS --
+watchOS 6.0
+watchOS 6.1.1
+watchOS 7.0
+watchOS 9.4 (Installed)
+watchOS 10.0
+-- tvOS --
+tvOS 12.4
+tvOS 16.0 (Installed)
+tvOS 16.1
+tvOS 16.4 (Installed)
+tvOS 17.0
+-- visionOS --
+visionOS 1.0
+
+Note: Bundled runtimes are indicated for the currently selected Xcode, more bundled runtimes may exist in other Xcode(s)
 """
 
-
 def test_get_all_simulators():
-    simulators = Simulators(mock_xcversion_simulators_output)
+    simulators = Simulators(mock_xcodes_runtimes_output)
 
     assert simulators.get_all_simulators(os_name='iOS') == [
-        Simulator(os_name='iOS', os_version=Version.parse('12.4'), is_installed=True),
-        Simulator(os_name='iOS', os_version=Version.parse('13.0'), is_installed=False),
-        Simulator(os_name='iOS', os_version=Version.parse('14.2'), is_installed=False),
-        Simulator(os_name='iOS', os_version=Version.parse('15.0'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('13.2.2'), is_installed=False),
+        Simulator(os_name='iOS', os_version=Version.parse('14.0.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.4'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('17.0'), is_installed=True),
     ]
     assert simulators.get_all_simulators(os_name='tvOS') == [
-        Simulator(os_name='tvOS', os_version=Version.parse('13.3'), is_installed=False),
+        Simulator(os_name='tvOS', os_version=Version.parse('12.4'), is_installed=False),
+        Simulator(os_name='tvOS', os_version=Version.parse('16.0'), is_installed=True),
+        Simulator(os_name='tvOS', os_version=Version.parse('16.1'), is_installed=False),
+        Simulator(os_name='tvOS', os_version=Version.parse('16.4'), is_installed=True),
+        Simulator(os_name='tvOS', os_version=Version.parse('17.0'), is_installed=False),
     ]
     assert simulators.get_all_simulators(os_name='watchOS') == [
-        Simulator(os_name='watchOS', os_version=Version.parse('7.1'), is_installed=True),
-        Simulator(os_name='watchOS', os_version=Version.parse('8.3'), is_installed=False),
+        Simulator(os_name='watchOS', os_version=Version.parse('6.0'), is_installed=False),
+        Simulator(os_name='watchOS', os_version=Version.parse('6.1.1'), is_installed=False),
+        Simulator(os_name='watchOS', os_version=Version.parse('7.0'), is_installed=False),
+        Simulator(os_name='watchOS', os_version=Version.parse('9.4'), is_installed=True),
+        Simulator(os_name='watchOS', os_version=Version.parse('10.0'), is_installed=False),
+    ]
+    assert simulators.get_all_simulators(os_name='visionOS') == [
+        Simulator(os_name='visionOS', os_version=Version.parse('1.0'), is_installed=False),
     ]
 
 
 def test_get_simulator():
-    simulators = Simulators(mock_xcversion_simulators_output)
+    simulators = Simulators(mock_xcodes_runtimes_output)
 
-    assert simulators.get_simulator(os_name='tvOS', os_version=Version.parse('13.3')) == \
-        Simulator(os_name='tvOS', os_version=Version.parse('13.3'), is_installed=False)
+    assert simulators.get_simulator(os_name='tvOS', os_version=Version.parse('12.4')) == \
+        Simulator(os_name='tvOS', os_version=Version.parse('12.4'), is_installed=False)
     assert simulators.get_simulator(os_name='tvOS', os_version=Version.parse('10.0')) == None
 
 
 def test_get_installed_simulators():
-    simulators = Simulators(mock_xcversion_simulators_output)
+    simulators = Simulators(mock_xcodes_runtimes_output)
 
     assert simulators.get_installed_simulators(os_name='iOS') == [
-        Simulator(os_name='iOS', os_version=Version.parse('12.4'), is_installed=True),
-        Simulator(os_name='iOS', os_version=Version.parse('15.0'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('14.0.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.4'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('17.0'), is_installed=True),
     ]
 
 
 def test_skipping_duplicates():
-    duplicated_output = mock_xcversion_simulators_output + '\n' + mock_xcversion_simulators_output
+    duplicated_output = mock_xcodes_runtimes_output + '\n' + mock_xcodes_runtimes_output
     simulators = Simulators(duplicated_output)
 
     assert simulators.get_all_simulators(os_name='iOS') == [
-        Simulator(os_name='iOS', os_version=Version.parse('12.4'), is_installed=True),
-        Simulator(os_name='iOS', os_version=Version.parse('13.0'), is_installed=False),
-        Simulator(os_name='iOS', os_version=Version.parse('14.2'), is_installed=False),
-        Simulator(os_name='iOS', os_version=Version.parse('15.0'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('13.2.2'), is_installed=False),
+        Simulator(os_name='iOS', os_version=Version.parse('14.0.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.1'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('16.4'), is_installed=True),
+        Simulator(os_name='iOS', os_version=Version.parse('17.0'), is_installed=True),
     ]


### PR DESCRIPTION
### What and why?

We want to build with Xcode 14.1 which is minimum version of supported Xcode for AppStore.

### How?

- Replace xcversion with xcodes.
- fix test cases

FAQs 
**Why not 14.1**
14.1 fails the CI for some unknown reason across the board, my hunch is due to CI visibility SDK but not confirmed.
failure
```
This Step failed, because it has not sent any output for 15m.
```

**Why not 14.2**
the only benefit that we get from 14.2 is to be able to install iOS 12 simulator but because bitrise runs this on Ventura, the Ventura version doesn't support iOS 12.4 simulator. Bummer.
```
The iOS 12.4 simulator runtime is not supported on hosts after macOS 12.99.0.
```
 **Why 14.3**
Our rest of the workflows run on 14.3 and it makes sense to match it if not below.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
