### PR TITLE
RUM-1197 fix: Passthrough Decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [IMPROVEMENT] Add UIBackgroundTask for uploading jobs. See [#1412][]
 - [IMPROVEMENT] Report Build Number in Logs and RUM. See [#1465][]
 - [BUGFIX] Fix wrong `view.name` reported in RUM crashes. See [#1488][]
+- [BUGFIX] Fix RUM sessions state propagation in Crash Reporting. See [#1498][]
 
 # 2.2.1 / 13-09-2023
 
@@ -533,6 +534,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1412]: https://github.com/DataDog/dd-sdk-ios/pull/1412
 [#1488]: https://github.com/DataDog/dd-sdk-ios/pull/1488
 [#1465]: https://github.com/DataDog/dd-sdk-ios/pull/1465
+[#1498]: https://github.com/DataDog/dd-sdk-ios/pull/1498
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -63,7 +63,7 @@ class CrashContextProviderTests: XCTestCase {
         let crashContextProvider = CrashContextCoreProvider()
         let core = PassthroughCoreMock(messageReceiver: crashContextProvider)
 
-        let viewEvent = AnyCodable(mockRandomAttributes())
+        let viewEvent: RUMViewEvent = .mockRandom()
 
         // When
         crashContextProvider.onCrashContextChange = {
@@ -86,7 +86,7 @@ class CrashContextProviderTests: XCTestCase {
         let crashContextProvider = CrashContextCoreProvider()
         let core = PassthroughCoreMock(messageReceiver: crashContextProvider)
 
-        var viewEvent: AnyCodable? = AnyCodable(mockRandomAttributes())
+        var viewEvent: AnyCodable? = nil
 
         // When
         crashContextProvider.onCrashContextChange = {
@@ -94,7 +94,10 @@ class CrashContextProviderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: viewEvent))
+        core.send(message: .baggage(key: RUMBaggageKeys.viewEvent, value: RUMViewEvent.mockRandom()))
+        crashContextProvider.flush()
+        XCTAssertNotNil(viewEvent)
+
         core.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
 
         // Then
@@ -112,7 +115,7 @@ class CrashContextProviderTests: XCTestCase {
         let crashContextProvider = CrashContextCoreProvider()
         let core = PassthroughCoreMock(messageReceiver: crashContextProvider)
 
-        let sessionState: AnyCodable? = AnyCodable(mockRandomAttributes())
+        let sessionState: RUMSessionState = .mockRandom()
 
         // When
         crashContextProvider.onCrashContextChange = {

--- a/DatadogInternal/Sources/Codable/AnyDecodable.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecodable.swift
@@ -93,7 +93,7 @@ extension _AnyDecodable {
             self.init(double)
         } else if let string = try? container.decode(String.self) {
             self.init(string)
-        } else if let passthrough = try? container.passthrough() {
+        } else if let passthrough = container.passthrough() {
             self.init(passthrough)
         } else if let array = try? container.decode([AnyDecodable].self) {
             self.init(array.map { $0.value })

--- a/DatadogInternal/Sources/Codable/AnyDecodable.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecodable.swift
@@ -93,6 +93,8 @@ extension _AnyDecodable {
             self.init(double)
         } else if let string = try? container.decode(String.self) {
             self.init(string)
+        } else if let container = container as? PassthroughValueDecodingContainer, let value = try? container.decodePassthrough() {
+            self.init(value)
         } else if let array = try? container.decode([AnyDecodable].self) {
             self.init(array.map { $0.value })
         } else if let dictionary = try? container.decode([String: AnyDecodable].self) {

--- a/DatadogInternal/Sources/Codable/AnyDecodable.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecodable.swift
@@ -93,8 +93,8 @@ extension _AnyDecodable {
             self.init(double)
         } else if let string = try? container.decode(String.self) {
             self.init(string)
-        } else if let container = container as? PassthroughValueDecodingContainer, let value = try? container.decodePassthrough() {
-            self.init(value)
+        } else if let passthrough = try? container.passthrough() {
+            self.init(passthrough)
         } else if let array = try? container.decode([AnyDecodable].self) {
             self.init(array.map { $0.value })
         } else if let dictionary = try? container.decode([String: AnyDecodable].self) {

--- a/DatadogInternal/Sources/Codable/AnyDecoder.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecoder.swift
@@ -864,18 +864,11 @@ extension SingleValueDecodingContainer {
     ///
     /// - returns: A passthrough value if any.
     /// - throws: `DecodingError.typeMismatch` if the value was not passthrough.
-    func passthrough() throws -> PassthroughAnyCodable {
+    func passthrough() -> PassthroughAnyCodable? {
         guard let container = self as? _AnyDecoder.SingleValueContainer else {
-            throw DecodingError.typeMismatch(PassthroughAnyCodable.self, DecodingError.Context(
-                codingPath: codingPath,
-                debugDescription: "Single Value Container cannot decode passthrough value."
-            ))
+            return nil
         }
 
-        guard let value = container.value as? PassthroughAnyCodable else {
-            throw DecodingError.typeMismatch(PassthroughAnyCodable.self, in: container)
-        }
-
-        return value
+        return container.value as? PassthroughAnyCodable
     }
 }

--- a/DatadogInternal/Sources/Codable/AnyDecoder.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecoder.swift
@@ -598,7 +598,7 @@ private class _AnyDecoder: Decoder {
 
     /// A container that can support the storage and direct decoding of a single
     /// nonkeyed value.
-    struct SingleValueContainer: SingleValueDecodingContainer, PassthroughValueDecodingContainer {
+    struct SingleValueContainer: SingleValueDecodingContainer {
         /// The path of coding keys taken to get to this point in encoding.
         let codingPath: [CodingKey]
 
@@ -777,17 +777,6 @@ private class _AnyDecoder: Decoder {
             return try T(from: decoder)
         }
 
-        /// Decodes a Passthrough value.
-        ///
-        /// - returns: Whether the encountered value was passthrough.
-        func decodePassthrough() throws -> PassthroughAnyCodable {
-            guard let value = value as? PassthroughAnyCodable else {
-                throw DecodingError.typeMismatch(PassthroughAnyCodable.self, in: self)
-            }
-
-            return value
-        }
-
         /// Converts value to any `BinaryInteger`.
         ///
         /// - Parameter type: The `BinaryInteger` to convert as.
@@ -868,9 +857,25 @@ private extension DecodingError {
     }
 }
 
-internal protocol PassthroughValueDecodingContainer where Self: SingleValueDecodingContainer {
-    /// Decodes a Passthrough value.
+extension SingleValueDecodingContainer {
+    /// Decodes a passthrough value of the given type.
     ///
-    /// - returns: Whether the encountered value was passthrough.
-    func decodePassthrough() throws -> PassthroughAnyCodable
+    /// This method can succeed only when using `AnyDecoder`.
+    ///
+    /// - returns: A passthrough value if any.
+    /// - throws: `DecodingError.typeMismatch` if the value was not passthrough.
+    func passthrough() throws -> PassthroughAnyCodable {
+        guard let container = self as? _AnyDecoder.SingleValueContainer else {
+            throw DecodingError.typeMismatch(PassthroughAnyCodable.self, DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "Single Value Container cannot decode passthrough value."
+            ))
+        }
+
+        guard let value = container.value as? PassthroughAnyCodable else {
+            throw DecodingError.typeMismatch(PassthroughAnyCodable.self, in: container)
+        }
+
+        return value
+    }
 }

--- a/DatadogInternal/Sources/Codable/AnyDecoder.swift
+++ b/DatadogInternal/Sources/Codable/AnyDecoder.swift
@@ -598,7 +598,7 @@ private class _AnyDecoder: Decoder {
 
     /// A container that can support the storage and direct decoding of a single
     /// nonkeyed value.
-    struct SingleValueContainer: SingleValueDecodingContainer {
+    struct SingleValueContainer: SingleValueDecodingContainer, PassthroughValueDecodingContainer {
         /// The path of coding keys taken to get to this point in encoding.
         let codingPath: [CodingKey]
 
@@ -777,6 +777,17 @@ private class _AnyDecoder: Decoder {
             return try T(from: decoder)
         }
 
+        /// Decodes a Passthrough value.
+        ///
+        /// - returns: Whether the encountered value was passthrough.
+        func decodePassthrough() throws -> PassthroughAnyCodable {
+            guard let value = value as? PassthroughAnyCodable else {
+                throw DecodingError.typeMismatch(PassthroughAnyCodable.self, in: self)
+            }
+
+            return value
+        }
+
         /// Converts value to any `BinaryInteger`.
         ///
         /// - Parameter type: The `BinaryInteger` to convert as.
@@ -855,4 +866,11 @@ private extension DecodingError {
 
         return .typeMismatch(type, context)
     }
+}
+
+internal protocol PassthroughValueDecodingContainer where Self: SingleValueDecodingContainer {
+    /// Decodes a Passthrough value.
+    ///
+    /// - returns: Whether the encountered value was passthrough.
+    func decodePassthrough() throws -> PassthroughAnyCodable
 }

--- a/DatadogInternal/Tests/Codable/AnyDecodableTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyDecodableTests.swift
@@ -47,12 +47,50 @@ class AnyDecodableTests: XCTestCase {
         let decoder = JSONDecoder()
         let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
 
-        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
+        XCTAssertEqual(dictionary["boolean"]?.value as? Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as? Int, 42)
         XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
-        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
-        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
-        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
-        XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+        XCTAssertEqual(dictionary["string"]?.value as? String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as? [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as? [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual(dictionary["null"]?.value as? NSNull, NSNull())
+    }
+
+    func testAnyDecoding() throws {
+        class Passthrough: PassthroughAnyCodable {
+            init() {}
+        }
+
+        let passthrough = Passthrough()
+
+        let any: [String: Any?] = [
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": [
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            ],
+            "null": nil,
+            "uuid": UUID(),
+            "url": URL(string: "https://test.com"),
+            "passthrough": passthrough
+        ]
+
+        let decoder = AnyDecoder()
+        let dictionary = try decoder.decode([String: AnyDecodable].self, from: any)
+
+        XCTAssertEqual(dictionary["boolean"]?.value as? Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as? Int, 42)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as? String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as? [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as? [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssert(dictionary["uuid"]?.value is UUID)
+        XCTAssertEqual(dictionary["url"]?.value as? URL, URL(string: "https://test.com"))
+        XCTAssert(dictionary["passthrough"]?.value as? Passthrough === passthrough)
     }
 }

--- a/DatadogInternal/Tests/Codable/AnyDecodableTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyDecodableTests.swift
@@ -93,4 +93,25 @@ class AnyDecodableTests: XCTestCase {
         XCTAssertEqual(dictionary["url"]?.value as? URL, URL(string: "https://test.com"))
         XCTAssert(dictionary["passthrough"]?.value as? Passthrough === passthrough)
     }
+
+    func testAnyDecodingFailue() throws {
+        class NotPassthrough {
+            init() {}
+        }
+
+        let passthrough = NotPassthrough()
+
+        let any: [String: Any?] = [
+            "passthrough": passthrough
+        ]
+
+        let decoder = AnyDecoder()
+        XCTAssertThrowsError(try decoder.decode(AnyDecodable.self, from: any)) { error in
+            guard case DecodingError.dataCorrupted(let context) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertEqual(context.debugDescription, "AnyDecodable value cannot be decoded")
+        }
+    }
 }

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -3979,16 +3979,16 @@ public class DDRUMViewEventDisplayScroll: NSObject {
         root.swiftModel.display!.scroll!.maxDepth as NSNumber
     }
 
-    @objc public var maxDepthScrollHeight: NSNumber {
-        root.swiftModel.display!.scroll!.maxDepthScrollHeight as NSNumber
-    }
-
     @objc public var maxDepthScrollTop: NSNumber {
         root.swiftModel.display!.scroll!.maxDepthScrollTop as NSNumber
     }
 
-    @objc public var maxDepthTime: NSNumber {
-        root.swiftModel.display!.scroll!.maxDepthTime as NSNumber
+    @objc public var maxScrollHeight: NSNumber {
+        root.swiftModel.display!.scroll!.maxScrollHeight as NSNumber
+    }
+
+    @objc public var maxScrollHeightTime: NSNumber {
+        root.swiftModel.display!.scroll!.maxScrollHeightTime as NSNumber
     }
 }
 
@@ -5544,4 +5544,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
+// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -1896,20 +1896,20 @@ public struct RUMViewEvent: RUMDataModel {
             /// Distance between the top and the lowest point reached on this view (in pixels)
             public let maxDepth: Double
 
-            /// Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)
-            public let maxDepthScrollHeight: Double
-
             /// Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)
             public let maxDepthScrollTop: Double
 
-            /// Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)
-            public let maxDepthTime: Double
+            /// Maximum page scroll height (total height) for this view (in pixels)
+            public let maxScrollHeight: Double
+
+            /// Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)
+            public let maxScrollHeightTime: Double
 
             enum CodingKeys: String, CodingKey {
                 case maxDepth = "max_depth"
-                case maxDepthScrollHeight = "max_depth_scroll_height"
                 case maxDepthScrollTop = "max_depth_scroll_top"
-                case maxDepthTime = "max_depth_time"
+                case maxScrollHeight = "max_scroll_height"
+                case maxScrollHeightTime = "max_scroll_height_time"
             }
         }
 
@@ -3398,4 +3398,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
+// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4


### PR DESCRIPTION
### What and why?

Transmitted a `PassthroughAnyCodable` property on the message-bus is failing when decoding it to `AnyDecodable`.
With the new `FeatureBaggage` introduced in #1442, the `RUMSessionState` decoding was failing on crash-reporting side.

> This is not resolving transmitting `nil` in core context.

### How?

Support decoding a `PassthroughAnyCodable` value in `AnyDecodable`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
