### PR TITLE
RUM-1197 fix: WebView Events Overwrite

### DIFF
--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -3979,16 +3979,16 @@ public class DDRUMViewEventDisplayScroll: NSObject {
         root.swiftModel.display!.scroll!.maxDepth as NSNumber
     }
 
-    @objc public var maxDepthScrollHeight: NSNumber {
-        root.swiftModel.display!.scroll!.maxDepthScrollHeight as NSNumber
-    }
-
     @objc public var maxDepthScrollTop: NSNumber {
         root.swiftModel.display!.scroll!.maxDepthScrollTop as NSNumber
     }
 
-    @objc public var maxDepthTime: NSNumber {
-        root.swiftModel.display!.scroll!.maxDepthTime as NSNumber
+    @objc public var maxScrollHeight: NSNumber {
+        root.swiftModel.display!.scroll!.maxScrollHeight as NSNumber
+    }
+
+    @objc public var maxScrollHeightTime: NSNumber {
+        root.swiftModel.display!.scroll!.maxScrollHeightTime as NSNumber
     }
 }
 
@@ -5544,4 +5544,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
+// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -1896,20 +1896,20 @@ public struct RUMViewEvent: RUMDataModel {
             /// Distance between the top and the lowest point reached on this view (in pixels)
             public let maxDepth: Double
 
-            /// Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)
-            public let maxDepthScrollHeight: Double
-
             /// Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)
             public let maxDepthScrollTop: Double
 
-            /// Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)
-            public let maxDepthTime: Double
+            /// Maximum page scroll height (total height) for this view (in pixels)
+            public let maxScrollHeight: Double
+
+            /// Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)
+            public let maxScrollHeightTime: Double
 
             enum CodingKeys: String, CodingKey {
                 case maxDepth = "max_depth"
-                case maxDepthScrollHeight = "max_depth_scroll_height"
                 case maxDepthScrollTop = "max_depth_scroll_top"
-                case maxDepthTime = "max_depth_time"
+                case maxScrollHeight = "max_scroll_height"
+                case maxScrollHeightTime = "max_scroll_height_time"
             }
         }
 
@@ -3398,4 +3398,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
+// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -77,7 +77,7 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
             }
             var event = event
 
-            if let date = event["date"] as? Int {
+            if let date = event["date"] as? Int64 {
                 let viewID = (event["view"] as? JSON)?["id"] as? String
                 let serverTimeOffsetInMs = self.getOffsetInMs(viewID: viewID, context: context)
                 let correctedDate = Int64(date) + serverTimeOffsetInMs
@@ -96,9 +96,9 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                 event["session"] = session
             }
 
-            if var dd = event["_dd"] as? JSON, var dd_sesion = dd["session"] as? [String: Int] {
-                dd_sesion["plan"] = 1
-                dd["session"] = dd_sesion
+            if var dd = event["_dd"] as? JSON, var dd_session = dd["session"] as? [String: Int64] {
+                dd_session["plan"] = 1
+                dd["session"] = dd_session
                 event["_dd"] = dd
             }
 

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -28,7 +28,10 @@ class WebViewEventReceiverTests: XCTestCase {
                     ]
                 ]
             ),
-            messageReceiver: WebViewEventReceiver.mockAny()
+            messageReceiver: WebViewEventReceiver(
+                dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+                commandSubscriber: mockCommandSubscriber
+            )
         )
     }
 
@@ -53,9 +56,10 @@ class WebViewEventReceiverTests: XCTestCase {
             "test": String.mockRandom()
         ]
 
-        core.send(
-            message: .baggage(key: WebViewEventReceiver.MessageKeys.browserEvent, value: AnyEncodable(sent))
-        )
+        core.send(message: .baggage(
+            key: WebViewEventReceiver.MessageKeys.browserEvent,
+            value: AnyEncodable(sent)
+        ))
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -65,11 +69,6 @@ class WebViewEventReceiverTests: XCTestCase {
     }
 
     func testWhenValidWebRUMEventPassed_itDecoratesAndPassesToCoreMessageBus() throws {
-        let receiver = WebViewEventReceiver(
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            commandSubscriber: mockCommandSubscriber
-        )
-
         let webRUMEvent: JSON = [
             "_dd": [
                 "session": ["plan": 2]
@@ -98,7 +97,10 @@ class WebViewEventReceiverTests: XCTestCase {
             "type": "action"
         ]
 
-        receiver.write(event: webRUMEvent, to: core)
+        core.send(message: .baggage(
+            key: WebViewEventReceiver.MessageKeys.browserEvent,
+            value: AnyEncodable(webRUMEvent)
+        ))
 
         let data = try JSONEncoder().encode(core.events.first as? AnyEncodable)
         let writtenJSON = try XCTUnwrap(try JSONSerialization.jsonObject(with: data, options: []) as? JSON)
@@ -110,11 +112,6 @@ class WebViewEventReceiverTests: XCTestCase {
 
     func testWhenValidWebRUMEventPassedWithoutRUMContext_itPassesToCoreMessageBus() throws {
         core.context.featuresAttributes = [:]
-
-        let receiver = WebViewEventReceiver(
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            commandSubscriber: mockCommandSubscriber
-        )
 
         let webRUMEvent: JSON = [
             "_dd": [
@@ -130,7 +127,10 @@ class WebViewEventReceiverTests: XCTestCase {
             "type": "action"
         ]
 
-        receiver.write(event: webRUMEvent, to: core)
+        core.send(message: .baggage(
+            key: WebViewEventReceiver.MessageKeys.browserEvent,
+            value: AnyEncodable(webRUMEvent)
+        ))
 
         let data = try JSONEncoder().encode(core.events.first as? AnyEncodable)
         let writtenJSON = try XCTUnwrap(try JSONSerialization.jsonObject(with: data, options: []) as? JSON)
@@ -141,17 +141,15 @@ class WebViewEventReceiverTests: XCTestCase {
     }
 
     func testWhenNativeSessionIsSampledOut_itPassesWebEventToWriter() throws {
-        let receiver = WebViewEventReceiver(
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            commandSubscriber: mockCommandSubscriber
-        )
-
         let webRUMEvent: JSON = [
             "new_key": "new_value",
             "type": "unknown"
         ]
 
-        receiver.write(event: webRUMEvent, to: core)
+        core.send(message: .baggage(
+            key: WebViewEventReceiver.MessageKeys.browserEvent,
+            value: AnyEncodable(webRUMEvent)
+        ))
 
         let data = try JSONEncoder().encode(core.events.first as? AnyEncodable)
         let writtenJSON = try XCTUnwrap(try JSONSerialization.jsonObject(with: data, options: []) as? JSON)
@@ -162,17 +160,15 @@ class WebViewEventReceiverTests: XCTestCase {
     }
 
     func testWhenUnknownWebRUMEventPassed_itPassesToCoreMessageBus() throws {
-        let receiver = WebViewEventReceiver(
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            commandSubscriber: mockCommandSubscriber
-        )
-
         let unknownWebRUMEvent: JSON = [
             "new_key": "new_value",
             "type": "unknown"
         ]
 
-        receiver.write(event: unknownWebRUMEvent, to: core)
+        core.send(message: .baggage(
+            key: WebViewEventReceiver.MessageKeys.browserEvent,
+            value: AnyEncodable(unknownWebRUMEvent)
+        ))
 
         let data = try JSONEncoder().encode(core.events.first as? AnyEncodable)
         let writtenJSON = try XCTUnwrap(try JSONSerialization.jsonObject(with: data, options: []) as? JSON)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
@@ -59,6 +59,7 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(browserViewEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
             XCTAssertEqual(browserViewEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
             XCTAssertEqual(browserViewEvent.source, .browser, "Webview events should use Browser SDK `source`")
+            XCTAssertEqual(browserViewEvent.dd.session?.plan, .plan1, "Webview events should use iOS SDK plan 1")
         }
         XCTAssertGreaterThan(browserView.resourceEvents.count, 0, "It should track some Webview resources")
         browserView.resourceEvents.forEach { browserResourceEvent in
@@ -66,6 +67,7 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(browserResourceEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
             XCTAssertEqual(browserResourceEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
             XCTAssertEqual(browserResourceEvent.source, .browser, "Webview events should use Browser SDK `source`")
+            XCTAssertEqual(browserResourceEvent.dd.session?.plan, .plan1, "Webview events should use iOS SDK plan 1")
         }
 
         // Get `LogMatchers`


### PR DESCRIPTION
### What and why?

#1433 broke Browser SDK event overwrite. The `AnyEncodable` did encoded integers to `Int64` but the the `WebViewEventReceiver` was still expected `Int`

### How?

As a quick fix and to release as part of `2.3.0`, the `WebViewEventReceiver` now expect `Int64`. But a more robust solution will be applied to `develop`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
