### PR TITLE
feat: Add internal `isEnabled` methods for Logs and RUM

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
 		49274907288048B800ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
+		49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */; };
+		49D8C0B82AC5D2160075E427 /* RUM+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */; };
+		49D8C0BD2AC5F2BB0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
+		49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */; };
 		61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */; };
 		61054E5E2A6EE10A00AAA894 /* EnrichedRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E052A6EE10A00AAA894 /* EnrichedRecord.swift */; };
@@ -1821,6 +1825,8 @@
 		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
+		49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUM+Internal.swift"; sourceTree = "<group>"; };
+		49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logs+Internal.swift"; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
 		61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundEventsViewController.swift; sourceTree = "<group>"; };
 		61054E052A6EE10A00AAA894 /* EnrichedRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrichedRecord.swift; sourceTree = "<group>"; };
@@ -5012,6 +5018,7 @@
 			isa = PBXGroup;
 			children = (
 				D2D30E5A2A40BF540020C553 /* Logs.swift */,
+				49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */,
 				D24C9C3E29A79772002057CF /* Logger.swift */,
 				D243BBEB29A614CE000B9CEC /* LoggerProtocol.swift */,
 				D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */,
@@ -5433,6 +5440,7 @@
 			isa = PBXGroup;
 			children = (
 				61C713B82A3C935C00FA735A /* RUM.swift */,
+				49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */,
 				61C713A02A3B78F900FA735A /* RUMMonitorProtocol.swift */,
 				61C713A22A3B78F900FA735A /* RUMMonitorProtocol+Convenience.swift */,
 				61C713A12A3B78F900FA735A /* RUMMonitorProtocol+Internal.swift */,
@@ -7756,6 +7764,7 @@
 				D243BBEC29A614CE000B9CEC /* LoggerProtocol.swift in Sources */,
 				D207319629A522F600ECBF94 /* ConsoleLogger.swift in Sources */,
 				D20731C529A528EC00ECBF94 /* LogEventSanitizer.swift in Sources */,
+				49D8C0BD2AC5F2BB0075E427 /* Logs+Internal.swift in Sources */,
 				D20731C429A528EC00ECBF94 /* LogFileOutput.swift in Sources */,
 				D207319529A522F600ECBF94 /* LogsFeature.swift in Sources */,
 				D242C29E2A14D6A6004B4980 /* RemoteLogger.swift in Sources */,
@@ -7795,6 +7804,7 @@
 				D243BBED29A614CE000B9CEC /* LoggerProtocol.swift in Sources */,
 				D20731A929A5279D00ECBF94 /* ConsoleLogger.swift in Sources */,
 				D20731CA29A528ED00ECBF94 /* LogEventSanitizer.swift in Sources */,
+				49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */,
 				D20731C929A528ED00ECBF94 /* LogFileOutput.swift in Sources */,
 				D20731AB29A5279D00ECBF94 /* LogsFeature.swift in Sources */,
 				D242C29F2A14D6A7004B4980 /* RemoteLogger.swift in Sources */,
@@ -7915,6 +7925,7 @@
 				D23F8E6B29DDCD28001CFAE8 /* RUMMonitor.swift in Sources */,
 				D23F8E6C29DDCD28001CFAE8 /* RUMContextProvider.swift in Sources */,
 				D23F8E6D29DDCD28001CFAE8 /* RUMViewIdentity.swift in Sources */,
+				49D8C0B82AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D23F8E6E29DDCD28001CFAE8 /* RUMViewsHandler.swift in Sources */,
 				61C713BA2A3C935C00FA735A /* RUM.swift in Sources */,
 				D23F8E6F29DDCD28001CFAE8 /* RequestBuilder.swift in Sources */,
@@ -8166,6 +8177,7 @@
 				D29A9F6329DD85BB005C54A4 /* RUMMonitor.swift in Sources */,
 				D29A9F7029DD85BB005C54A4 /* RUMContextProvider.swift in Sources */,
 				D29A9F6029DD85BB005C54A4 /* RUMViewIdentity.swift in Sources */,
+				49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D29A9F7629DD85BB005C54A4 /* RUMViewsHandler.swift in Sources */,
 				61C713B92A3C935C00FA735A /* RUM.swift in Sources */,
 				D29A9F7929DD85BB005C54A4 /* RequestBuilder.swift in Sources */,

--- a/DatadogLogs/Sources/Logs+Internal.swift
+++ b/DatadogLogs/Sources/Logs+Internal.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2023-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension Logs: InternalExtended {}
+
+extension InternalExtension where ExtendedType == Logs {
+    /// Check whether `Logs` has been enabled for a specific SDK instance.
+    /// 
+    /// - Parameters:
+    ///    - in: the core to check
+    ///
+    /// - Returns: true if `Logs` has been enabled for the supplied core.
+    public static func isEnabled(in core: DatadogCoreProtocol = CoreRegistry.default) -> Bool {
+        return core.get(feature: LogsFeature.self) != nil
+    }
+}

--- a/DatadogLogs/Tests/LogsTests.swift
+++ b/DatadogLogs/Tests/LogsTests.swift
@@ -20,6 +20,25 @@ class LogsTests: XCTestCase {
         XCTAssertNil(config.customEndpoint)
     }
 
+    func testWhenNotEnabled_thenLogsIsEnabledIsFalse() {
+        // When
+        let core = FeatureRegistrationCoreMock()
+        XCTAssertNil(core.get(feature: LogsFeature.self))
+
+        // Then
+        XCTAssertFalse(Logs._internal.isEnabled(in: core))
+    }
+
+    func testWhenEnabled_thenLogsIsEnabledIsTrue() {
+        // When
+        let core = FeatureRegistrationCoreMock()
+        let config = Logs.Configuration()
+        Logs.enable(with: config, in: core)
+
+        // Then
+        XCTAssertTrue(Logs._internal.isEnabled(in: core))
+    }
+
     func testConfigurationOverrides() throws {
         // Given
         let customEndpoint: URL = .mockRandom()

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2023-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension RUM: InternalExtended {}
+
+extension InternalExtension where ExtendedType == RUM {
+    /// Check whether `RUM` has been enabled for a specific SDK instance.
+    ///
+    /// - Parameters:
+    ///    - in: the core to check
+    ///
+    /// - Returns: true if `RUM` has been enabled for the supplied core.
+    public static func isEnabled(in core: DatadogCoreProtocol = CoreRegistry.default) -> Bool {
+        return core.get(feature: RUMFeature.self) != nil
+    }
+}

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -33,6 +33,14 @@ class RUMTests: XCTestCase {
         XCTAssertTrue(RUMMonitor.shared(in: core) is NOPMonitor)
     }
 
+    func testWhenNotEnabled_thenRumIsEnabledIsFalse() {
+        // When
+        XCTAssertNil(core.get(feature: RUMFeature.self))
+
+        // Then
+        XCTAssertFalse(RUM._internal.isEnabled(in: core))
+    }
+
     func testWhenEnabledInNOPCore_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
@@ -55,6 +63,15 @@ class RUMTests: XCTestCase {
 
         // Then
         XCTAssertTrue(RUMMonitor.shared(in: core) is Monitor)
+    }
+
+    func testWhenEnabled_thenRumIsEnabledIsTrue() {
+        // When
+        RUM.enable(with: config, in: core)
+        XCTAssertNotNil(core.get(feature: RUMFeature.self))
+
+        // Then
+        XCTAssertTrue(RUM._internal.isEnabled(in: core))
     }
 
     // MARK: - Configuration Tests


### PR DESCRIPTION
### What and why?

Adding methods to internal interfaces for the `RUM` and `Logs` structs to determine if the feature is enabled in a particular core.  These are needed for Flutter to correctly initialize RUM and Logs in `attachToExisting` scenarios.

refs: RUM-1066

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
