### PR TITLE
Fix `RUMMonitorTests` flakiness

### DIFF
--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -87,7 +87,10 @@ class RUMMonitorTests: XCTestCase {
         monitor.startResource(resourceKey: "/resource/1", request: .mockWith(httpMethod: "GET"))
         monitor.stopResource(resourceKey: "/resource/1", response: .mockWith(statusCode: 200, mimeType: "image/png"))
 
-        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers().filterApplicationLaunchView()
+        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
+            .filterApplicationLaunchView()
+            .filterTelemetry()
+
         verifyGlobalAttributes(in: rumEventMatchers)
         try rumEventMatchers[0].model(ofType: RUMViewEvent.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 0)
@@ -307,7 +310,10 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopResource(resourceKey: "/resource/2", response: .mockWith(statusCode: 202))
         monitor.stopAction(type: .scroll)
 
-        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers().filterApplicationLaunchView()
+        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
+            .filterApplicationLaunchView()
+            .filterTelemetry()
+
         verifyGlobalAttributes(in: rumEventMatchers)
         try rumEventMatchers[0].model(ofType: RUMViewEvent.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 0)
@@ -1115,7 +1121,10 @@ class RUMMonitorTests: XCTestCase {
         monitor.startView(viewController: mockView, attributes: randomViewEventAttributes)
 
         // Then
-        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers().filterApplicationLaunchView()
+        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
+            .filterApplicationLaunchView()
+            .filterTelemetry()
+
         let lastRUMViewEventSent: RUMViewEvent = try rumEventMatchers[0].model()
 
         let currentLastRUMViewEventSent = try XCTUnwrap(crashReporter.crashContextProvider.currentCrashContext?.lastRUMViewEvent)


### PR DESCRIPTION
### What and why?

RUM monitor tests would fail when Configuration telemetry is sent during the test.

### How?

Filter out Telemetry events when the test look for sequence of raw events.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
