### PR TITLE
RUM-1188 Add "consent" attribute to batch telemetry

### DIFF
--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -41,6 +41,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
     struct MetricsData {
         /// The name of the track reported for this orchestrator.
         let trackName: String
+        /// The label indicating the value of tracking consent that this orchestrator manages files for.
+        let consentLabel: String
         /// The preset for uploader performance in this feature to include in metric.
         let uploaderPerformance: UploadPerformancePreset
     }
@@ -252,6 +254,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                     BatchDeletedMetric.uploaderDelayMinKey: metricsData.uploaderPerformance.minUploadDelay.toMilliseconds,
                     BatchDeletedMetric.uploaderDelayMaxKey: metricsData.uploaderPerformance.maxUploadDelay.toMilliseconds,
                 ],
+                BatchMetric.consentKey: metricsData.consentLabel,
                 BatchDeletedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
                 BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
@@ -276,6 +279,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
             attributes: [
                 BatchMetric.typeKey: BatchClosedMetric.typeValue,
                 BatchMetric.trackKey: metricsData.trackName,
+                BatchMetric.consentKey: metricsData.consentLabel,
                 BatchClosedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
                 BatchClosedMetric.batchSizeKey: lastWritableFileApproximatedSize,
                 BatchClosedMetric.batchEventsCountKey: lastWritableFileObjectsCount,

--- a/DatadogCore/Sources/Utils/CoreMetrics.swift
+++ b/DatadogCore/Sources/Utils/CoreMetrics.swift
@@ -23,6 +23,13 @@ internal enum BatchMetric {
         default:                return nil
         }
     }
+    /// Consent label key.
+    /// It is added to differentiate telemetries for batches handled in `pending` and `granted` consents.
+    static let consentKey = "consent"
+    /// "granted" consent value.
+    static let consentGrantedValue = "granted"
+    /// "pending" consent value.
+    static let consentPendingValue = "pending"
 }
 
 /// Definition of "Batch Deleted" telemetry.

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -35,7 +35,11 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             performance: PerformancePreset.combining(storagePerformance: storage, uploadPerformance: upload),
             dateProvider: dateProvider,
             telemetry: telemetry,
-            metricsData: .init(trackName: "track name", uploaderPerformance: upload)
+            metricsData: FilesOrchestrator.MetricsData(
+                trackName: "track name",
+                consentLabel: "consent value",
+                uploaderPerformance: upload
+            )
         )
     }
 
@@ -57,6 +61,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         DDAssertReflectionEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
+            "consent": "consent value",
             "uploader_delay": [
                 "min": upload.minUploadDelay.toMilliseconds,
                 "max": upload.maxUploadDelay.toMilliseconds
@@ -85,6 +90,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         DDAssertReflectionEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
+            "consent": "consent value",
             "uploader_delay": [
                 "min": upload.minUploadDelay.toMilliseconds,
                 "max": upload.maxUploadDelay.toMilliseconds
@@ -116,6 +122,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         DDAssertReflectionEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
+            "consent": "consent value",
             "uploader_delay": [
                 "min": upload.minUploadDelay.toMilliseconds,
                 "max": upload.maxUploadDelay.toMilliseconds
@@ -150,6 +157,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         DDAssertReflectionEqual(metric.attributes, [
             "metric_type": "batch closed",
             "track": "track name",
+            "consent": "consent value",
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "batch_size": expectedWrites.reduce(0, +),
             "batch_events_count": expectedWrites.count,
@@ -180,6 +188,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         DDAssertReflectionEqual(metric.attributes, [
             "metric_type": "batch closed",
             "track": "track name",
+            "consent": "consent value",
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "batch_size": expectedWrites.reduce(0, +),
             "batch_events_count": expectedWrites.count,


### PR DESCRIPTION
### What and why?

📦 This PR adds observability to batches closed and deleted during `.pending` [Tracking Consent](https://swiftpackageindex.com/datadog/dd-sdk-ios/develop/documentation/datadogcore/trackingconsent). Previously, only `.granted` batches were counted in mobile metrics. To differentiate the value of consent, we add a new attribute:
```
consent: granted | pending
```

Lack of observability in `.pending` state might explain skews in volumes of "deleted" vs "closed" events (56% vs 44%). If batch was completed during `.pending` but sent in `.granted` consent, we would get "batch deleted" with no matching "batch closed".

### How?

* Enabled batching metrics for unauthorized orchestrator (the one managing `.pending` batches).
* Added new attribute to each telemetry.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
