### PR TITLE
Expose interfaces to add custom SR node recorders

### DIFF
--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -43,7 +43,8 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
         let recorder = try Recorder(
             processor: processor,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            additionalNodeRecorders: configuration.additionalNodeRecorders
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,

--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -7,7 +7,7 @@
 #if os(iOS)
 import Foundation
 
-internal protocol TextObfuscating {
+public protocol TextObfuscating {
     /// Obfuscates given `text`.
     /// - Parameter text: the text to be obfuscated
     /// - Returns: obfuscated text

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreGraphics
 import UIKit
 
-internal typealias WireframeID = NodeID
+public typealias WireframeID = NodeID
 
 /// Builds the actual wireframes from VTS snapshots (produced by `Recorder`) to be later transported in SR
 /// records (see `RecordsBuilder`) within SR segments (see `SegmentBuilder`).
@@ -17,7 +17,7 @@ internal typealias WireframeID = NodeID
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-internal class WireframesBuilder {
+public class WireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.
@@ -86,7 +86,7 @@ internal class WireframesBuilder {
         return .imageWireframe(value: wireframe)
     }
 
-    func createTextWireframe(
+    public func createTextWireframe(
         id: WireframeID,
         frame: CGRect,
         text: String,

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -5,10 +5,10 @@
  */
 
 #if os(iOS)
-internal typealias PrivacyLevel = SessionReplay.Configuration.PrivacyLevel
+public typealias PrivacyLevel = SessionReplay.Configuration.PrivacyLevel
 
 /// Text obfuscation strategies for different text types.
-internal extension SessionReplay.Configuration.PrivacyLevel {
+public extension SessionReplay.Configuration.PrivacyLevel {
     /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Sensitive Text" is:

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -18,11 +18,11 @@ internal protocol Recording {
 /// It instruments running application by observing current window(s) and
 /// captures intermediate representation of the view hierarchy. This representation
 /// is later passed to `Processor` and turned into wireframes uploaded to the BE.
-internal class Recorder: Recording {
+public class Recorder: Recording {
     /// The context of recording next snapshot.
-    struct Context: Equatable {
+    public struct Context: Equatable {
         /// The content recording policy from the moment of requesting snapshot.
-        let privacy: PrivacyLevel
+        public let privacy: PrivacyLevel
         /// Current RUM application ID - standard UUID string, lowecased.
         let applicationID: String
         /// Current RUM session ID - standard UUID string, lowecased.
@@ -64,12 +64,13 @@ internal class Recorder: Recording {
 
     convenience init(
         processor: Processing,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        additionalNodeRecorders: [NodeRecorder]?
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder()
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: additionalNodeRecorders)
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(
             windowObserver: windowObserver

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
-internal typealias NodeID = Int64
+public typealias NodeID = Int64
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -18,7 +18,7 @@ internal typealias NodeID = Int64
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-internal final class NodeIDGenerator {
+public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID
@@ -34,7 +34,7 @@ internal final class NodeIDGenerator {
     /// - Parameter view: the `UIView` object
     /// - Parameter nodeRecorder: the `NodeRecorder` responsible for recording `UIView`
     /// - Returns: the `NodeID` of queried instance
-    func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
+    public func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
         if let currentID = view.nodeID?[nodeRecorder.identifier] {
             return currentID
         } else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -11,7 +11,7 @@ import UIKit
 /// recognise specialised subclasses of `UIView` and record their semantics accordingly.
 ///
 /// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
-internal protocol NodeRecorder {
+public protocol NodeRecorder {
     /// Finds the semantic of given`view`.
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
@@ -29,7 +29,7 @@ internal protocol NodeRecorder {
 /// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
 ///
 /// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
-internal protocol NodeWireframesBuilder {
+public protocol NodeWireframesBuilder {
     /// The frame of produced wireframe in screen coordinates.
     var wireframeRect: CGRect { get }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,13 +12,13 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-internal struct ViewTreeRecordingContext {
+public struct ViewTreeRecordingContext {
     /// The context of the Recorder.
-    let recorder: Recorder.Context
+    public let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.
     let coordinateSpace: UICoordinateSpace
     /// Generates stable IDs for traversed views.
-    let ids: NodeIDGenerator
+    public let ids: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
     /// Variable view controller related context

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -35,54 +35,59 @@ internal struct ViewTreeSnapshot {
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
-internal struct Node {
+public struct Node {
     /// Attributes of the `UIView` that this node was created for.
     let viewAttributes: ViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
     let wireframesBuilder: NodeWireframesBuilder
+    
+    public init(viewAttributes: ViewAttributes, wireframesBuilder: NodeWireframesBuilder) {
+        self.viewAttributes = viewAttributes
+        self.wireframesBuilder = wireframesBuilder
+    }
 }
 
 /// Attributes of the `UIView` that the node was created for.
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-internal struct ViewAttributes: Equatable {
+public struct ViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
-    let frame: CGRect
+    public let frame: CGRect
 
-    /// Original view's `.backgorundColor`.
-    let backgroundColor: CGColor?
+    /// Original view's `.backgroundColor`.
+    public let backgroundColor: CGColor?
 
     /// Original view's `layer.borderColor`.
-    let layerBorderColor: CGColor?
+    public let layerBorderColor: CGColor?
 
     /// Original view's `layer.borderWidth`.
-    let layerBorderWidth: CGFloat
+    public let layerBorderWidth: CGFloat
 
     /// Original view's `layer.cornerRadius`.
-    let layerCornerRadius: CGFloat
+    public let layerCornerRadius: CGFloat
 
     /// Original view's `.alpha` (between `0.0` and `1.0`).
-    let alpha: CGFloat
+    public let alpha: CGFloat
 
     /// Original view's `.isHidden`.
-    let isHidden: Bool
+    public let isHidden: Bool
 
     /// Original view's `.intrinsicContentSize`.
-    let intrinsicContentSize: CGSize
+    public let intrinsicContentSize: CGSize
 
     /// If the view is technically visible (different than `!isHidden` because it also considers `alpha` and `frame != .zero`).
     /// A view can be technically visible, but it may have no appearance in practise (e.g. if its colors use `0` alpha component).
     ///
     /// Example 1: A view is invisible if it has `.zero` size or it is fully transparent (`alpha == 0`).
     /// Example 2: A view can be visible if it has fully transparent background color, but its `alpha` is `0.5` or it occupies non-zero area.
-    var isVisible: Bool { !isHidden && alpha > 0 && frame != .zero }
+    public var isVisible: Bool { !isHidden && alpha > 0 && frame != .zero }
 
     /// If the view has any visible appearance (considering: background color + border style).
     /// In other words: if this view brings anything visual.
     ///
     /// Example: A view might have no appearance if it has `0` border width and transparent fill color.
-    var hasAnyAppearance: Bool {
+    public var hasAnyAppearance: Bool {
         let borderAlpha = layerBorderColor?.alpha ?? 0
         let hasBorderAppearance = layerBorderWidth > 0 && borderAlpha > 0
 
@@ -96,7 +101,7 @@ internal struct ViewAttributes: Equatable {
     ///
     /// Example 1: A view with blue background of alpha `0.5` is considered "translucent".
     /// Example 2: A view with blue semi-transparent background, but alpha `1` is also conisdered "translucent".
-    var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
+    public var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
 
 extension ViewAttributes {
@@ -132,7 +137,7 @@ extension ViewAttributes {
 /// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
 /// assumption that is not met).
-internal protocol NodeSemantics {
+public protocol NodeSemantics {
     /// The severity of this semantic.
     ///
     /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
@@ -154,7 +159,7 @@ extension NodeSemantics {
 }
 
 /// Strategies for handling node's subtree by `Recorder`.
-internal enum NodeSubtreeStrategy {
+public enum NodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be
@@ -184,10 +189,10 @@ internal struct UnknownElement: NodeSemantics {
 /// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// Unlike `IgnoredElement`, this semantics can be overwritten with another one with higher importance. This means that even
 /// if the root view of certain element has no appearance, other node recorders will continue checking it for strictkier semantics.
-internal struct InvisibleElement: NodeSemantics {
-    static let importance: Int = 0
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node] = []
+public struct InvisibleElement: NodeSemantics {
+    public static let importance: Int = 0
+    public let subtreeStrategy: NodeSubtreeStrategy
+    public let nodes: [Node] = []
 
     /// Use `InvisibleElement.constant` instead.
     private init () {
@@ -199,7 +204,7 @@ internal struct InvisibleElement: NodeSemantics {
     }
 
     /// A constant value of `InvisibleElement` semantics.
-    static let constant = InvisibleElement()
+    public static let constant = InvisibleElement()
 }
 
 /// A semantics of an UI element that should be ignored when traversing view-tree. Unlike `InvisibleElement` this semantics cannot
@@ -223,9 +228,14 @@ internal struct AmbiguousElement: NodeSemantics {
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
 /// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
 /// "on" / "off" state of `UISwitch` control).
-internal struct SpecificElement: NodeSemantics {
-    static let importance: Int = .max
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node]
+public struct SpecificElement: NodeSemantics {
+    public static let importance: Int = .max
+    public let subtreeStrategy: NodeSubtreeStrategy
+    public let nodes: [Node]
+    
+    public init(subtreeStrategy: NodeSubtreeStrategy, nodes: [Node]) {
+        self.subtreeStrategy = subtreeStrategy
+        self.nodes = nodes
+    }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -44,9 +44,9 @@ internal struct ViewTreeSnapshotBuilder {
 }
 
 extension ViewTreeSnapshotBuilder {
-    init() {
+    init(additionalNodeRecorders: [NodeRecorder]? = nil) {
         self.init(
-            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders() + (additionalNodeRecorders ?? [])),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: ImageDataProvider()
         )

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -46,6 +46,8 @@ extension SessionReplay {
         // MARK: - Internal
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
+        
+        public var additionalNodeRecorders: [NodeRecorder]?
 
         /// Creates Session Replay configuration
         /// - Parameters:
@@ -55,11 +57,13 @@ extension SessionReplay {
         public init(
             replaySampleRate: Float,
             defaultPrivacyLevel: PrivacyLevel = .mask,
-            customEndpoint: URL? = nil
+            customEndpoint: URL? = nil,
+            additionalNodeRecorders: [NodeRecorder]? = nil
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
             self.customEndpoint = customEndpoint
+            self.additionalNodeRecorders = additionalNodeRecorders
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels+UIKit.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels+UIKit.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension SRTextPosition.Alignment {
     /// Custom initializer that allows transforming UIKit's `NSTextAlignment` into `SRTextPosition.Alignment`.
-    init(
+    public init(
         systemTextAlignment: NSTextAlignment,
         vertical: SRTextPosition.Alignment.Vertical = .center
     ) {

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -110,24 +110,31 @@ internal struct SRShapeBorder: Codable, Hashable {
 }
 
 /// Schema of clipping information for a Wireframe.
-internal struct SRContentClip: Codable, Hashable {
+public struct SRContentClip: Codable, Hashable {
     /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
-    internal let bottom: Int64?
+    public let bottom: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
-    internal let left: Int64?
+    public let left: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
-    internal let right: Int64?
+    public let right: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
-    internal let top: Int64?
+    public let top: Int64?
 
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case bottom = "bottom"
         case left = "left"
         case right = "right"
         case top = "top"
+    }
+    
+    public init(bottom: Int64?, left: Int64?, right: Int64?, top: Int64?) {
+        self.bottom = bottom
+        self.left = left
+        self.right = right
+        self.top = top
     }
 }
 
@@ -150,7 +157,7 @@ internal struct SRShapeStyle: Codable, Hashable {
 }
 
 /// Schema of all properties of a ShapeWireframe.
-internal struct SRShapeWireframe: Codable, Hashable {
+public struct SRShapeWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
     internal let border: SRShapeBorder?
 
@@ -192,7 +199,7 @@ internal struct SRShapeWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a TextPosition.
-internal struct SRTextPosition: Codable, Hashable {
+public struct SRTextPosition: Codable, Hashable {
     internal let alignment: Alignment?
 
     internal let padding: Padding?
@@ -202,7 +209,7 @@ internal struct SRTextPosition: Codable, Hashable {
         case padding = "padding"
     }
 
-    internal struct Alignment: Codable, Hashable {
+    public struct Alignment: Codable, Hashable {
         /// The horizontal text alignment. The default value is `left`.
         internal let horizontal: Horizontal?
 
@@ -222,7 +229,7 @@ internal struct SRTextPosition: Codable, Hashable {
         }
 
         /// The vertical text alignment. The default value is `top`.
-        internal enum Vertical: String, Codable {
+        public enum Vertical: String, Codable {
             case top = "top"
             case bottom = "bottom"
             case center = "center"
@@ -270,7 +277,7 @@ internal struct SRTextStyle: Codable, Hashable {
 }
 
 /// Schema of all properties of a TextWireframe.
-internal struct SRTextWireframe: Codable, Hashable {
+public struct SRTextWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
     internal let border: SRShapeBorder?
 
@@ -324,7 +331,7 @@ internal struct SRTextWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a ImageWireframe.
-internal struct SRImageWireframe: Codable, Hashable {
+public struct SRImageWireframe: Codable, Hashable {
     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
     internal var base64: String?
 
@@ -378,7 +385,7 @@ internal struct SRImageWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a PlaceholderWireframe.
-internal struct SRPlaceholderWireframe: Codable, Hashable {
+public struct SRPlaceholderWireframe: Codable, Hashable {
     /// Schema of clipping information for a Wireframe.
     internal let clip: SRContentClip?
 
@@ -416,7 +423,7 @@ internal struct SRPlaceholderWireframe: Codable, Hashable {
 }
 
 /// Schema of a Wireframe type.
-internal enum SRWireframe: Codable {
+public enum SRWireframe: Codable {
     case shapeWireframe(value: SRShapeWireframe)
     case textWireframe(value: SRTextWireframe)
     case imageWireframe(value: SRImageWireframe)
@@ -424,7 +431,7 @@ internal enum SRWireframe: Codable {
 
     // MARK: - Codable
 
-    internal func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         // Encode only the associated value, without encoding enum case
         var container = encoder.singleValueContainer()
 
@@ -440,7 +447,7 @@ internal enum SRWireframe: Codable {
         }
     }
 
-    internal init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         // Decode enum case from associated value
         let container = try decoder.singleValueContainer()
 


### PR DESCRIPTION
### What and why?

_This is a draft PR to get feedback on the implementation and possible improvements._

The goal of the feature is to enable cross-platform SDKs to add custom `NodeRecorder`s to the Session Replay configuration to map against custom elements and improve the support for these.
The feature in itself is in 2 parts: 
- adding the `additionalNodeRecorders` field and passing it along
- adding public interfaces for the CP SDKs

This could also potentially be used to add support to other 3rd party libraries or maybe SwiftUI, KMM, etc.


