### PR TITLE
RUM-984 Fix integration tests

### DIFF
--- a/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRMultipleViewsRecordingScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRMultipleViewsRecordingScenarioTests.swift
@@ -5,6 +5,7 @@
  */
 
 import HTTPServerMock
+import TestUtilities
 import XCTest
 
 private extension ExampleApplication {

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		612C13772A9E1BA40086B5D1 /* SRFixtures in Frameworks */ = {isa = PBXBuildFile; productRef = 612C13762A9E1BA40086B5D1 /* SRFixtures */; };
 		612C13CC2A9F94AF0086B5D1 /* SRMultipleViewsRecordingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C13CB2A9F94AF0086B5D1 /* SRMultipleViewsRecordingScenarioTests.swift */; };
 		612C13DB2AAB537F0086B5D1 /* SRSegmentMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C13D82AAB537F0086B5D1 /* SRSegmentMatcher.swift */; };
-		612C13DC2AAB537F0086B5D1 /* JSONObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C13D92AAB537F0086B5D1 /* JSONObjectMatcher.swift */; };
 		612C13DD2AAB537F0086B5D1 /* SRRequestMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C13DA2AAB537F0086B5D1 /* SRRequestMatcher.swift */; };
 		612C13DF2AAB6E940086B5D1 /* SRCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C13DE2AAB6E940086B5D1 /* SRCommonAsserts.swift */; };
 		612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */; };
@@ -161,7 +160,6 @@
 		612C13742A9DFEF70086B5D1 /* SRMultipleViewsRecordingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SRMultipleViewsRecordingScenario.storyboard; sourceTree = "<group>"; };
 		612C13CB2A9F94AF0086B5D1 /* SRMultipleViewsRecordingScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRMultipleViewsRecordingScenarioTests.swift; sourceTree = "<group>"; };
 		612C13D82AAB537F0086B5D1 /* SRSegmentMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRSegmentMatcher.swift; sourceTree = "<group>"; };
-		612C13D92AAB537F0086B5D1 /* JSONObjectMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONObjectMatcher.swift; sourceTree = "<group>"; };
 		612C13DA2AAB537F0086B5D1 /* SRRequestMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRRequestMatcher.swift; sourceTree = "<group>"; };
 		612C13DE2AAB6E940086B5D1 /* SRCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRCommonAsserts.swift; sourceTree = "<group>"; };
 		612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMScrubbingScenario.storyboard; sourceTree = "<group>"; };
@@ -717,7 +715,6 @@
 		D2774EDE299E2E90004EC36A /* Matchers */ = {
 			isa = PBXGroup;
 			children = (
-				612C13D92AAB537F0086B5D1 /* JSONObjectMatcher.swift */,
 				612C13DA2AAB537F0086B5D1 /* SRRequestMatcher.swift */,
 				612C13D82AAB537F0086B5D1 /* SRSegmentMatcher.swift */,
 				D2774EDF299E2E90004EC36A /* RUMSessionMatcher.swift */,
@@ -1016,7 +1013,6 @@
 				612C13DB2AAB537F0086B5D1 /* SRSegmentMatcher.swift in Sources */,
 				612D8F8125AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift in Sources */,
 				613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */,
-				612C13DC2AAB537F0086B5D1 /* JSONObjectMatcher.swift in Sources */,
 				9EA95C212791C9E200F6C1F3 /* WebViewScenarioTest.swift in Sources */,
 				6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */,
 				611EA16625825FB300BC0E56 /* TrackingConsentScenarioTests.swift in Sources */,

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -28,7 +28,8 @@ Pod::Spec.new do |s|
   
   s.source_files = [
     "TestUtilities/Helpers/**/*.swift",
-    "TestUtilities/Mocks/**/*.swift"
+    "TestUtilities/Mocks/**/*.swift",
+    "TestUtilities/Matchers/**/*.swift",
   ]
 
   s.dependency 'DatadogInternal'


### PR DESCRIPTION
### What and why?

📦 Fixing integration tests build.

### How?

#1515 added `JSONObjectMatcher.swift` to `TestUtilities` target in main `.pbxproj`. It overlooked the fact that `TestUtilities` are also exposed for integration tests project through `.podspec`, hence the new file was missing for compilation.

The fix ensures that `JSONObjectMatcher.swift` is included in `TestUtilities.podspec`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
