### PR TITLE
RUM-1507 Improved diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [BUGFIX] Optimize Session Replay diffing algorithm. See [#1524][]
 
 # 2.4.0 / 18-10-2023
 
@@ -546,6 +547,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1498]: https://github.com/DataDog/dd-sdk-ios/pull/1498
 [#1493]: https://github.com/DataDog/dd-sdk-ios/pull/1493
 [#1394]: https://github.com/DataDog/dd-sdk-ios/pull/1394
+[#1524]: https://github.com/DataDog/dd-sdk-ios/pull/1524
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -174,4 +174,34 @@ extension SRTextWireframe: MutableWireframe {
         )
     }
 }
+
+extension SRImageWireframe: Hashable {
+    static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool {
+        return lhs.id == rhs.id
+            && lhs.resourceId == rhs.resourceId
+            && lhs.border == rhs.border
+            && lhs.clip == rhs.clip
+            && lhs.height == rhs.height
+            && lhs.isEmpty == rhs.isEmpty
+            && lhs.mimeType == rhs.mimeType
+            && lhs.shapeStyle == rhs.shapeStyle
+            && lhs.width == rhs.width
+            && lhs.x == rhs.x
+            && lhs.y == rhs.y
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(resourceId)
+        hasher.combine(border)
+        hasher.combine(clip)
+        hasher.combine(height)
+        hasher.combine(isEmpty)
+        hasher.combine(mimeType)
+        hasher.combine(shapeStyle)
+        hasher.combine(width)
+        hasher.combine(x)
+        hasher.combine(y)
+    }
+}
 #endif

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -59,7 +59,7 @@ internal class WireframesBuilder {
     }
 
     func createImageWireframe(
-        base64: String,
+        imageResource: ImageResource,
         id: WireframeID,
         frame: CGRect,
         mimeType: String = "png",
@@ -71,13 +71,14 @@ internal class WireframesBuilder {
         opacity: CGFloat? = nil
     ) -> SRWireframe {
         let wireframe = SRImageWireframe(
-            base64: base64,
+            base64: imageResource.base64,
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
             height: Int64(withNoOverflow: frame.height),
             id: id,
             isEmpty: false, // field deprecated - we should use placeholder wireframe instead
             mimeType: mimeType,
+            resourceId: imageResource.identifier,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
             width: Int64(withNoOverflow: frame.width),
             x: Int64(withNoOverflow: frame.minX),

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -8,15 +8,20 @@
 import Foundation
 import UIKit
 
+internal struct ImageResource {
+    let identifier: String
+    let base64: String
+}
+
 internal protocol ImageDataProviding {
     func contentBase64String(
         of image: UIImage?
-    ) -> String
+    ) -> ImageResource?
 
     func contentBase64String(
         of image: UIImage?,
         tintColor: UIColor?
-    ) -> String
+    ) -> ImageResource?
 }
 
 internal final class ImageDataProvider: ImageDataProviding {
@@ -35,29 +40,29 @@ internal final class ImageDataProvider: ImageDataProviding {
     func contentBase64String(
         of image: UIImage?,
         tintColor: UIColor?
-    ) -> String {
-        autoreleasepool {
+    ) -> ImageResource? {
+        autoreleasepool { () -> ImageResource? in
             guard var image = image else {
-                return ""
+                return nil
             }
             var identifier = image.srIdentifier
             if let tintColorIdentifier = tintColor?.srIdentifier {
                 identifier += tintColorIdentifier
             }
             if let base64EncodedImage = cache[identifier] {
-                return base64EncodedImage
+                return ImageResource(identifier: identifier, base64: base64EncodedImage)
             } else {
                 if #available(iOS 13.0, *), let tintColor = tintColor {
                     image = image.withTintColor(tintColor)
                 }
                 let base64EncodedImage = image.scaledDownToApproximateSize(desiredMaxBytesSize).base64EncodedString()
                 cache[identifier, base64EncodedImage.count] = base64EncodedImage
-                return base64EncodedImage
+                return ImageResource(identifier: identifier, base64: base64EncodedImage)
             }
         }
     }
 
-    func contentBase64String(of image: UIImage?) -> String {
+    func contentBase64String(of image: UIImage?) -> ImageResource? {
         contentBase64String(of: image, tintColor: nil)
     }
 }
@@ -70,13 +75,49 @@ fileprivate extension CGSize {
 
 extension UIImage {
     var srIdentifier: String {
-        return "\(hash)"
+        return md5Hash
     }
 }
 
 extension UIColor {
     var srIdentifier: String {
         return "\(hash)"
+    }
+}
+
+import CommonCrypto
+
+fileprivate extension UIImage {
+    private struct AssociatedKeys {
+        static var md5HashKey = "md5Hash"
+    }
+
+    var md5Hash: String {
+        if let hash = objc_getAssociatedObject(self, &AssociatedKeys.md5HashKey) as? String {
+            return hash
+        }
+
+        let hash = computeMD5Hash()
+        objc_setAssociatedObject(self, &AssociatedKeys.md5HashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return hash
+    }
+
+    private func computeMD5Hash() -> String {
+        guard let imageData = self.pngData() else {
+            return ""
+        }
+
+        var hashString = ""
+        imageData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> Void in
+            var hash = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+            CC_MD5(bytes.baseAddress, CC_LONG(imageData.count), &hash)
+
+            for byte in hash {
+                hashString += String(format: "%02x", byte)
+            }
+        }
+
+        return hashString
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -85,20 +85,21 @@ extension UIColor {
     }
 }
 
-import CommonCrypto
+import CryptoKit
 
+private var md5HashKey: UInt8 = 11
 fileprivate extension UIImage {
     private struct AssociatedKeys {
-        static var md5HashKey = "md5Hash"
+
     }
 
     var md5Hash: String {
-        if let hash = objc_getAssociatedObject(self, &AssociatedKeys.md5HashKey) as? String {
+        if let hash = objc_getAssociatedObject(self, &md5HashKey) as? String {
             return hash
         }
 
         let hash = computeMD5Hash()
-        objc_setAssociatedObject(self, &AssociatedKeys.md5HashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, &md5HashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return hash
     }
 
@@ -106,18 +107,11 @@ fileprivate extension UIImage {
         guard let imageData = self.pngData() else {
             return ""
         }
-
-        var hashString = ""
-        imageData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> Void in
-            var hash = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
-            CC_MD5(bytes.baseAddress, CC_LONG(imageData.count), &hash)
-
-            for byte in hash {
-                hashString += String(format: "%02x", byte)
-            }
+        if #available(iOS 13.0, *) {
+            return Insecure.MD5.hash(data: imageData).map { String(format: "%02hhx", $0) }.joined()
+        } else {
+            return "\(hash)"
         }
-
-        return hashString
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -75,7 +75,7 @@ fileprivate extension CGSize {
 
 extension UIImage {
     var srIdentifier: String {
-        return md5Hash
+        return customHash
     }
 }
 
@@ -87,23 +87,19 @@ extension UIColor {
 
 import CryptoKit
 
-private var md5HashKey: UInt8 = 11
+private var customHashKey: UInt8 = 11
 fileprivate extension UIImage {
-    private struct AssociatedKeys {
-
-    }
-
-    var md5Hash: String {
-        if let hash = objc_getAssociatedObject(self, &md5HashKey) as? String {
+    var customHash: String {
+        if let hash = objc_getAssociatedObject(self, &customHashKey) as? String {
             return hash
         }
 
-        let hash = computeMD5Hash()
-        objc_setAssociatedObject(self, &md5HashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        let hash = computeHash()
+        objc_setAssociatedObject(self, &customHashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return hash
     }
 
-    private func computeMD5Hash() -> String {
+    private func computeHash() -> String {
         guard let imageData = self.pngData() else {
             return ""
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -136,18 +136,18 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
                 opacity: attributes.alpha
             )
         ]
-        var base64: String?
+        var imageResource: ImageResource?
         if shouldRecordImage {
-            base64 = imageDataProvider.contentBase64String(
+            imageResource = imageDataProvider.contentBase64String(
                 of: image,
                 tintColor: tintColor
             )
         }
         if let contentFrame = contentFrame {
-            if let base64 = base64 {
+            if let imageResource = imageResource {
                 wireframes.append(
                     builder.createImageWireframe(
-                        base64: base64,
+                        imageResource: imageResource,
                         id: imageWireframeID,
                         frame: contentFrame,
                         clip: clipsToBounds ? clip : nil

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -324,7 +324,7 @@ internal struct SRTextWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a ImageWireframe.
-internal struct SRImageWireframe: Codable, Hashable {
+internal struct SRImageWireframe: Codable {
     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
     internal var base64: String?
 
@@ -1154,3 +1154,4 @@ internal enum SRRecord: Codable {
 }
 
 // Generated from https://github.com/DataDog/rum-events-format/tree/5a79d9a36b6e76493420792055fc50aed780569b
+#endif

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -346,6 +346,9 @@ internal struct SRImageWireframe: Codable, Hashable {
     /// MIME type of the image file
     internal var mimeType: String?
 
+    /// Unique identifier of the image resource
+    internal var resourceId: String?
+
     /// The style of this wireframe.
     internal let shapeStyle: SRShapeStyle?
 
@@ -369,6 +372,7 @@ internal struct SRImageWireframe: Codable, Hashable {
         case id = "id"
         case isEmpty = "isEmpty"
         case mimeType = "mimeType"
+        case resourceId = "resourceId"
         case shapeStyle = "shapeStyle"
         case type = "type"
         case width = "width"
@@ -786,6 +790,9 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                     /// MIME type of the image file
                     internal var mimeType: String?
 
+                    /// Unique identifier of the image resource
+                    internal var resourceId: String?
+
                     /// The style of this wireframe.
                     internal let shapeStyle: SRShapeStyle?
 
@@ -809,6 +816,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                         case id = "id"
                         case isEmpty = "isEmpty"
                         case mimeType = "mimeType"
+                        case resourceId = "resourceId"
                         case shapeStyle = "shapeStyle"
                         case type = "type"
                         case width = "width"
@@ -1145,5 +1153,4 @@ internal enum SRRecord: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1c476e469d5827aa1f4e60916f42ad35bbd950ef
-#endif
+// Generated from https://github.com/DataDog/rum-events-format/tree/5a79d9a36b6e76493420792055fc50aed780569b

--- a/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
@@ -9,17 +9,22 @@ import UIKit
 
 struct MockImageDataProvider: ImageDataProviding {
     var contentBase64String: String
+    var identifier: String
 
-    func contentBase64String(of image: UIImage?) -> String {
-        return contentBase64String
+    func contentBase64String(of image: UIImage?) -> DatadogSessionReplay.ImageResource? {
+        return .init(identifier: identifier, base64: contentBase64String)
     }
 
-    func contentBase64String(of image: UIImage?, tintColor: UIColor?) -> String {
-        return contentBase64String
+    func contentBase64String(of image: UIImage?, tintColor: UIColor?) -> DatadogSessionReplay.ImageResource? {
+        return .init(identifier: identifier, base64: contentBase64String)
     }
 
-    init(contentBase64String: String = "mock_base64_string") {
+    init(
+        contentBase64String: String = "mock_base64_string",
+        identifier: String = "mock_identifier"
+    ) {
         self.contentBase64String = contentBase64String
+        self.identifier = identifier
     }
 }
 

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -119,6 +119,26 @@ class DiffSRWireframes: XCTestCase {
             }
         }
     }
+
+    func testWhenComputingMutationsForImageWireframe_base64IsNotTakenIntoAccount() {
+        // Given
+        let randomID: WireframeID = .mockRandom()
+        let base64: String = .mockRandom()
+        let wireframeA: SRWireframe = .imageWireframe(value: .mockWith(base64: .mockRandom(), id: randomID))
+        let wireframeB: SRWireframe = .imageWireframe(value: .mockWith(base64: base64, id: randomID))
+
+        // When
+        let mutations = try? XCTUnwrap(wireframeB.mutations(from: wireframeA))
+        let isDifferent = wireframeA.isDifferent(than: wireframeB)
+
+        // Then
+        XCTAssertFalse(isDifferent)
+        if case let .imageWireframeUpdate(update) = mutations {
+            XCTAssertEqual(update.base64, base64)
+        } else {
+            XCTFail("mutations are expected to be `.imageWireframeUpdate`")
+        }
+    }
 }
 
 // MARK: - Helpers

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -120,7 +120,7 @@ class DiffSRWireframes: XCTestCase {
         }
     }
 
-    func testWhenComputingMutationsForImageWireframe_base64IsNotTakenIntoAccount() {
+    func testWhenComputingMutationsForImageWireframe_isNotDifferentButUpdateBase64() {
         // Given
         let randomID: WireframeID = .mockRandom()
         let base64: String = .mockRandom()

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -8,29 +8,38 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class ImageDataProviderTests: XCTestCase {
-    func test_returnsEmptyString_WhenContentIsEmpty() {
+    func test_returnsNil_WhenImageIsNil() {
         let sut = ImageDataProvider()
-        let imageString = sut.contentBase64String(of: UIImage())
 
-        XCTAssertEqual(imageString, "")
+        XCTAssertNil(sut.contentBase64String(of: nil))
     }
 
-    func test_returnsValidString_WhenContentIsValid() throws {
+    func test_returnsEmptyStringAndIdentifier_WhenContentIsEmpty() {
+        let sut = ImageDataProvider()
+        let imageResource = sut.contentBase64String(of: UIImage())
+
+        XCTAssertEqual(imageResource?.base64, "")
+        XCTAssertEqual(imageResource?.identifier, "")
+    }
+
+    func test_returnsValidStringAndIdentifier_WhenContentIsValid() throws {
         let sut = ImageDataProvider()
         let base64 = "R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=="
         let image = UIImage(data: Data(base64Encoded: base64)!)
 
-        let imageData = try XCTUnwrap(sut.contentBase64String(of: image))
-        XCTAssertGreaterThan(imageData.count, 0)
+        let imageResource = try XCTUnwrap(sut.contentBase64String(of: image))
+        XCTAssertGreaterThan(imageResource.base64.count, 0)
+        XCTAssertEqual(imageResource.identifier, "536081631ad95d6f784c21dc5a3b3609")
     }
 
     @available(iOS 13.0, *)
-    func test_returnsValidString_forSFSymbolIcon() throws {
+    func test_returnsValidStringAndIdentifier_forSFSymbolIcon() throws {
         let sut = ImageDataProvider()
         let image = UIImage(systemName: "square.and.arrow.up")
 
-        let imageData = try XCTUnwrap(sut.contentBase64String(of: image))
-        XCTAssertGreaterThan(imageData.count, 0)
+        let imageResource = try XCTUnwrap(sut.contentBase64String(of: image))
+        XCTAssertGreaterThan(imageResource.base64.count, 0)
+        XCTAssertEqual(imageResource.identifier, "ae0bb15c82ec2dcddf937a0948ca9720")
     }
 
     func test_imageIdentifierConsistency() {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -29,7 +29,7 @@ class ImageDataProviderTests: XCTestCase {
 
         let imageResource = try XCTUnwrap(sut.contentBase64String(of: image))
         XCTAssertGreaterThan(imageResource.base64.count, 0)
-        XCTAssertEqual(imageResource.identifier, "536081631ad95d6f784c21dc5a3b3609")
+        XCTAssertEqual(imageResource.identifier, "258d046955bfb950883f0ed61b586b5a")
     }
 
     @available(iOS 13.0, *)
@@ -39,7 +39,7 @@ class ImageDataProviderTests: XCTestCase {
 
         let imageResource = try XCTUnwrap(sut.contentBase64String(of: image))
         XCTAssertGreaterThan(imageResource.base64.count, 0)
-        XCTAssertEqual(imageResource.identifier, "ae0bb15c82ec2dcddf937a0948ca9720")
+        XCTAssertEqual(imageResource.identifier, "89187ac6043b08c088090d348fbb397f")
     }
 
     func test_imageIdentifierConsistency() {


### PR DESCRIPTION
### What and why?

It leverages new `resourceId` field instead of `base64` for calculating diff of image wireframes, speeds up the calculation and lowers the CPU pressure.

### How?

We added new field to SR schema (that will be later on used for different purposes) and started using this field instead of base64 to calculate object's hash.

Now, on Shopist it goes as low as 12% of CPU for the most complex view on idle. Used to be 60% before the change.

<img width="230" alt="Screenshot 2023-10-23 at 11 40 13" src="https://github.com/DataDog/dd-sdk-ios/assets/6953112/7e04aff4-014b-4d25-843b-2f666bbf05b7">

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
