### PR TITLE
RUM-1554 Update default tracing headers to datadog + W3C (tracecontext)

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
@@ -27,7 +27,7 @@ public struct FirstPartyHosts: Equatable {
     public init(_ hosts: Set<String>) {
         self.init(
             hostsWithTracingHeaderTypes: hosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -76,7 +76,7 @@ open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
         self.init(
             in: nil,
             additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/FirstPartyHostsTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/FirstPartyHostsTests.swift
@@ -81,11 +81,11 @@ class FirstPartyHostsTests: XCTestCase {
         }
     }
 
-    func testGivenValidSet_itAssignsDatadogHeaderType() {
+    func testGivenValidSet_itAssignsDatadogAndTracecontextHeaderType() {
         let hosts = FirstPartyHosts(Set(otherHosts))
         otherHosts.forEach {
             let url = URL(string: $0)
-            XCTAssertEqual(hosts.tracingHeaderTypes(for: url), [.datadog])
+            XCTAssertEqual(hosts.tracingHeaderTypes(for: url), [.datadog, .tracecontext])
         }
     }
 

--- a/DatadogObjc/Sources/DDURLSessionDelegate+objc.swift
+++ b/DatadogObjc/Sources/DDURLSessionDelegate+objc.swift
@@ -40,7 +40,7 @@ open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionD
     public convenience init(additionalFirstPartyHosts: Set<String>) {
         self.init(
             additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }


### PR DESCRIPTION
### What and why?

Adds W3C tracecontext to default configuration along with datadog headers.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
