### PR TITLE
fix: add missing source directory required for JSONObjectMatcher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -186,7 +186,7 @@ let package = Package(
                 .target(name: "DatadogInternal"),
             ],
             path: "TestUtilities",
-            sources: ["Mocks", "Helpers"]
+            sources: ["Mocks", "Helpers", "Matchers"]
         )
     ]
 )


### PR DESCRIPTION
### What and why?

SPM only SDK fails to compile

### How?

Include the missing source files.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
