### PR TITLE
RUM-1555 Update default tracing headers to datadog + W3C (tracecontext)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [BUGFIX] Optimize Session Replay diffing algorithm. See [#1524][]
 - [FEATURE] Add network instrumentation for async/await URLSession APIs. See [#1394][]
+- [FEATURE] Change default tracing headers for first party hosts to use both Datadog headers and W3C `tracecontext` headers. See [#1529][]
 
 # 2.4.0 / 18-10-2023
 
@@ -548,6 +549,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1493]: https://github.com/DataDog/dd-sdk-ios/pull/1493
 [#1394]: https://github.com/DataDog/dd-sdk-ios/pull/1394
 [#1524]: https://github.com/DataDog/dd-sdk-ios/pull/1524
+[#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -207,4 +207,23 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
         XCTAssertEqual(log.attributes.userAttributes.count, 1)
     }
+
+    func testGivenAllTracingHeaderTypes_itUsesTheSameIds() throws {
+        let request: URLRequest = .mockWith(httpMethod: "GET")
+        let modifiedRequest = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
+
+        XCTAssertEqual(
+            modifiedRequest.allHTTPHeaderFields,
+            [
+                "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
+                "X-B3-SpanId": "0000000000000001",
+                "X-B3-Sampled": "1",
+                "X-B3-TraceId": "00000000000000000000000000000001",
+                "b3": "00000000000000000000000000000001-0000000000000001-1",
+                "x-datadog-trace-id": "1",
+                "x-datadog-parent-id": "1",
+                "x-datadog-sampling-priority": "1"
+            ]
+        )
+    }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
@@ -21,7 +21,7 @@ public struct FirstPartyHosts: Equatable {
         self.init(hostsWithTracingHeaderTypes: hostsWithTracingHeaderTypes)
     }
 
-    /// Creates a `FirstPartyHosts` instance with the given set of host names by assigning `.datadog` header type to each.
+    /// Creates a `FirstPartyHosts` instance with the given set of host names by assigning `.datadog` and `.tracecontext` header types to each.
     ///
     /// - Parameter hosts: The set of host names.
     public init(_ hosts: Set<String>) {

--- a/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/FirstPartyHosts.swift
@@ -27,7 +27,7 @@ public struct FirstPartyHosts: Equatable {
     public init(_ hosts: Set<String>) {
         self.init(
             hostsWithTracingHeaderTypes: hosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -76,7 +76,7 @@ open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
         self.init(
             in: nil,
             additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInstrumentation.swift
@@ -71,7 +71,7 @@ extension URLSessionInstrumentation {
 
     /// Defines configuration for first-party hosts in distributed tracing.
     public enum FirstPartyHostsTracing {
-        /// Trace the specified hosts using Datadog tracing headers.
+        /// Trace the specified hosts using Datadog and W3C `tracecontext` tracing headers.
         ///
         /// - Parameters:
         ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.

--- a/DatadogInternal/Tests/NetworkInstrumentation/FirstPartyHostsTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/FirstPartyHostsTests.swift
@@ -81,11 +81,11 @@ class FirstPartyHostsTests: XCTestCase {
         }
     }
 
-    func testGivenValidSet_itAssignsDatadogHeaderType() {
+    func testGivenValidSet_itAssignsDatadogAndTracecontextHeaderType() {
         let hosts = FirstPartyHosts(Set(otherHosts))
         otherHosts.forEach {
             let url = URL(string: $0)
-            XCTAssertEqual(hosts.tracingHeaderTypes(for: url), [.datadog])
+            XCTAssertEqual(hosts.tracingHeaderTypes(for: url), [.datadog, .tracecontext])
         }
     }
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -552,7 +552,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             required init(in core: DatadogCoreProtocol) {
                 ddURLSessionDelegate = DatadogURLSessionDelegate(
                     in: core,
-                    additionalFirstPartyHostsWithHeaderTypes: ["test.com": [.datadog]]
+                    additionalFirstPartyHostsWithHeaderTypes: ["test.com": [.datadog, .tracecontext]]
                 )
 
                 super.init()

--- a/DatadogObjc/Sources/DDURLSessionDelegate+objc.swift
+++ b/DatadogObjc/Sources/DDURLSessionDelegate+objc.swift
@@ -40,7 +40,7 @@ open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionD
     public convenience init(additionalFirstPartyHosts: Set<String>) {
         self.init(
             additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
-                partialResult[host] = [.datadog]
+                partialResult[host] = [.datadog, .tracecontext]
             })
         )
     }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -265,7 +265,7 @@ extension RUM {
 extension RUM.Configuration.URLSessionTracking {
     /// Defines configuration for first-party hosts in distributed tracing.
     public enum FirstPartyHostsTracing {
-        /// Trace the specified hosts using Datadog tracing headers.
+        /// Trace the specified hosts using Datadog and W3C `tracecontext` tracing headers.
         ///
         /// - Parameters:
         ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -97,7 +97,7 @@ extension Trace {
 
             /// Defines configuration for first-party hosts in distributed tracing.
             public enum FirstPartyHostsTracing {
-                /// Trace the specified hosts using Datadog tracing headers.
+                /// Trace the specified hosts using Datadog and W3C `tracecontext` tracing headers.
                 ///
                 /// - Parameters:
                 ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.


### PR DESCRIPTION
### What and why?

Adds W3C tracecontext to default configuration along with datadog headers.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
