### PR TITLE
RUM-1837 Update logic to send N batches sequentially in each cycle

### DIFF
--- a/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -71,7 +71,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch()
+            let batch = reader.readNextBatches(1).first
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")

--- a/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -71,7 +71,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch()
+            let batch = reader.readNextBatches(1).first
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")

--- a/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -84,7 +84,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
 }
 
 extension Reader {
-    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
-        return readFiles(limit).compactMap { readBatch(from: $0) }
+    func readNextBatches(_ limit: Int = .max) -> [Batch] {
+        return readFiles(limit: limit).compactMap { readBatch(from: $0) }
     }
 }

--- a/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -82,3 +82,9 @@ class RUMStorageBenchmarkTests: XCTestCase {
         }
     }
 }
+
+extension Reader {
+    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
+        return readFiles(limit).compactMap { readBatch(from: $0) }
+    }
+}

--- a/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -71,7 +71,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            let batch = reader.readNextBatch()
+            let batch = reader.readNextBatches(1).first
             self.stopMeasuring()
 
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,7 +555,6 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
-[#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1531]: https://github.com/DataDog/dd-sdk-ios/pull/1531
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,7 +555,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
-[#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1531
+[#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1531]: https://github.com/DataDog/dd-sdk-ios/pull/1531
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -556,6 +556,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1531
+[#1531]: https://github.com/DataDog/dd-sdk-ios/pull/1531
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FEATURE] Change default tracing headers for first party hosts to use both Datadog headers and W3C `tracecontext` headers. See [#1529][]
 - [FEATURE] Add tracestate headers when using W3C tracecontext. See [#1536][]
 - [BUGFIX] Fix RUM ViewController leaks. See [#1533][]
+- [FEATURE] Add `BatchProcessingLevel` configuration allowing to process more batches within single read/upload cycle. See [#1531][]
 
 # 2.4.0 / 18-10-2023
 
@@ -554,6 +555,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
+[#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1531
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -65,7 +65,11 @@ internal final class DatadogCore {
     /// The core context provider.
     internal let contextProvider: DatadogContextProvider
 
+    /// Flag defining if background tasks are enabled.
     internal let backgroundTasksEnabled: Bool
+
+    /// Maximum number of batches per upload.
+    internal let maxBatchesPerUpload: Int
 
     /// Creates a core instance.
     ///
@@ -87,6 +91,7 @@ internal final class DatadogCore {
     	encryption: DataEncryption?,
         contextProvider: DatadogContextProvider,
         applicationVersion: String,
+        maxBatchesPerUpload: Int,
         backgroundTasksEnabled: Bool
     ) {
         self.directory = directory
@@ -95,6 +100,7 @@ internal final class DatadogCore {
         self.httpClient = httpClient
         self.encryption = encryption
         self.contextProvider = contextProvider
+        self.maxBatchesPerUpload = maxBatchesPerUpload
         self.backgroundTasksEnabled = backgroundTasksEnabled
         self.applicationVersionPublisher = ApplicationVersionPublisher(version: applicationVersion)
         self.consentPublisher = TrackingConsentPublisher(consent: initialConsent)
@@ -246,6 +252,7 @@ extension DatadogCore: DatadogCoreProtocol {
                 httpClient: httpClient,
                 performance: performancePreset,
                 backgroundTasksEnabled: backgroundTasksEnabled,
+                maxBatchesPerUpload: maxBatchesPerUpload,
                 telemetry: telemetry
             )
 

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -160,6 +160,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
             if ignoreFilesAgeWhenReading {
                 return filesFromOldest
                     .prefix(min(limit ?? filesFromOldest.count, filesFromOldest.count))
+                    .sorted(by: { $0.creationDate < $1.creationDate })
                     .map { $0.file }
             }
             #endif

--- a/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
@@ -17,9 +17,15 @@ internal final class DataReader: Reader {
         self.fileReader = fileReader
     }
 
-    func readNextBatches(_ limit: Int?) -> [Batch] {
+    func readFiles(_ limit: Int?) -> [ReadableFile] {
         queue.sync {
-            self.fileReader.readNextBatches(limit)
+            self.fileReader.readFiles(limit)
+        }
+    }
+
+    func readBatch(from file: ReadableFile) -> Batch? {
+        queue.sync {
+            self.fileReader.readBatch(from: file)
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
@@ -17,9 +17,9 @@ internal final class DataReader: Reader {
         self.fileReader = fileReader
     }
 
-    func readNextBatch() -> Batch? {
+    func readNextBatches(_ limit: Int?) -> [Batch] {
         queue.sync {
-            self.fileReader.readNextBatch()
+            self.fileReader.readNextBatches(limit)
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/DataReader.swift
@@ -17,9 +17,9 @@ internal final class DataReader: Reader {
         self.fileReader = fileReader
     }
 
-    func readFiles(_ limit: Int?) -> [ReadableFile] {
+    func readFiles(limit: Int) -> [ReadableFile] {
         queue.sync {
-            self.fileReader.readFiles(limit)
+            self.fileReader.readFiles(limit: limit)
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
@@ -30,17 +30,20 @@ internal final class FileReader: Reader {
 
     // MARK: - Reading batches
 
-    func readNextBatch() -> Batch? {
-        guard let file = orchestrator.getReadableFile(excludingFilesNamed: filesRead) else {
-            return nil
+    func readNextBatches(_ limit: Int?) -> [Batch] {
+        let files = orchestrator.getReadableFiles(excludingFilesNamed: filesRead, limit: limit)
+        guard !files.isEmpty else {
+            return []
         }
 
         do {
-            let dataBlocks = try decode(stream: file.stream())
-            return Batch(dataBlocks: dataBlocks, file: file)
+            return try files.map { file in
+                let dataBlocks = try decode(stream: file.stream())
+                return Batch(dataBlocks: dataBlocks, file: file)
+            }
         } catch {
             telemetry.error("Failed to read data from file", error: error)
-            return nil
+            return []
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
@@ -30,7 +30,7 @@ internal final class FileReader: Reader {
 
     // MARK: - Reading batches
 
-    func readFiles(_ limit: Int?) -> [ReadableFile] {
+    func readFiles(limit: Int) -> [ReadableFile] {
         return orchestrator.getReadableFiles(excludingFilesNamed: filesRead, limit: limit)
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
@@ -30,19 +30,17 @@ internal final class FileReader: Reader {
 
     // MARK: - Reading batches
 
-    func readNextBatches(_ limit: Int?) -> [Batch] {
-        let files = orchestrator.getReadableFiles(excludingFilesNamed: filesRead, limit: limit)
-        guard !files.isEmpty else {
-            return []
-        }
-        return files.compactMap { file in
-            do {
-                let dataBlocks = try decode(stream: file.stream())
-                return Batch(dataBlocks: dataBlocks, file: file)
-            } catch {
-                telemetry.error("Failed to read data from file", error: error)
-                return nil
-            }
+    func readFiles(_ limit: Int?) -> [ReadableFile] {
+        return orchestrator.getReadableFiles(excludingFilesNamed: filesRead, limit: limit)
+    }
+
+    func readBatch(from file: ReadableFile) -> Batch? {
+        do {
+            let dataBlocks = try decode(stream: file.stream())
+            return Batch(dataBlocks: dataBlocks, file: file)
+        } catch {
+            telemetry.error("Failed to read data from file", error: error)
+            return nil
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/FileReader.swift
@@ -35,15 +35,14 @@ internal final class FileReader: Reader {
         guard !files.isEmpty else {
             return []
         }
-
-        do {
-            return try files.map { file in
+        return files.compactMap { file in
+            do {
                 let dataBlocks = try decode(stream: file.stream())
                 return Batch(dataBlocks: dataBlocks, file: file)
+            } catch {
+                telemetry.error("Failed to read data from file", error: error)
+                return nil
             }
-        } catch {
-            telemetry.error("Failed to read data from file", error: error)
-            return []
         }
     }
 

--- a/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
@@ -24,6 +24,6 @@ extension Batch {
 
 /// A type, reading batched data.
 internal protocol Reader {
-    func readNextBatch() -> Batch?
+    func readNextBatches(_ count: Int?) -> [Batch]
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason)
 }

--- a/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
@@ -24,6 +24,23 @@ extension Batch {
 
 /// A type, reading batched data.
 internal protocol Reader {
-    func readNextBatches(_ count: Int?) -> [Batch]
+    /// Reads files from the storage.
+    /// - Parameter limit: maximum number of files to read. If `nil`, all files are read.
+    func readFiles(_ limit: Int?) -> [ReadableFile]
+    /// Reads batch from given file.
+    /// - Parameter file: file to read batch from.
+    func readBatch(from file: ReadableFile) -> Batch?
+    /// Reads next batches from the storage.
+    /// - Parameter limit: maximum number of batches to read. If `nil`, all batches are read.
+    func readNextBatches(_ limit: Int?) -> [Batch]
+    /// Marks given batch as read.
+    /// - Parameter batch: batch to mark as read.
+    /// - Parameter reason: reason for removing the batch.
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason)
+}
+
+extension Reader {
+    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
+        return readFiles(limit).compactMap { readBatch(from: $0) }
+    }
 }

--- a/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
@@ -25,8 +25,8 @@ extension Batch {
 /// A type, reading batched data.
 internal protocol Reader {
     /// Reads files from the storage.
-    /// - Parameter limit: maximum number of files to read. If `nil`, all files are read.
-    func readFiles(_ limit: Int?) -> [ReadableFile]
+    /// - Parameter limit: maximum number of files to read.
+    func readFiles(limit: Int) -> [ReadableFile]
     /// Reads batch from given file.
     /// - Parameter file: file to read batch from.
     func readBatch(from file: ReadableFile) -> Batch?

--- a/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
+++ b/DatadogCore/Sources/Core/Storage/Reading/Reader.swift
@@ -30,17 +30,8 @@ internal protocol Reader {
     /// Reads batch from given file.
     /// - Parameter file: file to read batch from.
     func readBatch(from file: ReadableFile) -> Batch?
-    /// Reads next batches from the storage.
-    /// - Parameter limit: maximum number of batches to read. If `nil`, all batches are read.
-    func readNextBatches(_ limit: Int?) -> [Batch]
     /// Marks given batch as read.
     /// - Parameter batch: batch to mark as read.
     /// - Parameter reason: reason for removing the batch.
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason)
-}
-
-extension Reader {
-    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
-        return readFiles(limit).compactMap { readBatch(from: $0) }
-    }
 }

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -84,6 +84,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
                         if uploadStatus.needsRetry {
                             DD.logger.debug("   → (\(self.featureName)) not delivered, will be retransmitted: \(uploadStatus.userDebugDescription)")
+                            allUploadsSucceeded = false
                         } else {
                             DD.logger.debug("   → (\(self.featureName)) accepted, won't be retransmitted: \(uploadStatus.userDebugDescription)")
                             allUploadsSucceeded = true
@@ -94,7 +95,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
                         }
 
                         if let error = uploadStatus.error {
-                            allUploadsSucceeded = false
                             switch error {
                             case .unauthorized:
                                 DD.logger.error("⚠️ Make sure that the provided token still exists and you're targeting the relevant Datadog site.")

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -34,6 +34,9 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// Batch upload work scheduled by this worker.
     @ReadWriteLock
     private var uploadWork: DispatchWorkItem?
+
+    @ReadWriteLock
+    /// Indicates if the worker was cancelled.
     private var cancelled = false
 
     /// Telemetry interface.

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -95,14 +95,14 @@ internal class DataUploadWorker: DataUploadWorkerType {
                             switch error {
                             case .unauthorized:
                                 DD.logger.error("⚠️ Make sure that the provided token still exists and you're targeting the relevant Datadog site.")
-                                return
                             case let .httpError(statusCode: statusCode):
                                 telemetry.error("Data upload finished with status code: \(statusCode)")
-                                return
                             case let .networkError(error: error):
                                 telemetry.error("Data upload finished with error", error: error)
-                                return
                             }
+                        }
+                        if uploadStatus.error != nil {
+                            break // finish the cycle if any batch upload encountered an error
                         }
                     } catch let error {
                         // If upload can't be initiated do not retry, so drop the batch:

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -66,7 +66,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
             let context = contextProvider.read()
             let blockersForUpload = self.uploadConditions.blockersForUpload(with: context)
             let isSystemReady = blockersForUpload.isEmpty
-            let files = isSystemReady ? self.fileReader.readFiles(maxBatchesPerUpload) : nil
+            let files = isSystemReady ? self.fileReader.readFiles(limit: maxBatchesPerUpload) : nil
             var allUploadsSucceeded = false
             var uploadStatuses = [DataUploadStatus]()
             if let files = files, !files.isEmpty {
@@ -150,7 +150,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// - It performs arbitrary upload (without checking upload condition and without re-transmitting failed uploads).
     internal func flushSynchronously() {
         queue.sync { [fileReader, dataUploader, contextProvider] in
-            for file in fileReader.readFiles(nil) {
+            for file in fileReader.readFiles(limit: .max) {
                 guard let nextBatch = fileReader.readBatch(from: file) else {
                     continue
                 }

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -34,9 +34,8 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// Batch upload work scheduled by this worker.
     @ReadWriteLock
     private var uploadWork: DispatchWorkItem?
-
-    @ReadWriteLock
     /// Indicates if the worker was cancelled.
+    @ReadWriteLock
     private var cancelled = false
 
     /// Telemetry interface.

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -32,8 +32,10 @@ internal class DataUploadWorker: DataUploadWorkerType {
     private let maxBatchesPerUpload: Int
 
     /// Batch reading work scheduled by this worker.
+    @ReadWriteLock
     private var batchReadWork: DispatchWorkItem?
     /// Batch upload works scheduled by this worker.
+    @ReadWriteLock
     private var batchUploadWorks: [DispatchWorkItem] = []
 
     /// Telemetry interface.
@@ -155,6 +157,11 @@ internal class DataUploadWorker: DataUploadWorkerType {
         queue.async(execute: uploadWork)
     }
 
+    private func cancelUploads() {
+        self.batchUploadWorks.forEach { $0.cancel() }
+        self.batchUploadWorks.removeAll()
+    }
+
     /// Sends all unsent data synchronously.
     /// - It performs arbitrary upload (without checking upload condition and without re-transmitting failed uploads).
     internal func flushSynchronously() {
@@ -192,11 +199,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
             self.batchUploadWorks.forEach { $0.cancel() }
             self.batchUploadWorks.removeAll()
         }
-    }
-
-    internal func cancelUploads() {
-        self.batchUploadWorks.forEach { $0.cancel() }
-        self.batchUploadWorks.removeAll()
     }
 }
 

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -19,6 +19,7 @@ internal struct FeatureUpload {
         httpClient: HTTPClient,
         performance: PerformancePreset,
         backgroundTasksEnabled: Bool,
+        maxBatchesPerUpload: Int,
         telemetry: Telemetry
     ) {
         let uploadQueue = DispatchQueue(
@@ -50,6 +51,7 @@ internal struct FeatureUpload {
                 delay: DataUploadDelay(performance: performance),
                 featureName: featureName,
                 telemetry: telemetry,
+                maxBatchesPerUpload: maxBatchesPerUpload,
                 backgroundTaskCoordinator: backgroundTaskCoordinator
             )
         )

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -55,6 +55,12 @@ public struct Datadog {
             case rare
         }
 
+        public enum BatchProcessingLevel: Int {
+            case low = 1
+            case medium = 10
+            case high = 100
+        }
+
         /// Either the RUM client token (which supports RUM, Logging and APM) or regular client token, only for Logging and APM.
         public var clientToken: String
 
@@ -104,6 +110,9 @@ public struct Datadog {
 
         /// The bundle object that contains the current executable.
         public var bundle: Bundle
+
+        ///
+        public var batchProcessingLevel: BatchProcessingLevel
 
         /// Flag that determines if UIApplication methods [`beginBackgroundTask(expirationHandler:)`](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtaskwithexpiratio) and [`endBackgroundTask:`](https://developer.apple.com/documentation/uikit/uiapplication/1622970-endbackgroundtask)
         /// are utilized to perform background uploads. It may extend the amount of time the app is operating in background by 30 seconds.
@@ -166,6 +175,7 @@ public struct Datadog {
             proxyConfiguration: [AnyHashable: Any]? = nil,
             encryption: DataEncryption? = nil,
             serverDateProvider: ServerDateProvider? = nil,
+            batchProcessingLevel: BatchProcessingLevel = .medium,
             backgroundTasksEnabled: Bool = false
         ) {
             self.clientToken = clientToken
@@ -178,6 +188,7 @@ public struct Datadog {
             self.proxyConfiguration = proxyConfiguration
             self.encryption = encryption
             self.serverDateProvider = serverDateProvider ?? DatadogNTPDateProvider()
+            self.batchProcessingLevel = batchProcessingLevel
             self.backgroundTasksEnabled = backgroundTasksEnabled
         }
 
@@ -410,7 +421,8 @@ public struct Datadog {
                 dateProvider: configuration.dateProvider,
                 serverDateProvider: configuration.serverDateProvider
             ),
-            applicationVersion: applicationVersion,
+            applicationVersion: applicationVersion, 
+            maxBatchesPerUpload: configuration.batchProcessingLevel.rawValue,
             backgroundTasksEnabled: configuration.backgroundTasksEnabled
         )
 

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -421,7 +421,7 @@ public struct Datadog {
                 dateProvider: configuration.dateProvider,
                 serverDateProvider: configuration.serverDateProvider
             ),
-            applicationVersion: applicationVersion, 
+            applicationVersion: applicationVersion,
             maxBatchesPerUpload: configuration.batchProcessingLevel.rawValue,
             backgroundTasksEnabled: configuration.backgroundTasksEnabled
         )

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -55,10 +55,22 @@ public struct Datadog {
             case rare
         }
 
-        public enum BatchProcessingLevel: Int {
-            case low = 1
-            case medium = 10
-            case high = 100
+        /// Defines the maximum amount of batches processed sequentially without a delay within one reading/uploading cycle.
+        public enum BatchProcessingLevel {
+            case low
+            case medium
+            case high
+
+            var maxBatchesPerUpload: Int {
+                switch self {
+                case .low:
+                    return 1
+                case .medium:
+                    return 10
+                case .high:
+                    return 100
+                }
+            }
         }
 
         /// Either the RUM client token (which supports RUM, Logging and APM) or regular client token, only for Logging and APM.
@@ -111,7 +123,9 @@ public struct Datadog {
         /// The bundle object that contains the current executable.
         public var bundle: Bundle
 
+        /// Batch provessing level, defining the maximum number of batches processed sequencially without a delay within one reading/uploading cycle.
         ///
+        /// `.medium` by default.
         public var batchProcessingLevel: BatchProcessingLevel
 
         /// Flag that determines if UIApplication methods [`beginBackgroundTask(expirationHandler:)`](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtaskwithexpiratio) and [`endBackgroundTask:`](https://developer.apple.com/documentation/uikit/uiapplication/1622970-endbackgroundtask)
@@ -119,7 +133,7 @@ public struct Datadog {
         ///
         /// Tasks are normally stopped when there's nothing to upload or when encountering any upload blocker such us no internet connection or low battery.
         ///
-        /// By default it's set to `false`.
+        /// `false` by default.
         public var backgroundTasksEnabled: Bool
 
         /// Creates a Datadog SDK Configuration object.
@@ -422,7 +436,7 @@ public struct Datadog {
                 serverDateProvider: configuration.serverDateProvider
             ),
             applicationVersion: applicationVersion,
-            maxBatchesPerUpload: configuration.batchProcessingLevel.rawValue,
+            maxBatchesPerUpload: configuration.batchProcessingLevel.maxBatchesPerUpload,
             backgroundTasksEnabled: configuration.backgroundTasksEnabled
         )
 

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -441,6 +441,8 @@ public struct Datadog {
         )
 
         core.telemetry.configuration(
+            backgroundTaskEnabled: configuration.backgroundTasksEnabled,
+            batchProcessingLevel: Int64(exactly: configuration.batchProcessingLevel.maxBatchesPerUpload),
             batchSize: Int64(exactly: performance.maxFileSize),
             batchUploadFrequency: performance.minUploadDelay.toInt64Milliseconds,
             useLocalEncryption: configuration.encryption != nil,

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -441,7 +441,7 @@ public struct Datadog {
         )
 
         core.telemetry.configuration(
-            backgroundTaskEnabled: configuration.backgroundTasksEnabled,
+            backgroundTasksEnabled: configuration.backgroundTasksEnabled,
             batchProcessingLevel: Int64(exactly: configuration.batchProcessingLevel.maxBatchesPerUpload),
             batchSize: Int64(exactly: performance.maxFileSize),
             batchUploadFrequency: performance.minUploadDelay.toInt64Milliseconds,

--- a/DatadogCore/Sources/Utils/CoreMetrics.swift
+++ b/DatadogCore/Sources/Utils/CoreMetrics.swift
@@ -62,7 +62,7 @@ internal enum BatchDeletedMetric {
         /// The intake-code-202 represents a successful delivery. While some status codes, such as 401, indicate unrecoverable
         /// user errors, others, like 400, will indicate faults within the SDK. It is important to note that not all status codes will appear
         /// in this field, as the SDKs implement retry mechanisms for certain codes, e.g. 503 (see: ``DataUploadStatus``).
-        case intakeCode(responseCode: Int)
+        case intakeCode(responseCode: Int?)
         /// The batch become obsolete (older than allowed limit for this track's intake).
         case obsolete
         /// The batch was deleted due to exceeding allowed max size for batches directory.
@@ -77,7 +77,7 @@ internal enum BatchDeletedMetric {
         func toString() -> String {
             switch self {
             case .intakeCode(let responseCode):
-                return "intake-code-\(responseCode)"
+                return "intake-code-\(responseCode.map { String($0) } ?? "unknown")"
             case .obsolete:
                 return "obsolete"
             case .purged:

--- a/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
@@ -45,11 +45,11 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch())
+        let batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.count, 3, "All 3 events should be written to the same batch")
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batche")
+        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }
 
     func testWhenWritingEventsWithForcingNewBatch_itShouldWriteEachEventToSeparateBatch() throws {
@@ -61,19 +61,19 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        var batch = try XCTUnwrap(storage.reader.readNextBatch())
+        var batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch())
+        batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch())
+        batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.count, 1)
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
+        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }
 
     // MARK: - Behaviours on tracking consent
@@ -87,11 +87,11 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch())
+        let batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
+        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToGranted_itMakesPendingEventsReadable() throws {
@@ -106,15 +106,15 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        var batch = try XCTUnwrap(storage.reader.readNextBatch())
+        var batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        batch = try XCTUnwrap(storage.reader.readNextBatch())
+        batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"pending"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
+        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToNotGranted_itDeletesPendingEvents() throws {
@@ -129,14 +129,17 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        let batch = try XCTUnwrap(storage.reader.readNextBatch())
+        let batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
         XCTAssertEqual(batch.events.map { $0.data.utf8String }, [#"{"event.consent":"granted"}"#])
         storage.reader.markBatchAsRead(batch)
 
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches")
+        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
 
         storage.migrateUnauthorizedData(toConsent: .granted)
-        XCTAssertNil(storage.reader.readNextBatch(), "There must be no other batches, because pending events were deleted")
+        XCTAssertTrue(
+            storage.reader.readNextBatches(1).isEmpty,
+            "There must be no other batches, because pending events were deleted"
+        )
     }
 
     // MARK: - Data migration

--- a/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
@@ -61,17 +61,12 @@ class FeatureStorageTests: XCTestCase {
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
 
-        var batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
-        XCTAssertEqual(batch.events.count, 1)
-        storage.reader.markBatchAsRead(batch)
-
-        batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
-        XCTAssertEqual(batch.events.count, 1)
-        storage.reader.markBatchAsRead(batch)
-
-        batch = try XCTUnwrap(storage.reader.readNextBatches(1).first)
-        XCTAssertEqual(batch.events.count, 1)
-        storage.reader.markBatchAsRead(batch)
+        let batches = storage.reader.readNextBatches(3)
+        XCTAssertEqual(batches.count, 3)
+        batches.forEach { batch in
+            XCTAssertEqual(batch.events.count, 1)
+            storage.reader.markBatchAsRead(batch)
+        }
 
         XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -83,7 +83,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         // - wait more than batch obsolescence limit
         // - then request readable file, which should trigger obsolete files deletion
         dateProvider.advance(bySeconds: storage.maxFileAgeForRead + 1)
-        _ = orchestrator.getReadableFile()
+        _ = orchestrator.getReadableFiles()
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -187,7 +187,7 @@ class FilesOrchestratorTests: XCTestCase {
         let orchestrator = configureOrchestrator(using: dateProvider)
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFiles())
+        XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
     }
 
     func testWhenReadableFileIsOldEnough_itReturnsFile() throws {
@@ -207,7 +207,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 0.5 * performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFiles())
+        XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
     }
 
     func testWhenThereAreMultipleReadableFiles_itReturnsOldestFile() throws {
@@ -226,7 +226,7 @@ class FilesOrchestratorTests: XCTestCase {
         try orchestrator.directory.file(named: fileNames[2]).delete()
         XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[3])
         try orchestrator.directory.file(named: fileNames[3]).delete()
-        XCTAssertNil(orchestrator.getReadableFiles())
+        XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
     }
 
     func testsWhenThereAreMultipleReadableFiles_itReturnsFileByExcludingCertainNames() throws {

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -181,7 +181,7 @@ class FilesOrchestratorTests: XCTestCase {
 
     // MARK: - Readable file tests
 
-    func testGivenNoReadableFiles_whenObtainingFile_itReturnsNil() {
+    func testGivenNoReadableFiles_whenObtainingFiles_itReturnsEmpty() {
         let dateProvider = RelativeDateProvider()
 
         let orchestrator = configureOrchestrator(using: dateProvider)
@@ -190,17 +190,17 @@ class FilesOrchestratorTests: XCTestCase {
         XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
     }
 
-    func testWhenReadableFileIsOldEnough_itReturnsFile() throws {
+    func testWhenReadableFileIsOldEnough_itReturnsFiles() throws {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
-        let file = try orchestrator.directory.createFile(named: dateProvider.now.toFileName)
+        _ = try orchestrator.directory.createFile(named: dateProvider.now.toFileName)
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, file.name)
+        XCTAssertGreaterThan(orchestrator.getReadableFiles().count, 0)
     }
 
-    func testWhenReadableFileIsNotOldEnough_itReturnsNil() throws {
+    func testWhenReadableFilesAreNotOldEnough_itReturnsEmpty() throws {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
         _ = try orchestrator.directory.createFile(named: dateProvider.now.toFileName)
@@ -210,7 +210,7 @@ class FilesOrchestratorTests: XCTestCase {
         XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
     }
 
-    func testWhenThereAreMultipleReadableFiles_itReturnsOldestFile() throws {
+    func testWhenThereAreMultipleReadableFiles_itReturnsSortedFromOldestFile() throws {
         let dateProvider = RelativeDateProvider(advancingBySeconds: 1)
         let orchestrator = configureOrchestrator(using: dateProvider)
 
@@ -218,18 +218,14 @@ class FilesOrchestratorTests: XCTestCase {
         try fileNames.forEach { fileName in _ = try orchestrator.directory.createFile(named: fileName) }
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
-        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[0])
-        try orchestrator.directory.file(named: fileNames[0]).delete()
-        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[1])
-        try orchestrator.directory.file(named: fileNames[1]).delete()
-        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[2])
-        try orchestrator.directory.file(named: fileNames[2]).delete()
-        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[3])
-        try orchestrator.directory.file(named: fileNames[3]).delete()
-        XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
+        let readableFiles = orchestrator.getReadableFiles()
+        XCTAssertEqual(readableFiles[0].name, fileNames[0])
+        XCTAssertEqual(readableFiles[1].name, fileNames[1])
+        XCTAssertEqual(readableFiles[2].name, fileNames[2])
+        XCTAssertEqual(readableFiles[3].name, fileNames[3])
     }
 
-    func testsWhenThereAreMultipleReadableFiles_itReturnsFileByExcludingCertainNames() throws {
+    func testsWhenThereAreMultipleReadableFiles_itReturnsFilesByExcludingCertainNames() throws {
         let dateProvider = RelativeDateProvider(advancingBySeconds: 1)
         let orchestrator = configureOrchestrator(using: dateProvider)
 
@@ -237,26 +233,41 @@ class FilesOrchestratorTests: XCTestCase {
         try fileNames.forEach { fileName in _ = try orchestrator.directory.createFile(named: fileName) }
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
-        XCTAssertEqual(
-            orchestrator.getReadableFiles(excludingFilesNamed: Set(fileNames[0...2])).first?.name,
-            fileNames[3]
-        )
+        let readableFiles = orchestrator.getReadableFiles(excludingFilesNamed: Set(fileNames[0...2]))
+        XCTAssertEqual(readableFiles.count, 1)
+        XCTAssertEqual(readableFiles.first?.name, fileNames.last)
     }
 
-    func testWhenReadableFileIsTooOld_itGetsDeleted() throws {
+    func testWhenReadableFilesAreTooOld_theyGetDeleted() throws {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
         _ = try orchestrator.directory.createFile(named: dateProvider.now.toFileName)
 
         dateProvider.advance(bySeconds: 2 * performance.maxFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFiles())
+        XCTAssertTrue(orchestrator.getReadableFiles().isEmpty)
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
+    }
+
+    func testWhenThereAreMultipleReadableFiles_itRespectsTheLimit() throws {
+        let dateProvider = RelativeDateProvider(advancingBySeconds: 1)
+        let orchestrator = configureOrchestrator(using: dateProvider)
+
+        let fileNames = (0..<4).map { _ in dateProvider.now.toFileName }
+        try fileNames.forEach { fileName in _ = try orchestrator.directory.createFile(named: fileName) }
+
+        dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
+        let limit = 2
+        let readableFiles = orchestrator.getReadableFiles(limit: limit)
+
+        XCTAssertEqual(readableFiles.count, limit)
+        XCTAssertEqual(readableFiles[0].name, fileNames[0])
+        XCTAssertEqual(readableFiles[1].name, fileNames[1])
     }
 
     // MARK: - Deleting Files
 
-    func testItDeletesReadableFile() throws {
+    func testItDeletesReadableFiles() throws {
         let dateProvider = RelativeDateProvider()
         let orchestrator = configureOrchestrator(using: dateProvider)
         _ = try orchestrator.directory.createFile(named: dateProvider.now.toFileName)
@@ -303,12 +314,4 @@ class FilesOrchestratorTests: XCTestCase {
         XCTAssertEqual(fileCreationDateFrom(fileName: invalidFileName), Date(timeIntervalSinceReferenceDate: 0))
     }
     // swiftlint:enable number_separator
-}
-
-extension FilesOrchestrator {
-    func getReadableFiles(
-        context: DatadogContext
-    ) -> [ReadableFile] {
-        getReadableFiles(excludingFilesNamed: [])
-    }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -187,7 +187,7 @@ class FilesOrchestratorTests: XCTestCase {
         let orchestrator = configureOrchestrator(using: dateProvider)
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile())
+        XCTAssertNil(orchestrator.getReadableFiles())
     }
 
     func testWhenReadableFileIsOldEnough_itReturnsFile() throws {
@@ -197,7 +197,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        XCTAssertEqual(orchestrator.getReadableFile()?.name, file.name)
+        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, file.name)
     }
 
     func testWhenReadableFileIsNotOldEnough_itReturnsNil() throws {
@@ -207,7 +207,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 0.5 * performance.minFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile())
+        XCTAssertNil(orchestrator.getReadableFiles())
     }
 
     func testWhenThereAreMultipleReadableFiles_itReturnsOldestFile() throws {
@@ -218,15 +218,15 @@ class FilesOrchestratorTests: XCTestCase {
         try fileNames.forEach { fileName in _ = try orchestrator.directory.createFile(named: fileName) }
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
-        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[0])
+        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[0])
         try orchestrator.directory.file(named: fileNames[0]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[1])
+        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[1])
         try orchestrator.directory.file(named: fileNames[1]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[2])
+        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[2])
         try orchestrator.directory.file(named: fileNames[2]).delete()
-        XCTAssertEqual(orchestrator.getReadableFile()?.name, fileNames[3])
+        XCTAssertEqual(orchestrator.getReadableFiles().first?.name, fileNames[3])
         try orchestrator.directory.file(named: fileNames[3]).delete()
-        XCTAssertNil(orchestrator.getReadableFile())
+        XCTAssertNil(orchestrator.getReadableFiles())
     }
 
     func testsWhenThereAreMultipleReadableFiles_itReturnsFileByExcludingCertainNames() throws {
@@ -238,7 +238,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
         XCTAssertEqual(
-            orchestrator.getReadableFile(excludingFilesNamed: Set(fileNames[0...2]))?.name,
+            orchestrator.getReadableFiles(excludingFilesNamed: Set(fileNames[0...2])).first?.name,
             fileNames[3]
         )
     }
@@ -250,7 +250,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 2 * performance.maxFileAgeForRead)
 
-        XCTAssertNil(orchestrator.getReadableFile())
+        XCTAssertNil(orchestrator.getReadableFiles())
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
     }
 
@@ -263,7 +263,7 @@ class FilesOrchestratorTests: XCTestCase {
 
         dateProvider.advance(bySeconds: 1 + performance.minFileAgeForRead)
 
-        let readableFile = try orchestrator.getReadableFile().unwrapOrThrow()
+        let readableFile = try orchestrator.getReadableFiles().first.unwrapOrThrow()
         XCTAssertEqual(try orchestrator.directory.files().count, 1)
         orchestrator.delete(readableFile: readableFile)
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
@@ -306,9 +306,9 @@ class FilesOrchestratorTests: XCTestCase {
 }
 
 extension FilesOrchestrator {
-    func getReadableFile(
+    func getReadableFiles(
         context: DatadogContext
-    ) -> ReadableFile? {
-        getReadableFile(excludingFilesNamed: [])
+    ) -> [ReadableFile] {
+        getReadableFiles(excludingFilesNamed: [])
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -46,6 +46,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(try directory.files().count, 1)
+        XCTAssertEqual(reader.readNextBatches(nil).count, 1)
         let batch = reader.readNextBatches(1).first
 
         let expected = [
@@ -60,6 +61,7 @@ class FileReaderTests: XCTestCase {
 
         XCTAssertEqual(try directory.files().count, 2)
         XCTAssertEqual(reader.readNextBatches(2).count, 2)
+        XCTAssertEqual(reader.readNextBatches(nil).count, 2)
     }
 
     func testItReadsEncryptedBatches() throws {
@@ -93,6 +95,7 @@ class FileReaderTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
+        XCTAssertEqual(reader.readNextBatches(nil).count, 1)
         let batch = reader.readNextBatches(1).first
 
         let expected = [
@@ -108,6 +111,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(reader.readNextBatches(2).count, 2)
+        XCTAssertEqual(reader.readNextBatches(nil).count, 2)
     }
 
     func testItMarksBatchesAsRead() throws {

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -159,7 +159,7 @@ class FileReaderTests: XCTestCase {
 }
 
 extension Reader {
-    func readNextBatches(_ limit: Int) -> [Batch] {
+    func readNextBatches(_ limit: Int = .max) -> [Batch] {
         return readFiles(limit: limit).compactMap { readBatch(from: $0) }
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -46,7 +46,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(try directory.files().count, 1)
-        XCTAssertEqual(reader.readNextBatches(nil).count, 1)
+        XCTAssertEqual(reader.readNextBatches(.max).count, 1)
         let batch = reader.readNextBatches(1).first
 
         let expected = [
@@ -61,7 +61,7 @@ class FileReaderTests: XCTestCase {
 
         XCTAssertEqual(try directory.files().count, 2)
         XCTAssertEqual(reader.readNextBatches(2).count, 2)
-        XCTAssertEqual(reader.readNextBatches(nil).count, 2)
+        XCTAssertEqual(reader.readNextBatches(.max).count, 2)
     }
 
     func testItReadsEncryptedBatches() throws {
@@ -95,7 +95,7 @@ class FileReaderTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        XCTAssertEqual(reader.readNextBatches(nil).count, 1)
+        XCTAssertEqual(reader.readNextBatches(.max).count, 1)
         let batch = reader.readNextBatches(1).first
 
         let expected = [
@@ -111,7 +111,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(reader.readNextBatches(2).count, 2)
-        XCTAssertEqual(reader.readNextBatches(nil).count, 2)
+        XCTAssertEqual(reader.readNextBatches(.max).count, 2)
     }
 
     func testItMarksBatchesAsRead() throws {
@@ -159,7 +159,7 @@ class FileReaderTests: XCTestCase {
 }
 
 extension Reader {
-    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
-        return readFiles(limit).compactMap { readBatch(from: $0) }
+    func readNextBatches(_ limit: Int) -> [Batch] {
+        return readFiles(limit: limit).compactMap { readBatch(from: $0) }
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -45,7 +45,7 @@ class FileReaderTests: XCTestCase {
             .append(data: data)
 
         XCTAssertEqual(try directory.files().count, 1)
-        let batch = reader.readNextBatch()
+        let batch = reader.readNextBatches(1).first
 
         let expected = [
             Event(data: "ABCD".utf8Data, metadata: "EFGH".utf8Data)
@@ -84,7 +84,7 @@ class FileReaderTests: XCTestCase {
         )
 
         // When
-        let batch = reader.readNextBatch()
+        let batch = reader.readNextBatches(1).first
 
         // Then
         let expected = [
@@ -125,19 +125,19 @@ class FileReaderTests: XCTestCase {
         ]
 
         var batch: Batch
-        batch = try reader.readNextBatch().unwrapOrThrow()
+        batch = try reader.readNextBatches(1).first.unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[0])
         reader.markBatchAsRead(batch)
 
-        batch = try reader.readNextBatch().unwrapOrThrow()
+        batch = try reader.readNextBatches(1).first.unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[1])
         reader.markBatchAsRead(batch)
 
-        batch = try reader.readNextBatch().unwrapOrThrow()
+        batch = try reader.readNextBatches(1).first.unwrapOrThrow()
         XCTAssertEqual(batch.events.first, expected[2])
         reader.markBatchAsRead(batch)
 
-        XCTAssertNil(reader.readNextBatch())
+        XCTAssertTrue(reader.readNextBatches(1).isEmpty)
         XCTAssertEqual(try directory.files().count, 0)
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -157,3 +157,9 @@ class FileReaderTests: XCTestCase {
         XCTAssertEqual(try directory.files().count, 0)
     }
 }
+
+extension Reader {
+    func readNextBatches(_ limit: Int? = nil) -> [Batch] {
+        return readFiles(limit).compactMap { readBatch(from: $0) }
+    }
+}

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -376,7 +376,7 @@ class DataUploadWorkerTests: XCTestCase {
 
         XCTAssertEqual(
             dd.logger.debugLogs[0].message,
-            "⏳ (\(randomFeatureName)) Uploading batch...",
+            "⏳ (\(randomFeatureName)) Uploading batches...",
             "Batch start information should be printed to `userLogger`. All captured logs:\n\(dd.logger.recordedLogs)"
         )
 

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -66,7 +66,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: 1
         )
 
         // Then
@@ -98,7 +99,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -130,7 +132,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [initiatingUploadExpectation], timeout: 0.5)
@@ -159,7 +162,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -194,7 +198,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.neverUpload(),
             delay: delay,
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         // Then
@@ -230,7 +235,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: delay,
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         // Then
@@ -265,7 +271,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: delay,
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         // Then
@@ -303,7 +310,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: randomFeatureName,
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -348,7 +356,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockRandom(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -382,7 +391,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockRandom(),
-            telemetry: telemetry
+            telemetry: telemetry,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -415,7 +425,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockRandom(),
-            telemetry: telemetry
+            telemetry: telemetry,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [startUploadExpectation], timeout: 0.5)
@@ -450,7 +461,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: "some-feature",
-            telemetry: telemetry
+            telemetry: telemetry,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         wait(for: [initiatingUploadExpectation], timeout: 0.5)
@@ -482,7 +494,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.neverUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         // When
@@ -510,7 +523,8 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
 
         // Given
@@ -551,6 +565,7 @@ class DataUploadWorkerTests: XCTestCase {
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
             telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTaskCoordinator: backgroundTaskCoordinator
         )
         writer.write(value: ["k1": "v1"])
@@ -580,6 +595,7 @@ class DataUploadWorkerTests: XCTestCase {
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
             telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTaskCoordinator: backgroundTaskCoordinator
         )
         writer.write(value: ["k1": "v1"])
@@ -608,6 +624,7 @@ class DataUploadWorkerTests: XCTestCase {
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny(),
             telemetry: NOPTelemetry(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTaskCoordinator: backgroundTaskCoordinator
         )
         // Then

--- a/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
@@ -79,6 +79,7 @@ class DatadogConfigurationTests: XCTestCase {
         configuration.site = .eu1
         configuration.batchSize = .small
         configuration.uploadFrequency = .frequent
+        configuration.batchProcessingLevel = .high
         configuration.proxyConfiguration = [
             kCFNetworkProxiesHTTPEnable: true,
             kCFNetworkProxiesHTTPPort: 123,
@@ -103,6 +104,7 @@ class DatadogConfigurationTests: XCTestCase {
 
         XCTAssertEqual(configuration.batchSize, .small)
         XCTAssertEqual(configuration.uploadFrequency, .frequent)
+        XCTAssertEqual(configuration.batchProcessingLevel, .high)
         XCTAssertTrue(configuration.encryption is DataEncryptionMock)
         XCTAssertTrue(configuration.serverDateProvider is ServerDateProviderMock)
 

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
@@ -21,6 +21,7 @@ class FeatureContextTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
 

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -43,6 +43,7 @@ class DatadogCoreTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }
@@ -89,6 +90,7 @@ class DatadogCoreTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }
@@ -143,6 +145,7 @@ class DatadogCoreTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }
@@ -194,6 +197,7 @@ class DatadogCoreTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         let core2 = DatadogCore(
@@ -205,6 +209,7 @@ class DatadogCoreTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer {

--- a/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
@@ -67,6 +67,7 @@ class DatadogLogsFeatureTests: XCTestCase {
                 )
             ),
             applicationVersion: randomApplicationVersion,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: randomBackgroundTasksEnabled
         )
         defer { core.flushAndTearDown() }
@@ -129,6 +130,7 @@ class DatadogLogsFeatureTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -259,7 +259,7 @@ extension FilesOrchestratorType {
 }
 
 class NOPReader: Reader {
-    func readNextBatch() -> Batch? { nil }
+    func readNextBatches(_ limit: Int?) -> [Batch] { [] }
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {}
 }
 
@@ -276,7 +276,7 @@ internal class NOPFilesOrchestrator: FilesOrchestratorType {
 
     func getNewWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
     func getWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
-    func getReadableFile(excludingFilesNamed excludedFileNames: Set<String>) -> ReadableFile? { NOPFile() }
+    func getReadableFiles(excludingFilesNamed excludedFileNames: Set<String>, limit: Int?) -> [ReadableFile] { [] }
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) { }
 
     var ignoreFilesAgeWhenReading = false

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -259,7 +259,8 @@ extension FilesOrchestratorType {
 }
 
 class NOPReader: Reader {
-    func readNextBatches(_ limit: Int?) -> [Batch] { [] }
+    func readFiles(_ limit: Int?) -> [ReadableFile] { [] }
+    func readBatch(from file: ReadableFile) -> Batch? { nil }
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {}
 }
 

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -259,7 +259,7 @@ extension FilesOrchestratorType {
 }
 
 class NOPReader: Reader {
-    func readFiles(_ limit: Int?) -> [ReadableFile] { [] }
+    func readFiles(limit: Int) -> [ReadableFile] { [] }
     func readBatch(from file: ReadableFile) -> Batch? { nil }
     func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {}
 }
@@ -277,7 +277,7 @@ internal class NOPFilesOrchestrator: FilesOrchestratorType {
 
     func getNewWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
     func getWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
-    func getReadableFiles(excludingFilesNamed excludedFileNames: Set<String>, limit: Int?) -> [ReadableFile] { [] }
+    func getReadableFiles(excludingFilesNamed excludedFileNames: Set<String>, limit: Int) -> [ReadableFile] { [] }
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) { }
 
     var ignoreFilesAgeWhenReading = false

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -45,7 +45,7 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
             httpClient: HTTPClientMock(),
             encryption: nil,
             contextProvider: DatadogContextProvider(context: context),
-            applicationVersion: context.version, 
+            applicationVersion: context.version,
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -45,7 +45,8 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
             httpClient: HTTPClientMock(),
             encryption: nil,
             contextProvider: DatadogContextProvider(context: context),
-            applicationVersion: context.version,
+            applicationVersion: context.version, 
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
 

--- a/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -96,7 +96,11 @@ extension RUMOperatingSystem: RandomMockable {
 
 extension RUMViewEvent.DD.Configuration: RandomMockable {
     public static func mockRandom() -> RUMViewEvent.DD.Configuration {
-        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+        return .init(
+            sessionReplaySampleRate: .mockRandom(min: 0, max: 100),
+            sessionSampleRate: .mockRandom(min: 0, max: 100),
+            startSessionReplayRecordingManually: nil
+        )
     }
 }
 
@@ -466,6 +470,8 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     actionNameAttribute: nil,
                     allowFallbackToLocalStorage: nil,
                     allowUntrustedEvents: nil,
+                    backgroundTasksEnabled: .mockRandom(),
+                    batchProcessingLevel: .mockRandom(),
                     batchSize: .mockAny(),
                     batchUploadFrequency: .mockAny(),
                     defaultPrivacyLevel: .mockAny(),

--- a/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
@@ -71,6 +71,7 @@ class RUMFeatureTests: XCTestCase {
                 )
             ),
             applicationVersion: randomApplicationVersion,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: randomBackgroundTasksEnabled
         )
         defer { core.flushAndTearDown() }
@@ -138,6 +139,7 @@ class RUMFeatureTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }

--- a/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
@@ -67,6 +67,7 @@ class DatadogTraceFeatureTests: XCTestCase {
                 )
             ),
             applicationVersion: randomApplicationVersion,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: randomBackgroundTasksEnabled
         )
         defer { core.flushAndTearDown() }
@@ -130,6 +131,7 @@ class DatadogTraceFeatureTests: XCTestCase {
             encryption: nil,
             contextProvider: .mockAny(),
             applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
         defer { core.flushAndTearDown() }

--- a/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
@@ -62,6 +62,12 @@ class DDConfigurationTests: XCTestCase {
         objcConfig.uploadFrequency = .rare
         XCTAssertEqual(objcConfig.sdkConfiguration.uploadFrequency, .rare)
 
+        objcConfig.batchProcessingLevel = .low
+        XCTAssertEqual(objcConfig.sdkConfiguration.batchProcessingLevel, .low)
+
+        objcConfig.batchProcessingLevel = .high
+        XCTAssertEqual(objcConfig.sdkConfiguration.batchProcessingLevel, .high)
+
         objcConfig.proxyConfiguration = [kCFNetworkProxiesHTTPEnable: true, kCFNetworkProxiesHTTPPort: 123, kCFNetworkProxiesHTTPProxy: "www.example.com", kCFProxyUsernameKey: "proxyuser", kCFProxyPasswordKey: "proxypass" ]
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable] as? Bool, true)
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPPort] as? Int, 123)

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -10,6 +10,8 @@ public struct ConfigurationTelemetry: Equatable {
     public let actionNameAttribute: String?
     public let allowFallbackToLocalStorage: Bool?
     public let allowUntrustedEvents: Bool?
+    public let backgroundTaskEnabled: Bool?
+    public let batchProcessingLevel: Int64?
     public let batchSize: Int64?
     public let batchUploadFrequency: Int64?
     public let dartVersion: String?
@@ -178,6 +180,8 @@ extension Telemetry {
         actionNameAttribute: String? = nil,
         allowFallbackToLocalStorage: Bool? = nil,
         allowUntrustedEvents: Bool? = nil,
+        backgroundTaskEnabled: Bool? = nil,
+        batchProcessingLevel: Int64? = nil,
         batchSize: Int64? = nil,
         batchUploadFrequency: Int64? = nil,
         dartVersion: String? = nil,
@@ -227,6 +231,8 @@ extension Telemetry {
             actionNameAttribute: actionNameAttribute,
             allowFallbackToLocalStorage: allowFallbackToLocalStorage,
             allowUntrustedEvents: allowUntrustedEvents,
+            backgroundTaskEnabled: backgroundTaskEnabled,
+            batchProcessingLevel: batchProcessingLevel,
             batchSize: batchSize,
             batchUploadFrequency: batchUploadFrequency,
             dartVersion: dartVersion,
@@ -331,6 +337,8 @@ extension ConfigurationTelemetry {
             actionNameAttribute: other.actionNameAttribute ?? actionNameAttribute,
             allowFallbackToLocalStorage: other.allowFallbackToLocalStorage ?? allowFallbackToLocalStorage,
             allowUntrustedEvents: other.allowUntrustedEvents ?? allowUntrustedEvents,
+            backgroundTaskEnabled: other.backgroundTaskEnabled ?? backgroundTaskEnabled,
+            batchProcessingLevel: other.batchProcessingLevel ?? batchProcessingLevel,
             batchSize: other.batchSize ?? batchSize,
             batchUploadFrequency: other.batchUploadFrequency ?? batchUploadFrequency,
             dartVersion: other.dartVersion ?? dartVersion,

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -10,7 +10,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let actionNameAttribute: String?
     public let allowFallbackToLocalStorage: Bool?
     public let allowUntrustedEvents: Bool?
-    public let backgroundTaskEnabled: Bool?
+    public let backgroundTasksEnabled: Bool?
     public let batchProcessingLevel: Int64?
     public let batchSize: Int64?
     public let batchUploadFrequency: Int64?
@@ -180,7 +180,7 @@ extension Telemetry {
         actionNameAttribute: String? = nil,
         allowFallbackToLocalStorage: Bool? = nil,
         allowUntrustedEvents: Bool? = nil,
-        backgroundTaskEnabled: Bool? = nil,
+        backgroundTasksEnabled: Bool? = nil,
         batchProcessingLevel: Int64? = nil,
         batchSize: Int64? = nil,
         batchUploadFrequency: Int64? = nil,
@@ -231,7 +231,7 @@ extension Telemetry {
             actionNameAttribute: actionNameAttribute,
             allowFallbackToLocalStorage: allowFallbackToLocalStorage,
             allowUntrustedEvents: allowUntrustedEvents,
-            backgroundTaskEnabled: backgroundTaskEnabled,
+            backgroundTasksEnabled: backgroundTasksEnabled,
             batchProcessingLevel: batchProcessingLevel,
             batchSize: batchSize,
             batchUploadFrequency: batchUploadFrequency,
@@ -337,7 +337,7 @@ extension ConfigurationTelemetry {
             actionNameAttribute: other.actionNameAttribute ?? actionNameAttribute,
             allowFallbackToLocalStorage: other.allowFallbackToLocalStorage ?? allowFallbackToLocalStorage,
             allowUntrustedEvents: other.allowUntrustedEvents ?? allowUntrustedEvents,
-            backgroundTaskEnabled: other.backgroundTaskEnabled ?? backgroundTaskEnabled,
+            backgroundTasksEnabled: other.backgroundTasksEnabled ?? backgroundTasksEnabled,
             batchProcessingLevel: other.batchProcessingLevel ?? batchProcessingLevel,
             batchSize: other.batchSize ?? batchSize,
             batchUploadFrequency: other.batchUploadFrequency ?? batchUploadFrequency,

--- a/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
@@ -14,7 +14,7 @@ extension ConfigurationTelemetry {
             actionNameAttribute: .mockRandom(),
             allowFallbackToLocalStorage: .mockRandom(),
             allowUntrustedEvents: .mockRandom(),
-            backgroundTaskEnabled: .mockRandom(),
+            backgroundTasksEnabled: .mockRandom(),
             batchProcessingLevel: .mockRandom(),
             batchSize: .mockRandom(),
             batchUploadFrequency: .mockRandom(),

--- a/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
@@ -14,6 +14,8 @@ extension ConfigurationTelemetry {
             actionNameAttribute: .mockRandom(),
             allowFallbackToLocalStorage: .mockRandom(),
             allowUntrustedEvents: .mockRandom(),
+            backgroundTaskEnabled: .mockRandom(),
+            batchProcessingLevel: .mockRandom(),
             batchSize: .mockRandom(),
             batchUploadFrequency: .mockRandom(),
             dartVersion: .mockRandom(),

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -201,6 +201,8 @@ class TelemetryTest: Telemetry {
             actionNameAttribute: configuration.actionNameAttribute,
             allowFallbackToLocalStorage: configuration.allowFallbackToLocalStorage,
             allowUntrustedEvents: configuration.allowUntrustedEvents,
+            backgroundTaskEnabled: configuration.backgroundTaskEnabled,
+            batchProcessingLevel: configuration.batchProcessingLevel,
             batchSize: configuration.batchSize,
             batchUploadFrequency: configuration.batchUploadFrequency,
             dartVersion: configuration.dartVersion,

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -201,7 +201,7 @@ class TelemetryTest: Telemetry {
             actionNameAttribute: configuration.actionNameAttribute,
             allowFallbackToLocalStorage: configuration.allowFallbackToLocalStorage,
             allowUntrustedEvents: configuration.allowUntrustedEvents,
-            backgroundTaskEnabled: configuration.backgroundTaskEnabled,
+            backgroundTasksEnabled: configuration.backgroundTasksEnabled,
             batchProcessingLevel: configuration.batchProcessingLevel,
             batchSize: configuration.batchSize,
             batchUploadFrequency: configuration.batchUploadFrequency,

--- a/DatadogObjc/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogObjc/Sources/DatadogConfiguration+objc.swift
@@ -84,6 +84,29 @@ public enum DDUploadFrequency: Int {
 }
 
 @objc
+public enum DDBatchProcessingLevel: Int {
+    case low
+    case medium
+    case high
+
+    internal var swiftType: Datadog.Configuration.BatchProcessingLevel {
+        switch self {
+        case .low: return .low
+        case .medium: return .medium
+        case .high: return .high
+        }
+    }
+
+    internal init(swiftType: Datadog.Configuration.BatchProcessingLevel) {
+        switch swiftType {
+        case .low: self = .low
+        case .medium: self = .medium
+        case .high: self = .high
+        }
+    }
+}
+
+@objc
 public class DDTracingHeaderType: NSObject {
     internal let swiftType: TracingHeaderType
 
@@ -194,6 +217,12 @@ public class DDConfiguration: NSObject {
     @objc public var uploadFrequency: DDUploadFrequency {
         get { DDUploadFrequency(swiftType: sdkConfiguration.uploadFrequency) }
         set { sdkConfiguration.uploadFrequency = newValue.swiftType }
+    }
+
+    /// 
+    @objc public var batchProcessingLevel: DDBatchProcessingLevel {
+        get { DDBatchProcessingLevel(swiftType: sdkConfiguration.batchProcessingLevel) }
+        set { sdkConfiguration.batchProcessingLevel = newValue.swiftType }
     }
 
     /// Proxy configuration attributes.

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -3639,6 +3639,10 @@ public class DDRUMViewEventDDConfiguration: NSObject {
     @objc public var sessionSampleRate: NSNumber {
         root.swiftModel.dd.configuration!.sessionSampleRate as NSNumber
     }
+
+    @objc public var startSessionReplayRecordingManually: NSNumber? {
+        root.swiftModel.dd.configuration!.startSessionReplayRecordingManually as NSNumber?
+    }
 }
 
 @objc
@@ -5204,6 +5208,14 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.allowUntrustedEvents as NSNumber?
     }
 
+    @objc public var backgroundTasksEnabled: NSNumber? {
+        root.swiftModel.telemetry.configuration.backgroundTasksEnabled as NSNumber?
+    }
+
+    @objc public var batchProcessingLevel: NSNumber? {
+        root.swiftModel.telemetry.configuration.batchProcessingLevel as NSNumber?
+    }
+
     @objc public var batchSize: NSNumber? {
         root.swiftModel.telemetry.configuration.batchSize as NSNumber?
     }
@@ -5544,4 +5556,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4
+// Generated from https://github.com/DataDog/rum-events-format/tree/36e94a0cfb68b6dc0752a9bf4131b952b2aa1859

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -1804,9 +1804,13 @@ public struct RUMViewEvent: RUMDataModel {
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
 
+            /// Whether session replay recording configured to start manually
+            public let startSessionReplayRecordingManually: Bool?
+
             enum CodingKeys: String, CodingKey {
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
+                case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
             }
         }
 
@@ -2826,6 +2830,12 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether untrusted events are allowed
             public let allowUntrustedEvents: Bool?
 
+            /// Whether UIApplication background tasks are enabled
+            public let backgroundTasksEnabled: Bool?
+
+            /// Maximum number of batches processed sequencially without a delay
+            public let batchProcessingLevel: Int64?
+
             /// The window duration for batches sent by the SDK (in milliseconds)
             public let batchSize: Int64?
 
@@ -2977,6 +2987,8 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case actionNameAttribute = "action_name_attribute"
                 case allowFallbackToLocalStorage = "allow_fallback_to_local_storage"
                 case allowUntrustedEvents = "allow_untrusted_events"
+                case backgroundTasksEnabled = "background_tasks_enabled"
+                case batchProcessingLevel = "batch_processing_level"
                 case batchSize = "batch_size"
                 case batchUploadFrequency = "batch_upload_frequency"
                 case dartVersion = "dart_version"
@@ -3398,4 +3410,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f69ca4664ed6e69c929855d02c4ce3d4b85d0bb4
+// Generated from https://github.com/DataDog/rum-events-format/tree/36e94a0cfb68b6dc0752a9bf4131b952b2aa1859

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -391,7 +391,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 browserSdkVersion: nil,
                 configuration: .init(
                     sessionReplaySampleRate: nil,
-                    sessionSampleRate: Double(self.sessionSampler.samplingRate), 
+                    sessionSampleRate: Double(self.sessionSampler.samplingRate),
                     startSessionReplayRecordingManually: nil
                 ),
                 documentVersion: original.dd.documentVersion + 1,

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -389,7 +389,11 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
+                configuration: .init(
+                    sessionReplaySampleRate: nil,
+                    sessionSampleRate: Double(self.sessionSampler.samplingRate), 
+                    startSessionReplayRecordingManually: nil
+                ),
                 documentVersion: original.dd.documentVersion + 1,
                 pageStates: nil,
                 replayStats: nil,
@@ -472,7 +476,11 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
+                configuration: .init(
+                    sessionReplaySampleRate: nil,
+                    sessionSampleRate: Double(self.sessionSampler.samplingRate),
+                    startSessionReplayRecordingManually: nil
+                ),
                 documentVersion: 1,
                 pageStates: nil,
                 replayStats: nil,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -260,6 +260,8 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             actionNameAttribute: nil,
             allowFallbackToLocalStorage: nil,
             allowUntrustedEvents: nil,
+            backgroundTasksEnabled: configuration.backgroundTasksEnabled,
+            batchProcessingLevel: configuration.batchProcessingLevel,
             batchSize: configuration.batchSize,
             batchUploadFrequency: configuration.batchUploadFrequency,
             dartVersion: configuration.dartVersion,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -439,7 +439,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let viewEvent = RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
+                configuration: .init(
+                    sessionReplaySampleRate: nil,
+                    sessionSampleRate: Double(dependencies.sessionSampler.samplingRate),
+                    startSessionReplayRecordingManually: nil
+                ),
                 documentVersion: version.toInt64,
                 pageStates: nil,
                 replayStats: .init(

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -291,6 +291,8 @@ class TelemetryReceiverTests: XCTestCase {
             )
         )
 
+        let backgroundTasksEnabled: Bool? = .mockRandom()
+        let batchProcessingLevel: Int64? = .mockRandom()
         let batchSize: Int64? = .mockRandom()
         let batchUploadFrequency: Int64? = .mockRandom()
         let dartVersion: String? = .mockRandom()
@@ -316,6 +318,8 @@ class TelemetryReceiverTests: XCTestCase {
 
         // When
         core.telemetry.configuration(
+            backgroundTasksEnabled: backgroundTasksEnabled,
+            batchProcessingLevel: batchProcessingLevel,
             batchSize: batchSize,
             batchUploadFrequency: batchUploadFrequency,
             dartVersion: dartVersion,
@@ -346,6 +350,8 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.version, core.context.sdkVersion)
         XCTAssertEqual(event?.service, "dd-sdk-ios")
         XCTAssertEqual(event?.source.rawValue, core.context.source)
+        XCTAssertEqual(event?.telemetry.configuration.backgroundTasksEnabled, backgroundTasksEnabled)
+        XCTAssertEqual(event?.telemetry.configuration.batchProcessingLevel, batchProcessingLevel)
         XCTAssertEqual(event?.telemetry.configuration.batchSize, batchSize)
         XCTAssertEqual(event?.telemetry.configuration.batchUploadFrequency, batchUploadFrequency)
         XCTAssertEqual(event?.telemetry.configuration.dartVersion, dartVersion)

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -109,7 +109,7 @@ extension RUMOperatingSystem: RandomMockable {
 
 extension RUMViewEvent.DD.Configuration: RandomMockable {
     public static func mockRandom() -> RUMViewEvent.DD.Configuration {
-        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100), startSessionReplayRecordingManually: nil)
     }
 }
 
@@ -479,9 +479,11 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     actionNameAttribute: nil,
                     allowFallbackToLocalStorage: nil,
                     allowUntrustedEvents: nil,
+                    backgroundTasksEnabled: .mockAny(),
+                    batchProcessingLevel: .mockAny(),
                     batchSize: .mockAny(),
-                    batchUploadFrequency: .mockAny(),
-                    defaultPrivacyLevel: .mockAny(),
+                    batchUploadFrequency: .mockRandom(),
+                    defaultPrivacyLevel: .mockRandom(),
                     forwardConsoleLogs: nil,
                     forwardErrorsToLogs: nil,
                     forwardReports: nil,


### PR DESCRIPTION
### What and why?

Modifies the core logic to get a list of batches instead of single batch. It's done through a new configuration called `BatchProcessingLevel` that allows controlling the amount of batches processed sequentially without a delay within one reading/uploading cycle. Currently it exposed 3 levels: `low`, `medium` and `high` that translate to `1`, `10` and `100` of batches processed. By default it's taking up to `10` batches in a cycle.

This logic improves the data upload when batch back pressure occurs. 

### How?

Configuration is delivered to `DataUploadWorker` which implementation was modified to read up to X batches instead of single batch.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
