### PR TITLE
Fix Integration Tests

### DIFF
--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMStopSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMStopSessionScenarioTests.swift
@@ -118,7 +118,6 @@ class RUMStopSessionScenarioTests: IntegrationTests, RUMCommonAsserts {
             XCTAssertNil(interruptedSession.applicationLaunchView)
 
             let view1 = interruptedSession.viewVisits[0]
-            XCTAssertTrue(try XCTUnwrap(view1.viewEvents.first?.session.isActive))
             XCTAssertEqual(view1.name, "KioskSendInterruptedEvents")
             XCTAssertEqual(view1.path, "Runner.KioskSendInterruptedEventsViewController")
             XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")


### PR DESCRIPTION
### What and why?

Fixes integration test, by removing unnecessary assertion. This assert became flaky after adding view event reduction and now it depends on the number of batches created in the lifecycle of the UI Test.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
