### PR TITLE
RUM-1923 feat: add tracestate headers when using W3C tracecontext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [BUGFIX] Optimize Session Replay diffing algorithm. See [#1524][]
 - [FEATURE] Add network instrumentation for async/await URLSession APIs. See [#1394][]
 - [FEATURE] Change default tracing headers for first party hosts to use both Datadog headers and W3C `tracecontext` headers. See [#1529][]
+- [FEATURE] Add tracestate headers when using W3C tracecontext. See [#1536][]
 
 # 2.4.0 / 18-10-2023
 
@@ -550,6 +551,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1394]: https://github.com/DataDog/dd-sdk-ios/pull/1394
 [#1524]: https://github.com/DataDog/dd-sdk-ios/pull/1524
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
+[#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -879,6 +879,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
+            "tracestate": "dd=s:1;o:rum",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
@@ -888,6 +889,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders2 = [
+            "tracestate": "dd=s:1;o:rum",
             "traceparent": "00-00000000000000000000000000000004-0000000000000005-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
@@ -897,6 +899,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders3 = [
+            "tracestate": "dd=s:1;o:rum",
             "traceparent": "00-0000000000000000000000000000004d-0000000000000058-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
@@ -915,6 +918,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders = [
+            "tracestate": "dd=s:0;o:rum",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-00"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -221,6 +221,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "X-B3-TraceId": "00000000000000000000000000000001",
                 "b3": "00000000000000000000000000000001-0000000000000001-1",
                 "x-datadog-trace-id": "1",
+                "tracestate": "dd=s:1;o:rum",
                 "x-datadog-parent-id": "1",
                 "x-datadog-sampling-priority": "1"
             ]

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -309,7 +309,8 @@ class DDTracerTests: XCTestCase {
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-01"
+            "traceparent": "00-00000000000000000000000000000001-0000000000000002-01",
+            "tracestate": "dd=s:1;o:rum"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -325,7 +326,8 @@ class DDTracerTests: XCTestCase {
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-00"
+            "traceparent": "00-00000000000000000000000000000001-0000000000000002-00",
+            "tracestate": "dd=s:0;o:rum"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
@@ -40,10 +40,22 @@ public enum W3CHTTPHeaders {
     /// can troubleshoot the behavior of every recorded request.
     public static let traceparent = "traceparent"
 
+    /// The main purpose of the tracestate HTTP header is to provide additional vendor-specific trace identification
+    /// information across different distributed tracing systems and is a companion header for the traceparent field. It
+    /// also conveys information about the request’s position in multiple distributed tracing graphs.
+    public static let tracestate = "tracestate"
+
     public enum Constants {
         public static let version = "00"
         public static let sampledValue = "01"
         public static let unsampledValue = "00"
         public static let separator = "-"
+
+        // MARK: - Datadog specific tracestate keys
+        public static let dd = "dd"
+        public static let sampling = "s"
+        public static let origin = "o"
+        public static let originRUM = "rum"
+        public static let tracestateSeparator = ";"
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -70,12 +70,20 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
         typealias Constants = W3CHTTPHeaders.Constants
 
+        let sampled = sampler.sample()
+
         traceHeaderFields[W3CHTTPHeaders.traceparent] = [
             Constants.version,
             String(traceID, representation: .hexadecimal32Chars),
             String(spanID, representation: .hexadecimal16Chars),
-            sampler.sample() ? Constants.sampledValue : Constants.unsampledValue
+            sampled ? Constants.sampledValue : Constants.unsampledValue
         ]
         .joined(separator: Constants.separator)
+
+        let ddtracestate = [
+            "\(Constants.sampling):\(sampled ? 1 : 0)",
+            "\(Constants.origin):\(Constants.originRUM)"
+        ].joined(separator: Constants.tracestateSeparator)
+        traceHeaderFields[W3CHTTPHeaders.tracestate] = "\(Constants.dd)=\(ddtracestate)"
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -17,6 +17,7 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-01")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:1;o:rum")
     }
 
     func testW3CHTTPHeadersWriterwritesSingleHeaderWithSampling() {
@@ -28,5 +29,6 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-00")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:0;o:rum")
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -419,6 +419,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
             [
+                "tracestate": "dd=s:1;o:rum",
                 "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
                 "X-B3-SpanId": "0000000000000001",
                 "X-B3-Sampled": "1",


### PR DESCRIPTION
### What and why?

Currently, we don't send vendor specific information (Datadog here) when using W3C tracecontext headers for distibuted tracing.

### How?

This PR adds the vendor specific information to the tracecontext headers.

Datadog | tracecontext (W3C)
| - | - |
x-datadog-sampling-priority | s:{sampling-priority}
x-datadog-origin | o:{origin}

Example
```
x-datadog-trace-id: 1229782938247303441 (0x1111111111111111)
x-datadog-parent-id: 2459565876494606882 (0x2222222222222222)
x-datadog-sampling-priority: 2
x-datadog-origin: rum
x-datadog-tags: _dd.p.dm=-4,_dd.p.usr.id=baz64==
```
translates to
```
traceparent: 00-00000000000000001111111111111111-2222222222222222-01
tracestate: dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64~~,othervendor=t61rcWkgMzE
```

x-datadog-tags is not supported by the SDK, hence it is not added to the tracecontext headers.


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
