### PR TITLE
RUM-1923 fix: include hex parent id in tracestate

### DIFF
--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -879,7 +879,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "tracestate": "dd=s:1;o:rum",
+            "tracestate": "dd=s:1;o:rum;p:0000000000000002",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
@@ -889,7 +889,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders2 = [
-            "tracestate": "dd=s:1;o:rum",
+            "tracestate": "dd=s:1;o:rum;p:0000000000000005",
             "traceparent": "00-00000000000000000000000000000004-0000000000000005-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
@@ -899,7 +899,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders3 = [
-            "tracestate": "dd=s:1;o:rum",
+            "tracestate": "dd=s:1;o:rum;p:0000000000000058",
             "traceparent": "00-0000000000000000000000000000004d-0000000000000058-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
@@ -918,7 +918,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders = [
-            "tracestate": "dd=s:0;o:rum",
+            "tracestate": "dd=s:0;o:rum;p:0000000000000002",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-00"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -221,7 +221,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "X-B3-TraceId": "00000000000000000000000000000001",
                 "b3": "00000000000000000000000000000001-0000000000000001-1",
                 "x-datadog-trace-id": "1",
-                "tracestate": "dd=s:1;o:rum",
+                "tracestate": "dd=s:1;o:rum;p:0000000000000001",
                 "x-datadog-parent-id": "1",
                 "x-datadog-sampling-priority": "1"
             ]

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -310,7 +310,7 @@ class DDTracerTests: XCTestCase {
 
         let expectedHTTPHeaders = [
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-01",
-            "tracestate": "dd=s:1;o:rum"
+            "tracestate": "dd=s:1;o:rum;p:0000000000000002"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -327,7 +327,7 @@ class DDTracerTests: XCTestCase {
 
         let expectedHTTPHeaders = [
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-00",
-            "tracestate": "dd=s:0;o:rum"
+            "tracestate": "dd=s:0;o:rum;p:0000000000000002"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
@@ -56,6 +56,7 @@ public enum W3CHTTPHeaders {
         public static let sampling = "s"
         public static let origin = "o"
         public static let originRUM = "rum"
+        public static let parentId = "p"
         public static let tracestateSeparator = ";"
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -82,7 +82,8 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
 
         let ddtracestate = [
             "\(Constants.sampling):\(sampled ? 1 : 0)",
-            "\(Constants.origin):\(Constants.originRUM)"
+            "\(Constants.origin):\(Constants.originRUM)",
+            "\(Constants.parentId):\(String(spanID, representation: .hexadecimal16Chars))"
         ].joined(separator: Constants.tracestateSeparator)
         traceHeaderFields[W3CHTTPHeaders.tracestate] = "\(Constants.dd)=\(ddtracestate)"
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -17,7 +17,7 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-01")
-        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:1;o:rum")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:1;o:rum;p:0000000000000929")
     }
 
     func testW3CHTTPHeadersWriterwritesSingleHeaderWithSampling() {
@@ -29,6 +29,6 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-00")
-        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:0;o:rum")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:0;o:rum;p:0000000000000929")
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -419,7 +419,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
             [
-                "tracestate": "dd=s:1;o:rum",
+                "tracestate": "dd=s:1;o:rum;p:0000000000000001",
                 "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
                 "X-B3-SpanId": "0000000000000001",
                 "X-B3-Sampled": "1",


### PR DESCRIPTION
### What and why?

Currently, if there is broken proxy in between two system, we will have the broken trace.

Hence, we need datadog trace id which can be used to recover the trace.

Eg. RUM SDK > Broken W3C Proxy > DD Tracer (recovered by reading tracestate from RUM SDK).

### How?

This PR adds the datadog trace id to the tracestate header using following format

```
p:{hex-encoded parent-id}
```

Example
```
x-datadog-trace-id: 1229782938247303441 (0x1111111111111111)
x-datadog-parent-id: 2459565876494606882 (0x2222222222222222)
x-datadog-sampling-priority: 2
x-datadog-origin: rum
```

translates to
```
traceparent: 00-00000000000000001111111111111111-2222222222222222-01
tracestate: dd=s:2;o:rum;p:2222222222222222
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
