### PR TITLE
Enable custom node recorders

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1446,6 +1446,7 @@
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
 		E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
+		E1C4C1062AEBFE4F005E65B1 /* SessionReplay+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C4C1052AEBFE4F005E65B1 /* SessionReplay+Internal.swift */; };
 		E1C853142AA9B9A300C74BCF /* TelemetryMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */; };
 		E1C853152AA9B9A300C74BCF /* TelemetryMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */; };
 		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
@@ -2681,6 +2682,7 @@
 		E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CITestIntegrationTests.swift; sourceTree = "<group>"; };
 		E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
 		E1B082CB25641DF9002DB9D2 /* Example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Example.xcconfig; sourceTree = "<group>"; };
+		E1C4C1052AEBFE4F005E65B1 /* SessionReplay+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionReplay+Internal.swift"; sourceTree = "<group>"; };
 		E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMocks.swift; sourceTree = "<group>"; };
 		E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPool.swift; sourceTree = "<group>"; };
 		E1D203FB24C1884500D1AF3A /* ActiveSpansPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPoolTests.swift; sourceTree = "<group>"; };
@@ -3101,6 +3103,7 @@
 				61054E482A6EE10A00AAA894 /* Processor */,
 				61054E0D2A6EE10A00AAA894 /* Recorder */,
 				61054E0C2A6EE10A00AAA894 /* SessionReplay.swift */,
+				E1C4C1052AEBFE4F005E65B1 /* SessionReplay+Internal.swift */,
 				61054E0B2A6EE10A00AAA894 /* SessionReplayConfiguration.swift */,
 				61054E542A6EE10A00AAA894 /* Utilities */,
 				61054E032A6EE10A00AAA894 /* Writer */,
@@ -7609,6 +7612,7 @@
 				61054E692A6EE10A00AAA894 /* ImageDataProvider.swift in Sources */,
 				61054E782A6EE10A00AAA894 /* UIDatePickerRecorder.swift in Sources */,
 				61054E822A6EE10A00AAA894 /* UILabelRecorder.swift in Sources */,
+				E1C4C1062AEBFE4F005E65B1 /* SessionReplay+Internal.swift in Sources */,
 				61054E6C2A6EE10A00AAA894 /* SystemColors.swift in Sources */,
 				61054E812A6EE10A00AAA894 /* UIStepperRecorder.swift in Sources */,
 				61054E632A6EE10A00AAA894 /* SessionReplayConfiguration.swift in Sources */,

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -43,7 +43,8 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
         let recorder = try Recorder(
             processor: processor,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            additionalNodeRecorders: configuration._additionalNodeRecorders
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -17,7 +17,7 @@ internal typealias WireframeID = NodeID
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-internal class WireframesBuilder {
+@_spi(Internal) public class SessionReplayWireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.
@@ -191,6 +191,8 @@ internal class WireframesBuilder {
         )
     }
 }
+
+internal typealias WireframesBuilder = SessionReplayWireframesBuilder
 
 // MARK: - Convenience
 

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -64,12 +64,13 @@ internal class Recorder: Recording {
 
     convenience init(
         processor: Processing,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        additionalNodeRecorders: [NodeRecorder]
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder()
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: additionalNodeRecorders)
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(
             windowObserver: windowObserver

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -18,7 +18,7 @@ internal typealias NodeID = Int64
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-internal final class NodeIDGenerator {
+@_spi(Internal) public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,18 +12,20 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-internal struct ViewTreeRecordingContext {
+@_spi(Internal) public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
     let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.
     let coordinateSpace: UICoordinateSpace
     /// Generates stable IDs for traversed views.
-    let ids: NodeIDGenerator
+    public let ids: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
     /// Variable view controller related context
     var viewControllerContext: ViewControllerContext = .init()
 }
+
+internal typealias ViewTreeRecordingContext = SessionReplayViewTreeRecordingContext
 
 internal extension ViewTreeRecordingContext {
     /// The `ViewControllerContext` struct is used for storing context-related information about the parent view controller and its type.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -37,33 +37,33 @@ internal struct ViewTreeSnapshot {
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
 internal struct Node {
     /// Attributes of the `UIView` that this node was created for.
-    let viewAttributes: ViewAttributes
+    public let viewAttributes: ViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
-    let wireframesBuilder: NodeWireframesBuilder
+    public let wireframesBuilder: NodeWireframesBuilder
 }
 
 /// Attributes of the `UIView` that the node was created for.
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-internal struct ViewAttributes: Equatable {
+@_spi(Internal) public struct SessionReplayViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
-    let frame: CGRect
+    public let frame: CGRect
 
     /// Original view's `.backgorundColor`.
-    let backgroundColor: CGColor?
+    public let backgroundColor: CGColor?
 
     /// Original view's `layer.borderColor`.
-    let layerBorderColor: CGColor?
+    public let layerBorderColor: CGColor?
 
     /// Original view's `layer.borderWidth`.
-    let layerBorderWidth: CGFloat
+    public let layerBorderWidth: CGFloat
 
     /// Original view's `layer.cornerRadius`.
-    let layerCornerRadius: CGFloat
+    public let layerCornerRadius: CGFloat
 
     /// Original view's `.alpha` (between `0.0` and `1.0`).
-    let alpha: CGFloat
+    public let alpha: CGFloat
 
     /// Original view's `.isHidden`.
     let isHidden: Bool
@@ -98,6 +98,8 @@ internal struct ViewAttributes: Equatable {
     /// Example 2: A view with blue semi-transparent background, but alpha `1` is also conisdered "translucent".
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
+
+internal typealias ViewAttributes = SessionReplayViewAttributes
 
 extension ViewAttributes {
     init(frameInRootView: CGRect, view: UIView) {
@@ -153,8 +155,10 @@ extension NodeSemantics {
     var importance: Int { Self.importance }
 }
 
+internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
+
 /// Strategies for handling node's subtree by `Recorder`.
-internal enum NodeSubtreeStrategy {
+@_spi(Internal) public enum SessionReplayNodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -44,9 +44,9 @@ internal struct ViewTreeSnapshotBuilder {
 }
 
 extension ViewTreeSnapshotBuilder {
-    init() {
+    init(additionalNodeRecorders: [NodeRecorder]) {
         self.init(
-            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders() + additionalNodeRecorders),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: ImageDataProvider()
         )

--- a/DatadogSessionReplay/Sources/SessionReplay+Internal.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+Internal.swift
@@ -1,0 +1,152 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2023-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+import UIKit
+
+@_spi(Internal) public enum SessionReplayElement {
+    case specificElement (subtreeStrategy: SessionReplayNodeSubtreeStrategy, attributes: SessionReplayViewAttributes, builder: GenericTextWireframesBuilder)
+    case invisibleElement
+}
+
+@_spi(Internal) open class CustomNodeRecorder: NodeRecorder {
+    public let identifier = UUID()
+    
+    public init () {}
+
+    internal func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        let element = getSessionReplayElement(view: view, attributes: attributes, context: context)
+        switch element {
+        case .invisibleElement:
+            return InvisibleElement.constant
+        case .none:
+            return nil
+        case .specificElement(let subtreeStrategy, let attributes, let builder):
+            let nodes = [
+                Node(viewAttributes: attributes, wireframesBuilder: builder)
+            ]
+            return SpecificElement(subtreeStrategy: subtreeStrategy, nodes: nodes)
+        }
+    }
+
+    // will be overriden with actual implementation
+    open func getSessionReplayElement(
+        view: UIView,
+        attributes: SessionReplayViewAttributes,
+        context: SessionReplayViewTreeRecordingContext
+    ) -> SessionReplayElement? {
+        return nil
+    }
+}
+
+@_spi(Internal) public struct GenericTextWireframesBuilder: NodeWireframesBuilder {
+    public let id: NodeIDGenerator
+    public let frame: CGRect
+    public let text: String
+    public let textAlignment: TextAlignment
+    public let clip: SessionReplayContentClip
+    public let textColor: CGColor?
+    public let font: UIFont
+    public let fontScalingEnabled: Bool
+    public let borderColor: CGColor?
+    public let borderWidth: CGFloat?
+    public let backgroundColor: CGColor?
+    public let cornerRadius: CGFloat?
+    public let opacity: CGFloat?
+    public let view: UIView
+    public let nodeRecorder: CustomNodeRecorder
+    
+    public let wireframeRect: CGRect
+    
+    public init(id: NodeIDGenerator, frame: CGRect, text: String, textAlignment: TextAlignment, clip: SessionReplayContentClip, textColor: CGColor?, font: UIFont, fontScalingEnabled: Bool, borderColor: CGColor?, borderWidth: CGFloat?, backgroundColor: CGColor?, cornerRadius: CGFloat?, opacity: CGFloat?, view: UIView, nodeRecorder: CustomNodeRecorder, wireframeRect: CGRect) {
+        self.id = id
+        self.frame = frame
+        self.text = text
+        self.textAlignment = textAlignment
+        self.clip = clip
+        self.textColor = textColor
+        self.font = font
+        self.fontScalingEnabled = fontScalingEnabled
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
+        self.backgroundColor = backgroundColor
+        self.cornerRadius = cornerRadius
+        self.opacity = opacity
+        self.view = view
+        self.nodeRecorder = nodeRecorder
+        self.wireframeRect = wireframeRect
+    }
+
+    internal func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createTextWireframe(
+                id: id.nodeID(view: view, nodeRecorder: nodeRecorder),
+                frame: frame,
+                text: text,
+                textAlignment: textAlignment.toSRAlignment(),
+                clip: .init(bottom: clip.bottom, left: clip.left, right: clip.right, top: clip.top),
+                textColor: textColor,
+                font: font,
+                borderColor: borderColor,
+                borderWidth: borderWidth,
+                backgroundColor: backgroundColor,
+                cornerRadius: cornerRadius,
+                opacity: opacity
+            )
+        ]
+    }
+
+    public struct SessionReplayContentClip {
+        /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+        public let bottom: Int64?
+        
+        /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+        public let left: Int64?
+        
+        /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+        public let right: Int64?
+        
+        /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+        public let top: Int64?
+        
+        public init(bottom: Int64?, left: Int64?, right: Int64?, top: Int64?) {
+            self.bottom = bottom
+            self.left = left
+            self.right = right
+            self.top = top
+        }
+    }
+
+    public struct TextAlignment {
+        public enum VerticalTextAlignment: String {
+            case top = "top"
+            case bottom = "bottom"
+            case center = "center"
+        }
+        
+        public let textAlignment: NSTextAlignment
+        public let verticalTextAlignment: VerticalTextAlignment
+        
+        public init(textAlignment: NSTextAlignment, verticalTextAlignment: VerticalTextAlignment) {
+            self.textAlignment = textAlignment
+            self.verticalTextAlignment = verticalTextAlignment
+        }
+        
+        internal func toSRAlignment() -> SRTextPosition.Alignment {
+            switch verticalTextAlignment {
+            case .top:
+                return .init(systemTextAlignment: textAlignment, vertical: .top)
+            case .bottom:
+                return .init(systemTextAlignment: textAlignment, vertical: .bottom)
+            case .center:
+                return .init(systemTextAlignment: textAlignment, vertical: .center)
+            }
+        }
+    }
+}
+
+

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -46,6 +46,8 @@ extension SessionReplay {
         // MARK: - Internal
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
+        
+        internal var _additionalNodeRecorders: [NodeRecorder]? = nil
 
         /// Creates Session Replay configuration
         /// - Parameters:
@@ -60,6 +62,10 @@ extension SessionReplay {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
             self.customEndpoint = customEndpoint
+        }
+        
+        @_spi(Internal) public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [CustomNodeRecorder]) {
+            self._additionalNodeRecorders = additionalNodeRecorders
         }
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -47,7 +47,7 @@ extension SessionReplay {
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
         
-        internal var _additionalNodeRecorders: [NodeRecorder]? = nil
+        internal var _additionalNodeRecorders: [NodeRecorder] = []
 
         /// Creates Session Replay configuration
         /// - Parameters:


### PR DESCRIPTION
### What and why?

Add custom node recorders for cross platform SDKs to hook into.

### How?

A few notes on the implementation choices.

I've had to put more logic than I imagined into the iOS SDK since we rely quickly on functions to return types from Data models (that are defined from the schemas), that I cannot make public.
I've decided to add a adapter layer at the level of `NodeRecorders` and builders rather than at the level of Data models, which would have required more changes in the logic of Session Replay.
This means I need to write a generic mapper for each method of WireframesBuilder (`createTextWireframe`, `createImageWireframe`, etc.). I've gone with only an implementation for TextWireframe for now as it's likely the only one we'll need for RN, but it can be extended later.
This was the easiest implementation to start with, let me know if I should refactor this.

Also I could not put the `mutating` function to set the additionalNodeRecorders on the configuration object in an Extension since that extension would be readonly, so I only went with the `@_spi` solution to hide it.

I've implemented a Text mapper that works on RN, if you want to look at what implementation would look like: https://github.com/DataDog/dd-sdk-reactnative/blob/louiszawadzki/session-replay-poc/packages/core/ios/Sources/RCTTextViewRecorder.swift

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
