### PR TITLE
RUM-1040 Stop Core Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] RUM session not being linked to spans. See [#1615][]
+- [FEATURE] Allow stopping a core instance. See [#1541][]
 
 # 2.6.0 / 09-01-2024
 - [FEATURE] Add `currentSessionID(completion:)` accessor to access the current session ID.
@@ -575,6 +576,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1609]: https://github.com/DataDog/dd-sdk-ios/pull/1609
 [#1615]: https://github.com/DataDog/dd-sdk-ios/pull/1615
 [#1531]: https://github.com/DataDog/dd-sdk-ios/pull/1531
+[#1541]: https://github.com/DataDog/dd-sdk-ios/pull/1541
 [#1596]: https://github.com/DataDog/dd-sdk-ios/pull/1596
 [#1597]: https://github.com/DataDog/dd-sdk-ios/pull/1597
 [@00fa9a]: https://github.com/00FA9A

--- a/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
+++ b/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
@@ -125,8 +125,8 @@ internal final class DatadogContextProvider {
     ///   - keyPath: A context's key path that supports reading from and writing to the resulting value.
     ///   - publisher: The context value publisher.
     func subscribe<Publisher>(_ keyPath: WritableKeyPath<DatadogContext, Publisher.Value>, to publisher: Publisher) where Publisher: ContextValuePublisher {
-        let subscription = publisher.subscribe { value in
-            self.write { $0[keyPath: keyPath] = value }
+        let subscription = publisher.subscribe { [weak self] value in
+            self?.write { $0[keyPath: keyPath] = value }
         }
 
         write {

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -207,7 +207,12 @@ internal final class DatadogCore {
         allUploads.forEach { $0.flushAndTearDown() }
         allStorages.forEach { $0.setIgnoreFilesAgeWhenReading(to: false) }
 
-        // Deallocate all Features and their storage & upload units:
+        stop()
+    }
+
+    /// Stops all processes for this instance of the Datadog core by
+    /// deallocating all Features and their storage & upload units.
+    func stop() {
         stores = [:]
         features = [:]
     }

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -302,8 +302,11 @@ public enum Datadog {
     }
 
     /// Stops the initialized SDK instance attached to the given name.
+    ///
+    /// Stopping a core instance will stop all current processes by deallocating all Features registered
+    /// in the core as well as their storage & upload units.
     /// 
-    /// - Parameter instanceName: The core instance name
+    /// - Parameter instanceName: the name of the instance to stop.
     public static func stopInstance(named instanceName: String = CoreRegistry.defaultInstanceName) {
         let core = CoreRegistry.unregisterInstance(named: instanceName) as? DatadogCore
         core?.stop()

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -301,6 +301,14 @@ public enum Datadog {
         core?.clearAllData()
     }
 
+    /// Stops the initialized SDK instance attached to the given name.
+    /// 
+    /// - Parameter instanceName: The core instance name
+    public static func stopInstance(named instanceName: String = CoreRegistry.defaultInstanceName) {
+        let core = CoreRegistry.unregisterInstance(named: instanceName) as? DatadogCore
+        core?.stop()
+    }
+
     /// Initializes the Datadog SDK.
     ///
     /// You **must** initialize the core instance of the Datadog SDK prior to enabling any Product.
@@ -489,13 +497,10 @@ public enum Datadog {
 #endif
 
     internal static func internalFlushAndDeinitialize(instanceName: String = CoreRegistry.defaultInstanceName) {
-        assert(CoreRegistry.instance(named: instanceName) is DatadogCore, "SDK must be first initialized.")
-
+        // Unregister core instance:
+        let core = CoreRegistry.unregisterInstance(named: instanceName) as? DatadogCore
         // Flush and tear down SDK core:
-        (CoreRegistry.instance(named: instanceName) as? DatadogCore)?.flushAndTearDown()
-
-        // Deinitialize `Datadog`:
-        CoreRegistry.unregisterInstance(named: instanceName)
+        core?.flushAndTearDown()
     }
 }
 

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -46,7 +46,6 @@ class DatadogCoreTests: XCTestCase {
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
-        defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
@@ -93,7 +92,6 @@ class DatadogCoreTests: XCTestCase {
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
-        defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
@@ -148,7 +146,6 @@ class DatadogCoreTests: XCTestCase {
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
             backgroundTasksEnabled: .mockAny()
         )
-        defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
@@ -292,5 +289,41 @@ class DatadogCoreTests: XCTestCase {
         XCTAssertEqual(storage2?.authorizedFilesOrchestrator.performance.maxFileSize, 123)
         XCTAssertEqual(storage2?.authorizedFilesOrchestrator.performance.maxFileAgeForWrite, 95)
         XCTAssertEqual(storage2?.authorizedFilesOrchestrator.performance.minFileAgeForRead, 105)
+    }
+
+    func testWhenStoppingInstance_itDoesNotUploadEvents() throws {
+        // Given
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            initialConsent: .granted,
+            performance: .mockRandom(),
+            httpClient: HTTPClientMock(),
+            encryption: nil,
+            contextProvider: .mockAny(),
+            applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockAny(),
+            backgroundTasksEnabled: .mockAny()
+        )
+
+        let requestBuilderSpy = FeatureRequestBuilderSpy()
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
+
+        // When
+        scope.eventWriteContext { context, writer in
+            writer.write(value: FeatureMock.Event(event: "should not be sent"))
+        }
+
+        core.stop()
+
+        scope.eventWriteContext { context, writer in
+            writer.write(value: FeatureMock.Event(event: "should not be sent"))
+        }
+
+        // Then
+        XCTAssertNil(core.scope(for: FeatureMock.name))
+        core.flushAndTearDown()
+        XCTAssertEqual(requestBuilderSpy.requestParameters.count, 0, "It should not send any request")
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -311,10 +311,6 @@ class DatadogCoreTests: XCTestCase {
         let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
 
         // When
-        scope.eventWriteContext { context, writer in
-            writer.write(value: FeatureMock.Event(event: "should not be sent"))
-        }
-
         core.stop()
 
         scope.eventWriteContext { context, writer in
@@ -323,7 +319,7 @@ class DatadogCoreTests: XCTestCase {
 
         // Then
         XCTAssertNil(core.scope(for: FeatureMock.name))
-        core.flushAndTearDown()
+        core.flush()
         XCTAssertEqual(requestBuilderSpy.requestParameters.count, 0, "It should not send any request")
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogTests.swift
@@ -418,6 +418,24 @@ class DatadogTests: XCTestCase {
         XCTAssertTrue(CoreRegistry.instance(named: "test") is DatadogCore)
     }
 
+    func testStopSDKInstance() throws {
+        // Given
+        Datadog.initialize(
+            with: defaultConfig,
+            trackingConsent: .mockRandom(),
+            instanceName: "test"
+        )
+
+        // Then
+        XCTAssertTrue(CoreRegistry.instance(named: "test") is DatadogCore)
+
+        // When
+        Datadog.stopInstance(named: "test")
+
+        // Then
+        XCTAssertTrue(CoreRegistry.instance(named: "test") is NOPDatadogCore)
+    }
+
     func testGivenDefaultSDKInstanceInitialized_customOneCanBeInitializedAfterIt() throws {
         let defaultConfig = Datadog.Configuration(clientToken: "abc-123", env: "default")
         let customConfig = Datadog.Configuration(clientToken: "def-456", env: "custom")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Core/StopCoreScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Core/StopCoreScenarioTests.swift
@@ -1,0 +1,185 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+private class CSRootScreen: XCUIApplication {
+    func startCore() {
+        buttons["Start Core"].tap()
+    }
+
+    func stopCore() {
+        buttons["Stop Core"].tap()
+    }
+
+    func tapGoToHome() -> CSHomeScreen {
+        buttons["Go To Home"].tap()
+        return CSHomeScreen()
+    }
+}
+
+private class CSHomeScreen: XCUIApplication {
+    func tapTestLogging() {
+        buttons["Test Logging"].tap()
+    }
+
+    func tapTestTracing() {
+        buttons["Test Tracing"].tap()
+    }
+
+    func tapTestRUM() -> CSPictureScreen {
+        buttons["Test RUM"].tap()
+        return CSPictureScreen()
+    }
+
+    func tapBack() -> CSRootScreen {
+        navigationBars["Runner.CSHomeView"].buttons["Back"].tap()
+        return CSRootScreen()
+    }
+}
+
+private class CSPictureScreen: XCUIApplication {
+    func tapDownloadImage() {
+        buttons["Download image"].tap()
+    }
+
+    func waitForImageBeingDownloaded() {
+        _ = staticTexts["☑️"].waitForExistence(timeout: 10)
+    }
+
+    func tapBack() -> CSHomeScreen {
+        navigationBars["Runner.CSPictureView"].buttons["Back"].tap()
+        return CSHomeScreen()
+    }
+}
+
+class StopCoreScenarioTests: IntegrationTests, LoggingCommonAsserts, TracingCommonAsserts, RUMCommonAsserts {
+    func testStartAndStopCoreInstance() throws {
+        let loggingServerSession = server.obtainUniqueRecordingSession()
+        let tracingServerSession = server.obtainUniqueRecordingSession()
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "StopCoreScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                logsEndpoint: loggingServerSession.recordingURL,
+                tracesEndpoint: tracingServerSession.recordingURL,
+                rumEndpoint: rumServerSession.recordingURL
+            )
+        )
+
+        // Play scenarios
+
+        var root = playScenario()
+
+        try assertLoggingDataWasCollected(by: loggingServerSession)
+        try assertTracingDataWasCollected(by: tracingServerSession)
+        try assertRUMDataWasCollected(by: rumServerSession)
+        server.clearAllRequests()
+
+        root.stopCore()
+        root = playScenario(from: root)
+
+        Thread.sleep(forTimeInterval: dataDeliveryTimeout)
+
+        let recordedLoggingRequests = try loggingServerSession.getRecordedRequests()
+        XCTAssertEqual(recordedLoggingRequests.count, 0, "No logging data should be send.")
+        let recordedTracingRequests = try loggingServerSession.getRecordedRequests()
+        XCTAssertEqual(recordedTracingRequests.count, 0, "No tracing data should be send.")
+        let recordedRUMRequests = try rumServerSession.getRecordedRequests()
+        XCTAssertEqual(recordedRUMRequests.count, 0, "No RUM data should be send.")
+
+        root.startCore()
+        root = playScenario(from: root)
+
+        try assertLoggingDataWasCollected(by: loggingServerSession)
+        try assertTracingDataWasCollected(by: tracingServerSession)
+        try assertRUMDataWasCollected(by: rumServerSession)
+    }
+
+    /// Plays following scenario for started application:
+    /// * sends log and trace from home screen,
+    /// * goes to picture screen and downloads the image,
+    /// * goes back to the home screen.
+    private func playScenario(from root: CSRootScreen = CSRootScreen()) -> CSRootScreen {
+        let home = root.tapGoToHome()
+        home.tapTestLogging()
+        home.tapTestTracing()
+        let pictureScreen = home.tapTestRUM()
+        pictureScreen.tapDownloadImage()
+        pictureScreen.waitForImageBeingDownloaded()
+        return pictureScreen
+            .tapBack()
+            .tapBack()
+    }
+
+    // MARK: - Data assertions
+
+    private func assertLoggingDataWasCollected(by serverSession: ServerSession) throws {
+        let recordedRequests = try serverSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try LogMatcher.from(requests: requests).count == 1
+        }
+
+        assertLogging(requests: recordedRequests)
+
+        let logMatchers = try LogMatcher.from(requests: recordedRequests)
+        XCTAssertEqual(logMatchers.count, 1)
+        let logMatcher = logMatchers[0]
+        logMatcher.assertMessage(equals: "test message")
+        logMatcher.assertStatus(equals: "info")
+    }
+
+    private func assertTracingDataWasCollected(by serverSession: ServerSession) throws {
+        let recordedRequests = try serverSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try SpanMatcher.from(requests: requests).count == 1
+        }
+
+        assertTracing(requests: recordedRequests)
+
+        let spanMatchers = try SpanMatcher.from(requests: recordedRequests)
+        XCTAssertEqual(spanMatchers.count, 1)
+        let spanMatcher = spanMatchers[0]
+        XCTAssertEqual(try spanMatcher.operationName(), "test span")
+    }
+
+    private func assertRUMDataWasCollected(by serverSession: ServerSession) throws {
+        let recordedRequests = try serverSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            // ignore telemetry and application start view events
+            let eventMatchers = try requests
+                .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+                .filterTelemetry()
+                .filterApplicationLaunchView()
+
+            guard let session = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers).first else {
+                return false
+            }
+
+            return session.views.count >= 3
+        }
+
+        assertRUM(requests: recordedRequests)
+
+        // ignore telemetry and application start view events
+        let eventMatchers = try recordedRequests
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+            .filterTelemetry()
+            .filterApplicationLaunchView()
+
+        let session = try XCTUnwrap(RUMSessionMatcher.groupMatchersBySessions(eventMatchers).first)
+        sendCIAppLog(session)
+
+        XCTAssertEqual(session.views[0].name, "Home")
+        XCTAssertGreaterThan(session.views[0].actionEvents.count, 0)
+
+        XCTAssertEqual(session.views[1].name, "Picture")
+        XCTAssertEqual(session.views[1].resourceEvents.count, 1)
+        XCTAssertGreaterThan(session.views[1].actionEvents.count, 0)
+
+        XCTAssertEqual(session.views[2].name, "Home")
+    }
+}

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMCommonAsserts.swift
@@ -56,7 +56,7 @@ extension RUMSessionMatcher {
     class func sessions(maxCount: Int, from requests: [HTTPServerMock.Request], eventsPatch: ((Data) throws -> Data)? = nil) throws -> [RUMSessionMatcher] {
         let eventMatchers = try requests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody, eventsPatch: eventsPatch) }
-            .filter { event in try event.eventType() != "telemetry" }
+            .filterTelemetry()
         let sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers).sorted(by: {
             return $0.views.first?.viewEvents.first?.date ?? 0 < $1.views.first?.viewEvents.first?.date ?? 0
         })

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -41,7 +41,7 @@
 		6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */; };
 		613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */; };
 		61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */; };
-		61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C0424616DE9003D8BB8 /* ExampleAppDelegate.swift */; };
+		61441C0524616DE9003D8BB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C0424616DE9003D8BB8 /* AppDelegate.swift */; };
 		61441C0E24616DEC003D8BB8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 61441C0D24616DEC003D8BB8 /* Assets.xcassets */; };
 		61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C3B24617013003D8BB8 /* IntegrationTests.swift */; };
 		61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C3C24617013003D8BB8 /* LoggingScenarioTests.swift */; };
@@ -110,6 +110,13 @@
 		D2791EF927170A760046E07A /* RUMSwiftUIScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */; };
 		D2F5BB36271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2F5BB35271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard */; };
 		D2F5BB382718331800BDE2A4 /* SwiftUIRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F5BB372718331800BDE2A4 /* SwiftUIRootViewController.swift */; };
+		D2FCA74D2B4D829F0014DC87 /* CSPictureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA7482B4D829F0014DC87 /* CSPictureViewController.swift */; };
+		D2FCA74E2B4D829F0014DC87 /* StopCoreScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2FCA7492B4D829F0014DC87 /* StopCoreScenario.storyboard */; };
+		D2FCA74F2B4D829F0014DC87 /* CSHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA74A2B4D829F0014DC87 /* CSHomeViewController.swift */; };
+		D2FCA7512B4D829F0014DC87 /* CoreScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA74C2B4D829F0014DC87 /* CoreScenarios.swift */; };
+		D2FCA7532B4D84EE0014DC87 /* CustomURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA7522B4D84EE0014DC87 /* CustomURLSessionDelegate.swift */; };
+		D2FCA7552B4D87110014DC87 /* StopCoreScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA7542B4D87110014DC87 /* StopCoreScenarioTests.swift */; };
+		D2FCA7582B4DA8720014DC87 /* CSRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA7572B4DA8720014DC87 /* CSRootViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -172,7 +179,7 @@
 		613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTabBarControllerScenarioTests.swift; sourceTree = "<group>"; };
 		61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingCommonAsserts.swift; sourceTree = "<group>"; };
 		61441C0224616DE9003D8BB8 /* Integration Tests Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Integration Tests Runner.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		61441C0424616DE9003D8BB8 /* ExampleAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleAppDelegate.swift; sourceTree = "<group>"; };
+		61441C0424616DE9003D8BB8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61441C0D24616DEC003D8BB8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		61441C2A24616F1D003D8BB8 /* IntegrationScenarios.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationScenarios.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		61441C3B24617013003D8BB8 /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
@@ -256,6 +263,13 @@
 		D2AEFF1B29925BEC00A28997 /* DatadogIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DatadogIntegrationTests.xctestplan; sourceTree = "<group>"; };
 		D2F5BB35271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMSwiftUIInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		D2F5BB372718331800BDE2A4 /* SwiftUIRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIRootViewController.swift; sourceTree = "<group>"; };
+		D2FCA7482B4D829F0014DC87 /* CSPictureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSPictureViewController.swift; sourceTree = "<group>"; };
+		D2FCA7492B4D829F0014DC87 /* StopCoreScenario.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = StopCoreScenario.storyboard; sourceTree = "<group>"; };
+		D2FCA74A2B4D829F0014DC87 /* CSHomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSHomeViewController.swift; sourceTree = "<group>"; };
+		D2FCA74C2B4D829F0014DC87 /* CoreScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreScenarios.swift; sourceTree = "<group>"; };
+		D2FCA7522B4D84EE0014DC87 /* CustomURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLSessionDelegate.swift; sourceTree = "<group>"; };
+		D2FCA7542B4D87110014DC87 /* StopCoreScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopCoreScenarioTests.swift; sourceTree = "<group>"; };
+		D2FCA7572B4DA8720014DC87 /* CSRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSRootViewController.swift; sourceTree = "<group>"; };
 		E0F3607A83689002423C29E4 /* libPods-Runner iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6057106F868E6C529F89BE9 /* Pods-Runner iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner iOS.release.xcconfig"; path = "Target Support Files/Pods-Runner iOS/Pods-Runner iOS.release.xcconfig"; sourceTree = "<group>"; };
 		E93021D28790F380B3C63C4B /* libPods-Runner iOS-IntegrationScenarios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner iOS-IntegrationScenarios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -417,6 +431,7 @@
 			isa = PBXGroup;
 			children = (
 				614CADCD250FCA0200B93D2D /* TestScenarios.swift */,
+				D2FCA7462B4D829F0014DC87 /* Core */,
 				61337030250F829E00236D58 /* Logging */,
 				61337033250F847500236D58 /* Tracing */,
 				61337036250F84F100236D58 /* RUM */,
@@ -488,7 +503,7 @@
 		61441C0324616DE9003D8BB8 /* Runner */ = {
 			isa = PBXGroup;
 			children = (
-				61441C0424616DE9003D8BB8 /* ExampleAppDelegate.swift */,
+				61441C0424616DE9003D8BB8 /* AppDelegate.swift */,
 				61441C9C2461A796003D8BB8 /* AppConfiguration.swift */,
 				614CADD62510BAC000B93D2D /* Environment.swift */,
 				6133702F250F829000236D58 /* Scenarios */,
@@ -521,6 +536,7 @@
 				6111544725C9A88B007C84C9 /* PersistenceHelper.swift */,
 				61098D2A27FEE3F00021237A /* MessagePortChannel.swift */,
 				61098D2E27FF16A20021237A /* RUMSessionEndView.swift */,
+				D2FCA7522B4D84EE0014DC87 /* CustomURLSessionDelegate.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -607,6 +623,7 @@
 		61F3CD9C251106EB00C816E5 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				D2FCA7562B4D87180014DC87 /* Core */,
 				61F3CD9D251106FA00C816E5 /* Logging */,
 				61F3CD9E251106FF00C816E5 /* Tracing */,
 				61F3CD9F2511070300C816E5 /* RUM */,
@@ -768,6 +785,34 @@
 			path = xctestplans;
 			sourceTree = "<group>";
 		};
+		D2FCA7462B4D829F0014DC87 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				D2FCA74C2B4D829F0014DC87 /* CoreScenarios.swift */,
+				D2FCA7472B4D829F0014DC87 /* StopCoreInstance */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		D2FCA7472B4D829F0014DC87 /* StopCoreInstance */ = {
+			isa = PBXGroup;
+			children = (
+				D2FCA7492B4D829F0014DC87 /* StopCoreScenario.storyboard */,
+				D2FCA7572B4DA8720014DC87 /* CSRootViewController.swift */,
+				D2FCA74A2B4D829F0014DC87 /* CSHomeViewController.swift */,
+				D2FCA7482B4D829F0014DC87 /* CSPictureViewController.swift */,
+			);
+			path = StopCoreInstance;
+			sourceTree = "<group>";
+		};
+		D2FCA7562B4D87180014DC87 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				D2FCA7542B4D87110014DC87 /* StopCoreScenarioTests.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -877,6 +922,7 @@
 				9EC2835E26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard in Resources */,
 				6167AD19251A27B80012B4D0 /* URLSessionScenario.storyboard in Resources */,
 				61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */,
+				D2FCA74E2B4D829F0014DC87 /* StopCoreScenario.storyboard in Resources */,
 				61337035250F84BF00236D58 /* TracingManualInstrumentationScenario.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -942,6 +988,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2FCA7532B4D84EE0014DC87 /* CustomURLSessionDelegate.swift in Sources */,
 				D2F5BB382718331800BDE2A4 /* SwiftUIRootViewController.swift in Sources */,
 				618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */,
 				D22F06CF29DAE5360026CC3C /* KioskSendInterruptedEventsViewController.swift in Sources */,
@@ -950,6 +997,7 @@
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
 				612C13732A9DFE1C0086B5D1 /* SRMultipleViewsRecordingViewController.swift in Sources */,
 				611EA14225810E1900BC0E56 /* TSHomeViewController.swift in Sources */,
+				D2FCA7582B4DA8720014DC87 /* CSRootViewController.swift in Sources */,
 				612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */,
 				61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */,
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,
@@ -973,10 +1021,13 @@
 				61D50C3C2580EEF8006038A3 /* LoggingScenarios.swift in Sources */,
 				611EA14E25810E3700BC0E56 /* TSConsentSettingViewController.swift in Sources */,
 				6164AF0E252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m in Sources */,
-				61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */,
+				D2FCA74D2B4D829F0014DC87 /* CSPictureViewController.swift in Sources */,
+				61441C0524616DE9003D8BB8 /* AppDelegate.swift in Sources */,
 				6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */,
+				D2FCA7512B4D829F0014DC87 /* CoreScenarios.swift in Sources */,
 				612C13702A9CF9140086B5D1 /* SRScenarios.swift in Sources */,
 				61098D2F27FF16A20021237A /* RUMSessionEndView.swift in Sources */,
+				D2FCA74F2B4D829F0014DC87 /* CSHomeViewController.swift in Sources */,
 				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
 				617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
@@ -1024,6 +1075,7 @@
 				612C13CC2A9F94AF0086B5D1 /* SRMultipleViewsRecordingScenarioTests.swift in Sources */,
 				61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */,
 				615AAC29251E322D00C89EE9 /* RUMCommonAsserts.swift in Sources */,
+				D2FCA7552B4D87110014DC87 /* StopCoreScenarioTests.swift in Sources */,
 				D2774EE7299E2E90004EC36A /* LogMatcher.swift in Sources */,
 				6164AF2E252C9C51000D78C4 /* RUMResourcesScenarioTests.swift in Sources */,
 				D2774EE8299E2E90004EC36A /* JSONDataMatcher.swift in Sources */,

--- a/IntegrationTests/Runner/AppDelegate.swift
+++ b/IntegrationTests/Runner/AppDelegate.swift
@@ -10,18 +10,11 @@ import DatadogLogs
 import DatadogTrace
 import DatadogRUM
 
-@_exported import enum DatadogInternal.TrackingConsent
-@_exported import class DatadogInternal.DDURLSessionDelegate
-
-var logger: LoggerProtocol!
-var tracer: OTTracer { Tracer.shared() }
-var rumMonitor: RUMMonitorProtocol { RUMMonitor.shared() }
-
 var serviceName = "integration-scenarios-service-name"
 var appConfiguration: AppConfiguration!
 
 @UIApplicationMain
-class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -32,38 +25,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         appConfiguration = UITestsAppConfiguration()
 
         // Initialize Datadog SDK
-        Datadog.initialize(
-            with: appConfiguration.sdkConfiguration(),
-            trackingConsent: appConfiguration.initialTrackingConsent
-        )
-
-        // Set user information
-        Datadog.setUserInfo(id: "abcd-1234", name: "foo", email: "foo@example.com", extraInfo: ["key-extraUserInfo": "value-extraUserInfo"])
-
-        appConfiguration.testScenario?.configureFeatures()
-
-        // Create Logger
-        logger = Logger.create(
-            with: Logger.Configuration(
-                name: "logger-name",
-                networkInfoEnabled: true,
-                consoleLogFormat: .shortWith(prefix: "[iOS App] ")
-            )
-        )
-
-        logger.addAttribute(forKey: "device-model", value: UIDevice.current.model)
-
-        #if DEBUG
-        logger.addTag(withKey: "build_configuration", value: "debug")
-        #else
-        logger.addTag(withKey: "build_configuration", value: "release")
-        #endif
-
-        // Set highest verbosity level to see debugging logs from the SDK
-        Datadog.verbosityLevel = .debug
-
-        // Enable RUM Views debugging
-        RUMMonitor.shared().debug = true
+        appConfiguration.initializeSDK()
 
         // Launch initial screen depending on the launch configuration
         if let storyboard = appConfiguration.initialStoryboard() {

--- a/IntegrationTests/Runner/Scenarios/Core/CoreScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/Core/CoreScenarios.swift
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogTrace
+import DatadogRUM
+import DatadogLogs
+import DatadogCore
+
+internal class StopCoreScenario: TestScenario {
+    static let storyboardName = "StopCoreScenario"
+
+    required init() { }
+
+    func configureFeatures() {
+        // Enable RUM
+        var rumConfig = RUM.Configuration(applicationID: "rum-application-id")
+        rumConfig.customEndpoint = Environment.serverMockConfiguration()?.rumEndpoint
+        rumConfig.uiKitViewsPredicate = StopCoreScenarioUIKitRUMViewsPredicate()
+        rumConfig.uiKitActionsPredicate = DefaultUIKitRUMActionsPredicate()
+        rumConfig.urlSessionTracking = .init()
+        RUM.enable(with: rumConfig)
+
+        // Enable Trace
+        var traceConfig = Trace.Configuration()
+        traceConfig.networkInfoEnabled = true
+        traceConfig.customEndpoint = Environment.serverMockConfiguration()?.tracesEndpoint
+        Trace.enable(with: traceConfig)
+
+        // Enable Logs
+        Logs.enable(
+            with: Logs.Configuration(
+                customEndpoint: Environment.serverMockConfiguration()?.logsEndpoint
+            )
+        )
+
+        URLSessionInstrumentation.enable(
+            with: URLSessionInstrumentation.Configuration(delegateClass: CustomURLSessionDelegate.self)
+        )
+
+        URLSessionInstrumentation.enable(with: .init(delegateClass: CustomURLSessionDelegate.self))
+    }
+}
+
+private struct StopCoreScenarioUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
+    func rumView(for viewController: UIViewController) -> RUMView? {
+        switch viewController {
+        case is CSHomeViewController:
+            return RUMView(name: "Home")
+        case is CSPictureViewController:
+            return RUMView(name: "Picture")
+        default:
+            return nil
+        }
+    }
+}

--- a/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSHomeViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSHomeViewController.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+import DatadogCore
+import DatadogTrace
+
+internal class CSHomeViewController: UIViewController {
+    @IBAction func didTapTestLogging(_ sender: UIButton) {
+        sender.disableFor(seconds: 0.5)
+        logger?.info("test message")
+    }
+
+    @IBAction func didTapTestTracing(_ sender: UIButton) {
+        sender.disableFor(seconds: 0.5)
+        let span = Tracer.shared().startSpan(operationName: "test span")
+        span.finish(at: Date(timeIntervalSinceNow: 1))
+    }
+}

--- a/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSPictureViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSPictureViewController.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal class CSPictureViewController: UIViewController {
+    let sessionDelegate = CustomURLSessionDelegate()
+
+    private lazy var session = URLSession(
+        configuration: .default,
+        delegate: sessionDelegate,
+        delegateQueue: nil
+    )
+
+    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var successLabel: UILabel!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        successLabel.isHidden = true
+    }
+
+    @IBAction func didTapDownloadImage(_ sender: UIButton) {
+        let enableSender = sender.disableUntilCompletion()
+
+        let imageURL = URL(string: "https://imgix.datadoghq.com/img/about/presskit/usage/logousage_white.png")!
+        var imageRequest = URLRequest(url: imageURL)
+        imageRequest.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let imageTask = session.dataTask(with: imageRequest) { [weak self] data, _, error in
+            if let error = error {
+                // Crash the app, so we have obvious feedback in integration test
+                fatalError("Failed to download image: \(error)")
+            } else if let data = data {
+                DispatchQueue.main.async {
+                    enableSender()
+                    self?.showImage(from: data)
+                }
+            } else {
+                fatalError("Failed to download image with no clue")
+            }
+        }
+        imageTask.resume()
+    }
+
+    private func showImage(from imageData: Data) {
+        imageView.image = UIImage(data: imageData)
+        successLabel.isHidden = false
+    }
+}

--- a/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSRootViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/CSRootViewController.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+import DatadogCore
+import DatadogTrace
+
+internal class CSRootViewController: UIViewController {
+    @IBAction func startCore(_ sender: UIButton) {
+        appConfiguration.initializeSDK()
+    }
+
+    @IBAction func stopCore(_ sender: UIButton) {
+        appConfiguration.deinitializeSDK()
+    }
+}

--- a/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/StopCoreScenario.storyboard
+++ b/IntegrationTests/Runner/Scenarios/Core/StopCoreInstance/StopCoreScenario.storyboard
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uGs-3A-Nmr">
+    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="h6h-EX-fvZ">
+            <objects>
+                <navigationController id="uGs-3A-Nmr" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Yjn-hf-CAD">
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" red="0.4705848098" green="0.27062672380000002" blue="0.70971673729999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="8K4-9Z-gec" kind="relationship" relationship="rootViewController" id="uOX-WR-hFJ"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hYR-Ng-aDJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1210" y="313"/>
+        </scene>
+        <!--Home View Controller-->
+        <scene sceneID="4RZ-NA-XXQ">
+            <objects>
+                <viewController id="UdD-TK-p3B" customClass="CSHomeViewController" customModule="Runner" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="dVO-w5-gph">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xAa-HR-Khy">
+                                <rect key="frame" x="10" y="102" width="394" height="182"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UdV-6V-6cs">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Test RUM"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="5yO-qX-sfZ"/>
+                                            <constraint firstAttribute="height" constant="44" id="Fvj-KH-xBy"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Test RUM">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="aVv-ta-0FU" kind="show" id="aiQ-1d-UeZ"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qi6-SF-4ei">
+                                        <rect key="frame" x="0.0" y="54" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Test Logging"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="Xp8-1S-34m"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="clA-JA-dme"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Test Logging">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapTestLogging:" destination="UdD-TK-p3B" eventType="touchUpInside" id="5n9-bq-WlI"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NG0-xH-ZyU">
+                                        <rect key="frame" x="0.0" y="108" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Test Tracing"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Mp6-w6-JEc"/>
+                                            <constraint firstAttribute="height" constant="44" id="XHX-CH-Ju8"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Test Tracing">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapTestTracing:" destination="UdD-TK-p3B" eventType="touchUpInside" id="K0l-Ov-xRn"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KHq-r6-y4w">
+                                        <rect key="frame" x="0.0" y="162" width="394" height="20"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="VEd-PQ-L3h"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="G0A-Ew-b6R"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="xAa-HR-Khy" firstAttribute="top" secondItem="G0A-Ew-b6R" secondAttribute="top" constant="10" id="LSZ-11-azd"/>
+                            <constraint firstItem="G0A-Ew-b6R" firstAttribute="trailing" secondItem="xAa-HR-Khy" secondAttribute="trailing" constant="10" id="Lq2-ak-bSq"/>
+                            <constraint firstItem="xAa-HR-Khy" firstAttribute="leading" secondItem="G0A-Ew-b6R" secondAttribute="leading" constant="10" id="WrZ-hW-2H3"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="vLs-jm-oHm"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="th4-r0-e5C" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="187" y="313"/>
+        </scene>
+        <!--Picture View Controller-->
+        <scene sceneID="z4J-kD-5aw">
+            <objects>
+                <viewController id="aVv-ta-0FU" customClass="CSPictureViewController" customModule="Runner" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rrY-Bi-nP5">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="JRc-Qi-ULt">
+                                <rect key="frame" x="77" y="102" width="260" height="160"/>
+                                <color key="backgroundColor" systemColor="quaternaryLabelColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="160" id="9e7-iD-VJU"/>
+                                    <constraint firstAttribute="width" constant="260" id="dHi-dd-Jze"/>
+                                </constraints>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0NV-CN-bDg">
+                                <rect key="frame" x="57" y="272" width="300" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <accessibility key="accessibilityConfiguration" identifier="Download image"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="Jlv-Ak-eMd"/>
+                                    <constraint firstAttribute="width" constant="300" id="lc9-On-PaV"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Download image">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="didTapDownloadImage:" destination="aVv-ta-0FU" eventType="touchUpInside" id="B2P-XQ-D2Q"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="☑️" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6l-Q0-fbR">
+                                <rect key="frame" x="193" y="336" width="28" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="28t-2u-rJw"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="JRc-Qi-ULt" firstAttribute="top" secondItem="28t-2u-rJw" secondAttribute="top" constant="10" id="GYI-hL-Cdm"/>
+                            <constraint firstItem="i6l-Q0-fbR" firstAttribute="top" secondItem="0NV-CN-bDg" secondAttribute="bottom" constant="20" id="O3n-zB-Roh"/>
+                            <constraint firstItem="JRc-Qi-ULt" firstAttribute="centerX" secondItem="rrY-Bi-nP5" secondAttribute="centerX" id="d60-eM-XUp"/>
+                            <constraint firstItem="0NV-CN-bDg" firstAttribute="top" secondItem="JRc-Qi-ULt" secondAttribute="bottom" constant="10" id="dkk-aH-f3G"/>
+                            <constraint firstItem="i6l-Q0-fbR" firstAttribute="centerX" secondItem="rrY-Bi-nP5" secondAttribute="centerX" id="jfP-fB-hCS"/>
+                            <constraint firstItem="0NV-CN-bDg" firstAttribute="centerX" secondItem="rrY-Bi-nP5" secondAttribute="centerX" id="qrj-qy-OX6"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="S5T-lW-V2S"/>
+                    <connections>
+                        <outlet property="imageView" destination="JRc-Qi-ULt" id="DbZ-Sm-kdo"/>
+                        <outlet property="successLabel" destination="i6l-Q0-fbR" id="nQf-7e-0eO"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mh8-ee-Jn8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1065" y="313"/>
+        </scene>
+        <!--Root View Controller-->
+        <scene sceneID="SAf-AT-Rff">
+            <objects>
+                <viewController id="8K4-9Z-gec" customClass="CSRootViewController" customModule="Runner" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="uJw-bz-q68">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Cj-6y-UxI">
+                                <rect key="frame" x="10" y="102" width="394" height="148"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rxL-zK-b91">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Stop Core"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="dZD-cq-7zN"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Stop Core">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="stopCore:" destination="8K4-9Z-gec" eventType="touchUpInside" id="Ytd-6x-qZ7"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4iE-kD-nsw" userLabel="Start Core">
+                                        <rect key="frame" x="0.0" y="52" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Start Core"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="hlI-07-54L"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Start Core">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="startCore:" destination="8K4-9Z-gec" eventType="touchUpInside" id="h1O-Uo-nie"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4H-r4-pxa">
+                                        <rect key="frame" x="0.0" y="104" width="394" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Go To Home"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="XXo-6d-gdd"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Go To Home">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="UdD-TK-p3B" kind="show" id="ccL-ER-ruH"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="xLL-5C-zDD"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="2Cj-6y-UxI" firstAttribute="top" secondItem="xLL-5C-zDD" secondAttribute="top" constant="10" id="DHo-RN-dko"/>
+                            <constraint firstItem="2Cj-6y-UxI" firstAttribute="leading" secondItem="xLL-5C-zDD" secondAttribute="leading" constant="10" id="gpa-Fu-Itw"/>
+                            <constraint firstItem="xLL-5C-zDD" firstAttribute="trailing" secondItem="2Cj-6y-UxI" secondAttribute="trailing" constant="10" id="yVc-ZZ-iL7"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="kD2-II-8GF"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="RLA-F6-C1o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-516" y="313"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="quaternaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.17647058823529413" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
@@ -11,18 +11,18 @@ internal class SendLogsFixtureViewController: UIViewController {
         super.viewDidLoad()
 
         // Send logs
-        logger.addTag(withKey: "tag1", value: "tag-value")
-        logger.add(tag: "tag2")
+        logger?.addTag(withKey: "tag1", value: "tag-value")
+        logger?.add(tag: "tag2")
 
-        logger.addAttribute(forKey: "logger-attribute1", value: "string value")
-        logger.addAttribute(forKey: "logger-attribute2", value: 1_000)
-        logger.addAttribute(forKey: "some-url", value: URL(string: "https://example.com/image.png")!)
+        logger?.addAttribute(forKey: "logger-attribute1", value: "string value")
+        logger?.addAttribute(forKey: "logger-attribute2", value: 1_000)
+        logger?.addAttribute(forKey: "some-url", value: URL(string: "https://example.com/image.png")!)
 
-        logger.debug("debug message", attributes: ["attribute": "value"])
-        logger.info("info message", attributes: ["attribute": "value"])
-        logger.notice("notice message", attributes: ["attribute": "value"])
-        logger.warn("warn message", attributes: ["attribute": "value"])
-        logger.error("error message", attributes: ["attribute": "value"])
-        logger.critical("critical message", attributes: ["attribute": "value"])
+        logger?.debug("debug message", attributes: ["attribute": "value"])
+        logger?.info("info message", attributes: ["attribute": "value"])
+        logger?.notice("notice message", attributes: ["attribute": "value"])
+        logger?.warn("warn message", attributes: ["attribute": "value"])
+        logger?.error("error message", attributes: ["attribute": "value"])
+        logger?.critical("critical message", attributes: ["attribute": "value"])
     }
 }

--- a/IntegrationTests/Runner/Scenarios/Tracing/ManualInstrumentation/SendTracesFixtureViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Tracing/ManualInstrumentation/SendTracesFixtureViewController.swift
@@ -14,6 +14,8 @@ internal class SendTracesFixtureViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let tracer = Tracer.shared()
+
         let viewLoadingSpan = tracer
             .startRootSpan(operationName: "view loading")
             .setActive()

--- a/IntegrationTests/Runner/Scenarios/TrackingConsent/TrackingConsent/TSHomeViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/TrackingConsent/TrackingConsent/TSHomeViewController.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import DatadogCore
+import DatadogTrace
 
 internal class TSHomeViewController: UIViewController {
     override func viewDidLoad() {
@@ -39,13 +40,12 @@ internal class TSHomeViewController: UIViewController {
     @IBAction func didTapTestLogging(_ sender: UIButton) {
         sender.disableFor(seconds: 0.5)
 
-        logger.info("test message")
+        logger?.info("test message")
     }
 
     @IBAction func didTapTestTracing(_ sender: UIButton) {
         sender.disableFor(seconds: 0.5)
-
-        let span = tracer.startSpan(operationName: "test span")
+        let span = Tracer.shared().startSpan(operationName: "test span")
         span.finish(at: Date(timeIntervalSinceNow: 1))
     }
 }

--- a/IntegrationTests/Runner/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/URLSession/URLSessionScenarios.swift
@@ -39,11 +39,6 @@ private class CompositedURLSessionDelegate: NSObject, URLSessionTaskDelegate, UR
     }
 }
 
-/// An example of instrumenting existing `URLSessionDelegate` with `DDURLSessionDelegate` through inheritance.
-private class CustomURLSessionDelegate: NSObject, URLSessionDataDelegate {
-
-}
-
 /// Base scenario for `URLSession` and `NSURLSession` instrumentation.  It makes
 /// both Swift and Objective-C tests share the same endpoints and SDK configuration.
 ///

--- a/IntegrationTests/Runner/Utils/CustomURLSessionDelegate.swift
+++ b/IntegrationTests/Runner/Utils/CustomURLSessionDelegate.swift
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A custion ``URLSessionDataDelegate`` for instrumenting ``URLSession``.
+internal class CustomURLSessionDelegate: NSObject, URLSessionDataDelegate {
+
+}

--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
@@ -64,6 +64,12 @@ public class ServerMock {
         return ServerSession(server: self)
     }
 
+    public func clearAllRequests() {
+        var request = URLRequest(url: baseURL.appendingPathComponent("/requests"))
+        request.httpMethod = "DELETE"
+        URLSession.shared.dataTask(with: request).resume()
+    }
+
     // MARK: - Endpoints
 
     /// Fetches all requests recorded by the server.

--- a/instrumented-tests/http-server-mock/python/start_mock_server.py
+++ b/instrumented-tests/http-server-mock/python/start_mock_server.py
@@ -47,6 +47,14 @@ class HTTPMockServer(BaseHTTPRequestHandler):
             (r"/inspect$", self.__GET_inspect),
         ])
 
+    def do_DELETE(self):
+        """
+        Routes all incoming DELETE requests
+        """
+        self.__route([
+            (r"/requests$", self.__DELETE_requests),
+        ])
+
     def __POST_any(self, parameters):
         """
         POST /*
@@ -83,6 +91,16 @@ class HTTPMockServer(BaseHTTPRequestHandler):
             })
 
         return json.dumps(inspection_info).encode("utf-8")
+
+    def __DELETE_requests(self, parameters):
+        """
+        DELETE /requests
+
+        Remove all.
+        """
+        global history
+        history.clear()
+        return bytes()
 
     def __route(self, routes):
         try:
@@ -131,6 +149,9 @@ class GenericRequestsHistory:
 
     def request(self, request_id):
         return self.__requests[int(request_id)]
+
+    def clear(self):
+        self.__requests.clear()
 
 # If any previous instance of this server is running - kill it
 os.system('pkill -f start_mock_server.py')


### PR DESCRIPTION
### What and why?

Add public interface for stopping core instance of the SDK. Stopping the core will deallocate all Features and their storage & upload units.

### How?

In parity with Android, the `stopInstance` static method will stop and unregister all feature of the core. Their storage and upload process will be deallocated so no event-write-context and upload will execute.

### Note

This change was a good opportunity to streamline flushing mechanism of the core (e.g. #1522). But the number of GDC queues involved in the core and Features made the task very tedious with high risk of introducing flakiness. I believe we should continue decreasing the number of queues, by using exclusion-queue as described in [WWDC 2017 - Modernizing Grand Central Dispatch Usage](https://developer.apple.com/videos/play/wwdc2017/706/), with clear and efficient queue hierarchy. **We should do so after building continuous benchmark to make sure we don't decrease performances.** 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
