### PR TITLE
RUM-1335 Add `sessionPrecondition` to RUM events

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -38,6 +38,12 @@ extension RUMMethod: RandomMockable {
     }
 }
 
+extension RUMSessionPrecondition: RandomMockable {
+    public static func mockRandom() -> RUMSessionPrecondition {
+        return [.userAppLaunch, .inactivityTimeout, .maxDuration, .backgroundLaunch, .prewarm, .fromNonInteractiveSession, .explicitStop].randomElement()!
+    }
+}
+
 extension RUMEventAttributes: RandomMockable {
     public static func mockRandom() -> RUMEventAttributes {
         return .init(contextInfo: mockRandomAttributes())
@@ -122,7 +128,10 @@ extension RUMViewEvent: RandomMockable {
                 documentVersion: .mockRandom(),
                 pageStates: nil,
                 replayStats: nil,
-                session: .init(plan: .plan1, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             application: .init(id: .mockRandom()),
             buildVersion: .mockRandom(),
@@ -214,7 +223,10 @@ extension RUMResourceEvent: RandomMockable {
                 configuration: .mockRandom(),
                 discarded: nil,
                 rulePsr: nil,
-                session: .init(plan: .plan1, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement()),
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                ),
                 spanId: .mockRandom(),
                 traceId: .mockRandom()
             ),
@@ -288,7 +300,10 @@ extension RUMActionEvent: RandomMockable {
                 ),
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
-                session: .init(plan: .plan1, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(
                 crash: .init(count: .mockRandom()),
@@ -349,7 +364,10 @@ extension RUMErrorEvent: RandomMockable {
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
-                session: .init(plan: .plan1, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
@@ -429,7 +447,10 @@ extension RUMLongTaskEvent: RandomMockable {
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
                 discarded: nil,
-                session: .init(plan: .plan1, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -750,6 +750,7 @@ extension RUMSessionScope {
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
         startTime: Date = .mockAny(),
+        startPrecondition: RUMSessionPrecondition? = .userAppLaunch,
         dependencies: RUMScopeDependencies = .mockAny(),
         hasReplay: Bool? = .mockAny()
     ) -> RUMSessionScope {
@@ -757,6 +758,7 @@ extension RUMSessionScope {
             isInitialSession: isInitialSession,
             parent: parent,
             startTime: startTime,
+            startPrecondition: startPrecondition,
             dependencies: dependencies,
             hasReplay: hasReplay
         )

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -214,7 +214,7 @@ public class DDRUMActionEventDDSession: NSObject {
         .init(swift: root.swiftModel.dd.session!.plan)
     }
 
-    @objc public var sessionPrecondition: DDRUMActionEventDDSessionSessionPrecondition {
+    @objc public var sessionPrecondition: DDRUMActionEventDDSessionRUMSessionPrecondition {
         .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
     }
 }
@@ -243,8 +243,8 @@ public enum DDRUMActionEventDDSessionPlan: Int {
 }
 
 @objc
-public enum DDRUMActionEventDDSessionSessionPrecondition: Int {
-    internal init(swift: RUMActionEvent.DD.Session.SessionPrecondition?) {
+public enum DDRUMActionEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
         switch swift {
         case nil: self = .none
         case .userAppLaunch?: self = .userAppLaunch
@@ -257,7 +257,7 @@ public enum DDRUMActionEventDDSessionSessionPrecondition: Int {
         }
     }
 
-    internal var toSwift: RUMActionEvent.DD.Session.SessionPrecondition? {
+    internal var toSwift: RUMSessionPrecondition? {
         switch self {
         case .none: return nil
         case .userAppLaunch: return .userAppLaunch
@@ -1086,7 +1086,7 @@ public class DDRUMErrorEventDDSession: NSObject {
         .init(swift: root.swiftModel.dd.session!.plan)
     }
 
-    @objc public var sessionPrecondition: DDRUMErrorEventDDSessionSessionPrecondition {
+    @objc public var sessionPrecondition: DDRUMErrorEventDDSessionRUMSessionPrecondition {
         .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
     }
 }
@@ -1115,8 +1115,8 @@ public enum DDRUMErrorEventDDSessionPlan: Int {
 }
 
 @objc
-public enum DDRUMErrorEventDDSessionSessionPrecondition: Int {
-    internal init(swift: RUMErrorEvent.DD.Session.SessionPrecondition?) {
+public enum DDRUMErrorEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
         switch swift {
         case nil: self = .none
         case .userAppLaunch?: self = .userAppLaunch
@@ -1129,7 +1129,7 @@ public enum DDRUMErrorEventDDSessionSessionPrecondition: Int {
         }
     }
 
-    internal var toSwift: RUMErrorEvent.DD.Session.SessionPrecondition? {
+    internal var toSwift: RUMSessionPrecondition? {
         switch self {
         case .none: return nil
         case .userAppLaunch: return .userAppLaunch
@@ -2180,7 +2180,7 @@ public class DDRUMLongTaskEventDDSession: NSObject {
         .init(swift: root.swiftModel.dd.session!.plan)
     }
 
-    @objc public var sessionPrecondition: DDRUMLongTaskEventDDSessionSessionPrecondition {
+    @objc public var sessionPrecondition: DDRUMLongTaskEventDDSessionRUMSessionPrecondition {
         .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
     }
 }
@@ -2209,8 +2209,8 @@ public enum DDRUMLongTaskEventDDSessionPlan: Int {
 }
 
 @objc
-public enum DDRUMLongTaskEventDDSessionSessionPrecondition: Int {
-    internal init(swift: RUMLongTaskEvent.DD.Session.SessionPrecondition?) {
+public enum DDRUMLongTaskEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
         switch swift {
         case nil: self = .none
         case .userAppLaunch?: self = .userAppLaunch
@@ -2223,7 +2223,7 @@ public enum DDRUMLongTaskEventDDSessionSessionPrecondition: Int {
         }
     }
 
-    internal var toSwift: RUMLongTaskEvent.DD.Session.SessionPrecondition? {
+    internal var toSwift: RUMSessionPrecondition? {
         switch self {
         case .none: return nil
         case .userAppLaunch: return .userAppLaunch
@@ -2929,7 +2929,7 @@ public class DDRUMResourceEventDDSession: NSObject {
         .init(swift: root.swiftModel.dd.session!.plan)
     }
 
-    @objc public var sessionPrecondition: DDRUMResourceEventDDSessionSessionPrecondition {
+    @objc public var sessionPrecondition: DDRUMResourceEventDDSessionRUMSessionPrecondition {
         .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
     }
 }
@@ -2958,8 +2958,8 @@ public enum DDRUMResourceEventDDSessionPlan: Int {
 }
 
 @objc
-public enum DDRUMResourceEventDDSessionSessionPrecondition: Int {
-    internal init(swift: RUMResourceEvent.DD.Session.SessionPrecondition?) {
+public enum DDRUMResourceEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
         switch swift {
         case nil: self = .none
         case .userAppLaunch?: self = .userAppLaunch
@@ -2972,7 +2972,7 @@ public enum DDRUMResourceEventDDSessionSessionPrecondition: Int {
         }
     }
 
-    internal var toSwift: RUMResourceEvent.DD.Session.SessionPrecondition? {
+    internal var toSwift: RUMSessionPrecondition? {
         switch self {
         case .none: return nil
         case .userAppLaunch: return .userAppLaunch
@@ -4109,7 +4109,7 @@ public class DDRUMViewEventDDSession: NSObject {
         .init(swift: root.swiftModel.dd.session!.plan)
     }
 
-    @objc public var sessionPrecondition: DDRUMViewEventDDSessionSessionPrecondition {
+    @objc public var sessionPrecondition: DDRUMViewEventDDSessionRUMSessionPrecondition {
         .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
     }
 }
@@ -4138,8 +4138,8 @@ public enum DDRUMViewEventDDSessionPlan: Int {
 }
 
 @objc
-public enum DDRUMViewEventDDSessionSessionPrecondition: Int {
-    internal init(swift: RUMViewEvent.DD.Session.SessionPrecondition?) {
+public enum DDRUMViewEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
         switch swift {
         case nil: self = .none
         case .userAppLaunch?: self = .userAppLaunch
@@ -4152,7 +4152,7 @@ public enum DDRUMViewEventDDSessionSessionPrecondition: Int {
         }
     }
 
-    internal var toSwift: RUMViewEvent.DD.Session.SessionPrecondition? {
+    internal var toSwift: RUMSessionPrecondition? {
         switch self {
         case .none: return nil
         case .userAppLaunch: return .userAppLaunch

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -186,7 +186,7 @@ public struct RUMActionEvent: RUMDataModel {
             public let plan: Plan?
 
             /// The precondition that led to the creation of the session
-            public let sessionPrecondition: SessionPrecondition?
+            public let sessionPrecondition: RUMSessionPrecondition?
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -197,17 +197,6 @@ public struct RUMActionEvent: RUMDataModel {
             public enum Plan: Int, Codable {
                 case plan1 = 1
                 case plan2 = 2
-            }
-
-            /// The precondition that led to the creation of the session
-            public enum SessionPrecondition: String, Codable {
-                case userAppLaunch = "user_app_launch"
-                case inactivityTimeout = "inactivity_timeout"
-                case maxDuration = "max_duration"
-                case backgroundLaunch = "background_launch"
-                case prewarm = "prewarm"
-                case fromNonInteractiveSession = "from_non_interactive_session"
-                case explicitStop = "explicit_stop"
             }
         }
     }
@@ -580,7 +569,7 @@ public struct RUMErrorEvent: RUMDataModel {
             public let plan: Plan?
 
             /// The precondition that led to the creation of the session
-            public let sessionPrecondition: SessionPrecondition?
+            public let sessionPrecondition: RUMSessionPrecondition?
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -591,17 +580,6 @@ public struct RUMErrorEvent: RUMDataModel {
             public enum Plan: Int, Codable {
                 case plan1 = 1
                 case plan2 = 2
-            }
-
-            /// The precondition that led to the creation of the session
-            public enum SessionPrecondition: String, Codable {
-                case userAppLaunch = "user_app_launch"
-                case inactivityTimeout = "inactivity_timeout"
-                case maxDuration = "max_duration"
-                case backgroundLaunch = "background_launch"
-                case prewarm = "prewarm"
-                case fromNonInteractiveSession = "from_non_interactive_session"
-                case explicitStop = "explicit_stop"
             }
         }
     }
@@ -1066,7 +1044,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             public let plan: Plan?
 
             /// The precondition that led to the creation of the session
-            public let sessionPrecondition: SessionPrecondition?
+            public let sessionPrecondition: RUMSessionPrecondition?
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -1077,17 +1055,6 @@ public struct RUMLongTaskEvent: RUMDataModel {
             public enum Plan: Int, Codable {
                 case plan1 = 1
                 case plan2 = 2
-            }
-
-            /// The precondition that led to the creation of the session
-            public enum SessionPrecondition: String, Codable {
-                case userAppLaunch = "user_app_launch"
-                case inactivityTimeout = "inactivity_timeout"
-                case maxDuration = "max_duration"
-                case backgroundLaunch = "background_launch"
-                case prewarm = "prewarm"
-                case fromNonInteractiveSession = "from_non_interactive_session"
-                case explicitStop = "explicit_stop"
             }
         }
     }
@@ -1375,7 +1342,7 @@ public struct RUMResourceEvent: RUMDataModel {
             public let plan: Plan?
 
             /// The precondition that led to the creation of the session
-            public let sessionPrecondition: SessionPrecondition?
+            public let sessionPrecondition: RUMSessionPrecondition?
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -1386,17 +1353,6 @@ public struct RUMResourceEvent: RUMDataModel {
             public enum Plan: Int, Codable {
                 case plan1 = 1
                 case plan2 = 2
-            }
-
-            /// The precondition that led to the creation of the session
-            public enum SessionPrecondition: String, Codable {
-                case userAppLaunch = "user_app_launch"
-                case inactivityTimeout = "inactivity_timeout"
-                case maxDuration = "max_duration"
-                case backgroundLaunch = "background_launch"
-                case prewarm = "prewarm"
-                case fromNonInteractiveSession = "from_non_interactive_session"
-                case explicitStop = "explicit_stop"
             }
         }
     }
@@ -1937,7 +1893,7 @@ public struct RUMViewEvent: RUMDataModel {
             public let plan: Plan?
 
             /// The precondition that led to the creation of the session
-            public let sessionPrecondition: SessionPrecondition?
+            public let sessionPrecondition: RUMSessionPrecondition?
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -1948,17 +1904,6 @@ public struct RUMViewEvent: RUMDataModel {
             public enum Plan: Int, Codable {
                 case plan1 = 1
                 case plan2 = 2
-            }
-
-            /// The precondition that led to the creation of the session
-            public enum SessionPrecondition: String, Codable {
-                case userAppLaunch = "user_app_launch"
-                case inactivityTimeout = "inactivity_timeout"
-                case maxDuration = "max_duration"
-                case backgroundLaunch = "background_launch"
-                case prewarm = "prewarm"
-                case fromNonInteractiveSession = "from_non_interactive_session"
-                case explicitStop = "explicit_stop"
             }
         }
     }
@@ -3227,6 +3172,17 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             case id = "id"
         }
     }
+}
+
+/// The precondition that led to the creation of the session
+public enum RUMSessionPrecondition: String, Codable {
+    case userAppLaunch = "user_app_launch"
+    case inactivityTimeout = "inactivity_timeout"
+    case maxDuration = "max_duration"
+    case backgroundLaunch = "background_launch"
+    case prewarm = "prewarm"
+    case fromNonInteractiveSession = "from_non_interactive_session"
+    case explicitStop = "explicit_stop"
 }
 
 /// CI Visibility properties

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -341,7 +341,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: lastRUMView.dd.session?.sessionPrecondition
                 )
             ),
             action: nil,
@@ -407,7 +407,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 replayStats: nil,
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: original.dd.session?.sessionPrecondition
                 )
             ),
             application: original.application,

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -339,7 +339,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: nil,
             application: .init(id: lastRUMView.application.id),
@@ -402,7 +405,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 documentVersion: original.dd.documentVersion + 1,
                 pageStates: nil,
                 replayStats: nil,
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             application: original.application,
             buildVersion: original.buildVersion,
@@ -490,7 +496,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 documentVersion: 1,
                 pageStates: nil,
                 replayStats: nil,
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             application: .init(
                 id: applicationID

--- a/DatadogRUM/Sources/RUMContext/RUMContext.swift
+++ b/DatadogRUM/Sources/RUMContext/RUMContext.swift
@@ -13,6 +13,8 @@ internal struct RUMContext {
     var sessionID: RUMUUID
     /// Whether the session for this context is currently active
     var isSessionActive: Bool
+    /// The precondition that led to the creation of current session.
+    var sessionPrecondition: RUMSessionPrecondition?
 
     /// The ID of currently displayed view.
     var activeViewID: RUMUUID?

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -56,7 +56,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         // Added in https://github.com/DataDog/dd-sdk-ios/pull/1278 to ensure that logs and traces
         // can be correlated with valid RUM session id (even if occurring before any user interaction).
         if command is RUMSDKInitCommand {
-            createInitialSession(on: command, context: context, writer: writer)
+            createInitialSession(with: context)
             return true // always keep application scope
         }
 
@@ -66,7 +66,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         if sessionScopes.isEmpty && !applicationActive {
             // This flow is likely stale code as`RUMSDKInitCommand` should already start the session before reaching this point
             dependencies.telemetry.debug("Starting initial session from lazy flow")
-            createInitialSession(on: command, context: context, writer: writer)
+            createInitialSession(with: context)
         }
 
         // Create the application launch view on any command
@@ -129,7 +129,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private var didCreateInitialSession = false
 
     /// Starts initial RUM Session.
-    private func createInitialSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
+    private func createInitialSession(with context: DatadogContext) {
         if didCreateInitialSession { // Sanity check
             dependencies.telemetry.error("Initial session was created more than once (previous end reason: \(lastSessionEndReason?.rawValue ?? "unknown"))")
         }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -237,4 +237,3 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         )
     }
 }
-

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -18,8 +18,11 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// Might be re-created later according to session duration constraints.
     private(set) var sessionScopes: [RUMSessionScope] = []
 
-    /// Last active view from the last active  session. Used to restart the active view on a user action.
+    /// Last active view from the last active session. Used to restart the active view on a user action.
     private var lastActiveView: RUMViewScope?
+
+    /// The end reason from the last active session. Used as "start reason" for the new session.
+    private var lastSessionEndReason: RUMSessionScope.EndReason?
 
     var activeSession: RUMSessionScope? {
         get { return sessionScopes.first(where: { $0.isActive }) }
@@ -50,14 +53,19 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     func process(command: RUMCommand, context: DatadogContext, writer: Writer) -> Bool {
         // `RUMSDKInitCommand` forces the creation of the initial session
+        // Added in https://github.com/DataDog/dd-sdk-ios/pull/1278 to ensure that logs and traces
+        // can be correlated with valid RUM session id (even if occurring before any user interaction).
         if command is RUMSDKInitCommand {
             createInitialSession(on: command, context: context, writer: writer)
-            return true
+            return true // always keep application scope
         }
 
-        // If the application has not been yet activated and no sessions exist
-        // -> create the initial session
+        // If the application has not been yet activated and no sessions exist -> create the initial session
+        // Added in https://github.com/DataDog/dd-sdk-ios/pull/1219 to start new session automatically when
+        // a user action is sent (startView or addUserAction).
         if sessionScopes.isEmpty && !applicationActive {
+            // This flow is likely stale code as`RUMSDKInitCommand` should already start the session before reaching this point
+            dependencies.telemetry.debug("Starting initial session from lazy flow")
             createInitialSession(on: command, context: context, writer: writer)
         }
 
@@ -85,34 +93,48 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
                 return scope
             }
 
-            // proccss(command:context:writer) returned false, but if the scope is  still active
-            // it means we timed out or expired and we need to refresh the session
-            if scope.isActive {
-                return refresh(expiredSession: scope, on: command, context: context, writer: writer)
+            // proccss(command:context:writer) returned false, but if the scope is still active
+            // it means the session reached one of the end reasons
+            guard let endReason = scope.endReason else {
+                // Sanity telemetry, we don't expect reaching this flow
+                dependencies.telemetry.error("A session has ended with no 'end reason'")
+                return nil
             }
 
-            // Else, an inactive scope is done processing events and can be removed
-            return nil
+            // Store "end reason" so it will be used as "start reason" for next session
+            lastSessionEndReason = endReason
+
+            switch endReason {
+            case .timeOut, .maxDuration:
+                // Replace this session scope with the scope for refreshed session:
+                return refresh(expiredSession: scope, on: command, context: context, writer: writer)
+            case .stopAPI:
+                // Remove this session scope (a new on will be started upon receiving user interaction):
+                return nil
+            }
         })
 
         // Sanity telemety, only end up with one active session
-        if sessionScopes.filter({ $0.isActive }).count > 1 {
-            dependencies.telemetry.error("An application has multiple active sessions!")
+        let activeSessions = sessionScopes.filter { $0.isActive }
+        if activeSessions.count > 1 {
+            dependencies.telemetry.error("An application has \(activeSessions.count) active sessions")
         }
 
-        return activeSession != nil
+        return true // always keep application scope
     }
 
     // MARK: - Private
 
-    private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
-        let refreshedSession = RUMSessionScope(from: expiredSession, startTime: command.time, context: context)
-        sessionScopeDidUpdate(refreshedSession)
-        _ = refreshedSession.process(command: command, context: context, writer: writer)
-        return refreshedSession
-    }
+    /// Sanity flag to make sure initial session is created only once.
+    private var didCreateInitialSession = false
 
+    /// Starts initial RUM Session.
     private func createInitialSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
+        if didCreateInitialSession { // Sanity check
+            dependencies.telemetry.error("Initial session was created more than once")
+        }
+        didCreateInitialSession = true
+
         let initialSession = RUMSessionScope(
             isInitialSession: true,
             parent: self,
@@ -121,10 +143,55 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             hasReplay: context.hasReplay
         )
 
+        lastSessionEndReason = nil
         sessionScopes.append(initialSession)
         sessionScopeDidUpdate(initialSession)
     }
 
+    /// Starts new RUM Session immediately after previous one expires or time outs. It transfers some of the state from the expired session to the new one.
+    private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
+        if lastSessionEndReason == .timeOut || lastSessionEndReason == .maxDuration { // Sanity check
+            dependencies.telemetry.error("Session was refreshed but previous one ended with unexpected reason: \(lastSessionEndReason?.rawValue ?? "unknown")")
+        }
+
+        let refreshedSession = RUMSessionScope(from: expiredSession, startTime: command.time, context: context)
+        sessionScopeDidUpdate(refreshedSession)
+        lastSessionEndReason = nil
+        _ = refreshedSession.process(command: command, context: context, writer: writer)
+        return refreshedSession
+    }
+
+    /// Starts new RUM Session some time after previous one was ended with ``RUMMonitorProtocol.stopSession()`` API. It may re-activate the last view from previous session.
+    private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
+        if lastSessionEndReason != .stopAPI { // Sanity check
+            dependencies.telemetry.error("New session was started but previous one ended with unexpected reason: \(lastSessionEndReason?.rawValue ?? "unknown")")
+        }
+
+        let resumingViewScope = command is RUMStartViewCommand ? nil : lastActiveView
+        let newSession = RUMSessionScope(
+            isInitialSession: false,
+            parent: self,
+            startTime: command.time,
+            dependencies: dependencies,
+            hasReplay: context.hasReplay,
+            resumingViewScope: resumingViewScope
+        )
+        lastActiveView = nil
+        lastSessionEndReason = nil
+
+        sessionScopes.append(newSession)
+        sessionScopeDidUpdate(newSession)
+    }
+
+    private func sessionScopeDidUpdate(_ sessionScope: RUMSessionScope) {
+        let sessionID = sessionScope.sessionUUID.rawValue.uuidString
+        let isDiscarded = !sessionScope.isSampled
+        dependencies.onSessionStart?(sessionID, isDiscarded)
+    }
+
+    /// Forces the `ApplicationLaunchView` to be started.
+    /// Added as part of https://github.com/DataDog/dd-sdk-ios/pull/1290 to separate creation of first view
+    /// from creation of initial session due to receiving `RUMSDKInitCommand`.
     private func applicationStart(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         applicationActive = true
 
@@ -141,27 +208,5 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             context: context,
             writer: writer
         )
-    }
-
-    private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        let resumingViewScope = command is RUMStartViewCommand ? nil : lastActiveView
-        let newSession = RUMSessionScope(
-            isInitialSession: false,
-            parent: self,
-            startTime: command.time,
-            dependencies: dependencies,
-            hasReplay: context.hasReplay,
-            resumingViewScope: resumingViewScope
-        )
-        lastActiveView = nil
-
-        sessionScopes.append(newSession)
-        sessionScopeDidUpdate(newSession)
-    }
-
-    private func sessionScopeDidUpdate(_ sessionScope: RUMSessionScope) {
-        let sessionID = sessionScope.sessionUUID.rawValue.uuidString
-        let isDiscarded = !sessionScope.isSampled
-        dependencies.onSessionStart?(sessionID, isDiscarded)
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -152,10 +152,16 @@ internal class RUMResourceScope: RUMScope {
         let resourceEvent = RUMResourceEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
+                configuration: .init(
+                    sessionReplaySampleRate: nil,
+                    sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)
+                ),
                 discarded: nil,
                 rulePsr: traceSamplingRate,
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch),
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                ),
                 spanId: spanId,
                 traceId: traceId
             ),
@@ -250,7 +256,10 @@ internal class RUMResourceScope: RUMScope {
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: self.context.activeUserActionID.map { rumUUID in
                 .init(id: .string(value: rumUUID.toRUMDataFormat))

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -160,7 +160,7 @@ internal class RUMResourceScope: RUMScope {
                 rulePsr: traceSamplingRate,
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 ),
                 spanId: spanId,
                 traceId: traceId
@@ -258,7 +258,7 @@ internal class RUMResourceScope: RUMScope {
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             action: self.context.activeUserActionID.map { rumUUID in

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -144,7 +144,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             action: .init(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -142,7 +142,10 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 action: nil,
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: .init(
                 crash: .init(count: 0),

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -369,7 +369,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 action: nil,
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: .init(
                 crash: .init(count: 0),
@@ -452,7 +455,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                     segmentsCount: nil,
                     segmentsTotalRawSize: nil
                 ),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             application: .init(id: self.context.rumApplicationID),
             buildVersion: context.buildNumber,
@@ -549,7 +555,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: self.context.activeUserActionID.map { rumUUID in
                 .init(id: .string(value: rumUUID.toRUMDataFormat))
@@ -614,7 +623,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 discarded: nil,
-                session: .init(plan: .plan1, sessionPrecondition: .userAppLaunch)
+                session: .init(
+                    plan: .plan1,
+                    sessionPrecondition: nil
+                )
             ),
             action: self.context.activeUserActionID.map {
                 .init(id: .string(value: $0.toRUMDataFormat))

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -371,7 +371,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             action: .init(
@@ -457,7 +457,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 ),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             application: .init(id: self.context.rumApplicationID),
@@ -557,7 +557,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             action: self.context.activeUserActionID.map { rumUUID in
@@ -625,7 +625,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 discarded: nil,
                 session: .init(
                     plan: .plan1,
-                    sessionPrecondition: nil
+                    sessionPrecondition: self.context.sessionPrecondition
                 )
             ),
             action: self.context.activeUserActionID.map {

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -51,6 +51,12 @@ extension RUMMethod: RandomMockable {
     }
 }
 
+extension RUMSessionPrecondition: RandomMockable {
+    public static func mockRandom() -> RUMSessionPrecondition {
+        return [.userAppLaunch, .inactivityTimeout, .maxDuration, .backgroundLaunch, .prewarm, .fromNonInteractiveSession, .explicitStop].randomElement()!
+    }
+}
+
 extension RUMEventAttributes: RandomMockable {
     public static func mockRandom() -> RUMEventAttributes {
         return .init(contextInfo: mockRandomAttributes())
@@ -109,7 +115,11 @@ extension RUMOperatingSystem: RandomMockable {
 
 extension RUMViewEvent.DD.Configuration: RandomMockable {
     public static func mockRandom() -> RUMViewEvent.DD.Configuration {
-        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100), startSessionReplayRecordingManually: nil)
+        return .init(
+            sessionReplaySampleRate: .mockRandom(min: 0, max: 100),
+            sessionSampleRate: .mockRandom(min: 0, max: 100),
+            startSessionReplayRecordingManually: nil
+        )
     }
 }
 
@@ -131,7 +141,10 @@ extension RUMViewEvent: RandomMockable {
                 documentVersion: .mockRandom(),
                 pageStates: nil,
                 replayStats: nil,
-                session: .init(plan: [.plan1, .plan2].randomElement()!, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             application: .init(id: .mockRandom()),
             buildVersion: .mockRandom(),
@@ -223,7 +236,10 @@ extension RUMResourceEvent: RandomMockable {
                 configuration: .mockRandom(),
                 discarded: nil,
                 rulePsr: nil,
-                session: .init(plan: [.plan1, .plan2].randomElement()!, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement()),
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                ),
                 spanId: .mockRandom(),
                 traceId: .mockRandom()
             ),
@@ -297,7 +313,10 @@ extension RUMActionEvent: RandomMockable {
                 ),
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
-                session: .init(plan: [.plan1, .plan2].randomElement()!, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(
                 crash: .init(count: .mockRandom()),
@@ -358,7 +377,10 @@ extension RUMErrorEvent: RandomMockable {
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
-                session: .init(plan: [.plan1, .plan2].randomElement()!, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
@@ -438,7 +460,10 @@ extension RUMLongTaskEvent: RandomMockable {
                 browserSdkVersion: nil,
                 configuration: .mockRandom(),
                 discarded: nil,
-                session: .init(plan: [.plan1, .plan2].randomElement()!, sessionPrecondition: [.userAppLaunch, .backgroundLaunch].randomElement())
+                session: .init(
+                    plan: [.plan1, .plan2].randomElement()!,
+                    sessionPrecondition: .mockRandom()
+                )
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
@@ -483,8 +508,8 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     actionNameAttribute: nil,
                     allowFallbackToLocalStorage: nil,
                     allowUntrustedEvents: nil,
-                    backgroundTasksEnabled: .mockAny(),
-                    batchProcessingLevel: .mockAny(),
+                    backgroundTasksEnabled: .mockRandom(),
+                    batchProcessingLevel: .mockRandom(),
                     batchSize: .mockAny(),
                     batchUploadFrequency: .mockRandom(),
                     defaultPrivacyLevel: .mockRandom(),

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -730,6 +730,7 @@ extension RUMSessionScope {
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
         startTime: Date = .mockAny(),
+        startPrecondition: RUMSessionPrecondition? = .userAppLaunch,
         dependencies: RUMScopeDependencies = .mockAny(),
         hasReplay: Bool? = .mockAny()
     ) -> RUMSessionScope {
@@ -737,6 +738,7 @@ extension RUMSessionScope {
             isInitialSession: isInitialSession,
             parent: parent,
             startTime: startTime,
+            startPrecondition: startPrecondition,
             dependencies: dependencies,
             hasReplay: hasReplay
         )

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -172,7 +172,7 @@ extension RUMApplicationStartCommand: AnyMockable, RandomMockable {
 
     static func mockWith(
         time: Date = Date(),
-        attributes: [AttributeKey : AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:]
     ) -> RUMApplicationStartCommand {
         return RUMApplicationStartCommand(
             time: time,

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -160,6 +160,29 @@ extension RUMCommand {
     }
 }
 
+extension RUMApplicationStartCommand: AnyMockable, RandomMockable {
+    public static func mockAny() -> RUMApplicationStartCommand { mockWith() }
+
+    public static func mockRandom() -> RUMApplicationStartCommand {
+        return .mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes()
+        )
+    }
+
+    static func mockWith(
+        time: Date = Date(),
+        attributes: [AttributeKey : AttributeValue] = [:]
+    ) -> RUMApplicationStartCommand {
+        return RUMApplicationStartCommand(
+            time: time,
+            attributes: attributes,
+            canStartBackgroundView: false,
+            isUserInteraction: false
+        )
+    }
+}
+
 extension RUMStartViewCommand: AnyMockable, RandomMockable {
     public static func mockAny() -> RUMStartViewCommand { mockWith() }
 
@@ -613,6 +636,7 @@ extension RUMContext {
         rumApplicationID: String = .mockAny(),
         sessionID: RUMUUID = .mockRandom(),
         isSessionActive: Bool = true,
+        sessionPrecondition: RUMSessionPrecondition? = .userAppLaunch,
         activeViewID: RUMUUID? = nil,
         activeViewPath: String? = nil,
         activeViewName: String? = nil,

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -166,6 +166,18 @@ extension LaunchTime: AnyMockable {
             isActivePrewarm: .mockAny()
         )
     }
+
+    public static func mockWith(
+        launchTime: TimeInterval? = 1,
+        launchDate: Date = Date(),
+        isActivePrewarm: Bool = false
+    ) -> LaunchTime {
+        .init(
+            launchTime: launchTime,
+            launchDate: launchDate,
+            isActivePrewarm: isActivePrewarm
+        )
+    }
 }
 
 extension AppState: AnyMockable, RandomMockable {

--- a/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
@@ -25,6 +25,7 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
                 "RUMDevice",
                 "RUMOperatingSystem",
                 "RUMActionID",
+                "RUMSessionPrecondition",
             ]
         )
     }
@@ -116,6 +117,10 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
         // context we generate single root type: `RUMActionID`.
         if fixedName == "ID", let parentStructName = (context.parent as? SwiftStruct)?.name, parentStructName == "action" {
             fixedName = "RUMActionID"
+        }
+
+        if fixedName == "SessionPrecondition" {
+            fixedName = "RUMSessionPrecondition"
         }
 
         return fixedName


### PR DESCRIPTION
### What and why?

📦 As part of **RUM Session Standarization** project, this PR introduces `sessionPrecondition` attribute to RUM events. This is to add more visibility over the reasons for creating RUM sessions.
```swift
enum RUMSessionPrecondition {
    case userAppLaunch
    case inactivityTimeout
    case maxDuration
    case backgroundLaunch
    case prewarm
    case fromNonInteractiveSession    // not implemented in this PR - TODO in RUM-1646
    case explicitStop
}
```

Mid-term goal is to simplify the logic of RUM Sessions creation and pay off portions of tech debt incurred in recent https://github.com/DataDog/dd-sdk-ios/pull/1278, https://github.com/DataDog/dd-sdk-ios/pull/1219 and https://github.com/DataDog/dd-sdk-ios/pull/1290 and previous work.

### How?

`RUMApplicationScope` is the main component modified in this PR. 

The idea behind this work is to:
* Avoid doing changes in RUM Session creation logic - we want to first add observability to the current state of affair.
* Add `sessionPrecondition` attribute to all RUM events.
* Insert sanity checks and error telemetry to validate assumptions and eventually erase ambiguity and pieces of technical debt in future increments.

Counterpart PR to RUM schema: https://github.com/DataDog/rum-events-format/pull/169

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
