### PR TITLE
RUM-717 fix: use delegate based check to decide swizzle or not for delegate types

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionDataDelegateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionDataDelegateSwizzler.swift
@@ -37,7 +37,8 @@ internal class URLSessionDataDelegateSwizzler {
         lock.lock()
         defer { lock.unlock() }
 
-        guard isBinded == false else {
+        let key = MetaTypeExtensions.key(from: delegateClass)
+        guard didReceiveMap[key] == nil else {
             return
         }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskDelegateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskDelegateSwizzler.swift
@@ -51,7 +51,8 @@ internal class URLSessionTaskDelegateSwizzler {
         lock.lock()
         defer { lock.unlock() }
 
-        guard isBinded == false else {
+        let key = MetaTypeExtensions.key(from: delegateClass)
+        guard didFinishCollectingMap[key] == nil || didCompleteWithErrorMap[key] == nil else {
             return
         }
 


### PR DESCRIPTION
### What and why?

Check on map items is not correct.

### How?

Use delegate key checks to see if the type has been swizzled or not.

Manual test

https://github.com/ganeshnj/dd-sdk-ios-example/blob/main/Example/Example/ContentView.swift#L19

<img width="880" alt="image" src="https://github.com/DataDog/dd-sdk-ios/assets/8882380/d7763997-08a7-4e0f-ab6b-04b05813f15b">


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
