### PR TITLE
Enable custom node recorders for cross platform

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1443,6 +1443,7 @@
 		D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FB1256292E0F0B005B13F8 /* TrackingConsentPublisherTests.swift */; };
 		D2FB125D292FBB56005B13F8 /* Datadog+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FB125C292FBB56005B13F8 /* Datadog+Internal.swift */; };
 		D2FB125E292FBB56005B13F8 /* Datadog+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FB125C292FBB56005B13F8 /* Datadog+Internal.swift */; };
+		E12D0FE82AFC04F60094BCB7 /* Wireframes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12D0FE72AFC04F60094BCB7 /* Wireframes.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
 		E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
@@ -2676,6 +2677,7 @@
 		D2FB125C292FBB56005B13F8 /* Datadog+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Datadog+Internal.swift"; sourceTree = "<group>"; };
 		D2FCA238271D896E0020286F /* SwiftUIExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensions.swift; sourceTree = "<group>"; };
 		E11625D727B681D200E428C6 /* CITestIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CITestIntegration.swift; sourceTree = "<group>"; };
+		E12D0FE72AFC04F60094BCB7 /* Wireframes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wireframes.swift; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
 		E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CITestIntegrationTests.swift; sourceTree = "<group>"; };
@@ -3319,6 +3321,7 @@
 		61054E4F2A6EE10A00AAA894 /* SRDataModelsBuilder */ = {
 			isa = PBXGroup;
 			children = (
+				E12D0FE72AFC04F60094BCB7 /* Wireframes.swift */,
 				61054E502A6EE10A00AAA894 /* RecordsBuilder.swift */,
 				61054E512A6EE10A00AAA894 /* WireframesBuilder.swift */,
 			);
@@ -7645,6 +7648,7 @@
 				61054E6E2A6EE10A00AAA894 /* RecordingCoordinator.swift in Sources */,
 				61054E9F2A6EE10B00AAA894 /* Errors.swift in Sources */,
 				61054E642A6EE10A00AAA894 /* SessionReplay.swift in Sources */,
+				E12D0FE82AFC04F60094BCB7 /* Wireframes.swift in Sources */,
 				61054E952A6EE10A00AAA894 /* Processor.swift in Sources */,
 				61054E722A6EE10A00AAA894 /* TouchIdentifierGenerator.swift in Sources */,
 				61054E912A6EE10A00AAA894 /* EnrichedRecordJSON.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -45,7 +45,7 @@ internal class SnapshotTestCase: XCTestCase {
             srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
             telemetry: TelemetryMock()
         )
-        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock())
+        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock(), additionalNodeRecorders: [])
 
         // Set up wireframes interception :
         var wireframes: [SRWireframe]?

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -43,7 +43,8 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
         let recorder = try Recorder(
             processor: processor,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            additionalNodeRecorders: configuration._additionalNodeRecorders
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,

--- a/DatadogSessionReplay/Sources/Processor/Processor.swift
+++ b/DatadogSessionReplay/Sources/Processor/Processor.swift
@@ -84,6 +84,7 @@ internal class Processor: Processing {
         let wireframes: [SRWireframe] = flattenedNodes
             .map { node in node.wireframesBuilder }
             .flatMap { nodeBuilder in nodeBuilder.buildWireframes(with: wireframesBuilder) }
+            .map { wireframe in wireframe.toSRWireframe() }
 
         #if DEBUG
         interceptWireframes?(wireframes)

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/Wireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/Wireframes.swift
@@ -1,0 +1,404 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import UIKit
+
+/// The border properties of this wireframe. The default value is null (no-border).
+@_spi(Internal) public struct ShapeBorder {
+    /// The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
+    public let color: String
+
+    /// The width of the border in pixels.
+    public let width: Int64
+
+    internal func toSRShapeBorder() -> SRShapeBorder {
+        return .init(color: color, width: width)
+    }
+}
+
+/// Schema of clipping information for a Wireframe.
+@_spi(Internal) public struct ContentClip {
+    /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+    public let bottom: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+    public let left: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+    public let right: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+    public let top: Int64?
+
+    public init(bottom: Int64?, left: Int64?, right: Int64?, top: Int64?) {
+        self.bottom = bottom
+        self.left = left
+        self.right = right
+        self.top = top
+    }
+
+    internal func toSRContentClip() -> SRContentClip {
+        return .init(bottom: bottom, left: left, right: right, top: top)
+    }
+}
+
+/// The style of this wireframe.
+@_spi(Internal) public struct ShapeStyle {
+    /// The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
+    public let backgroundColor: String?
+
+    /// The corner(border) radius of this wireframe in pixels. The default value is 0.
+    public let cornerRadius: Double?
+
+    /// The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
+    public let opacity: Double?
+
+    internal func toSRShapeStyle() -> SRShapeStyle {
+        return .init(
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            opacity: opacity
+        )
+    }
+}
+
+/// Schema of all properties of a ShapeWireframe.
+@_spi(Internal) public struct ShapeWireframe {
+    /// The border properties of this wireframe. The default value is null (no-border).
+    public let border: ShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    public let clip: ContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// The style of this wireframe.
+    public let shapeStyle: ShapeStyle?
+
+    /// The type of the wireframe.
+    public let type: String = "shape"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    internal func toSRShapeWireframe() -> SRShapeWireframe {
+        return SRShapeWireframe(
+            border: border?.toSRShapeBorder(),
+            clip: clip?.toSRContentClip(),
+            height: height,
+            id: id,
+            shapeStyle: shapeStyle?.toSRShapeStyle(),
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+/// Schema of all properties of a TextPosition.
+@_spi(Internal) public struct TextPosition {
+    public let alignment: Alignment?
+
+    public let padding: Padding?
+
+    public struct Alignment {
+        /// The horizontal text alignment. The default value is `left`.
+        public let horizontal: Horizontal?
+
+        /// The vertical text alignment. The default value is `top`.
+        public let vertical: Vertical?
+
+        /// The horizontal text alignment. The default value is `left`.
+        public enum Horizontal: String, Codable {
+            case left = "left"
+            case right = "right"
+            case center = "center"
+        }
+
+        /// The vertical text alignment. The default value is `top`.
+        public enum Vertical: String, Codable {
+            case top = "top"
+            case bottom = "bottom"
+            case center = "center"
+        }
+
+        public init(horizontal: Horizontal?, vertical: Vertical?) {
+            self.horizontal = horizontal
+            self.vertical = vertical
+        }
+
+        internal func toSRAlignment() -> SRTextPosition.Alignment? {
+            if let verticalValue = vertical?.rawValue as? String {
+                if let horizontalValue = horizontal?.rawValue as? String {
+                    return .init(
+                        horizontal: .init(rawValue: horizontalValue),
+                        vertical: .init(rawValue: verticalValue)
+                    )
+                }
+
+                return .init(horizontal: nil, vertical: .init(rawValue: verticalValue))
+            }
+
+            if let horizontalValue = horizontal?.rawValue as? String {
+                return .init(horizontal: .init(rawValue: horizontalValue), vertical: nil)
+            }
+
+            return .init(horizontal: nil, vertical: nil)
+        }
+    }
+
+    public struct Padding: Codable, Hashable {
+        /// The bottom padding in pixels. The default value is 0.
+        public let bottom: Int64?
+
+        /// The left padding in pixels. The default value is 0.
+        public let left: Int64?
+
+        /// The right padding in pixels. The default value is 0.
+        public let right: Int64?
+
+        /// The top padding in pixels. The default value is 0.
+        public let top: Int64?
+    }
+
+    internal func toSRTextPosition() -> SRTextPosition {
+        return .init(
+            alignment: alignment?.toSRAlignment(),
+            padding: .init(
+                bottom: padding?.bottom,
+                left: padding?.left,
+                right: padding?.right,
+                top: padding?.top
+            )
+        )
+    }
+}
+
+/// Schema of all properties of a TextStyle.
+@_spi(Internal) public struct TextStyle {
+    /// The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
+    public let color: String
+
+    /// The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
+    public let family: String
+
+    /// The font size in pixels.
+    public let size: Int64
+
+    internal func toSRTextStyle() -> SRTextStyle {
+        return .init(color: color, family: family, size: size)
+    }
+}
+
+/// Schema of all properties of a TextWireframe.
+@_spi(Internal) public struct TextWireframe {
+    /// The border properties of this wireframe. The default value is null (no-border).
+    public let border: ShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    public let clip: ContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// The style of this wireframe.
+    public let shapeStyle: ShapeStyle?
+
+    /// The text value of the wireframe.
+    public var text: String
+
+    /// Schema of all properties of a TextPosition.
+    public let textPosition: TextPosition?
+
+    /// Schema of all properties of a TextStyle.
+    public let textStyle: TextStyle
+
+    /// The type of the wireframe.
+    public let type: String = "text"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    internal func toSRTextWireframe() -> SRTextWireframe {
+        return SRTextWireframe(
+            border: border?.toSRShapeBorder(),
+            clip: clip?.toSRContentClip(),
+            height: height,
+            id: id,
+            shapeStyle: shapeStyle?.toSRShapeStyle(),
+            text: text,
+            textPosition: textPosition?.toSRTextPosition(),
+            textStyle: textStyle.toSRTextStyle(),
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+/// Schema of all properties of a ImageWireframe.
+@_spi(Internal) public struct ImageWireframe {
+    /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
+    public var base64: String?
+
+    /// The border properties of this wireframe. The default value is null (no-border).
+    public let border: ShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    public let clip: ContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// Flag describing an image wireframe that should render an empty state placeholder
+    public var isEmpty: Bool?
+
+    /// MIME type of the image file
+    public var mimeType: String?
+
+    /// Unique identifier of the image resource
+    public var resourceId: String?
+
+    /// The style of this wireframe.
+    public let shapeStyle: ShapeStyle?
+
+    /// The type of the wireframe.
+    public let type: String = "image"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    internal func toSRImageWireframe() -> SRImageWireframe {
+        return SRImageWireframe(
+            base64: base64,
+            border: border?.toSRShapeBorder(),
+            clip: clip?.toSRContentClip(),
+            height: height,
+            id: id,
+            isEmpty: isEmpty,
+            mimeType: mimeType,
+            resourceId: resourceId,
+            shapeStyle: shapeStyle?.toSRShapeStyle(),
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+/// Schema of all properties of a PlaceholderWireframe.
+@_spi(Internal) public struct PlaceholderWireframe {
+    /// Schema of clipping information for a Wireframe.
+    public let clip: ContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// Label of the placeholder
+    public var label: String?
+
+    /// The type of the wireframe.
+    public let type: String = "placeholder"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    internal func toSRPlaceholderWireframe() -> SRPlaceholderWireframe {
+        return SRPlaceholderWireframe(
+            clip: clip?.toSRContentClip(),
+            height: height,
+            id: id,
+            label: label,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+/// Schema of a Wireframe type.
+@_spi(Internal) public enum Wireframe {
+    case shapeWireframe(value: ShapeWireframe)
+    case textWireframe(value: TextWireframe)
+    case imageWireframe(value: ImageWireframe)
+    case placeholderWireframe(value: PlaceholderWireframe)
+
+    internal func toSRWireframe() -> SRWireframe {
+        switch self {
+        case .shapeWireframe(let value):
+            return .shapeWireframe(value: value.toSRShapeWireframe())
+        case .textWireframe(let value):
+            return .textWireframe(value: value.toSRTextWireframe())
+        case .imageWireframe(let value):
+            return .imageWireframe(value: value.toSRImageWireframe())
+        case .placeholderWireframe(let value):
+            return .placeholderWireframe(value: value.toSRPlaceholderWireframe())
+        }
+    }
+}
+
+extension TextPosition.Alignment {
+    /// Custom initializer that allows transforming UIKit's `NSTextAlignment` into `SRTextPosition.Alignment`.
+    public init(
+        systemTextAlignment: NSTextAlignment,
+        vertical: TextPosition.Alignment.Vertical = .center
+    ) {
+        self.vertical = vertical
+        switch systemTextAlignment {
+        case .left:
+            self.horizontal = .left
+        case .center:
+            self.horizontal = .center
+        case .right:
+            self.horizontal = .right
+        case .justified:
+            self.horizontal = .left
+        case .natural:
+            self.horizontal = .left
+        @unknown default:
+            self.horizontal = .left
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/Wireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/Wireframes.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 /// The border properties of this wireframe. The default value is null (no-border).
-@_spi(Internal) public struct ShapeBorder {
+@_spi(Internal)
+public struct ShapeBorder {
     /// The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
     public let color: String
 
@@ -21,7 +22,8 @@ import UIKit
 }
 
 /// Schema of clipping information for a Wireframe.
-@_spi(Internal) public struct ContentClip {
+@_spi(Internal)
+public struct ContentClip {
     /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
     public let bottom: Int64?
 
@@ -47,7 +49,8 @@ import UIKit
 }
 
 /// The style of this wireframe.
-@_spi(Internal) public struct ShapeStyle {
+@_spi(Internal)
+public struct ShapeStyle {
     /// The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
     public let backgroundColor: String?
 
@@ -67,7 +70,8 @@ import UIKit
 }
 
 /// Schema of all properties of a ShapeWireframe.
-@_spi(Internal) public struct ShapeWireframe {
+@_spi(Internal)
+public struct ShapeWireframe {
     /// The border properties of this wireframe. The default value is null (no-border).
     public let border: ShapeBorder?
 
@@ -110,7 +114,8 @@ import UIKit
 }
 
 /// Schema of all properties of a TextPosition.
-@_spi(Internal) public struct TextPosition {
+@_spi(Internal)
+public struct TextPosition {
     public let alignment: Alignment?
 
     public let padding: Padding?
@@ -189,7 +194,8 @@ import UIKit
 }
 
 /// Schema of all properties of a TextStyle.
-@_spi(Internal) public struct TextStyle {
+@_spi(Internal)
+public struct TextStyle {
     /// The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
     public let color: String
 
@@ -205,7 +211,8 @@ import UIKit
 }
 
 /// Schema of all properties of a TextWireframe.
-@_spi(Internal) public struct TextWireframe {
+@_spi(Internal)
+public struct TextWireframe {
     /// The border properties of this wireframe. The default value is null (no-border).
     public let border: ShapeBorder?
 
@@ -260,7 +267,8 @@ import UIKit
 }
 
 /// Schema of all properties of a ImageWireframe.
-@_spi(Internal) public struct ImageWireframe {
+@_spi(Internal)
+public struct ImageWireframe {
     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
     public var base64: String?
 
@@ -319,7 +327,8 @@ import UIKit
 }
 
 /// Schema of all properties of a PlaceholderWireframe.
-@_spi(Internal) public struct PlaceholderWireframe {
+@_spi(Internal)
+public struct PlaceholderWireframe {
     /// Schema of clipping information for a Wireframe.
     public let clip: ContentClip?
 
@@ -358,7 +367,8 @@ import UIKit
 }
 
 /// Schema of a Wireframe type.
-@_spi(Internal) public enum Wireframe {
+@_spi(Internal)
+public enum Wireframe {
     case shapeWireframe(value: ShapeWireframe)
     case textWireframe(value: TextWireframe)
     case imageWireframe(value: ImageWireframe)

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -9,10 +9,10 @@ import Foundation
 import CoreGraphics
 import UIKit
 
-internal typealias WireframeID = NodeID
+@_spi(Internal) public typealias WireframeID = NodeID
 
-/// Builds the actual wireframes from VTS snapshots (produced by `Recorder`) to be later transported in SR
-/// records (see `RecordsBuilder`) within SR segments (see `SegmentBuilder`).
+/// Builds the actual wireframes from VTS snapshots (produced by `Recorder`) to be later transported in 
+/// records (see `RecordsBuilder`) within  segments (see `SegmentBuilder`).
 /// A wireframe stands for semantic definition of an UI element (i.a.: label, button, tab bar).
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
@@ -34,17 +34,17 @@ internal typealias WireframeID = NodeID
         static let fontSize: CGFloat = 10
     }
 
-    func createShapeWireframe(
+    public func createShapeWireframe(
         id: WireframeID,
         frame: CGRect,
-        clip: SRContentClip? = nil,
+        clip: ContentClip? = nil,
         borderColor: CGColor? = nil,
         borderWidth: CGFloat? = nil,
         backgroundColor: CGColor? = nil,
         cornerRadius: CGFloat? = nil,
         opacity: CGFloat? = nil
-    ) -> SRWireframe {
-        let wireframe = SRShapeWireframe(
+    ) -> Wireframe {
+        let wireframe = ShapeWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
             height: Int64(withNoOverflow: frame.height),
@@ -58,19 +58,19 @@ internal typealias WireframeID = NodeID
         return .shapeWireframe(value: wireframe)
     }
 
-    func createImageWireframe(
-        imageResource: ImageResource,
+    public func createImageWireframe(
+        imageResource: SessionReplayImageResource,
         id: WireframeID,
         frame: CGRect,
         mimeType: String = "png",
-        clip: SRContentClip? = nil,
+        clip: ContentClip? = nil,
         borderColor: CGColor? = nil,
         borderWidth: CGFloat? = nil,
         backgroundColor: CGColor? = nil,
         cornerRadius: CGFloat? = nil,
         opacity: CGFloat? = nil
-    ) -> SRWireframe {
-        let wireframe = SRImageWireframe(
+    ) -> Wireframe {
+        let wireframe = ImageWireframe(
             base64: imageResource.base64,
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
@@ -87,13 +87,13 @@ internal typealias WireframeID = NodeID
         return .imageWireframe(value: wireframe)
     }
 
-    func createTextWireframe(
+    public func createTextWireframe(
         id: WireframeID,
         frame: CGRect,
         text: String,
         textFrame: CGRect? = nil,
-        textAlignment: SRTextPosition.Alignment? = nil,
-        clip: SRContentClip? = nil,
+        textAlignment: TextPosition.Alignment? = nil,
+        clip: ContentClip? = nil,
         textColor: CGColor? = nil,
         font: UIFont? = nil,
         fontScalingEnabled: Bool = false,
@@ -102,9 +102,9 @@ internal typealias WireframeID = NodeID
         backgroundColor: CGColor? = nil,
         cornerRadius: CGFloat? = nil,
         opacity: CGFloat? = nil
-    ) -> SRWireframe {
+    ) -> Wireframe {
         let textFrame = textFrame ?? frame
-        let textPosition = SRTextPosition(
+        let textPosition = TextPosition(
             alignment: textAlignment,
             padding: .init(
                 bottom: Int64(withNoOverflow: frame.maxY - textFrame.maxY),
@@ -125,13 +125,13 @@ internal typealias WireframeID = NodeID
         }
 
         // TODO: RUMM-2452 Better recognize the font:
-        let textStyle = SRTextStyle(
+        let textStyle = TextStyle(
             color: textColor.flatMap { hexString(from: $0) } ?? Fallback.color,
             family: Fallback.fontFamily,
             size: fontSize
         )
 
-        let wireframe = SRTextWireframe(
+        let wireframe = TextWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
             height: Int64(withNoOverflow: frame.height),
@@ -148,13 +148,13 @@ internal typealias WireframeID = NodeID
         return .textWireframe(value: wireframe)
     }
 
-    func createPlaceholderWireframe(
+    public func createPlaceholderWireframe(
         id: Int64,
         frame: CGRect,
         label: String,
-        clip: SRContentClip? = nil
-    ) -> SRWireframe {
-        let wireframe = SRPlaceholderWireframe(
+        clip: ContentClip? = nil
+    ) -> Wireframe {
+        let wireframe = PlaceholderWireframe(
             clip: clip,
             height: Int64(withNoOverflow: frame.size.height),
             id: id,
@@ -168,7 +168,7 @@ internal typealias WireframeID = NodeID
 
     // MARK: - Private
 
-    private func createShapeBorder(borderColor: CGColor?, borderWidth: CGFloat?) -> SRShapeBorder? {
+    private func createShapeBorder(borderColor: CGColor?, borderWidth: CGFloat?) -> ShapeBorder? {
         guard let borderColor = borderColor, let borderWidth = borderWidth, borderWidth > 0.0 else {
             return nil
         }
@@ -179,7 +179,7 @@ internal typealias WireframeID = NodeID
         )
     }
 
-    private func createShapeStyle(backgroundColor: CGColor?, cornerRadius: CGFloat?, opacity: CGFloat?) -> SRShapeStyle? {
+    private func createShapeStyle(backgroundColor: CGColor?, cornerRadius: CGFloat?, opacity: CGFloat?) -> ShapeStyle? {
         guard let backgroundColor = backgroundColor else {
             return nil
         }
@@ -197,7 +197,7 @@ internal typealias WireframesBuilder = SessionReplayWireframesBuilder
 // MARK: - Convenience
 
 internal extension WireframesBuilder {
-    func createShapeWireframe(id: WireframeID, frame: CGRect, attributes: ViewAttributes) -> SRWireframe {
+    func createShapeWireframe(id: WireframeID, frame: CGRect, attributes: ViewAttributes) -> Wireframe {
         return createShapeWireframe(
             id: id,
             frame: frame,

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -17,7 +17,7 @@ internal typealias WireframeID = NodeID
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-internal class WireframesBuilder {
+@_spi(Internal) public class SessionReplayWireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.
@@ -191,6 +191,8 @@ internal class WireframesBuilder {
         )
     }
 }
+
+internal typealias WireframesBuilder = SessionReplayWireframesBuilder
 
 // MARK: - Convenience
 

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -192,6 +192,7 @@ import UIKit
     }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias WireframesBuilder = SessionReplayWireframesBuilder
 
 // MARK: - Convenience

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -9,7 +9,8 @@ import Foundation
 import CoreGraphics
 import UIKit
 
-@_spi(Internal) public typealias WireframeID = NodeID
+@_spi(Internal)
+public typealias WireframeID = NodeID
 
 /// Builds the actual wireframes from VTS snapshots (produced by `Recorder`) to be later transported in 
 /// records (see `RecordsBuilder`) within  segments (see `SegmentBuilder`).
@@ -17,7 +18,8 @@ import UIKit
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-@_spi(Internal) public class SessionReplayWireframesBuilder {
+@_spi(Internal)
+public class SessionReplayWireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -64,12 +64,13 @@ internal class Recorder: Recording {
 
     convenience init(
         processor: Processing,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        additionalNodeRecorders: [NodeRecorder]
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder()
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: additionalNodeRecorders)
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(
             windowObserver: windowObserver

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -13,6 +13,7 @@ import UIKit
     let base64: String
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias ImageResource = SessionReplayImageResource
 
 internal protocol ImageDataProviding {

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 import UIKit
 
-@_spi(Internal) public struct SessionReplayImageResource {
+@_spi(Internal)
+public struct SessionReplayImageResource {
     let identifier: String
     let base64: String
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -8,10 +8,12 @@
 import Foundation
 import UIKit
 
-internal struct ImageResource {
+@_spi(Internal) public struct SessionReplayImageResource {
     let identifier: String
     let base64: String
 }
+
+internal typealias ImageResource = SessionReplayImageResource
 
 internal protocol ImageDataProviding {
     func contentBase64String(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
-internal typealias NodeID = Int64
+@_spi(Internal) public typealias NodeID = Int64
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -34,7 +34,7 @@ internal typealias NodeID = Int64
     /// - Parameter view: the `UIView` object
     /// - Parameter nodeRecorder: the `NodeRecorder` responsible for recording `UIView`
     /// - Returns: the `NodeID` of queried instance
-    func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
+    public func nodeID(view: UIView, nodeRecorder: SessionReplayNodeRecorder) -> NodeID {
         if let currentID = view.nodeID?[nodeRecorder.identifier] {
             return currentID
         } else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -10,7 +10,8 @@ import UIKit
 
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
-@_spi(Internal) public typealias NodeID = Int64
+@_spi(Internal)
+public typealias NodeID = Int64
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -18,7 +19,8 @@ import UIKit
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-@_spi(Internal) public final class NodeIDGenerator {
+@_spi(Internal)
+public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -18,7 +18,7 @@ internal typealias NodeID = Int64
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-internal final class NodeIDGenerator {
+@_spi(Internal) public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -11,7 +11,8 @@ import UIKit
 /// recognise specialised subclasses of `UIView` and record their semantics accordingly.
 ///
 /// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
-@_spi(Internal) public protocol SessionReplayNodeRecorder {
+@_spi(Internal)
+public protocol SessionReplayNodeRecorder {
     /// Finds the semantic of given`view`.
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
@@ -32,7 +33,8 @@ internal typealias NodeRecorder = SessionReplayNodeRecorder
 /// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
 ///
 /// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
-@_spi(Internal) public protocol SessionReplayNodeWireframesBuilder {
+@_spi(Internal)
+public protocol SessionReplayNodeWireframesBuilder {
     /// The frame of produced wireframe in screen coordinates.
     var wireframeRect: CGRect { get }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -11,31 +11,35 @@ import UIKit
 /// recognise specialised subclasses of `UIView` and record their semantics accordingly.
 ///
 /// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
-internal protocol NodeRecorder {
+@_spi(Internal) public protocol SessionReplayNodeRecorder {
     /// Finds the semantic of given`view`.
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
     ///   - attributes: attributes of this view inferred from its base `UIView` interface
     ///   - context: the context of recording current view-tree
     /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics?
+    func semantics(of view: UIView, with attributes: SessionReplayViewAttributes, in context: SessionReplayViewTreeRecordingContext) -> SessionReplayNodeSemantics?
 
     /// Unique identifier of the node recorder.
     var identifier: UUID { get }
 }
+
+internal typealias NodeRecorder = SessionReplayNodeRecorder
 
 /// A type producing SR wireframes.
 ///
 /// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
 ///
 /// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
-internal protocol NodeWireframesBuilder {
+@_spi(Internal) public protocol SessionReplayNodeWireframesBuilder {
     /// The frame of produced wireframe in screen coordinates.
     var wireframeRect: CGRect { get }
 
     /// Creates wireframes that are later uploaded to SR backend.
     /// - Parameter builder: the generic builder for constructing SR data models.
     /// - Returns: one or more wireframes that describe a node in SR.
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe]
+    func buildWireframes(with builder: SessionReplayWireframesBuilder) -> [SRWireframe]
 }
+
+internal typealias NodeWireframesBuilder = SessionReplayNodeWireframesBuilder
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -38,7 +38,7 @@ internal typealias NodeRecorder = SessionReplayNodeRecorder
     /// Creates wireframes that are later uploaded to SR backend.
     /// - Parameter builder: the generic builder for constructing SR data models.
     /// - Returns: one or more wireframes that describe a node in SR.
-    func buildWireframes(with builder: SessionReplayWireframesBuilder) -> [SRWireframe]
+    func buildWireframes(with builder: SessionReplayWireframesBuilder) -> [Wireframe]
 }
 
 internal typealias NodeWireframesBuilder = SessionReplayNodeWireframesBuilder

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -24,6 +24,7 @@ import UIKit
     var identifier: UUID { get }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias NodeRecorder = SessionReplayNodeRecorder
 
 /// A type producing SR wireframes.
@@ -41,5 +42,6 @@ internal typealias NodeRecorder = SessionReplayNodeRecorder
     func buildWireframes(with builder: SessionReplayWireframesBuilder) -> [Wireframe]
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias NodeWireframesBuilder = SessionReplayNodeWireframesBuilder
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -156,7 +156,7 @@ internal struct UIDatePickerWireframesBuilder: NodeWireframesBuilder {
     /// If date picker is displayed in popover view (possible only in iOS 15.0+).
     let isDisplayedInPopover: Bool
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createShapeWireframe(
                 id: backgroundWireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -101,7 +101,7 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
 
     let shouldRecordImage: Bool
 
-    private var clip: SRContentClip? {
+    private var clip: ContentClip? {
         guard let contentFrame = contentFrame else {
             return nil
         }
@@ -109,7 +109,7 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
         let left = max(relativeIntersectedRect.origin.x - contentFrame.origin.x, 0)
         let bottom = max(contentFrame.height - (relativeIntersectedRect.height + top), 0)
         let right = max(contentFrame.width - (relativeIntersectedRect.width + left), 0)
-        return SRContentClip(
+        return ContentClip(
             bottom: Int64(withNoOverflow: bottom),
             left: Int64(withNoOverflow: left),
             right: Int64(withNoOverflow: right),
@@ -124,7 +124,7 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
         return attributes.frame.intersection(contentFrame)
     }
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         var wireframes = [
             builder.createShapeWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -71,7 +71,7 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
         attributes.frame
     }
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createTextWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -61,7 +61,7 @@ internal struct UINavigationBarWireframesBuilder: NodeWireframesBuilder {
     /// The color of navigation bar.
     let color: CGColor
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createShapeWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -96,7 +96,7 @@ internal struct UIPickerViewWireframesBuilder: NodeWireframesBuilder {
     let attributes: ViewAttributes
     let backgroundWireframeID: WireframeID
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createShapeWireframe(id: backgroundWireframeID, frame: wireframeRect, attributes: attributes)
         ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -61,7 +61,7 @@ internal struct UISegmentWireframesBuilder: NodeWireframesBuilder {
     let selectedSegmentIndex: Int?
     let selectedSegmentTintColor: UIColor?
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         let numberOfSegments = segmentWireframeIDs.count
         guard numberOfSegments > 0, segmentTitles.count == numberOfSegments, (selectedSegmentIndex ?? 0) < numberOfSegments else {
             return [] // illegal, should not happen
@@ -94,7 +94,7 @@ internal struct UISegmentWireframesBuilder: NodeWireframesBuilder {
             segmentRects.append(segmentRect)
         }
 
-        let segments: [SRWireframe] = (0..<numberOfSegments).map { idx in
+        let segments: [Wireframe] = (0..<numberOfSegments).map { idx in
             let isSelected = idx == selectedSegmentIndex
             return builder.createTextWireframe(
                 id: segmentWireframeIDs[idx],

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -55,7 +55,7 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
     let maxTrackTintColor: CGColor?
     let thumbTintColor: CGColor?
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         if isMasked {
             return createMasked(with: builder)
         } else {
@@ -63,7 +63,7 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
         }
     }
 
-    private func createMasked(with builder: WireframesBuilder) -> [SRWireframe] {
+    private func createMasked(with builder: WireframesBuilder) -> [Wireframe] {
         let trackFrame = wireframeRect.divided(atDistance: 3, from: .minYEdge)
             .slice
             .putInside(wireframeRect, horizontalAlignment: .left, verticalAlignment: .middle)
@@ -88,7 +88,7 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
         }
     }
 
-    private func createNotMasked(with builder: WireframesBuilder) -> [SRWireframe] {
+    private func createNotMasked(with builder: WireframesBuilder) -> [Wireframe] {
         guard value.max > value.min else {
             return [] // illegal, should not happen
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -49,7 +49,7 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
     let isMinusEnabled: Bool
     let isPlusEnabled: Bool
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         let background = builder.createShapeWireframe(
             id: backgroundWireframeID,
             frame: wireframeRect,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -57,7 +57,7 @@ internal struct UISwitchWireframesBuilder: NodeWireframesBuilder {
     let onTintColor: CGColor?
     let offTintColor: CGColor?
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         if isMasked {
             return createMasked(with: builder)
         } else {
@@ -65,7 +65,7 @@ internal struct UISwitchWireframesBuilder: NodeWireframesBuilder {
         }
     }
 
-    private func createMasked(with builder: WireframesBuilder) -> [SRWireframe] {
+    private func createMasked(with builder: WireframesBuilder) -> [Wireframe] {
         let track = builder.createShapeWireframe(
             id: trackWireframeID,
             frame: wireframeRect,
@@ -86,7 +86,7 @@ internal struct UISwitchWireframesBuilder: NodeWireframesBuilder {
         }
     }
 
-    private func createNotMasked(with builder: WireframesBuilder) -> [SRWireframe] {
+    private func createNotMasked(with builder: WireframesBuilder) -> [Wireframe] {
         let radius = wireframeRect.height * 0.5
 
         // Create track wireframe:

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -59,7 +59,7 @@ internal struct UITabBarWireframesBuilder: NodeWireframesBuilder {
     /// The color of navigation bar.
     let color: CGColor
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createShapeWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -113,7 +113,7 @@ internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
     let fontScalingEnabled: Bool
     let textObfuscator: TextObfuscating
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createTextWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -66,12 +66,12 @@ internal struct UITextViewWireframesBuilder: NodeWireframesBuilder {
         attributes.frame
     }
 
-    private var clip: SRContentClip {
+    private var clip: ContentClip {
         let top = abs(contentRect.origin.y)
         let left = abs(contentRect.origin.x)
         let bottom = max(contentRect.height - attributes.frame.height - top, 0)
         let right = max(contentRect.width - attributes.frame.width - left, 0)
-        return SRContentClip(
+        return ContentClip(
             bottom: Int64(withNoOverflow: bottom),
             left: Int64(withNoOverflow: left),
             right: Int64(withNoOverflow: right),
@@ -90,7 +90,7 @@ internal struct UITextViewWireframesBuilder: NodeWireframesBuilder {
         )
     }
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createTextWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -63,7 +63,7 @@ internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
         attributes.frame
     }
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createShapeWireframe(id: wireframeID, frame: wireframeRect, attributes: attributes)
         ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -47,7 +47,7 @@ internal struct UnsupportedViewWireframesBuilder: NodeWireframesBuilder {
     let unsupportedClassName: String
     let attributes: ViewAttributes
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [
             builder.createPlaceholderWireframe(
                 id: wireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,7 +12,8 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-@_spi(Internal) public struct SessionReplayViewTreeRecordingContext {
+@_spi(Internal)
+public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
     let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,18 +12,20 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-internal struct ViewTreeRecordingContext {
+@_spi(Internal) public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
     let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.
     let coordinateSpace: UICoordinateSpace
     /// Generates stable IDs for traversed views.
-    let ids: NodeIDGenerator
+    public let ids: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
     /// Variable view controller related context
     var viewControllerContext: ViewControllerContext = .init()
 }
+
+internal typealias ViewTreeRecordingContext = SessionReplayViewTreeRecordingContext
 
 internal extension ViewTreeRecordingContext {
     /// The `ViewControllerContext` struct is used for storing context-related information about the parent view controller and its type.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -25,6 +25,7 @@ import SwiftUI
     var viewControllerContext: ViewControllerContext = .init()
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias ViewTreeRecordingContext = SessionReplayViewTreeRecordingContext
 
 internal extension ViewTreeRecordingContext {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -197,10 +197,10 @@ internal struct UnknownElement: NodeSemantics {
 /// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// Unlike `IgnoredElement`, this semantics can be overwritten with another one with higher importance. This means that even
 /// if the root view of certain element has no appearance, other node recorders will continue checking it for strictkier semantics.
-internal struct InvisibleElement: NodeSemantics {
-    static let importance: Int = 0
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node] = []
+@_spi(Internal) public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
+    public static let importance: Int = 0
+    public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
+    public let nodes: [SessionReplayNode] = []
 
     /// Use `InvisibleElement.constant` instead.
     private init () {
@@ -212,8 +212,10 @@ internal struct InvisibleElement: NodeSemantics {
     }
 
     /// A constant value of `InvisibleElement` semantics.
-    static let constant = InvisibleElement()
+    public static let constant = SessionReplayInvisibleElement()
 }
+
+internal typealias InvisibleElement = SessionReplayInvisibleElement
 
 /// A semantics of an UI element that should be ignored when traversing view-tree. Unlike `InvisibleElement` this semantics cannot
 /// be overwritten by any other. This means that next node recorders won't be asked for further check of a strictkier semantics.
@@ -236,9 +238,16 @@ internal struct AmbiguousElement: NodeSemantics {
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
 /// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
 /// "on" / "off" state of `UISwitch` control).
-internal struct SpecificElement: NodeSemantics {
-    static let importance: Int = .max
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node]
+@_spi(Internal) public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
+    public static let importance: Int = .max
+    public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
+    public let nodes: [SessionReplayNode]
+
+    public init(subtreeStrategy: SessionReplayNodeSubtreeStrategy, nodes: [SessionReplayNode]) {
+        self.subtreeStrategy = subtreeStrategy
+        self.nodes = nodes
+    }
 }
+
+internal typealias SpecificElement = SessionReplaySpecificElement
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -35,35 +35,42 @@ internal struct ViewTreeSnapshot {
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
-internal struct Node {
+@_spi(Internal) public struct SessionReplayNode {
     /// Attributes of the `UIView` that this node was created for.
-    let viewAttributes: ViewAttributes
+    public let viewAttributes: SessionReplayViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
-    let wireframesBuilder: NodeWireframesBuilder
+    public let wireframesBuilder: SessionReplayNodeWireframesBuilder
+
+    public init(viewAttributes: SessionReplayViewAttributes, wireframesBuilder: SessionReplayNodeWireframesBuilder) {
+        self.viewAttributes = viewAttributes
+        self.wireframesBuilder = wireframesBuilder
+    }
 }
+
+internal typealias Node = SessionReplayNode
 
 /// Attributes of the `UIView` that the node was created for.
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-internal struct ViewAttributes: Equatable {
+@_spi(Internal) public struct SessionReplayViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
-    let frame: CGRect
+    public let frame: CGRect
 
     /// Original view's `.backgorundColor`.
-    let backgroundColor: CGColor?
+    public let backgroundColor: CGColor?
 
     /// Original view's `layer.borderColor`.
-    let layerBorderColor: CGColor?
+    public let layerBorderColor: CGColor?
 
     /// Original view's `layer.borderWidth`.
-    let layerBorderWidth: CGFloat
+    public let layerBorderWidth: CGFloat
 
     /// Original view's `layer.cornerRadius`.
-    let layerCornerRadius: CGFloat
+    public let layerCornerRadius: CGFloat
 
     /// Original view's `.alpha` (between `0.0` and `1.0`).
-    let alpha: CGFloat
+    public let alpha: CGFloat
 
     /// Original view's `.isHidden`.
     let isHidden: Bool
@@ -99,6 +106,8 @@ internal struct ViewAttributes: Equatable {
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
 
+internal typealias ViewAttributes = SessionReplayViewAttributes
+
 extension ViewAttributes {
     init(frameInRootView: CGRect, view: UIView) {
         self.frame = frameInRootView
@@ -132,7 +141,7 @@ extension ViewAttributes {
 /// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
 /// assumption that is not met).
-internal protocol NodeSemantics {
+@_spi(Internal) public protocol SessionReplayNodeSemantics {
     /// The severity of this semantic.
     ///
     /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
@@ -140,10 +149,12 @@ internal protocol NodeSemantics {
     static var importance: Int { get }
 
     /// Defines the strategy which `Recorder` should apply to subtree of this node.
-    var subtreeStrategy: NodeSubtreeStrategy { get }
+    var subtreeStrategy: SessionReplayNodeSubtreeStrategy { get }
     /// Nodes that share this semantics.
-    var nodes: [Node] { get }
+    var nodes: [SessionReplayNode] { get }
 }
+
+internal typealias NodeSemantics = SessionReplayNodeSemantics
 
 extension NodeSemantics {
     /// The severity of this semantic.
@@ -153,8 +164,10 @@ extension NodeSemantics {
     var importance: Int { Self.importance }
 }
 
+internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
+
 /// Strategies for handling node's subtree by `Recorder`.
-internal enum NodeSubtreeStrategy {
+@_spi(Internal) public enum SessionReplayNodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -35,7 +35,8 @@ internal struct ViewTreeSnapshot {
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
-@_spi(Internal) public struct SessionReplayNode {
+@_spi(Internal)
+public struct SessionReplayNode {
     /// Attributes of the `UIView` that this node was created for.
     public let viewAttributes: SessionReplayViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
@@ -54,7 +55,8 @@ internal typealias Node = SessionReplayNode
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-@_spi(Internal) public struct SessionReplayViewAttributes: Equatable {
+@_spi(Internal)
+public struct SessionReplayViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
     public let frame: CGRect
 
@@ -143,7 +145,8 @@ extension ViewAttributes {
 /// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
 /// assumption that is not met).
-@_spi(Internal) public protocol SessionReplayNodeSemantics {
+@_spi(Internal)
+public protocol SessionReplayNodeSemantics {
     /// The severity of this semantic.
     ///
     /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
@@ -171,7 +174,8 @@ extension NodeSemantics {
 internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
 
 /// Strategies for handling node's subtree by `Recorder`.
-@_spi(Internal) public enum SessionReplayNodeSubtreeStrategy {
+@_spi(Internal)
+public enum SessionReplayNodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be
@@ -201,7 +205,8 @@ internal struct UnknownElement: NodeSemantics {
 /// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// Unlike `IgnoredElement`, this semantics can be overwritten with another one with higher importance. This means that even
 /// if the root view of certain element has no appearance, other node recorders will continue checking it for strictkier semantics.
-@_spi(Internal) public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
+@_spi(Internal)
+public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
     public static let importance: Int = 0
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode] = []
@@ -243,7 +248,8 @@ internal struct AmbiguousElement: NodeSemantics {
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
 /// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
 /// "on" / "off" state of `UISwitch` control).
-@_spi(Internal) public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
+@_spi(Internal)
+public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
     public static let importance: Int = .max
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -47,6 +47,7 @@ internal struct ViewTreeSnapshot {
     }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias Node = SessionReplayNode
 
 /// Attributes of the `UIView` that the node was created for.
@@ -106,6 +107,7 @@ internal typealias Node = SessionReplayNode
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias ViewAttributes = SessionReplayViewAttributes
 
 extension ViewAttributes {
@@ -154,6 +156,7 @@ extension ViewAttributes {
     var nodes: [SessionReplayNode] { get }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias NodeSemantics = SessionReplayNodeSemantics
 
 extension NodeSemantics {
@@ -164,6 +167,7 @@ extension NodeSemantics {
     var importance: Int { Self.importance }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
 
 /// Strategies for handling node's subtree by `Recorder`.
@@ -215,6 +219,7 @@ internal struct UnknownElement: NodeSemantics {
     public static let constant = SessionReplayInvisibleElement()
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias InvisibleElement = SessionReplayInvisibleElement
 
 /// A semantics of an UI element that should be ignored when traversing view-tree. Unlike `InvisibleElement` this semantics cannot
@@ -249,5 +254,6 @@ internal struct AmbiguousElement: NodeSemantics {
     }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias SpecificElement = SessionReplaySpecificElement
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -44,9 +44,9 @@ internal struct ViewTreeSnapshotBuilder {
 }
 
 extension ViewTreeSnapshotBuilder {
-    init() {
+    init(additionalNodeRecorders: [NodeRecorder]) {
         self.init(
-            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders() + additionalNodeRecorders),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: ImageDataProvider()
         )

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -47,6 +47,8 @@ extension SessionReplay {
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
 
+        internal var _additionalNodeRecorders: [NodeRecorder] = []
+
         /// Creates Session Replay configuration
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
@@ -60,6 +62,10 @@ extension SessionReplay {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
             self.customEndpoint = customEndpoint
+        }
+
+        @_spi(Internal) public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
+            self._additionalNodeRecorders = additionalNodeRecorders
         }
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -64,7 +64,8 @@ extension SessionReplay {
             self.customEndpoint = customEndpoint
         }
 
-        @_spi(Internal) public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
+        @_spi(Internal)
+public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
             self._additionalNodeRecorders = additionalNodeRecorders
         }
     }

--- a/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
@@ -5,7 +5,7 @@
  */
 
 import UIKit
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 struct MockImageDataProvider: ImageDataProviding {
     var contentBase64String: String

--- a/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
@@ -5,7 +5,8 @@
  */
 
 import UIKit
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 struct MockImageDataProvider: ImageDataProviding {
     var contentBase64String: String

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 extension PrivacyLevel: AnyMockable, RandomMockable {
@@ -196,7 +196,7 @@ extension ViewAttributes: AnyMockable, RandomMockable {
 struct NOPWireframesBuilderMock: NodeWireframesBuilder {
     let wireframeRect: CGRect = .zero
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return []
     }
 }
@@ -229,12 +229,12 @@ func mockRandomNodeSemantics() -> NodeSemantics {
 struct ShapeWireframesBuilderMock: NodeWireframesBuilder {
     let wireframeRect: CGRect
 
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] {
         return [builder.createShapeWireframe(id: .mockAny(), frame: wireframeRect)]
     }
 }
 
-extension Node: AnyMockable, RandomMockable {
+@_spi(Internal) extension Node: AnyMockable, RandomMockable {
     public static func mockAny() -> Node {
         return mockWith()
     }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -333,6 +333,25 @@ class NodeRecorderMock: NodeRecorder {
     }
 }
 
+class SessionReplayNodeRecorderMock: SessionReplayNodeRecorder {
+    var identifier = UUID()
+    var queriedViews: Set<UIView> = []
+    var queryContexts: [ViewTreeRecordingContext] = []
+    var queryContextsByView: [UIView: ViewTreeRecordingContext] = [:]
+    var resultForView: ((UIView) -> NodeSemantics?)?
+
+    init(resultForView: ((UIView) -> NodeSemantics?)? = nil) {
+        self.resultForView = resultForView
+    }
+
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        queriedViews.insert(view)
+        queryContexts.append(context)
+        queryContextsByView[view] = context
+        return resultForView?(view)
+    }
+}
+
 // MARK: - TouchSnapshot Mocks
 
 extension TouchSnapshot: AnyMockable, RandomMockable {

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -7,7 +7,8 @@
 import Foundation
 import UIKit
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 extension PrivacyLevel: AnyMockable, RandomMockable {
@@ -234,7 +235,8 @@ struct ShapeWireframesBuilderMock: NodeWireframesBuilder {
     }
 }
 
-@_spi(Internal) extension Node: AnyMockable, RandomMockable {
+@_spi(Internal)
+extension Node: AnyMockable, RandomMockable {
     public static func mockAny() -> Node {
         return mockWith()
     }

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -5,7 +5,8 @@
  */
 
 import Foundation
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // MARK: - Wireframe Mocks

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // MARK: - Wireframe Mocks

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 @testable import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class DiffSRWireframes: XCTestCase {
     // MARK: - Diffable Conformance

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 @testable import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class DiffSRWireframes: XCTestCase {
     // MARK: - Diffable Conformance

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -279,7 +279,7 @@ class ProcessorTests: XCTestCase {
 
     // MARK: - `ViewTreeSnapshot` generation
 
-    private let snapshotBuilder = ViewTreeSnapshotBuilder()
+    private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [])
 
     private func generateViewTreeSnapshot(for viewTree: UIView, date: Date, rumContext: RUMContext) -> ViewTreeSnapshot {
         snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, rumContext: rumContext, date: date))

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class RecorderTests: XCTestCase {
@@ -77,5 +77,31 @@ class RecorderTests: XCTestCase {
              - [error] [SR] Failed to take snapshot - snapshot creation error, kind: ErrorMock, stack: snapshot creation error
             """
         )
+    }
+
+    func testWhenCapturingSnapshots_itUsesAdditionalNodeRecorders() throws {
+        let recorderContext: Recorder.Context = .mockRandom()
+        let additionalNodeRecorder = SessionReplayNodeRecorderMock()
+        let windowObserver = AppWindowObserverMock()
+        let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
+            windowObserver: windowObserver,
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+        )
+        let touchSnapshotProducer = TouchSnapshotProducerMock()
+
+        // Given
+        let recorder = Recorder(
+            uiApplicationSwizzler: .mockAny(),
+            viewTreeSnapshotProducer: viewTreeSnapshotProducer,
+            touchSnapshotProducer: touchSnapshotProducer,
+            snapshotProcessor: ProcessorSpy(),
+            telemetry: TelemetryMock()
+        )
+        // When
+        recorder.captureNextRecord(recorderContext)
+
+        // Then
+        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
+        XCTAssertEqual(queryContext.recorder, recorderContext)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class RecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class ImageDataProviderTests: XCTestCase {
     func test_returnsNil_WhenImageIsNil() {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class ImageDataProviderTests: XCTestCase {
     func test_returnsNil_WhenImageIsNil() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import UIKit
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class NodeIDGeneratorTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import UIKit
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class NodeIDGeneratorTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIDatePickerRecorderTests: XCTestCase {
     private let recorder = UIDatePickerRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIDatePickerRecorderTests: XCTestCase {
     private let recorder = UIDatePickerRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIImageViewWireframesBuilderTests: XCTestCase {
     var wireframesBuilder: WireframesBuilder = .init()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIImageViewWireframesBuilderTests: XCTestCase {
     var wireframesBuilder: WireframesBuilder = .init()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIPickerViewRecorderTests: XCTestCase {
     private let recorder = UIPickerViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIPickerViewRecorderTests: XCTestCase {
     private let recorder = UIPickerViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
     private let recorder = UISegmentRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
     private let recorder = UISegmentRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
     private let recorder = UISliderRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
     private let recorder = UISliderRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIStepperRecorderTests: XCTestCase {
     private let recorder = UIStepperRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIStepperRecorderTests: XCTestCase {
     private let recorder = UIStepperRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
     private let recorder = UISwitchRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
     private let recorder = UISwitchRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
     private let recorder = UIViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
     private let recorder = UIViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -8,7 +8,8 @@ import XCTest
 import WebKit
 import SwiftUI
 import SafariServices
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import WebKit
 import SwiftUI
 import SafariServices
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 import SafariServices
 
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 private struct MockSemantics: NodeSemantics {
@@ -26,7 +26,7 @@ private struct MockSemantics: NodeSemantics {
 private struct MockWireframesBuilder: NodeWireframesBuilder {
     let nodeName: String
     var wireframeRect: CGRect = .mockAny()
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] { [] }
+    func buildWireframes(with builder: WireframesBuilder) -> [Wireframe] { [] }
 }
 
 class ViewTreeRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -7,7 +7,8 @@
 import XCTest
 import SafariServices
 
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 private struct MockSemantics: NodeSemantics {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import SafariServices
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class ViewTreeRecordingContextTests: XCTestCase {
     func testViewControllerTypeInit() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import SafariServices
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class ViewTreeRecordingContextTests: XCTestCase {
     func testViewControllerTypeInit() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class ViewTreeSnapshotBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class ViewTreeSnapshotBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -48,4 +48,22 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // Then
         XCTAssertGreaterThan(snapshot.date, now)
     }
+
+    func testWhenQueryingNodeRecorders_itCallsAdditionalNodeRecorders() throws {
+        // Given
+        let view = UIView(frame: .mockRandom())
+        let randomRecorderContext: Recorder.Context = .mockRandom()
+        let additionalNodeRecorder = SessionReplayNodeRecorderMock(resultForView: { _ in nil })
+        let builder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+
+        // When
+        let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
+
+        // Then
+        XCTAssertEqual(snapshot.context, randomRecorderContext)
+
+        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
+        XCTAssertTrue(queryContext.coordinateSpace === view)
+        XCTAssertEqual(queryContext.recorder, randomRecorderContext)
+    }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
+@testable import TestUtilities
 
 class SessionReplayConfigurationTests: XCTestCase {
     func testDefaultConfiguration() {
@@ -18,5 +19,19 @@ class SessionReplayConfigurationTests: XCTestCase {
         XCTAssertEqual(config.replaySampleRate, random)
         XCTAssertEqual(config.defaultPrivacyLevel, .mask)
         XCTAssertNil(config.customEndpoint)
+        XCTAssertEqual(config._additionalNodeRecorders.count, 0)
+    }
+
+    func testConfigurationWithAdditionalNodeRecorders() {
+        let random: Float = .mockRandom(min: 0, max: 100)
+        let mockNodeRecorder = SessionReplayNodeRecorderMock()
+
+        // When
+        var config = SessionReplay.Configuration(replaySampleRate: random)
+        config.setAdditionalNodeRecorders([mockNodeRecorder])
+
+        // Then
+        XCTAssertEqual(config._additionalNodeRecorders.count, 1)
+        XCTAssertEqual(config._additionalNodeRecorders[0].identifier, mockNodeRecorder.identifier)
     }
 }

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class SessionReplayConfigurationTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 import TestUtilities
 @testable import DatadogInternal
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class SessionReplayTests: XCTestCase {
     private var core: SingleFeatureCoreMock<SessionReplayFeature>! // swiftlint:disable:this implicitly_unwrapped_optional

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -7,7 +7,8 @@
 import XCTest
 import TestUtilities
 @testable import DatadogInternal
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class SessionReplayTests: XCTestCase {
     private var core: SingleFeatureCoreMock<SessionReplayFeature>! // swiftlint:disable:this implicitly_unwrapped_optional


### PR DESCRIPTION
### What and why?

Enable cross platform SDKs to provide additional node recorders to be used for session replay

### How?

I've added a layer to hide `SRWireframe` so that all the needed APIs could be made public.

I've added a few tests to check that additional node recorders are indeed passed down to the snapshot builder.

I've split some refactoring/fix commits to avoid bringing too much noise in commits where actual features happen.

`@_spi` is still hidden but seems to be used already: https://pspdfkit.com/blog/2023/swifts-approach-to-spi/
Although it is supported since XCode 12, would there be (reasonable) cases where users of the SDK would not be able to use the SDK because of this attribute?

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
