### PR TITLE
Chore: Fix SR data models validation

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -175,7 +175,7 @@ extension SRTextWireframe: MutableWireframe {
     }
 }
 
-extension SRImageWireframe: Hashable {
+extension SRImageWireframe {
     static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool {
         return lhs.id == rhs.id
             && lhs.resourceId == rhs.resourceId

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -324,7 +324,7 @@ internal struct SRTextWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a ImageWireframe.
-internal struct SRImageWireframe: Codable {
+internal struct SRImageWireframe: Codable, Hashable {
     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
     internal var base64: String?
 
@@ -1152,6 +1152,5 @@ internal enum SRRecord: Codable {
         throw DecodingError.typeMismatch(SRRecord.self, error)
     }
 }
-
-// Generated from https://github.com/DataDog/rum-events-format/tree/5a79d9a36b6e76493420792055fc50aed780569b
 #endif
+// Generated from https://github.com/DataDog/rum-events-format/tree/5a79d9a36b6e76493420792055fc50aed780569b

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -197,6 +197,14 @@ workflows:
             #!/usr/bin/env zsh
             set -e
             make rum-models-verify ci=${CI}
+    - script:
+        title: Verify SR data models
+        run_if: '{{enveq "DD_RUN_SR_UNIT_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env zsh
+            set -e
+            make sr-models-verify ci=${CI}
     - xcode-test:
         title: Run unit tests for Datadog - iOS Simulator
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'

--- a/tools/rum-models-generator/Sources/rum-models-generator/GenerateSRModels.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/GenerateSRModels.swift
@@ -19,6 +19,7 @@ internal func generateSRSwiftModels(from schema: URL) throws -> String {
              * Copyright 2019-Present Datadog, Inc.
              */
 
+            #if os(iOS)
             import DatadogInternal
 
             // This file was generated from JSON Schema. Do not modify it directly.
@@ -26,7 +27,9 @@ internal func generateSRSwiftModels(from schema: URL) throws -> String {
             internal protocol SRDataModel: Codable {}
 
             """,
-        footer: ""
+        footer: """
+        #endif
+        """
     )
     let printer = SwiftPrinter(
         configuration: .init(


### PR DESCRIPTION
### What and why?

🧰 This PR enables validation of SR data models in CI.

[SRDataModels.swift](https://github.com/DataDog/dd-sdk-ios/blob/develop/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift) is an auto-generated file created from [RUM Events Format](https://github.com/DataDog/rum-events-format) schema. This file should not be modified manually and to assure this, this PR enables CI validation with `make sr-models-validate` (the same way as we check RUM data models).

### How?

1. (in `rum-models-generator`) The template file for SR models generation was updated with `#if os(iOS)` macro introduced in https://github.com/DataDog/dd-sdk-ios/pull/1428
2. (in `bitrise.yml`) The `make sr-models-validate` is now run in separate CI step.
3. To make it pass, the manual change inserted to `SRDataModels.swift` in https://github.com/DataDog/dd-sdk-ios/pull/1524 was reverted.

```diff
- internal struct SRImageWireframe: Codable {
+ internal struct SRImageWireframe: Codable, Hashable {
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
