### PR TITLE
RUM-2108 fix: include rum origin when using RUM feature for distributed tracing

### DIFF
--- a/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
+++ b/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
@@ -111,7 +111,10 @@ internal struct DebugManualTraceInjectionView: View {
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         case .w3c:
-            let writer = W3CHTTPHeadersWriter(sampleRate: sampleRate)
+            let writer = W3CHTTPHeadersWriter(
+                sampleRate: sampleRate,
+                tracestate: [:]
+            )
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         case .b3Single:

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -871,7 +871,12 @@ class TracerTests: XCTestCase {
         let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
         let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
 
-        let httpHeadersWriter = W3CHTTPHeadersWriter(sampler: .mockKeepAll())
+        let httpHeadersWriter = W3CHTTPHeadersWriter(
+            sampler: .mockKeepAll(),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -879,7 +884,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "tracestate": "dd=s:1;o:rum;p:0000000000000002",
+            "tracestate": "dd=o:rum;p:0000000000000002;s:1",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
@@ -889,7 +894,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders2 = [
-            "tracestate": "dd=s:1;o:rum;p:0000000000000005",
+            "tracestate": "dd=o:rum;p:0000000000000005;s:1",
             "traceparent": "00-00000000000000000000000000000004-0000000000000005-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
@@ -899,7 +904,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders3 = [
-            "tracestate": "dd=s:1;o:rum;p:0000000000000058",
+            "tracestate": "dd=o:rum;p:0000000000000058;s:1",
             "traceparent": "00-0000000000000000000000000000004d-0000000000000058-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
@@ -910,7 +915,12 @@ class TracerTests: XCTestCase {
         let tracer = Tracer.shared(in: core)
         let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
-        let httpHeadersWriter = W3CHTTPHeadersWriter(sampler: .mockRejectAll())
+        let httpHeadersWriter = W3CHTTPHeadersWriter(
+            sampler: .mockRejectAll(),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -918,7 +928,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders = [
-            "tracestate": "dd=s:0;o:rum;p:0000000000000002",
+            "tracestate": "dd=o:rum;p:0000000000000002;s:0",
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-00"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
@@ -1001,7 +1011,12 @@ class TracerTests: XCTestCase {
         let tracer = Tracer.shared(in: core)
         let injectedSpanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
 
-        let httpHeadersWriter = W3CHTTPHeadersWriter(sampler: .mockKeepAll())
+        let httpHeadersWriter = W3CHTTPHeadersWriter(
+            sampler: .mockKeepAll(),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
 
         let httpHeadersReader = W3CHTTPHeadersReader(

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -221,7 +221,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "X-B3-TraceId": "00000000000000000000000000000001",
                 "b3": "00000000000000000000000000000001-0000000000000001-1",
                 "x-datadog-trace-id": "1",
-                "tracestate": "dd=s:1;o:rum;p:0000000000000001",
+                "tracestate": "dd=p:0000000000000001;s:1",
                 "x-datadog-parent-id": "1",
                 "x-datadog-sampling-priority": "1"
             ]

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -310,7 +310,7 @@ class DDTracerTests: XCTestCase {
 
         let expectedHTTPHeaders = [
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-01",
-            "tracestate": "dd=s:1;o:rum;p:0000000000000002"
+            "tracestate": "dd=p:0000000000000002;s:1"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -327,7 +327,7 @@ class DDTracerTests: XCTestCase {
 
         let expectedHTTPHeaders = [
             "traceparent": "00-00000000000000000000000000000001-0000000000000002-00",
-            "tracestate": "dd=s:0;o:rum;p:0000000000000002"
+            "tracestate": "dd=p:0000000000000002;s:0"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
@@ -57,6 +57,7 @@ public enum W3CHTTPHeaders {
         public static let origin = "o"
         public static let originRUM = "rum"
         public static let parentId = "p"
-        public static let tracestateSeparator = ";"
+        public static let tracestateKeyValueSeparator = ":"
+        public static let tracestatePairSeparator = ";"
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -34,6 +34,10 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     public private(set) var traceHeaderFields: [String: String] = [:]
 
+    /// A dictionary containing the tracestate to be injected.
+    /// This value will be merged with the tracestate from the trace context.
+    private let tracestate: [String: String]
+
     /// The tracing sampler.
     ///
     /// This value will decide of the `FLAG_SAMPLED` header field value
@@ -43,23 +47,27 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     /// Initializes the headers writer.
     ///
     /// - Parameter samplingRate: The sampling rate applied for headers injection.
+    /// - Parameter tracestate: The tracestate to be injected.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
     public convenience init(samplingRate: Float) {
-        self.init(sampleRate: samplingRate)
+        self.init(sampleRate: samplingRate, tracestate: [:])
     }
 
     /// Initializes the headers writer.
     ///
     /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
-    public convenience init(sampleRate: Float = 20) {
-        self.init(sampler: Sampler(samplingRate: sampleRate))
+    /// - Parameter tracestate: The tracestate to be injected.
+    public convenience init(sampleRate: Float = 20, tracestate: [String: String] = [:]) {
+        self.init(sampler: Sampler(samplingRate: sampleRate), tracestate: tracestate)
     }
 
     /// Initializes the headers writer.
     ///
     /// - Parameter sampler: The sampler used for headers injection.
-    public init(sampler: Sampler) {
+    /// - Parameter tracestate: The tracestate to be injected.
+    public init(sampler: Sampler, tracestate: [String: String]) {
         self.sampler = sampler
+        self.tracestate = tracestate
     }
 
     /// Writes the trace ID, span ID, and optional parent span ID into the trace propagation headers.
@@ -80,11 +88,20 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
         ]
         .joined(separator: Constants.separator)
 
-        let ddtracestate = [
-            "\(Constants.sampling):\(sampled ? 1 : 0)",
-            "\(Constants.origin):\(Constants.originRUM)",
-            "\(Constants.parentId):\(String(spanID, representation: .hexadecimal16Chars))"
-        ].joined(separator: Constants.tracestateSeparator)
+        // while merging, the tracestate values from the tracestate property take precedence
+        // over the ones from the trace context
+        let tracestate: [String: String] = [
+            Constants.sampling: "\(sampled ? 1 : 0)",
+            Constants.parentId: String(spanID, representation: .hexadecimal16Chars)
+        ].merging(tracestate) { old, new in
+            return new
+        }
+
+        let ddtracestate = tracestate
+            .map { "\($0.key)\(Constants.tracestateKeyValueSeparator)\($0.value)" }
+            .sorted()
+            .joined(separator: Constants.tracestatePairSeparator)
+
         traceHeaderFields[W3CHTTPHeaders.tracestate] = "\(Constants.dd)=\(ddtracestate)"
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -459,7 +459,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testGivenW3C_whenInterceptingRequests_itInjectsTrace() throws {
         // Given
         var request: URLRequest = .mockWith(url: "https://test.com")
-        let writer = W3CHTTPHeadersWriter(sampler: .mockKeepAll())
+        let writer = W3CHTTPHeadersWriter(
+            sampler: .mockKeepAll(),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
         handler.firstPartyHosts = .init(["test.com": [.tracecontext]])
 
         // When

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -11,24 +11,30 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
     func testW3CHTTPHeadersWriterwritesSingleHeader() {
         let sampler: Sampler = .mockKeepAll()
         let w3cHTTPHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: sampler
+            sampler: sampler,
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
         )
         w3cHTTPHeadersWriter.write(traceID: 1_234, spanID: 2_345)
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-01")
-        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:1;o:rum;p:0000000000000929")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
     }
 
     func testW3CHTTPHeadersWriterwritesSingleHeaderWithSampling() {
         let sampler: Sampler = .mockRejectAll()
         let w3cHTTPHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: sampler
+            sampler: sampler,
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
         )
         w3cHTTPHeadersWriter.write(traceID: 1_234, spanID: 2_345, parentSpanID: 5_678)
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-00")
-        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=s:0;o:rum;p:0000000000000929")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
     }
 }

--- a/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
@@ -23,6 +23,6 @@ public class DDW3CHTTPHeadersWriter: NSObject {
 
     @objc
     public init(sampleRate: Float = 20) {
-        swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(sampleRate: sampleRate)
+        swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(sampleRate: sampleRate, tracestate: [:])
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -164,7 +164,12 @@ extension DistributedTracing {
                     injectEncoding: .multiple
                 )
             case .tracecontext:
-                writer = W3CHTTPHeadersWriter(sampler: sampler)
+                writer = W3CHTTPHeadersWriter(
+                    sampler: sampler,
+                    tracestate: [
+                        W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+                    ]
+                )
             }
 
             writer.write(

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -419,7 +419,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
             [
-                "tracestate": "dd=s:1;o:rum;p:0000000000000001",
+                "tracestate": "dd=o:rum;p:0000000000000001;s:1",
                 "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
                 "X-B3-SpanId": "0000000000000001",
                 "X-B3-Sampled": "1",

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -53,7 +53,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
                     injectEncoding: .multiple
                 )
             case .tracecontext:
-                writer = W3CHTTPHeadersWriter(sampler: tracingSampler)
+                writer = W3CHTTPHeadersWriter(sampler: tracingSampler, tracestate: [:])
             }
 
             writer.write(


### PR DESCRIPTION
### What and why?

Currently, "rum" origin is added to the tracestate for Trace and RUM features both. This must be added only when using with RUM feature.

### How?

This PR adds the origin to the tracestate only when using with RUM feature. Also refactored some code to make the logic more clear.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
