### PR TITLE
[cherry-pick] Fix WebView event parser following Browser v5

### DIFF
--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -97,9 +97,10 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                     event["session"] = session
                 }
 
-                if var dd = event["_dd"] as? JSON, var dd_sesion = dd["session"] as? [String: Int64] {
-                    dd_sesion["plan"] = 1
-                    dd["session"] = dd_sesion
+                if var dd = event["_dd"] as? JSON {
+                    var session = dd["session"] as? [String: Any] ?? [:]
+                    session["plan"] = 1
+                    dd["session"] = session
                     event["_dd"] = dd
                 }
 

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -100,7 +100,7 @@ class WebViewEventReceiverTests: XCTestCase {
         let random = mockRandomAttributes() // because below we only mock partial web event, we use this random to make the test fuzzy
         let webEventMock: JSON = [
             // Known properties:
-            "_dd": ["session": ["plan": 2]],
+            "_dd": ["browser_sdk_version": "5.2.0"],
             "application": ["id": String.mockRandom()],
             "session": ["id": String.mockRandom()],
             "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
@@ -113,7 +113,10 @@ class WebViewEventReceiverTests: XCTestCase {
         // Then
         let expectedWebEventWritten: JSON = [
             // Known properties:
-            "_dd": ["session": ["plan": 1]],
+            "_dd": [
+                "session": ["plan": 1],
+                "browser_sdk_version": "5.2.0"
+            ] as [String: Any],
             "application": ["id": rumContext.applicationID],
             "session": ["id": rumContext.sessionID],
             "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
@@ -126,7 +129,6 @@ class WebViewEventReceiverTests: XCTestCase {
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
     }
 
-    // swiftlint:disable opening_brace
     func testGivenRUMContextNotAvailable_whenReceivingWebEvent_itIsDropped() throws {
         let core = PassthroughCoreMock()
 
@@ -145,7 +147,6 @@ class WebViewEventReceiverTests: XCTestCase {
         XCTAssertTrue(result, "It must accept the message")
         XCTAssertTrue(core.events.isEmpty, "The event must be dropped")
     }
-    // swiftlint:enable opening_brace
 
     func testGivenInvalidRUMContext_whenReceivingEvent_itSendsErrorTelemetry() throws {
         struct InvalidRUMContext: Codable {


### PR DESCRIPTION
### What and why?

🍒 Cherry-picking https://github.com/DataDog/dd-sdk-ios/pull/1552 to have the _"Browser V5 Event Parser"_ fix available in `develop` without waiting for `release/2.5.0`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
