### PR TITLE
Enable custom node recorders for cross platform

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import Framer
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 /// Renders application window into image.

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -7,6 +7,7 @@
 import XCTest
 import SRFixtures
 import TestUtilities
+@_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import SRHost
 
@@ -45,7 +46,7 @@ internal class SnapshotTestCase: XCTestCase {
             srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
             telemetry: TelemetryMock()
         )
-        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock())
+        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock(), additionalNodeRecorders: [])
 
         // Set up wireframes interception :
         var wireframes: [SRWireframe]?

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -43,7 +43,8 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
         let recorder = try Recorder(
             processor: processor,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            additionalNodeRecorders: configuration._additionalNodeRecorders
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -176,7 +176,8 @@ extension SRTextWireframe: MutableWireframe {
 }
 
 extension SRImageWireframe {
-    static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool {
+    @_spi(Internal)
+    public static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool {
         return lhs.id == rhs.id
             && lhs.resourceId == rhs.resourceId
             && lhs.border == rhs.border

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -9,7 +9,8 @@ import Foundation
 import CoreGraphics
 import UIKit
 
-internal typealias WireframeID = NodeID
+@_spi(Internal)
+public typealias WireframeID = NodeID
 
 /// Builds the actual wireframes from VTS snapshots (produced by `Recorder`) to be later transported in SR
 /// records (see `RecordsBuilder`) within SR segments (see `SegmentBuilder`).
@@ -17,7 +18,7 @@ internal typealias WireframeID = NodeID
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-internal class WireframesBuilder {
+@_spi(Internal) public class SessionReplayWireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.
@@ -34,7 +35,7 @@ internal class WireframesBuilder {
         static let fontSize: CGFloat = 10
     }
 
-    func createShapeWireframe(
+    public func createShapeWireframe(
         id: WireframeID,
         frame: CGRect,
         clip: SRContentClip? = nil,
@@ -58,7 +59,7 @@ internal class WireframesBuilder {
         return .shapeWireframe(value: wireframe)
     }
 
-    func createImageWireframe(
+    public func createImageWireframe(
         imageResource: ImageResource,
         id: WireframeID,
         frame: CGRect,
@@ -87,7 +88,7 @@ internal class WireframesBuilder {
         return .imageWireframe(value: wireframe)
     }
 
-    func createTextWireframe(
+    public func createTextWireframe(
         id: WireframeID,
         frame: CGRect,
         text: String,
@@ -148,7 +149,7 @@ internal class WireframesBuilder {
         return .textWireframe(value: wireframe)
     }
 
-    func createPlaceholderWireframe(
+    public func createPlaceholderWireframe(
         id: Int64,
         frame: CGRect,
         label: String,
@@ -191,6 +192,9 @@ internal class WireframesBuilder {
         )
     }
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias WireframesBuilder = SessionReplayWireframesBuilder
 
 // MARK: - Convenience
 

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -18,7 +18,8 @@ public typealias WireframeID = NodeID
 /// It is used by the player to reconstruct individual elements of the recorded app UI.
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
-@_spi(Internal) public class SessionReplayWireframesBuilder {
+@_spi(Internal)
+public class SessionReplayWireframesBuilder {
     /// A set of fallback values to use if the actual value cannot be read or converted.
     ///
     /// The idea is to always provide value, which would make certain element visible in the player.

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -213,4 +213,22 @@ internal extension WireframesBuilder {
         )
     }
 }
+
+extension SRContentClip {
+    /// This method is a convenience for exposing the internal default init.
+    @_spi(Internal)
+    public static func create(
+        bottom: Int64?,
+        left: Int64?,
+        right: Int64?,
+        top: Int64?
+    ) -> SRContentClip {
+        return SRContentClip(
+            bottom: bottom,
+            left: left,
+            right: right,
+            top: top
+        )
+    }
+}
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -64,12 +64,13 @@ internal class Recorder: Recording {
 
     convenience init(
         processor: Processing,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        additionalNodeRecorders: [NodeRecorder]
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder()
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: additionalNodeRecorders)
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(
             windowObserver: windowObserver

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 import UIKit
 
-internal struct ImageResource {
+@_spi(Internal)
+public struct ImageResource {
     let identifier: String
     let base64: String
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -10,7 +10,8 @@ import UIKit
 
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
-@_spi(Internal) public typealias NodeID = Int64
+@_spi(Internal)
+public typealias NodeID = Int64
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -18,7 +19,8 @@ import UIKit
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-@_spi(Internal) public final class NodeIDGenerator {
+@_spi(Internal)
+public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
-internal typealias NodeID = Int64
+@_spi(Internal) public typealias NodeID = Int64
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -18,7 +18,7 @@ internal typealias NodeID = Int64
 /// IDs for the same instance of `UIView` will always give the same values.
 ///
 /// **Note**: All `NodeIDGenerator` APIs must be called on the main thread.
-internal final class NodeIDGenerator {
+@_spi(Internal) public final class NodeIDGenerator {
     /// Upper limit for generated IDs.
     /// After `currentID` reaches this limit, it will start from `0`.
     private let maxID: NodeID
@@ -34,7 +34,7 @@ internal final class NodeIDGenerator {
     /// - Parameter view: the `UIView` object
     /// - Parameter nodeRecorder: the `NodeRecorder` responsible for recording `UIView`
     /// - Returns: the `NodeID` of queried instance
-    func nodeID(view: UIView, nodeRecorder: NodeRecorder) -> NodeID {
+    public func nodeID(view: UIView, nodeRecorder: SessionReplayNodeRecorder) -> NodeID {
         if let currentID = view.nodeID?[nodeRecorder.identifier] {
             return currentID
         } else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -11,7 +11,8 @@ import UIKit
 /// recognise specialised subclasses of `UIView` and record their semantics accordingly.
 ///
 /// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
-@_spi(Internal) public protocol SessionReplayNodeRecorder {
+@_spi(Internal)
+public protocol SessionReplayNodeRecorder {
     /// Finds the semantic of given`view`.
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
@@ -32,7 +33,8 @@ internal typealias NodeRecorder = SessionReplayNodeRecorder
 /// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
 ///
 /// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
-@_spi(Internal) public protocol SessionReplayNodeWireframesBuilder {
+@_spi(Internal)
+public protocol SessionReplayNodeWireframesBuilder {
     /// The frame of produced wireframe in screen coordinates.
     var wireframeRect: CGRect { get }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -11,31 +11,37 @@ import UIKit
 /// recognise specialised subclasses of `UIView` and record their semantics accordingly.
 ///
 /// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
-internal protocol NodeRecorder {
+@_spi(Internal) public protocol SessionReplayNodeRecorder {
     /// Finds the semantic of given`view`.
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
     ///   - attributes: attributes of this view inferred from its base `UIView` interface
     ///   - context: the context of recording current view-tree
     /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics?
+    func semantics(of view: UIView, with attributes: SessionReplayViewAttributes, in context: SessionReplayViewTreeRecordingContext) -> SessionReplayNodeSemantics?
 
     /// Unique identifier of the node recorder.
     var identifier: UUID { get }
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias NodeRecorder = SessionReplayNodeRecorder
 
 /// A type producing SR wireframes.
 ///
 /// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
 ///
 /// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
-internal protocol NodeWireframesBuilder {
+@_spi(Internal) public protocol SessionReplayNodeWireframesBuilder {
     /// The frame of produced wireframe in screen coordinates.
     var wireframeRect: CGRect { get }
 
     /// Creates wireframes that are later uploaded to SR backend.
     /// - Parameter builder: the generic builder for constructing SR data models.
     /// - Returns: one or more wireframes that describe a node in SR.
-    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe]
+    func buildWireframes(with builder: SessionReplayWireframesBuilder) -> [SRWireframe]
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias NodeWireframesBuilder = SessionReplayNodeWireframesBuilder
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,7 +12,8 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-@_spi(Internal) public struct SessionReplayViewTreeRecordingContext {
+@_spi(Internal)
+public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
     let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -12,18 +12,21 @@ import SwiftUI
 /// The context of recording subtree hierarchy.
 ///
 /// Some fields are mutable, so `NodeRecorders` can specialise it for their subtree traversal.
-internal struct ViewTreeRecordingContext {
+@_spi(Internal) public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
     let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.
     let coordinateSpace: UICoordinateSpace
     /// Generates stable IDs for traversed views.
-    let ids: NodeIDGenerator
+    public let ids: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
     /// Variable view controller related context
     var viewControllerContext: ViewControllerContext = .init()
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias ViewTreeRecordingContext = SessionReplayViewTreeRecordingContext
 
 internal extension ViewTreeRecordingContext {
     /// The `ViewControllerContext` struct is used for storing context-related information about the parent view controller and its type.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -35,7 +35,8 @@ internal struct ViewTreeSnapshot {
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
-@_spi(Internal) public struct SessionReplayNode {
+@_spi(Internal)
+public struct SessionReplayNode {
     /// Attributes of the `UIView` that this node was created for.
     public let viewAttributes: SessionReplayViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
@@ -54,7 +55,8 @@ internal typealias Node = SessionReplayNode
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-@_spi(Internal) public struct SessionReplayViewAttributes: Equatable {
+@_spi(Internal)
+public struct SessionReplayViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
     public let frame: CGRect
 
@@ -143,7 +145,8 @@ extension ViewAttributes {
 /// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
 /// assumption that is not met).
-@_spi(Internal) public protocol SessionReplayNodeSemantics {
+@_spi(Internal)
+public protocol SessionReplayNodeSemantics {
     /// The severity of this semantic.
     ///
     /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
@@ -171,7 +174,8 @@ extension NodeSemantics {
 internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
 
 /// Strategies for handling node's subtree by `Recorder`.
-@_spi(Internal) public enum SessionReplayNodeSubtreeStrategy {
+@_spi(Internal)
+public enum SessionReplayNodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be
@@ -201,7 +205,8 @@ internal struct UnknownElement: NodeSemantics {
 /// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// Unlike `IgnoredElement`, this semantics can be overwritten with another one with higher importance. This means that even
 /// if the root view of certain element has no appearance, other node recorders will continue checking it for strictkier semantics.
-@_spi(Internal) public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
+@_spi(Internal)
+public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
     public static let importance: Int = 0
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode] = []
@@ -243,7 +248,8 @@ internal struct AmbiguousElement: NodeSemantics {
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
 /// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
 /// "on" / "off" state of `UISwitch` control).
-@_spi(Internal) public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
+@_spi(Internal)
+public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
     public static let importance: Int = .max
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -35,35 +35,43 @@ internal struct ViewTreeSnapshot {
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
-internal struct Node {
+@_spi(Internal) public struct SessionReplayNode {
     /// Attributes of the `UIView` that this node was created for.
-    let viewAttributes: ViewAttributes
+    public let viewAttributes: SessionReplayViewAttributes
     /// A type defining how to build SR wireframes for the UI element described by this node.
-    let wireframesBuilder: NodeWireframesBuilder
+    public let wireframesBuilder: SessionReplayNodeWireframesBuilder
+
+    public init(viewAttributes: SessionReplayViewAttributes, wireframesBuilder: SessionReplayNodeWireframesBuilder) {
+        self.viewAttributes = viewAttributes
+        self.wireframesBuilder = wireframesBuilder
+    }
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias Node = SessionReplayNode
 
 /// Attributes of the `UIView` that the node was created for.
 ///
 /// It is used by the `Recorder` to capture view attributes on the main thread.
 /// It enforces immutability for later (thread safe) access from background queue in `Processor`.
-internal struct ViewAttributes: Equatable {
+@_spi(Internal) public struct SessionReplayViewAttributes: Equatable {
     /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
-    let frame: CGRect
+    public let frame: CGRect
 
     /// Original view's `.backgorundColor`.
-    let backgroundColor: CGColor?
+    public let backgroundColor: CGColor?
 
     /// Original view's `layer.borderColor`.
-    let layerBorderColor: CGColor?
+    public let layerBorderColor: CGColor?
 
     /// Original view's `layer.borderWidth`.
-    let layerBorderWidth: CGFloat
+    public let layerBorderWidth: CGFloat
 
     /// Original view's `layer.cornerRadius`.
-    let layerCornerRadius: CGFloat
+    public let layerCornerRadius: CGFloat
 
     /// Original view's `.alpha` (between `0.0` and `1.0`).
-    let alpha: CGFloat
+    public let alpha: CGFloat
 
     /// Original view's `.isHidden`.
     let isHidden: Bool
@@ -99,6 +107,9 @@ internal struct ViewAttributes: Equatable {
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias ViewAttributes = SessionReplayViewAttributes
+
 extension ViewAttributes {
     init(frameInRootView: CGRect, view: UIView) {
         self.frame = frameInRootView
@@ -132,7 +143,7 @@ extension ViewAttributes {
 /// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
 /// assumption that is not met).
-internal protocol NodeSemantics {
+@_spi(Internal) public protocol SessionReplayNodeSemantics {
     /// The severity of this semantic.
     ///
     /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
@@ -140,10 +151,13 @@ internal protocol NodeSemantics {
     static var importance: Int { get }
 
     /// Defines the strategy which `Recorder` should apply to subtree of this node.
-    var subtreeStrategy: NodeSubtreeStrategy { get }
+    var subtreeStrategy: SessionReplayNodeSubtreeStrategy { get }
     /// Nodes that share this semantics.
-    var nodes: [Node] { get }
+    var nodes: [SessionReplayNode] { get }
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias NodeSemantics = SessionReplayNodeSemantics
 
 extension NodeSemantics {
     /// The severity of this semantic.
@@ -153,8 +167,11 @@ extension NodeSemantics {
     var importance: Int { Self.importance }
 }
 
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias NodeSubtreeStrategy = SessionReplayNodeSubtreeStrategy
+
 /// Strategies for handling node's subtree by `Recorder`.
-internal enum NodeSubtreeStrategy {
+@_spi(Internal) public enum SessionReplayNodeSubtreeStrategy {
     /// Continue traversing subtree of this node to record nested nodes automatically.
     ///
     /// This strategy is particularly useful for semantics that do not make assumption on node's content (e.g. this strategy can be
@@ -184,10 +201,10 @@ internal struct UnknownElement: NodeSemantics {
 /// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
 /// Unlike `IgnoredElement`, this semantics can be overwritten with another one with higher importance. This means that even
 /// if the root view of certain element has no appearance, other node recorders will continue checking it for strictkier semantics.
-internal struct InvisibleElement: NodeSemantics {
-    static let importance: Int = 0
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node] = []
+@_spi(Internal) public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
+    public static let importance: Int = 0
+    public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
+    public let nodes: [SessionReplayNode] = []
 
     /// Use `InvisibleElement.constant` instead.
     private init () {
@@ -199,8 +216,11 @@ internal struct InvisibleElement: NodeSemantics {
     }
 
     /// A constant value of `InvisibleElement` semantics.
-    static let constant = InvisibleElement()
+    public static let constant = SessionReplayInvisibleElement()
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias InvisibleElement = SessionReplayInvisibleElement
 
 /// A semantics of an UI element that should be ignored when traversing view-tree. Unlike `InvisibleElement` this semantics cannot
 /// be overwritten by any other. This means that next node recorders won't be asked for further check of a strictkier semantics.
@@ -223,9 +243,17 @@ internal struct AmbiguousElement: NodeSemantics {
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
 /// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
 /// "on" / "off" state of `UISwitch` control).
-internal struct SpecificElement: NodeSemantics {
-    static let importance: Int = .max
-    let subtreeStrategy: NodeSubtreeStrategy
-    let nodes: [Node]
+@_spi(Internal) public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
+    public static let importance: Int = .max
+    public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
+    public let nodes: [SessionReplayNode]
+
+    public init(subtreeStrategy: SessionReplayNodeSubtreeStrategy, nodes: [SessionReplayNode]) {
+        self.subtreeStrategy = subtreeStrategy
+        self.nodes = nodes
+    }
 }
+
+// This alias enables us to have a more unique name exposed through public-internal access level
+internal typealias SpecificElement = SessionReplaySpecificElement
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -44,9 +44,9 @@ internal struct ViewTreeSnapshotBuilder {
 }
 
 extension ViewTreeSnapshotBuilder {
-    init() {
+    init(additionalNodeRecorders: [NodeRecorder]) {
         self.init(
-            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders() + additionalNodeRecorders),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: ImageDataProvider()
         )

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -47,6 +47,8 @@ extension SessionReplay {
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
 
+        internal var _additionalNodeRecorders: [NodeRecorder] = []
+
         /// Creates Session Replay configuration
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
@@ -60,6 +62,10 @@ extension SessionReplay {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
             self.customEndpoint = customEndpoint
+        }
+
+        @_spi(Internal) public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
+            self._additionalNodeRecorders = additionalNodeRecorders
         }
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -64,7 +64,8 @@ extension SessionReplay {
             self.customEndpoint = customEndpoint
         }
 
-        @_spi(Internal) public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
+        @_spi(Internal)
+public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {
             self._additionalNodeRecorders = additionalNodeRecorders
         }
     }

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels+UIKit.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels+UIKit.swift
@@ -9,7 +9,8 @@ import UIKit
 
 extension SRTextPosition.Alignment {
     /// Custom initializer that allows transforming UIKit's `NSTextAlignment` into `SRTextPosition.Alignment`.
-    init(
+    @_spi(Internal)
+    public init(
         systemTextAlignment: NSTextAlignment,
         vertical: SRTextPosition.Alignment.Vertical = .center
     ) {

--- a/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Writer/Models/SRDataModels.swift
@@ -12,36 +12,37 @@ import DatadogInternal
 internal protocol SRDataModel: Codable {}
 
 /// Mobile-specific. Schema of a Session Replay data Segment.
-internal struct SRSegment: SRDataModel {
+@_spi(Internal)
+public struct SRSegment: SRDataModel {
     /// Application properties
-    internal let application: Application
+    public let application: Application
 
     /// The end UTC timestamp in milliseconds corresponding to the last record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-    internal let end: Int64
+    public let end: Int64
 
     /// Whether this Segment contains a full snapshot record or not.
-    internal let hasFullSnapshot: Bool?
+    public let hasFullSnapshot: Bool?
 
     /// The index of this Segment in the segments list that was recorded for this view ID. Starts from 0.
-    internal let indexInView: Int64?
+    public let indexInView: Int64?
 
     /// The records contained by this Segment.
-    internal let records: [SRRecord]
+    public let records: [SRRecord]
 
     /// The number of records in this Segment.
-    internal let recordsCount: Int64
+    public let recordsCount: Int64
 
     /// Session properties
-    internal let session: Session
+    public let session: Session
 
     /// The source of this record
-    internal let source: Source
+    public let source: Source
 
     /// The start UTC timestamp in milliseconds corresponding to the first record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-    internal let start: Int64
+    public let start: Int64
 
     /// View properties
-    internal let view: View
+    public let view: View
 
     enum CodingKeys: String, CodingKey {
         case application = "application"
@@ -57,9 +58,10 @@ internal struct SRSegment: SRDataModel {
     }
 
     /// Application properties
-    internal struct Application: Codable {
+    @_spi(Internal)
+    public struct Application: Codable {
         /// UUID of the application
-        internal let id: String
+        public let id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -67,9 +69,10 @@ internal struct SRSegment: SRDataModel {
     }
 
     /// Session properties
-    internal struct Session: Codable {
+    @_spi(Internal)
+    public struct Session: Codable {
         /// UUID of the session
-        internal let id: String
+        public let id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -77,7 +80,8 @@ internal struct SRSegment: SRDataModel {
     }
 
     /// The source of this record
-    internal enum Source: String, Codable {
+    @_spi(Internal)
+    public enum Source: String, Codable {
         case android = "android"
         case ios = "ios"
         case flutter = "flutter"
@@ -85,9 +89,10 @@ internal struct SRSegment: SRDataModel {
     }
 
     /// View properties
-    internal struct View: Codable {
+    @_spi(Internal)
+    public struct View: Codable {
         /// UUID of the view
-        internal let id: String
+        public let id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -96,12 +101,13 @@ internal struct SRSegment: SRDataModel {
 }
 
 /// The border properties of this wireframe. The default value is null (no-border).
-internal struct SRShapeBorder: Codable, Hashable {
+@_spi(Internal)
+public struct SRShapeBorder: Codable, Hashable {
     /// The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
-    internal let color: String
+    public let color: String
 
     /// The width of the border in pixels.
-    internal let width: Int64
+    public let width: Int64
 
     enum CodingKeys: String, CodingKey {
         case color = "color"
@@ -110,18 +116,19 @@ internal struct SRShapeBorder: Codable, Hashable {
 }
 
 /// Schema of clipping information for a Wireframe.
-internal struct SRContentClip: Codable, Hashable {
+@_spi(Internal)
+public struct SRContentClip: Codable, Hashable {
     /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
-    internal let bottom: Int64?
+    public let bottom: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
-    internal let left: Int64?
+    public let left: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
-    internal let right: Int64?
+    public let right: Int64?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
-    internal let top: Int64?
+    public let top: Int64?
 
     enum CodingKeys: String, CodingKey {
         case bottom = "bottom"
@@ -132,15 +139,16 @@ internal struct SRContentClip: Codable, Hashable {
 }
 
 /// The style of this wireframe.
-internal struct SRShapeStyle: Codable, Hashable {
+@_spi(Internal)
+public struct SRShapeStyle: Codable, Hashable {
     /// The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
-    internal let backgroundColor: String?
+    public let backgroundColor: String?
 
     /// The corner(border) radius of this wireframe in pixels. The default value is 0.
-    internal let cornerRadius: Double?
+    public let cornerRadius: Double?
 
     /// The opacity of this wireframe. Takes values from 0 to 1, default value is 1.
-    internal let opacity: Double?
+    public let opacity: Double?
 
     enum CodingKeys: String, CodingKey {
         case backgroundColor = "backgroundColor"
@@ -150,33 +158,34 @@ internal struct SRShapeStyle: Codable, Hashable {
 }
 
 /// Schema of all properties of a ShapeWireframe.
-internal struct SRShapeWireframe: Codable, Hashable {
+@_spi(Internal)
+public struct SRShapeWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
-    internal let border: SRShapeBorder?
+    public let border: SRShapeBorder?
 
     /// Schema of clipping information for a Wireframe.
-    internal let clip: SRContentClip?
+    public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    internal let height: Int64
+    public let height: Int64
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    internal let id: Int64
+    public let id: Int64
 
     /// The style of this wireframe.
-    internal let shapeStyle: SRShapeStyle?
+    public let shapeStyle: SRShapeStyle?
 
     /// The type of the wireframe.
-    internal let type: String = "shape"
+    public let type: String = "shape"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    internal let width: Int64
+    public let width: Int64
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let x: Int64
+    public let x: Int64
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let y: Int64
+    public let y: Int64
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
@@ -192,22 +201,24 @@ internal struct SRShapeWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a TextPosition.
-internal struct SRTextPosition: Codable, Hashable {
-    internal let alignment: Alignment?
+@_spi(Internal)
+public struct SRTextPosition: Codable, Hashable {
+    public let alignment: Alignment?
 
-    internal let padding: Padding?
+    public let padding: Padding?
 
     enum CodingKeys: String, CodingKey {
         case alignment = "alignment"
         case padding = "padding"
     }
 
-    internal struct Alignment: Codable, Hashable {
+    @_spi(Internal)
+    public struct Alignment: Codable, Hashable {
         /// The horizontal text alignment. The default value is `left`.
-        internal let horizontal: Horizontal?
+        public let horizontal: Horizontal?
 
         /// The vertical text alignment. The default value is `top`.
-        internal let vertical: Vertical?
+        public let vertical: Vertical?
 
         enum CodingKeys: String, CodingKey {
             case horizontal = "horizontal"
@@ -215,32 +226,35 @@ internal struct SRTextPosition: Codable, Hashable {
         }
 
         /// The horizontal text alignment. The default value is `left`.
-        internal enum Horizontal: String, Codable {
+        @_spi(Internal)
+        public enum Horizontal: String, Codable {
             case left = "left"
             case right = "right"
             case center = "center"
         }
 
         /// The vertical text alignment. The default value is `top`.
-        internal enum Vertical: String, Codable {
+        @_spi(Internal)
+        public enum Vertical: String, Codable {
             case top = "top"
             case bottom = "bottom"
             case center = "center"
         }
     }
 
-    internal struct Padding: Codable, Hashable {
+    @_spi(Internal)
+    public struct Padding: Codable, Hashable {
         /// The bottom padding in pixels. The default value is 0.
-        internal let bottom: Int64?
+        public let bottom: Int64?
 
         /// The left padding in pixels. The default value is 0.
-        internal let left: Int64?
+        public let left: Int64?
 
         /// The right padding in pixels. The default value is 0.
-        internal let right: Int64?
+        public let right: Int64?
 
         /// The top padding in pixels. The default value is 0.
-        internal let top: Int64?
+        public let top: Int64?
 
         enum CodingKeys: String, CodingKey {
             case bottom = "bottom"
@@ -252,15 +266,16 @@ internal struct SRTextPosition: Codable, Hashable {
 }
 
 /// Schema of all properties of a TextStyle.
-internal struct SRTextStyle: Codable, Hashable {
+@_spi(Internal)
+public struct SRTextStyle: Codable, Hashable {
     /// The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.
-    internal let color: String
+    public let color: String
 
     /// The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif
-    internal let family: String
+    public let family: String
 
     /// The font size in pixels.
-    internal let size: Int64
+    public let size: Int64
 
     enum CodingKeys: String, CodingKey {
         case color = "color"
@@ -270,42 +285,43 @@ internal struct SRTextStyle: Codable, Hashable {
 }
 
 /// Schema of all properties of a TextWireframe.
-internal struct SRTextWireframe: Codable, Hashable {
+@_spi(Internal)
+public struct SRTextWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
-    internal let border: SRShapeBorder?
+    public let border: SRShapeBorder?
 
     /// Schema of clipping information for a Wireframe.
-    internal let clip: SRContentClip?
+    public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    internal let height: Int64
+    public let height: Int64
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    internal let id: Int64
+    public let id: Int64
 
     /// The style of this wireframe.
-    internal let shapeStyle: SRShapeStyle?
+    public let shapeStyle: SRShapeStyle?
 
     /// The text value of the wireframe.
-    internal var text: String
+    public var text: String
 
     /// Schema of all properties of a TextPosition.
-    internal let textPosition: SRTextPosition?
+    public let textPosition: SRTextPosition?
 
     /// Schema of all properties of a TextStyle.
-    internal let textStyle: SRTextStyle
+    public let textStyle: SRTextStyle
 
     /// The type of the wireframe.
-    internal let type: String = "text"
+    public let type: String = "text"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    internal let width: Int64
+    public let width: Int64
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let x: Int64
+    public let x: Int64
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let y: Int64
+    public let y: Int64
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
@@ -324,45 +340,46 @@ internal struct SRTextWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a ImageWireframe.
-internal struct SRImageWireframe: Codable, Hashable {
+@_spi(Internal)
+public struct SRImageWireframe: Codable, Hashable {
     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
-    internal var base64: String?
+    public var base64: String?
 
     /// The border properties of this wireframe. The default value is null (no-border).
-    internal let border: SRShapeBorder?
+    public let border: SRShapeBorder?
 
     /// Schema of clipping information for a Wireframe.
-    internal let clip: SRContentClip?
+    public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    internal let height: Int64
+    public let height: Int64
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    internal let id: Int64
+    public let id: Int64
 
     /// Flag describing an image wireframe that should render an empty state placeholder
-    internal var isEmpty: Bool?
+    public var isEmpty: Bool?
 
     /// MIME type of the image file
-    internal var mimeType: String?
+    public var mimeType: String?
 
     /// Unique identifier of the image resource
-    internal var resourceId: String?
+    public var resourceId: String?
 
     /// The style of this wireframe.
-    internal let shapeStyle: SRShapeStyle?
+    public let shapeStyle: SRShapeStyle?
 
     /// The type of the wireframe.
-    internal let type: String = "image"
+    public let type: String = "image"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    internal let width: Int64
+    public let width: Int64
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let x: Int64
+    public let x: Int64
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let y: Int64
+    public let y: Int64
 
     enum CodingKeys: String, CodingKey {
         case base64 = "base64"
@@ -382,30 +399,31 @@ internal struct SRImageWireframe: Codable, Hashable {
 }
 
 /// Schema of all properties of a PlaceholderWireframe.
-internal struct SRPlaceholderWireframe: Codable, Hashable {
+@_spi(Internal)
+public struct SRPlaceholderWireframe: Codable, Hashable {
     /// Schema of clipping information for a Wireframe.
-    internal let clip: SRContentClip?
+    public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    internal let height: Int64
+    public let height: Int64
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    internal let id: Int64
+    public let id: Int64
 
     /// Label of the placeholder
-    internal var label: String?
+    public var label: String?
 
     /// The type of the wireframe.
-    internal let type: String = "placeholder"
+    public let type: String = "placeholder"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    internal let width: Int64
+    public let width: Int64
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let x: Int64
+    public let x: Int64
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    internal let y: Int64
+    public let y: Int64
 
     enum CodingKeys: String, CodingKey {
         case clip = "clip"
@@ -420,7 +438,8 @@ internal struct SRPlaceholderWireframe: Codable, Hashable {
 }
 
 /// Schema of a Wireframe type.
-internal enum SRWireframe: Codable {
+@_spi(Internal)
+public enum SRWireframe: Codable {
     case shapeWireframe(value: SRShapeWireframe)
     case textWireframe(value: SRTextWireframe)
     case imageWireframe(value: SRImageWireframe)
@@ -428,7 +447,7 @@ internal enum SRWireframe: Codable {
 
     // MARK: - Codable
 
-    internal func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         // Encode only the associated value, without encoding enum case
         var container = encoder.singleValueContainer()
 
@@ -444,7 +463,7 @@ internal enum SRWireframe: Codable {
         }
     }
 
-    internal init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         // Decode enum case from associated value
         let container = try decoder.singleValueContainer()
 
@@ -476,14 +495,15 @@ internal enum SRWireframe: Codable {
 }
 
 /// Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.
-internal struct SRFullSnapshotRecord: Codable {
-    internal let data: Data
+@_spi(Internal)
+public struct SRFullSnapshotRecord: Codable {
+    public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 10
+    public let type: Int64 = 10
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -491,9 +511,10 @@ internal struct SRFullSnapshotRecord: Codable {
         case type = "type"
     }
 
-    internal struct Data: Codable {
+    @_spi(Internal)
+    public struct Data: Codable {
         /// The Wireframes contained by this Record.
-        internal let wireframes: [SRWireframe]
+        public let wireframes: [SRWireframe]
 
         enum CodingKeys: String, CodingKey {
             case wireframes = "wireframes"
@@ -502,15 +523,16 @@ internal struct SRFullSnapshotRecord: Codable {
 }
 
 /// Mobile-specific. Schema of a Record type which contains mutations of a screen.
-internal struct SRIncrementalSnapshotRecord: Codable {
+@_spi(Internal)
+public struct SRIncrementalSnapshotRecord: Codable {
     /// Mobile-specific. Schema of a Session Replay IncrementalData type.
-    internal let data: Data
+    public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 11
+    public let type: Int64 = 11
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -519,7 +541,8 @@ internal struct SRIncrementalSnapshotRecord: Codable {
     }
 
     /// Mobile-specific. Schema of a Session Replay IncrementalData type.
-    internal enum Data: Codable {
+    @_spi(Internal)
+    public enum Data: Codable {
         case mutationData(value: MutationData)
         case touchData(value: TouchData)
         case viewportResizeData(value: ViewportResizeData)
@@ -527,7 +550,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
 
         // MARK: - Codable
 
-        internal func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             // Encode only the associated value, without encoding enum case
             var container = encoder.singleValueContainer()
 
@@ -543,7 +566,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
             }
         }
 
-        internal init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             // Decode enum case from associated value
             let container = try decoder.singleValueContainer()
 
@@ -574,18 +597,19 @@ internal struct SRIncrementalSnapshotRecord: Codable {
         }
 
         /// Mobile-specific. Schema of a MutationData.
-        internal struct MutationData: Codable {
+        @_spi(Internal)
+        public struct MutationData: Codable {
             /// Contains the newly added wireframes.
-            internal let adds: [Adds]
+            public let adds: [Adds]
 
             /// Contains the removed wireframes as an array of ids.
-            internal let removes: [Removes]
+            public let removes: [Removes]
 
             /// The source of this type of incremental data.
-            internal let source: Int64 = 0
+            public let source: Int64 = 0
 
             /// Contains the updated wireframes mutations.
-            internal let updates: [Updates]
+            public let updates: [Updates]
 
             enum CodingKeys: String, CodingKey {
                 case adds = "adds"
@@ -594,12 +618,13 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 case updates = "updates"
             }
 
-            internal struct Adds: Codable {
+            @_spi(Internal)
+            public struct Adds: Codable {
                 /// The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively.
-                internal let previousId: Int64?
+                public let previousId: Int64?
 
                 /// Schema of a Wireframe type.
-                internal let wireframe: SRWireframe
+                public let wireframe: SRWireframe
 
                 enum CodingKeys: String, CodingKey {
                     case previousId = "previousId"
@@ -607,9 +632,10 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 }
             }
 
-            internal struct Removes: Codable {
+            @_spi(Internal)
+            public struct Removes: Codable {
                 /// The id of the wireframe that needs to be removed.
-                internal let id: Int64
+                public let id: Int64
 
                 enum CodingKeys: String, CodingKey {
                     case id = "id"
@@ -617,7 +643,8 @@ internal struct SRIncrementalSnapshotRecord: Codable {
             }
 
             /// Schema of a WireframeUpdateMutation type.
-            internal enum Updates: Codable {
+            @_spi(Internal)
+            public enum Updates: Codable {
                 case textWireframeUpdate(value: TextWireframeUpdate)
                 case shapeWireframeUpdate(value: ShapeWireframeUpdate)
                 case imageWireframeUpdate(value: ImageWireframeUpdate)
@@ -625,7 +652,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
 
                 // MARK: - Codable
 
-                internal func encode(to encoder: Encoder) throws {
+                public func encode(to encoder: Encoder) throws {
                     // Encode only the associated value, without encoding enum case
                     var container = encoder.singleValueContainer()
 
@@ -641,7 +668,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                     }
                 }
 
-                internal init(from decoder: Decoder) throws {
+                public init(from decoder: Decoder) throws {
                     // Decode enum case from associated value
                     let container = try decoder.singleValueContainer()
 
@@ -672,42 +699,43 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 }
 
                 /// Schema of all properties of a TextWireframeUpdate.
-                internal struct TextWireframeUpdate: Codable {
+                @_spi(Internal)
+                public struct TextWireframeUpdate: Codable {
                     /// The border properties of this wireframe. The default value is null (no-border).
-                    internal let border: SRShapeBorder?
+                    public let border: SRShapeBorder?
 
                     /// Schema of clipping information for a Wireframe.
-                    internal let clip: SRContentClip?
+                    public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    internal let height: Int64?
+                    public let height: Int64?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    internal let id: Int64
+                    public let id: Int64
 
                     /// The style of this wireframe.
-                    internal let shapeStyle: SRShapeStyle?
+                    public let shapeStyle: SRShapeStyle?
 
                     /// The text value of the wireframe.
-                    internal var text: String?
+                    public var text: String?
 
                     /// Schema of all properties of a TextPosition.
-                    internal let textPosition: SRTextPosition?
+                    public let textPosition: SRTextPosition?
 
                     /// Schema of all properties of a TextStyle.
-                    internal let textStyle: SRTextStyle?
+                    public let textStyle: SRTextStyle?
 
                     /// The type of the wireframe.
-                    internal let type: String = "text"
+                    public let type: String = "text"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    internal let width: Int64?
+                    public let width: Int64?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let x: Int64?
+                    public let x: Int64?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let y: Int64?
+                    public let y: Int64?
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
@@ -726,33 +754,34 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 }
 
                 /// Schema of a ShapeWireframeUpdate.
-                internal struct ShapeWireframeUpdate: Codable {
+                @_spi(Internal)
+                public struct ShapeWireframeUpdate: Codable {
                     /// The border properties of this wireframe. The default value is null (no-border).
-                    internal let border: SRShapeBorder?
+                    public let border: SRShapeBorder?
 
                     /// Schema of clipping information for a Wireframe.
-                    internal let clip: SRContentClip?
+                    public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    internal let height: Int64?
+                    public let height: Int64?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    internal let id: Int64
+                    public let id: Int64
 
                     /// The style of this wireframe.
-                    internal let shapeStyle: SRShapeStyle?
+                    public let shapeStyle: SRShapeStyle?
 
                     /// The type of the wireframe.
-                    internal let type: String = "shape"
+                    public let type: String = "shape"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    internal let width: Int64?
+                    public let width: Int64?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let x: Int64?
+                    public let x: Int64?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let y: Int64?
+                    public let y: Int64?
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
@@ -768,45 +797,46 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 }
 
                 /// Schema of all properties of a ImageWireframeUpdate.
-                internal struct ImageWireframeUpdate: Codable {
+                @_spi(Internal)
+                public struct ImageWireframeUpdate: Codable {
                     /// base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64
-                    internal var base64: String?
+                    public var base64: String?
 
                     /// The border properties of this wireframe. The default value is null (no-border).
-                    internal let border: SRShapeBorder?
+                    public let border: SRShapeBorder?
 
                     /// Schema of clipping information for a Wireframe.
-                    internal let clip: SRContentClip?
+                    public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    internal let height: Int64?
+                    public let height: Int64?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    internal let id: Int64
+                    public let id: Int64
 
                     /// Flag describing an image wireframe that should render an empty state placeholder
-                    internal var isEmpty: Bool?
+                    public var isEmpty: Bool?
 
                     /// MIME type of the image file
-                    internal var mimeType: String?
+                    public var mimeType: String?
 
                     /// Unique identifier of the image resource
-                    internal var resourceId: String?
+                    public var resourceId: String?
 
                     /// The style of this wireframe.
-                    internal let shapeStyle: SRShapeStyle?
+                    public let shapeStyle: SRShapeStyle?
 
                     /// The type of the wireframe.
-                    internal let type: String = "image"
+                    public let type: String = "image"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    internal let width: Int64?
+                    public let width: Int64?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let x: Int64?
+                    public let x: Int64?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let y: Int64?
+                    public let y: Int64?
 
                     enum CodingKeys: String, CodingKey {
                         case base64 = "base64"
@@ -826,30 +856,31 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 }
 
                 /// Schema of all properties of a PlaceholderWireframe.
-                internal struct PlaceholderWireframeUpdate: Codable {
+                @_spi(Internal)
+                public struct PlaceholderWireframeUpdate: Codable {
                     /// Schema of clipping information for a Wireframe.
-                    internal let clip: SRContentClip?
+                    public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    internal let height: Int64?
+                    public let height: Int64?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    internal let id: Int64
+                    public let id: Int64
 
                     /// Label of the placeholder
-                    internal var label: String?
+                    public var label: String?
 
                     /// The type of the wireframe.
-                    internal let type: String = "placeholder"
+                    public let type: String = "placeholder"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    internal let width: Int64?
+                    public let width: Int64?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let x: Int64?
+                    public let x: Int64?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    internal let y: Int64?
+                    public let y: Int64?
 
                     enum CodingKeys: String, CodingKey {
                         case clip = "clip"
@@ -866,30 +897,32 @@ internal struct SRIncrementalSnapshotRecord: Codable {
         }
 
         /// Schema of a TouchData.
-        internal struct TouchData: Codable {
+        @_spi(Internal)
+        public struct TouchData: Codable {
             /// Contains the positions of the finger on the screen during the touchDown/touchUp event lifecycle.
-            internal let positions: [Positions]?
+            public let positions: [Positions]?
 
             /// The source of this type of incremental data.
-            internal let source: Int64 = 2
+            public let source: Int64 = 2
 
             enum CodingKeys: String, CodingKey {
                 case positions = "positions"
                 case source = "source"
             }
 
-            internal struct Positions: Codable {
+            @_spi(Internal)
+            public struct Positions: Codable {
                 /// The touch id of the touch event this position corresponds to. In mobile it is possible to have multiple touch events (fingers touching the screen) happening at the same time.
-                internal let id: Int64
+                public let id: Int64
 
                 /// The UTC timestamp in milliseconds corresponding to the moment the position change was recorded. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-                internal let timestamp: Int64
+                public let timestamp: Int64
 
                 /// The x coordinate value of the position.
-                internal let x: Int64
+                public let x: Int64
 
                 /// The y coordinate value of the position.
-                internal let y: Int64
+                public let y: Int64
 
                 enum CodingKeys: String, CodingKey {
                     case id = "id"
@@ -901,15 +934,16 @@ internal struct SRIncrementalSnapshotRecord: Codable {
         }
 
         /// Schema of a ViewportResizeData.
-        internal struct ViewportResizeData: Codable {
+        @_spi(Internal)
+        public struct ViewportResizeData: Codable {
             /// The new height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height is divided by 2 to get a normalized height.
-            internal let height: Int64
+            public let height: Int64
 
             /// The source of this type of incremental data.
-            internal let source: Int64 = 4
+            public let source: Int64 = 4
 
             /// The new width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width is divided by 2 to get a normalized width.
-            internal let width: Int64
+            public let width: Int64
 
             enum CodingKeys: String, CodingKey {
                 case height = "height"
@@ -919,24 +953,25 @@ internal struct SRIncrementalSnapshotRecord: Codable {
         }
 
         /// Schema of a PointerInteractionData.
-        internal struct PointerInteractionData: Codable {
+        @_spi(Internal)
+        public struct PointerInteractionData: Codable {
             /// Schema of an PointerEventType
-            internal let pointerEventType: PointerEventType
+            public let pointerEventType: PointerEventType
 
             /// Id of the pointer of this PointerInteraction.
-            internal let pointerId: Int64
+            public let pointerId: Int64
 
             /// Schema of an PointerType
-            internal let pointerType: PointerType
+            public let pointerType: PointerType
 
             /// The source of this type of incremental data.
-            internal let source: Int64 = 9
+            public let source: Int64 = 9
 
             /// X-axis coordinate for this PointerInteraction.
-            internal let x: Double
+            public let x: Double
 
             /// Y-axis coordinate for this PointerInteraction.
-            internal let y: Double
+            public let y: Double
 
             enum CodingKeys: String, CodingKey {
                 case pointerEventType = "pointerEventType"
@@ -948,14 +983,16 @@ internal struct SRIncrementalSnapshotRecord: Codable {
             }
 
             /// Schema of an PointerEventType
-            internal enum PointerEventType: String, Codable {
+            @_spi(Internal)
+            public enum PointerEventType: String, Codable {
                 case down = "down"
                 case up = "up"
                 case move = "move"
             }
 
             /// Schema of an PointerType
-            internal enum PointerType: String, Codable {
+            @_spi(Internal)
+            public enum PointerType: String, Codable {
                 case mouse = "mouse"
                 case touch = "touch"
                 case pen = "pen"
@@ -965,15 +1002,16 @@ internal struct SRIncrementalSnapshotRecord: Codable {
 }
 
 /// Schema of a Record which contains the screen properties.
-internal struct SRMetaRecord: Codable {
+@_spi(Internal)
+public struct SRMetaRecord: Codable {
     /// The data contained by this record.
-    internal let data: Data
+    public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 4
+    public let type: Int64 = 4
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -982,15 +1020,16 @@ internal struct SRMetaRecord: Codable {
     }
 
     /// The data contained by this record.
-    internal struct Data: Codable {
+    @_spi(Internal)
+    public struct Data: Codable {
         /// The height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized height is the current height divided by 2.
-        internal let height: Int64
+        public let height: Int64
 
         /// Browser-specific. URL of the view described by this record.
-        internal let href: String?
+        public let href: String?
 
         /// The width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized width is the current width divided by 2.
-        internal let width: Int64
+        public let width: Int64
 
         enum CodingKeys: String, CodingKey {
             case height = "height"
@@ -1001,14 +1040,15 @@ internal struct SRMetaRecord: Codable {
 }
 
 /// Schema of a Record type which contains focus information.
-internal struct SRFocusRecord: Codable {
-    internal let data: Data
+@_spi(Internal)
+public struct SRFocusRecord: Codable {
+    public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 6
+    public let type: Int64 = 6
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -1016,9 +1056,10 @@ internal struct SRFocusRecord: Codable {
         case type = "type"
     }
 
-    internal struct Data: Codable {
+    @_spi(Internal)
+    public struct Data: Codable {
         /// Whether this screen has a focus or not. For now it will always be true for mobile.
-        internal let hasFocus: Bool
+        public let hasFocus: Bool
 
         enum CodingKeys: String, CodingKey {
             case hasFocus = "has_focus"
@@ -1027,12 +1068,13 @@ internal struct SRFocusRecord: Codable {
 }
 
 /// Schema of a Record which signifies that view lifecycle ended.
-internal struct SRViewEndRecord: Codable {
+@_spi(Internal)
+public struct SRViewEndRecord: Codable {
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 7
+    public let type: Int64 = 7
 
     enum CodingKeys: String, CodingKey {
         case timestamp = "timestamp"
@@ -1041,14 +1083,15 @@ internal struct SRViewEndRecord: Codable {
 }
 
 /// Schema of a Record which signifies that the viewport properties have changed.
-internal struct SRVisualViewportRecord: Codable {
-    internal let data: Data
+@_spi(Internal)
+public struct SRVisualViewportRecord: Codable {
+    public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    internal let timestamp: Int64
+    public let timestamp: Int64
 
     /// The type of this Record.
-    internal let type: Int64 = 8
+    public let type: Int64 = 8
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -1056,20 +1099,21 @@ internal struct SRVisualViewportRecord: Codable {
         case type = "type"
     }
 
-    internal struct Data: Codable {
-        internal let height: Double
+    @_spi(Internal)
+    public struct Data: Codable {
+        public let height: Double
 
-        internal let offsetLeft: Double
+        public let offsetLeft: Double
 
-        internal let offsetTop: Double
+        public let offsetTop: Double
 
-        internal let pageLeft: Double
+        public let pageLeft: Double
 
-        internal let pageTop: Double
+        public let pageTop: Double
 
-        internal let scale: Double
+        public let scale: Double
 
-        internal let width: Double
+        public let width: Double
 
         enum CodingKeys: String, CodingKey {
             case height = "height"
@@ -1084,7 +1128,8 @@ internal struct SRVisualViewportRecord: Codable {
 }
 
 /// Mobile-specific. Schema of a Session Replay Record.
-internal enum SRRecord: Codable {
+@_spi(Internal)
+public enum SRRecord: Codable {
     case fullSnapshotRecord(value: SRFullSnapshotRecord)
     case incrementalSnapshotRecord(value: SRIncrementalSnapshotRecord)
     case metaRecord(value: SRMetaRecord)
@@ -1094,7 +1139,7 @@ internal enum SRRecord: Codable {
 
     // MARK: - Codable
 
-    internal func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         // Encode only the associated value, without encoding enum case
         var container = encoder.singleValueContainer()
 
@@ -1114,7 +1159,7 @@ internal enum SRRecord: Codable {
         }
     }
 
-    internal init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         // Decode enum case from associated value
         let container = try decoder.singleValueContainer()
 

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+@_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 

--- a/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
@@ -5,7 +5,7 @@
  */
 
 import UIKit
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 struct MockImageDataProvider: ImageDataProviding {
     var contentBase64String: String

--- a/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockImageDataProvider.swift
@@ -5,7 +5,8 @@
  */
 
 import UIKit
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 struct MockImageDataProvider: ImageDataProviding {
     var contentBase64String: String

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -333,6 +333,25 @@ class NodeRecorderMock: NodeRecorder {
     }
 }
 
+class SessionReplayNodeRecorderMock: SessionReplayNodeRecorder {
+    var identifier = UUID()
+    var queriedViews: Set<UIView> = []
+    var queryContexts: [ViewTreeRecordingContext] = []
+    var queryContextsByView: [UIView: ViewTreeRecordingContext] = [:]
+    var resultForView: ((UIView) -> NodeSemantics?)?
+
+    init(resultForView: ((UIView) -> NodeSemantics?)? = nil) {
+        self.resultForView = resultForView
+    }
+
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        queriedViews.insert(view)
+        queryContexts.append(context)
+        queryContextsByView[view] = context
+        return resultForView?(view)
+    }
+}
+
 // MARK: - TouchSnapshot Mocks
 
 extension TouchSnapshot: AnyMockable, RandomMockable {

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 extension PrivacyLevel: AnyMockable, RandomMockable {
@@ -234,7 +234,7 @@ struct ShapeWireframesBuilderMock: NodeWireframesBuilder {
     }
 }
 
-extension Node: AnyMockable, RandomMockable {
+@_spi(Internal) extension Node: AnyMockable, RandomMockable {
     public static func mockAny() -> Node {
         return mockWith()
     }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -7,7 +7,8 @@
 import Foundation
 import UIKit
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 extension PrivacyLevel: AnyMockable, RandomMockable {
@@ -234,7 +235,8 @@ struct ShapeWireframesBuilderMock: NodeWireframesBuilder {
     }
 }
 
-@_spi(Internal) extension Node: AnyMockable, RandomMockable {
+@_spi(Internal)
+extension Node: AnyMockable, RandomMockable {
     public static func mockAny() -> Node {
         return mockWith()
     }

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -5,7 +5,8 @@
  */
 
 import Foundation
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // MARK: - Wireframe Mocks

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // MARK: - Wireframe Mocks

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 @testable import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class DiffSRWireframes: XCTestCase {
     // MARK: - Diffable Conformance

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 @testable import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class DiffSRWireframes: XCTestCase {
     // MARK: - Diffable Conformance

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import DatadogInternal
 import TestUtilities
 
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 private class WriterMock: Writing {
@@ -279,7 +280,7 @@ class ProcessorTests: XCTestCase {
 
     // MARK: - `ViewTreeSnapshot` generation
 
-    private let snapshotBuilder = ViewTreeSnapshotBuilder()
+    private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [])
 
     private func generateViewTreeSnapshot(for viewTree: UIView, date: Date, rumContext: RUMContext) -> ViewTreeSnapshot {
         snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, rumContext: rumContext, date: date))

--- a/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 class RecordsBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class RecorderTests: XCTestCase {
@@ -77,5 +77,31 @@ class RecorderTests: XCTestCase {
              - [error] [SR] Failed to take snapshot - snapshot creation error, kind: ErrorMock, stack: snapshot creation error
             """
         )
+    }
+
+    func testWhenCapturingSnapshots_itUsesAdditionalNodeRecorders() throws {
+        let recorderContext: Recorder.Context = .mockRandom()
+        let additionalNodeRecorder = SessionReplayNodeRecorderMock()
+        let windowObserver = AppWindowObserverMock()
+        let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
+            windowObserver: windowObserver,
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+        )
+        let touchSnapshotProducer = TouchSnapshotProducerMock()
+
+        // Given
+        let recorder = Recorder(
+            uiApplicationSwizzler: .mockAny(),
+            viewTreeSnapshotProducer: viewTreeSnapshotProducer,
+            touchSnapshotProducer: touchSnapshotProducer,
+            snapshotProcessor: ProcessorSpy(),
+            telemetry: TelemetryMock()
+        )
+        // When
+        recorder.captureNextRecord(recorderContext)
+
+        // Then
+        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
+        XCTAssertEqual(queryContext.recorder, recorderContext)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class RecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class ImageDataProviderTests: XCTestCase {
     func test_returnsNil_WhenImageIsNil() {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class ImageDataProviderTests: XCTestCase {
     func test_returnsNil_WhenImageIsNil() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import UIKit
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class NodeIDGeneratorTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import UIKit
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class NodeIDGeneratorTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIDatePickerRecorderTests: XCTestCase {
     private let recorder = UIDatePickerRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIDatePickerRecorderTests: XCTestCase {
     private let recorder = UIDatePickerRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIImageViewWireframesBuilderTests: XCTestCase {
     var wireframesBuilder: WireframesBuilder = .init()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIImageViewWireframesBuilderTests: XCTestCase {
     var wireframesBuilder: WireframesBuilder = .init()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIPickerViewRecorderTests: XCTestCase {
     private let recorder = UIPickerViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIPickerViewRecorderTests: XCTestCase {
     private let recorder = UIPickerViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
     private let recorder = UISegmentRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
     private let recorder = UISegmentRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
     private let recorder = UISliderRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
     private let recorder = UISliderRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIStepperRecorderTests: XCTestCase {
     private let recorder = UIStepperRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIStepperRecorderTests: XCTestCase {
     private let recorder = UIStepperRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
     private let recorder = UISwitchRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
     private let recorder = UISwitchRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import TestUtilities
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import TestUtilities
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
     private let recorder = UIViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
     private let recorder = UIViewRecorder()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -8,7 +8,8 @@ import XCTest
 import WebKit
 import SwiftUI
 import SafariServices
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import WebKit
 import SwiftUI
 import SafariServices
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 import SafariServices
 
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 private struct MockSemantics: NodeSemantics {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -7,7 +7,8 @@
 import XCTest
 import SafariServices
 
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 private struct MockSemantics: NodeSemantics {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
@@ -6,7 +6,8 @@
 
 import XCTest
 import SafariServices
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class ViewTreeRecordingContextTests: XCTestCase {
     func testViewControllerTypeInit() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import SafariServices
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class ViewTreeRecordingContextTests: XCTestCase {
     func testViewControllerTypeInit() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class ViewTreeSnapshotBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class ViewTreeSnapshotBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -48,4 +48,22 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // Then
         XCTAssertGreaterThan(snapshot.date, now)
     }
+
+    func testWhenQueryingNodeRecorders_itCallsAdditionalNodeRecorders() throws {
+        // Given
+        let view = UIView(frame: .mockRandom())
+        let randomRecorderContext: Recorder.Context = .mockRandom()
+        let additionalNodeRecorder = SessionReplayNodeRecorderMock(resultForView: { _ in nil })
+        let builder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+
+        // When
+        let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
+
+        // Then
+        XCTAssertEqual(snapshot.context, randomRecorderContext)
+
+        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
+        XCTAssertTrue(queryContext.coordinateSpace === view)
+        XCTAssertEqual(queryContext.recorder, randomRecorderContext)
+    }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable opening_brace

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
+@testable import TestUtilities
 
 class SessionReplayConfigurationTests: XCTestCase {
     func testDefaultConfiguration() {
@@ -18,5 +19,19 @@ class SessionReplayConfigurationTests: XCTestCase {
         XCTAssertEqual(config.replaySampleRate, random)
         XCTAssertEqual(config.defaultPrivacyLevel, .mask)
         XCTAssertNil(config.customEndpoint)
+        XCTAssertEqual(config._additionalNodeRecorders.count, 0)
+    }
+
+    func testConfigurationWithAdditionalNodeRecorders() {
+        let random: Float = .mockRandom(min: 0, max: 100)
+        let mockNodeRecorder = SessionReplayNodeRecorderMock()
+
+        // When
+        var config = SessionReplay.Configuration(replaySampleRate: random)
+        config.setAdditionalNodeRecorders([mockNodeRecorder])
+
+        // Then
+        XCTAssertEqual(config._additionalNodeRecorders.count, 1)
+        XCTAssertEqual(config._additionalNodeRecorders[0].identifier, mockNodeRecorder.identifier)
     }
 }

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -5,7 +5,8 @@
  */
 
 import XCTest
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 @testable import TestUtilities
 
 class SessionReplayConfigurationTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 import TestUtilities
 @testable import DatadogInternal
-@testable import DatadogSessionReplay
+@_spi(Internal) @testable import DatadogSessionReplay
 
 class SessionReplayTests: XCTestCase {
     private var core: SingleFeatureCoreMock<SessionReplayFeature>! // swiftlint:disable:this implicitly_unwrapped_optional

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -7,7 +7,8 @@
 import XCTest
 import TestUtilities
 @testable import DatadogInternal
-@_spi(Internal) @testable import DatadogSessionReplay
+@_spi(Internal)
+@testable import DatadogSessionReplay
 
 class SessionReplayTests: XCTestCase {
     private var core: SingleFeatureCoreMock<SessionReplayFeature>! // swiftlint:disable:this implicitly_unwrapped_optional

--- a/DatadogSessionReplay/Tests/Writer/Models/EnrichedRecordTests.swift
+++ b/DatadogSessionReplay/Tests/Writer/Models/EnrichedRecordTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 @testable import TestUtilities
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 class EnrichedRecordTests: XCTestCase {

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
@@ -14,6 +14,7 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
             case `public`
             /// Use to make all generated models visible in internal interface.
             case `internal`
+            case `spi`
         }
 
         /// Access level for for entities within printed code.
@@ -66,6 +67,9 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
         let conformance = implementedProtocols.isEmpty ? "" : ": \(implementedProtocols.joined(separator: ", "))"
 
         printComment(swiftStruct.comment)
+        if let attribute = configuration.accessLevel.attribute {
+            writeLine("\(attribute)")
+        }
         writeLine("\(configuration.accessLevel) struct \(swiftStruct.name)\(conformance) {")
         indentRight()
         try printPropertiesList(swiftStruct.properties)
@@ -303,6 +307,9 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
         }()
 
         printComment(enumeration.comment)
+        if let attribute = configuration.accessLevel.attribute {
+            writeLine("\(attribute)")
+        }
         writeLine("\(configuration.accessLevel) enum \(enumeration.name): \(rawValueType)\(conformance) {")
         indentRight()
         enumeration.cases.forEach { `case` in
@@ -373,6 +380,9 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
         let conformance = implementedProtocols.isEmpty ? "" : ": \(implementedProtocols.joined(separator: ", "))"
 
         printComment(enumeration.comment)
+        if let attribute = configuration.accessLevel.attribute {
+            writeLine("\(attribute)")
+        }
         writeLine("\(configuration.accessLevel) enum \(enumeration.name)\(conformance) {")
         indentRight()
         try enumeration.cases.forEach { `case` in
@@ -476,6 +486,19 @@ extension SwiftPrinter.Configuration.AccessLevel: CustomStringConvertible {
             return "public"
         case .internal:
             return "internal"
+        case .spi:
+            return "public"
+        }
+    }
+
+    public var attribute: String? {
+        switch self {
+        case .public:
+            return nil
+        case .internal:
+            return nil
+        case .spi:
+            return "@_spi(Internal)"
         }
     }
 }

--- a/tools/rum-models-generator/Sources/rum-models-generator/GenerateSRModels.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/GenerateSRModels.swift
@@ -33,7 +33,7 @@ internal func generateSRSwiftModels(from schema: URL) throws -> String {
     )
     let printer = SwiftPrinter(
         configuration: .init(
-            accessLevel: .internal
+            accessLevel: .spi
         )
     )
 


### PR DESCRIPTION
### What and why?

Enable cross platform SDKs to provide additional node recorders to be used for session replay

### How?

I've made all SRDataModels `@spi(Internal) public` instead of `internal`.

I've added a few tests to check that additional node recorders are indeed passed down to the snapshot builder.

I've split some refactoring/fix commits to avoid bringing too much noise in commits where actual features happen.

`@_spi` is still hidden but seems to be used already: https://pspdfkit.com/blog/2023/swifts-approach-to-spi/
Although it is supported since XCode 12, would there be (reasonable) cases where users of the SDK would not be able to use the SDK because of this attribute?

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
