### PR TITLE
Expose text obfuscator for cross platform SDKs

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -7,12 +7,15 @@
 #if os(iOS)
 import Foundation
 
-internal protocol TextObfuscating {
+@_spi(Internal)
+public protocol SessionReplayTextObfuscating {
     /// Obfuscates given `text`.
     /// - Parameter text: the text to be obfuscated
     /// - Returns: obfuscated text
     func mask(text: String) -> String
 }
+
+internal typealias TextObfuscating = SessionReplayTextObfuscating
 
 /// Text obfuscator which replaces all readable characters with space-preserving `"x"` characters.
 internal struct SpacePreservingMaskObfuscator: TextObfuscating {

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -5,16 +5,20 @@
  */
 
 #if os(iOS)
-internal typealias PrivacyLevel = SessionReplay.Configuration.PrivacyLevel
+@_spi(Internal)
+public typealias SessionReplayPrivacyLevel = SessionReplay.Configuration.PrivacyLevel
+
+internal typealias PrivacyLevel = SessionReplayPrivacyLevel
 
 /// Text obfuscation strategies for different text types.
-internal extension SessionReplay.Configuration.PrivacyLevel {
+@_spi(Internal)
+public extension SessionReplay.Configuration.PrivacyLevel {
     /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Sensitive Text" is:
     /// - passwords, e-mails and phone numbers marked in a platform-specific way
     /// - AND other forms of sensitivity in text available to each platform
-    var sensitiveTextObfuscator: TextObfuscating {
+    var sensitiveTextObfuscator: SessionReplayTextObfuscating {
         return FixLengthMaskObfuscator()
     }
 
@@ -23,7 +27,7 @@ internal extension SessionReplay.Configuration.PrivacyLevel {
     /// In Session Replay, "Input & Option Text" is:
     /// - a text entered by the user with a keyboard or other text-input device
     /// - OR a custom (non-generic) value in selection elements
-    var inputAndOptionTextObfuscator: TextObfuscating {
+    var inputAndOptionTextObfuscator: SessionReplayTextObfuscating {
         switch self {
         case .allow:         return NOPTextObfuscator()
         case .mask:          return FixLengthMaskObfuscator()
@@ -34,7 +38,7 @@ internal extension SessionReplay.Configuration.PrivacyLevel {
     /// Returns "Static Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Static Text" is a text not directly entered by the user.
-    var staticTextObfuscator: TextObfuscating {
+    var staticTextObfuscator: SessionReplayTextObfuscating {
         switch self {
         case .allow:         return NOPTextObfuscator()
         case .mask:          return SpacePreservingMaskObfuscator()
@@ -45,7 +49,7 @@ internal extension SessionReplay.Configuration.PrivacyLevel {
     /// Returns "Hint Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Hint Text" is a static text in editable text elements or option selectors, displayed when there isn't any value set.
-    var hintTextObfuscator: TextObfuscating {
+    var hintTextObfuscator: SessionReplayTextObfuscating {
         switch self {
         case .allow:         return NOPTextObfuscator()
         case .mask:          return FixLengthMaskObfuscator()

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -18,11 +18,12 @@ internal protocol Recording {
 /// It instruments running application by observing current window(s) and
 /// captures intermediate representation of the view hierarchy. This representation
 /// is later passed to `Processor` and turned into wireframes uploaded to the BE.
-internal class Recorder: Recording {
+@_spi(Internal)
+public class Recorder: Recording {
     /// The context of recording next snapshot.
-    struct Context: Equatable {
+    public struct Context: Equatable {
         /// The content recording policy from the moment of requesting snapshot.
-        let privacy: PrivacyLevel
+        public let privacy: SessionReplayPrivacyLevel
         /// Current RUM application ID - standard UUID string, lowecased.
         let applicationID: String
         /// Current RUM session ID - standard UUID string, lowecased.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -15,7 +15,7 @@ import SwiftUI
 @_spi(Internal)
 public struct SessionReplayViewTreeRecordingContext {
     /// The context of the Recorder.
-    let recorder: Recorder.Context
+    public let recorder: Recorder.Context
     /// The coordinate space to convert node positions to.
     let coordinateSpace: UICoordinateSpace
     /// Generates stable IDs for traversed views.

--- a/DatadogSessionReplay/Tests/Mocks/SnapshotProducerMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SnapshotProducerMocks.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 // MARK: - `ViewTreeSnapshotProducer` Mocks

--- a/DatadogSessionReplay/Tests/Recorder/PrivacyLevelTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/PrivacyLevelTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 class PrivacyLevelTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import DatadogInternal
+@_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 


### PR DESCRIPTION
### What and why?

Expose Text Obfuscator and related types for it to be usable in cross platform SDKs

### How?

Using `@_spi(Internal)` to make it public.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
