### PR TITLE
Add GPG signing to dogfooding script commit

### DIFF
--- a/tools/distribution/src/dogfood/repository.py
+++ b/tools/distribution/src/dogfood/repository.py
@@ -66,6 +66,11 @@ class Repository:
             print(f'⚙️️️️ Committing changes using git user from current git config')
         print('    → commit message:')
         print(message)
+
+        # Add GPG signing
+        signer = self.repo.config_reader().get_value("user", "signingkey")
+        self.repo.head.commit.sign(signer)
+
         self.repo.git.add(update=True)
         self.repo.index.commit(message=message, author=author, committer=author)
 


### PR DESCRIPTION
### What and why?

Adds required GPG signing to dogfooding's automated commits.