### PR TITLE
Update Session Replay default maxID

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -27,7 +27,7 @@ public final class NodeIDGenerator {
     /// Tracks next `NodeID` to assign.
     private var currentID: NodeID
 
-    init(currentID: NodeID = 0, maxID: NodeID = .max) {
+    init(currentID: NodeID = 0, maxID: NodeID = Int64(Int32.max)) {
         self.currentID = currentID
         self.maxID = maxID
     }


### PR DESCRIPTION
### What and why?

Updates maximum Session Replay ID to not exceed 32-bit. It's an overlooked requirement needed by the player to work correctly. Potentially we'll replace ids with String type in the future.
