### PR TITLE
RUM-1820 Create full snapshot if root has changed

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -62,7 +62,11 @@ internal class RecordsBuilder {
     ///
     /// It may return `nil` if there is no diff between `wireframes` and `lastWireframes`.
     /// In case of unexpected failure, it will fallback to creating FSR instead.
+    /// If the root wireframe has changed, we trigger a full snapshot so it is added first in the replay.
     func createIncrementalSnapshotRecord(from snapshot: ViewTreeSnapshot, with wireframes: [SRWireframe], lastWireframes: [SRWireframe]) -> SRRecord? {
+        if wireframes.first?.id != lastWireframes.first?.id {
+            return createFullSnapshotRecord(from: snapshot, wireframes: wireframes)
+        }
         do {
             return try createIncrementalSnapshotRecord(from: snapshot, newWireframes: wireframes, lastWireframes: lastWireframes)
         } catch {

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -130,8 +130,8 @@ class ProcessorTests: XCTestCase {
         XCTAssertTrue(enrichedRecords[0].records[1].isFocusRecord)
         XCTAssertTrue(enrichedRecords[0].records[2].isFullSnapshotRecord && enrichedRecords[0].hasFullSnapshot)
 
-        XCTAssertEqual(enrichedRecords[1].records.count, 2, "It should follow with two 'incremental snapshot' records")
-        XCTAssertTrue(enrichedRecords[1].records[0].isIncrementalSnapshotRecord)
+        XCTAssertEqual(enrichedRecords[1].records.count, 2, "It should follow with 'full snapshot' → 'incremental snapshot' records")
+        XCTAssertTrue(enrichedRecords[1].records[0].isFullSnapshotRecord && enrichedRecords[1].hasFullSnapshot)
         XCTAssertTrue(enrichedRecords[1].records[1].isIncrementalSnapshotRecord)
         XCTAssertEqual(enrichedRecords[1].records[1].incrementalSnapshot?.viewportResizeData?.height, 100)
         XCTAssertEqual(enrichedRecords[1].records[1].incrementalSnapshot?.viewportResizeData?.width, 200)

--- a/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
@@ -46,6 +46,38 @@ class RecordsBuilderTests: XCTestCase {
         DDAssertReflectionEqual(mutations.adds[0].wireframe, next[2])
     }
 
+    func testWhenNextWireframesAddsNewRoot_itCreatesFullSnapshotRecord() throws {
+        let builder = RecordsBuilder(telemetry: TelemetryMock())
+
+        // Given
+        let previous: [SRWireframe] = [.mockRandomWith(id: 0), .mockRandomWith(id: 1)]
+        let next: [SRWireframe] = [.mockRandomWith(id: 2)] + previous
+
+        // When
+        let record = builder.createIncrementalSnapshotRecord(from: .mockAny(), with: next, lastWireframes: previous)
+
+        // Then
+        let fullRecord = try XCTUnwrap(record?.fullSnapshot)
+        DDAssertReflectionEqual(fullRecord.data.wireframes, next)
+    }
+
+    // This case does not need a full snapshot for the player to work, but adding a
+    // test documents the behavior if we want to change it.
+    func testWhenNextWireframesDeletesRoot_itCreatesFullSnapshotRecord() throws {
+        let builder = RecordsBuilder(telemetry: TelemetryMock())
+
+        // Given
+        let previous: [SRWireframe] = [.mockRandomWith(id: 0), .mockRandomWith(id: 1)]
+        let next: [SRWireframe] = [.mockRandomWith(id: 1)]
+
+        // When
+        let record = builder.createIncrementalSnapshotRecord(from: .mockAny(), with: next, lastWireframes: previous)
+
+        // Then
+        let fullRecord = try XCTUnwrap(record?.fullSnapshot)
+        DDAssertReflectionEqual(fullRecord.data.wireframes, next)
+    }
+
     func testWhenWireframesAreNotConsistent_itFallbacksToFullSnapshotRecordAndSendsErrorTelemetry() throws {
         let telemetry = TelemetryMock()
         let builder = RecordsBuilder(telemetry: telemetry)


### PR DESCRIPTION
### What and why?

I noticed a bug in Session Replay when the root wireframe (first wireframe in the list) is added in an incremental snapshot.

This wireframe will have no `previousId`, and the replay will add it last in the list of wireframes.

This should not happen very often, given we create a full snapshot on every RUM view.

Possible improvements for the PR:
- if the new root is already present in the previous wireframe, there is no need to create a new full snapshot

Also it's worth investigating why we're removing root wireframes in the first place (and thus adding them back afterwards).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
