### PR TITLE
Remove node when it's outside of the bounds of the screen

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
+++ b/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
@@ -32,8 +32,10 @@ internal struct NodesFlattener {
 
                 return dropPreviousNode ? nil : previousNode
             }
-
-            flattened.append(nextNode)
+            // Add only node that intersects with the screen bounds
+            if CGRect(origin: .zero, size: snapshot.viewportSize).intersects(nextNode.wireframesBuilder.wireframeRect) {
+                flattened.append(nextNode)
+            }
         }
 
         return flattened

--- a/DatadogSessionReplay/Tests/Mocks/CoreGraphicsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/CoreGraphicsMocks.swift
@@ -18,7 +18,7 @@ extension CGFloat: AnyMockable, RandomMockable {
     }
 
     static func mockRandom(min: CGFloat, max: CGFloat?) -> CGFloat {
-        return .random(in: min...(max ?? .greatestFiniteMagnitude))
+        return .random(in: min...(max ?? 1_000))
     }
 }
 
@@ -54,7 +54,7 @@ extension CGPoint: AnyMockable, RandomMockable {
     }
 
     public static func mockRandom() -> CGPoint {
-        return mockRandom(minX: -1000, maxX: 1000, minY: -1000, maxY: 1000)
+        return mockRandom(minX: -1_000, maxX: 1_000, minY: -1_000, maxY: 1_000)
     }
 
     public static func mockRandom(

--- a/DatadogSessionReplay/Tests/Mocks/CoreGraphicsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/CoreGraphicsMocks.swift
@@ -17,8 +17,8 @@ extension CGFloat: AnyMockable, RandomMockable {
         return mockRandom(min: .leastNormalMagnitude, max: .greatestFiniteMagnitude)
     }
 
-    static func mockRandom(min: CGFloat, max: CGFloat) -> CGFloat {
-        return .random(in: min...max)
+    static func mockRandom(min: CGFloat, max: CGFloat?) -> CGFloat {
+        return .random(in: min...(max ?? .greatestFiniteMagnitude))
     }
 }
 
@@ -32,13 +32,17 @@ extension CGRect: AnyMockable, RandomMockable {
     }
 
     static func mockRandom(
+        minX: CGFloat = 0,
+        maxX: CGFloat? = nil,
+        minY: CGFloat = 0,
+        maxY: CGFloat? = nil,
         minWidth: CGFloat = 0,
         maxWidth: CGFloat? = nil,
         minHeight: CGFloat = 0,
         maxHeight: CGFloat? = nil
     ) -> CGRect {
         return .init(
-            origin: .mockRandom(),
+            origin: .mockRandom(minX: minX, maxX: maxX, minY: minY, maxY: maxY),
             size: .mockRandom(minWidth: minWidth, maxWidth: maxWidth, minHeight: minHeight, maxHeight: maxHeight)
         )
     }
@@ -50,9 +54,18 @@ extension CGPoint: AnyMockable, RandomMockable {
     }
 
     public static func mockRandom() -> CGPoint {
+        return mockRandom(minX: -1000, maxX: 1000, minY: -1000, maxY: 1000)
+    }
+
+    public static func mockRandom(
+        minX: CGFloat,
+        maxX: CGFloat?,
+        minY: CGFloat,
+        maxY: CGFloat?
+    ) -> CGPoint {
         return .init(
-            x: .mockRandom(min: -1_000, max: 1_000),
-            y: .mockRandom(min: -1_000, max: 1_000)
+            x: .mockRandom(min: minX, max: maxX),
+            y: .mockRandom(min: minY, max: maxY)
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
@@ -90,7 +90,7 @@ class NodesFlattenerTests: XCTestCase {
         DDAssertReflectionEqual(flattenedNodes, [coveringNode])
     }
 
-    func testFlattenNodes_removesNodeWhenItsOutsideOfViewport() {
+    func testFlattenNodes_removesNodeWhenItsOutsideOfViewportSize() {
         // Given
         let viewportSize = CGSize.mockRandom()
         let outsideFrame = CGRect(origin: .init(x: viewportSize.width, y: viewportSize.height), size: .mockRandom())
@@ -106,5 +106,23 @@ class NodesFlattenerTests: XCTestCase {
 
         // Then
         DDAssertReflectionEqual(flattenedNodes, [])
+    }
+
+    func testFlattenNodes_doesntRemovesNodeWhenItIntersectsWithViewportSize() {
+        // Given
+        let viewportSize = CGSize.mockRandom()
+        let intersectingFrame = CGRect(origin: .init(x: viewportSize.width - 1, y: viewportSize.height - 1), size: .mockRandom())
+        let intersectingNode = Node.mockWith(
+            viewAttributes: .mock(fixture: .opaque),
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: intersectingFrame)
+        )
+        let snapshot = ViewTreeSnapshot.mockWith(viewportSize: viewportSize, nodes: [intersectingNode])
+        let flattener = NodesFlattener()
+
+        // When
+        let flattenedNodes = flattener.flattenNodes(in: snapshot)
+
+        // Then
+        DDAssertReflectionEqual(flattenedNodes, [intersectingNode])
     }
 }

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -287,7 +287,27 @@ class ProcessorTests: XCTestCase {
 
     private func generateSimpleViewTree() -> UIView {
         let root = UIView.mock(withFixture: .visible(.someAppearance))
+        root.frame = .mockRandom(
+            minX: 0,
+            maxX: 0,
+            minY: 0,
+            maxY: 0,
+            minWidth: 1_000,
+            maxWidth: 2_000,
+            minHeight: 1_000,
+            maxHeight: 2_000
+        )
         let child = UIView.mock(withFixture: .visible(.someAppearance))
+        child.frame = .mockRandom(
+            minX: 0,
+            maxX: 100,
+            minY: 0,
+            maxY: 100,
+            minWidth: 100,
+            maxWidth: 200,
+            minHeight: 100,
+            maxHeight: 200
+        )
         root.addSubview(child)
         return root
     }

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class RecorderTests: XCTestCase {
     func testAfterCapturingSnapshot_itIsPassesToProcessor() {
-        let mockViewTreeSnapshots: [ViewTreeSnapshot] = .mockRandom()
-        let mockTouchSnapshots: [TouchSnapshot] = .mockRandom()
+        let mockViewTreeSnapshots: [ViewTreeSnapshot] = .mockRandom(count: 1)
+        let mockTouchSnapshots: [TouchSnapshot] = .mockRandom(count: 1)
         let processor = ProcessorSpy()
 
         // Given

--- a/TestUtilities/Helpers/DDAssert.swift
+++ b/TestUtilities/Helpers/DDAssert.swift
@@ -54,15 +54,15 @@ private func _DDAssertReflectionEqual(_ expression1: @autoclosure () throws -> A
     let mirror1 = Mirror(reflecting: value1)
     let mirror2 = Mirror(reflecting: value2)
 
-    guard mirror1.displayStyle == mirror1.displayStyle else {
+    guard mirror1.displayStyle == mirror2.displayStyle else {
         throw DDAssertError.expectedFailure("(\"\(value1)\") and (\"\(value2)\") have different types", keyPath: keyPath)
     }
 
-    guard mirror1.children.count == mirror1.children.count else {
+    guard mirror1.children.count == mirror2.children.count else {
         throw DDAssertError.expectedFailure("(\"\(value1)\") and (\"\(value2)\") have different number of children", keyPath: keyPath)
     }
 
-    if mirror1.children.isEmpty, mirror1.children.isEmpty {
+    if mirror1.children.isEmpty && mirror2.children.isEmpty {
         guard String(describing: value1) == String(describing: value2) else { // plain values, compare debug strings
             throw DDAssertError.expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")", keyPath: keyPath)
         }


### PR DESCRIPTION
### What and why?

Improve nodes flattener and adds ability to drop the node when it's outside of the bounds of the screen.

### How?

It's based on the assumption each node should intersect with the viewport of the snapshot.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
