### PR TITLE
Fix "KeyError: 'branch'" in dogfooding automation

### DIFF
--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -27,6 +27,7 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
     dd_sdk_package_path = '../..'
     os.system(f'swift package --package-path {dd_sdk_package_path} resolve')
     dd_sdk_ios_package = PackageResolvedFile(path=f'{dd_sdk_package_path}/Package.resolved')
+    dd_sdk_ios_package.print()
 
     if dd_sdk_ios_package.version > 2:
         raise Exception(
@@ -49,8 +50,8 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
                 map(lambda path: PackageResolvedFile(path=path), repository_package_resolved_paths)
             )
 
-            # Update version of `dd-sdk-ios`:
             for package in packages:
+                # Update version of `dd-sdk-ios`:
                 package.update_dependency(
                     package_id=PackageID(v1='DatadogSDK', v2='dd-sdk-ios'),
                     new_branch='dogfooding',
@@ -58,24 +59,24 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
                     new_version=None
                 )
 
-                # Add or update `dd-sdk-ios` dependencies
+                # Add or update `dd-sdk-ios` dependencies:
                 for dependency_id in dd_sdk_ios_package.read_dependency_ids():
                     dependency = dd_sdk_ios_package.read_dependency(package_id=dependency_id)
 
                     if package.has_dependency(package_id=dependency_id):
                         package.update_dependency(
                             package_id=dependency_id,
-                            new_branch=dependency['state']['branch'],
+                            new_branch=dependency['state'].get('branch'),
                             new_revision=dependency['state']['revision'],
-                            new_version=dependency['state']['version'],
+                            new_version=dependency['state'].get('version'),
                         )
                     else:
                         package.add_dependency(
                             package_id=dependency_id,
                             repository_url=dependency['repositoryURL'],
-                            branch=dependency['state']['branch'],
+                            branch=dependency['state'].get('branch'),
                             revision=dependency['state']['revision'],
-                            version=dependency['state']['version']
+                            version=dependency['state'].get('version'),
                         )
 
                 package.save()

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -165,6 +165,7 @@ class PackageResolvedContentV1(PackageResolvedContent):
         return package_id.v1 in [p['package'] for p in pins]
 
     def update_dependency(self, package_id: PackageID, new_branch: Optional[str], new_revision: str, new_version: Optional[str]):
+        print(f'⚙️ ️ Updating "{package_id.v1}" in {self.path} (V1):')
         package = self.__get_package(package_id=package_id)
 
         old_state = deepcopy(package['state'])
@@ -264,6 +265,7 @@ class PackageResolvedContentV2(PackageResolvedContent):
         return package_id.v2 in [p['identity'] for p in pins]
 
     def update_dependency(self, package_id: PackageID, new_branch: Optional[str], new_revision: str, new_version: Optional[str]):
+        print(f'⚙️ ️ Updating "{package_id.v2}" in {self.path} (V2):')
         package = self.__get_package(package_id=package_id)
 
         old_state = deepcopy(package['state'])


### PR DESCRIPTION
### What and why?

💊 This PR fixes following error in dogfooding automation:
```
❌ Failed to dogfood: 'branch'
------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/vagrant/git/tools/distribution/dogfood.py", line 118, in <module>
    dogfood(
  File "/Users/vagrant/git/tools/distribution/dogfood.py", line 68, in dogfood
    new_branch=dependency['state']['branch'],
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'branch'
------------------------------------------------------------
```

### How?

As shown [in example](https://github.com/DataDog/dd-sdk-ios/blob/2ee9279870711548fbad89e38ca59637b315a0a4/tools/distribution/tests/dogfood/test_package_resolved.py#L18-L35), in V1 package definition the `branch` or `version` can be `null`, e.g.:
```json
{
  "package": "B",
  "repositoryURL": "https://github.com/B-org/b.git",
  "state": {
    "branch": null,
    "revision": "b-revision",
    "version": "1.0.0"
  }
}
```

Even though [`update_dependency`](https://github.com/DataDog/dd-sdk-ios/blob/2ee9279870711548fbad89e38ca59637b315a0a4/tools/distribution/src/dogfood/package_resolved.py#L40) defines `new_branch` and `new_version` as optionals:
```py
def update_dependency(self, package_id: PackageID, new_branch: Optional[str], new_revision: str, new_version: Optional[str]):
```
the method was called with `dependency['state']['branch']`, which raises exception on key absence. Changing it to `.get('branch')`, which returns `None` if it doesn't exist.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [x] Run tests for `tools/`
