### PR TITLE
Issue 1582: Fix typo of initialized 

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -87,7 +87,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         guard let subscriber = subscriber else {
             return DD.logger.warn(
                 """
-                RUM Resource was completed, but no `RUMMonitor` is initiaized in the core. RUM auto instrumentation will not work.
+                RUM Resource was completed, but no `RUMMonitor` is initialized in the core. RUM auto instrumentation will not work.
                 Make sure `RUMMonitor.initialize()` is called before any network request is send.
                 """
             )


### PR DESCRIPTION
### What and why?

Fixes https://github.com/DataDog/dd-sdk-ios/issues/1582

It's just fixing the typo of `initialized` in a warning message

### How?

Updated the typo

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
