### PR TITLE
RUM-2153 Resources Recording

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		61054FA32A6EE1BA00AAA894 /* Diff+SRWireframesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F522A6EE1BA00AAA894 /* Diff+SRWireframesTests.swift */; };
 		61054FA42A6EE1BA00AAA894 /* DiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F532A6EE1BA00AAA894 /* DiffTests.swift */; };
 		61054FA52A6EE1BA00AAA894 /* RecordsBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F552A6EE1BA00AAA894 /* RecordsBuilderTests.swift */; };
-		61054FA62A6EE1BA00AAA894 /* ProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F562A6EE1BA00AAA894 /* ProcessorTests.swift */; };
+		61054FA62A6EE1BA00AAA894 /* SnapshotProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F562A6EE1BA00AAA894 /* SnapshotProcessorTests.swift */; };
 		61054FA72A6EE1BA00AAA894 /* NodesFlattenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F582A6EE1BA00AAA894 /* NodesFlattenerTests.swift */; };
 		61054FA82A6EE1BA00AAA894 /* RecordingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F5A2A6EE1BA00AAA894 /* RecordingCoordinatorTests.swift */; };
 		61054FAA2A6EE1BA00AAA894 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F5D2A6EE1BA00AAA894 /* UIKitExtensionsTests.swift */; };
@@ -189,7 +189,7 @@
 		61054FC52A6EE1BA00AAA894 /* UIKitMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F7E2A6EE1BA00AAA894 /* UIKitMocks.swift */; };
 		61054FC62A6EE1BA00AAA894 /* CoreGraphicsMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F7F2A6EE1BA00AAA894 /* CoreGraphicsMocks.swift */; };
 		61054FC72A6EE1BA00AAA894 /* SRDataModelsMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F802A6EE1BA00AAA894 /* SRDataModelsMocks.swift */; };
-		61054FC82A6EE1BA00AAA894 /* ProcessorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F812A6EE1BA00AAA894 /* ProcessorSpy.swift */; };
+		61054FC82A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F812A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift */; };
 		61054FC92A6EE1BA00AAA894 /* RecorderMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F822A6EE1BA00AAA894 /* RecorderMocks.swift */; };
 		61054FCA2A6EE1BA00AAA894 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F832A6EE1BA00AAA894 /* TestScheduler.swift */; };
 		61054FCB2A6EE1BA00AAA894 /* QueueMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F842A6EE1BA00AAA894 /* QueueMocks.swift */; };
@@ -521,6 +521,8 @@
 		A7B932FE2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932FA2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift */; };
 		A7C816AB2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
 		A7C816AC2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
+		A7D9528A2B28BD94004C79B1 /* ResourceProcessorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D952892B28BD94004C79B1 /* ResourceProcessorSpy.swift */; };
+		A7D9528C2B28C18D004C79B1 /* ResourceProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D9528B2B28C18D004C79B1 /* ResourceProcessorTests.swift */; };
 		A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
 		A7DA18052AB0C91300F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
 		A7DA18072AB0CA5E00F76337 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
@@ -1987,7 +1989,7 @@
 		61054F522A6EE1BA00AAA894 /* Diff+SRWireframesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Diff+SRWireframesTests.swift"; sourceTree = "<group>"; };
 		61054F532A6EE1BA00AAA894 /* DiffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiffTests.swift; sourceTree = "<group>"; };
 		61054F552A6EE1BA00AAA894 /* RecordsBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordsBuilderTests.swift; sourceTree = "<group>"; };
-		61054F562A6EE1BA00AAA894 /* ProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessorTests.swift; sourceTree = "<group>"; };
+		61054F562A6EE1BA00AAA894 /* SnapshotProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotProcessorTests.swift; sourceTree = "<group>"; };
 		61054F582A6EE1BA00AAA894 /* NodesFlattenerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodesFlattenerTests.swift; sourceTree = "<group>"; };
 		61054F5A2A6EE1BA00AAA894 /* RecordingCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingCoordinatorTests.swift; sourceTree = "<group>"; };
 		61054F5D2A6EE1BA00AAA894 /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2020,7 +2022,7 @@
 		61054F7E2A6EE1BA00AAA894 /* UIKitMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitMocks.swift; sourceTree = "<group>"; };
 		61054F7F2A6EE1BA00AAA894 /* CoreGraphicsMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreGraphicsMocks.swift; sourceTree = "<group>"; };
 		61054F802A6EE1BA00AAA894 /* SRDataModelsMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRDataModelsMocks.swift; sourceTree = "<group>"; };
-		61054F812A6EE1BA00AAA894 /* ProcessorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessorSpy.swift; sourceTree = "<group>"; };
+		61054F812A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotProcessorSpy.swift; sourceTree = "<group>"; };
 		61054F822A6EE1BA00AAA894 /* RecorderMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecorderMocks.swift; sourceTree = "<group>"; };
 		61054F832A6EE1BA00AAA894 /* TestScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestScheduler.swift; sourceTree = "<group>"; };
 		61054F842A6EE1BA00AAA894 /* QueueMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueMocks.swift; sourceTree = "<group>"; };
@@ -2447,6 +2449,8 @@
 		A7B932F92B1F6A0A00AE6477 /* EnrichedResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrichedResource.swift; sourceTree = "<group>"; };
 		A7B932FA2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SRDataModels+UIKit.swift"; sourceTree = "<group>"; };
 		A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBackgroundTaskCoordinatorTests.swift; sourceTree = "<group>"; };
+		A7D952892B28BD94004C79B1 /* ResourceProcessorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceProcessorSpy.swift; sourceTree = "<group>"; };
+		A7D9528B2B28C18D004C79B1 /* ResourceProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceProcessorTests.swift; sourceTree = "<group>"; };
 		A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
 		A7EA88552B17639A00FE2580 /* ResourcesWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesWriter.swift; sourceTree = "<group>"; };
@@ -3421,7 +3425,8 @@
 				61054F4F2A6EE1BA00AAA894 /* Privacy */,
 				61054F512A6EE1BA00AAA894 /* Diffing */,
 				61054F542A6EE1BA00AAA894 /* SRDataModelsBuilder */,
-				61054F562A6EE1BA00AAA894 /* ProcessorTests.swift */,
+				61054F562A6EE1BA00AAA894 /* SnapshotProcessorTests.swift */,
+				A7D9528B2B28C18D004C79B1 /* ResourceProcessorTests.swift */,
 				61054F572A6EE1BA00AAA894 /* Flattening */,
 			);
 			path = Processor;
@@ -3549,7 +3554,7 @@
 				61054F7E2A6EE1BA00AAA894 /* UIKitMocks.swift */,
 				61054F7F2A6EE1BA00AAA894 /* CoreGraphicsMocks.swift */,
 				61054F802A6EE1BA00AAA894 /* SRDataModelsMocks.swift */,
-				61054F812A6EE1BA00AAA894 /* ProcessorSpy.swift */,
+				61054F812A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift */,
 				61054F822A6EE1BA00AAA894 /* RecorderMocks.swift */,
 				61054F832A6EE1BA00AAA894 /* TestScheduler.swift */,
 				61054F842A6EE1BA00AAA894 /* QueueMocks.swift */,
@@ -3559,6 +3564,7 @@
 				A74A72862B10CE4100771FEB /* ResourceMocks.swift */,
 				A74A72882B10D95D00771FEB /* MultipartBuilderSpy.swift */,
 				A71265852B17980C007D63CE /* MockFeature.swift */,
+				A7D952892B28BD94004C79B1 /* ResourceProcessorSpy.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7758,7 +7764,7 @@
 				61054F952A6EE1BA00AAA894 /* SessionReplayConfigurationTests.swift in Sources */,
 				61054FAC2A6EE1BA00AAA894 /* CGRect+ContentFrameTests.swift in Sources */,
 				61054FC72A6EE1BA00AAA894 /* SRDataModelsMocks.swift in Sources */,
-				61054FC82A6EE1BA00AAA894 /* ProcessorSpy.swift in Sources */,
+				61054FC82A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift in Sources */,
 				A74A72872B10CE4100771FEB /* ResourceMocks.swift in Sources */,
 				61054FA42A6EE1BA00AAA894 /* DiffTests.swift in Sources */,
 				61054FA02A6EE1BA00AAA894 /* SRCompressionTests.swift in Sources */,
@@ -7772,8 +7778,10 @@
 				61054FAF2A6EE1BA00AAA894 /* ViewTreeRecordingContextTests.swift in Sources */,
 				61054FC52A6EE1BA00AAA894 /* UIKitMocks.swift in Sources */,
 				61054FB92A6EE1BA00AAA894 /* UINavigationBarRecorderTests.swift in Sources */,
-				61054FA62A6EE1BA00AAA894 /* ProcessorTests.swift in Sources */,
+				61054FA62A6EE1BA00AAA894 /* SnapshotProcessorTests.swift in Sources */,
 				61054FB72A6EE1BA00AAA894 /* UISegmentRecorderTests.swift in Sources */,
+				A7D9528A2B28BD94004C79B1 /* ResourceProcessorSpy.swift in Sources */,
+				A7D9528C2B28C18D004C79B1 /* ResourceProcessorTests.swift in Sources */,
 				A74A72892B10D95D00771FEB /* MultipartBuilderSpy.swift in Sources */,
 				61054FCF2A6EE1BA00AAA894 /* RUMContextReceiverTests.swift in Sources */,
 				61054FC92A6EE1BA00AAA894 /* RecorderMocks.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		61054E922A6EE10A00AAA894 /* SegmentJSONBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E452A6EE10A00AAA894 /* SegmentJSONBuilder.swift */; };
 		61054E932A6EE10A00AAA894 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E472A6EE10A00AAA894 /* MultipartFormData.swift */; };
 		61054E942A6EE10A00AAA894 /* TextObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4A2A6EE10A00AAA894 /* TextObfuscator.swift */; };
-		61054E952A6EE10A00AAA894 /* Processor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4B2A6EE10A00AAA894 /* Processor.swift */; };
+		61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */; };
 		61054E962A6EE10A00AAA894 /* Diff+SRWireframes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4D2A6EE10A00AAA894 /* Diff+SRWireframes.swift */; };
 		61054E972A6EE10A00AAA894 /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4E2A6EE10A00AAA894 /* Diff.swift */; };
 		61054E982A6EE10A00AAA894 /* RecordsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E502A6EE10A00AAA894 /* RecordsBuilder.swift */; };
@@ -1955,7 +1955,7 @@
 		61054E452A6EE10A00AAA894 /* SegmentJSONBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentJSONBuilder.swift; sourceTree = "<group>"; };
 		61054E472A6EE10A00AAA894 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		61054E4A2A6EE10A00AAA894 /* TextObfuscator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextObfuscator.swift; sourceTree = "<group>"; };
-		61054E4B2A6EE10A00AAA894 /* Processor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Processor.swift; sourceTree = "<group>"; };
+		61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotProcessor.swift; sourceTree = "<group>"; };
 		61054E4D2A6EE10A00AAA894 /* Diff+SRWireframes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Diff+SRWireframes.swift"; sourceTree = "<group>"; };
 		61054E4E2A6EE10A00AAA894 /* Diff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
 		61054E502A6EE10A00AAA894 /* RecordsBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordsBuilder.swift; sourceTree = "<group>"; };
@@ -3317,7 +3317,7 @@
 			isa = PBXGroup;
 			children = (
 				61054E492A6EE10A00AAA894 /* Privacy */,
-				61054E4B2A6EE10A00AAA894 /* Processor.swift */,
+				61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */,
 				61054E4C2A6EE10A00AAA894 /* Diffing */,
 				61054E4F2A6EE10A00AAA894 /* SRDataModelsBuilder */,
 				61054E522A6EE10A00AAA894 /* Flattening */,
@@ -7690,7 +7690,7 @@
 				61054E6E2A6EE10A00AAA894 /* RecordingCoordinator.swift in Sources */,
 				61054E9F2A6EE10B00AAA894 /* Errors.swift in Sources */,
 				61054E642A6EE10A00AAA894 /* SessionReplay.swift in Sources */,
-				61054E952A6EE10A00AAA894 /* Processor.swift in Sources */,
+				61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */,
 				61054E722A6EE10A00AAA894 /* TouchIdentifierGenerator.swift in Sources */,
 				61054E912A6EE10A00AAA894 /* EnrichedRecordJSON.swift in Sources */,
 				61054E742A6EE10A00AAA894 /* ViewTreeSnapshotProducer.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -501,10 +501,6 @@
 		A70A82662A935F210072F5DC /* BackgroundTaskCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70A82642A935F210072F5DC /* BackgroundTaskCoordinator.swift */; };
 		A71013D62B178FAD00101E60 /* ResourcesWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71013D52B178FAD00101E60 /* ResourcesWriterTests.swift */; };
 		A71265862B17980C007D63CE /* MockFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71265852B17980C007D63CE /* MockFeature.swift */; };
-		A712658F2B179C94007D63CE /* EnrichedResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712658B2B179C93007D63CE /* EnrichedResource.swift */; };
-		A71265902B179C94007D63CE /* SRDataModels+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712658C2B179C93007D63CE /* SRDataModels+UIKit.swift */; };
-		A71265912B179C94007D63CE /* SRDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712658D2B179C93007D63CE /* SRDataModels.swift */; };
-		A71265922B179C94007D63CE /* EnrichedRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A712658E2B179C93007D63CE /* EnrichedRecord.swift */; };
 		A728ADAB2934EA2100397996 /* W3CHTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A728ADAA2934EA2100397996 /* W3CHTTPHeadersWriter+objc.swift */; };
 		A728ADAC2934EA2100397996 /* W3CHTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A728ADAA2934EA2100397996 /* W3CHTTPHeadersWriter+objc.swift */; };
 		A728ADB02934EB0900397996 /* DDW3CHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A728ADAD2934EB0300397996 /* DDW3CHTTPHeadersWriter+apiTests.m */; };
@@ -518,6 +514,11 @@
 		A79B0F65292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */; };
 		A79B0F66292BD7CA008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
 		A79B0F67292BD7CC008742B3 /* B3HTTPHeadersWriter+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */; };
+		A7B932F52B1F694000AE6477 /* ResourcesProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932F42B1F694000AE6477 /* ResourcesProcessor.swift */; };
+		A7B932FB2B1F6A0A00AE6477 /* EnrichedRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932F72B1F6A0A00AE6477 /* EnrichedRecord.swift */; };
+		A7B932FC2B1F6A0A00AE6477 /* SRDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932F82B1F6A0A00AE6477 /* SRDataModels.swift */; };
+		A7B932FD2B1F6A0A00AE6477 /* EnrichedResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932F92B1F6A0A00AE6477 /* EnrichedResource.swift */; };
+		A7B932FE2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B932FA2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift */; };
 		A7C816AB2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
 		A7C816AC2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */; };
 		A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */; };
@@ -2424,10 +2425,6 @@
 		A70A82642A935F210072F5DC /* BackgroundTaskCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskCoordinator.swift; sourceTree = "<group>"; };
 		A71013D52B178FAD00101E60 /* ResourcesWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesWriterTests.swift; sourceTree = "<group>"; };
 		A71265852B17980C007D63CE /* MockFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeature.swift; sourceTree = "<group>"; };
-		A712658B2B179C93007D63CE /* EnrichedResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnrichedResource.swift; path = ../../Models/EnrichedResource.swift; sourceTree = "<group>"; };
-		A712658C2B179C93007D63CE /* SRDataModels+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "SRDataModels+UIKit.swift"; path = "../../Models/SRDataModels+UIKit.swift"; sourceTree = "<group>"; };
-		A712658D2B179C93007D63CE /* SRDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SRDataModels.swift; path = ../../Models/SRDataModels.swift; sourceTree = "<group>"; };
-		A712658E2B179C93007D63CE /* EnrichedRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnrichedRecord.swift; path = ../../Models/EnrichedRecord.swift; sourceTree = "<group>"; };
 		A728AD9C2934CE4400397996 /* W3CHTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CHTTPHeaders.swift; sourceTree = "<group>"; };
 		A728AD9E2934CE5000397996 /* W3CHTTPHeadersWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CHTTPHeadersWriter.swift; sourceTree = "<group>"; };
 		A728ADA02934CE5D00397996 /* W3CHTTPHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = W3CHTTPHeadersReader.swift; sourceTree = "<group>"; };
@@ -2444,6 +2441,11 @@
 		A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "B3HTTPHeadersWriter+objc.swift"; sourceTree = "<group>"; };
 		A79B0F60292BB071008742B3 /* B3HTTPHeadersReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReaderTests.swift; sourceTree = "<group>"; };
 		A79B0F63292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDB3HTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
+		A7B932F42B1F694000AE6477 /* ResourcesProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesProcessor.swift; sourceTree = "<group>"; };
+		A7B932F72B1F6A0A00AE6477 /* EnrichedRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrichedRecord.swift; sourceTree = "<group>"; };
+		A7B932F82B1F6A0A00AE6477 /* SRDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRDataModels.swift; sourceTree = "<group>"; };
+		A7B932F92B1F6A0A00AE6477 /* EnrichedResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrichedResource.swift; sourceTree = "<group>"; };
+		A7B932FA2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SRDataModels+UIKit.swift"; sourceTree = "<group>"; };
 		A7C816AA2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBackgroundTaskCoordinatorTests.swift; sourceTree = "<group>"; };
 		A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDUIKitRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
@@ -3124,7 +3126,7 @@
 				61054E0C2A6EE10A00AAA894 /* SessionReplay.swift */,
 				61054E0B2A6EE10A00AAA894 /* SessionReplayConfiguration.swift */,
 				61054E542A6EE10A00AAA894 /* Utilities */,
-				61054E042A6EE10A00AAA894 /* Models */,
+				A7B932F62B1F6A0A00AE6477 /* Models */,
 				61054E032A6EE10A00AAA894 /* Writers */,
 			);
 			name = DatadogSessionReplay;
@@ -3156,18 +3158,6 @@
 				A7EA88552B17639A00FE2580 /* ResourcesWriter.swift */,
 			);
 			path = Writers;
-			sourceTree = "<group>";
-		};
-		61054E042A6EE10A00AAA894 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				A712658E2B179C93007D63CE /* EnrichedRecord.swift */,
-				A712658B2B179C93007D63CE /* EnrichedResource.swift */,
-				A712658D2B179C93007D63CE /* SRDataModels.swift */,
-				A712658C2B179C93007D63CE /* SRDataModels+UIKit.swift */,
-			);
-			name = Models;
-			path = Writers/Models;
 			sourceTree = "<group>";
 		};
 		61054E0D2A6EE10A00AAA894 /* Recorder */ = {
@@ -3316,8 +3306,9 @@
 		61054E482A6EE10A00AAA894 /* Processor */ = {
 			isa = PBXGroup;
 			children = (
-				61054E492A6EE10A00AAA894 /* Privacy */,
 				61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */,
+				A7B932F42B1F694000AE6477 /* ResourcesProcessor.swift */,
+				61054E492A6EE10A00AAA894 /* Privacy */,
 				61054E4C2A6EE10A00AAA894 /* Diffing */,
 				61054E4F2A6EE10A00AAA894 /* SRDataModelsBuilder */,
 				61054E522A6EE10A00AAA894 /* Flattening */,
@@ -5090,6 +5081,17 @@
 				A728ADA02934CE5D00397996 /* W3CHTTPHeadersReader.swift */,
 			);
 			path = W3C;
+			sourceTree = "<group>";
+		};
+		A7B932F62B1F6A0A00AE6477 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A7B932F72B1F6A0A00AE6477 /* EnrichedRecord.swift */,
+				A7B932F82B1F6A0A00AE6477 /* SRDataModels.swift */,
+				A7B932F92B1F6A0A00AE6477 /* EnrichedResource.swift */,
+				A7B932FA2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		A7F773D929253F5900AC1A62 /* Datadog */ = {
@@ -7644,7 +7646,9 @@
 			files = (
 				61054EA22A6EE10B00AAA894 /* Scheduler.swift in Sources */,
 				A7EA88562B17639A00FE2580 /* ResourcesWriter.swift in Sources */,
+				A7B932FB2B1F6A0A00AE6477 /* EnrichedRecord.swift in Sources */,
 				61054E8D2A6EE10A00AAA894 /* RUMContextReceiver.swift in Sources */,
+				A7B932FD2B1F6A0A00AE6477 /* EnrichedResource.swift in Sources */,
 				61054E922A6EE10A00AAA894 /* SegmentJSONBuilder.swift in Sources */,
 				61054E622A6EE10A00AAA894 /* RecordWriter.swift in Sources */,
 				61054E692A6EE10A00AAA894 /* ImageDataProvider.swift in Sources */,
@@ -7652,7 +7656,6 @@
 				61054E822A6EE10A00AAA894 /* UILabelRecorder.swift in Sources */,
 				A73A54982B16406900E1F7E3 /* ResourcesFeature.swift in Sources */,
 				61054E6C2A6EE10A00AAA894 /* SystemColors.swift in Sources */,
-				A71265902B179C94007D63CE /* SRDataModels+UIKit.swift in Sources */,
 				61054E812A6EE10A00AAA894 /* UIStepperRecorder.swift in Sources */,
 				61054E632A6EE10A00AAA894 /* SessionReplayConfiguration.swift in Sources */,
 				61054E702A6EE10A00AAA894 /* TouchSnapshotProducer.swift in Sources */,
@@ -7676,10 +7679,8 @@
 				61054E9C2A6EE10B00AAA894 /* UIImage+Scaling.swift in Sources */,
 				61054EA12A6EE10B00AAA894 /* MainThreadScheduler.swift in Sources */,
 				61054E7C2A6EE10A00AAA894 /* UINavigationBarRecorder.swift in Sources */,
-				A71265922B179C94007D63CE /* EnrichedRecord.swift in Sources */,
 				61054E772A6EE10A00AAA894 /* ViewTreeRecorder.swift in Sources */,
 				61054E9E2A6EE10B00AAA894 /* Queue.swift in Sources */,
-				A712658F2B179C94007D63CE /* EnrichedResource.swift in Sources */,
 				61054E872A6EE10A00AAA894 /* ViewAttributes+Copy.swift in Sources */,
 				61054E6A2A6EE10A00AAA894 /* UIKitExtensions.swift in Sources */,
 				61054E7D2A6EE10A00AAA894 /* UITextFieldRecorder.swift in Sources */,
@@ -7692,19 +7693,21 @@
 				61054E642A6EE10A00AAA894 /* SessionReplay.swift in Sources */,
 				61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */,
 				61054E722A6EE10A00AAA894 /* TouchIdentifierGenerator.swift in Sources */,
+				A7B932F52B1F694000AE6477 /* ResourcesProcessor.swift in Sources */,
 				61054E912A6EE10A00AAA894 /* EnrichedRecordJSON.swift in Sources */,
 				61054E742A6EE10A00AAA894 /* ViewTreeSnapshotProducer.swift in Sources */,
 				61054E7E2A6EE10A00AAA894 /* NodeRecorder.swift in Sources */,
 				61054E6F2A6EE10A00AAA894 /* UIApplicationSwizzler.swift in Sources */,
 				61054E6D2A6EE10A00AAA894 /* CGRect+ContentFrame.swift in Sources */,
 				61054E942A6EE10A00AAA894 /* TextObfuscator.swift in Sources */,
+				A7B932FE2B1F6A0A00AE6477 /* SRDataModels+UIKit.swift in Sources */,
 				61054E862A6EE10A00AAA894 /* UnsupportedViewRecorder.swift in Sources */,
 				61054E882A6EE10A00AAA894 /* ViewTreeRecordingContext.swift in Sources */,
 				61054E932A6EE10A00AAA894 /* MultipartFormData.swift in Sources */,
 				61054E712A6EE10A00AAA894 /* TouchSnapshot.swift in Sources */,
 				61054E8A2A6EE10A00AAA894 /* WindowViewTreeSnapshotProducer.swift in Sources */,
 				61054E7A2A6EE10A00AAA894 /* UIImageViewRecorder.swift in Sources */,
-				A71265912B179C94007D63CE /* SRDataModels.swift in Sources */,
+				A7B932FC2B1F6A0A00AE6477 /* SRDataModels.swift in Sources */,
 				61054E752A6EE10A00AAA894 /* ViewTreeSnapshot.swift in Sources */,
 				61054EA02A6EE10B00AAA894 /* Colors.swift in Sources */,
 				61054E7F2A6EE10A00AAA894 /* UISliderRecorder.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/RUM/RUMDebuggingTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMDebuggingTests.swift
@@ -24,7 +24,7 @@ class RUMDebuggingTests: XCTestCase {
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "FirstView"),
             context: .mockAny(),
-            recordsWriter: FileWriterMock()
+            writer: FileWriterMock()
         )
 
         let debugging = RUMDebugging()
@@ -47,7 +47,7 @@ class RUMDebuggingTests: XCTestCase {
 
     func testWhenOneRUMViewIsInactive_andSecondIsActive_itDisplaysTwoRUMViewOutlines() throws {
         let context: DatadogContext = .mockAny()
-        let recordsWriter = FileWriterMock()
+        let writer = FileWriterMock()
 
         let expectation = self.expectation(description: "Render RUMDebugging")
 
@@ -58,17 +58,17 @@ class RUMDebuggingTests: XCTestCase {
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "FirstView"),
             context: context,
-            recordsWriter: recordsWriter
+            writer: writer
         )
         _ = applicationScope.process(
             command: RUMStartResourceCommand.mockAny(),
             context: context,
-            recordsWriter: recordsWriter
+            writer: writer
         )
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "SecondView"),
             context: context,
-            recordsWriter: recordsWriter
+            writer: writer
         )
 
         let debugging = RUMDebugging()

--- a/DatadogCore/Tests/Datadog/RUM/RUMDebuggingTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMDebuggingTests.swift
@@ -24,7 +24,7 @@ class RUMDebuggingTests: XCTestCase {
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "FirstView"),
             context: .mockAny(),
-            writer: FileWriterMock()
+            recordsWriter: FileWriterMock()
         )
 
         let debugging = RUMDebugging()
@@ -47,7 +47,7 @@ class RUMDebuggingTests: XCTestCase {
 
     func testWhenOneRUMViewIsInactive_andSecondIsActive_itDisplaysTwoRUMViewOutlines() throws {
         let context: DatadogContext = .mockAny()
-        let writer = FileWriterMock()
+        let recordsWriter = FileWriterMock()
 
         let expectation = self.expectation(description: "Render RUMDebugging")
 
@@ -58,17 +58,17 @@ class RUMDebuggingTests: XCTestCase {
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "FirstView"),
             context: context,
-            writer: writer
+            recordsWriter: recordsWriter
         )
         _ = applicationScope.process(
             command: RUMStartResourceCommand.mockAny(),
             context: context,
-            writer: writer
+            recordsWriter: recordsWriter
         )
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockViewIdentity, name: "SecondView"),
             context: context,
-            writer: writer
+            recordsWriter: recordsWriter
         )
 
         let debugging = RUMDebugging()

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -40,17 +40,26 @@ internal class SnapshotTestCase: XCTestCase {
         let expectation = self.expectation(description: "Wait for wireframes")
 
         // Set up SR recorder:
-        let processor = Processor(
+        let snapshotProcessor = SnapshotProcessor(
             queue: NoQueue(),
-            writer: RecordWriter(core: PassthroughCoreMock()),
+            recordWriter: RecordWriter(core: PassthroughCoreMock()),
             srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
             telemetry: TelemetryMock()
         )
-        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock(), additionalNodeRecorders: [])
+        let resourceProcessor = ResourceProcessor(
+            queue: NoQueue(),
+            resourcesWriter: ResourcesWriter(core: PassthroughCoreMock())
+        )
+        let recorder = try Recorder(
+            snapshotProcessor: snapshotProcessor,
+            resourceProcessor: resourceProcessor,
+            telemetry: TelemetryMock(),
+            additionalNodeRecorders: []
+        )
 
         // Set up wireframes interception :
         var wireframes: [SRWireframe]?
-        processor.interceptWireframes = {
+        snapshotProcessor.interceptWireframes = {
             wireframes = $0
             expectation.fulfill()
         }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -114,6 +114,6 @@ internal class SnapshotTestCase: XCTestCase {
 
 // MARK: - SR Mocks
 
-private struct NoQueue: Queue {
+private class NoQueue: Queue {
     func run(_ block: @escaping () -> Void) { block() }
 }

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -19,7 +19,7 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
     /// Orchestrates the process of capturing next snapshots on the main thread.
     let recordingCoordinator: RecordingCoordinator
     /// Processes each new snapshot on a background thread and transforms it into records.
-    let processor: Processing
+    let processor: SnapshotProcessing
 
     // MARK: - Initialization
 
@@ -27,7 +27,7 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         core: DatadogCoreProtocol,
         configuration: SessionReplay.Configuration
     ) throws {
-        let processor = Processor(
+        let processor = SnapshotProcessor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processor"),
             writer: RecordWriter(core: core),
             srContextPublisher: SRContextPublisher(core: core),

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 
 internal class SessionReplayFeature: DatadogRemoteFeature {
     static let name: String = "session-replay"
-    
+
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -28,13 +28,13 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
     ) throws {
         let snapshotProcessor = SnapshotProcessor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.snapshot-processor"),
-            recordsWriter: RecordWriter(core: core),
+            recordWriter: RecordWriter(core: core),
             srContextPublisher: SRContextPublisher(core: core),
             telemetry: core.telemetry
         )
         let resourceProcessor = ResourceProcessor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.resource-processor"),
-            writer: ResourcesWriter(core: core),
+            resourcesWriter: ResourcesWriter(core: core),
             telemetry: core.telemetry
         )
 

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -26,15 +26,16 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         core: DatadogCoreProtocol,
         configuration: SessionReplay.Configuration
     ) throws {
+        let queue = BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processor")
         let snapshotProcessor = SnapshotProcessor(
-            queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.snapshot-processor"),
+            queue: queue,
             recordWriter: RecordWriter(core: core),
             srContextPublisher: SRContextPublisher(core: core),
             telemetry: core.telemetry
         )
         // RUM-2154 Disabled until prod backend is ready
         _ = ResourceProcessor(
-            queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.resource-processor"),
+            queue: queue,
             resourcesWriter: ResourcesWriter(core: core)
         )
         let recorder = try Recorder(

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -34,20 +34,19 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         )
         let resourceProcessor = ResourceProcessor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.resource-processor"),
-            resourcesWriter: ResourcesWriter(core: core),
-            telemetry: core.telemetry
+            resourcesWriter: ResourcesWriter(core: core)
         )
-
-        let scheduler = MainThreadScheduler(interval: 0.1)
-        let messageReceiver = RUMContextReceiver()
-
         let recorder = try Recorder(
             snapshotProcessor: snapshotProcessor,
             resourceProcessor: resourceProcessor,
             telemetry: core.telemetry,
             additionalNodeRecorders: configuration._additionalNodeRecorders
         )
-        let recordingCoordinator = RecordingCoordinator(
+        let scheduler = MainThreadScheduler(interval: 0.1)
+        let messageReceiver = RUMContextReceiver()
+
+        self.messageReceiver = messageReceiver
+        self.recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
             privacy: configuration.defaultPrivacyLevel,
             rumContextObserver: messageReceiver,
@@ -55,10 +54,6 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
             recorder: recorder,
             sampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.replaySampleRate)
         )
-
-        self.messageReceiver = messageReceiver
-        self.recordingCoordinator = recordingCoordinator
-
         self.requestBuilder = SegmentRequestBuilder(
             customUploadURL: configuration.customEndpoint,
             telemetry: core.telemetry

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -32,13 +32,15 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
             srContextPublisher: SRContextPublisher(core: core),
             telemetry: core.telemetry
         )
-        let resourceProcessor = ResourceProcessor(
+        // RUM-2154 Disabled until prod backend is ready
+        _ = ResourceProcessor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.resource-processor"),
             resourcesWriter: ResourcesWriter(core: core)
         )
         let recorder = try Recorder(
+
             snapshotProcessor: snapshotProcessor,
-            resourceProcessor: resourceProcessor,
+            resourceProcessor: nil,
             telemetry: core.telemetry,
             additionalNodeRecorders: configuration._additionalNodeRecorders
         )

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -38,7 +38,6 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
             resourcesWriter: ResourcesWriter(core: core)
         )
         let recorder = try Recorder(
-
             snapshotProcessor: snapshotProcessor,
             resourceProcessor: nil,
             telemetry: core.telemetry,

--- a/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
+++ b/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Extends the resource information with context.
-internal struct EnrichedResource: Codable, Resource, Equatable {
+internal struct EnrichedResource: Codable, Equatable {
     internal struct Context: Codable, Equatable {
         internal struct Application: Codable, Equatable {
             let id: String
@@ -24,10 +24,6 @@ internal struct EnrichedResource: Codable, Resource, Equatable {
     internal var identifier: String
     internal var data: Data
     internal var context: Context
-
-    internal init(resource: Resource, context: Context) {
-        self.init(identifier: resource.identifier, data: resource.data, context: context)
-    }
 
     internal init(
         identifier: String,

--- a/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
+++ b/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Extends the resource information with context.
-internal struct EnrichedResource: Hashable, Codable, Resource {
+internal struct EnrichedResource: Codable, Resource, Equatable {
     internal struct Context: Codable, Equatable {
         internal struct Application: Codable, Equatable {
             let id: String
@@ -37,10 +37,6 @@ internal struct EnrichedResource: Hashable, Codable, Resource {
         self.identifier = identifier
         self.data = data
         self.context = context
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
+++ b/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Extends the resource information with context.
-internal struct EnrichedResource: Codable, Resource {
+internal struct EnrichedResource: Hashable, Codable, Resource {
     internal struct Context: Codable, Equatable {
         internal struct Application: Codable, Equatable {
             let id: String
@@ -37,6 +37,10 @@ internal struct EnrichedResource: Codable, Resource {
         self.identifier = identifier
         self.data = data
         self.context = context
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -13,9 +13,7 @@ internal protocol ResourceProcessing {
 }
 
 internal class ResourceProcessor: ResourceProcessing {
-    /// The background queue for executing all logic.
     private let queue: Queue
-    /// Writes records to `DatadogCore`.
     private let resourcesWriter: ResourcesWriting
 
     func process(resources: [Resource], context: EnrichedResource.Context) {

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -17,8 +17,6 @@ internal class ResourceProcessor: ResourceProcessing {
     private let queue: Queue
     /// Writes records to `DatadogCore`.
     private let resourcesWriter: ResourcesWriting
-    /// Sends telemetry through sdk core.
-    private let telemetry: Telemetry
 
     func process(resources: [Resource], context: EnrichedResource.Context) {
         queue.run { [resourcesWriter] in
@@ -26,10 +24,9 @@ internal class ResourceProcessor: ResourceProcessing {
         }
     }
 
-    init(queue: Queue, resourcesWriter: ResourcesWriting, telemetry: Telemetry) {
+    init(queue: Queue, resourcesWriter: ResourcesWriting) {
         self.queue = queue
         self.resourcesWriter = resourcesWriter
-        self.telemetry = telemetry
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -21,7 +21,15 @@ internal class ResourceProcessor: ResourceProcessing {
             return
         }
         queue.run { [resourcesWriter] in
-            resourcesWriter.write(resources: resources.map { EnrichedResource(resource: $0, context: context) })
+            resourcesWriter.write(
+                resources: resources.map {
+                    EnrichedResource(
+                        identifier: $0.calculateIdentifier(),
+                        data: $0.calculateData(),
+                        context: context
+                    )
+                }
+            )
         }
     }
 

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import DatadogInternal
+
+internal protocol ResourceProcessing {
+    func process(resources: [Resource], context: EnrichedResource.Context)
+}
+
+internal class ResourceProcessor: ResourceProcessing {
+    /// The background queue for executing all logic.
+    private let queue: Queue
+    /// Writes records to `DatadogCore`.
+    private let writer: ResourcesWriting
+    /// Sends telemetry through sdk core.
+    private let telemetry: Telemetry
+
+    func process(resources: [Resource], context: EnrichedResource.Context) {
+        queue.run { [writer] in
+            writer.write(resources: Set(resources.map { EnrichedResource(resource: $0, context: context) }))
+        }
+    }
+
+    init(queue: Queue, writer: ResourcesWriting, telemetry: Telemetry) {
+        self.queue = queue
+        self.writer = writer
+        self.telemetry = telemetry
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -16,19 +16,19 @@ internal class ResourceProcessor: ResourceProcessing {
     /// The background queue for executing all logic.
     private let queue: Queue
     /// Writes records to `DatadogCore`.
-    private let writer: ResourcesWriting
+    private let resourcesWriter: ResourcesWriting
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
     func process(resources: [Resource], context: EnrichedResource.Context) {
-        queue.run { [writer] in
-            writer.write(resources: Set(resources.map { EnrichedResource(resource: $0, context: context) }))
+        queue.run { [resourcesWriter] in
+            resourcesWriter.write(resources: Set(resources.map { EnrichedResource(resource: $0, context: context) }))
         }
     }
 
-    init(queue: Queue, writer: ResourcesWriting, telemetry: Telemetry) {
+    init(queue: Queue, resourcesWriter: ResourcesWriting, telemetry: Telemetry) {
         self.queue = queue
-        self.writer = writer
+        self.resourcesWriter = resourcesWriter
         self.telemetry = telemetry
     }
 }

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -17,8 +17,11 @@ internal class ResourceProcessor: ResourceProcessing {
     private let resourcesWriter: ResourcesWriting
 
     func process(resources: [Resource], context: EnrichedResource.Context) {
+        guard !resources.isEmpty else {
+            return
+        }
         queue.run { [resourcesWriter] in
-            resourcesWriter.write(resources: Set(resources.map { EnrichedResource(resource: $0, context: context) }))
+            resourcesWriter.write(resources: resources.map { EnrichedResource(resource: $0, context: context) })
         }
     }
 

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -13,7 +13,7 @@ import DatadogInternal
 /// This is the actual brain of Session Replay. Based on the sequence of snapshots it receives, it computes the sequence
 /// of records that will to be send to SR BE. It implements the logic of reducing snapshots into Full or Incremental
 /// mutation records.
-internal protocol Processing {
+internal protocol SnapshotProcessing {
     /// Accepts next view-tree and touch snapshots.
     /// - Parameter viewTreeSnapshot: the snapshot of a next view tree
     /// - Parameter touchSnapshot: the snapshot of next touch interactions (or `nil` if no interactions happened)
@@ -30,7 +30,7 @@ internal protocol Processing {
 /// - the array of wireframes is attached to SR record (see `RecordsBuidler`);
 /// - succeeding records are enriched with their RUM context and written to `DatadogCore`;
 /// - when `DatadogCore` triggers an upload, batched records are deserialized, grouped into SR segments and then uploaded.
-internal class Processor: Processing {
+internal class SnapshotProcessor: SnapshotProcessing {
     /// Flattens VTS received from `Recorder` by removing invisible nodes.
     private let nodesFlattener = NodesFlattener()
     /// Builds SR wireframes to describe UI elements.

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -41,7 +41,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
     /// The background queue for executing all logic.
     private let queue: Queue
     /// Writes records to `DatadogCore`.
-    private let writer: RecordWriting
+    private let recordsWriter: RecordWriting
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
@@ -62,12 +62,12 @@ internal class SnapshotProcessor: SnapshotProcessing {
 
     init(
         queue: Queue,
-        writer: RecordWriting,
+        recordsWriter: RecordWriting,
         srContextPublisher: SRContextPublisher,
         telemetry: Telemetry
     ) {
         self.queue = queue
-        self.writer = writer
+        self.recordsWriter = recordsWriter
         self.srContextPublisher = srContextPublisher
         self.telemetry = telemetry
         self.recordsBuilder = RecordsBuilder(telemetry: telemetry)
@@ -132,7 +132,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
             let enrichedRecord = EnrichedRecord(context: viewTreeSnapshot.context, records: records)
             trackRecord(key: enrichedRecord.viewID, value: Int64(records.count))
 
-            writer.write(nextRecord: enrichedRecord)
+            recordsWriter.write(nextRecord: enrichedRecord)
         }
 
         // Track state:

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -41,7 +41,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
     /// The background queue for executing all logic.
     private let queue: Queue
     /// Writes records to `DatadogCore`.
-    private let recordsWriter: RecordWriting
+    private let recordWriter: RecordWriting
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
@@ -62,12 +62,12 @@ internal class SnapshotProcessor: SnapshotProcessing {
 
     init(
         queue: Queue,
-        recordsWriter: RecordWriting,
+        recordWriter: RecordWriting,
         srContextPublisher: SRContextPublisher,
         telemetry: Telemetry
     ) {
         self.queue = queue
-        self.recordsWriter = recordsWriter
+        self.recordWriter = recordWriter
         self.srContextPublisher = srContextPublisher
         self.telemetry = telemetry
         self.recordsBuilder = RecordsBuilder(telemetry: telemetry)
@@ -132,7 +132,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
             let enrichedRecord = EnrichedRecord(context: viewTreeSnapshot.context, records: records)
             trackRecord(key: enrichedRecord.viewID, value: Int64(records.count))
 
-            recordsWriter.write(nextRecord: enrichedRecord)
+            recordWriter.write(nextRecord: enrichedRecord)
         }
 
         // Track state:

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -59,12 +59,12 @@ public class Recorder: Recording {
     /// Captures touch snapshot.
     private let touchSnapshotProducer: TouchSnapshotProducer
     /// Turns view tree snapshots into data models that will be uploaded to SR BE.
-    private let snapshotProcessor: Processing
+    private let snapshotProcessor: SnapshotProcessing
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
     convenience init(
-        processor: Processing,
+        processor: SnapshotProcessing,
         telemetry: Telemetry,
         additionalNodeRecorders: [NodeRecorder]
     ) throws {
@@ -90,7 +90,7 @@ public class Recorder: Recording {
         uiApplicationSwizzler: UIApplicationSwizzler,
         viewTreeSnapshotProducer: ViewTreeSnapshotProducer,
         touchSnapshotProducer: TouchSnapshotProducer,
-        snapshotProcessor: Processing,
+        snapshotProcessor: SnapshotProcessing,
         telemetry: Telemetry
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -124,12 +124,10 @@ public class Recorder: Recording {
             let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
             snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
 
-            if !viewTreeSnapshot.resources.isEmpty {
-                resourceProcessor.process(
-                    resources: viewTreeSnapshot.resources,
-                    context: .init(recorderContext.applicationID)
-                )
-            }
+            resourceProcessor.process(
+                resources: viewTreeSnapshot.resources,
+                context: .init(recorderContext.applicationID)
+            )
         } catch let error {
             telemetry.error("[SR] Failed to take snapshot", error: DDError(error: error))
         }

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -61,13 +61,13 @@ public class Recorder: Recording {
     /// Turns view tree snapshots into data models that will be uploaded to SR BE.
     private let snapshotProcessor: SnapshotProcessing
     /// Processes resources on a background thread.
-    private let resourceProcessor: ResourceProcessing
+    private let resourceProcessor: ResourceProcessing? // RUM-2154 Optional until prod backend is ready
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
     convenience init(
         snapshotProcessor: SnapshotProcessing,
-        resourceProcessor: ResourceProcessing,
+        resourceProcessor: ResourceProcessing?,
         telemetry: Telemetry,
         additionalNodeRecorders: [NodeRecorder]
     ) throws {
@@ -95,7 +95,7 @@ public class Recorder: Recording {
         viewTreeSnapshotProducer: ViewTreeSnapshotProducer,
         touchSnapshotProducer: TouchSnapshotProducer,
         snapshotProcessor: SnapshotProcessing,
-        resourceProcessor: ResourceProcessing,
+        resourceProcessor: ResourceProcessing?,
         telemetry: Telemetry
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
@@ -124,7 +124,7 @@ public class Recorder: Recording {
             let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
             snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
 
-            resourceProcessor.process(
+            resourceProcessor?.process(
                 resources: viewTreeSnapshot.resources,
                 context: .init(recorderContext.applicationID)
             )

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -100,18 +100,14 @@ import CryptoKit
 
 private var customHashKey: UInt8 = 11
 fileprivate extension UIImage {
-    private static var associatedObjectQueue = DispatchQueue(label: "com.datadoghq.customHashQueue")
-
     var customHash: String {
-        return UIImage.associatedObjectQueue.sync {
-            if let hash = objc_getAssociatedObject(self, &customHashKey) as? String {
-                return hash
-            }
-
-            let hash = computeHash()
-            objc_setAssociatedObject(self, &customHashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        if let hash = objc_getAssociatedObject(self, &customHashKey) as? String {
             return hash
         }
+
+        let hash = computeHash()
+        objc_setAssociatedObject(self, &customHashKey, hash, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return hash
     }
 
     private func computeHash() -> String {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -7,11 +7,11 @@
 #if os(iOS)
 import UIKit
 
-struct UIImageResource {
-    let image: UIImage
-    let tintColor: UIColor?
+internal struct UIImageResource {
+    internal let image: UIImage
+    internal let tintColor: UIColor?
 
-    init(image: UIImage, tintColor: UIColor?) {
+    internal init(image: UIImage, tintColor: UIColor?) {
         self.image = image
         self.tintColor = tintColor
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -7,7 +7,6 @@
 #if os(iOS)
 import UIKit
 @_spi(Internal)
-
 extension UIImage: Resource {
     public var identifier: String {
         return srIdentifier
@@ -88,12 +87,14 @@ internal struct UIImageViewRecorder: NodeRecorder {
         return SpecificElement(
            subtreeStrategy: .record,
            nodes: [node],
-           resources: [imageView.image].filter { image in
+           resources: [imageView.image]
+            .filter { image in
                defer {
-                   image?.recorded = true
+                   image?.recorded = shouldRecordImage
                }
                return image?.recorded == false && shouldRecordImage
-           }.compactMap { $0 }
+            }
+            .compactMap { $0 }
        )
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -7,8 +7,7 @@
 #if os(iOS)
 import UIKit
 
-@_spi(Internal)
-public struct UIImageResource: Resource {
+struct UIImageResource {
     let image: UIImage
     let tintColor: UIColor?
 
@@ -16,8 +15,10 @@ public struct UIImageResource: Resource {
         self.image = image
         self.tintColor = tintColor
     }
+}
 
-    public var identifier: String {
+extension UIImageResource: Resource {
+    func calculateIdentifier() -> String {
         var identifier = image.srIdentifier
         if let tintColorIdentifier = tintColor?.srIdentifier {
             identifier += tintColorIdentifier
@@ -25,12 +26,12 @@ public struct UIImageResource: Resource {
         return identifier
     }
 
-    public var data: Data {
+    func calculateData() -> Data {
         var image = self.image
         if #available(iOS 13.0, *), let tintColor = tintColor {
             image = image.withTintColor(tintColor)
         }
-        return image.scaledDownToApproximateSize(512.KB)
+        return image.scaledDownToApproximateSize(1.MB) // Intake limit is 10MB - to be adjusted in RUM-2153
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 @_spi(Internal)
 
-extension UIImage: SessionReplayResource {
+extension UIImage: Resource {
     public var identifier: String {
         return srIdentifier
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -71,13 +71,17 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         // in the actual `UIPickerView's` tree their order is opposite (blending is used to make the label
         // pass through the shape). For that reason, we record both kinds of nodes separately and then reorder
         // them in returned semantics:
-        let backgroundNodes = selectionRecorder.recordNodes(for: picker, in: context)
-        let titleNodes = labelsRecorder.recordNodes(for: picker, in: context)
+        let backgroundRecordingResult = selectionRecorder.record(picker, in: context)
+        let titleRecordingResult = labelsRecorder.record(picker, in: context)
 
         guard attributes.hasAnyAppearance else {
             // If the root view of `UIPickerView` defines no other appearance (e.g. no custom `.background`), we can
             // safely ignore it, with only forwarding child nodes to final recording.
-            return SpecificElement(subtreeStrategy: .ignore, nodes: backgroundNodes + titleNodes)
+            return SpecificElement(
+                subtreeStrategy: .ignore,
+                nodes: backgroundRecordingResult.nodes + titleRecordingResult.nodes,
+                resources: backgroundRecordingResult.resources + titleRecordingResult.resources
+            )
         }
 
         // Otherwise, we build dedicated wireframes to describe extra appearance coming from picker's root `UIView`:
@@ -87,7 +91,11 @@ internal struct UIPickerViewRecorder: NodeRecorder {
             backgroundWireframeID: context.ids.nodeID(view: picker, nodeRecorder: self)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
-        return SpecificElement(subtreeStrategy: .ignore, nodes: [node] + backgroundNodes + titleNodes)
+        return SpecificElement(
+            subtreeStrategy: .ignore,
+            nodes: [node] + backgroundRecordingResult.nodes + titleRecordingResult.nodes,
+            resources: backgroundRecordingResult.resources + titleRecordingResult.resources
+        )
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -42,7 +42,8 @@ internal struct UITextFieldRecorder: NodeRecorder {
 
         // For our "approximation", we render text field's text on top of other TF's appearance.
         // Here we record both kind of nodes separately and order them respectively in returned semantics:
-        let appearanceNodes = recordAppearance(in: textField, textFieldAttributes: attributes, using: context)
+        let appearanceRecordingResult = recordAppearance(in: textField, textFieldAttributes: attributes, using: context)
+        let appearanceNodes = appearanceRecordingResult.nodes
         if let textNode = recordText(in: textField, attributes: attributes, using: context) {
             return SpecificElement(subtreeStrategy: .ignore, nodes: appearanceNodes + [textNode])
         } else {
@@ -51,7 +52,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
     }
 
     /// Records `UIView` and `UIImageViewRecorder` nodes that define text field's appearance.
-    private func recordAppearance(in textField: UITextField, textFieldAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> [Node] {
+    private func recordAppearance(in textField: UITextField, textFieldAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> RecordingResult {
         backgroundViewRecorder.semanticsOverride = { _, viewAttributes in
             // We consider view to define text field's appearance if it has the same
             // size as text field:
@@ -60,7 +61,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             return !isBackground ? IgnoredElement(subtreeStrategy: .record) : nil
         }
 
-        return subtreeRecorder.recordNodes(for: textField, in: context)
+        return subtreeRecorder.record(textField, in: context)
     }
 
     /// Creates node that represents TF's text.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -50,7 +50,7 @@ internal class UIViewRecorder: NodeRecorder {
             attributes: attributes
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
-        return AmbiguousElement(nodes: [node])
+        return AmbiguousElement(nodes: [node], resources: [])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -26,7 +26,7 @@ internal struct ViewTreeSnapshot {
     /// An array of nodes recorded for this snapshot - sequenced in DFS order.
     let nodes: [Node]
     /// An array of resource references recorded for this snapshot - sequenced in DFS order.
-    /// May contain references to the same resource if it appears multiple times in the snapshot.
+    /// May contain multiple references to the same resource, if it appears multiple times in the snapshot.
     let resources: [Resource]
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -56,10 +56,10 @@ internal typealias Node = SessionReplayNode
 // An individual resource in `ViewTreeSnapshot`. It is used to describe binary representation of heavy resources such as images.
 @_spi(Internal)
 public protocol SessionReplayResource {
-    /// The unique identifier of the resource.
-    var identifier: String { get }
-    /// The data of the resource.
-    var data: Data { get }
+    /// Calculates the unique identifier of the resource.
+    func calculateIdentifier() -> String
+    /// Calculates the data of the resource.
+    func calculateData() -> Data
 }
 
 /// This alias enables us to have a more unique name exposed through public-internal access level

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -26,7 +26,6 @@ internal struct ViewTreeSnapshot {
     /// An array of nodes recorded for this snapshot - sequenced in DFS order.
     let nodes: [Node]
     /// An array of resource references recorded for this snapshot - sequenced in DFS order.
-    /// May contain multiple references to the same resource, if it appears multiple times in the snapshot.
     let resources: [Resource]
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -57,8 +57,10 @@ internal typealias Node = SessionReplayNode
 @_spi(Internal)
 public protocol SessionReplayResource {
     /// Calculates the unique identifier of the resource.
+    /// This function is not thread safe and needs to be synchronized by the caller.
     func calculateIdentifier() -> String
     /// Calculates the data of the resource.
+    /// This function is not thread safe and needs to be synchronized by the caller.
     func calculateData() -> Data
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -25,6 +25,9 @@ internal struct ViewTreeSnapshot {
     let viewportSize: CGSize
     /// An array of nodes recorded for this snapshot - sequenced in DFS order.
     let nodes: [Node]
+    /// An array of resource references recorded for this snapshot - sequenced in DFS order.
+    /// May contain references to the same resource if it appears multiple times in the snapshot.
+    let resources: [Resource]
 }
 
 /// An individual node in `ViewTreeSnapshot`. A `SessionReplayNode` describes a single view - similar: an array of nodes describes
@@ -169,6 +172,8 @@ public protocol SessionReplayNodeSemantics {
     var subtreeStrategy: SessionReplayNodeSubtreeStrategy { get }
     /// Nodes that share this semantics.
     var nodes: [SessionReplayNode] { get }
+    /// Resources collected while traversing the subtree of this node.
+    var resources: [SessionReplayResource] { get }
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
@@ -205,6 +210,7 @@ internal struct UnknownElement: NodeSemantics {
     static let importance: Int = .min
     let subtreeStrategy: NodeSubtreeStrategy = .record
     let nodes: [Node] = []
+    let resources: [Resource] = []
 
     /// Use `UnknownElement.constant` instead.
     private init () {}
@@ -222,6 +228,7 @@ public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
     public static let importance: Int = 0
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode] = []
+    public let resources: [SessionReplayResource] = []
 
     /// Use `InvisibleElement.constant` instead.
     private init () {
@@ -245,6 +252,7 @@ internal struct IgnoredElement: NodeSemantics {
     static var importance: Int = .max
     let subtreeStrategy: NodeSubtreeStrategy
     let nodes: [Node] = []
+    let resources: [Resource] = []
 }
 
 /// A semantics of an UI element that is of `UIView` type. This semantics mean that the element has visual appearance in SR, but
@@ -255,6 +263,7 @@ internal struct AmbiguousElement: NodeSemantics {
     static let importance: Int = 0
     let subtreeStrategy: NodeSubtreeStrategy = .record
     let nodes: [Node]
+    let resources: [Resource]
 }
 
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
@@ -265,10 +274,16 @@ public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
     public static let importance: Int = .max
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode]
+    public let resources: [SessionReplayResource]
 
-    public init(subtreeStrategy: SessionReplayNodeSubtreeStrategy, nodes: [SessionReplayNode]) {
+    public init(
+        subtreeStrategy: SessionReplayNodeSubtreeStrategy,
+        nodes: [SessionReplayNode],
+        resources: [SessionReplayResource] = []
+    ) {
         self.subtreeStrategy = subtreeStrategy
         self.nodes = nodes
+        self.resources = resources
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -33,11 +33,13 @@ internal struct ViewTreeSnapshotBuilder {
             ids: idsGenerator,
             imageDataProvider: imageDataProvider
         )
+        let recording = viewTreeRecorder.record(rootView, in: context)
         let snapshot = ViewTreeSnapshot(
             date: recorderContext.date.addingTimeInterval(recorderContext.viewServerTimeOffset ?? 0),
             context: recorderContext,
             viewportSize: rootView.bounds.size,
-            nodes: viewTreeRecorder.recordNodes(for: rootView, in: context)
+            nodes: recording.nodes,
+            resources: recording.resources
         )
         return snapshot
     }

--- a/DatadogSessionReplay/Sources/Utilities/Queue.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Queue.swift
@@ -7,11 +7,11 @@
 #if os(iOS)
 import Foundation
 
-internal protocol Queue {
+internal protocol Queue: AnyObject {
     func run(_ block: @escaping () -> Void)
 }
 
-internal struct MainAsyncQueue: Queue {
+internal class MainAsyncQueue: Queue {
     private let queue: DispatchQueue = .main
 
     func run(_ block: @escaping () -> Void) {
@@ -19,7 +19,7 @@ internal struct MainAsyncQueue: Queue {
     }
 }
 
-internal struct BackgroundAsyncQueue: Queue {
+internal class BackgroundAsyncQueue: Queue {
     private let queue: DispatchQueue
 
     init(named queueName: String) {

--- a/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
@@ -42,8 +42,8 @@ internal class RecordWriter: RecordWriting {
             return
         }
 
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: forceNewBatch) { _, writer in
-            writer.write(value: nextRecord)
+        scope.eventWriteContext(bypassConsent: false, forceNewBatch: forceNewBatch) { _, recordsWriter in
+            recordsWriter.write(value: nextRecord)
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
@@ -42,8 +42,8 @@ internal class RecordWriter: RecordWriting {
             return
         }
 
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: forceNewBatch) { _, recordsWriter in
-            recordsWriter.write(value: nextRecord)
+        scope.eventWriteContext(bypassConsent: false, forceNewBatch: forceNewBatch) { _, recordWriter in
+            recordWriter.write(value: nextRecord)
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -31,7 +31,9 @@ internal class ResourcesWriter: ResourcesWriting {
             return
         }
         scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, recordWriter in
-            recordWriter.write(value: resources)
+            resources.forEach {
+                recordWriter.write(value: $0)
+            }
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -9,12 +9,12 @@ import Foundation
 import DatadogInternal
 
 /// A type writing Session Replay records to `DatadogCore`.
-internal protocol ResourceWriting {
+internal protocol ResourcesWriting {
     /// Writes next records to SDK core.
-    func write(resources: [EnrichedResource])
+    func write(resources: Set<EnrichedResource>)
 }
 
-internal class ResourcesWriter: ResourceWriting {
+internal class ResourcesWriter: ResourcesWriting {
     /// An instance of SDK core the SR feature is registered to.
     private weak var core: DatadogCoreProtocol?
 
@@ -26,7 +26,7 @@ internal class ResourcesWriter: ResourceWriting {
 
     // MARK: - Writing
 
-    func write(resources: [EnrichedResource]) {
+    func write(resources: Set<EnrichedResource>) {
         guard let scope = core?.scope(for: ResourcesFeature.name) else {
             return
         }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -30,8 +30,8 @@ internal class ResourcesWriter: ResourcesWriting {
         guard let scope = core?.scope(for: ResourcesFeature.name) else {
             return
         }
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, writer in
-            writer.write(value: resources)
+        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, recordsWriter in
+            recordsWriter.write(value: resources)
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -30,8 +30,8 @@ internal class ResourcesWriter: ResourcesWriting {
         guard let scope = core?.scope(for: ResourcesFeature.name) else {
             return
         }
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, recordsWriter in
-            recordsWriter.write(value: resources)
+        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, recordWriter in
+            recordWriter.write(value: resources)
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -11,7 +11,7 @@ import DatadogInternal
 /// A type writing Session Replay records to `DatadogCore`.
 internal protocol ResourcesWriting {
     /// Writes next records to SDK core.
-    func write(resources: Set<EnrichedResource>)
+    func write(resources: [EnrichedResource])
 }
 
 internal class ResourcesWriter: ResourcesWriting {
@@ -26,7 +26,7 @@ internal class ResourcesWriter: ResourcesWriting {
 
     // MARK: - Writing
 
-    func write(resources: Set<EnrichedResource>) {
+    func write(resources: [EnrichedResource]) {
         guard let scope = core?.scope(for: ResourcesFeature.name) else {
             return
         }

--- a/DatadogSessionReplay/Tests/Mocks/ProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ProcessorSpy.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import DatadogSessionReplay
 
 /// Spies the interaction with `Processing`.
-internal class ProcessorSpy: Processing {
+internal class ProcessorSpy: SnapshotProcessing {
     /// An array of snapshots recorded in `process(viewTreeSnapshot:touchSnapshot:)`
     private(set) var processedSnapshots: [(viewTreeSnapshot: ViewTreeSnapshot, touchSnapshot: TouchSnapshot?)] = []
 

--- a/DatadogSessionReplay/Tests/Mocks/QueueMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/QueueMocks.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import DatadogSessionReplay
 
 /// A queue that executes synchronously on the caller thread.
-internal struct NoQueue: Queue {
+internal class NoQueue: Queue {
     func run(_ block: @escaping () -> Void) {
         block()
     }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -267,11 +267,19 @@ extension Node: AnyMockable, RandomMockable {
 
 struct MockResource: Resource, AnyMockable, RandomMockable {
     var identifier: String
-    let data: Data
+    var data: Data
 
     init(identifier: String, data: Data) {
         self.identifier = identifier
         self.data = data
+    }
+
+    func calculateIdentifier() -> String {
+        return identifier
+    }
+
+    func calculateData() -> Data {
+        return data
     }
 
     static func mockAny() -> MockResource {

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -33,7 +33,7 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
             date: .mockRandom(),
             context: .mockRandom(),
             viewportSize: .mockRandom(),
-            nodes: .mockRandom(count: .random(in: (5..<50))), 
+            nodes: .mockRandom(count: .random(in: (5..<50))),
             resources: .mockRandom(count: .random(in: (5..<50)))
         )
     }
@@ -49,7 +49,7 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
             date: date,
             context: context,
             viewportSize: viewportSize,
-            nodes: nodes, 
+            nodes: nodes,
             resources: resources
         )
     }
@@ -274,11 +274,11 @@ struct MockResource: Resource, AnyMockable, RandomMockable {
         self.data = data
     }
 
-    static func mockAny() -> Self {
-        return .init(identifier: .mockAny(), data: .mockAny())
+    static func mockAny() -> MockResource {
+        return MockResource(identifier: .mockAny(), data: .mockAny())
     }
 
-    static func mockRandom() -> Self {
+    static func mockRandom() -> MockResource {
         return MockResource(identifier: . mockRandom(), data: .mockRandom())
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -274,11 +274,11 @@ struct MockResource: Resource, AnyMockable, RandomMockable {
         self.data = data
     }
 
-    static func mockAny() -> MockResource {
-        return MockResource(identifier: .mockAny(), data: .mockAny())
+    static func mockAny() -> Self {
+        return .init(identifier: .mockAny(), data: .mockAny())
     }
 
-    static func mockRandom() -> MockResource {
+    static func mockRandom() -> Self {
         return MockResource(identifier: . mockRandom(), data: .mockRandom())
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -33,7 +33,8 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
             date: .mockRandom(),
             context: .mockRandom(),
             viewportSize: .mockRandom(),
-            nodes: .mockRandom(count: .random(in: (5..<50)))
+            nodes: .mockRandom(count: .random(in: (5..<50))), 
+            resources: .mockRandom(count: .random(in: (5..<50)))
         )
     }
 
@@ -41,13 +42,15 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
         date: Date = .mockAny(),
         context: Recorder.Context = .mockAny(),
         viewportSize: CGSize = .mockAny(),
-        nodes: [Node] = .mockAny()
+        nodes: [Node] = .mockAny(),
+        resources: [Resource] = .mockAny()
     ) -> ViewTreeSnapshot {
         return ViewTreeSnapshot(
             date: date,
             context: context,
             viewportSize: viewportSize,
-            nodes: nodes
+            nodes: nodes, 
+            resources: resources
         )
     }
 }
@@ -221,7 +224,10 @@ func mockRandomNodeSemantics() -> NodeSemantics {
     let all: [NodeSemantics] = [
         UnknownElement.constant,
         InvisibleElement.constant,
-        AmbiguousElement(nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))),
+        AmbiguousElement(
+            nodes: .mockRandom(count: .mockRandom(min: 1, max: 5)),
+            resources: .mockRandom(count: .mockRandom(min: 1, max: 5))
+        ),
         SpecificElement(subtreeStrategy: .mockRandom(), nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))),
     ]
     return all.randomElement()!
@@ -256,6 +262,34 @@ extension Node: AnyMockable, RandomMockable {
             viewAttributes: .mockRandom(),
             wireframesBuilder: NOPWireframesBuilderMock()
         )
+    }
+}
+
+struct MockResource: Resource, AnyMockable, RandomMockable {
+    var identifier: String
+    let data: Data
+
+    init(identifier: String, data: Data) {
+        self.identifier = identifier
+        self.data = data
+    }
+
+    static func mockAny() -> MockResource {
+        return MockResource(identifier: .mockAny(), data: .mockAny())
+    }
+
+    static func mockRandom() -> MockResource {
+        return MockResource(identifier: . mockRandom(), data: .mockRandom())
+    }
+}
+
+extension Collection where Element == Resource {
+    static func mockAny() -> [Resource] {
+        return [MockResource].mockAny()
+    }
+
+    static func mockRandom(count: Int = 10) -> [Resource] {
+        return [MockResource].mockRandom(count: count)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Mocks/ResourceMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceMocks.swift
@@ -8,7 +8,15 @@ import Foundation
 import TestUtilities
 @testable import DatadogSessionReplay
 
-extension EnrichedResource: RandomMockable {
+extension EnrichedResource: RandomMockable, AnyMockable {
+    public static func mockAny() -> EnrichedResource {
+        return .init(
+            identifier: .mockAny(),
+            data: .mockAny(),
+            context: .mockAny()
+        )
+    }
+
     public static func mockRandom() -> Self {
         return .init(
             identifier: .mockRandom(),
@@ -18,7 +26,13 @@ extension EnrichedResource: RandomMockable {
     }
 }
 
-extension EnrichedResource.Context: RandomMockable {
+extension EnrichedResource.Context: RandomMockable, AnyMockable {
+    public static func mockAny() -> DatadogSessionReplay.EnrichedResource.Context {
+        return .init(
+            .mockAny()
+        )
+    }
+    
     public static func mockRandom() -> Self {
         return .init(
             .mockRandom()

--- a/DatadogSessionReplay/Tests/Mocks/ResourceMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceMocks.swift
@@ -32,7 +32,7 @@ extension EnrichedResource.Context: RandomMockable, AnyMockable {
             .mockAny()
         )
     }
-    
+
     public static func mockRandom() -> Self {
         return .init(
             .mockRandom()

--- a/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
@@ -9,9 +9,9 @@ import Foundation
 
 /// Spies the interaction with `Processing`.
 internal class ResourceProcessorSpy: ResourceProcessing {
-    var processedResources: [([Resource], EnrichedResource.Context)] = []
+    var processedResources: [(resources: [Resource], context: EnrichedResource.Context)] = []
 
     func process(resources: [Resource], context: EnrichedResource.Context) {
-        processedResources.append((resources, context))
+        processedResources.append((resources: resources, context: context))
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
@@ -14,5 +14,4 @@ internal class ResourceProcessorSpy: ResourceProcessing {
     func process(resources: [Resource], context: EnrichedResource.Context) {
         processedResources.append((resources, context))
     }
-
 }

--- a/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+@testable import DatadogSessionReplay
+
+/// Spies the interaction with `Processing`.
+internal class ResourceProcessorSpy: ResourceProcessing {
+    var processedResources: [([Resource], EnrichedResource.Context)] = []
+
+    func process(resources: [Resource], context: EnrichedResource.Context) {
+        processedResources.append((resources, context))
+    }
+
+}

--- a/DatadogSessionReplay/Tests/Mocks/SnapshotProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SnapshotProcessorSpy.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import DatadogSessionReplay
 
 /// Spies the interaction with `Processing`.
-internal class ProcessorSpy: SnapshotProcessing {
+internal class SnapshotProcessorSpy: SnapshotProcessing {
     /// An array of snapshots recorded in `process(viewTreeSnapshot:touchSnapshot:)`
     private(set) var processedSnapshots: [(viewTreeSnapshot: ViewTreeSnapshot, touchSnapshot: TouchSnapshot?)] = []
 

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -29,7 +29,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -61,7 +61,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -108,7 +108,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let view = UIView.mock(withFixture: .visible(.someAppearance))
         view.frame = CGRect(x: 0, y: 0, width: 100, height: 200)
         let rotatedView = UIView.mock(withFixture: .visible(.someAppearance))
@@ -147,7 +147,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -201,7 +201,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
 
         // When
         let touchSnapshot = generateTouchSnapshot(startAt: earliestTouchTime, endAt: snapshotTime, numberOfTouches: numberOfTouches)
@@ -246,7 +246,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -24,8 +24,7 @@ class ResourceProcessorTests: XCTestCase {
         let writer = ResourceWriterMock()
         let processor = ResourceProcessor(
             queue: NoQueue(),
-            resourcesWriter: writer,
-            telemetry: NOPTelemetry()
+            resourcesWriter: writer
         )
 
         let resource1: MockResource = .mockAny()

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+private class ResourceWriterMock: ResourcesWriting {
+    var resources: [Set<EnrichedResource>] = []
+
+    func write(resources: Set<EnrichedResource>) {
+        self.resources.append(resources)
+    }
+}
+
+class ResourceProcessorTests: XCTestCase {
+    func testItWritesResources() {
+        let writer = ResourceWriterMock()
+        let processor = ResourceProcessor(
+            queue: NoQueue(),
+            resourcesWriter: writer,
+            telemetry: NOPTelemetry()
+        )
+
+        let resource1: MockResource = .mockAny()
+        let resource2: MockResource = .mockAny()
+        let context: EnrichedResource.Context = .mockAny()
+
+        processor.process(resources: [resource1, resource2], context: context)
+
+        XCTAssertEqual(writer.resources.count, 1)
+        XCTAssertEqual(
+            writer.resources[0],
+            Set([
+                EnrichedResource(resource: resource1, context: context),
+                EnrichedResource(resource: resource2, context: context)
+            ])
+        )
+    }
+}

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -27,9 +27,9 @@ class ResourceProcessorTests: XCTestCase {
             resourcesWriter: writer
         )
 
-        let resource1: MockResource = .mockAny()
-        let resource2: MockResource = .mockAny()
-        let context: EnrichedResource.Context = .mockAny()
+        let resource1: MockResource = .mockRandom()
+        let resource2: MockResource = .mockRandom()
+        let context: EnrichedResource.Context = .mockRandom()
 
         processor.process(resources: [resource1, resource2], context: context)
 
@@ -39,6 +39,27 @@ class ResourceProcessorTests: XCTestCase {
             Set([
                 EnrichedResource(resource: resource1, context: context),
                 EnrichedResource(resource: resource2, context: context)
+            ])
+        )
+    }
+
+    func testItRemovesDuplicateResources() {
+        let writer = ResourceWriterMock()
+        let processor = ResourceProcessor(
+            queue: NoQueue(),
+            resourcesWriter: writer
+        )
+
+        let resource: MockResource = .mockRandom()
+        let context: EnrichedResource.Context = .mockRandom()
+
+        processor.process(resources: [resource, resource], context: context)
+
+        XCTAssertEqual(writer.resources.count, 1)
+        XCTAssertEqual(
+            writer.resources[0],
+            Set([
+                EnrichedResource(resource: resource, context: context)
             ])
         )
     }

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -12,9 +12,9 @@ import TestUtilities
 @testable import DatadogSessionReplay
 
 private class ResourceWriterMock: ResourcesWriting {
-    var resources: [Set<EnrichedResource>] = []
+    var resources: [[EnrichedResource]] = []
 
-    func write(resources: Set<EnrichedResource>) {
+    func write(resources: [EnrichedResource]) {
         self.resources.append(resources)
     }
 }
@@ -36,31 +36,22 @@ class ResourceProcessorTests: XCTestCase {
         XCTAssertEqual(writer.resources.count, 1)
         XCTAssertEqual(
             writer.resources[0],
-            Set([
+            [
                 EnrichedResource(resource: resource1, context: context),
                 EnrichedResource(resource: resource2, context: context)
-            ])
+            ]
         )
     }
 
-    func testItRemovesDuplicateResources() {
+    func testItDoesNotTryToWriteEmptyResources() {
         let writer = ResourceWriterMock()
         let processor = ResourceProcessor(
             queue: NoQueue(),
             resourcesWriter: writer
         )
 
-        let resource: MockResource = .mockRandom()
-        let context: EnrichedResource.Context = .mockRandom()
+        processor.process(resources: [], context: .mockRandom())
 
-        processor.process(resources: [resource, resource], context: context)
-
-        XCTAssertEqual(writer.resources.count, 1)
-        XCTAssertEqual(
-            writer.resources[0],
-            Set([
-                EnrichedResource(resource: resource, context: context)
-            ])
-        )
+        XCTAssertTrue(writer.resources.isEmpty)
     }
 }

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -37,8 +37,16 @@ class ResourceProcessorTests: XCTestCase {
         XCTAssertEqual(
             writer.resources[0],
             [
-                EnrichedResource(resource: resource1, context: context),
-                EnrichedResource(resource: resource2, context: context)
+                EnrichedResource(
+                    identifier: resource1.calculateIdentifier(),
+                    data: resource1.calculateData(),
+                    context: context
+                ),
+                EnrichedResource(
+                    identifier: resource2.calculateIdentifier(),
+                    data: resource2.calculateData(),
+                    context: context
+                ),
             ]
         )
     }

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -11,14 +11,14 @@ import TestUtilities
 @_spi(Internal)
 @testable import DatadogSessionReplay
 
-private class WriterMock: RecordWriting {
+private class RecordWriterMock: RecordWriting {
     var records: [EnrichedRecord] = []
 
     func write(nextRecord: EnrichedRecord) { records.append(nextRecord) }
 }
 
-class ProcessorTests: XCTestCase {
-    private let writer = WriterMock()
+class SnapshotProcessorTests: XCTestCase {
+    private let recordWriter = RecordWriterMock()
 
     // MARK: - Processing `ViewTreeSnapshots`
 
@@ -29,7 +29,12 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(
+            queue: NoQueue(),
+            recordWriter: recordWriter,
+            srContextPublisher: srContextPublisher,
+            telemetry: TelemetryMock()
+        )
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -37,9 +42,9 @@ class ProcessorTests: XCTestCase {
         processor.process(viewTreeSnapshot: snapshot, touchSnapshot: nil)
 
         // Then
-        XCTAssertEqual(writer.records.count, 1)
+        XCTAssertEqual(recordWriter.records.count, 1)
 
-        let enrichedRecord = try XCTUnwrap(writer.records.first)
+        let enrichedRecord = try XCTUnwrap(recordWriter.records.first)
         XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
         XCTAssertEqual(enrichedRecord.sessionID, rum.sessionID)
         XCTAssertEqual(enrichedRecord.viewID, rum.viewID)
@@ -61,7 +66,12 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(
+            queue: NoQueue(),
+            recordWriter: recordWriter,
+            srContextPublisher: srContextPublisher,
+            telemetry: TelemetryMock()
+        )
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -74,8 +84,8 @@ class ProcessorTests: XCTestCase {
         processor.process(viewTreeSnapshot: snapshot3, touchSnapshot: nil)
 
         // Then
-        let enrichedRecords = writer.records
-        XCTAssertEqual(writer.records.count, 3)
+        let enrichedRecords = recordWriter.records
+        XCTAssertEqual(recordWriter.records.count, 3)
 
         XCTAssertEqual(enrichedRecords[0].records.count, 3, "Segment must start with 'meta' → 'focus' → 'full snapshot' records")
         XCTAssertTrue(enrichedRecords[0].records[0].isMetaRecord)
@@ -108,7 +118,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), recordWriter: recordWriter, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let view = UIView.mock(withFixture: .visible(.someAppearance))
         view.frame = CGRect(x: 0, y: 0, width: 100, height: 200)
         let rotatedView = UIView.mock(withFixture: .visible(.someAppearance))
@@ -122,8 +132,8 @@ class ProcessorTests: XCTestCase {
         processor.process(viewTreeSnapshot: snapshot2, touchSnapshot: nil)
 
         // Then
-        let enrichedRecords = writer.records
-        XCTAssertEqual(writer.records.count, 2)
+        let enrichedRecords = recordWriter.records
+        XCTAssertEqual(recordWriter.records.count, 2)
 
         XCTAssertEqual(enrichedRecords[0].records.count, 3, "Segment must start with 'meta' → 'focus' → 'full snapshot' records")
         XCTAssertTrue(enrichedRecords[0].records[0].isMetaRecord)
@@ -147,7 +157,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), recordWriter: recordWriter, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -162,8 +172,8 @@ class ProcessorTests: XCTestCase {
         processor.process(viewTreeSnapshot: snapshot4, touchSnapshot: nil)
 
         // Then
-        let enrichedRecords = writer.records
-        XCTAssertEqual(writer.records.count, 4)
+        let enrichedRecords = recordWriter.records
+        XCTAssertEqual(recordWriter.records.count, 4)
 
         XCTAssertEqual(enrichedRecords[0].records.count, 3, "Segment must start with 'meta' → 'focus' → 'full snapshot' records")
         XCTAssertTrue(enrichedRecords[0].records[0].isMetaRecord)
@@ -201,16 +211,16 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), recordWriter: recordWriter, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
 
         // When
         let touchSnapshot = generateTouchSnapshot(startAt: earliestTouchTime, endAt: snapshotTime, numberOfTouches: numberOfTouches)
         processor.process(viewTreeSnapshot: .mockWith(date: snapshotTime, context: .mockWith(rumContext: rum)), touchSnapshot: touchSnapshot)
 
         // Then
-        XCTAssertEqual(writer.records.count, 1)
+        XCTAssertEqual(recordWriter.records.count, 1)
 
-        let enrichedRecord = try XCTUnwrap(writer.records.first)
+        let enrichedRecord = try XCTUnwrap(recordWriter.records.first)
         XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
         XCTAssertEqual(enrichedRecord.sessionID, rum.sessionID)
         XCTAssertEqual(enrichedRecord.viewID, rum.viewID)
@@ -246,7 +256,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = SnapshotProcessor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
+        let processor = SnapshotProcessor(queue: NoQueue(), recordWriter: recordWriter, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -257,8 +267,8 @@ class ProcessorTests: XCTestCase {
         processor.process(viewTreeSnapshot: snapshot2, touchSnapshot: nil)
 
         // Then
-        let enrichedRecords = writer.records
-        XCTAssertEqual(writer.records.count, 2)
+        let enrichedRecords = recordWriter.records
+        XCTAssertEqual(recordWriter.records.count, 2)
 
         XCTAssertEqual(enrichedRecords[0].records.count, 3, "Segment must start with 'meta' → 'focus' → 'full snapshot' records")
         XCTAssertTrue(enrichedRecords[0].records[0].isMetaRecord)

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -25,12 +25,16 @@ class RecorderTests: XCTestCase {
             resourceProcessor: resourceProcessor,
             telemetry: TelemetryMock()
         )
+        let recorderContext = Recorder.Context.mockRandom()
+
         // When
-        recorder.captureNextRecord(.mockRandom())
+        recorder.captureNextRecord(recorderContext)
 
         // Then
         DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.viewTreeSnapshot }, mockViewTreeSnapshots)
         DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.touchSnapshot }, mockTouchSnapshots)
+        DDAssertReflectionEqual(resourceProcessor.processedResources.map { $0.resources }, mockViewTreeSnapshots.map { $0.resources })
+        DDAssertReflectionEqual(resourceProcessor.processedResources.map { $0.context }, mockViewTreeSnapshots.map { _ in EnrichedResource.Context(recorderContext.applicationID) })
     }
 
     func testWhenCapturingSnapshots_itUsesDefaultRecorderContext() {

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -13,22 +13,24 @@ class RecorderTests: XCTestCase {
     func testAfterCapturingSnapshot_itIsPassesToProcessor() {
         let mockViewTreeSnapshots: [ViewTreeSnapshot] = .mockRandom(count: 1)
         let mockTouchSnapshots: [TouchSnapshot] = .mockRandom(count: 1)
-        let processor = ProcessorSpy()
+        let snapshotProcessor = SnapshotProcessorSpy()
+        let resourceProcessor = ResourceProcessorSpy()
 
         // Given
         let recorder = Recorder(
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: ViewTreeSnapshotProducerMock(succeedingSnapshots: mockViewTreeSnapshots),
             touchSnapshotProducer: TouchSnapshotProducerMock(succeedingSnapshots: mockTouchSnapshots),
-            snapshotProcessor: processor,
+            snapshotProcessor: snapshotProcessor,
+            resourceProcessor: resourceProcessor,
             telemetry: TelemetryMock()
         )
         // When
         recorder.captureNextRecord(.mockRandom())
 
         // Then
-        DDAssertReflectionEqual(processor.processedSnapshots.map { $0.viewTreeSnapshot }, mockViewTreeSnapshots)
-        DDAssertReflectionEqual(processor.processedSnapshots.map { $0.touchSnapshot }, mockTouchSnapshots)
+        DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.viewTreeSnapshot }, mockViewTreeSnapshots)
+        DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.touchSnapshot }, mockTouchSnapshots)
     }
 
     func testWhenCapturingSnapshots_itUsesDefaultRecorderContext() {
@@ -41,7 +43,8 @@ class RecorderTests: XCTestCase {
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: ProcessorSpy(),
+            snapshotProcessor: SnapshotProcessorSpy(),
+            resourceProcessor: ResourceProcessorSpy(),
             telemetry: TelemetryMock()
         )
         // When
@@ -63,7 +66,8 @@ class RecorderTests: XCTestCase {
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: TouchSnapshotProducerMock(),
-            snapshotProcessor: ProcessorSpy(),
+            snapshotProcessor: SnapshotProcessorSpy(),
+            resourceProcessor: ResourceProcessorSpy(),
             telemetry: telemetry
         )
 
@@ -95,7 +99,8 @@ class RecorderTests: XCTestCase {
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: ProcessorSpy(),
+            snapshotProcessor: SnapshotProcessorSpy(),
+            resourceProcessor: ResourceProcessorSpy(),
             telemetry: TelemetryMock()
         )
         // When

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -64,6 +64,24 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
         let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
         XCTAssertFalse(builder.shouldRecordImage)
+        XCTAssertNil(semantics.resources.first as? UIImage)
+        XCTAssertEqual(imageView.image?.recorded, false)
+    }
+
+    func testWhenShouldRecordImagePredicateReturnsTrue() throws {
+        // When
+        let recorder = UIImageViewRecorder(shouldRecordImagePredicate: { _ in return true })
+        imageView.image = UIImage()
+        viewAttributes = .mock(fixture: .visible())
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
+        XCTAssertTrue(builder.shouldRecordImage)
+        XCTAssertEqual(semantics.resources.first as? UIImage, imageView.image)
+        XCTAssertEqual(imageView.image?.recorded, true)
     }
 
     func testWhenTintColorIsProvided() throws {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -80,7 +80,7 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
         let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
         XCTAssertTrue(builder.shouldRecordImage)
-        XCTAssertEqual(semantics.resources.first as? UIImage, imageView.image)
+        XCTAssertNotNil(semantics.resources.first)
         XCTAssertEqual(imageView.image?.recorded, true)
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -144,7 +144,7 @@ class ViewTreeRecorderTests: XCTestCase {
         XCTAssertEqual(expectedNodes, actualNodes, "Nodes must be recorded in DFS order")
 
         let expectedResources = ["rootResource", "a", "aa", "aav1", "aav2", "aav3", "ab", "aba", "abb", "b", "c"]
-        let actualResources = resources.map { $0.identifier }
+        let actualResources = resources.map { $0.calculateIdentifier() }
         XCTAssertEqual(expectedResources, actualResources, "Resources must be recorded in DFS order")
 
         let expectedQueriedViews: [UIView] = [rootView, a, b, c, aa, ab, aba, abb]

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -181,7 +181,7 @@ class NodeSemanticsTests: XCTestCase {
     func testImportance() {
         let unknownElement = UnknownElement.constant
         let invisibleElement = InvisibleElement.constant
-        let ambiguousElement = AmbiguousElement(nodes: [])
+        let ambiguousElement = AmbiguousElement(nodes: [], resources: [])
         let specificElement = SpecificElement(subtreeStrategy: .mockAny(), nodes: [])
 
         XCTAssertGreaterThan(

--- a/DatadogSessionReplay/Tests/Writer/ResourcesWriterTests.swift
+++ b/DatadogSessionReplay/Tests/Writer/ResourcesWriterTests.swift
@@ -22,7 +22,7 @@ class ResourcesWriterTests: XCTestCase {
         writer.write(resources: [.mockRandom()])
         writer.write(resources: [.mockRandom()])
 
-        XCTAssertEqual(core.events(ofType: [EnrichedResource].self).count, 3)
+        XCTAssertEqual(core.events(ofType: EnrichedResource.self).count, 3)
     }
 
     func testWhenFeatureScopeIsNotConnected_itDoesNotWriteRecordsToCore() throws {


### PR DESCRIPTION
### What and why?

Adds capability of recording image resources when traversing the view tree.

### How?

It modifies the view tree snapshot to provide references to resources along with the nodes. Those references are later used on the background thread by the resource processor and stored into batches.

It's currently disabled in the production code and marked with the `RUM-2154` ticket.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
