### PR TITLE
fix: Fix `view.time_spent` skews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 2.5.1 / 20-12-2023
+
+- [BUGFIX] Fix `view.time_spent` in RUM view events. See [#1596][]
+
 # 2.5.0 / 08-11-2023
 
 - [BUGFIX] Optimize Session Replay diffing algorithm. See [#1524][]
@@ -557,6 +561,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
+[#1596]: https://github.com/DataDog/dd-sdk-ios/pull/1596
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -179,9 +179,12 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             }
             didReceiveStartCommand = true
             needsViewUpdate = true
-        case let command as RUMStartViewCommand where !identity.equals(command.identity):
+        case let command as RUMStartViewCommand where !identity.equals(command.identity) && isActiveView:
+            // This gets effective in case when the user didn't end the view explicitly.
+            // If the view is flagged as "active" but another view is started, we know it needs to be
+            // deactivated. This is achieved by setting `isActiveView` to `false` and sending one more view update.
             isActiveView = false
-            needsViewUpdate = true // sanity update (in case if the user forgets to end this View)
+            needsViewUpdate = true
         case let command as RUMStopViewCommand where identity.equals(command.identity):
             isActiveView = false
             needsViewUpdate = true

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -243,7 +243,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.dd.replayStats?.recordsCount, 1)
     }
 
-    func testWhenInitialViewHasCconfiguredSource_itSendsViewUpdateEventWithConfiguredSource() throws {
+    func testWhenInitialViewHasConfiguredSource_itSendsViewUpdateEventWithConfiguredSource() throws {
         // GIVEN
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let source = String.mockAnySource()
@@ -603,6 +603,8 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     func testGivenViewWithPendingResources_whenItGetsStopped_itDoesNotFinishUntilResourcesComplete() throws {
+        let viewStartTime = Date()
+        var currentTime = viewStartTime
         let scope = RUMViewScope(
             isInitialView: .mockRandom(),
             parent: parent,
@@ -612,37 +614,40 @@ class RUMViewScopeTests: XCTestCase {
             name: .mockAny(),
             attributes: [:],
             customTimings: [:],
-            startTime: Date(),
+            startTime: currentTime,
             serverTimeOffset: .zero
         )
 
         // given
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand.mockWith(identity: mockViewIdentity),
+                command: RUMStartViewCommand.mockWith(time: currentTime, identity: mockViewIdentity),
                 context: context,
                 writer: writer
             )
         )
+        currentTime.addTimeInterval(1)
         XCTAssertTrue(
             scope.process(
-                command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/1"),
+                command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/1", time: currentTime),
                 context: context,
                 writer: writer
             )
         )
+        currentTime.addTimeInterval(1)
         XCTAssertTrue(
             scope.process(
-                command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/2"),
+                command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/2", time: currentTime),
                 context: context,
                 writer: writer
             )
         )
 
         // when
+        currentTime.addTimeInterval(1)
         XCTAssertTrue(
             scope.process(
-                command: RUMStopViewCommand.mockWith(identity: mockViewIdentity),
+                command: RUMStopViewCommand.mockWith(time: currentTime, identity: mockViewIdentity),
                 context: context,
                 writer: writer
             ),
@@ -650,9 +655,10 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         // then
+        currentTime.addTimeInterval(1)
         XCTAssertTrue(
             scope.process(
-                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1"),
+                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1", time: currentTime),
                 context: context,
                 writer: writer
             ),
@@ -662,9 +668,11 @@ class RUMViewScopeTests: XCTestCase {
         var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
         XCTAssertTrue(event.view.isActive ?? false, "View should stay active")
 
+        currentTime.addTimeInterval(1)
+        let lastResourceCompletionTime = currentTime
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/2"),
+                command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/2", time: currentTime),
                 context: context,
                 writer: writer
             ),
@@ -675,6 +683,63 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.view.resource.count, 1, "View should record 1 successful Resource")
         XCTAssertEqual(event.view.error.count, 1, "View should record 1 error due to second Resource failure")
         XCTAssertFalse(event.view.isActive ?? true, "View should be inactive")
+        XCTAssertEqual(event.view.timeSpent, lastResourceCompletionTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds, "View should last until the last resource completes")
+    }
+
+    func testGivenViewWithUnfinishedResources_whenNextViewsAreStarted_itNoLongerUpdatesTimeSpent() throws {
+        let view1StartTime = Date()
+        var currentTime = view1StartTime
+        let view1 = "view1".asRUMViewIdentity()
+
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockAny(),
+            identity: view1,
+            path: .mockAny(),
+            name: .mockAny(),
+            attributes: [:],
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero
+        )
+
+        // given
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(time: currentTime, identity: view1),
+                context: context,
+                writer: writer
+            )
+        )
+        currentTime.addTimeInterval(1)
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand.mockWith(resourceKey: "/dangling/resource", time: currentTime),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // when (start 2 next views)
+        currentTime.addTimeInterval(1)
+        let nextViewStartTime = currentTime
+        var nextViewStartCommand = RUMStartViewCommand.mockWith(time: currentTime, identity: String.mockRandom().asRUMViewIdentity())
+        XCTAssertTrue(
+            scope.process(command: nextViewStartCommand, context: context, writer: writer),
+            "The View should be kept alive as `/dangling/resource` haven't yet finished loading"
+        )
+        currentTime.addTimeInterval(1)
+        nextViewStartCommand = RUMStartViewCommand.mockWith(time: currentTime, identity: String.mockRandom().asRUMViewIdentity())
+        XCTAssertTrue(
+            scope.process(command: nextViewStartCommand, context: context, writer: writer),
+            "The View should be kept alive as `/dangling/resource` haven't yet finished loading"
+        )
+
+        let lastEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastEvent.view.resource.count, 0, "View should record no resources as `/dangling/resource` never finished")
+        XCTAssertEqual(lastEvent.view.isActive, true, "View should remain active because it has pending resource")
+        XCTAssertEqual(lastEvent.view.timeSpent, nextViewStartTime.timeIntervalSince(view1StartTime).toInt64Nanoseconds, "View should last until next view was started")
     }
 
     // MARK: - User Action Tracking


### PR DESCRIPTION
### What and why?

🧰 Fixes the problem of `view.time_spent` increasing infinitely if view scope tracks dangling resources (ones that were started, but never finished). 

### How?

The problem originated in the condition meant to close current view scope if next view is started. This piece of logic was executed for every next view, instead of being limited to the succeeding view only.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
