### PR TITLE
RUM-2442 print RUM info for Synthetics

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -43,6 +43,11 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             activeViewName: nil,
             activeUserActionID: nil
         )
+
+        // Notify Synthetics if needed
+        if dependencies.syntheticsTest != nil {
+            print("_dd.application.id=" + dependencies.rumApplicationID)
+        }
     }
 
     // MARK: - RUMContextProvider

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -121,6 +121,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Update `CrashContext` with recent RUM session state:
         dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+
+        // Notify Synthetics if needed
+        if dependencies.syntheticsTest != nil && self.sessionUUID != .nullUUID {
+            print("_dd.session.id=" + self.sessionUUID.toRUMDataFormat)
+        }
     }
 
     /// Creates a new Session upon expiration of the previous one.

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -124,6 +124,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 frequency: $0.frequency
             )
         }
+
+        // Notify Synthetics if needed
+        if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {
+            print("_dd.view.id=" + self.viewUUID.toRUMDataFormat)
+        }
     }
 
     // MARK: - RUMContextProvider


### PR DESCRIPTION
### What and why?

Print RUM info in case of synthetics run, to let the Synthetics runner create a link to the RUM session
