### PR TITLE
GH-1606 refactor: make non instantiable types as enums

### DIFF
--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -31,7 +31,7 @@ import DatadogInternal
 /// )
 /// ```
 ///     
-public struct Datadog {
+public enum Datadog {
     /// Configuration of Datadog SDK.
     public struct Configuration {
         /// Defines the Datadog SDK policy when batching data together before uploading it to Datadog servers.

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -14,7 +14,7 @@ import DatadogInternal
 /// - Use default and add custom attributes to each log sent.
 /// - Record real client IP addresses and User-Agents.
 /// - Leverage optimized network usage with automatic bulk posts.
-public struct Logs {
+public enum Logs {
     /// The Logs general configuration.
     ///
     /// This configuration will be applied to all Logger instances.

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -8,7 +8,7 @@ import DatadogInternal
 import Foundation
 
 /// An entry point to Datadog RUM feature.
-public struct RUM {
+public enum RUM {
     /// Enables Datadog RUM feature.
     ///
     /// After RUM is enabled, use `RUMMonitor.shared(in:)` to collect RUM events.

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -9,7 +9,7 @@ import Foundation
 import DatadogInternal
 
 /// An entry point to Datadog Session Replay feature.
-public struct SessionReplay {
+public enum SessionReplay {
     /// Enables Datadog Session Replay feature.
     ///
     /// Recording will start automatically after enabling Session Replay.


### PR DESCRIPTION


### What and why?

Swift enums are can't be instantiated and the types which are not meant to be instantiated such as Logs, Trace or Datadog must be enums to make the clear to customers.

### How?

Change some types from struct to enum

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
