### PR TITLE
GH-1607 fix: use currentRequest instead originalRequest for interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [FEATURE] Add `BatchProcessingLevel` configuration allowing to process more batches within single read/upload cycle. See [#1531][]
+- [FIX] Use `currentRequest` instead `originalRequest` for URLSession request interception
 
 # 2.5.1 / 20-12-2023
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -159,18 +159,18 @@ extension NetworkInstrumentationFeature {
     }
 
     private func _intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts?) {
-        guard let currentRequest = task.currentRequest else {
+        guard let request = task.currentRequest ?? task.originalRequest else {
             return
         }
 
         var interceptedRequest: URLRequest
         /// task.setValue is not available on iOS 12, hence for iOS 12 we modify the request by swizzling URLSession methods
         if #available(iOS 13, tvOS 13, *) {
-            let request = self.intercept(request: currentRequest, additionalFirstPartyHosts: additionalFirstPartyHosts)
+            let request = self.intercept(request: request, additionalFirstPartyHosts: additionalFirstPartyHosts)
             interceptedRequest = request
             task.setValue(interceptedRequest, forKey: "currentRequest")
         } else {
-            interceptedRequest = currentRequest
+            interceptedRequest = request
         }
 
         let firstPartyHosts = self.firstPartyHosts(with: additionalFirstPartyHosts)

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -159,18 +159,18 @@ extension NetworkInstrumentationFeature {
     }
 
     private func _intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts?) {
-        guard let originalRequest = task.originalRequest else {
+        guard let currentRequest = task.currentRequest else {
             return
         }
 
         var interceptedRequest: URLRequest
         /// task.setValue is not available on iOS 12, hence for iOS 12 we modify the request by swizzling URLSession methods
         if #available(iOS 13, tvOS 13, *) {
-            let request = self.intercept(request: originalRequest, additionalFirstPartyHosts: additionalFirstPartyHosts)
+            let request = self.intercept(request: currentRequest, additionalFirstPartyHosts: additionalFirstPartyHosts)
             interceptedRequest = request
             task.setValue(interceptedRequest, forKey: "currentRequest")
         } else {
-            interceptedRequest = originalRequest
+            interceptedRequest = currentRequest
         }
 
         let firstPartyHosts = self.firstPartyHosts(with: additionalFirstPartyHosts)


### PR DESCRIPTION
Fixes #1607 

### What and why?

Because we intercept originalRequest which could have already been mutated, we end up using a stale version of the request.

### How?

Use `currentRequest` for interception.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
