### PR TITLE
RUM-1836 feat(otel-tracer): take dependency on opentelemetry-swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.1"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "1.8.0")
     ],
     targets: [
         .target(
@@ -105,6 +106,7 @@ let package = Package(
             name: "DatadogTrace",
             dependencies: [
                 .target(name: "DatadogInternal"),
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift")
             ],
             path: "DatadogTrace/Sources"
         ),


### PR DESCRIPTION
### What and why?

First PR of otel tracer, to start with only SPM support is going to be provided followed by other supported package managers.

### How?

Take a direct dependency on `opentelemetry-swift` and `OpenTelemetryApi` as dependency to Trace product.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
