### PR TITLE
RUM-1836 feat(otel-tracer): update project with opentelemetry-swift dependency

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		3C394EFA2AA5F4C8008F48BA /* URLSessionDataDelegateSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C394EF92AA5F4C8008F48BA /* URLSessionDataDelegateSwizzlerTests.swift */; };
 		3C394EFB2AA5F4C8008F48BA /* URLSessionDataDelegateSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C394EF92AA5F4C8008F48BA /* URLSessionDataDelegateSwizzlerTests.swift */; };
 		3C41693C29FBF4D50042B9D2 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
+		3C6C7FDB2B45738C006F5CBC /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */; };
+		3C6C7FDD2B457392006F5CBC /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */; };
 		3C74305C29FBC0480053B80F /* DatadogInternal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DA2385298D57AA00C6C7E6 /* DatadogInternal.framework */; };
 		3C85D42129F7C5C900AFF894 /* WebViewTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C85D41429F7C59C00AFF894 /* WebViewTracking.swift */; };
 		3C85D42A29F7C70300AFF894 /* TestUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D257953E298ABA65008A1BE5 /* TestUtilities.framework */; };
@@ -2945,6 +2947,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2C1A50E29C4C4EF00946C31 /* DatadogInternal.framework in Frameworks */,
+				3C6C7FDB2B45738C006F5CBC /* OpenTelemetryApi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2988,6 +2991,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2C1A57429C4F30000946C31 /* DatadogInternal.framework in Frameworks */,
+				3C6C7FDD2B457392006F5CBC /* OpenTelemetryApi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6468,6 +6472,9 @@
 				D2C1A51129C4C4EF00946C31 /* PBXTargetDependency */,
 			);
 			name = "DatadogTrace iOS";
+			packageProductDependencies = (
+				3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */,
+			);
 			productName = DatadogTrace;
 			productReference = D25EE93429C4C3C300CE3839 /* DatadogTrace.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6560,6 +6567,9 @@
 				D2C1A57729C4F30000946C31 /* PBXTargetDependency */,
 			);
 			name = "DatadogTrace tvOS";
+			packageProductDependencies = (
+				3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */,
+			);
 			productName = DatadogTrace;
 			productReference = D2C1A55A29C4F2DF00946C31 /* DatadogTrace.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6840,6 +6850,9 @@
 				Base,
 			);
 			mainGroup = 61133B78242393DE00786299;
+			packageReferences = (
+				3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */,
+			);
 			productRefGroup = 61133B83242393DE00786299 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13073,7 +13086,28 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.9.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
+			productName = OpenTelemetryApi;
+		};
+		3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
+			productName = OpenTelemetryApi;
+		};
 		6152C83D24BE1C91006A1679 /* HTTPServerMock */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = HTTPServerMock;

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import DatadogInternal
+import OpenTelemetryApi
 
 /// An entry point to Datadog Trace feature.
 public enum Trace {

--- a/DatadogTrace/Tests/TraceTests.swift
+++ b/DatadogTrace/Tests/TraceTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+import OpenTelemetryApi
 @testable import DatadogInternal
 @testable import DatadogTrace
 


### PR DESCRIPTION
### What and why?

CI uses workspace file to build and test ie changes to `Package.swift` file don't help.

```
Signing libclang_rt.tsan_iossim_dynamic.dylib (in target 'DatadogWebViewTrackingTests iOS' from project 'Datadog')
❌ /Users/vagrant/git/DatadogTrace/Sources/Tracer.swift:9:8: no such module 'OpenTelemetryApi'
```

### How?

Include `opentelemetry-swift` dependency in project file.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
