### PR TITLE
Add font size argument in text Wireframe builder

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -98,6 +98,7 @@ public class SessionReplayWireframesBuilder {
         clip: SRContentClip? = nil,
         textColor: CGColor? = nil,
         font: UIFont? = nil,
+        fontSize: CGFloat? = nil,
         fontScalingEnabled: Bool = false,
         borderColor: CGColor? = nil,
         borderWidth: CGFloat? = nil,
@@ -116,7 +117,7 @@ public class SessionReplayWireframesBuilder {
             )
         )
 
-        var fontSize = Int64(withNoOverflow: font?.pointSize ?? Fallback.fontSize)
+        var fontSize = Int64(withNoOverflow: fontSize ?? font?.pointSize ?? Fallback.fontSize)
         if text.count > 0, fontScalingEnabled {
             // Calculates the approximate font size for available text area √(frameArea / numberOfCharacters)
             let area = textFrame.width * textFrame.height

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -36,6 +36,14 @@ public class SessionReplayWireframesBuilder {
         static let fontSize: CGFloat = 10
     }
 
+    public struct FontOverride {
+        let size: CGFloat?
+
+        public init(size: CGFloat?) {
+            self.size = size
+        }
+    }
+
     public func createShapeWireframe(
         id: WireframeID,
         frame: CGRect,
@@ -98,7 +106,7 @@ public class SessionReplayWireframesBuilder {
         clip: SRContentClip? = nil,
         textColor: CGColor? = nil,
         font: UIFont? = nil,
-        fontSize: CGFloat? = nil,
+        fontOverride: FontOverride? = nil,
         fontScalingEnabled: Bool = false,
         borderColor: CGColor? = nil,
         borderWidth: CGFloat? = nil,
@@ -117,7 +125,7 @@ public class SessionReplayWireframesBuilder {
             )
         )
 
-        var fontSize = Int64(withNoOverflow: fontSize ?? font?.pointSize ?? Fallback.fontSize)
+        var fontSize = Int64(withNoOverflow: fontOverride?.size ?? font?.pointSize ?? Fallback.fontSize)
         if text.count > 0, fontScalingEnabled {
             // Calculates the approximate font size for available text area √(frameArea / numberOfCharacters)
             let area = textFrame.width * textFrame.height


### PR DESCRIPTION
### What and why?

Add font size argument in `createTextWireframe` public builder.

Today passing a `font` argument is the only way to specify a font size for the text wireframe.
With React Native text views we don't get direct access to the `UIFont`. However we get direct access to the fontSize, 
 so we can bypass this by creating a new font on every call, but that takes a lot of time and impacts performance (on an app I tested, it took up to 300ms of time over a minute of usage of the app).

I've tried passing `nil` as font (https://github.com/DataDog/dd-sdk-reactnative/pull/570), but then all elements have a small font size.

I believe enabling to specify only the font size is the best way to get a great fidelity with a small performance cost.

### How?

It seems that there is no test covering this part of the code, let me know if I should add some.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
