### PR TITLE
RUM-1836 feat(otel-tracer): add support for event APIs

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		3CCCA5C82ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */; };
 		3CE11A1129F7BE0900202522 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
+		3CF673372B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
 		3CFD81952ABBB66400977C22 /* MetaTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFD81942ABBB66400977C22 /* MetaTypeExtensionsTests.swift */; };
 		3CFD81962ABBB66400977C22 /* MetaTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFD81942ABBB66400977C22 /* MetaTypeExtensionsTests.swift */; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
@@ -1924,6 +1926,7 @@
 		3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDURLSessionInstrumentationConfigurationTests.swift; sourceTree = "<group>"; };
 		3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogWebViewTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CF673352B4807490016CE17 /* OTelSpanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanTests.swift; sourceTree = "<group>"; };
 		3CFD81942ABBB66400977C22 /* MetaTypeExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaTypeExtensionsTests.swift; sourceTree = "<group>"; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
@@ -4813,6 +4816,7 @@
 		61C5A89724509C1100DA608C /* Tracing */ = {
 			isa = PBXGroup;
 			children = (
+				3CF673352B4807490016CE17 /* OTelSpanTests.swift */,
 				61AD4E3924534075006E34EA /* DatadogTraceFeatureTests.swift */,
 				D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */,
 				D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */,
@@ -7631,6 +7635,7 @@
 				D24C9C6429A7CB7B002057CF /* CrashLogReceiverTests.swift in Sources */,
 				61B5E42126DF85C7000B0A5F /* DDRUMMonitor+apiTests.m in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
+				3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */,
 				D20FD9D32ACC08D1004D3569 /* WebKitMocks.swift in Sources */,
 				618353BC2A69470A0085F84A /* CoreMetricsIntegrationTests.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
@@ -8752,6 +8757,7 @@
 				D2B3F053282E827B00C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */,
 				D20605BA2875729E0047275C /* ContextValuePublisherMock.swift in Sources */,
 				D22743E729DEB953001A7EF9 /* UIApplicationSwizzlerTests.swift in Sources */,
+				3CF673372B4807490016CE17 /* OTelSpanTests.swift in Sources */,
 				D25CFAA029C860E300E3A43D /* TracingFeatureMocks.swift in Sources */,
 				D2CB6F5F27C520D400A62B57 /* DDNSURLSessionDelegate+apiTests.m in Sources */,
 				D224430E29E95D6700274EC7 /* CrashReportReceiverTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
@@ -27,7 +27,7 @@ final class OTelSpanTests: XCTestCase {
             .startSpan()
 
         // When
-        let attributes: [String: OpenTelemetryApi.AttributeValue] = .mock()
+        let attributes: [String: OpenTelemetryApi.AttributeValue] = .leafMock()
         span.addEvent(name: "Otel Span Event", attributes: attributes, timestamp: Date())
 
         // Then

--- a/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+import OpenTelemetryApi
+
+@testable import DatadogLogs
+@testable import DatadogTrace
+
+final class OTelSpanTests: XCTestCase {
+    func testAddEvent() {
+        let core = DatadogCoreProxy()
+        defer { core.flushAndTearDown() }
+
+        Logs.enable(in: core)
+        Trace.enable(in: core)
+
+        // Given
+        let tracer = Tracer.shared(in: core)
+        let span = tracer
+            .spanBuilder(spanName: "OperationName")
+            .startSpan()
+
+        // When
+        let attributes: [String: OpenTelemetryApi.AttributeValue] = .mock()
+        span.addEvent(name: "Otel Span Event", attributes: attributes, timestamp: Date())
+
+        // Then
+        let logs: [LogEvent] = core.waitAndReturnEvents(ofFeature: LogsFeature.name, ofType: LogEvent.self)
+        XCTAssertEqual(logs.count, 1)
+        DDAssertJSONEqual(AnyEncodable(logs[0].attributes.userAttributes), AnyEncodable(attributes))
+    }
+}
+
+extension Dictionary where Key == String, Value == OpenTelemetryApi.AttributeValue {
+    static func mock() -> Self {
+        return [
+            "string": .string("value"),
+            "bool": .bool(true),
+            "int": .int(2),
+            "double": .double(2.0),
+            "stringArray": .stringArray(["value1", "value2"]),
+            "boolArray": .boolArray([true, false]),
+            "intArray": .intArray([1, 2]),
+            "doubleArray": .doubleArray([1.0, 2.0]),
+            "set": .set(.init(labels: .leafMock()))
+        ]
+    }
+
+    static func leafMock() -> Self {
+        return [
+            "string": .string("value"),
+            "bool": .bool(true),
+            "int": .int(2),
+            "double": .double(2.0),
+            "stringArray": .stringArray(["value1", "value2"]),
+            "boolArray": .boolArray([true, false]),
+            "intArray": .intArray([1, 2]),
+            "doubleArray": .doubleArray([1.0, 2.0])
+        ]
+    }
+}

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -108,13 +108,17 @@ internal final class DDSpan: OTSpan {
     }
 
     func log(fields: [String: Encodable], timestamp: Date) {
+        log(message: nil, fields: fields, timestamp: timestamp)
+    }
+
+    func log(message: String?, fields: [String: Encodable], timestamp: Date) {
         queue.async {
             if self.warnIfFinished("log(fields:timestamp:)") {
                 return
             }
             self.unsafeLogFields.append(fields)
         }
-        sendSpanLogs(fields: fields, date: timestamp)
+        sendSpanLogs(message: message, fields: fields, date: timestamp)
     }
 
     func finish(at time: Date) {
@@ -177,8 +181,8 @@ internal final class DDSpan: OTSpan {
         }
     }
 
-    private func sendSpanLogs(fields: [String: Encodable], date: Date) {
-        loggingIntegration.writeLog(withSpanContext: ddContext, fields: fields, date: date, else: {
+    private func sendSpanLogs(message: String?, fields: [String: Encodable], date: Date) {
+        loggingIntegration.writeLog(withSpanContext: ddContext, message: message, fields: fields, date: date, else: {
             self.queue.async { DD.logger.warn("The log for span \"\(self.unsafeOperationName)\" will not be send, because the Logs feature is not enabled.") }
         })
     }

--- a/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
+++ b/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
@@ -60,7 +60,14 @@ internal struct TracingWithLoggingIntegration {
         self.networkInfoEnabled = networkInfoEnabled
     }
 
-    func writeLog(withSpanContext spanContext: DDSpanContext, fields: [String: Encodable], date: Date, else fallback: @escaping () -> Void) {
+    // swiftlint:disable function_default_parameter_at_end
+    func writeLog(
+        withSpanContext spanContext: DDSpanContext,
+        message: String? = nil,
+        fields: [String: Encodable],
+        date: Date,
+        else fallback: @escaping () -> Void
+    ) {
         guard let core = core else {
             return
         }
@@ -69,7 +76,7 @@ internal struct TracingWithLoggingIntegration {
 
         // get the log message and optional error kind
         let errorKind = userAttributes.removeValue(forKey: OTLogFields.errorKind) as? String
-        let message = (userAttributes.removeValue(forKey: OTLogFields.message) as? String) ?? Constants.defaultLogMessage
+        let message = (userAttributes.removeValue(forKey: OTLogFields.message) as? String) ?? message ?? Constants.defaultLogMessage
         let errorStack = userAttributes.removeValue(forKey: OTLogFields.stack) as? String
 
         // infer the log level
@@ -107,4 +114,5 @@ internal struct TracingWithLoggingIntegration {
             else: fallback
         )
     }
+    // swiftlint:enable function_default_parameter_at_end
 }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -97,7 +97,7 @@ internal class OTelSpan: OpenTelemetryApi.Span {
     ///  - name: name of the event
     /// - timestamp: timestamp of the event
     func addEvent(name: String, timestamp: Date) {
-        addEvent(name: name, attributes: .init(), timestamp: .init())
+        addEvent(name: name, attributes: .init(), timestamp: timestamp)
     }
 
     /// Sends a span event which is akin to a log in Datadog

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -94,26 +94,26 @@ internal class OTelSpan: OpenTelemetryApi.Span {
 
     /// Sends a span event which is akin to a log in Datadog
     /// - Parameters:
-    ///  - name: name of the event
-    /// - timestamp: timestamp of the event
+    ///   - name: name of the event
+    ///   - timestamp: timestamp of the event
     func addEvent(name: String, timestamp: Date) {
         addEvent(name: name, attributes: .init(), timestamp: timestamp)
     }
 
     /// Sends a span event which is akin to a log in Datadog
     /// - Parameters:
-    /// - name: name of the event
-    /// - attributes: attributes of the event
-    /// - timestamp: timestamp of the event
+    ///   - name: name of the event
+    ///   - attributes: attributes of the event
+    ///   - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue]) {
         addEvent(name: name, attributes: attributes, timestamp: .init())
     }
 
     /// Sends a span event which is akin to a log in Datadog
     /// - Parameters:
-    /// - name: name of the event
-    /// - attributes: attributes of the event
-    /// - timestamp: timestamp of the event
+    ///   - name: name of the event
+    ///   - attributes: attributes of the event
+    ///   - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
         var ended = false
         queue.sync {

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -86,23 +86,57 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         )
     }
 
-    // swiftlint:disable unavailable_function
+    /// Sends a span event which is akin to a log in Datadog
+    /// - Parameter name: name of the event
     func addEvent(name: String) {
-        fatalError("Not implemented yet")
+        addEvent(name: name, timestamp: .init())
     }
 
+    /// Sends a span event which is akin to a log in Datadog
+    /// - Parameters:
+    ///  - name: name of the event
+    /// - timestamp: timestamp of the event
     func addEvent(name: String, timestamp: Date) {
-        fatalError("Not implemented yet")
+        addEvent(name: name, attributes: .init(), timestamp: .init())
     }
 
+    /// Sends a span event which is akin to a log in Datadog
+    /// - Parameters:
+    /// - name: name of the event
+    /// - attributes: attributes of the event
+    /// - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue]) {
-        fatalError("Not implemented yet")
+        addEvent(name: name, attributes: attributes, timestamp: .init())
     }
 
+    /// Sends a span event which is akin to a log in Datadog
+    /// - Parameters:
+    /// - name: name of the event
+    /// - attributes: attributes of the event
+    /// - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
-        fatalError("Not implemented yet")
+        let semaphore = DispatchSemaphore(value: 0)
+        var ended = false
+        queue.sync {
+            guard isRecording else {
+                ended = true
+                return
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        // if the span was already ended before, we don't want to end it again
+        guard !ended else {
+            return
+        }
+
+        // There is no need to lock here, because `DDSpan` is thread-safe
+
+        // fields needs to be a dictionary of [String: Encodable] which is satisfied by opentelemetry-swift
+        // and Datadog SDK doesn't care about the representation
+        ddSpan.log(message: name, fields: attributes, timestamp: timestamp)
     }
-    // swiftlint:enable unavailable_function
 
     func end() {
         end(time: Date())

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -115,16 +115,13 @@ internal class OTelSpan: OpenTelemetryApi.Span {
     /// - attributes: attributes of the event
     /// - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
-        let semaphore = DispatchSemaphore(value: 0)
         var ended = false
         queue.sync {
             guard isRecording else {
                 ended = true
                 return
             }
-            semaphore.signal()
         }
-        semaphore.wait()
 
         // if the span was already ended before, we don't want to end it again
         guard !ended else {


### PR DESCRIPTION
### What and why?

event API support which is akin to log API in Datadog

### How?

Like other implementations, we leverage the underlying OT log API to send the OTel event.

In OTel world, the name of the event maps to message in Datadog.

Now this 

```swift
        let tracer = Tracer.shared()
        let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
        span.addEvent(name: "foo")
        span.setAttribute(key: resourceKey, value: resourceValue)
        span.addEvent(name: "My event", attributes: ["message": AttributeValue.string("test message"),
                                                     "newKey": AttributeValue.string("New Value")])
        span.end()
```

results in 

![Screenshot 2024-01-05 at 13 55 54](https://github.com/DataDog/dd-sdk-ios/assets/8882380/c248436c-11d0-4809-af38-f40637190c7e)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
