### PR TITLE
Do not start Session Replay when it is sampled out

### DIFF
--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -37,6 +37,9 @@ public enum SessionReplay {
                 description: "Datadog SDK must be initialized before calling `SessionReplay.enable(with:)`."
             )
         }
+        guard configuration.replaySampleRate > 0 else {
+            return
+        }
 
         let sessionReplay = try SessionReplayFeature(core: core, configuration: configuration)
         try core.register(feature: sessionReplay)

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -128,4 +128,16 @@ class SessionReplayTests: XCTestCase {
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
         XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, random)
     }
+
+    func testItDoesntStartFeatureWhenSamplingRateIsZero() throws {
+        // Given
+        config.replaySampleRate = 0
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNil(core.get(feature: SessionReplayFeature.self))
+        XCTAssertNil(core.get(feature: ResourcesFeature.self))
+    }
 }


### PR DESCRIPTION
### What and why?

Customer pointed out that when sample rate for session replay is 0, we still run it's code (including swizzling), but the code remains dormant. It makes sense to provide early return in the enable function, so in cases like using remote config, customer can use the same code and just change the parameter.

### How?

Adds a guard that early returns from the enable function when sampling rate is 0. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
