### PR TITLE
RUM-1836 feat(otel-tracer): add support for status API

### DIFF
--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -203,7 +203,7 @@ internal class OTelSpan: OpenTelemetryApi.Span {
 
             // send error log to Datadog
             // Empty kind or description is equivalent to not present
-            ddSpan.setError(kind: "" , message: description)
+            ddSpan.setError(kind: "", message: description)
         }
 
         // SpanKind maps to the `span.kind` tag in Datadog

--- a/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
@@ -297,7 +297,7 @@ final class OTelSpanTests: XCTestCase {
         XCTAssertEqual(recordedSpan.tags["error.msg"], nil)
     }
 
-    func testStatus_givenStatusError_whenSetStatusCalledWithOkAndUnset() {
+    func testStatus_givenStatusError_whenSetStatusCalledWithUnset() {
         let writeSpanExpectation = expectation(description: "write span event")
         let core = PassthroughCoreMock(expectation: writeSpanExpectation)
 


### PR DESCRIPTION
### What and why?

Status API

### How?

Status API saves of the status of the span indicating whether the span has recorded errors.

This is done by setting error.message tag on the span.

Along with the updating the tags, given dd-sdk-ios sends logs for errors, we replicate the same behavior and record error on the DDSpan which eventually sends a log entry.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
