### PR TITLE
RUM-2149 Propagate Parent Span

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -592,6 +592,8 @@
 		D2160CF829C0EE2B00FAA9A5 /* UploadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2160CF629C0EE2B00FAA9A5 /* UploadMocks.swift */; };
 		D2181A8E2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2181A8D2B051B7900A518C0 /* URLSessionSwizzlerTests.swift */; };
 		D2181A8F2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2181A8D2B051B7900A518C0 /* URLSessionSwizzlerTests.swift */; };
+		D21831552B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */; };
+		D21831562B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */; };
 		D21AE6BC29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */; };
 		D21AE6BD29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */; };
 		D21C26C528A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
@@ -2450,6 +2452,7 @@
 		D2160CF629C0EE2B00FAA9A5 /* UploadMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMocks.swift; sourceTree = "<group>"; };
 		D2181A8A2B0500BB00A518C0 /* NetworkInstrumentationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentationSwizzler.swift; sourceTree = "<group>"; };
 		D2181A8D2B051B7900A518C0 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
+		D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentationIntegrationTests.swift; sourceTree = "<group>"; };
 		D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTests.swift; sourceTree = "<group>"; };
 		D21C26C428A3B49C005DD405 /* FeatureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureStorage.swift; sourceTree = "<group>"; };
 		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
@@ -3580,6 +3583,7 @@
 				6176991D2A8791880030022B /* Datadog+MultipleInstancesIntegrationTests.swift */,
 				610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */,
 				D20FD9D52ACC0934004D3569 /* WebLogIntegrationTests.swift */,
+				D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -7374,6 +7378,7 @@
 				E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */,
 				D224430D29E95D6700274EC7 /* CrashReportReceiverTests.swift in Sources */,
 				D234613228B7713000055D4C /* FeatureContextTests.swift in Sources */,
+				D21831552B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */,
 				61D3E0E4277B3D92008BE766 /* KronosNTPPacketTests.swift in Sources */,
 				61E8C5082B28898800E709B4 /* StartingRUMSessionTests.swift in Sources */,
 				616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */,
@@ -8545,6 +8550,7 @@
 				D2CB6F7327C520D400A62B57 /* CoreTelephonyMocks.swift in Sources */,
 				D20605B7287572640047275C /* DatadogContextProviderMock.swift in Sources */,
 				D2CB6F7527C520D400A62B57 /* UIKitExtensionsTests.swift in Sources */,
+				D21831562B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */,
 				61DA8CB928647A500074A606 /* InternalLoggerTests.swift in Sources */,
 				D2CB6F7C27C520D400A62B57 /* CrashReporterTests.swift in Sources */,
 				D2CB6F7D27C520D400A62B57 /* CrashContextTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogTrace
+@testable import DatadogCore
+
+class NetworkInstrumentationIntegrationTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var core: DatadogCoreProxy!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() {
+        core = DatadogCoreProxy(
+            context: .mockWith(
+                env: "test",
+                version: "1.1.1",
+                serverTimeOffset: 123
+            )
+        )
+
+        var config = Trace.Configuration(
+            urlSessionTracking: Trace.Configuration.URLSessionTracking(
+                firstPartyHostsTracing: .traceWithHeaders(
+                    hostsWithHeaders: ["www.example.com": [.datadog]],
+                    sampleRate: 100
+                )
+            )
+        )
+        config.traceIDGenerator = RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 1)
+
+        Trace.enable(
+            with: config,
+            in: core
+        )
+
+        URLSessionInstrumentation.enable(
+            with: URLSessionInstrumentation.Configuration(delegateClass: MockDelegate.self),
+            in: core
+        )
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+    }
+    
+    func testParentSpanPropagation() throws {
+        // Given
+        let request: URLRequest = .mockWith(url: "https://www.example.com")
+        let span = Tracer.shared(in: core).startRootSpan(operationName: "root")
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let session = server.getInterceptedURLSession(delegate: MockDelegate())
+
+        // When
+        span.setActive() // start root span
+        
+        session
+            .dataTask(with: request) { _,_,_ in
+                span.finish() // finish root span
+            }
+            .resume()
+
+        // Then
+        server.waitFor(requestsCompletion: 1)
+        let matchers = try core.waitAndReturnSpanMatchers()
+
+        let matcher1 = try XCTUnwrap(matchers.first)
+        try XCTAssertEqual(matcher1.operationName(), "root")
+        try XCTAssertEqual(matcher1.traceID(), "1")
+        try XCTAssertEqual(matcher1.spanID(), "2")
+        try XCTAssertEqual(matcher1.metrics.isRootSpan(), 1)
+
+        let matcher2 = try XCTUnwrap(matchers.last)
+        try XCTAssertEqual(matcher2.operationName(), "urlsession.request")
+        try XCTAssertEqual(matcher2.traceID(), "1")
+        try XCTAssertEqual(matcher2.parentSpanID(), "2")
+        try XCTAssertEqual(matcher2.spanID(), "3")
+    }
+
+    class MockDelegate: NSObject, URLSessionDataDelegate {
+    }
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
@@ -19,6 +19,9 @@ public protocol DatadogURLSessionHandler {
     /// - Returns: The modified request.
     func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest
 
+    /// Returns the trace of the current execution context.
+    func traceContext() -> TraceContext?
+
     /// Tells the interceptor that the session did start.
     ///
     /// - Parameter interception: The URLSession interception.
@@ -35,6 +38,8 @@ internal struct NOPDatadogURLSessionInterceptor: DatadogURLSessionHandler {
     var firstPartyHosts: FirstPartyHosts { .init() }
     /// no-op
     func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest { request }
+    /// no-op
+    func traceContext() -> TraceContext? { nil }
     /// no-op
     func interceptionDidStart(interception: URLSessionTaskInterception) { }
     /// no-op

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -151,6 +151,9 @@ extension NetworkInstrumentationFeature {
     ///   - task: The created task.
     ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
     func intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts?) {
+        // Get the current trace context from all handlers.
+        let traceContexts = handlers.compactMap { $0.traceContext() }
+
         queue.async { [weak self] in
             guard let self = self, let request = task.currentRequest else {
                 return
@@ -167,7 +170,19 @@ extension NetworkInstrumentationFeature {
             interception.register(request: request)
 
             if let trace = self.extractTrace(firstPartyHosts: firstPartyHosts, request: request) {
-                interception.register(traceID: trace.traceID, spanID: trace.spanID, parentSpanID: trace.parentSpanID)
+                // The parent span id is extracted from the headers unless
+                // the propagation headers does not support it (only B3 does).
+                // In that case, we register the current trace context as parent
+                // if the trace ID matches.
+                let parentSpanID = trace.parentSpanID ??
+                    traceContexts.first(where: { $0.traceID == trace.traceID })?.spanID
+
+                // Register the trace with parent
+                interception.register(trace: TraceContext(
+                    traceID: trace.traceID,
+                    spanID: trace.spanID,
+                    parentSpanID: parentSpanID
+                ))
             }
 
             if let origin = request.value(forHTTPHeaderField: TracingHTTPHeaders.originField) {

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -22,11 +22,7 @@ public class URLSessionTaskInterception {
     public private(set) var completion: ResourceCompletion?
     /// Trace information propagated with the task. Not available when Tracing is disabled
     /// or when the task was created through `URLSession.dataTask(with:url)` on some iOS13+.
-    public private(set) var trace: (
-        traceID: TraceID,
-        spanID: SpanID,
-        parentSpanID: SpanID?
-    )?
+    public private(set) var trace: TraceContext?
     /// The Datadog origin of the Trace.
     ///
     /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
@@ -61,16 +57,8 @@ public class URLSessionTaskInterception {
         )
     }
 
-    public func register(
-        traceID: TraceID,
-        spanID: SpanID,
-        parentSpanID: SpanID?
-    ) {
-        self.trace = (
-            traceID: traceID,
-            spanID: spanID,
-            parentSpanID: parentSpanID
-        )
+    public func register(trace: TraceContext) {
+        self.trace = trace
     }
 
     public func register(origin: String) {
@@ -80,6 +68,22 @@ public class URLSessionTaskInterception {
     /// Tells if the interception is done (mean: both metrics and completion were collected).
     public var isDone: Bool {
         metrics != nil && completion != nil
+    }
+}
+
+public struct TraceContext {
+    public let traceID: TraceID
+    public let spanID: SpanID
+    public let parentSpanID: SpanID?
+
+    public init(
+        traceID: TraceID,
+        spanID: SpanID,
+        parentSpanID: SpanID? = nil
+    ) {
+        self.traceID = traceID
+        self.spanID = spanID
+        self.parentSpanID = parentSpanID
     }
 }
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -473,9 +473,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = HTTPHeadersWriter(sampler: .mockKeepAll())
         handler.firstPartyHosts = .init(["test.com": [.datadog]])
+        handler.parentSpan = TraceContext(traceID: .mock(1), spanID: .mock(2))
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(2))
+        writer.write(traceID: .mock(1), spanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -486,7 +487,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         let interception = handler.interceptions.first?.value
         XCTAssertEqual(interception?.trace?.traceID, .mock(1))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
 
     func testGivenOpenTelemetry_b3single_whenInterceptingRequests_itInjectsTrace() throws {
@@ -496,7 +498,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.firstPartyHosts = .init(["test.com": [.b3]])
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(2), parentSpanID: .mock(3))
+        writer.write(traceID: .mock(1), spanID: .mock(3), parentSpanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -507,8 +509,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         let interception = handler.interceptions.first?.value
         XCTAssertEqual(interception?.trace?.traceID, .mock(1))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(3))
+        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
 
     func testGivenOpenTelemetry_b3multi_whenInterceptingRequests_itInjectsTrace() throws {
@@ -518,7 +520,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.firstPartyHosts = .init(["test.com": [.b3multi]])
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(2), parentSpanID: .mock(3))
+        writer.write(traceID: .mock(1), spanID: .mock(3), parentSpanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -529,8 +531,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         let interception = handler.interceptions.first?.value
         XCTAssertEqual(interception?.trace?.traceID, .mock(1))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(3))
+        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
 
     func testGivenW3C_whenInterceptingRequests_itInjectsTrace() throws {
@@ -543,9 +545,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             ]
         )
         handler.firstPartyHosts = .init(["test.com": [.tracecontext]])
+        handler.parentSpan = TraceContext(traceID: .mock(1), spanID: .mock(2))
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(2))
+        writer.write(traceID: .mock(1), spanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -556,7 +559,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         let interception = handler.interceptions.first?.value
         XCTAssertEqual(interception?.trace?.traceID, .mock(1))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
+        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
 
     // MARK: - First Party Hosts

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -66,6 +66,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         distributedTracing?.modify(request: request, headerTypes: headerTypes) ?? request
     }
 
+    func traceContext() -> DatadogInternal.TraceContext? {
+        nil // no-op
+    }
+
     func interceptionDidStart(interception: DatadogInternal.URLSessionTaskInterception) {
         let url = interception.request.url?.absoluteString ?? "unknown_url"
         interception.register(origin: "rum")
@@ -179,7 +183,10 @@ extension DistributedTracing {
             )
 
             writer.traceHeaderFields.forEach { field, value in
-                request.setValue(value, forHTTPHeaderField: field)
+                // do not overwrite existing header
+                if request.value(forHTTPHeaderField: field) == nil {
+                    request.setValue(value, forHTTPHeaderField: field)
+                }
             }
         }
 

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -24,7 +24,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         tracer = .mockWith(
             core: core,
-            tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+            tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 1)
         )
 
         handler = TracingURLSessionHandler(
@@ -63,14 +63,56 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "2")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "00000000000000000000000000000001")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000001")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000002")
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000001-1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000001-01")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000002-1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000002-01")
+    }
+
+    func testGivenFirstPartyInterception_withSampledTrace_itDoesNotOverwriteTraceHeaders() throws {
+        // Given
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            tracingSampler: .mockKeepAll(),
+            firstPartyHosts: .init()
+        )
+
+        // When
+        var request: URLRequest = .mockWith(url: "https://www.example.com")
+        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
+        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
+        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField)
+        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField)
+        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField)
+        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField)
+        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField)
+        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
+        request.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
+
+        request = handler.modify(
+            request: request,
+            headerTypes: [
+                .datadog,
+                .b3,
+                .b3multi,
+                .tracecontext
+            ]
+        )
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "custom")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectTraceHeaders() throws {
@@ -101,7 +143,43 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "0")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "0")
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000001-00")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000002-00")
+    }
+
+    func testGivenFirstPartyInterception_withActiveSpan_itInjectParentSpanID() throws {
+        // Given
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            tracingSampler: .mockKeepAll(),
+            firstPartyHosts: .init()
+        )
+
+        let span = tracer.startRootSpan(operationName: "root")
+        span.setActive()
+
+        // When
+        let request = handler.modify(
+            request: .mockWith(url: "https://www.example.com"),
+            headerTypes: [
+                .datadog,
+                .b3,
+                .b3multi,
+                .tracecontext
+            ]
+        )
+
+        span.finish()
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "3")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "00000000000000000000000000000001")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000003")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField), "0000000000000002")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000003-1-0000000000000002")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000003-01")
     }
 
     func testGivenFirstPartyInterceptionWithSpanContext_whenInterceptionCompletes_itUsesInjectedSpanContext() throws {
@@ -121,7 +199,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 )
             )
         )
-        interception.register(traceID: 100, spanID: 200, parentSpanID: nil)
+        interception.register(trace: TraceContext(
+            traceID: 100,
+            spanID: 200,
+            parentSpanID: nil
+        ))
 
         // When
         handler.interceptionDidComplete(interception: interception)
@@ -171,6 +253,70 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
         XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
         XCTAssertEqual(span.tags.count, 5)
+    }
+
+    func testTraceContext_whenInterceptionStarts_withActiveSpan_itReturnCurrentSpan() {
+        // When
+        let span = tracer.startRootSpan(operationName: "root")
+        span.setActive()
+        // Then
+        let context = handler.traceContext()
+        XCTAssertEqual(context?.traceID, TraceID(rawValue: 1))
+        XCTAssertEqual(context?.spanID, SpanID(rawValue: 2))
+
+        // When
+        span.finish()
+        // Then
+        XCTAssertNil(handler.traceContext())
+    }
+
+    func testGivenFirstPartyInterception_whenInterceptionStarts_withActiveSpan_itSendParentSpanID() throws {
+        core.expectation = expectation(description: "Send span")
+        core.expectation?.expectedFulfillmentCount = 2
+
+        // Given
+        let request: URLRequest = .mockWith(httpMethod: "POST")
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
+
+        // When
+        let span = tracer.startRootSpan(operationName: "root")
+        span.setActive()
+        interception.register(trace: TraceContext(
+            traceID: span.context.dd.traceID,
+            spanID: SpanID(rawValue: 3),
+            parentSpanID: span.context.dd.spanID
+        ))
+        handler.interceptionDidStart(interception: interception)
+        // Then
+        XCTAssertEqual(interception.trace?.parentSpanID?.rawValue, 2)
+
+        // When
+        span.finish()
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2)
+                )
+            )
+        )
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let envelopes: [SpanEventsEnvelope] = core.events()
+        let event1 = try XCTUnwrap(envelopes.first?.spans.first)
+        XCTAssertEqual(event1.operationName, "root")
+        XCTAssertEqual(event1.traceID, TraceID(rawValue: 1))
+        XCTAssertEqual(event1.spanID, SpanID(rawValue: 2))
+        XCTAssertNil(event1.parentID)
+        let event2 = try XCTUnwrap(envelopes.last?.spans.first)
+        XCTAssertEqual(event2.operationName, "urlsession.request")
+        XCTAssertEqual(event2.traceID, TraceID(rawValue: 1))
+        XCTAssertEqual(event2.parentID, SpanID(rawValue: 2))
+        XCTAssertEqual(event2.spanID, SpanID(rawValue: 3))
     }
 
     func testGivenFirstPartyIncompleteInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -49,6 +49,7 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     public var firstPartyHosts: FirstPartyHosts
 
     public var modifiedRequest: URLRequest?
+    public var parentSpan: TraceContext?
     public var shouldInterceptRequest: ((URLRequest) -> Bool)?
 
     public var onRequestMutation: ((URLRequest, Set<TracingHeaderType>) -> Void)?
@@ -74,6 +75,10 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     public func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest {
         onRequestMutation?(request, headerTypes)
         return modifiedRequest ?? request
+    }
+
+    public func traceContext() -> TraceContext? {
+        parentSpan
     }
 
     public func interceptionDidStart(interception: URLSessionTaskInterception) {


### PR DESCRIPTION
### What and why?

Proposal on propagating parent span id to distributing tracing.
Additionally, stop overwriting propagation headers.

### How?
`DatadogTrace` now uses the active span as parent context in distributing tracing, if available.

### Note

Parent span propagation only works with APM, not with RUM-to-APM.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
