### PR TITLE
GH1618 Simplify (internal) flushing logic

### DIFF
--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -157,13 +157,11 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 .compactMap { try deleteFileIfItsObsolete(file: $0.file, fileCreationDate: $0.creationDate) }
                 .sorted(by: { $0.creationDate < $1.creationDate })
 
-            #if DD_SDK_COMPILED_FOR_TESTING
             if ignoreFilesAgeWhenReading {
                 return filesFromOldest
                     .prefix(limit)
                     .map { $0.file }
             }
-            #endif
 
             let filtered = filesFromOldest
                 .filter {


### PR DESCRIPTION
### What and why?

🧰 The internal `Datadog.internalFlushAndDeinitialize()` does not work without setting `DD_SDK_COMPILED_FOR_TESTING` compiler flag. To simplify the reasoning about internal "flush", I propose to remove this macro from downstream logic. It will be still used to hide the public API behind this feature, see:

https://github.com/DataDog/dd-sdk-ios/blob/a43c63dd422ffd050ed24a1ac1dfd7b156f063c2/DatadogCore/Sources/Datadog.swift#L485-L489

Solves #1618

### How?

The "flush" logic was protected twice:
- first, the public API was hidden behind `DD_SDK_COMPILED_FOR_TESTING` flag,
- second, part of its implementation was conditionally enabled on `DD_SDK_COMPILED_FOR_TESTING`.

The second occurrence was redundant and it is removed.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
