### PR TITLE
Add core observer for UI level testing

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1454,6 +1454,8 @@
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
 		E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
+		E19D3B362B163277001D02CF /* DatadogCoreObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19D3B352B163277001D02CF /* DatadogCoreObserver.swift */; };
+		E19D3B372B163277001D02CF /* DatadogCoreObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19D3B352B163277001D02CF /* DatadogCoreObserver.swift */; };
 		E1C853142AA9B9A300C74BCF /* TelemetryMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */; };
 		E1C853152AA9B9A300C74BCF /* TelemetryMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */; };
 		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
@@ -2698,6 +2700,7 @@
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
 		E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CITestIntegrationTests.swift; sourceTree = "<group>"; };
 		E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
+		E19D3B352B163277001D02CF /* DatadogCoreObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreObserver.swift; sourceTree = "<group>"; };
 		E1B082CB25641DF9002DB9D2 /* Example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Example.xcconfig; sourceTree = "<group>"; };
 		E1C853132AA9B9A300C74BCF /* TelemetryMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMocks.swift; sourceTree = "<group>"; };
 		E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPool.swift; sourceTree = "<group>"; };
@@ -3764,6 +3767,7 @@
 			isa = PBXGroup;
 			children = (
 				D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */,
+				E19D3B352B163277001D02CF /* DatadogCoreObserver.swift */,
 				D214DAA429E072D7004D0AE8 /* MessageBus.swift */,
 				D2EFA866286DA82700F1FAA6 /* Context */,
 				61133BA62423979B00786299 /* Storage */,
@@ -7421,6 +7425,7 @@
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
 				D29294E0291D5ED100F8EFF9 /* ApplicationVersionPublisher.swift in Sources */,
 				61D3E0D9277B23F1008BE766 /* KronosNTPProtocol.swift in Sources */,
+				E19D3B362B163277001D02CF /* DatadogCoreObserver.swift in Sources */,
 				61D3E0DA277B23F1008BE766 /* KronosTimeFreeze.swift in Sources */,
 				61ED39D426C2A36B002C0F26 /* DataUploadStatus.swift in Sources */,
 				61133BD72423979B00786299 /* DataUploadWorker.swift in Sources */,
@@ -8536,6 +8541,7 @@
 				D26C49C0288982DA00802B2D /* FeatureUpload.swift in Sources */,
 				D2CB6E8127C50EAE00A62B57 /* DataUploader.swift in Sources */,
 				D2CB6E8827C50EAE00A62B57 /* FileReader.swift in Sources */,
+				E19D3B372B163277001D02CF /* DatadogCoreObserver.swift in Sources */,
 				D2CB6E8D27C50EAE00A62B57 /* KronosNTPProtocol.swift in Sources */,
 				D2CB6E9127C50EAE00A62B57 /* KronosTimeFreeze.swift in Sources */,
 				D2FB125E292FBB56005B13F8 /* Datadog+Internal.swift in Sources */,

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -70,6 +70,11 @@ internal final class DatadogCore {
 
     /// Maximum number of batches per upload.
     internal let maxBatchesPerUpload: Int
+    
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Internal scope overrides for internal testing.
+    internal var scopeOverrides: [String: FeatureScope] = [:]
+#endif
 
     /// Creates a core instance.
     ///
@@ -289,6 +294,12 @@ extension DatadogCore: DatadogCoreProtocol {
         guard let storage = stores[feature]?.storage else {
             return nil
         }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+        if let scopeOverride = scopeOverrides[feature] {
+            return scopeOverride
+        }
+#endif
 
         return DatadogCoreFeatureScope(
             contextProvider: contextProvider,

--- a/DatadogCore/Sources/Core/DatadogCoreObserver.swift
+++ b/DatadogCore/Sources/Core/DatadogCoreObserver.swift
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+#if DD_SDK_COMPILED_FOR_TESTING
+/// An observer which intercepts all calls to eventWriteContext. 
+/// It intercepts all events written to the actual core and provides APIs to read their values back for tests.
+/// It must be initialized after all features have been registered in the core.
+///
+/// Usage example:
+///     ```
+///     let core = Datadog.sdkInstance(named: CoreRegistry.defaultInstanceName)
+///     defer { core.flushAndTearDown() }
+///     core.register(feature: LoggingFeature.mockAny())
+///     let observer = DatadogCoreProxy(core: core)
+/// 
+///     let logger = Logger.builder.build(in: core)
+///     logger.debug("message")
+///
+///     let events = observer.waitAndReturnEvents(of: LoggingFeature.self, ofType: LogEvent.self)
+///     XCTAssertEqual(events[0].serviceName, "foo-bar")
+///     ```
+///
+public class DatadogCoreObserver {
+    /// The SDK core managed by this observer.
+    private let core: DatadogCoreProtocol
+
+    private var featureScopeInterceptors: [String: FeatureScopeInterceptor] = [:]
+
+    public init(core: DatadogCoreProtocol) {
+        self.core = core
+
+        register(featureName: "rum")
+        register(featureName: "logging")
+        register(featureName: "tracing")
+        register(featureName: "session-replay")
+    }
+
+    func register(featureName: String) {
+        if let scope = core.scope(for: featureName) {
+            let interceptor = FeatureScopeInterceptor()
+            featureScopeInterceptors[featureName] = interceptor
+            if let ddCore = core as? DatadogCore {
+                ddCore.scopeOverrides[featureName] = FeatureScopeProxy(proxy: scope, interceptor: interceptor)
+            }
+        }
+    }
+
+    /// Returns all events of given type for certain Feature.
+    /// - Parameters:
+    ///   - name: The Feature to retrieve events from
+    ///   - type: The type of events to filter out
+    /// - Returns: A list of events.
+    public func waitAndReturnEvents<T>(ofFeature name: String, ofType type: T.Type) -> [T] where T: Encodable {
+        flush()
+        let interceptor = self.featureScopeInterceptors[name]!
+        return interceptor.waitAndReturnEvents().compactMap { $0.event as? T }
+    }
+
+    /// Returns serialized events of given Feature.
+    ///
+    /// - Parameter feature: The Feature to retrieve events from
+    /// - Returns: A list of serialized events.
+    public func waitAndReturnEventsData(ofFeature name: String) -> [String] {
+        flush()
+        let interceptor = self.featureScopeInterceptors[name]!
+        return interceptor.waitAndReturnEvents().compactMap { $0.data.base64EncodedString() }
+    }
+    
+    /// Clears all events of a given Feature
+    ///
+    /// - Parameter feature: The Feature to delete events from
+    public func waitAndDeleteEvents(ofFeature name: String) -> Void {
+        let interceptor = self.featureScopeInterceptors[name]!
+        interceptor.waitAndDeleteEvents()
+    }
+    
+    func flush() {
+        if let ddCore = core as? DatadogCore {
+            ddCore.flush()
+        }
+    }
+}
+
+private struct FeatureScopeProxy: FeatureScope {
+    func context(_ block: @escaping (DatadogInternal.DatadogContext) -> Void) {
+        // not implemented
+    }
+    
+    let proxy: FeatureScope
+    let interceptor: FeatureScopeInterceptor
+
+    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+        interceptor.enter()
+        proxy.eventWriteContext(bypassConsent: bypassConsent, forceNewBatch: forceNewBatch) { context, writer in
+            block(context, interceptor.intercept(writer: writer))
+            interceptor.leave()
+        }
+    }
+}
+
+private class FeatureScopeInterceptor {
+    struct InterceptingWriter: Writer {
+        static let jsonEncoder = JSONEncoder.dd.default()
+
+        let actualWriter: Writer
+        unowned var interception: FeatureScopeInterceptor?
+
+        func write<T: Encodable, M: Encodable>(value: T, metadata: M) {
+            actualWriter.write(value: value, metadata: metadata)
+
+            let event = value
+            let data = try! InterceptingWriter.jsonEncoder.encode(value)
+            NSLog(data.base64EncodedString())
+            interception?.events.append((event, data))
+        }
+    }
+
+    func intercept(writer: Writer) -> Writer {
+        return InterceptingWriter(actualWriter: writer, interception: self)
+    }
+
+    // MARK: - Synchronizing and awaiting events:
+
+    @ReadWriteLock
+    private var events: [(event: Any, data: Data)] = []
+
+    private let group = DispatchGroup()
+
+    func enter() { group.enter() }
+    func leave() { group.leave() }
+    
+    func waitAndDeleteEvents() -> Void {
+        _ = group.wait(timeout: .distantFuture)
+        events = []
+    }
+
+    func waitAndReturnEvents() -> [(event: Any, data: Data)] {
+        _ = group.wait(timeout: .distantFuture)
+        return events
+    }
+}
+#endif


### PR DESCRIPTION
### What and why?

This is the next evolution from the POC that was done in https://github.com/DataDog/dd-sdk-ios/pull/1570
I've changed the pattern from a Proxy to an observer as it is less intrusive in the core logic.

I've hidden the feature behind the `DD_SDK_COMPILED_FOR_TESTING` compilation condition so it's not available to users.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
