### PR TITLE
RUM-1836 feat(otel-tracer): refactor "how to get otel tracer"

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "microsoft/plcrashreporter" ~> 1.11.1
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/ganeshnj/ci/pod-push/OpenTelemetryApi.json" ~> 1.9.1
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" ~> 1.9.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/ganeshnj/ci/pod-push/OpenTelemetryApi.json" "1.9.1"
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.9.1"
 github "microsoft/plcrashreporter" "1.11.1"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
 		3CF673372B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
+		3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */; };
+		3CFF5D4A2B555F4F00FC483A /* OTelTracerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
 		49274907288048B800ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
 		49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */; };
@@ -1917,6 +1919,7 @@
 		3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogWebViewTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CF673352B4807490016CE17 /* OTelSpanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanTests.swift; sourceTree = "<group>"; };
+		3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelTracerProvider.swift; sourceTree = "<group>"; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
 		49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUM+Internal.swift"; sourceTree = "<group>"; };
@@ -3096,6 +3099,7 @@
 		3C6C7FDE2B459AAA006F5CBC /* OpenTelemetry */ = {
 			isa = PBXGroup;
 			children = (
+				3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */,
 				3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */,
 				3C32359C2B55386C000B4258 /* OTelSpanLink.swift */,
 				3CC6AD172B4F07DC00015B18 /* OTelAttributeValue+Datadog.swift */,
@@ -8246,6 +8250,7 @@
 				D2C1A4FF29C4C4CB00946C31 /* Warnings.swift in Sources */,
 				D2C1A51729C4C53F00946C31 /* OTFormat.swift in Sources */,
 				D22C5BCB2A98A5400024CC1F /* Baggages.swift in Sources */,
+				3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */,
 				D2C1A4FA29C4C4CB00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
@@ -8450,6 +8455,7 @@
 				D2C1A54D29C4F2DF00946C31 /* Warnings.swift in Sources */,
 				D2C1A54E29C4F2DF00946C31 /* OTFormat.swift in Sources */,
 				D22C5BCC2A98A5400024CC1F /* Baggages.swift in Sources */,
+				3CFF5D4A2B555F4F00FC483A /* OTelTracerProvider.swift in Sources */,
 				D2C1A54F29C4F2DF00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A55029C4F2DF00946C31 /* TraceFeature.swift in Sources */,
 				D2C1A55129C4F2DF00946C31 /* TracingURLSessionHandler.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
@@ -21,7 +21,15 @@ final class OTelSpanTests: XCTestCase {
         Trace.enable(in: core)
 
         // Given
-        let tracer = Tracer.shared(in: core)
+        OpenTelemetry.registerTracerProvider(
+            tracerProvider: OTelTracerProvider(in: core)
+        )
+
+        let tracer = OpenTelemetry
+            .instance
+            .tracerProvider
+            .get(instrumentationName: "", instrumentationVersion: nil)
+
         let span = tracer
             .spanBuilder(spanName: "OperationName")
             .startSpan()

--- a/DatadogTrace/Sources/OpenTelemetry/OTelTracerProvider.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelTracerProvider.swift
@@ -1,0 +1,70 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import Foundation
+import DatadogInternal
+import OpenTelemetryApi
+
+/// The Datadog implementation of OpenTelemetry `TracerProvider`.
+/// It takes the Datadog SDK instance as a dependency and returns the tracer from it.
+///
+/// Usage:
+///
+/// ```swift
+/// import OpenTelemetryApi
+/// import DatadogTrace
+///
+/// // Register the tracer provider
+/// OpenTelemetry.registerTracerProvider(
+///     tracerProvider: OTelTracerProvider()
+/// )
+///
+/// // Get the tracer
+/// let tracer = OpenTelemetry
+///     .instance
+///     .tracerProvider
+///     .get(instrumentationName: "", instrumentationVersion: nil)
+///
+/// // Start a span
+/// let span = tracer
+///     .spanBuilder(spanName: "OperationName")
+///     .startSpan()
+/// ```
+public class OTelTracerProvider: OpenTelemetryApi.TracerProvider {
+    private weak var core: DatadogCoreProtocol?
+
+    /// Creates a tracer provider with the given Datadog SDK instance.
+    /// - Parameter core: the instance of Datadog SDK the Trace feature was enabled in (global instance by default)
+    public init(in core: DatadogCoreProtocol = CoreRegistry.default) {
+        self.core = core
+    }
+
+    /// Returns a tracer with the given instrumentation name and version.
+    /// - Parameters:
+    ///   - instrumentationName: the name of the instrumentation library, not the name of the instrumented library
+    ///     Note: This is ignored, as the Datadog SDK works on concept of core.
+    ///   - instrumentationVersion:  The version of the instrumentation library (e.g., "semver:1.0.0"). Optional
+    ///     Note: This is ignored, as the Datadog SDK works on concept of core.
+    public func get(instrumentationName: String, instrumentationVersion: String?) -> OpenTelemetryApi.Tracer {
+        do {
+            guard !(core is NOPDatadogCore) else {
+                throw ProgrammerError(
+                    description: "Datadog SDK must be initialized and RUM feature must be enabled before calling `OTelTracerProvider.get(instrumentationName:instrumentationVersion:)`."
+                )
+            }
+            guard let feature = core?.get(feature: TraceFeature.self) else {
+                throw ProgrammerError(
+                    description: "Trace feature must be enabled before calling `OTelTracerProvider.get(instrumentationName:instrumentationVersion:)`."
+                )
+            }
+
+            return feature.tracer
+        } catch {
+            consolePrint("\(error)", .error)
+            return DDNoopTracer()
+        }
+    }
+}

--- a/DatadogTrace/Sources/OpenTelemetry/OTelTracerProvider.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelTracerProvider.swift
@@ -52,7 +52,7 @@ public class OTelTracerProvider: OpenTelemetryApi.TracerProvider {
         do {
             guard !(core is NOPDatadogCore) else {
                 throw ProgrammerError(
-                    description: "Datadog SDK must be initialized and RUM feature must be enabled before calling `OTelTracerProvider.get(instrumentationName:instrumentationVersion:)`."
+                    description: "Datadog SDK must be initialized and Trace feature must be enabled before calling `OTelTracerProvider.get(instrumentationName:instrumentationVersion:)`."
                 )
             }
             guard let feature = core?.get(feature: TraceFeature.self) else {

--- a/DatadogTrace/Sources/Tracer.swift
+++ b/DatadogTrace/Sources/Tracer.swift
@@ -59,7 +59,7 @@ public class Tracer {
     /// It requires `Trace.enable(with:in:)` to be called first - otherwise it will return no-op implementation.
     /// - Parameter core: the instance of Datadog SDK the Trace feature was enabled in (global instance by default)
     /// - Returns: the Tracer that conforms to Open Tracing API (`OTTracer`)
-    public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> OTTracer & OpenTelemetryApi.Tracer {
+    public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> OTTracer {
         do {
             guard !(core is NOPDatadogCore) else {
                 throw ProgrammerError(


### PR DESCRIPTION
### What and why?

In current setup, `Tracer.shared(in:)` returns instances of both OT and OTel tracers which can be confusing to customers. Specially new customers who don't understand both standards and they will end mix using both OT and OTel APIs which is not a great experience.

### How?

Fallback on the OTel way of doing the things by providing `OTelTracerProvider` which conforms to `OpenTelemetryApi.TracerProvider`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
