### PR TITLE
RUM-2746 feat: Add additional status codes as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] RUM session not being linked to spans. See [#1615][]
 - [FEATURE] Allow stopping a core instance. See [#1541][]
+- [IMPROVEMENT] Add extra HTTP codes to the list of retryable status codes. See [#1639][]
 
 # 2.6.0 / 09-01-2024
 - [FEATURE] Add `currentSessionID(completion:)` accessor to access the current session ID.
@@ -574,6 +575,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1594]: https://github.com/DataDog/dd-sdk-ios/pull/1594
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
 [#1609]: https://github.com/DataDog/dd-sdk-ios/pull/1609
+[#1639]: https://github.com/DataDog/dd-sdk-ios/pull/1639
 [#1615]: https://github.com/DataDog/dd-sdk-ios/pull/1615
 [#1531]: https://github.com/DataDog/dd-sdk-ios/pull/1531
 [#1541]: https://github.com/DataDog/dd-sdk-ios/pull/1541

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadStatusTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadStatusTests.swift
@@ -23,7 +23,10 @@ class DataUploadStatusTests: XCTestCase {
         408, // REQUEST TIMEOUT
         429, // TOO MANY REQUESTS
         500, // INTERNAL SERVER ERROR
+        502, // BAD GATEWAY
         503, // SERVICE UNAVAILABLE
+        504, // GATEWAY TIMEOUT
+        507, // INSUFFICIENT STORAGE
     ]
 
     private lazy var expectedStatusCodes = statusCodesExpectingNoRetry + statusCodesExpectingRetry


### PR DESCRIPTION
### What and why?

📦 This PR adds following HTTP status codes to the list of retryable codes. This is to prevent data loss upon receiving them from Intake:

- 502 - bad gateway
- 504 - gateway timeout
- 507 - insufficient storage

Counterpart of: https://github.com/DataDog/dd-sdk-android/pull/1819

### How?

Added these codes to `HTTPResponseStatusCode`. We use fuzzy testing in this part, so no extra tests added, but the configuration of existing ones is updated.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
