### PR TITLE
chore: Update RUM models to fix webview integration tests

### DIFF
--- a/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -26,6 +26,7 @@ extension RUMConnectivity {
                 carrierName: .mockRandom(),
                 technology: .mockRandom()
             ),
+            effectiveType: nil,
             interfaces: [.bluetooth, .cellular].randomElements(),
             status: [.connected, .maybe, .notConnected].randomElement()!
         )

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -690,6 +690,7 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
         let expectedConnectivityInfo = RUMConnectivity(
             cellular: RUMConnectivity.Cellular(carrierName: "Carrier Name", technology: "GPRS"),
+            effectiveType: nil,
             interfaces: [.cellular],
             status: .connected
         )

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -510,8 +510,12 @@ public class DDRUMActionEventRUMConnectivity: NSObject {
         root.swiftModel.connectivity!.cellular != nil ? DDRUMActionEventRUMConnectivityCellular(root: root) : nil
     }
 
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMActionEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    @objc public var effectiveType: DDRUMActionEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    @objc public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { DDRUMActionEventRUMConnectivityInterfaces(swift: $0).rawValue }
     }
 
     @objc public var status: DDRUMActionEventRUMConnectivityStatus {
@@ -537,23 +541,54 @@ public class DDRUMActionEventRUMConnectivityCellular: NSObject {
 }
 
 @objc
-public enum DDRUMActionEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
+public enum DDRUMActionEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
         switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
         }
     }
 
-    internal var toSwift: RUMConnectivity.Interfaces {
+    internal var toSwift: RUMConnectivity.EffectiveType? {
         switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc
+public enum DDRUMActionEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
         case .bluetooth: return .bluetooth
         case .cellular: return .cellular
         case .ethernet: return .ethernet
@@ -562,10 +597,11 @@ public enum DDRUMActionEventRUMConnectivityInterfaces: Int {
         case .mixed: return .mixed
         case .other: return .other
         case .unknown: return .unknown
-        case .none: return .none
+        case .interfacesNone: return .interfacesNone
         }
     }
 
+    case none
     case bluetooth
     case cellular
     case ethernet
@@ -574,7 +610,7 @@ public enum DDRUMActionEventRUMConnectivityInterfaces: Int {
     case mixed
     case other
     case unknown
-    case none
+    case interfacesNone
 }
 
 @objc
@@ -1253,8 +1289,12 @@ public class DDRUMErrorEventRUMConnectivity: NSObject {
         root.swiftModel.connectivity!.cellular != nil ? DDRUMErrorEventRUMConnectivityCellular(root: root) : nil
     }
 
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMErrorEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    @objc public var effectiveType: DDRUMErrorEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    @objc public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { DDRUMErrorEventRUMConnectivityInterfaces(swift: $0).rawValue }
     }
 
     @objc public var status: DDRUMErrorEventRUMConnectivityStatus {
@@ -1280,23 +1320,54 @@ public class DDRUMErrorEventRUMConnectivityCellular: NSObject {
 }
 
 @objc
-public enum DDRUMErrorEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
+public enum DDRUMErrorEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
         switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
         }
     }
 
-    internal var toSwift: RUMConnectivity.Interfaces {
+    internal var toSwift: RUMConnectivity.EffectiveType? {
         switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc
+public enum DDRUMErrorEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
         case .bluetooth: return .bluetooth
         case .cellular: return .cellular
         case .ethernet: return .ethernet
@@ -1305,10 +1376,11 @@ public enum DDRUMErrorEventRUMConnectivityInterfaces: Int {
         case .mixed: return .mixed
         case .other: return .other
         case .unknown: return .unknown
-        case .none: return .none
+        case .interfacesNone: return .interfacesNone
         }
     }
 
+    case none
     case bluetooth
     case cellular
     case ethernet
@@ -1317,7 +1389,7 @@ public enum DDRUMErrorEventRUMConnectivityInterfaces: Int {
     case mixed
     case other
     case unknown
-    case none
+    case interfacesNone
 }
 
 @objc
@@ -2370,8 +2442,12 @@ public class DDRUMLongTaskEventRUMConnectivity: NSObject {
         root.swiftModel.connectivity!.cellular != nil ? DDRUMLongTaskEventRUMConnectivityCellular(root: root) : nil
     }
 
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMLongTaskEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    @objc public var effectiveType: DDRUMLongTaskEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    @objc public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { DDRUMLongTaskEventRUMConnectivityInterfaces(swift: $0).rawValue }
     }
 
     @objc public var status: DDRUMLongTaskEventRUMConnectivityStatus {
@@ -2397,23 +2473,54 @@ public class DDRUMLongTaskEventRUMConnectivityCellular: NSObject {
 }
 
 @objc
-public enum DDRUMLongTaskEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
+public enum DDRUMLongTaskEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
         switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
         }
     }
 
-    internal var toSwift: RUMConnectivity.Interfaces {
+    internal var toSwift: RUMConnectivity.EffectiveType? {
         switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc
+public enum DDRUMLongTaskEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
         case .bluetooth: return .bluetooth
         case .cellular: return .cellular
         case .ethernet: return .ethernet
@@ -2422,10 +2529,11 @@ public enum DDRUMLongTaskEventRUMConnectivityInterfaces: Int {
         case .mixed: return .mixed
         case .other: return .other
         case .unknown: return .unknown
-        case .none: return .none
+        case .interfacesNone: return .interfacesNone
         }
     }
 
+    case none
     case bluetooth
     case cellular
     case ethernet
@@ -2434,7 +2542,7 @@ public enum DDRUMLongTaskEventRUMConnectivityInterfaces: Int {
     case mixed
     case other
     case unknown
-    case none
+    case interfacesNone
 }
 
 @objc
@@ -3142,8 +3250,12 @@ public class DDRUMResourceEventRUMConnectivity: NSObject {
         root.swiftModel.connectivity!.cellular != nil ? DDRUMResourceEventRUMConnectivityCellular(root: root) : nil
     }
 
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMResourceEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    @objc public var effectiveType: DDRUMResourceEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    @objc public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { DDRUMResourceEventRUMConnectivityInterfaces(swift: $0).rawValue }
     }
 
     @objc public var status: DDRUMResourceEventRUMConnectivityStatus {
@@ -3169,23 +3281,54 @@ public class DDRUMResourceEventRUMConnectivityCellular: NSObject {
 }
 
 @objc
-public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
+public enum DDRUMResourceEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
         switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
         }
     }
 
-    internal var toSwift: RUMConnectivity.Interfaces {
+    internal var toSwift: RUMConnectivity.EffectiveType? {
         switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc
+public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
         case .bluetooth: return .bluetooth
         case .cellular: return .cellular
         case .ethernet: return .ethernet
@@ -3194,10 +3337,11 @@ public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
         case .mixed: return .mixed
         case .other: return .other
         case .unknown: return .unknown
-        case .none: return .none
+        case .interfacesNone: return .interfacesNone
         }
     }
 
+    case none
     case bluetooth
     case cellular
     case ethernet
@@ -3206,7 +3350,7 @@ public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
     case mixed
     case other
     case unknown
-    case none
+    case interfacesNone
 }
 
 @objc
@@ -4309,8 +4453,12 @@ public class DDRUMViewEventRUMConnectivity: NSObject {
         root.swiftModel.connectivity!.cellular != nil ? DDRUMViewEventRUMConnectivityCellular(root: root) : nil
     }
 
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMViewEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    @objc public var effectiveType: DDRUMViewEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    @objc public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { DDRUMViewEventRUMConnectivityInterfaces(swift: $0).rawValue }
     }
 
     @objc public var status: DDRUMViewEventRUMConnectivityStatus {
@@ -4336,23 +4484,54 @@ public class DDRUMViewEventRUMConnectivityCellular: NSObject {
 }
 
 @objc
-public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
+public enum DDRUMViewEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
         switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
         }
     }
 
-    internal var toSwift: RUMConnectivity.Interfaces {
+    internal var toSwift: RUMConnectivity.EffectiveType? {
         switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc
+public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
         case .bluetooth: return .bluetooth
         case .cellular: return .cellular
         case .ethernet: return .ethernet
@@ -4361,10 +4540,11 @@ public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
         case .mixed: return .mixed
         case .other: return .other
         case .unknown: return .unknown
-        case .none: return .none
+        case .interfacesNone: return .interfacesNone
         }
     }
 
+    case none
     case bluetooth
     case cellular
     case ethernet
@@ -4373,7 +4553,7 @@ public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
     case mixed
     case other
     case unknown
-    case none
+    case interfacesNone
 }
 
 @objc
@@ -6123,4 +6303,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/83f8760b46e9a117b5975cfb592b1803d643ee3e
+// Generated from https://github.com/DataDog/rum-events-format/tree/389581be98dcf8efbfcfe7bffaa32d53f960fb6f

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -3287,14 +3287,18 @@ public struct RUMConnectivity: Codable {
     /// Cellular connectivity properties
     public let cellular: Cellular?
 
+    /// Cellular connection type reflecting the measured network performance
+    public let effectiveType: EffectiveType?
+
     /// The list of available network interfaces
-    public let interfaces: [Interfaces]
+    public let interfaces: [Interfaces]?
 
     /// Status of the device connectivity
     public let status: Status
 
     enum CodingKeys: String, CodingKey {
         case cellular = "cellular"
+        case effectiveType = "effective_type"
         case interfaces = "interfaces"
         case status = "status"
     }
@@ -3313,6 +3317,14 @@ public struct RUMConnectivity: Codable {
         }
     }
 
+    /// Cellular connection type reflecting the measured network performance
+    public enum EffectiveType: String, Codable {
+        case slow2g = "slow_2g"
+        case effectiveType2g = "2g"
+        case effectiveType3g = "3g"
+        case effectiveType4g = "4g"
+    }
+
     public enum Interfaces: String, Codable {
         case bluetooth = "bluetooth"
         case cellular = "cellular"
@@ -3322,7 +3334,7 @@ public struct RUMConnectivity: Codable {
         case mixed = "mixed"
         case other = "other"
         case unknown = "unknown"
-        case none = "none"
+        case interfacesNone = "none"
     }
 
     /// Status of the device connectivity
@@ -3555,4 +3567,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/83f8760b46e9a117b5975cfb592b1803d643ee3e
+// Generated from https://github.com/DataDog/rum-events-format/tree/389581be98dcf8efbfcfe7bffaa32d53f960fb6f

--- a/DatadogRUM/Sources/RUMEvent/RUMConnectivityInfoProvider.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMConnectivityInfoProvider.swift
@@ -22,6 +22,7 @@ extension RUMConnectivity {
 
         self.init(
             cellular: carrierInfo.flatMap { RUMConnectivity.connectivityCellularInfo(for: $0) },
+            effectiveType: nil,
             interfaces: RUMConnectivity.connectivityInterfaces(for: networkInfo),
             status: RUMConnectivity.connectivityStatus(for: networkInfo)
         )
@@ -39,7 +40,7 @@ extension RUMConnectivity {
 
     private static func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMConnectivity.Interfaces] {
         guard let availableInterfaces = networkInfo.availableInterfaces, !availableInterfaces.isEmpty else {
-            return [.none]
+            return [.interfacesNone]
         }
 
         return availableInterfaces.map { interface in

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -39,6 +39,7 @@ extension RUMConnectivity: RandomMockable {
                 carrierName: .mockRandom(),
                 technology: .mockRandom()
             ),
+            effectiveType: nil,
             interfaces: [.bluetooth, .cellular].randomElements(),
             status: [.connected, .maybe, .notConnected].randomElement()!
         )

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,10 @@ test-xcframeworks:
 		@cd dependency-manager-tests/xcframeworks && $(MAKE)
 
 # Generate RUM data models from rum-events-format JSON Schemas
+#  - run with `git_ref=<commit hash>` argument to generate models for given schema commit or branch name (default is 'master').
 rum-models-generate:
 		@echo "⚙️  Generating RUM models..."
-		./tools/rum-models-generator/run.py generate rum
+		./tools/rum-models-generator/run.py generate rum --git_ref=$(if $(git_ref),$(git_ref),master)
 		@echo "OK 👌"
 
 # Verify if RUM data models follow rum-events-format JSON Schemas
@@ -122,9 +123,10 @@ rum-models-verify:
 		@echo "OK 👌"
 
 # Generate Session Replay data models from rum-events-format JSON Schemas
+#  - run with `git_ref=<commit hash>` argument to generate models for given schema commit or branch name (default is 'master').
 sr-models-generate:
 		@echo "⚙️  Generating Session Replay models..."
-		./tools/rum-models-generator/run.py generate sr
+		./tools/rum-models-generator/run.py generate sr --git_ref=$(if $(git_ref),$(git_ref),master)
 		@echo "OK 👌"
 
 # Verify if Session Replay data models follow rum-events-format JSON Schemas

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
@@ -96,7 +96,13 @@ internal class JSONToSwiftTypeTransformer {
                     // case with the name of enumeration so it is transformed into valid `SwiftEnum.Case`.
                     var labelValue = value
                     if let first = value.first?.unicodeScalars.first, CharacterSet.decimalDigits.contains(first) {
-                        labelValue = "\(jsonEnumeration.name)\(value)"
+                        labelValue = "\(jsonEnumeration.name.lowercasingFirst)\(value)"
+                    }
+                    // In Swift, naming case a "none" might clash with `Optional<E>.none` type if the property of
+                    // this enum value is declared as optional. For that reason, prefix "none" case with the
+                    // name of enumeration to avoid compiler ambiguity.
+                    if labelValue == "none" {
+                        labelValue = "\(jsonEnumeration.name.lowercasingFirst)\(labelValue.uppercasingFirst)"
                     }
 
                     return SwiftEnum.Case(label: labelValue, rawValue: .string(value: value))

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
@@ -92,8 +92,17 @@ internal class JSONToSwiftTypeTransformer {
             cases: jsonEnumeration.values.map { value in
                 switch value {
                 case .string(let value):
-                    return SwiftEnum.Case(label: value, rawValue: .string(value: value))
+                    // In Swift, enum case names cannot start with digits. In such situation prefix the
+                    // case with the name of enumeration so it is transformed into valid `SwiftEnum.Case`.
+                    var labelValue = value
+                    if let first = value.first?.unicodeScalars.first, CharacterSet.decimalDigits.contains(first) {
+                        labelValue = "\(jsonEnumeration.name)\(value)"
+                    }
+
+                    return SwiftEnum.Case(label: labelValue, rawValue: .string(value: value))
                 case .integer(let value):
+                    // In Swift, enum case names cannot start with digits, so prefix the case with the name
+                    // of enumeration so it is transformed into valid `SwiftEnum.Case`.
                     return SwiftEnum.Case(label: "\(jsonEnumeration.name)\(value)", rawValue: .integer(value: value))
                 }
             },

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
@@ -173,7 +173,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                             .string(value: "case1"),
                             .string(value: "case2"),
                             .string(value: "3case"), // case name starting with number
-                            .string(value: "4case"),
+                            .string(value: "none"), // explicit case named as "none"
                         ]
                     ),
                     defaultValue: nil,
@@ -194,8 +194,8 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         cases: [
                             SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
                             SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
-                            SwiftEnum.Case(label: "Foo3case", rawValue: .string(value: "3case")),
-                            SwiftEnum.Case(label: "Foo4case", rawValue: .string(value: "4case")),
+                            SwiftEnum.Case(label: "foo3case", rawValue: .string(value: "3case")),
+                            SwiftEnum.Case(label: "fooNone", rawValue: .string(value: "none")),
                         ],
                         conformance: []
                     ),

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
@@ -158,6 +158,114 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
         XCTAssertEqual(expected, actual[0])
     }
 
+    func testTransformingJSONObjectWithStringEnumerationIntoSwiftStruct() throws {
+        let object = JSONObject(
+            name: "Container",
+            comment: nil,
+            properties: [
+                JSONObject.Property(
+                    name: "enumeration",
+                    comment: nil,
+                    type: JSONEnumeration(
+                        name: "Foo",
+                        comment: "Description of Foo",
+                        values: [
+                            .string(value: "case1"),
+                            .string(value: "case2"),
+                            .string(value: "3case"), // case name starting with number
+                            .string(value: "4case"),
+                        ]
+                    ),
+                    defaultValue: nil,
+                    isRequired: false,
+                    isReadOnly: false
+                )
+            ]
+        )
+
+        let expected = SwiftStruct(
+            name: "Container",
+            properties: [
+                SwiftStruct.Property(
+                    name: "enumeration",
+                    type: SwiftEnum(
+                        name: "Foo",
+                        comment: "Description of Foo",
+                        cases: [
+                            SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
+                            SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
+                            SwiftEnum.Case(label: "Foo3case", rawValue: .string(value: "3case")),
+                            SwiftEnum.Case(label: "Foo4case", rawValue: .string(value: "4case")),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    mutability: .mutable,
+                    codingKey: .static(value: "enumeration")
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try JSONToSwiftTypeTransformer().transform(jsonType: object)
+
+        XCTAssertEqual(actual.count, 1)
+        XCTAssertEqual(expected, actual[0])
+    }
+
+    func testTransformingJSONObjectWithIntegerEnumerationIntoSwiftStruct() throws {
+        let object = JSONObject(
+            name: "Container",
+            comment: nil,
+            properties: [
+                JSONObject.Property(
+                    name: "enumeration",
+                    comment: nil,
+                    type: JSONEnumeration(
+                        name: "Foo",
+                        comment: "Description of Foo",
+                        values: [
+                            .integer(value: 1),
+                            .integer(value: 2),
+                            .integer(value: 3),
+                        ]
+                    ),
+                    defaultValue: nil,
+                    isRequired: false,
+                    isReadOnly: false
+                )
+            ]
+        )
+
+        let expected = SwiftStruct(
+            name: "Container",
+            properties: [
+                SwiftStruct.Property(
+                    name: "enumeration",
+                    type: SwiftEnum(
+                        name: "Foo",
+                        comment: "Description of Foo",
+                        cases: [
+                            SwiftEnum.Case(label: "Foo1", rawValue: .integer(value: 1)),
+                            SwiftEnum.Case(label: "Foo2", rawValue: .integer(value: 2)),
+                            SwiftEnum.Case(label: "Foo3", rawValue: .integer(value: 3)),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    mutability: .mutable,
+                    codingKey: .static(value: "enumeration")
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try JSONToSwiftTypeTransformer().transform(jsonType: object)
+
+        XCTAssertEqual(actual.count, 1)
+        XCTAssertEqual(expected, actual[0])
+    }
+
     // MARK: - Transforming `additionalProperties`
 
     func testTransformingNestedJSONObjectWithIntAdditionalPropertiesIntoSwiftDictionaryInsideRootStruct() throws {


### PR DESCRIPTION
### What and why?

🧰 Fixes the impact of recent update in rum-events-format: https://github.com/DataDog/rum-events-format/pull/177. The PR to Browser RUM schema has changed optionality of the `RUMConnectivity.interfaces` field (non-optional → optional) breaking decoding of browser events in our WebView integration tests:
```
failed - keyNotFound(CodingKeys(stringValue: "interfaces", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "connectivity", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"interfaces\", intValue: nil) (\"interfaces\").", underlyingError: nil)):
```

### How?

I updated RUM models to the new commit in `rum-events-format`, so we use recent schema for decoding Browser events.

This comes along with 2 changes to `rum-models-generator` after https://github.com/DataDog/rum-events-format/pull/177:
- That PR added an enum with case names starting with digits (Connectivity → Effective Type: "2G", "3G", "4G"). Because enum cases in Swift cannot start with digit, the generator now sanitizes them by adding a prefix (the name of the enumeration).
- That PR also changed `interfaces: [Interfaces]` to be optional (`interfaces: [Interfaces]?`). Because one of the cases in `Interfaces` enum is named "none", this caused compiler ambiguity with `Optional<Interfaces>.none`. To avoid this, in such situation the generator also uses the prefix (`<enumName>None`).

🎁 As a bonus, I added an option to the `make` command so we can now generate RUM and SR models for a certain commit of the `rum-events-format` repo, e.g.:
```
make rum-models-generate git_ref=389581be98dcf8efbfcfe7bffaa32d53f960fb6f
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [x] Run tests for `tools/`
