### PR TITLE
RUM-1833 feat: Link (emergency) crash Logs to crashed RUM session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FIX] RUM session not being linked to spans. See [#1615][]
 - [FIX] `URLSessionTask.resume()` swizzling in iOS 13 and 12. See [#1637][]
 - [FEATURE] Allow stopping a core instance. See [#1541][]
+- [FEATURE] Link crashes sent as Log events to RUM session. See [#1645][]
 - [IMPROVEMENT] Add extra HTTP codes to the list of retryable status codes. See [#1639][]
 
 # 2.6.0 / 09-01-2024
@@ -573,6 +574,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1524]: https://github.com/DataDog/dd-sdk-ios/pull/1524
 [#1529]: https://github.com/DataDog/dd-sdk-ios/pull/1529
 [#1533]: https://github.com/DataDog/dd-sdk-ios/pull/1533
+[#1645]: https://github.com/DataDog/dd-sdk-ios/pull/1645
 [#1594]: https://github.com/DataDog/dd-sdk-ios/pull/1594
 [#1536]: https://github.com/DataDog/dd-sdk-ios/pull/1536
 [#1609]: https://github.com/DataDog/dd-sdk-ios/pull/1609

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -309,6 +309,8 @@
 		6176C1732ABDBA2E00131A70 /* MonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176C1712ABDBA2E00131A70 /* MonitorTests.swift */; };
 		61776CED273BEA5500F93802 /* DebugRUMSessionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */; };
 		61776D4E273E6D9F00F93802 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61776D4D273E6D9F00F93802 /* SwiftUI.swift */; };
+		6179DB562B6022EA00E9E04E /* SendingCrashReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179DB552B6022EA00E9E04E /* SendingCrashReportTests.swift */; };
+		6179DB572B6022EA00E9E04E /* SendingCrashReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179DB552B6022EA00E9E04E /* SendingCrashReportTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
@@ -2166,6 +2168,7 @@
 		61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRUMSessionViewController.swift; sourceTree = "<group>"; };
 		61776D4D273E6D9F00F93802 /* SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI.swift; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
+		6179DB552B6022EA00E9E04E /* SendingCrashReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendingCrashReportTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
 		617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorTests.swift; sourceTree = "<group>"; };
@@ -3563,6 +3566,7 @@
 		610ABD492A69309900AFEA34 /* IntegrationUnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				6179DB542B60229D00E9E04E /* CrashReporting */,
 				61E8C5062B28896100E709B4 /* RUM */,
 				610ABD4A2A6930AB00AFEA34 /* Public */,
 				618353BA2A6946F40085F84A /* Internal */,
@@ -4360,6 +4364,14 @@
 				61776D4D273E6D9F00F93802 /* SwiftUI.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		6179DB542B60229D00E9E04E /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6179DB552B6022EA00E9E04E /* SendingCrashReportTests.swift */,
+			);
+			path = CrashReporting;
 			sourceTree = "<group>";
 		};
 		617B953B24BF4D7300E6F443 /* RUMMonitor */ = {
@@ -7345,6 +7357,7 @@
 				6176991E2A8791880030022B /* Datadog+MultipleInstancesIntegrationTests.swift in Sources */,
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
 				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,
+				6179DB562B6022EA00E9E04E /* SendingCrashReportTests.swift in Sources */,
 				3C0D5DE22A543DC400446CF9 /* EventGeneratorTests.swift in Sources */,
 				6136CB4A2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
@@ -8422,6 +8435,7 @@
 				D24C9C4E29A7BA41002057CF /* LogsMocks.swift in Sources */,
 				D2CB6EDE27C520D400A62B57 /* RUMEventMatcher.swift in Sources */,
 				D2CB6EE027C520D400A62B57 /* SpanMatcher.swift in Sources */,
+				6179DB572B6022EA00E9E04E /* SendingCrashReportTests.swift in Sources */,
 				61112F8F2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */,
 				D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */,
 				D2CB6EE427C520D400A62B57 /* FeatureTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/CrashReporting/SendingCrashReportTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/SendingCrashReportTests.swift
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogCrashReporting
+import DatadogInternal
+@testable import DatadogLogs
+@testable import DatadogRUM
+
+/// A crash reporter mock with two capabilities:
+/// - notifying a pending crash report found at SDK init,
+/// - recording crash context data injected from SDK core and features like RUM.
+private class CrashReporterMock: CrashReportingPlugin {
+    @ReadWriteLock
+    internal var pendingCrashReport: DDCrashReport?
+    @ReadWriteLock
+    internal var injectedContext: Data? = nil
+
+    init(pendingCrashReport: DDCrashReport? = nil) {
+        self.pendingCrashReport = pendingCrashReport
+    }
+
+    func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) { _ = completion(pendingCrashReport) }
+    func inject(context: Data) { injectedContext = context }
+}
+
+/// Covers broad scenarios of sending Crash Reports.
+class SendingCrashReportTests: XCTestCase {
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy(context: .mockWith(trackingConsent: .granted))
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        super.tearDown()
+    }
+
+    func testWhenSDKStartsWithPendingCrashReport_itSendsItAsLogAndRUMEvent() throws {
+        // Given
+        let crashReport: DDCrashReport = .mockRandomWith(
+            context: .mockWith(
+                trackingConsent: .granted, // CR from the app session that has enabled data collection
+                lastIsAppInForeground: true // CR occurred while the app was in the foreground
+            )
+        )
+
+        // When
+        Logs.enable(with: .init(), in: core)
+        RUM.enable(with: .init(applicationID: "rum-app-id"), in: core)
+        CrashReporting.enable(with: CrashReporterMock(pendingCrashReport: crashReport), in: core)
+
+        // Then (an emergency log is sent)
+        let log = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: LogsFeature.name, ofType: LogEvent.self).first)
+        XCTAssertEqual(log.status, .emergency)
+        XCTAssertEqual(log.message, crashReport.message)
+        XCTAssertEqual(log.error?.message, crashReport.message)
+        XCTAssertEqual(log.error?.kind, crashReport.type)
+        XCTAssertEqual(log.error?.stack, crashReport.stack)
+        XCTAssertNotNil(log.attributes.internalAttributes?[DDError.threads])
+        XCTAssertNotNil(log.attributes.internalAttributes?[DDError.binaryImages])
+        XCTAssertNotNil(log.attributes.internalAttributes?[DDError.meta])
+        XCTAssertNotNil(log.attributes.internalAttributes?[DDError.wasTruncated])
+
+        // Then (RUMError is sent)
+        let rumEvent = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMCrashEvent.self).first)
+        XCTAssertEqual(rumEvent.model.error.message, crashReport.message)
+        XCTAssertEqual(rumEvent.model.error.type, crashReport.type)
+        XCTAssertEqual(rumEvent.model.error.stack, crashReport.stack)
+        XCTAssertNotNil(rumEvent.additionalAttributes?[DDError.threads])
+        XCTAssertNotNil(rumEvent.additionalAttributes?[DDError.binaryImages])
+        XCTAssertNotNil(rumEvent.additionalAttributes?[DDError.meta])
+        XCTAssertNotNil(rumEvent.additionalAttributes?[DDError.wasTruncated])
+    }
+
+    func testWhenSendingCrashReportAsLog_itIsLinkedToTheRUMSessionThatHasCrashed() throws {
+        let crashReporter = CrashReporterMock()
+
+        // Given (RUM session)
+        Logs.enable(with: .init(), in: core)
+        RUM.enable(with: .init(applicationID: "rum-app-id"), in: core)
+        CrashReporting.enable(with: crashReporter, in: core)
+        RUMMonitor.shared(in: core).startView(key: "view-1", name: "FirstView")
+
+        let rumEvent = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMViewEvent.self).last)
+
+        // Flush async tasks in Crash Reporting feature (this is yet not a part of `core.flushAndTearDown()` today)
+        // TODO: RUM-2766 Stop core instance with completion
+        (core.get(feature: CrashReportingFeature.self)!.crashContextProvider as! CrashContextCoreProvider).flush()
+        core.flushAndTearDown()
+
+        // When (starting an SDK with pending crash report)
+        core = DatadogCoreProxy()
+
+        let crashReport: DDCrashReport = .mockRandomWith( // mock a CR with context injected from previous instance of the SDK
+            contextData: crashReporter.injectedContext!
+        )
+
+        Logs.enable(with: .init(), in: core)
+        RUM.enable(with: .init(applicationID: "rum-app-id"), in: core)
+        CrashReporting.enable(with: CrashReporterMock(pendingCrashReport: crashReport), in: core)
+
+        // Then (an emergency log is sent)
+        let log = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: LogsFeature.name, ofType: LogEvent.self).first)
+        XCTAssertEqual(log.status, .emergency)
+        XCTAssertEqual(log.message, crashReport.message)
+        XCTAssertEqual(log.attributes.internalAttributes?["application_id"] as? String, rumEvent.application.id)
+        XCTAssertEqual(log.attributes.internalAttributes?["session_id"] as? String, rumEvent.session.id)
+        XCTAssertEqual(log.attributes.internalAttributes?["view.id"] as? String, rumEvent.view.id)
+    }
+}

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -217,12 +217,16 @@ internal extension DDCrashReport {
     }
 
     static func mockRandomWith(context: CrashContext) -> DDCrashReport {
+        return mockRandomWith(contextData: context.data)
+    }
+
+    static func mockRandomWith(contextData: Data) -> DDCrashReport {
         return mockWith(
             date: .mockRandomInThePast(),
             type: .mockRandom(),
             message: .mockRandom(),
             stack: .mockRandom(),
-            context: context.data
+            context: contextData
         )
     }
 }

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -21,11 +21,15 @@ import DatadogInternal
 public final class CrashReporting {
     /// Initializes the Datadog Crash Reporter.
     public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default) {
+        enable(with: PLCrashReporterPlugin(), in: core)
+    }
+
+    internal static func enable(with plugin: CrashReportingPlugin, in core: DatadogCoreProtocol) {
         do {
             let contextProvider = CrashContextCoreProvider()
 
             let reporter = CrashReportingFeature(
-                crashReportingPlugin: PLCrashReporterPlugin(),
+                crashReportingPlugin: plugin,
                 crashContextProvider: contextProvider,
                 sender: MessageBusSender(core: core),
                 messageReceiver: contextProvider,

--- a/DatadogLogs/Sources/Feature/Baggages.swift
+++ b/DatadogLogs/Sources/Feature/Baggages.swift
@@ -33,13 +33,6 @@ internal struct SpanContext: Decodable {
 
     let traceID: String?
     let spanID: String?
-
-    var internalAttributes: [String: String?] {
-        [
-            CodingKeys.traceID.rawValue: traceID,
-            CodingKeys.spanID.rawValue: spanID
-        ]
-    }
 }
 
 /// The RUM context received from `DatadogCore`.
@@ -61,15 +54,4 @@ internal struct RUMContext: Decodable {
     let viewID: String?
     /// The ID of current RUM action (standard UUID `String`, lowercased).
     let userActionID: String?
-
-    var internalAttributes: [String: String] {
-        var context: [String: String] = [
-            "application_id": applicationID,
-            "session_id": sessionID
-        ]
-
-        context["view.id"] = viewID
-        context["user_action.id"] = userActionID
-        return context
-    }
 }

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -23,6 +23,28 @@ public struct LogEvent: Encodable {
 
     /// Custom attributes associated with a the log event.
     public struct Attributes {
+        /// List of log attribute keys used to establish the link between the Log event and the RUM session that it was collected within.
+        /// Those keys are recognised by Datadog app and used to render the link in web UI.
+        internal enum RUM {
+            /// Key referencing the RUM applicaiton ID.
+            static let applicationID = "application_id"
+            /// Key referencing the RUM session ID.
+            static let sessionID = "session_id"
+            /// Key referencing the RUM view ID.
+            static let viewID = "view.id"
+            /// Key referencing the RUM action ID.
+            static let actionID = "user_action.id"
+        }
+
+        /// List of log attribute keys used to establish the link between the Log event and the Tracing span that it was collected within.
+        /// Those keys are recognised by Datadog app and used to render the link in web UI.
+        internal enum Trace {
+            /// Key referencing the trace ID.
+            static let traceID = "dd.trace_id"
+            /// Key referencing the span ID.
+            static let spanID = "dd.span_id"
+        }
+
         /// Log custom attributes, They are subject for sanitization.
         public var userAttributes: [String: Encodable]
         /// Log attributes added internally by the SDK. They are not a subject for sanitization.

--- a/DatadogLogs/Tests/WebViewLogReceiverTests.swift
+++ b/DatadogLogs/Tests/WebViewLogReceiverTests.swift
@@ -222,6 +222,6 @@ class WebViewLogReceiverTests: XCTestCase {
         XCTAssertNil(log["user_action.id"])
 
         let error = try XCTUnwrap(telemetryReceiver.messages.first?.asError)
-        XCTAssert(error.message.contains("Fails to decode RUM context from Logs - typeMismatch"))
+        XCTAssert(error.message.contains("Fails to decode RUM context from Logs in `WebViewLogReceiver` - typeMismatch"))
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds link to the RUM session for crash reports sent as emergency Log event.

See:

<img width="40%" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/33521703-668a-4398-bd2f-798dd3668292">

### How?

With the "last `RUMViewEvent`" being already encoded in `CrashContext.data`, this PR adds extra logic in `DatadogLogs` to decode RUM session attributes. Decoding is limited only to these fields that are required so we don't decode the whole event (that wouldn't be even possible as `DatadogLogs` has no dependency on `DatadogRUM`).

Once decoded, these attributes are attached to `LogEvent` following the contract between SDK and Datadog app.

Except unit tests covering edge cases (like malformed RUM view information), this PR also adds integration unit tests for "Sending Crash Reports as Logs and RUM".

Last, I took extra time to document logs, spans and RUM correlations in [this spec (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3416820413/Event+Correlations+-+SDK+Datadog+App+Contracts).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
