### PR TITLE
RUM-456 fix: SPM resource path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,9 +53,10 @@ let package = Package(
                 .target(name: "DatadogInternal"),
                 .target(name: "DatadogPrivate"),
             ],
-            path: "DatadogCore/Sources",
+            path: "DatadogCore",
+            sources: ["Sources"],
             resources: [
-                .copy("DatadogCore/Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ],
             swiftSettings: [.define("SPM_BUILD")]
         ),


### PR DESCRIPTION
### What and why?

Resource path was invalid in `Package.swift`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
