### PR TITLE
[Contribution] WebView Tracking - Expose the reference to message handler

### DIFF
--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -36,6 +36,7 @@ public enum WebViewTracking {
     ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
     ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
     ///   - core: Datadog SDK core to use for tracking.
+    @discardableResult
     public static func enable(
         webView: WKWebView,
         hosts: Set<String> = [],
@@ -69,6 +70,7 @@ public enum WebViewTracking {
 
     static let jsCodePrefix = "/* DatadogEventBridge */"
 
+    @discardableResult
     static func enable(
         tracking controller: WKUserContentController,
         hosts: Set<String>,

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -41,7 +41,7 @@ public enum WebViewTracking {
         hosts: Set<String> = [],
         logsSampleRate: Float = 100,
         in core: DatadogCoreProtocol = CoreRegistry.default
-    ) {
+    ) -> WKScriptMessageHandler? {
         enable(
             tracking: webView.configuration.userContentController,
             hosts: hosts,
@@ -75,11 +75,11 @@ public enum WebViewTracking {
         hostsSanitizer: HostsSanitizing,
         logsSampleRate: Float,
         in core: DatadogCoreProtocol
-    ) {
+    ) -> WKScriptMessageHandler? {
         let isTracking = controller.userScripts.contains { $0.source.starts(with: Self.jsCodePrefix) }
         guard !isTracking else {
             DD.logger.warn("`startTrackingDatadogEvents(core:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
-            return
+            return nil
        }
 
         let bridgeName = DDScriptMessageHandler.name
@@ -125,6 +125,8 @@ public enum WebViewTracking {
                 forMainFrameOnly: false
             )
         )
+
+        return messageHandler
     }
 #endif
 }


### PR DESCRIPTION
### What and why?

In our iOS mobile app we're leveraging custom webview bridging.
We define our own class that conforms to `WKScriptMessageHandler` protocol -> we override the following func internally

```swift
func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)
```

The Datadog SDK declares it's own `WKScriptMessageHandler`, but since we override the conformance the messages from `WKWebView` won't be passed onto the DD message handler.

This work exposes the message handler via public API. Once we keep the message handler reference internally, we're able to pass the messages from our `WKWebView` instance towards the DD message handler.

Im opening this PR to discuss if this could be a sensible addition to your SDK. Im happy to add missing unit tests once this approach proves viable for you.

### How?

Calling `enable` function now returns the reference to DD message handler.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
