### PR TITLE
Add `NSPrivacyCollectedDataTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Propagate parent span in distributing tracing. See [#1627][]
+- [FIX] Privacy Report missing properties. See [#1656][]
 
 # 2.7.0 / 25-01-2024
 
@@ -592,6 +593,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1597]: https://github.com/DataDog/dd-sdk-ios/pull/1597
 [#1627]: https://github.com/DataDog/dd-sdk-ios/pull/1627
 [#1644]: https://github.com/DataDog/dd-sdk-ios/pull/1644
+[#1656]: https://github.com/DataDog/dd-sdk-ios/pull/1656
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Resources/PrivacyInfo.xcprivacy
+++ b/DatadogCore/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
### What and why?

Missing the `NSPrivacyCollectedDataTypes` prevents from generating the Privacy Report.

Resolve #1655

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
