### PR TITLE
RUM-2700 chore: Allow job failures in shadowing test runs on GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ ENV info:
   stage: info
   tags:
     - mac-ventura-preview
+  allow_failure: true # do not block GH PRs
   script:
     - system_profiler SPSoftwareDataType # system info
     - xcodebuild -version
@@ -26,6 +27,7 @@ Lint:
   stage: lint
   tags:
     - mac-ventura-preview
+  allow_failure: true # do not block GH PRs
   script:
     - ./tools/lint/run-linter.sh
     - ./tools/license/check-license.sh
@@ -34,6 +36,7 @@ SDK unit tests (iOS):
   stage: test
   tags:
     - mac-ventura-preview
+  allow_failure: true # do not block GH PRs
   variables:
     TEST_WORKSPACE: "Datadog.xcworkspace"
     TEST_DESTINATION: "platform=iOS Simulator,name=iPhone 15 Pro Max,OS=17.0.1"
@@ -52,6 +55,7 @@ SDK unit tests (tvOS):
   stage: test
   tags:
     - mac-ventura-preview
+  allow_failure: true # do not block GH PRs
   variables:
     TEST_WORKSPACE: "Datadog.xcworkspace"
     TEST_DESTINATION: "platform=tvOS Simulator,name=Apple TV,OS=17.0"
@@ -68,6 +72,7 @@ SDK integration tests (iOS):
   stage: test
   tags:
     - mac-ventura-preview
+  allow_failure: true # do not block GH PRs
   variables:
     TEST_WORKSPACE: "IntegrationTests/IntegrationTests.xcworkspace"
     TEST_DESTINATION: "platform=iOS Simulator,name=iPhone 15 Pro Max,OS=17.0.1"


### PR DESCRIPTION
### What and why?

📦 Supplement for #1654. This PR allows failure in GitLab jobs. This is to not block the status of GH PRs while GitLab setup is still being evaluated.

### How?

Adding `allow_failure: true` to all GitLab jobs.

We can still know which jobs have failed, but their faults will not block our workflow. I also created `RUM-3158` to enable [Pipelines Visibility](https://docs.datadoghq.com/continuous_integration/pipelines/gitlab/?tab=gitlabcom) product and get further insights into performance of GitLab in our work.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
