### PR TITLE
RUM-2818 New Replay Payload Format

### DIFF
--- a/DatadogCore/Tests/Matchers/SRRequestMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SRRequestMatcher.swift
@@ -61,43 +61,23 @@ internal struct SRRequestMatcher {
         self.multipartForm = try MultipartFormDataParser(data: multipartBody, boundary: multipartBoundary)
     }
 
-    /// The value of "segment" field in underlying multipart form.
-    func segment() throws -> String { try valueOfField(named: "segment") }
-
-    /// The value of "application.id" field in underlying multipart form.
-    func applicationID() throws -> String { try valueOfField(named: "application.id") }
-
-    /// The value of "session.id" field in underlying multipart form.
-    func sessionID() throws -> String { try valueOfField(named: "session.id") }
-
-    /// The  value of "view.id" field in underlying multipart form.
-    func viewID() throws -> String { try valueOfField(named: "view.id") }
-
-    /// The  value of "has_full_snapshot" field in underlying multipart form.
-    func hasFullSnapshot() throws -> String { try valueOfField(named: "has_full_snapshot") }
-
-    /// The  value of "records_count" field in underlying multipart form.
-    func recordsCount() throws -> String { try valueOfField(named: "records_count") }
-
-    /// The  value of "raw_segment_size" field in underlying multipart form.
-    func rawSegmentSize() throws -> String { try valueOfField(named: "raw_segment_size") }
-
-    /// The  value of "start" field in underlying multipart form.
-    func start() throws -> String { try valueOfField(named: "start") }
-
-    /// The  value of "end" field in underlying multipart form.
-    func end() throws -> String { try valueOfField(named: "end") }
-
-    /// The  value of "source" field in underlying multipart form.
-    func source() throws -> String { try valueOfField(named: "source") }
+    /// Returns an array of JSON object matchers for all records in this segment.
+    func blob() throws -> [SRSegmentMatcher] {
+        let data = try dataOfFile(named: "blob", fieldName: "event", mimeType: "application/json")
+        let array = try data.toArrayOfJSONObjects()
+        let matcher = JSONArrrayMatcher(array: array)
+        return try matcher.values().map(SRSegmentMatcher.init(object:))
+    }
 
     /// Data of "segment" file in underlying multipart form.
-    func segmentJSONData() throws -> Data {
-        let compressedData = try dataOfFile(named: try sessionID(), fieldName: "segment", mimeType: "application/octet-stream")
+    func segment(at index: Int) throws -> SRSegmentMatcher {
+        let compressedData = try dataOfFile(named: "file\(index)", fieldName: "segment", mimeType: "application/octet-stream")
         guard let data = zlib.decode(compressedData) else {
             throw SRRequestException.segmentException("Failed to decompress segment JSON data: \(compressedData)")
         }
-        return data
+
+        let object = try data.toJSONObject()
+        return SRSegmentMatcher(object: object)
     }
 
     // MARK: - Querying Multipart Fields and Files

--- a/DatadogCore/Tests/Matchers/SRSegmentMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SRSegmentMatcher.swift
@@ -11,26 +11,6 @@ import TestUtilities
 ///
 /// See: ``DatadogSessionReplay.SRSegment`` to understand how underlying data is encoded.
 internal class SRSegmentMatcher: JSONObjectMatcher {
-    /// Creates matcher from Session Replay `URLRequest`. The `request` must be a valid Session Replay (multipart) request.
-    /// This method extracts SR segment from the "segment" file encoded in multipart request. Other multipart fields are ignored.
-    ///
-    /// - Parameter request: Session Replay request.
-    static func fromURLRequest(_ request: URLRequest) throws -> SRSegmentMatcher {
-        let requestMatcher = try SRRequestMatcher(request: request)
-        let segmentJSONObjectData = try requestMatcher.segmentJSONData()
-        return SRSegmentMatcher(jsonObject: try segmentJSONObjectData.toJSONObject())
-    }
-
-    /// Creates matcher from JSON-encoded SR segment.
-    /// - Parameter data: JSON-encoded SR segment data (not compressed).
-    static func fromJSONData(_ data: Data) throws -> SRSegmentMatcher {
-        return SRSegmentMatcher(jsonObject: try data.toJSONObject())
-    }
-
-    private init(jsonObject: [String: Any]) {
-        super.init(object: jsonObject)
-    }
-
     /// Enumerates SR record types.
     /// Raw values correspond to record types defined in SR JSON schema.
     ///
@@ -43,6 +23,39 @@ internal class SRSegmentMatcher: JSONObjectMatcher {
         case viewEndRecord = 7
         case visualViewportRecord = 8
     }
+
+    /// The value of "segment" field in underlying multipart form.
+    func segment() throws -> String { try value("segment") }
+
+    /// The value of "application.id" field in underlying multipart form.
+    func applicationID() throws -> String { try value("application.id") }
+
+    /// The value of "session.id" field in underlying multipart form.
+    func sessionID() throws -> String { try value("session.id") }
+
+    /// The  value of "view.id" field in underlying multipart form.
+    func viewID() throws -> String { try value("view.id") }
+
+    /// The  value of "has_full_snapshot" field in underlying multipart form.
+    func hasFullSnapshot() throws -> Bool { try value("has_full_snapshot") }
+
+    /// The  value of "records_count" field in underlying multipart form.
+    func recordsCount() throws -> Int { try value("records_count") }
+
+    /// The  value of "raw_segment_size" field in underlying multipart form.
+    func rawSegmentSize() throws -> Int { try value("raw_segment_size") }
+
+    /// The  value of "compressed_segment_size" field in underlying multipart form.
+    func compressedSegmentSize() throws -> Int { try value("compressed_segment_size") }
+
+    /// The  value of "start" field in underlying multipart form.
+    func start() throws -> Int { try value("start") }
+
+    /// The  value of "end" field in underlying multipart form.
+    func end() throws -> Int { try value("end") }
+
+    /// The  value of "source" field in underlying multipart form.
+    func source() throws -> String { try value("source") }
 
     /// Returns an array of JSON object matchers for all records in this segment.
     func records() throws -> [JSONObjectMatcher] {

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -19,7 +19,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
     init(
         customUploadURL: URL?,
         telemetry: Telemetry,
-        multipartBuilder: MultipartFormDataBuilder = MultipartFormData(boundary: UUID())
+        multipartBuilder: MultipartFormDataBuilder = MultipartFormData()
     ) {
         self.customUploadURL = customUploadURL
         self.telemetry = telemetry
@@ -41,7 +41,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
             url: url(with: context),
             queryItems: [],
             headers: [
-                .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary.uuidString)),
+                .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
                 .userAgentHeader(appName: context.applicationName, appVersion: context.version, device: context.device),
                 .ddAPIKeyHeader(clientToken: context.clientToken),
                 .ddEVPOriginHeader(source: context.source),
@@ -69,7 +69,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
             )
         }
 
-        return builder.uploadRequest(with: multipart.data, compress: true)
+        return builder.uploadRequest(with: multipart.build(), compress: true)
     }
 
     private func url(with context: DatadogContext) -> URL {

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
@@ -76,7 +76,7 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
                 data: compressedData,
                 mimeType: "application/octet-stream"
             )
-
+            // Remove the 'records' for the metadata
             json["records"] = nil
             json["raw_segment_size"] = data.count
             json["compressed_segment_size"] = compressedData.count

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
@@ -30,12 +30,12 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
         // If we can't decode `events: [Data]` there is no way to recover, so we throw an
         // error to let the core delete the batch:
         let records = try events.map { try EnrichedRecordJSON(jsonObjectData: $0.data) }
-        let segment = try segmentBuilder.createSegmentJSON(from: records)
+        let segments = try segmentBuilder.segments(from: records)
 
-        return try createRequest(segment: segment, context: context)
+        return try createRequest(segments: segments, context: context)
     }
 
-    private func createRequest(segment: SegmentJSON, context: DatadogContext) throws -> URLRequest {
+    private func createRequest(segments: [SegmentJSON], context: DatadogContext) throws -> URLRequest {
         var multipart = multipartBuilder
 
         let builder = URLRequestBuilder(
@@ -52,29 +52,34 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
             telemetry: telemetry
         )
 
-        // Session Replay BE accepts compressed segment data followed by newline character (before compression):
-        var segmentData = try JSONSerialization.data(withJSONObject: segment.toJSONObject())
-        segmentData.append(SegmentRequestBuilder.newlineByte)
-        let compressedSegmentData = try SRCompression.compress(data: segmentData)
+        let metadata = try segments.enumerated().map { index, segment in
+            // Session Replay BE accepts compressed segment data followed by newline character (before compression):
+            var json = segment.toJSONObject()
+            var data = try JSONSerialization.data(withJSONObject: json)
+            data.append(SegmentRequestBuilder.newlineByte)
+            let compressedData = try SRCompression.compress(data: data)
+            // Compressed segment is sent within multipart form data - with some of segment (metadata)
+            // attributes listed as form fields:
+            multipart.addFormData(
+                name: "segment",
+                filename: "file\(index)",
+                data: compressedData,
+                mimeType: "application/octet-stream"
+            )
 
-        // Compressed segment is sent within multipart form data - with some of segment (metadata)
-        // attributes listed as form fields:
+            json["records"] = nil
+            json["raw_segment_size"] = data.count
+            json["compressed_segment_size"] = compressedData.count
+            return json
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: metadata)
         multipart.addFormData(
-            name: "segment",
-            filename: segment.sessionID,
-            data: compressedSegmentData,
-            mimeType: "application/octet-stream"
+            name: "event",
+            filename: "blob",
+            data: data,
+            mimeType: "application/json"
         )
-        multipart.addFormField(name: "segment", value: segment.sessionID)
-        multipart.addFormField(name: "application.id", value: segment.applicationID)
-        multipart.addFormField(name: "session.id", value: segment.sessionID)
-        multipart.addFormField(name: "view.id", value: segment.viewID)
-        multipart.addFormField(name: "has_full_snapshot", value: segment.hasFullSnapshot ? "true" : "false")
-        multipart.addFormField(name: "records_count", value: "\(segment.recordsCount)")
-        multipart.addFormField(name: "raw_segment_size", value: "\(compressedSegmentData.count)")
-        multipart.addFormField(name: "start", value: "\(segment.start)")
-        multipart.addFormField(name: "end", value: "\(segment.end)")
-        multipart.addFormField(name: "source", value: "\(context.source)")
 
         // Data is already compressed, so request building request w/o compression:
         return builder.uploadRequest(with: multipart.data, compress: false)

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -5,47 +5,35 @@
  */
 
 import XCTest
+import TestUtilities
+import DatadogInternal
+
 @_spi(Internal)
 @testable import DatadogSessionReplay
-@testable import TestUtilities
 
 class SegmentJSONBuilderTests: XCTestCase {
     private let builder = SegmentJSONBuilder(source: .mockRandom())
 
     func testGivenSRSegmentWithRecords_whenCreatingSegmentJSON_itEcodesToTheSameJSON() throws {
         // Given
-        let expectedSegment = generateSegment(maxRecordsCount: 50)
-        let records = try generateEnrichedRecordJSONs(for: expectedSegment)
+        let segment1 = generateSegment(maxRecordsCount: 50)
+        let segment2 = generateSegment(maxRecordsCount: 50)
+        let records1 = try generateEnrichedRecordJSONs(for: segment1)
+        let records2 = try generateEnrichedRecordJSONs(for: segment2)
 
         // When
-        let actualSegment = try builder.createSegmentJSON(from: records)
+        let segments = try builder.segments(from: records1 + records2).map { $0.toJSONObject() }
 
         // Then
-        XCTAssertEqual(
-            try prettyJSONString(for: expectedSegment),
-            try prettyJSONString(for: actualSegment),
-            "`SegmentJSON` must encode the same JSON string as `SRSegment: Codable`"
-        )
+        DDAssertJSONEqual(AnyEncodable(segments.first), segment1)
+        DDAssertJSONEqual(AnyEncodable(segments.last), segment2)
     }
 
     func testWhenBuildingSegmentWithNoRecords_itThrows() {
         // When
-        XCTAssertThrowsError(try builder.createSegmentJSON(from: [])) { error in
+        XCTAssertThrowsError(try builder.segments(from: [])) { error in
             // Then
             XCTAssertEqual((error as? SegmentJSONBuilderError)?.description, "Records array must not be empty.")
-        }
-    }
-
-    func testWhenBuildingSegmentWithInvalidRecords_itThrows() throws {
-        // Given
-        let segment1 = generateSegment(maxRecordsCount: 25)
-        let segment2 = generateSegment(maxRecordsCount: 25)
-        let records = try generateEnrichedRecordJSONs(for: segment1) + generateEnrichedRecordJSONs(for: segment2)
-
-        // When
-        XCTAssertThrowsError(try builder.createSegmentJSON(from: records)) { error in
-            // Then
-            XCTAssertEqual((error as? SegmentJSONBuilderError)?.description, "All records must reference the same RUM context.")
         }
     }
 
@@ -80,6 +68,8 @@ class SegmentJSONBuilderTests: XCTestCase {
                 viewServerTimeOffset: 0
             )
         )
+
+        let encoder = JSONEncoder()
         return try segment.records
             // To make it more challenging for tested `SegmentJSONBuilder`, we chunk records in
             // expected `segment`, so they are spread among many enriched records:
@@ -87,30 +77,9 @@ class SegmentJSONBuilderTests: XCTestCase {
             .map { EnrichedRecord(context: context, records: $0) }
             // Encode `EnrichedRecords` into `Data`, just like it happens in `DatadogCore` when
             // writting them into batches:
-            .map { try encode($0) }
+            .map { try encoder.encode($0) }
             // Decode it back to `EnrichedRecordJSON` just like it happens when preparing
             // upload requests for SR:
             .map { try EnrichedRecordJSON(jsonObjectData: $0) }
-    }
-
-    private func encode<T: Encodable>(_ value: T) throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        return try encoder.encode(value)
-    }
-
-    private func encode(_ segment: SegmentJSON) throws -> Data {
-        return try JSONSerialization.data(
-            withJSONObject: segment.toJSONObject(),
-            options: [.sortedKeys, .prettyPrinted]
-        )
-    }
-
-    private func prettyJSONString<T: Encodable>(for value: T) throws -> String {
-        return String(data: try encode(value), encoding: .utf8) ?? ""
-    }
-
-    private func prettyJSONString(for segment: SegmentJSON) throws -> String {
-        return String(data: try encode(segment), encoding: .utf8) ?? ""
     }
 }

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/Multipart/MultipartFormDataTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/Multipart/MultipartFormDataTests.swift
@@ -32,7 +32,7 @@ class MultipartFormDataTests: XCTestCase {
         )
 
         // Then
-        let actualDataString = try XCTUnwrap(String(data: multipart.data, encoding: .utf8))
+        let actualDataString = try XCTUnwrap(String(data: multipart.build(), encoding: .utf8))
         let expectedDataString = """
         --12345678-0000-0000-0000-000000000000
         Content-Disposition: form-data; name="field1"

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -135,7 +135,7 @@ class ResourceRequestBuilderTests: XCTestCase {
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
-        XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary.uuidString)"))
+        XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary)"))
 
         for i in 0..<resources.count {
             XCTAssertNotNil(multipartSpy.formFiles[i].filename)

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -6,6 +6,8 @@
 
 import XCTest
 import DatadogInternal
+
+@_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
@@ -132,23 +134,99 @@ class SegmentRequestBuilderTests: XCTestCase {
         let multipartSpy = MultipartBuilderSpy()
         let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock(), multipartBuilder: multipartSpy)
 
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let context0: RUMContext = .mockRandom()
+        let context1: RUMContext = .mockRandom()
+        let events = try [
+            EnrichedRecord(context: .mockWith(rumContext: context0), records: .mockRandom(count: 5)),
+            EnrichedRecord(context: .mockWith(rumContext: context0), records: .mockRandom(count: 10)),
+            EnrichedRecord(context: .mockWith(rumContext: context0), records: .mockRandom(count: 15)),
+            EnrichedRecord(context: .mockWith(rumContext: context1), records: .mockRandom(count: 5)),
+            EnrichedRecord(context: .mockWith(rumContext: context1), records: .mockRandom(count: 10)),
+            EnrichedRecord(context: .mockWith(rumContext: context1), records: .mockRandom(count: 15)),
+        ].map {
+            try Event.mockWith(data: encoder.encode($0))
+        }
+
         // When
-        let request = try builder.request(for: mockEvents, with: .mockWith(source: "ios"))
+        let request = try builder.request(for: events, with: .mockWith(source: "ios"))
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
         XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary.uuidString)"))
-        XCTAssertEqual(multipartSpy.formFiles.first?.filename, rumContext.sessionID)
-        XCTAssertEqual(multipartSpy.formFiles.first?.mimeType, "application/octet-stream")
-        XCTAssertEqual(multipartSpy.formFields["segment"], rumContext.sessionID)
-        XCTAssertEqual(multipartSpy.formFields["application.id"], rumContext.applicationID)
-        XCTAssertEqual(multipartSpy.formFields["view.id"], rumContext.viewID!)
-        XCTAssertTrue(["true", "false"].contains(multipartSpy.formFields["has_full_snapshot"]!))
-        XCTAssertEqual(multipartSpy.formFields["records_count"], "30")
-        XCTAssertNotNil(multipartSpy.formFields["raw_segment_size"])
-        XCTAssertNotNil(multipartSpy.formFields["start"])
-        XCTAssertNotNil(multipartSpy.formFields["end"])
-        XCTAssertEqual(multipartSpy.formFields["source"], "ios")
+        XCTAssertEqual(multipartSpy.formFiles.count, 3)
+
+        let file0 = multipartSpy.formFiles[0]
+        XCTAssertEqual(file0.filename, "file0")
+        XCTAssertEqual(file0.mimeType, "application/octet-stream")
+
+        let segment0 = try decoder.decode(SRSegment.self, from: XCTUnwrap(zlib.decode(file0.data)))
+        XCTAssertEqual(segment0.application.id, context0.applicationID)
+        XCTAssertEqual(segment0.session.id, context0.sessionID)
+        XCTAssertEqual(segment0.view.id, context0.viewID)
+        XCTAssertEqual(segment0.source, .ios)
+        XCTAssertEqual(segment0.recordsCount, 30)
+
+        let file1 = multipartSpy.formFiles[1]
+        XCTAssertEqual(file1.filename, "file1")
+        XCTAssertEqual(file1.mimeType, "application/octet-stream")
+
+        let segment1 = try decoder.decode(SRSegment.self, from: XCTUnwrap(zlib.decode(file1.data)))
+        XCTAssertEqual(segment1.application.id, context1.applicationID)
+        XCTAssertEqual(segment1.session.id, context1.sessionID)
+        XCTAssertEqual(segment1.view.id, context1.viewID)
+        XCTAssertEqual(segment1.source, .ios)
+        XCTAssertEqual(segment1.recordsCount, 30)
+
+        let blob = multipartSpy.formFiles[2]
+        XCTAssertEqual(blob.filename, "blob")
+        XCTAssertEqual(blob.mimeType, "application/json")
+        let metadata = try decoder.decode([Metadata].self, from: blob.data)
+        XCTAssertEqual(metadata.count, 2)
+        XCTAssertEqual(metadata[0].application.id, context0.applicationID)
+        XCTAssertEqual(metadata[0].session.id, context0.sessionID)
+        XCTAssertEqual(metadata[0].view.id, context0.viewID)
+        XCTAssertNil(metadata[0].records)
+        XCTAssertGreaterThanOrEqual(metadata[0].rawSegmentSize, metadata[0].compressedSegmentSize)
+        XCTAssertEqual(metadata[1].application.id, context1.applicationID)
+        XCTAssertEqual(metadata[1].session.id, context1.sessionID)
+        XCTAssertEqual(metadata[1].view.id, context1.viewID)
+        XCTAssertNil(metadata[1].records)
+        XCTAssertGreaterThanOrEqual(metadata[1].rawSegmentSize, metadata[1].compressedSegmentSize)
+
+        // This definition is only used for assertion as it does not exist in the shared
+        // schema yet.
+        struct Metadata: Decodable {
+            let application: SRSegment.Application
+            let end: Int64
+            let hasFullSnapshot: Bool?
+            let indexInView: Int64?
+            let records: [SRRecord]?
+            let recordsCount: Int64
+            let session: SRSegment.Session
+            let source: SRSegment.Source
+            let start: Int64
+            let view: SRSegment.View
+            let rawSegmentSize: Int
+            let compressedSegmentSize: Int
+
+            enum CodingKeys: String, CodingKey {
+                case application = "application"
+                case end = "end"
+                case hasFullSnapshot = "has_full_snapshot"
+                case indexInView = "index_in_view"
+                case records = "records"
+                case recordsCount = "records_count"
+                case session = "session"
+                case source = "source"
+                case start = "start"
+                case view = "view"
+                case rawSegmentSize = "raw_segment_size"
+                case compressedSegmentSize = "compressed_segment_size"
+            }
+        }
     }
 
     func testWhenBatchDataIsMalformed_itThrows() {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -155,7 +155,7 @@ class SegmentRequestBuilderTests: XCTestCase {
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
-        XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary.uuidString)"))
+        XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary)"))
         XCTAssertEqual(multipartSpy.formFiles.count, 3)
 
         let file0 = multipartSpy.formFiles[0]

--- a/DatadogSessionReplay/Tests/Mocks/MultipartBuilderSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MultipartBuilderSpy.swift
@@ -12,10 +12,13 @@ class MultipartBuilderSpy: MultipartFormDataBuilder {
     var formFiles: [(filename: String, data: Data, mimeType: String)] = []
     var returnedData: Data = .mockRandom()
 
-    var boundary = UUID()
+    let boundary: String = UUID().uuidString
+
     func addFormField(name: String, value: String) { formFields[name] = value }
+
     func addFormData(name: String, filename: String, data: Data, mimeType: String) {
         formFiles.append((filename: filename, data: data, mimeType: mimeType))
     }
-    var data: Data { returnedData }
+
+    func build() -> Data { returnedData }
 }


### PR DESCRIPTION
### What and why?

The replay endpoint now supports multiple segments in multipart forms.

### How?

Follow specs from https://github.com/DataDog/dd-sdk-android/pull/1805

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
