### PR TITLE
RUM-2817 Remove forcing a new batch

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -314,11 +314,11 @@ internal struct DatadogCoreFeatureScope: FeatureScope {
     let contextProvider: DatadogContextProvider
     let storage: FeatureStorage
 
-    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
         // (on user thread) request SDK context
         context { context in
             // (on context thread) call the block
-            let writer = storage.writer(for: bypassConsent ? .granted : context.trackingConsent, forceNewBatch: forceNewBatch)
+            let writer = storage.writer(for: bypassConsent ? .granted : context.trackingConsent)
             block(context, writer)
         }
     }

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -23,13 +23,12 @@ internal struct FeatureStorage {
     /// Telemetry interface.
     let telemetry: Telemetry
 
-    func writer(for trackingConsent: TrackingConsent, forceNewBatch: Bool) -> Writer {
+    func writer(for trackingConsent: TrackingConsent) -> Writer {
         switch trackingConsent {
         case .granted:
             return AsyncWriter(
                 execute: FileWriter(
                     orchestrator: authorizedFilesOrchestrator,
-                    forceNewFile: forceNewBatch,
                     encryption: encryption,
                     telemetry: telemetry
                 ),
@@ -41,7 +40,6 @@ internal struct FeatureStorage {
             return AsyncWriter(
                 execute: FileWriter(
                     orchestrator: unauthorizedFilesOrchestrator,
-                    forceNewFile: forceNewBatch,
                     encryption: encryption,
                     telemetry: telemetry
                 ),

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -16,20 +16,16 @@ internal struct FileWriter: Writer {
     let orchestrator: FilesOrchestratorType
     /// Algorithm to encrypt written data.
     let encryption: DataEncryption?
-    /// If this writer should force creation of a new file for writing events.
-    let forceNewFile: Bool
     /// Telemetry interface.
     let telemetry: Telemetry
 
     init(
         orchestrator: FilesOrchestratorType,
-        forceNewFile: Bool,
         encryption: DataEncryption?,
         telemetry: Telemetry
     ) {
         self.orchestrator = orchestrator
         self.encryption = encryption
-        self.forceNewFile = forceNewFile
         self.telemetry = telemetry
     }
 
@@ -55,7 +51,7 @@ internal struct FileWriter: Writer {
             // This is to avoid a situation where event is written to one file and event metadata to another.
             // If this happens, the reader will not be able to match event with its metadata.
             let writeSize = UInt64(encoded.count)
-            let file = try forceNewFile ? orchestrator.getNewWritableFile(writeSize: writeSize) : orchestrator.getWritableFile(writeSize: writeSize)
+            let file = try orchestrator.getWritableFile(writeSize: writeSize)
             try file.append(data: encoded)
         } catch {
             DD.logger.error("Failed to write data", error: error)

--- a/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
@@ -38,9 +38,9 @@ class FeatureStorageTests: XCTestCase {
 
     func testWhenWritingEventsWithoutForcingNewBatch_itShouldWriteAllEventsToTheSameBatch() throws {
         // When
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event1": "1"])
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event2": "2"])
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event3": "3"])
+        storage.writer(for: .granted).write(value: ["event1": "1"])
+        storage.writer(for: .granted).write(value: ["event2": "2"])
+        storage.writer(for: .granted).write(value: ["event3": "3"])
 
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
@@ -52,32 +52,13 @@ class FeatureStorageTests: XCTestCase {
         XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
     }
 
-    func testWhenWritingEventsWithForcingNewBatch_itShouldWriteEachEventToSeparateBatch() throws {
-        // When
-        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event1": "1"])
-        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event2": "2"])
-        storage.writer(for: .granted, forceNewBatch: true).write(value: ["event3": "3"])
-
-        // Then
-        storage.setIgnoreFilesAgeWhenReading(to: true)
-
-        let batches = storage.reader.readNextBatches(3)
-        XCTAssertEqual(batches.count, 3)
-        batches.forEach { batch in
-            XCTAssertEqual(batch.events.count, 1)
-            storage.reader.markBatchAsRead(batch)
-        }
-
-        XCTAssertTrue(storage.reader.readNextBatches(1).isEmpty, "There must be no other batches")
-    }
-
     // MARK: - Behaviours on tracking consent
 
     func testWhenWritingEventsInDifferentConsents_itOnlyReadsGrantedEvents() throws {
         // When
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
-        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
-        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted).write(value: ["event.consent": "notGranted"])
 
         // Then
         storage.setIgnoreFilesAgeWhenReading(to: true)
@@ -91,9 +72,9 @@ class FeatureStorageTests: XCTestCase {
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToGranted_itMakesPendingEventsReadable() throws {
         // Given
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
-        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
-        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted).write(value: ["event.consent": "notGranted"])
 
         // When
         storage.migrateUnauthorizedData(toConsent: .granted)
@@ -114,9 +95,9 @@ class FeatureStorageTests: XCTestCase {
 
     func testGivenEventsWrittenInDifferentConsents_whenChangingConsentToNotGranted_itDeletesPendingEvents() throws {
         // Given
-        storage.writer(for: .granted, forceNewBatch: false).write(value: ["event.consent": "granted"])
-        storage.writer(for: .pending, forceNewBatch: false).write(value: ["event.consent": "pending"])
-        storage.writer(for: .notGranted, forceNewBatch: false).write(value: ["event.consent": "notGranted"])
+        storage.writer(for: .granted).write(value: ["event.consent": "granted"])
+        storage.writer(for: .pending).write(value: ["event.consent": "pending"])
+        storage.writer(for: .notGranted).write(value: ["event.consent": "notGranted"])
 
         // When
         storage.migrateUnauthorizedData(toConsent: .notGranted)

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -115,7 +115,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
         // When:
         // - then request new batch, which triggers directory purging
         dateProvider.advance(bySeconds: expectedBatchAge)
-        _ = try orchestrator.getNewWritableFile(writeSize: 1)
+        _ = try orchestrator.getWritableFile(writeSize: 1)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
@@ -161,39 +161,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "batch_size": expectedWrites.reduce(0, +),
             "batch_events_count": expectedWrites.count,
-            "batch_duration": (storage.maxFileAgeForWrite + 1).toMilliseconds,
-            "forced_new": false
-        ])
-    }
-
-    func testWhenNewBatchIsForced_itSendsBatchClosedMetric() throws {
-        // Given
-        // - request batch to be created
-        // - request few writes on that batch
-        let orchestrator = createOrchestrator()
-        let expectedWrites: [UInt64] = [10, 5, 2]
-        try expectedWrites.forEach { writeSize in
-            _ = try orchestrator.getWritableFile(writeSize: writeSize)
-        }
-        let expectedBatchDuration = storage.maxFileAgeForWrite - 1
-
-        // When
-        // - wait less than allowed batch age for writes
-        // - then request new batch, which closes the previous one
-        dateProvider.advance(bySeconds: expectedBatchDuration)
-        _ = try orchestrator.getNewWritableFile(writeSize: 1)
-
-        // Then
-        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Closed"))
-        DDAssertReflectionEqual(metric.attributes, [
-            "metric_type": "batch closed",
-            "track": "track name",
-            "consent": "consent value",
-            "uploader_window": storage.uploaderWindow.toMilliseconds,
-            "batch_size": expectedWrites.reduce(0, +),
-            "batch_events_count": expectedWrites.count,
-            "batch_duration": expectedBatchDuration.toMilliseconds,
-            "forced_new": true
+            "batch_duration": (storage.maxFileAgeForWrite + 1).toMilliseconds
         ])
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -166,19 +166,6 @@ class FilesOrchestratorTests: XCTestCase {
         XCTAssertNil(try? orchestrator.directory.file(named: file2.name))
     }
 
-    func testWhenNewWritableFileIsObtained_itAlwaysCreatesNewFile() throws {
-        let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
-
-        let file1 = try orchestrator.getNewWritableFile(writeSize: 1)
-        let file2 = try orchestrator.getNewWritableFile(writeSize: 1)
-        let file3 = try orchestrator.getNewWritableFile(writeSize: 1)
-
-        XCTAssertEqual(try orchestrator.directory.files().count, 3)
-        XCTAssertNotEqual(file1.name, file2.name)
-        XCTAssertNotEqual(file2.name, file3.name)
-        XCTAssertNotEqual(file3.name, file1.name)
-    }
-
     // MARK: - Readable file tests
 
     func testGivenNoReadableFiles_whenObtainingFiles_itReturnsEmpty() {

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -31,7 +31,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -69,7 +68,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: DataEncryptionMock(
                 encrypt: { data in
                     "encrypted".utf8Data + data + "encrypted".utf8Data
@@ -111,7 +109,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -135,42 +132,6 @@ class FileWriterTests: XCTestCase {
         XCTAssertEqual(block?.data, #"{"key3":"value3"}"#.utf8Data)
     }
 
-    func testWhenForceNewBatchIsSet_itWritesDataToSeparateFilesInTLVFormat() throws {
-        let writer = FileWriter(
-            orchestrator: FilesOrchestrator(
-                directory: directory,
-                performance: PerformancePreset.mockAny(),
-                dateProvider: RelativeDateProvider(advancingBySeconds: 1),
-                telemetry: NOPTelemetry()
-            ),
-            forceNewFile: true,
-            encryption: nil,
-            telemetry: NOPTelemetry()
-        )
-
-        writer.write(value: ["key1": "value1"])
-        writer.write(value: ["key2": "value2"])
-        writer.write(value: ["key3": "value3"])
-
-        XCTAssertEqual(try directory.files().count, 3)
-
-        let dataBlocks = try directory.files()
-            .sorted { $0.name < $1.name } // read files in their creation order
-            .map { try DataBlockReader(input: $0.stream()).all() }
-
-        XCTAssertEqual(dataBlocks[0].count, 1)
-        XCTAssertEqual(dataBlocks[0][0].type, .event)
-        XCTAssertEqual(dataBlocks[0][0].data, #"{"key1":"value1"}"#.utf8Data)
-
-        XCTAssertEqual(dataBlocks[1].count, 1)
-        XCTAssertEqual(dataBlocks[1][0].type, .event)
-        XCTAssertEqual(dataBlocks[1][0].data, #"{"key2":"value2"}"#.utf8Data)
-
-        XCTAssertEqual(dataBlocks[2].count, 1)
-        XCTAssertEqual(dataBlocks[2][0].type, .event)
-        XCTAssertEqual(dataBlocks[2][0].data, #"{"key3":"value3"}"#.utf8Data)
-    }
-
     func testGivenErrorVerbosity_whenIndividualDataExceedsMaxWriteSize_itDropsDataAndPrintsError() throws {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -190,7 +151,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -223,7 +183,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -245,7 +204,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -276,7 +234,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )
@@ -339,7 +296,6 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: DataEncryptionMock(
                 encrypt: { _ in "foo".utf8Data }
             ),

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -21,7 +21,6 @@ class DataUploadWorkerTests: XCTestCase {
     )
     lazy var writer = FileWriter(
         orchestrator: orchestrator,
-        forceNewFile: false,
         encryption: nil,
         telemetry: NOPTelemetry()
     )

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -132,57 +132,6 @@ class DatadogCoreTests: XCTestCase {
         XCTAssertEqual(requestBuilderSpy.requestParameters.count, 1, "It should send only one request")
     }
 
-    func testWhenWritingEventsWithForcingNewBatch_itUploadsEachEventInSeparateRequest() throws {
-        // Given
-        let core = DatadogCore(
-            directory: temporaryCoreDirectory,
-            dateProvider: RelativeDateProvider(advancingBySeconds: 0.01),
-            initialConsent: .granted,
-            performance: .mockRandom(),
-            httpClient: HTTPClientMock(),
-            encryption: nil,
-            contextProvider: .mockAny(),
-            applicationVersion: .mockAny(),
-            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
-            backgroundTasksEnabled: .mockAny()
-        )
-
-        let requestBuilderSpy = FeatureRequestBuilderSpy()
-        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
-
-        // When
-        scope.eventWriteContext(forceNewBatch: true) { context, writer in
-            writer.write(value: FeatureMock.Event(event: "1"))
-        }
-
-        scope.eventWriteContext(forceNewBatch: true) { context, writer in
-            writer.write(value: FeatureMock.Event(event: "2"))
-        }
-
-        scope.eventWriteContext(forceNewBatch: true) { context, writer in
-            writer.write(value: FeatureMock.Event(event: "3"))
-        }
-
-        // Then
-        core.flushAndTearDown()
-
-        let uploadedEvents = requestBuilderSpy.requestParameters
-            .flatMap { $0.events }
-            .map { $0.data.utf8String }
-
-        XCTAssertEqual(
-            uploadedEvents,
-            [
-                #"{"event":"1"}"#,
-                #"{"event":"2"}"#,
-                #"{"event":"3"}"#,
-            ],
-            "It should upload all events"
-        )
-        XCTAssertEqual(requestBuilderSpy.requestParameters.count, 3, "It should send 3 requests")
-    }
-
     func testWhenFeatureBaggageIsUpdated_thenNewValueIsImmediatellyAvailable() throws {
         // Given
         let core = DatadogCore(

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -275,7 +275,6 @@ internal class NOPFilesOrchestrator: FilesOrchestratorType {
 
     var performance: StoragePerformancePreset { StoragePerformanceMock.noOp }
 
-    func getNewWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
     func getWritableFile(writeSize: UInt64) throws -> WritableFile { NOPFile() }
     func getReadableFiles(excludingFilesNamed excludedFileNames: Set<String>, limit: Int) -> [ReadableFile] { [] }
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) { }

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -110,9 +110,9 @@ private struct FeatureScopeProxy: FeatureScope {
     let proxy: FeatureScope
     let interceptor: FeatureScopeInterceptor
 
-    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
         interceptor.enter()
-        proxy.eventWriteContext(bypassConsent: bypassConsent, forceNewBatch: forceNewBatch) { context, writer in
+        proxy.eventWriteContext(bypassConsent: bypassConsent) { context, writer in
             block(context, interceptor.intercept(writer: writer))
             interceptor.leave()
         }

--- a/DatadogCore/Tests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -37,7 +37,6 @@ class RUMEventFileOutputTests: XCTestCase {
                 dateProvider: fileCreationDateProvider,
                 telemetry: NOPTelemetry()
             ),
-            forceNewFile: false,
             encryption: nil,
             telemetry: NOPTelemetry()
         )

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -214,12 +214,8 @@ public protocol FeatureScope {
     ///   - bypassConsent: `true` to bypass the current core consent and write events as authorized.
     ///                    Default is `false`, setting `true` must still respect user's consent for
     ///                    collecting information.
-    ///   - forceNewBatch: `true` to enforce that event will be written to a separate batch than previous events.
-    ///                     Default is `false`, which means the core uses its own heuristic to split events between
-    ///                     batches. This parameter can be leveraged in Features which require a clear separation
-    ///                     of group of events for preparing their upload (a single upload is always constructed from a single batch).
     ///   - block: The block to execute; it is called on the context queue.
-    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) -> Void)
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void)
 
     /// Retrieve the core context.
     ///
@@ -249,8 +245,8 @@ public extension FeatureScope {
     ///                     batches. This parameter can be leveraged in Features which require a clear separation
     ///                     of group of events for preparing their upload (a single upload is always constructed from a single batch).
     ///   - block: The block to execute; it is called on the context queue.
-    func eventWriteContext(bypassConsent: Bool = false, forceNewBatch: Bool = false, _ block: @escaping (DatadogContext, Writer) -> Void) {
-        eventWriteContext(bypassConsent: bypassConsent, forceNewBatch: forceNewBatch, block)
+    func eventWriteContext(_ block: @escaping (DatadogContext, Writer) -> Void) {
+        eventWriteContext(bypassConsent: false, block)
     }
 }
 

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -261,7 +261,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
 
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
-        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: true, forceNewBatch: false) { _, writer in
+        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: true) { _, writer in
             writer.write(value: event)
         }
 

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -30,7 +30,7 @@ internal class ResourcesWriter: ResourcesWriting {
         guard let scope = core?.scope(for: ResourcesFeature.name) else {
             return
         }
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, recordWriter in
+        scope.eventWriteContext { _, recordWriter in
             resources.forEach {
                 recordWriter.write(value: $0)
             }

--- a/DatadogSessionReplay/Tests/Writer/RecordsWriterTests.swift
+++ b/DatadogSessionReplay/Tests/Writer/RecordsWriterTests.swift
@@ -40,22 +40,5 @@ class RecordsWriterTests: XCTestCase {
 
         XCTAssertEqual(core.events(ofType: EnrichedRecord.self).count, 0)
     }
-
-    func testWhenSucceedingRecordsDescribeDifferentRUMViews_itWritesThemToSeparateBatches() throws {
-        // Given
-        let forceNewBatchExpectation = expectation(description: "Should force new batch on view-id change")
-        forceNewBatchExpectation.expectedFulfillmentCount = 2
-        let core = PassthroughCoreMock(forceNewBatchExpectation: forceNewBatchExpectation)
-
-        // When
-        let writer = RecordWriter(core: core)
-
-        // Then
-        writer.write(nextRecord: EnrichedRecord(context: .mockWith(rumContext: .mockWith(viewID: "view1")), records: .mockRandom()))
-        writer.write(nextRecord: EnrichedRecord(context: .mockWith(rumContext: .mockWith(viewID: "view2")), records: .mockRandom()))
-
-        XCTAssertEqual(core.events(ofType: EnrichedRecord.self).count, 2)
-        waitForExpectations(timeout: 0.5, handler: nil)
-    }
 }
 // swiftlint:enable empty_xctest_method

--- a/DatadogTrace/Sources/Span/SpanWriteContext.swift
+++ b/DatadogTrace/Sources/Span/SpanWriteContext.swift
@@ -41,7 +41,7 @@ internal final class LazySpanWriteContext: SpanWriteContext {
         }
 
         // Ignore the current context and use the one captured at initialization:
-        scope.eventWriteContext(bypassConsent: false, forceNewBatch: false) { _, writer in
+        scope.eventWriteContext { _, writer in
             guard let context = self.context else {
                 return // unexpected
             }

--- a/DatadogTrace/Tests/Span/SpanWriteContextTests.swift
+++ b/DatadogTrace/Tests/Span/SpanWriteContextTests.swift
@@ -34,8 +34,7 @@ class SpanWriteContextTests: XCTestCase {
     func testWhenWritingEvent_itRespectsCoreConsentAndBatching() {
         let core = PassthroughCoreMock(
             expectation: expectation(description: "write event to core"),
-            bypassConsentExpectation: invertedExpectation(description: "do not bypass consent"),
-            forceNewBatchExpectation: invertedExpectation(description: "do not force new batch")
+            bypassConsentExpectation: invertedExpectation(description: "do not bypass consent")
         )
 
         // Given

--- a/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
@@ -51,10 +51,6 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
     /// is executed with `bypassConsent` parameter set to `true`.
     public var bypassConsentExpectation: XCTestExpectation?
 
-    /// Test expectation that will be fullfilled when the `eventWriteContext` closure
-    /// is executed with `forceNewBatch` parameter set to `true`.
-    public var forceNewBatchExpectation: XCTestExpectation?
-
     /// Creates a Passthrough core mock.
     ///
     /// - Parameters:
@@ -63,20 +59,16 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
     ///                  is invoked.
     ///   - bypassConsentExpectation: The test exepection to fullfill when `eventWriteContext`
     ///                  is invoked with `bypassConsent` parameter set to `true`.
-    ///   - forceNewBatchExpectation: The test exepection to fullfill when `eventWriteContext`
-    ///                  is invoked with `forceNewBatch` parameter set to `true`.
 
     public required init(
         context: DatadogContext = .mockAny(),
         expectation: XCTestExpectation? = nil,
         bypassConsentExpectation: XCTestExpectation? = nil,
-        forceNewBatchExpectation: XCTestExpectation? = nil,
         messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     ) {
         self.context = context
         self.expectation = expectation
         self.bypassConsentExpectation = bypassConsentExpectation
-        self.forceNewBatchExpectation = forceNewBatchExpectation
         self.messageReceiver = messageReceiver
 
         messageReceiver.receive(message: .context(context), from: self)
@@ -112,13 +104,9 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
     /// Execute `block` with the current context and a `writer` to record events.
     ///
     /// - Parameter block: The block to execute.
-    public func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+    public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
         if bypassConsent {
             bypassConsentExpectation?.fulfill()
-        }
-
-        if forceNewBatch {
-            forceNewBatchExpectation?.fulfill()
         }
 
         block(context, writer)

--- a/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
@@ -40,14 +40,11 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
     ///                  is invoked.
     ///   - bypassConsentExpectation: The test exepection to fullfill when `eventWriteContext`
     ///                  is invoked with `bypassConsent` parameter set to `true`.
-    ///   - forceNewBatchExpectation: The test exepection to fullfill when `eventWriteContext`
-    ///                  is invoked with `forceNewBatch` parameter set to `true`.
     public required init(
         context: DatadogContext = .mockAny(),
         feature: Feature? = nil,
         expectation: XCTestExpectation? = nil,
         bypassConsentExpectation: XCTestExpectation? = nil,
-        forceNewBatchExpectation: XCTestExpectation? = nil,
         messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     ) {
         self.feature = feature
@@ -56,7 +53,6 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
             context: context,
             expectation: expectation,
             bypassConsentExpectation: bypassConsentExpectation,
-            forceNewBatchExpectation: forceNewBatchExpectation,
             messageReceiver: messageReceiver
         )
     }
@@ -69,13 +65,10 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
     ///                  is invoked.
     ///   - bypassConsentExpectation: The test exepection to fullfill when `eventWriteContext`
     ///                  is invoked with `bypassConsent` parameter set to `true`.
-    ///   - forceNewBatchExpectation: The test exepection to fullfill when `eventWriteContext`
-    ///                  is invoked with `forceNewBatch` parameter set to `true`.
     public required init(
         context: DatadogContext = .mockAny(),
         expectation: XCTestExpectation? = nil,
         bypassConsentExpectation: XCTestExpectation? = nil,
-        forceNewBatchExpectation: XCTestExpectation? = nil,
         messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     ) {
         self.feature = nil
@@ -84,7 +77,6 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
             context: context,
             expectation: expectation,
             bypassConsentExpectation: bypassConsentExpectation,
-            forceNewBatchExpectation: forceNewBatchExpectation,
             messageReceiver: messageReceiver
         )
     }


### PR DESCRIPTION
### What and why?

Replay endpoint now support multiple segments per request, remove the need for forcing a new batch.

### How?

Remove force-new-batch ability.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
