### PR TITLE
Fix privacy manifest collision

### DIFF
--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -22,7 +22,10 @@ Pod::Spec.new do |s|
   
   s.source_files = ["DatadogCore/Sources/**/*.swift",
                     "DatadogCore/Private/**/*.{h,m}"]
-  s.resource = "DatadogCore/Resources/PrivacyInfo.xcprivacy"
+
+  s.resource_bundle = {
+    "DatadogPrivacyInfo" => "DatadogCore/Resources/PrivacyInfo.xcprivacy"
+  }
 
   s.dependency 'DatadogInternal', s.version.to_s
 

--- a/DatadogCore/Resources/PrivacyInfo.xcprivacy
+++ b/DatadogCore/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/dependency-manager-tests/carthage/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/carthage/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/dependency-manager-tests/carthage/App/ViewController.swift
+++ b/dependency-manager-tests/carthage/App/ViewController.swift
@@ -41,13 +41,6 @@ internal class ViewController: UIViewController {
         RUM.enable(with: .init(applicationID: "app-id"))
         RUMMonitor.shared().startView(viewController: self)
 
-        // DDURLSessionDelegate APIs must be visible:
-        _ = DDURLSessionDelegate()
-        _ = DatadogURLSessionDelegate()
-        class CustomDelegate: NSObject, __URLSessionDelegateProviding {
-            var ddURLSessionDelegate: DatadogURLSessionDelegate { DatadogURLSessionDelegate() }
-        }
-
         // Trace APIs must be visible:
         Trace.enable()
 

--- a/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		D20D6FE929F6C2ED00D2886E /* DatadogTrace.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2966C2329CA1C5300FC6B3C /* DatadogTrace.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D20D6FEA29F6C2F200D2886E /* DatadogRUM.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20D6FE329F6C2D600D2886E /* DatadogRUM.xcframework */; };
 		D20D6FEB29F6C2F200D2886E /* DatadogRUM.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20D6FE329F6C2D600D2886E /* DatadogRUM.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D22919292B76525C00C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D22919282B76525C00C38A18 /* PrivacyInfo.xcprivacy */; };
+		D229192A2B76525C00C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D22919282B76525C00C38A18 /* PrivacyInfo.xcprivacy */; };
 		D2675BF32A019CF500190669 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; };
 		D2675BF42A019CF500190669 /* DatadogCrashReporting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2675BF52A019CF600190669 /* DatadogInternal.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D240FC8B2995183D00D9F099 /* DatadogInternal.xcframework */; };
@@ -148,6 +150,7 @@
 		9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogObjc.xcframework; path = Carthage/Build/DatadogObjc.xcframework; sourceTree = "<group>"; };
 		9E9D5E8725F90FC6002F12A0 /* DatadogCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogCore.xcframework; path = Carthage/Build/DatadogCore.xcframework; sourceTree = "<group>"; };
 		D20D6FE329F6C2D600D2886E /* DatadogRUM.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogRUM.xcframework; path = Carthage/Build/DatadogRUM.xcframework; sourceTree = "<group>"; };
+		D22919282B76525C00C38A18 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D240FC8B2995183D00D9F099 /* DatadogInternal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogInternal.xcframework; path = Carthage/Build/DatadogInternal.xcframework; sourceTree = "<group>"; };
 		D26F741729ACC61E00D25622 /* DatadogLogs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogLogs.xcframework; path = Carthage/Build/DatadogLogs.xcframework; sourceTree = "<group>"; };
 		D290BA2D27CD09740019936D /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -262,6 +265,7 @@
 				61C3641A243752A500C4D4E6 /* SceneDelegate.swift */,
 				61C3641C243752A500C4D4E6 /* ViewController.swift */,
 				61C36426243752A600C4D4E6 /* Info.plist */,
+				D22919282B76525C00C38A18 /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -471,6 +475,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D22919292B76525C00C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,6 +497,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D229192A2B76525C00C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dependency-manager-tests/cocoapods/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/cocoapods/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/dependency-manager-tests/cocoapods/App/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/App/ViewController.swift
@@ -41,13 +41,6 @@ internal class ViewController: UIViewController {
         RUM.enable(with: .init(applicationID: "app-id"))
         RUMMonitor.shared().startView(viewController: self)
 
-        // DDURLSessionDelegate APIs must be visible:
-        _ = DDURLSessionDelegate()
-        _ = DatadogURLSessionDelegate()
-        class CustomDelegate: NSObject, __URLSessionDelegateProviding {
-            var ddURLSessionDelegate: DatadogURLSessionDelegate { DatadogURLSessionDelegate() }
-        }
-
         // Trace APIs must be visible:
         Trace.enable()
 

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 				61373B2526E0E78300E0F46E /* Sources */,
 				61373B2626E0E78300E0F46E /* Frameworks */,
 				61373B2726E0E78300E0F46E /* Resources */,
+				CC86EE069424642723D0C2E2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -592,6 +593,7 @@
 				D245427827C8E93D0039E0A6 /* Sources */,
 				D245427C27C8E93D0039E0A6 /* Frameworks */,
 				D245427E27C8E93D0039E0A6 /* Resources */,
+				5B109A73B29580A024EBCD59 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -807,6 +809,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		5B109A73B29580A024EBCD59 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8D0504D0CD7CAFBBB5B63F13 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -827,6 +846,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CC86EE069424642723D0C2E2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D235937827C8EB0500BF32D7 /* [CP] Check Pods Manifest.lock */ = {

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,10 @@
 		A0DBB7E71DD4888837ED81B5 /* Pods_Common_App_Dynamic_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8CCD75AF46655F78F7A3D7A /* Pods_Common_App_Dynamic_iOS.framework */; };
 		B162FE141838120027D821F9 /* libPods-Common-App Static iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C285D46A1E0E371443F0F77 /* libPods-Common-App Static iOS.a */; };
 		CCA17085193225EE98A8B997 /* Pods_Common_App_Dynamic_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F08D599966036C2B51829AB /* Pods_Common_App_Dynamic_tvOS.framework */; };
+		D229192C2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */; };
+		D229192D2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */; };
+		D229192E2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */; };
+		D229192F2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */; };
 		D235937A27C8EB0500BF32D7 /* CPProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8C31D26E0E27A006EDF53 /* CPProjectTests.swift */; };
 		D235938927C8ECD800BF32D7 /* CPProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8C32826E0E27A006EDF53 /* CPProjectUITests.swift */; };
 		D245424627C8D3200039E0A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8C30626E0E278006EDF53 /* AppDelegate.swift */; };
@@ -144,6 +148,7 @@
 		BC677EB73CB7FE4A474BB0D5 /* Pods-Common-CPProjectNoUseFrameworks-CPProjectNoUseFrameworksUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-CPProjectNoUseFrameworks-CPProjectNoUseFrameworksUITests.release.xcconfig"; path = "Target Support Files/Pods-Common-CPProjectNoUseFrameworks-CPProjectNoUseFrameworksUITests/Pods-Common-CPProjectNoUseFrameworks-CPProjectNoUseFrameworksUITests.release.xcconfig"; sourceTree = "<group>"; };
 		BFCEA18578B6134001291BD5 /* Pods-Common-CPProjectNoUseFrameworks tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-CPProjectNoUseFrameworks tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Common-CPProjectNoUseFrameworks tvOS/Pods-Common-CPProjectNoUseFrameworks tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		CA325D6A1605874914378E3E /* libPods-App Static tvOS Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-App Static tvOS Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D235938127C8EB0500BF32D7 /* App Static tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App Static tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D235938F27C8ECD800BF32D7 /* App Static tvOS UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App Static tvOS UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D245425127C8D3200039E0A6 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -293,6 +298,7 @@
 				61B8C30826E0E278006EDF53 /* SceneDelegate.swift */,
 				D245425627C8DE3D0039E0A6 /* ViewController.swift */,
 				61B8C31426E0E27A006EDF53 /* Info.plist */,
+				D229192B2B76580600C38A18 /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -675,6 +681,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D229192D2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -696,6 +703,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D229192C2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -731,6 +739,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D229192E2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -752,6 +761,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D229192F2B76580600C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dependency-manager-tests/spm/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/spm/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/dependency-manager-tests/spm/App/ViewController.swift
+++ b/dependency-manager-tests/spm/App/ViewController.swift
@@ -39,13 +39,6 @@ internal class ViewController: UIViewController {
         RUM.enable(with: .init(applicationID: "app-id"))
         RUMMonitor.shared().startView(viewController: self)
 
-        // DDURLSessionDelegate APIs must be visible:
-        _ = DDURLSessionDelegate()
-        _ = DatadogURLSessionDelegate()
-        class CustomDelegate: NSObject, __URLSessionDelegateProviding {
-            var ddURLSessionDelegate: DatadogURLSessionDelegate { DatadogURLSessionDelegate() }
-        }
-
         // Trace APIs must be visible:
         Trace.enable()
 

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -3,20 +3,19 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		3CB7A04C29F6ABDA007A27ED /* DatadogWebViewTracking in Frameworks */ = {isa = PBXBuildFile; productRef = 3CB7A04B29F6ABDA007A27ED /* DatadogWebViewTracking */; };
-		61253AF62A6FEAEF00A15E18 /* DatadogSessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = 61253AF52A6FEAEF00A15E18 /* DatadogSessionReplay */; };
-		612C055B2A93C4DF00A1DA8C /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = 612C055A2A93C4DF00A1DA8C /* DatadogObjc */; };
-		612C055D2A93C51300A1DA8C /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = 612C055C2A93C51300A1DA8C /* DatadogObjc */; };
 		61C363DA24374D5F00C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363D924374D5F00C4D4E6 /* AppDelegate.swift */; };
 		61C363DC24374D5F00C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363DB24374D5F00C4D4E6 /* SceneDelegate.swift */; };
 		61C363DE24374D5F00C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363DD24374D5F00C4D4E6 /* ViewController.swift */; };
 		61C363F124374D6100C4D4E6 /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363F024374D6100C4D4E6 /* AppTests.swift */; };
 		61C363FC24374D6100C4D4E6 /* AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363FB24374D6100C4D4E6 /* AppUITests.swift */; };
 		9E73374026B0123500917C24 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 9E73373F26B0123500917C24 /* DatadogCrashReporting */; };
+		D22919312B76589B00C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D22919302B76589B00C38A18 /* PrivacyInfo.xcprivacy */; };
+		D22919322B76589B00C38A18 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D22919302B76589B00C38A18 /* PrivacyInfo.xcprivacy */; };
 		D2344E1F29ACDE61007F5BD2 /* DatadogLogs in Frameworks */ = {isa = PBXBuildFile; productRef = D2344E1E29ACDE61007F5BD2 /* DatadogLogs */; };
 		D2344E2129ACDE68007F5BD2 /* DatadogLogs in Frameworks */ = {isa = PBXBuildFile; productRef = D2344E2029ACDE68007F5BD2 /* DatadogLogs */; };
 		D23BF5F327CCCC3300BB4CCD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363DD24374D5F00C4D4E6 /* ViewController.swift */; };
@@ -25,6 +24,9 @@
 		D23BF5F727CCCC3300BB4CCD /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = D23BF5F027CCCC3300BB4CCD /* DatadogCrashReporting */; };
 		D23BF60427CCCCF800BB4CCD /* AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363FB24374D6100C4D4E6 /* AppUITests.swift */; };
 		D23BF61027CCCD5700BB4CCD /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363F024374D6100C4D4E6 /* AppTests.swift */; };
+		D266C6872B766095008866F9 /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = D266C6862B766095008866F9 /* DatadogObjc */; };
+		D266C6892B766095008866F9 /* DatadogSessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = D266C6882B766095008866F9 /* DatadogSessionReplay */; };
+		D266C68B2B76609F008866F9 /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = D266C68A2B76609F008866F9 /* DatadogObjc */; };
 		D26A32D72A4C892A00903514 /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = D26A32D62A4C892A00903514 /* DatadogCore */; };
 		D26A32D92A4C893300903514 /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = D26A32D82A4C893300903514 /* DatadogCore */; };
 		D2966C2E29CA1F2D00FC6B3C /* DatadogTrace in Frameworks */ = {isa = PBXBuildFile; productRef = D2966C2D29CA1F2D00FC6B3C /* DatadogTrace */; };
@@ -101,6 +103,7 @@
 		61C363FD24374D6100C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61CE5FD52461D3C2005EA621 /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		61CE5FD62461D3C2005EA621 /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
+		D22919302B76589B00C38A18 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D23BF5FE27CCCC3300BB4CCD /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D23BF60A27CCCCF800BB4CCD /* App tvOS UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D23BF61627CCCD5700BB4CCD /* App tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,11 +115,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				D26A32D72A4C892A00903514 /* DatadogCore in Frameworks */,
+				D266C6892B766095008866F9 /* DatadogSessionReplay in Frameworks */,
 				D2966C2E29CA1F2D00FC6B3C /* DatadogTrace in Frameworks */,
+				D266C6872B766095008866F9 /* DatadogObjc in Frameworks */,
 				D2344E1F29ACDE61007F5BD2 /* DatadogLogs in Frameworks */,
-				61253AF62A6FEAEF00A15E18 /* DatadogSessionReplay in Frameworks */,
 				D2CE76BC29F6B9EE00D79713 /* DatadogRUM in Frameworks */,
-				612C055B2A93C4DF00A1DA8C /* DatadogObjc in Frameworks */,
 				3CB7A04C29F6ABDA007A27ED /* DatadogWebViewTracking in Frameworks */,
 				9E73374026B0123500917C24 /* DatadogCrashReporting in Frameworks */,
 			);
@@ -141,7 +144,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2966C3029CA1F3300FC6B3C /* DatadogTrace in Frameworks */,
-				612C055D2A93C51300A1DA8C /* DatadogObjc in Frameworks */,
+				D266C68B2B76609F008866F9 /* DatadogObjc in Frameworks */,
 				D2344E2129ACDE68007F5BD2 /* DatadogLogs in Frameworks */,
 				D2CE76BA29F6B9E300D79713 /* DatadogRUM in Frameworks */,
 				D26A32D92A4C893300903514 /* DatadogCore in Frameworks */,
@@ -198,6 +201,7 @@
 				61C363DB24374D5F00C4D4E6 /* SceneDelegate.swift */,
 				61C363DD24374D5F00C4D4E6 /* ViewController.swift */,
 				61C363E724374D6000C4D4E6 /* Info.plist */,
+				D22919302B76589B00C38A18 /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -262,8 +266,8 @@
 				D2CE76BB29F6B9EE00D79713 /* DatadogRUM */,
 				3CB7A04B29F6ABDA007A27ED /* DatadogWebViewTracking */,
 				D26A32D62A4C892A00903514 /* DatadogCore */,
-				61253AF52A6FEAEF00A15E18 /* DatadogSessionReplay */,
-				612C055A2A93C4DF00A1DA8C /* DatadogObjc */,
+				D266C6862B766095008866F9 /* DatadogObjc */,
+				D266C6882B766095008866F9 /* DatadogSessionReplay */,
 			);
 			productName = SPMProject;
 			productReference = 61C363D624374D5F00C4D4E6 /* App.app */;
@@ -326,7 +330,7 @@
 				D2966C2F29CA1F3300FC6B3C /* DatadogTrace */,
 				D2CE76B929F6B9E300D79713 /* DatadogRUM */,
 				D26A32D82A4C893300903514 /* DatadogCore */,
-				612C055C2A93C51300A1DA8C /* DatadogObjc */,
+				D266C68A2B76609F008866F9 /* DatadogObjc */,
 			);
 			productName = SPMProject;
 			productReference = D23BF5FE27CCCC3300BB4CCD /* App.app */;
@@ -428,6 +432,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D22919312B76589B00C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -449,6 +454,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D22919322B76589B00C38A18 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -725,7 +731,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -748,7 +753,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -867,7 +871,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = appletvos;
-				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -889,7 +892,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SDKROOT = appletvos;
-				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1083,21 +1085,6 @@
 			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogWebViewTracking;
 		};
-		61253AF52A6FEAEF00A15E18 /* DatadogSessionReplay */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = DatadogSessionReplay;
-		};
-		612C055A2A93C4DF00A1DA8C /* DatadogObjc */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = DatadogObjc;
-		};
-		612C055C2A93C51300A1DA8C /* DatadogObjc */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = DatadogObjc;
-		};
 		9E73373F26B0123500917C24 /* DatadogCrashReporting */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
@@ -1117,6 +1104,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D23BF5F127CCCC3300BB4CCD /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogCrashReporting;
+		};
+		D266C6862B766095008866F9 /* DatadogObjc */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogObjc;
+		};
+		D266C6882B766095008866F9 /* DatadogSessionReplay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogSessionReplay;
+		};
+		D266C68A2B76609F008866F9 /* DatadogObjc */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogObjc;
 		};
 		D26A32D62A4C892A00903514 /* DatadogCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/dependency-manager-tests/xcframeworks/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/xcframeworks/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/dependency-manager-tests/xcframeworks/App/ViewController.swift
+++ b/dependency-manager-tests/xcframeworks/App/ViewController.swift
@@ -41,13 +41,6 @@ internal class ViewController: UIViewController {
         RUM.enable(with: .init(applicationID: "app-id"))
         RUMMonitor.shared().startView(viewController: self)
 
-        // DDURLSessionDelegate APIs must be visible:
-        _ = DDURLSessionDelegate()
-        _ = DatadogURLSessionDelegate()
-        class CustomDelegate: NSObject, __URLSessionDelegateProviding {
-            var ddURLSessionDelegate: DatadogURLSessionDelegate { DatadogURLSessionDelegate() }
-        }
-
         // Trace APIs must be visible:
         Trace.enable()
 

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		D2966C2A29CA1E1600FC6B3C /* DatadogTrace.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2966C2829CA1E1600FC6B3C /* DatadogTrace.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2966C2B29CA1E1C00FC6B3C /* DatadogTrace.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2966C2829CA1E1600FC6B3C /* DatadogTrace.xcframework */; };
 		D2966C2C29CA1E1C00FC6B3C /* DatadogTrace.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2966C2829CA1E1600FC6B3C /* DatadogTrace.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2C2E9C52B76593F0076B3AB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2C2E9C42B76593F0076B3AB /* PrivacyInfo.xcprivacy */; };
+		D2C2E9C62B76593F0076B3AB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2C2E9C42B76593F0076B3AB /* PrivacyInfo.xcprivacy */; };
 		D2EBEDA929B7862C00B15732 /* DatadogLogs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2EBEDA829B7862C00B15732 /* DatadogLogs.xcframework */; };
 		D2EBEDAA29B7862C00B15732 /* DatadogLogs.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2EBEDA829B7862C00B15732 /* DatadogLogs.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2EBEDAB29B7863B00B15732 /* DatadogLogs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2EBEDA829B7862C00B15732 /* DatadogLogs.xcframework */; };
@@ -147,6 +149,7 @@
 		D290BA3927CD09A20019936D /* App tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D290BA4527CD09C70019936D /* App tvOS UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2966C2829CA1E1600FC6B3C /* DatadogTrace.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogTrace.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogTrace.xcframework"; sourceTree = "<group>"; };
+		D2C2E9C42B76593F0076B3AB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D2EBEDA829B7862C00B15732 /* DatadogLogs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogLogs.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogLogs.xcframework"; sourceTree = "<group>"; };
 		D2EBEDAD29B7867600B15732 /* DatadogInternal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogInternal.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogInternal.xcframework"; sourceTree = "<group>"; };
 		D2F09A2429F6C65A0036B910 /* DatadogRUM.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogRUM.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogRUM.xcframework"; sourceTree = "<group>"; };
@@ -262,6 +265,7 @@
 				61C3641A243752A500C4D4E6 /* SceneDelegate.swift */,
 				61C3641C243752A500C4D4E6 /* ViewController.swift */,
 				61C36426243752A600C4D4E6 /* Info.plist */,
+				D2C2E9C42B76593F0076B3AB /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -471,6 +475,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2C2E9C52B76593F0076B3AB /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,6 +497,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2C2E9C62B76593F0076B3AB /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### What and why?

When using static linkage in CocoaPods with `use_frameworks! :linkage => :static`. The pod's resource gets copied at root of the app bundle, resulting in collision with the app's `PrivacyInfo.xcprivacy`.

Resolve #1665

### How?

Use `resource_bundle` to keep the `PrivacyInfo.xcprivacy` in it own bundle.

The smoke tests apps now all define privacy-manifest to catch any collision.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
