### PR TITLE
RUM-1836 feat(otel-tracer) integrate OpenTelemetrySwiftApi in package managers

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "microsoft/plcrashreporter" ~> 1.11.1
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/ganeshnj/ci/pod-push/OpenTelemetryApi.json" ~> 1.9.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/ganeshnj/ci/pod-push/OpenTelemetryApi.json" "1.9.1"
 github "microsoft/plcrashreporter" "1.11.1"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		3C5D636A2B55512B00FEB4BA /* OTelTraceState+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */; };
 		3C5D636C2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D636B2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift */; };
 		3C5D636D2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D636B2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift */; };
-		3C6C7FDB2B45738C006F5CBC /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */; };
-		3C6C7FDD2B457392006F5CBC /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */; };
+		3C5D691F2B76825500C4E07E /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; };
+		3C5D69222B76826000C4E07E /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; };
 		3C6C7FE72B459AAA006F5CBC /* OTelSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C7FE02B459AAA006F5CBC /* OTelSpan.swift */; };
 		3C6C7FE82B459AAA006F5CBC /* OTelSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C7FE02B459AAA006F5CBC /* OTelSpan.swift */; };
 		3C6C7FE92B459AAA006F5CBC /* OTelSpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C7FE12B459AAA006F5CBC /* OTelSpanBuilder.swift */; };
@@ -1892,11 +1892,9 @@
 		3C0D5DEE2A5442A900446CF9 /* EventMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMocks.swift; sourceTree = "<group>"; };
 		3C0D5DF42A5443B100446CF9 /* DataFormatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataFormatTests.swift; sourceTree = "<group>"; };
 		3C1890132ABDE99200CE9E73 /* DDURLSessionInstrumentationTests+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDURLSessionInstrumentationTests+apiTests.m"; sourceTree = "<group>"; };
-		3C2206F22AB9CE9300DE780C /* MetaTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaTypeExtensions.swift; sourceTree = "<group>"; };
+		3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenTelemetryApi.xcframework; path = ../Carthage/Build/OpenTelemetryApi.xcframework; sourceTree = "<group>"; };
 		3C32359C2B55386C000B4258 /* OTelSpanLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLink.swift; sourceTree = "<group>"; };
 		3C32359F2B55387A000B4258 /* OTelSpanLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLinkTests.swift; sourceTree = "<group>"; };
-		3C394EF62AA5F49F008F48BA /* URLSessionDataDelegateSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataDelegateSwizzler.swift; sourceTree = "<group>"; };
-		3C394EF92AA5F4C8008F48BA /* URLSessionDataDelegateSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataDelegateSwizzlerTests.swift; sourceTree = "<group>"; };
 		3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTelTraceState+Datadog.swift"; sourceTree = "<group>"; };
 		3C5D636B2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTelTraceState+DatadogTests.swift"; sourceTree = "<group>"; };
 		3C6C7FE02B459AAA006F5CBC /* OTelSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpan.swift; sourceTree = "<group>"; };
@@ -2957,8 +2955,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C5D691F2B76825500C4E07E /* OpenTelemetryApi.xcframework in Frameworks */,
 				D2C1A50E29C4C4EF00946C31 /* DatadogInternal.framework in Frameworks */,
-				3C6C7FDB2B45738C006F5CBC /* OpenTelemetryApi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3001,8 +2999,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C5D69222B76826000C4E07E /* OpenTelemetryApi.xcframework in Frameworks */,
 				D2C1A57429C4F30000946C31 /* DatadogInternal.framework in Frameworks */,
-				3C6C7FDD2B457392006F5CBC /* OpenTelemetryApi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4087,6 +4085,7 @@
 		61133C6F2423993200786299 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */,
 				D2579591298ABCED008A1BE5 /* XCTest.framework */,
 				D2579593298ABCF5008A1BE5 /* XCTest.framework */,
 				61B03ECC274FF00E00EB1AE1 /* SwiftUI.framework */,
@@ -6444,7 +6443,6 @@
 			);
 			name = "DatadogTrace iOS";
 			packageProductDependencies = (
-				3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */,
 			);
 			productName = DatadogTrace;
 			productReference = D25EE93429C4C3C300CE3839 /* DatadogTrace.framework */;
@@ -6539,7 +6537,6 @@
 			);
 			name = "DatadogTrace tvOS";
 			packageProductDependencies = (
-				3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */,
 			);
 			productName = DatadogTrace;
 			productReference = D2C1A55A29C4F2DF00946C31 /* DatadogTrace.framework */;
@@ -6818,7 +6815,6 @@
 			);
 			mainGroup = 61133B78242393DE00786299;
 			packageReferences = (
-				3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */,
 			);
 			productRefGroup = 61133B83242393DE00786299 /* Products */;
 			projectDirPath = "";
@@ -12954,34 +12950,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.9.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		3C6C7FDA2B45738C006F5CBC /* OpenTelemetryApi */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
-			productName = OpenTelemetryApi;
-		};
-		3C6C7FDC2B457392006F5CBC /* OpenTelemetryApi */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3C6C7FD92B457381006F5CBC /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
-			productName = OpenTelemetryApi;
-		};
-		6152C83D24BE1C91006A1679 /* HTTPServerMock */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = HTTPServerMock;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 61133B79242393DE00786299 /* Project object */;
 }

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -2,12 +2,12 @@ Pod::Spec.new do |s|
   s.name         = "DatadogTrace"
   s.version      = "2.7.0"
   s.summary      = "Datadog Trace Module."
-  
+
   s.homepage     = "https://www.datadoghq.com"
   s.social_media_url   = "https://twitter.com/datadoghq"
 
   s.license            = { :type => "Apache", :file => 'LICENSE' }
-  s.authors            = { 
+  s.authors            = {
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
     "Maciej Burda" => "maciej.burda@datadoghq.com",
     "Maxime Epain" => "maxime.epain@datadoghq.com",
@@ -19,9 +19,9 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '11.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
-  
+
   s.source_files = ["DatadogTrace/Sources/**/*.swift"]
 
   s.dependency 'DatadogInternal', s.version.to_s
-
+  s.dependency 'OpenTelemetrySwiftApi', '1.9.1'
 end

--- a/DatadogTrace/Sources/OpenTelemetry/OTelAttributeValue+Datadog.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelAttributeValue+Datadog.swift
@@ -64,6 +64,8 @@ extension Dictionary where Key == String, Value == OpenTelemetryApi.AttributeVal
                         tags["\(key).\(nestedKey)"] = nestedValue
                     }
                 }
+            @unknown default:
+                break
             }
         }
         return tags

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -33,6 +33,8 @@ internal extension OpenTelemetryApi.Status {
             return 2
         case .unset:
             return 1
+        @unknown default:
+            return 1
         }
     }
 }
@@ -202,6 +204,8 @@ internal class OTelSpan: OpenTelemetryApi.Span {
             // send error log to Datadog
             // Empty kind or description is equivalent to not present
             ddSpan.setError(kind: "", message: description)
+        @unknown default:
+            break
         }
 
         // SpanKind maps to the `span.kind` tag in Datadog

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: dependencies templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
 DD_SDK_SWIFT_TESTING_VERSION = 2.3.2
+DD_DISABLE_TEST_INSTRUMENTING = true
 
 define DD_SDK_TESTING_XCCONFIG_CI
 DD_SDK_TESTING_PATH=$$(DD_SDK_TESTING_OVERRIDE_PATH:default=$$(SRCROOT)/../instrumented-tests/)\n
@@ -42,7 +43,7 @@ define DD_SDK_BASE_XCCONFIG_CI
 SWIFT_TREAT_WARNINGS_AS_ERRORS = YES\n
 \n
 // If running on CI. This value is injected to some targets through their `Info.plist`:\n
-IS_CI = true\n 
+IS_CI = true\n
 \n
 // Use iOS 11 deployment target on CI as long as we use Xcode 14.x for integration\n
 IPHONEOS_DEPLOYMENT_TARGET=11.0\n
@@ -70,7 +71,7 @@ ifeq (${ci}, true)
 		@echo $$DD_SDK_BASE_XCCONFIG_CI >> xcconfigs/Base.local.xcconfig;
 		@echo $$DD_SDK_DATADOG_XCCONFIG_CI > xcconfigs/Datadog.local.xcconfig;
 ifndef DD_DISABLE_TEST_INSTRUMENTING
-		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;	
+		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;
 		@rm -rf instrumented-tests/DatadogSDKTesting.xcframework
 		@rm -rf instrumented-tests/DatadogSDKTesting.zip
 		@rm -rf instrumented-tests/LICENSE
@@ -78,7 +79,7 @@ ifndef DD_DISABLE_TEST_INSTRUMENTING
 		@unzip -q instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
 		@[ -e "instrumented-tests/DatadogSDKTesting.xcframework" ] && echo "DatadogSDKTesting.xcframework - OK" || { echo "DatadogSDKTesting.xcframework - missing"; exit 1; }
 endif
-		
+
 endif
 
 # Prepare project on GitLab CI (this will replace `make dependencies` once we're fully on GitLab).

--- a/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C0F8E222B768A05004948CD /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */; };
+		3C0F8E232B768A05004948CD /* OpenTelemetryApi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C0F8E242B768A17004948CD /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */; };
+		3C0F8E252B768A17004948CD /* OpenTelemetryApi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3CB135E729F6B90F0000234F /* DatadogWebViewTracking.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CB135E429F6B8F90000234F /* DatadogWebViewTracking.xcframework */; };
 		3CB135E829F6B90F0000234F /* DatadogWebViewTracking.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CB135E429F6B8F90000234F /* DatadogWebViewTracking.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		617803D22A6FF2EA005FE258 /* DatadogSessionReplay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 617803D12A6FF2EA005FE258 /* DatadogSessionReplay.xcframework */; };
@@ -101,6 +105,7 @@
 				9E9D5E8D25F90FC6002F12A0 /* DatadogCore.xcframework in Embed Frameworks */,
 				D20D6FEB29F6C2F200D2886E /* DatadogRUM.xcframework in Embed Frameworks */,
 				D2675BF42A019CF500190669 /* DatadogCrashReporting.xcframework in Embed Frameworks */,
+				3C0F8E232B768A05004948CD /* OpenTelemetryApi.xcframework in Embed Frameworks */,
 				9E9D5E8B25F90FC6002F12A0 /* DatadogObjc.xcframework in Embed Frameworks */,
 				D26F741929ACC61E00D25622 /* DatadogLogs.xcframework in Embed Frameworks */,
 			);
@@ -114,6 +119,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				D290BA2627CD09740019936D /* CrashReporter.xcframework in Embed Frameworks */,
+				3C0F8E252B768A17004948CD /* OpenTelemetryApi.xcframework in Embed Frameworks */,
 				D20D6FE729F6C2EB00D2886E /* DatadogRUM.xcframework in Embed Frameworks */,
 				D20D6FE929F6C2ED00D2886E /* DatadogTrace.xcframework in Embed Frameworks */,
 				D2675BFA2A019D0100190669 /* DatadogInternal.xcframework in Embed Frameworks */,
@@ -128,6 +134,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenTelemetryApi.xcframework; path = Carthage/Build/OpenTelemetryApi.xcframework; sourceTree = "<group>"; };
 		3CB135E429F6B8F90000234F /* DatadogWebViewTracking.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogWebViewTracking.xcframework; path = Carthage/Build/DatadogWebViewTracking.xcframework; sourceTree = "<group>"; };
 		615519322461CDB4002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519332461CDB4002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -169,6 +176,7 @@
 				D20D6FEA29F6C2F200D2886E /* DatadogRUM.xcframework in Frameworks */,
 				3CB135E729F6B90F0000234F /* DatadogWebViewTracking.xcframework in Frameworks */,
 				9E9D5E8C25F90FC6002F12A0 /* DatadogCore.xcframework in Frameworks */,
+				3C0F8E222B768A05004948CD /* OpenTelemetryApi.xcframework in Frameworks */,
 				D2675BF32A019CF500190669 /* DatadogCrashReporting.xcframework in Frameworks */,
 				9E9D5E8A25F90FC6002F12A0 /* DatadogObjc.xcframework in Frameworks */,
 			);
@@ -193,6 +201,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2B946AE29ACF6C20080CB40 /* DatadogLogs.xcframework in Frameworks */,
+				3C0F8E242B768A17004948CD /* OpenTelemetryApi.xcframework in Frameworks */,
 				D20D6FE829F6C2ED00D2886E /* DatadogTrace.xcframework in Frameworks */,
 				D2675BF92A019D0100190669 /* DatadogInternal.xcframework in Frameworks */,
 				D290BA1F27CD09740019936D /* CrashReporter.xcframework in Frameworks */,
@@ -287,6 +296,7 @@
 		61C364492437547A00C4D4E6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3C0F8E212B768A05004948CD /* OpenTelemetryApi.xcframework */,
 				617803D12A6FF2EA005FE258 /* DatadogSessionReplay.xcframework */,
 				D20D6FE329F6C2D600D2886E /* DatadogRUM.xcframework */,
 				D2966C2329CA1C5300FC6B3C /* DatadogTrace.xcframework */,

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -30,4 +30,5 @@ test:
 		@[ -e "Carthage/Build/DatadogCrashReporting.xcframework" ] && echo "DatadogCrashReporting.xcframework - OK" || { echo "DatadogCrashReporting.xcframework - missing"; false; }
 		@[ -e "Carthage/Build/CrashReporter.xcframework" ] && echo "CrashReporter.xcframework - OK" || { echo "CrashReporter.xcframework - missing"; false; }
 		@[ -e "Carthage/Build/DatadogWebViewTracking.xcframework" ] && echo "DatadogWebViewTracking.xcframework - OK" || { echo "DatadogWebViewTracking.xcframework - missing"; false; }
+		@[ -e "Carthage/Build/OpenTelemetryApi.xcframework" ] && echo "OpenTelemetryApi.xcframework - OK" || { echo "OpenTelemetryApi.xcframework - missing"; false; }
 		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -384,6 +384,8 @@
 				61373B2526E0E78300E0F46E /* Sources */,
 				61373B2626E0E78300E0F46E /* Frameworks */,
 				61373B2726E0E78300E0F46E /* Resources */,
+				9AB54E91F6CF9F39B153DDCF /* [CP] Copy Pods Resources */,
+				8A0FC3D9BCDA15BFE1388572 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -586,6 +588,8 @@
 				D245427827C8E93D0039E0A6 /* Sources */,
 				D245427C27C8E93D0039E0A6 /* Frameworks */,
 				D245427E27C8E93D0039E0A6 /* Resources */,
+				902D6AE45E60E1B9A2AD5BD5 /* [CP] Copy Pods Resources */,
+				CBDFC631D4E69499312261B3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -797,6 +801,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		8A0FC3D9BCDA15BFE1388572 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8D0504D0CD7CAFBBB5B63F13 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -817,6 +838,57 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		902D6AE45E60E1B9A2AD5BD5 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9AB54E91F6CF9F39B153DDCF /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static iOS/Pods-Common-App Static iOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CBDFC631D4E69499312261B3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Static tvOS/Pods-Common-App Static tvOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D235937827C8EB0500BF32D7 /* [CP] Check Pods Manifest.lock */ = {

--- a/dependency-manager-tests/xcframeworks/Makefile
+++ b/dependency-manager-tests/xcframeworks/Makefile
@@ -26,4 +26,5 @@ test:
 		@[ -e "dd-sdk-ios/build/xcframeworks/DatadogObjc.xcframework" ] && echo "DatadogObjc.xcframework - OK" || { echo "DatadogObjc.xcframework - missing"; false; }
 		@[ -e "dd-sdk-ios/build/xcframeworks/DatadogCrashReporting.xcframework" ] && echo "DatadogCrashReporting.xcframework - OK" || { echo "DatadogCrashReporting.xcframework - missing"; false; }
 		@[ -e "dd-sdk-ios/build/xcframeworks/CrashReporter.xcframework" ] && echo "CrashReporter.xcframework - OK" || { echo "CrashReporter.xcframework - missing"; false; }
+		@[ -e "dd-sdk-ios/build/xcframeworks/OpenTelemetryApi.xcframework" ] && echo "OpenTelemetryApi.xcframework - OK" || { echo "OpenTelemetryApi.xcframework - missing"; false; }
 		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C14BEF42B76815800D8F265 /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */; };
+		3C14BEF52B76815800D8F265 /* OpenTelemetryApi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CAD15512B7BCAE4006480B5 /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */; };
+		3CAD15522B7BCAE4006480B5 /* OpenTelemetryApi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		617803D52A701052005FE258 /* DatadogSessionReplay.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 617803D42A701051005FE258 /* DatadogSessionReplay.xcframework */; };
 		617803D62A701052005FE258 /* DatadogSessionReplay.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 617803D42A701051005FE258 /* DatadogSessionReplay.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61C36419243752A500C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C36418243752A500C4D4E6 /* AppDelegate.swift */; };
@@ -101,6 +105,7 @@
 				D2F09A2629F6C65B0036B910 /* DatadogRUM.xcframework in Embed Frameworks */,
 				D2F9244B29A4B9A4006733B2 /* CrashReporter.xcframework in Embed Frameworks */,
 				D2675BFE2A019F7500190669 /* DatadogWebViewTracking.xcframework in Embed Frameworks */,
+				3C14BEF52B76815800D8F265 /* OpenTelemetryApi.xcframework in Embed Frameworks */,
 				D2675C002A01A03300190669 /* DatadogCrashReporting.xcframework in Embed Frameworks */,
 				D2EBEDAF29B7867700B15732 /* DatadogInternal.xcframework in Embed Frameworks */,
 			);
@@ -114,6 +119,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				D2F9245A29A4B9D8006733B2 /* DatadogObjc.xcframework in Embed Frameworks */,
+				3CAD15522B7BCAE4006480B5 /* OpenTelemetryApi.xcframework in Embed Frameworks */,
 				D2EBEDAC29B7863B00B15732 /* DatadogLogs.xcframework in Embed Frameworks */,
 				D2F9245629A4B9D8006733B2 /* DatadogCore.xcframework in Embed Frameworks */,
 				D2966C2C29CA1E1C00FC6B3C /* DatadogTrace.xcframework in Embed Frameworks */,
@@ -128,6 +134,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenTelemetryApi.xcframework; path = "dd-sdk-ios/build/xcframeworks/OpenTelemetryApi.xcframework"; sourceTree = "<group>"; };
 		3C4C2BB629F6B9C100152C4B /* DatadogWebViewTracking.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogWebViewTracking.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogWebViewTracking.xcframework"; sourceTree = "<group>"; };
 		615519322461CDB4002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519332461CDB4002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -169,6 +176,7 @@
 				D2F09A2529F6C65B0036B910 /* DatadogRUM.xcframework in Frameworks */,
 				D2F9244A29A4B9A4006733B2 /* CrashReporter.xcframework in Frameworks */,
 				D2675BFD2A019F7500190669 /* DatadogWebViewTracking.xcframework in Frameworks */,
+				3C14BEF42B76815800D8F265 /* OpenTelemetryApi.xcframework in Frameworks */,
 				D2675BFF2A01A03300190669 /* DatadogCrashReporting.xcframework in Frameworks */,
 				D2EBEDAE29B7867700B15732 /* DatadogInternal.xcframework in Frameworks */,
 			);
@@ -193,6 +201,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2F9245929A4B9D8006733B2 /* DatadogObjc.xcframework in Frameworks */,
+				3CAD15512B7BCAE4006480B5 /* OpenTelemetryApi.xcframework in Frameworks */,
 				D2EBEDAB29B7863B00B15732 /* DatadogLogs.xcframework in Frameworks */,
 				D2F9245529A4B9D8006733B2 /* DatadogCore.xcframework in Frameworks */,
 				D2966C2B29CA1E1C00FC6B3C /* DatadogTrace.xcframework in Frameworks */,
@@ -287,6 +296,7 @@
 		61C364492437547A00C4D4E6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3C14BEF32B76815800D8F265 /* OpenTelemetryApi.xcframework */,
 				617803D42A701051005FE258 /* DatadogSessionReplay.xcframework */,
 				D2F09A2429F6C65A0036B910 /* DatadogRUM.xcframework */,
 				D2966C2829CA1E1600FC6B3C /* DatadogTrace.xcframework */,

--- a/tools/distribution/build-xcframework.sh
+++ b/tools/distribution/build-xcframework.sh
@@ -90,6 +90,7 @@ rm -rf $OUTPUT
 carthage bootstrap --platform $PLATFORM --use-xcframeworks
 mkdir -p "$XCFRAMEWORK_OUTPUT"
 cp -r "Carthage/Build/CrashReporter.xcframework" "$XCFRAMEWORK_OUTPUT"
+cp -r "Carthage/Build/OpenTelemetryApi.xcframework" "$XCFRAMEWORK_OUTPUT"
 
 bundle DatadogInternal
 bundle DatadogCore


### PR DESCRIPTION
### What and why?

Otel APIs must work on all packages manager setups.

### How?

This PR introduces mechanism to consume the Trace package with pure xcframework, CP, Carthage  and SPM (already added). This is done via shipping the `OpenTelemetryApi` package as a standalone package in all three formats. Its release are managed at https://github.com/DataDog/opentelemetry-swift-packages

 https://datadoghq.atlassian.net/browse/RUM-3185 is created to re-enable the CI visibility.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
