### PR TITLE
RUM-2815 [SR] feat: Web-view Wireframe and Recorder

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1086,6 +1086,8 @@
 		D2B3F04E282A85FD00C2B5EE /* DatadogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */; };
 		D2B3F052282E827700C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
 		D2B3F053282E827B00C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
+		D2BCB2A12B7B8107005C2AAB /* WKWebViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BCB2A02B7B8107005C2AAB /* WKWebViewRecorder.swift */; };
+		D2BCB2A32B7B9683005C2AAB /* WKWebViewRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BCB2A22B7B9683005C2AAB /* WKWebViewRecorderTests.swift */; };
 		D2BEEDAC2B3356710065F3AC /* URLSessionTaskSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEEDAB2B3356710065F3AC /* URLSessionTaskSwizzler.swift */; };
 		D2BEEDAD2B3356710065F3AC /* URLSessionTaskSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEEDAB2B3356710065F3AC /* URLSessionTaskSwizzler.swift */; };
 		D2BEEDAF2B335C400065F3AC /* URLSessionTaskSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BEEDAE2B335C400065F3AC /* URLSessionTaskSwizzlerTests.swift */; };
@@ -2611,6 +2613,8 @@
 		D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDHTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
 		D2BCB11E29D30AF000737A9A /* URLSessionRUMResourcesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandler.swift; sourceTree = "<group>"; };
 		D2BCB12129D34A5F00737A9A /* URLSessionRUMResourcesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandlerTests.swift; sourceTree = "<group>"; };
+		D2BCB2A02B7B8107005C2AAB /* WKWebViewRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKWebViewRecorder.swift; sourceTree = "<group>"; };
+		D2BCB2A22B7B9683005C2AAB /* WKWebViewRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKWebViewRecorderTests.swift; sourceTree = "<group>"; };
 		D2BEEDAB2B3356710065F3AC /* URLSessionTaskSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskSwizzler.swift; sourceTree = "<group>"; };
 		D2BEEDAE2B335C400065F3AC /* URLSessionTaskSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskSwizzlerTests.swift; sourceTree = "<group>"; };
 		D2BEEDB12B335DA90065F3AC /* URLSessionTaskDelegateSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskDelegateSwizzler.swift; sourceTree = "<group>"; };
@@ -3209,6 +3213,7 @@
 				61054E342A6EE10A00AAA894 /* UITabBarRecorder.swift */,
 				61054E352A6EE10A00AAA894 /* UISegmentRecorder.swift */,
 				61054E362A6EE10A00AAA894 /* UnsupportedViewRecorder.swift */,
+				D2BCB2A02B7B8107005C2AAB /* WKWebViewRecorder.swift */,
 			);
 			path = NodeRecorders;
 			sourceTree = "<group>";
@@ -3489,6 +3494,7 @@
 				61054F762A6EE1BA00AAA894 /* UIImageViewWireframesBuilderTests.swift */,
 				61054F772A6EE1BA00AAA894 /* UIPickerViewRecorderTests.swift */,
 				61054F782A6EE1BA00AAA894 /* UITextViewRecorderTests.swift */,
+				D2BCB2A22B7B9683005C2AAB /* WKWebViewRecorderTests.swift */,
 				A7F6512F2B7655DE004B0EDB /* UIImageResourceTests.swift */,
 			);
 			path = NodeRecorders;
@@ -7564,6 +7570,7 @@
 				61054E862A6EE10A00AAA894 /* UnsupportedViewRecorder.swift in Sources */,
 				61054E882A6EE10A00AAA894 /* ViewTreeRecordingContext.swift in Sources */,
 				61054E932A6EE10A00AAA894 /* MultipartFormData.swift in Sources */,
+				D2BCB2A12B7B8107005C2AAB /* WKWebViewRecorder.swift in Sources */,
 				61054E712A6EE10A00AAA894 /* TouchSnapshot.swift in Sources */,
 				61054E8A2A6EE10A00AAA894 /* WindowViewTreeSnapshotProducer.swift in Sources */,
 				61054E7A2A6EE10A00AAA894 /* UIImageViewRecorder.swift in Sources */,
@@ -7610,6 +7617,7 @@
 				61054FCB2A6EE1BA00AAA894 /* QueueMocks.swift in Sources */,
 				61054FC42A6EE1BA00AAA894 /* RecorderTests.swift in Sources */,
 				61054FC22A6EE1BA00AAA894 /* ViewTreeSnapshotTests.swift in Sources */,
+				D2BCB2A32B7B9683005C2AAB /* WKWebViewRecorderTests.swift in Sources */,
 				61054FC62A6EE1BA00AAA894 /* CoreGraphicsMocks.swift in Sources */,
 				61054FCA2A6EE1BA00AAA894 /* TestScheduler.swift in Sources */,
 				61054FBD2A6EE1BA00AAA894 /* UIViewRecorderTests.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -66,6 +66,8 @@ private extension SRWireframe {
             )
         case .placeholderWireframe(value: let placeholder):
             return placeholder.toFrame()
+        case .webviewWireframe(value: let webview):
+            return webview.toFrame()
         }
     }
 }
@@ -105,6 +107,26 @@ private extension SRImageWireframe {
             height: CGFloat(height),
             style: frameStyle(border: border, style: shapeStyle),
             content: frameContent(imageData: imageData)
+        )
+    }
+}
+
+private extension SRWebviewWireframe {
+    func toFrame() -> BlueprintFrame {
+        BlueprintFrame(
+            x: CGFloat(x),
+            y: CGFloat(y),
+            width: CGFloat(width),
+            height: CGFloat(height),
+            style: frameStyle(border: border, style: shapeStyle),
+            content: frameContent(
+                text: "WKWebView",
+                textStyle: nil,
+                textPosition: SRTextPosition(
+                    alignment: SRTextPosition.Alignment(horizontal: .center, vertical: .center),
+                    padding: nil
+                )
+            )
         )
     }
 }

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -437,6 +437,53 @@ public struct SRPlaceholderWireframe: Codable, Hashable {
     }
 }
 
+/// Schema of all properties of a WebviewWireframe.
+@_spi(Internal)
+public struct SRWebviewWireframe: Codable, Hashable {
+    /// The border properties of this wireframe. The default value is null (no-border).
+    public let border: SRShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    public let clip: SRContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// The style of this wireframe.
+    public let shapeStyle: SRShapeStyle?
+
+    /// Unique Id of the slot containing this webview.
+    public let slotId: String
+
+    /// The type of the wireframe.
+    public let type: String = "webview"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case border = "border"
+        case clip = "clip"
+        case height = "height"
+        case id = "id"
+        case shapeStyle = "shapeStyle"
+        case slotId = "slotId"
+        case type = "type"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    }
+}
+
 /// Schema of a Wireframe type.
 @_spi(Internal)
 public enum SRWireframe: Codable {
@@ -444,6 +491,7 @@ public enum SRWireframe: Codable {
     case textWireframe(value: SRTextWireframe)
     case imageWireframe(value: SRImageWireframe)
     case placeholderWireframe(value: SRPlaceholderWireframe)
+    case webviewWireframe(value: SRWebviewWireframe)
 
     // MARK: - Codable
 
@@ -459,6 +507,8 @@ public enum SRWireframe: Codable {
         case .imageWireframe(let value):
             try container.encode(value)
         case .placeholderWireframe(let value):
+            try container.encode(value)
+        case .webviewWireframe(let value):
             try container.encode(value)
         }
     }
@@ -481,6 +531,10 @@ public enum SRWireframe: Codable {
         }
         if let value = try? container.decode(SRPlaceholderWireframe.self) {
             self = .placeholderWireframe(value: value)
+            return
+        }
+        if let value = try? container.decode(SRWebviewWireframe.self) {
+            self = .webviewWireframe(value: value)
             return
         }
         let error = DecodingError.Context(
@@ -649,6 +703,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
                 case shapeWireframeUpdate(value: ShapeWireframeUpdate)
                 case imageWireframeUpdate(value: ImageWireframeUpdate)
                 case placeholderWireframeUpdate(value: PlaceholderWireframeUpdate)
+                case webviewWireframeUpdate(value: WebviewWireframeUpdate)
 
                 // MARK: - Codable
 
@@ -664,6 +719,8 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     case .imageWireframeUpdate(let value):
                         try container.encode(value)
                     case .placeholderWireframeUpdate(let value):
+                        try container.encode(value)
+                    case .webviewWireframeUpdate(let value):
                         try container.encode(value)
                     }
                 }
@@ -686,6 +743,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     }
                     if let value = try? container.decode(PlaceholderWireframeUpdate.self) {
                         self = .placeholderWireframeUpdate(value: value)
+                        return
+                    }
+                    if let value = try? container.decode(WebviewWireframeUpdate.self) {
+                        self = .webviewWireframeUpdate(value: value)
                         return
                     }
                     let error = DecodingError.Context(
@@ -893,6 +954,53 @@ public struct SRIncrementalSnapshotRecord: Codable {
                         case y = "y"
                     }
                 }
+
+                /// Schema of all properties of a WebviewWireframeUpdate.
+                @_spi(Internal)
+                public struct WebviewWireframeUpdate: Codable {
+                    /// The border properties of this wireframe. The default value is null (no-border).
+                    public let border: SRShapeBorder?
+
+                    /// Schema of clipping information for a Wireframe.
+                    public let clip: SRContentClip?
+
+                    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+                    public let height: Int64?
+
+                    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+                    public let id: Int64
+
+                    /// The style of this wireframe.
+                    public let shapeStyle: SRShapeStyle?
+
+                    /// Unique Id of the slot containing this webview.
+                    public let slotId: String
+
+                    /// The type of the wireframe.
+                    public let type: String = "webview"
+
+                    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+                    public let width: Int64?
+
+                    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    public let x: Int64?
+
+                    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    public let y: Int64?
+
+                    enum CodingKeys: String, CodingKey {
+                        case border = "border"
+                        case clip = "clip"
+                        case height = "height"
+                        case id = "id"
+                        case shapeStyle = "shapeStyle"
+                        case slotId = "slotId"
+                        case type = "type"
+                        case width = "width"
+                        case x = "x"
+                        case y = "y"
+                    }
+                }
             }
         }
 
@@ -1007,6 +1115,9 @@ public struct SRMetaRecord: Codable {
     /// The data contained by this record.
     public let data: Data
 
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -1015,6 +1126,7 @@ public struct SRMetaRecord: Codable {
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -1044,6 +1156,9 @@ public struct SRMetaRecord: Codable {
 public struct SRFocusRecord: Codable {
     public let data: Data
 
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -1052,6 +1167,7 @@ public struct SRFocusRecord: Codable {
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -1070,6 +1186,9 @@ public struct SRFocusRecord: Codable {
 /// Schema of a Record which signifies that view lifecycle ended.
 @_spi(Internal)
 public struct SRViewEndRecord: Codable {
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -1077,6 +1196,7 @@ public struct SRViewEndRecord: Codable {
     public let type: Int64 = 7
 
     enum CodingKeys: String, CodingKey {
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -1087,6 +1207,9 @@ public struct SRViewEndRecord: Codable {
 public struct SRVisualViewportRecord: Codable {
     public let data: Data
 
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -1095,6 +1218,7 @@ public struct SRVisualViewportRecord: Codable {
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -1198,4 +1322,4 @@ public enum SRRecord: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/5a79d9a36b6e76493420792055fc50aed780569b
+// Generated from https://github.com/DataDog/rum-events-format/tree/c3747b3facf75e51cbad4c32f77ec3894f5a7249

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -20,6 +20,8 @@ extension SRWireframe: Diffable {
             return wireframe.id
         case .placeholderWireframe(let wireframe):
             return wireframe.id
+        case .webviewWireframe(let wireframe):
+            return wireframe.id
         }
     }
 
@@ -70,6 +72,8 @@ extension SRWireframe: MutableWireframe {
         case .textWireframe(let this):
             return try this.mutations(from: otherWireframe)
         case .placeholderWireframe(let this):
+            return try this.mutations(from: otherWireframe)
+        case .webviewWireframe(let this):
             return try this.mutations(from: otherWireframe)
         }
     }
@@ -167,6 +171,31 @@ extension SRTextWireframe: MutableWireframe {
                 text: use(text, ifDifferentThan: other.text),
                 textPosition: use(textPosition, ifDifferentThan: other.textPosition),
                 textStyle: use(textStyle, ifDifferentThan: other.textStyle),
+                width: use(width, ifDifferentThan: other.width),
+                x: use(x, ifDifferentThan: other.x),
+                y: use(y, ifDifferentThan: other.y)
+            )
+        )
+    }
+}
+
+extension SRWebviewWireframe: MutableWireframe {
+    func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
+        guard case .webviewWireframe(let other) = otherWireframe else {
+            throw WireframeMutationError.typeMismatch
+        }
+        guard other.id == id, other.slotId == slotId else {
+            throw WireframeMutationError.idMismatch
+        }
+
+        return .webviewWireframeUpdate(
+            value: .init(
+                border: use(border, ifDifferentThan: other.border),
+                clip: use(clip, ifDifferentThan: other.clip),
+                height: use(height, ifDifferentThan: other.height),
+                id: id,
+                shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),
+                slotId: slotId,
                 width: use(width, ifDifferentThan: other.width),
                 x: use(x, ifDifferentThan: other.x),
                 y: use(y, ifDifferentThan: other.y)

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -30,6 +30,7 @@ internal class RecordsBuilder {
                 href: nil,
                 width: Int64(withNoOverflow: snapshot.viewportSize.width)
             ),
+            slotId: nil,
             timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
         )
         return .metaRecord(value: record)
@@ -40,6 +41,7 @@ internal class RecordsBuilder {
     func createFocusRecord(from snapshot: ViewTreeSnapshot) -> SRRecord {
         let record = SRFocusRecord(
             data: SRFocusRecord.Data(hasFocus: true),
+            slotId: nil,
             timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
         )
         return .focusRecord(value: record)

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -177,6 +177,32 @@ public class SessionReplayWireframesBuilder {
         return .placeholderWireframe(value: wireframe)
     }
 
+    public func createWebViewWireframe(
+        id: Int64,
+        frame: CGRect,
+        slotId: String,
+        clip: SRContentClip? = nil,
+        borderColor: CGColor? = nil,
+        borderWidth: CGFloat? = nil,
+        backgroundColor: CGColor? = nil,
+        cornerRadius: CGFloat? = nil,
+        opacity: CGFloat? = nil
+    ) -> SRWireframe {
+        let wireframe = SRWebviewWireframe(
+            border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
+            clip: clip,
+            height: Int64(withNoOverflow: frame.height),
+            id: id,
+            shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
+            slotId: slotId,
+            width: Int64(withNoOverflow: frame.size.width),
+            x: Int64(withNoOverflow: frame.minX),
+            y: Int64(withNoOverflow: frame.minY)
+        )
+
+        return .webviewWireframe(value: wireframe)
+    }
+
     // MARK: - Private
 
     private func createShapeBorder(borderColor: CGColor?, borderWidth: CGFloat?) -> SRShapeBorder? {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import UIKit
+import WebKit
+
+internal class WKWebViewRecorder: NodeRecorder {
+    let identifier = UUID()
+
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        guard let webView = view as? WKWebView else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        let builder = WKWebViewWireframesBuilder(
+            wireframeID: context.ids.nodeID(view: webView, nodeRecorder: self),
+            attributes: attributes
+        )
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
+    }
+}
+
+internal struct WKWebViewWireframesBuilder: NodeWireframesBuilder {
+    let wireframeID: WireframeID
+    /// Attributes of the `UIView`.
+    let attributes: ViewAttributes
+
+    var wireframeRect: CGRect {
+        attributes.frame
+    }
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createWebViewWireframe(
+                id: wireframeID,
+                frame: wireframeRect,
+                slotId: String(wireframeID),
+                borderColor: attributes.layerBorderColor,
+                borderWidth: attributes.layerBorderWidth,
+                backgroundColor: attributes.backgroundColor,
+                cornerRadius: attributes.layerCornerRadius,
+                opacity: attributes.alpha
+            )
+        ]
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
@@ -21,9 +21,11 @@ internal class WKWebViewRecorder: NodeRecorder {
         }
 
         let builder = WKWebViewWireframesBuilder(
-            wireframeID: context.ids.nodeID(view: webView, nodeRecorder: self),
+            wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
+            slotID: webView.configuration.userContentController.hash,
             attributes: attributes
         )
+
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
@@ -31,6 +33,8 @@ internal class WKWebViewRecorder: NodeRecorder {
 
 internal struct WKWebViewWireframesBuilder: NodeWireframesBuilder {
     let wireframeID: WireframeID
+    /// The slot identifier of the webview controller.
+    let slotID: Int
     /// Attributes of the `UIView`.
     let attributes: ViewAttributes
 
@@ -43,7 +47,7 @@ internal struct WKWebViewWireframesBuilder: NodeWireframesBuilder {
             builder.createWebViewWireframe(
                 id: wireframeID,
                 frame: wireframeRect,
-                slotId: String(wireframeID),
+                slotId: String(slotID),
                 borderColor: attributes.layerBorderColor,
                 borderWidth: attributes.layerBorderWidth,
                 backgroundColor: attributes.backgroundColor,

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -485,6 +485,7 @@ extension SRVisualViewportRecord: AnyMockable, RandomMockable {
     public static func mockRandom() -> SRVisualViewportRecord {
         return SRVisualViewportRecord(
             data: .mockRandom(),
+            slotId: .mockRandom(),
             timestamp: .mockRandom()
         )
     }
@@ -495,6 +496,7 @@ extension SRVisualViewportRecord: AnyMockable, RandomMockable {
     ) -> SRVisualViewportRecord {
         return SRVisualViewportRecord(
             data: data,
+            slotId: .mockRandom(),
             timestamp: timestamp
         )
     }
@@ -545,6 +547,7 @@ extension SRViewEndRecord: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> SRViewEndRecord {
         return SRViewEndRecord(
+            slotId: .mockRandom(),
             timestamp: .mockRandom()
         )
     }
@@ -553,6 +556,7 @@ extension SRViewEndRecord: AnyMockable, RandomMockable {
         timestamp: Int64 = .mockAny()
     ) -> SRViewEndRecord {
         return SRViewEndRecord(
+            slotId: .mockRandom(),
             timestamp: timestamp
         )
     }
@@ -566,6 +570,7 @@ extension SRFocusRecord: AnyMockable, RandomMockable {
     public static func mockRandom() -> SRFocusRecord {
         return SRFocusRecord(
             data: .mockRandom(),
+            slotId: .mockRandom(),
             timestamp: .mockRandom()
         )
     }
@@ -576,6 +581,7 @@ extension SRFocusRecord: AnyMockable, RandomMockable {
     ) -> SRFocusRecord {
         return SRFocusRecord(
             data: data,
+            slotId: .mockRandom(),
             timestamp: timestamp
         )
     }
@@ -609,6 +615,7 @@ extension SRMetaRecord: AnyMockable, RandomMockable {
     public static func mockRandom() -> SRMetaRecord {
         return SRMetaRecord(
             data: .mockRandom(),
+            slotId: .mockRandom(),
             timestamp: .mockRandom()
         )
     }
@@ -619,6 +626,7 @@ extension SRMetaRecord: AnyMockable, RandomMockable {
     ) -> SRMetaRecord {
         return SRMetaRecord(
             data: data,
+            slotId: .mockRandom(),
             timestamp: timestamp
         )
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import WebKit
+import TestUtilities
+
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+class WKWebViewRecorderTests: XCTestCase {
+    private let recorder = WKWebViewRecorder()
+    /// The web-view under test.
+    private let webView = WKWebView()
+    /// `ViewAttributes` simulating common attributes of web-view's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenViewIsNotOfExpectedType() {
+        // Given
+        let view = UILabel()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: .mockAny(), in: .mockAny()))
+    }
+
+    func testWhenWebViewIsNotVisible() throws {
+        // Given
+        let viewAttributes: ViewAttributes = .mock(fixture: .invisible)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: webView, with: viewAttributes, in: .mockAny()))
+
+        // Then
+        XCTAssertTrue(semantics is InvisibleElement)
+    }
+
+    func testWhenWebViewIsVisible() throws {
+        // Given
+        let viewAttributes: ViewAttributes = .mock(fixture: .visible())
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: webView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore, "WebView's subtree should not be recorded")
+
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? WKWebViewWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+    }
+
+    func testWebViewWireframeBuilder() throws {
+        // Given
+        let id: WireframeID = .mockRandom()
+        let attributes: ViewAttributes = .mock(fixture: .visible())
+
+        let builder = WKWebViewWireframesBuilder(
+            wireframeID: id,
+            attributes: attributes
+        )
+
+        // When
+        let wireframes = builder.buildWireframes(with: WireframesBuilder())
+
+        // Then
+        XCTAssertEqual(wireframes.count, 1)
+
+        guard case let .webviewWireframe(wireframe) = wireframes.first else {
+            return XCTFail("First wireframe needs to be webviewWireframe case")
+        }
+
+        XCTAssertEqual(wireframe.id, id)
+        XCTAssertEqual(wireframe.slotId, String(id))
+        XCTAssertNil(wireframe.clip)
+        XCTAssertEqual(wireframe.x, Int64(withNoOverflow: attributes.frame.minX))
+        XCTAssertEqual(wireframe.y, Int64(withNoOverflow: attributes.frame.minY))
+        XCTAssertEqual(wireframe.width, Int64(withNoOverflow: attributes.frame.width))
+        XCTAssertEqual(wireframe.height, Int64(withNoOverflow: attributes.frame.height))
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
@@ -54,10 +54,12 @@ class WKWebViewRecorderTests: XCTestCase {
     func testWebViewWireframeBuilder() throws {
         // Given
         let id: WireframeID = .mockRandom()
+        let slotId: Int = .mockRandom()
         let attributes: ViewAttributes = .mock(fixture: .visible())
 
         let builder = WKWebViewWireframesBuilder(
             wireframeID: id,
+            slotID: slotId,
             attributes: attributes
         )
 
@@ -72,7 +74,7 @@ class WKWebViewRecorderTests: XCTestCase {
         }
 
         XCTAssertEqual(wireframe.id, id)
-        XCTAssertEqual(wireframe.slotId, String(id))
+        XCTAssertEqual(wireframe.slotId, String(slotId))
         XCTAssertNil(wireframe.clip)
         XCTAssertEqual(wireframe.x, Int64(withNoOverflow: attributes.frame.minX))
         XCTAssertEqual(wireframe.y, Int64(withNoOverflow: attributes.frame.minY))

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -22,6 +22,7 @@ public class SRCodeDecorator: SwiftCodeDecorator {
                 "SRTextWireframe",
                 "SRImageWireframe",
                 "SRPlaceholderWireframe",
+                "SRWebviewWireframe",
                 // For convenience, make fat `*Record` structures to be root types:
                 "SRFullSnapshotRecord",
                 "SRIncrementalSnapshotRecord",


### PR DESCRIPTION
### What and why?

Add support of the new `WebViewWireframe`.

### How?

`WKWebView` is still part of the unsupported views as we need updates in the JS bridge which are coming in a following PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
