### PR TITLE
RUM-2925 feat: Report non-fatal App Hangs as RUM errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FEATURE] App Hangs are tracked as RUM errors. See [#1685][]
 - [FIX] Propagate parent span in distributing tracing. See [#1627][]
 
 # 2.7.1 / 12-02-2024
@@ -597,6 +598,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1597]: https://github.com/DataDog/dd-sdk-ios/pull/1597
 [#1627]: https://github.com/DataDog/dd-sdk-ios/pull/1627
 [#1644]: https://github.com/DataDog/dd-sdk-ios/pull/1644
+[#1685]: https://github.com/DataDog/dd-sdk-ios/pull/1685
 [#1656]: https://github.com/DataDog/dd-sdk-ios/pull/1656
 [#1666]: https://github.com/DataDog/dd-sdk-ios/pull/1666
 [@00fa9a]: https://github.com/00FA9A

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -287,6 +287,14 @@
 		615CC4132695957C0005F08C /* CrashReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615CC4122695957C0005F08C /* CrashReportTests.swift */; };
 		6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C79226665D6900D4CF07 /* E2EUtils.swift */; };
 		6167C7952666622800D4CF07 /* LoggingE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */; };
+		6167E6D32B7F8B3300C3CA2D /* AppHangsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D22B7F8B3300C3CA2D /* AppHangsObserver.swift */; };
+		6167E6D42B7F8B3300C3CA2D /* AppHangsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D22B7F8B3300C3CA2D /* AppHangsObserver.swift */; };
+		6167E6D62B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */; };
+		6167E6D72B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */; };
+		6167E6DA2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D92B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift */; };
+		6167E6DB2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D92B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift */; };
+		6167E6DD2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */; };
+		6167E6DE2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		6170DC1C25C18729003AED5C /* PLCrashReporterPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* PLCrashReporterPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
@@ -2144,6 +2152,10 @@
 		6167ACBD251A0B410012B4D0 /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Bridging-Header.h"; sourceTree = "<group>"; };
 		6167C79226665D6900D4CF07 /* E2EUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EUtils.swift; sourceTree = "<group>"; };
 		6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingE2EHelpers.swift; sourceTree = "<group>"; };
+		6167E6D22B7F8B3300C3CA2D /* AppHangsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsObserver.swift; sourceTree = "<group>"; };
+		6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsWatchdogThread.swift; sourceTree = "<group>"; };
+		6167E6D92B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsWatchdogThreadTests.swift; sourceTree = "<group>"; };
+		6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsMonitoringTests.swift; sourceTree = "<group>"; };
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfo.swift; sourceTree = "<group>"; };
 		616C0AA028573F6300C13264 /* RUMOperatingSystemInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfoTests.swift; sourceTree = "<group>"; };
@@ -4280,6 +4292,23 @@
 			path = CrashContext;
 			sourceTree = "<group>";
 		};
+		6167E6D12B7F8B1300C3CA2D /* AppHangs */ = {
+			isa = PBXGroup;
+			children = (
+				6167E6D22B7F8B3300C3CA2D /* AppHangsObserver.swift */,
+				6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */,
+			);
+			path = AppHangs;
+			sourceTree = "<group>";
+		};
+		6167E6D82B80047900C3CA2D /* AppHangs */ = {
+			isa = PBXGroup;
+			children = (
+				6167E6D92B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift */,
+			);
+			path = AppHangs;
+			sourceTree = "<group>";
+		};
 		616CCE11250A181C009FED46 /* Instrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -4289,6 +4318,7 @@
 				6141014D251A578D00E3C2D9 /* Actions */,
 				6157FA5C252767B3009A8A3B /* Resources */,
 				9E06058F26EF904200F5F935 /* LongTasks */,
+				6167E6D12B7F8B1300C3CA2D /* AppHangs */,
 			);
 			path = Instrumentation;
 			sourceTree = "<group>";
@@ -4791,6 +4821,7 @@
 			isa = PBXGroup;
 			children = (
 				61E8C5072B28898800E709B4 /* StartingRUMSessionTests.swift */,
+				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -4873,6 +4904,7 @@
 				61F3CDA925121FA100C816E5 /* Views */,
 				6141014C251A577D00E3C2D9 /* Actions */,
 				613F23EF252B1287006CD2D7 /* Resources */,
+				6167E6D82B80047900C3CA2D /* AppHangs */,
 				61C713BB2A3C95AD00FA735A /* RUMInstrumentationTests.swift */,
 			);
 			path = Instrumentation;
@@ -7333,6 +7365,7 @@
 				614798962A459AA80095CB02 /* DDTraceTests.swift in Sources */,
 				D25085102976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				A7C816AB2A98CEBA00BF097B /* UIKitBackgroundTaskCoordinatorTests.swift in Sources */,
+				6167E6DD2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */,
 				612C13D02AA772FA0086B5D1 /* SRRequestMatcher.swift in Sources */,
 				61A1A44929643254007909E7 /* DatadogCoreProxy.swift in Sources */,
 				D2A1EE3B287EECC000D28DFB /* CarrierInfoPublisherTests.swift in Sources */,
@@ -7908,6 +7941,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6167E6D42B7F8B3300C3CA2D /* AppHangsObserver.swift in Sources */,
 				D23F8E5229DDCD28001CFAE8 /* UIViewControllerHandler.swift in Sources */,
 				D23F8E5329DDCD28001CFAE8 /* RUMCommand.swift in Sources */,
 				D23F8E5429DDCD28001CFAE8 /* ValuePublisher.swift in Sources */,
@@ -7945,6 +7979,7 @@
 				D23F8E7329DDCD28001CFAE8 /* SwiftUIActionModifier.swift in Sources */,
 				D23F8E7429DDCD28001CFAE8 /* RUMCommandSubscriber.swift in Sources */,
 				D23F8E7529DDCD28001CFAE8 /* RUMUserActionScope.swift in Sources */,
+				6167E6D72B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */,
 				61C713A42A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */,
 				3C0D5DED2A54405A00446CF9 /* RUMViewEventsFilter.swift in Sources */,
 				D23F8E7629DDCD28001CFAE8 /* RUMConnectivityInfoProvider.swift in Sources */,
@@ -8014,6 +8049,7 @@
 				D23F8EC029DDCD38001CFAE8 /* RUMEventSanitizerTests.swift in Sources */,
 				6176C1732ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D23F8EC129DDCD38001CFAE8 /* RUMEventsMapperTests.swift in Sources */,
+				6167E6DB2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,
 				3C0D5DEA2A543EA300446CF9 /* RUMViewEventsFilterTests.swift in Sources */,
 				D23F8EC429DDCD38001CFAE8 /* RUMCommandTests.swift in Sources */,
 			);
@@ -8168,6 +8204,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6167E6D32B7F8B3300C3CA2D /* AppHangsObserver.swift in Sources */,
 				D29A9F8029DD85BB005C54A4 /* UIViewControllerHandler.swift in Sources */,
 				D29A9F5929DD85BB005C54A4 /* RUMCommand.swift in Sources */,
 				D29A9F8C29DD861C005C54A4 /* ValuePublisher.swift in Sources */,
@@ -8205,6 +8242,7 @@
 				D29A9F8729DD85BB005C54A4 /* SwiftUIActionModifier.swift in Sources */,
 				D29A9F5D29DD85BB005C54A4 /* RUMCommandSubscriber.swift in Sources */,
 				D29A9F6529DD85BB005C54A4 /* RUMUserActionScope.swift in Sources */,
+				6167E6D62B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */,
 				61C713A32A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */,
 				3C0D5DEC2A54405A00446CF9 /* RUMViewEventsFilter.swift in Sources */,
 				D29A9F5829DD85BB005C54A4 /* RUMConnectivityInfoProvider.swift in Sources */,
@@ -8274,6 +8312,7 @@
 				D29A9FA229DDB483005C54A4 /* RUMEventSanitizerTests.swift in Sources */,
 				6176C1722ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D29A9FB929DDB483005C54A4 /* RUMEventsMapperTests.swift in Sources */,
+				6167E6DA2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,
 				3C0D5DE92A543EA200446CF9 /* RUMViewEventsFilterTests.swift in Sources */,
 				D29A9FA729DDB483005C54A4 /* RUMCommandTests.swift in Sources */,
 			);
@@ -8454,6 +8493,7 @@
 				D2CB6F0027C520D400A62B57 /* RUMSessionMatcher.swift in Sources */,
 				A728ADB12934EB0C00397996 /* DDW3CHTTPHeadersWriter+apiTests.m in Sources */,
 				D2CB6F0127C520D400A62B57 /* DatadogPrivateMocks.swift in Sources */,
+				6167E6DE2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */,
 				D26C49B02886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */,
 				D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */,
 				61DA8CB3286215DE0074A606 /* CryptographyTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -14,14 +14,12 @@ class AppHangsMonitoringTests: XCTestCase {
     private var rumConfig = RUM.Configuration(applicationID: .mockAny())
 
     override func setUp() {
-        super.setUp()
         core = DatadogCoreProxy()
     }
 
     override func tearDown() {
         core.flushAndTearDown()
         core = nil
-        super.tearDown()
     }
 
     func testWhenMainThreadHangsAboveThreshold_itTracksAppHang() throws {

--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+
+/// Test case covering scenarios of App Hangs monitoring in RUM.
+class AppHangsMonitoringTests: XCTestCase {
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var rumConfig = RUM.Configuration(applicationID: .mockAny())
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy()
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        super.tearDown()
+    }
+
+    func testWhenMainThreadHangsAboveThreshold_itTracksAppHang() throws {
+        let mainQueue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+        rumConfig.mainQueue = mainQueue
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        // When
+        let beforeHang = Date()
+        mainQueue.sync {
+            Thread.sleep(forTimeInterval: self.rumConfig.defaultAppHangThreshold * 1.5)
+        }
+
+        // Then
+        Thread.sleep(forTimeInterval: 0.5) // wait to make sure watchdog thread completes hang tracking
+        RUMMonitor.shared(in: core).dd.flush() // flush RUM monitor to await hang processing
+
+        let errors = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMErrorEvent.self)
+        let appHangError = try XCTUnwrap(errors.first)
+
+        XCTAssertEqual(appHangError.error.message, "App Hang")
+        XCTAssertEqual(appHangError.error.type, "AppHang")
+        XCTAssertEqual(appHangError.error.source, .source)
+        XCTAssertGreaterThanOrEqual(appHangError.date, beforeHang.timeIntervalSince1970.toInt64Milliseconds)
+    }
+}

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -80,7 +80,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
             uiKitRUMViewsPredicate: configuration.uiKitViewsPredicate,
             uiKitRUMActionsPredicate: configuration.uiKitActionsPredicate,
             longTaskThreshold: configuration.longTaskThreshold,
-            dateProvider: configuration.dateProvider
+            appHangThreshold: configuration.defaultAppHangThreshold,
+            mainQueue: configuration.mainQueue,
+            dateProvider: configuration.dateProvider,
+            telemetry: core.telemetry
         )
         self.requestBuilder = RequestBuilder(
             customIntakeURL: configuration.customEndpoint,

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+internal class AppHangsObserver: RUMCommandPublisher {
+    /// Watchdog thread that monitors the main queue for App Hangs.
+    private let watchdogThread: AppHangsWatchdogThread
+    /// Weak reference to RUM monitor for sending App Hang events.
+    private(set) weak var subscriber: RUMCommandSubscriber?
+
+    init(
+        appHangThreshold: TimeInterval,
+        observedQueue: DispatchQueue,
+        dateProvider: DateProvider,
+        telemetry: Telemetry
+    ) {
+        watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: observedQueue,
+            dateProvider: dateProvider,
+            telemetry: telemetry
+        )
+        watchdogThread.onHangEnded = { [weak self] appHang in
+            // called on watchdog thread
+            self?.report(appHang: appHang)
+        }
+    }
+
+    func start() {
+        watchdogThread.start()
+    }
+
+    func stop() {
+        watchdogThread.cancel()
+    }
+
+    func publish(to subscriber: RUMCommandSubscriber) {
+        self.subscriber = subscriber
+    }
+
+    private func report(appHang: AppHang) {
+        let addHangCommand = RUMAddCurrentViewErrorCommand(
+            time: appHang.date,
+            message: "App Hang",
+            type: "AppHang",
+            stack: nil, // TODO: RUM-2925 Add hang stack trace
+            source: .source,
+            attributes: [
+                "hang_duration": appHang.duration
+            ]
+        )
+        subscriber?.process(command: addHangCommand)
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -1,0 +1,131 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+internal struct AppHang {
+    /// The date of hang end.
+    let date: Date
+    /// The duration of the hang.
+    let duration: TimeInterval
+    // TODO: RUM-2925 Add hang stack trace
+}
+
+internal final class AppHangsWatchdogThread: Thread {
+    struct Constants {
+        /// The "idle" interval for sleeping the watchdog thread before scheduling the next task on the main queue, represented as a percentage of the `appHangThreshold`.
+        ///
+        /// Introducing even a small sleep significantly reduces CPU consumption by the watchdog thread (nearly 0%). No sleep would result in close to 100% CPU usage.
+        ///
+        /// `tolerance` defines the margin of error in hang monitoring. The "measured hang duration" may differ from `0` to `tolerance` % when compared to the "actual hang duration".
+        /// This means some actual hangs very close to `appHangThreshold` might be considered false negatives and not reported.
+        ///
+        /// **Example:**
+        /// If `appHangThreshold` is 2 seconds and tolerance is 2.5%, the watchdog thread will idle for 50 milliseconds before taking each sample of the main thread.
+        /// Because the sleep might start right at the moment of hang beginning on the main thread, the watchdog thread will miss the first 50 milliseconds of hang duration.
+        /// If the actual hang lasts exactly 2 seconds, the watchdog will measure it as 1950 milliseconds. As a result, the SDK will not report it as it falls under `appHangThreshold`.
+        static let tolerance: Double = 0.025 // 2.5%
+    }
+
+    /// The minimal duration of the main thread hang to consider it an App Hang.
+    private let appHangThreshold: TimeInterval
+    /// The "idle" interval for watchdog thread operations. Reduces the pressure on CPU.
+    private let idleInterval: TimeInterval
+    /// Semaphore used to block this thread until main thread responds.
+    private let mainThreadTask = DispatchSemaphore(value: 0)
+    /// The queue to observe by this thread (main queue).
+    private let mainQueue: DispatchQueue
+    /// SDK date provider.
+    private let dateProvider: DateProvider
+    /// Telemetry interface.
+    private let telemetry: Telemetry
+    /// Closure to be notified when App Hang ends. It will be executed on the watchdog thread.
+    @ReadWriteLock
+    internal var onHangEnded: ((AppHang) -> Void)?
+
+    /// Creates an instance of an App Hang watchdog thread.
+    ///
+    /// This thread is not started by default and requires manual invocation of `.start()`.
+    ///
+    /// - Parameters:
+    ///   - appHangThreshold: Minimum duration of the `queue` hang to consider it an App Hang.
+    ///   - queue: The queue to observe for hangs. (main queue)
+    ///   - dateProvider: Date provider.
+    ///   - telemetry: The handler to report issues through RUM Telemetry.
+    init(
+        appHangThreshold: TimeInterval,
+        queue: DispatchQueue,
+        dateProvider: DateProvider,
+        telemetry: Telemetry
+    ) {
+        self.appHangThreshold = appHangThreshold
+        self.idleInterval = appHangThreshold * Constants.tolerance
+        self.mainQueue = queue
+        self.dateProvider = dateProvider
+        self.telemetry = telemetry
+        super.init()
+        self.name = "com.datadoghq.app-hang-watchdog"
+    }
+
+    override func main() {
+        let mainThreadTask = self.mainThreadTask
+
+        while !isCancelled {
+            defer {
+                // Before continuing, sleep for a while, to reduce the CPU consumption by watchdog thread.
+                Thread.sleep(forTimeInterval: idleInterval)
+            }
+
+            let waitStart: DispatchTime = .now()
+
+            // Schedule task on the main thread to measure how fast it responds
+            mainQueue.async {
+                mainThreadTask.signal()
+            }
+
+            // Await task completion
+            let result = mainThreadTask.wait(timeout: waitStart + appHangThreshold)
+
+            if result == .success {
+                // This is predominant case of "no hang" situation. The main thread executed the task way below hang threshold.
+                continue
+            } // Otherwise, `result == .timeOut`, meaning that the main thread task is delayed to more than hang threshold.
+
+            // We expect to be here roughtly `~appHangThreshold` after `wait()`. If this code is executed well after (50% margin),
+            // assume that the thread was suspended and app just woke up. In such case, ignore the hang as likely false-positive.
+            if interval(from: waitStart, to: .now()) > appHangThreshold * 1.5 {
+                DD.logger.debug("Ignoring likely false-positive App Hang")
+                continue // ignore likely false-positive
+            }
+
+            // TODO: RUM-2925 Capture stack trace of the pending App Hang
+
+            // Previous wait timed out, so wait again for the task completion, this time infinitely until the hang ends.
+            mainThreadTask.wait()
+
+            // The hang has finished.
+            let hangDuration = interval(from: waitStart, to: .now())
+
+            if hangDuration > 30 { // sanity-check
+                // If the hang duration is irrealistically long (way more than assumed iOS watchdog termination limit: ~10s), send telemetry.
+                // This could be another false-positive caused by thread suspension between the two `wait()` calls.
+                telemetry.debug("Detected an App Hang with an unusually long duration", attributes: ["hang_duration": hangDuration])
+                return
+            }
+
+            let appHang = AppHang(
+                date: dateProvider.now,
+                duration: hangDuration
+            )
+            onHangEnded?(appHang)
+        }
+    }
+
+    private func interval(from t1: DispatchTime, to t2: DispatchTime) -> TimeInterval {
+        TimeInterval(t2.uptimeNanoseconds - t1.uptimeNanoseconds) / 1_000_000_000
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -16,7 +16,7 @@ internal struct AppHang {
 }
 
 internal final class AppHangsWatchdogThread: Thread {
-    struct Constants {
+    enum Constants {
         /// The "idle" interval for sleeping the watchdog thread before scheduling the next task on the main queue, represented as a percentage of the `appHangThreshold`.
         ///
         /// Introducing even a small sleep significantly reduces CPU consumption by the watchdog thread (nearly 0%). No sleep would result in close to 100% CPU usage.
@@ -114,7 +114,7 @@ internal final class AppHangsWatchdogThread: Thread {
                 // If the hang duration is irrealistically long (way more than assumed iOS watchdog termination limit: ~10s), send telemetry.
                 // This could be another false-positive caused by thread suspension between the two `wait()` calls.
                 telemetry.debug("Detected an App Hang with an unusually long duration", attributes: ["hang_duration": hangDuration])
-                return
+                continue
             }
 
             let appHang = AppHang(

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -256,6 +256,10 @@ extension RUM {
         internal var traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator()
 
         internal var dateProvider: DateProvider = SystemDateProvider()
+        /// The main queue, subject to App Hangs monitoring.
+        internal var mainQueue: DispatchQueue = .main
+        /// The minimum main queue hang to be tracked as App Hang.
+        internal var defaultAppHangThreshold: TimeInterval = 2
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
         internal var debugViews: Bool = ProcessInfo.processInfo.arguments.contains("DD_DEBUG_RUM")

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class AppHangsWatchdogThreadTests: XCTestCase {
+    func testWhenQueueHangsAboveThreshold_itReportsAppHangs() {
+        let trackHangs = expectation(description: "track 3 App Hangs")
+        trackHangs.expectedFulfillmentCount = 3
+
+        // Given
+        let appHangThreshold: TimeInterval = 0.1
+        let hangDuration: TimeInterval = appHangThreshold * 2
+        let queue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+
+        let watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: queue,
+            dateProvider: SystemDateProvider(),
+            telemetry: TelemetryMock()
+        )
+        watchdogThread.onHangEnded = { _ in
+            trackHangs.fulfill()
+        }
+        watchdogThread.start()
+
+        // When (multiple hangs above threshold)
+        queue.async {
+            Thread.sleep(forTimeInterval: hangDuration)
+            queue.async { // async from queue so watchdog thread can interleve with its own tasks
+                Thread.sleep(forTimeInterval: hangDuration)
+                queue.async {
+                    Thread.sleep(forTimeInterval: hangDuration)
+                }
+            }
+        }
+
+        // Then
+        waitForExpectations(timeout: hangDuration * 10)
+        watchdogThread.cancel()
+    }
+
+    func testWhenQueueHangsBelowThreshold_itDoesNotReportAppHangs() {
+        let doNotTrackHangs = invertedExpectation(description: "track no App Hangs")
+
+        // Given
+        let appHangThreshold: TimeInterval = 0.5
+        let hangDuration: TimeInterval = appHangThreshold * 0.1
+        let queue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+
+        let watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: queue,
+            dateProvider: SystemDateProvider(),
+            telemetry: TelemetryMock()
+        )
+        watchdogThread.onHangEnded = { _ in
+            doNotTrackHangs.fulfill()
+        }
+        watchdogThread.start()
+
+        // When (multiple hangs below threshold)
+        queue.async {
+            Thread.sleep(forTimeInterval: hangDuration)
+            queue.async { // async from queue so watchdog thread can interleve with its own tasks
+                Thread.sleep(forTimeInterval: hangDuration)
+                queue.async {
+                    Thread.sleep(forTimeInterval: hangDuration)
+                }
+            }
+        }
+
+        // Then
+        waitForExpectations(timeout: hangDuration * 10)
+        watchdogThread.cancel()
+    }
+
+    func testItTracksHangDateAndDuration() {
+        let trackHang = expectation(description: "track App Hang")
+
+        // Given
+        let appHangThreshold: TimeInterval = 0.5
+        let hangDuration: TimeInterval = appHangThreshold * 2
+        let queue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+
+        let watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: queue,
+            dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
+            telemetry: TelemetryMock()
+        )
+        watchdogThread.onHangEnded = { hang in
+            XCTAssertEqual(hang.date, .mockDecember15th2019At10AMUTC())
+            XCTAssertGreaterThanOrEqual(hang.duration, hangDuration * (1 - AppHangsWatchdogThread.Constants.tolerance))
+            XCTAssertLessThanOrEqual(hang.duration, hangDuration * (1 + AppHangsWatchdogThread.Constants.tolerance))
+            trackHang.fulfill()
+        }
+        watchdogThread.start()
+
+        // When
+        queue.async {
+            Thread.sleep(forTimeInterval: hangDuration)
+        }
+
+        // Then
+        waitForExpectations(timeout: hangDuration * 10)
+        watchdogThread.cancel()
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -18,7 +18,10 @@ class RUMInstrumentationTests: XCTestCase {
             uiKitRUMViewsPredicate: UIKitRUMViewsPredicateMock(),
             uiKitRUMActionsPredicate: nil,
             longTaskThreshold: nil,
-            dateProvider: SystemDateProvider()
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            telemetry: NOPTelemetry()
         )
 
         // Then
@@ -37,7 +40,10 @@ class RUMInstrumentationTests: XCTestCase {
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: UIKitRUMActionsPredicateMock(),
             longTaskThreshold: nil,
-            dateProvider: SystemDateProvider()
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            telemetry: NOPTelemetry()
         )
 
         // Then
@@ -53,7 +59,10 @@ class RUMInstrumentationTests: XCTestCase {
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
             longTaskThreshold: 0.5,
-            dateProvider: SystemDateProvider()
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            telemetry: NOPTelemetry()
         )
 
         // Then
@@ -72,7 +81,10 @@ class RUMInstrumentationTests: XCTestCase {
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
             longTaskThreshold: .mockRandom(min: -100, max: 0),
-            dateProvider: SystemDateProvider()
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            telemetry: NOPTelemetry()
         )
 
         // Then
@@ -87,7 +99,10 @@ class RUMInstrumentationTests: XCTestCase {
             uiKitRUMViewsPredicate: UIKitRUMViewsPredicateMock(),
             uiKitRUMActionsPredicate: UIKitRUMActionsPredicateMock(),
             longTaskThreshold: 0.5,
-            dateProvider: SystemDateProvider()
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            telemetry: NOPTelemetry()
         )
         let subscriber = RUMCommandSubscriberMock()
 

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -75,10 +75,10 @@ attributes:
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference
     name: "TODO without JIRA"
-    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? RUMM-[0-9]{2,})" # "TODO: RUMM-123", "TODO RUMM-123", "FIX RUMM-123", etc.
+    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
     match_kinds:
       - comment
-    message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUMM-123\""
+    message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUM-123\""
     severity: error
   unsafe_uiapplication_shared: # prevents from using `UIApplication.shared` API
     included: Sources

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -68,10 +68,10 @@ attributes:
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference
     name: "TODO without JIRA"
-    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? RUMM-[0-9]{2,})" # "TODO: RUMM-123", "TODO RUMM-123", "FIX RUMM-123", etc.
+    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
     match_kinds:
       - comment
-    message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUMM-123\""
+    message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUM-123\""
     severity: error
   unmanaged_deallocation: # prevents from unmanaged singletons deallocation with `.instance = nil`
     name: "Unmanaged singleton deallocation: `.instance = nil`"


### PR DESCRIPTION
### What and why?

📦 First part of non-fatal App Hangs monitoring as RUM errors. App Hangs lasting more than 2s (TBD) will be reported as RUM errors.

Before this change, App Hangs were only tracked as RUM long tasks through [`RUM.LongTaskObserver`](https://github.com/DataDog/dd-sdk-ios/blob/3f2d8a043ec54b0f0aaa719797e97809551d0643/DatadogRUM/Sources/Instrumentation/LongTasks/LongTaskObserver.swift#L73), using the default threshold of 0.1s. Because long tasks are tracked on the main thread (using `CFRunLoopObserver`) it is impossible to capture their backtrace during the hang. Lack of stack traces makes it harder to troubleshoot, hence we implement additional layer of reporting hangs as RUM errors using secondary watchdog thread.

Next PRs will add logic for capturing the stack trace of the hanged main thread. In this PR we only send RUM error `"App Hang"` when the hang ends.

### How?

The solution is using secondary thread (`com.datadoghq.app-hang-watchdog`, called "watchdog thread") to schedule periodic tasks on the main queue, await their completion and determine "hang" or "no hang" situation accordingly:

<img width="812" alt="Screenshot 2024-02-19 at 09 23 33" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/526941ef-28fd-4b1e-a910-0bcba14dc0d2">

- at the beginning of watchdog thread loop, main thread **task** is scheduled;
- if **task** is executed under hang `threshold`, there is no hang;
- if **task** completion arrives after `threshold`, SDK considers it a hang.

By using secondary thread, the SDK will capture the stack trace of the main thread between `treshold` and "**task** completion" to associate it with RUM error. This work will be done in next PRs.

To not cause excessive use of CPU, the "watchdog thread" implements "IDLE" periods, which prevent it from scheduling main queue tasks too often. It is defined as `Constants.tolerance` value in watchdog thread implementation. The trade-off is adding maring of error in hangs monitoring, so the whole solution requires tuning to avoid to many false-negatives:

<img width="798" alt="Screenshot 2024-02-19 at 09 32 10" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/815a7331-823f-4b83-b068-ac96c3327027">

"IDLE" periods make the impact of watchdog thread negligible:

<img width="447" alt="Screenshot 2024-02-19 at 09 28 26" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/938efc91-10df-4bab-924d-67982009f7ee">

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
