### PR TITLE
RUM-2925 feat: Add stack trace to App Hang errors in RUM

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -313,6 +313,22 @@
 		6167E7072B82A9FD00C3CA2D /* GeneratingBacktraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7052B82A9FD00C3CA2D /* GeneratingBacktraceTests.swift */; };
 		6167E70E2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E70D2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift */; };
 		6167E70F2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E70D2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift */; };
+		6167E7122B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
+		6167E7132B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
+		6167E7142B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
+		6167E7152B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
+		6167E7192B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
+		6167E71A2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
+		6167E71B2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
+		6167E71C2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
+		6167E71E2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
+		6167E71F2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
+		6167E7202B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
+		6167E7212B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
+		6167E7232B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
+		6167E7242B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
+		6167E7252B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
+		6167E7262B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		6170DC1C25C18729003AED5C /* PLCrashReporterPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* PLCrashReporterPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
@@ -2183,6 +2199,10 @@
 		6167E7022B81F2EB00C3CA2D /* BacktraceReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacktraceReporter.swift; sourceTree = "<group>"; };
 		6167E7052B82A9FD00C3CA2D /* GeneratingBacktraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratingBacktraceTests.swift; sourceTree = "<group>"; };
 		6167E70D2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogCore+FeatureDirectoriesTests.swift"; sourceTree = "<group>"; };
+		6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacktraceReportingMocks.swift; sourceTree = "<group>"; };
+		6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacktraceReportMocks.swift; sourceTree = "<group>"; };
+		6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDThreadMocks.swift; sourceTree = "<group>"; };
+		6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageMocks.swift; sourceTree = "<group>"; };
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfo.swift; sourceTree = "<group>"; };
 		616C0AA028573F6300C13264 /* RUMOperatingSystemInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfoTests.swift; sourceTree = "<group>"; };
@@ -4364,6 +4384,24 @@
 			path = BacktraceReporting;
 			sourceTree = "<group>";
 		};
+		6167E7162B837F4200C3CA2D /* FeatureModels */ = {
+			isa = PBXGroup;
+			children = (
+				6167E7172B837F6300C3CA2D /* CrashReporting */,
+			);
+			path = FeatureModels;
+			sourceTree = "<group>";
+		};
+		6167E7172B837F6300C3CA2D /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */,
+				6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */,
+				6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */,
+			);
+			path = CrashReporting;
+			sourceTree = "<group>";
+		};
 		616CCE11250A181C009FED46 /* Instrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5438,6 +5476,7 @@
 		D2579546298ABB04008A1BE5 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				6167E7162B837F4200C3CA2D /* FeatureModels */,
 				6188900D2AC58B5D00D0B966 /* MessageReceiverMocks */,
 				61C713C52A3CA08B00FA735A /* CoreMocks */,
 				3C85D42B29F7C87D00AFF894 /* HostsSanitizerMock.swift */,
@@ -5448,6 +5487,7 @@
 				D257954B298ABB04008A1BE5 /* FoundationMocks.swift */,
 				D257954C298ABB04008A1BE5 /* AttributesMocks.swift */,
 				D2DA23C6298D5AC000C6C7E6 /* TelemetryMocks.swift */,
+				6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */,
 				D2DA23C9298D5C1300C6C7E6 /* UIKitMocks.swift */,
 				D2A7840229A536AD003B03BB /* PrintFunctionMock.swift */,
 				D24C9C5129A7BD12002057CF /* SamplerMock.swift */,
@@ -7438,6 +7478,7 @@
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
+				6167E7122B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				D2A434AC2A8E416F0028E329 /* DDSessionReplay+apiTests.m in Sources */,
 				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,
@@ -7543,9 +7584,11 @@
 				D20605B6287572640047275C /* DatadogContextProviderMock.swift in Sources */,
 				6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */,
 				61DA8CB828647A500074A606 /* InternalLoggerTests.swift in Sources */,
+				6167E71E2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2FB1257292E0F0E005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,
 				614B78F1296D7B63009C6B92 /* LowPowerModePublisherTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
+				6167E7232B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
 				61A2CC242A44454D0000FF25 /* DDRUMTests.swift in Sources */,
 				D2A1EE26287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
@@ -7555,6 +7598,7 @@
 				A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* TracingWithLoggingIntegrationTests.swift in Sources */,
 				D2A1EE3E2885D7EC00D28DFB /* LaunchTimePublisherTests.swift in Sources */,
+				6167E7192B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				61B5E42926DFB60A000B0A5F /* DDConfiguration+apiTests.m in Sources */,
 				D22743E429DEB933001A7EF9 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				3CCCA5C72ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */,
@@ -8147,13 +8191,17 @@
 				D2579556298ABB04008A1BE5 /* FoundationMocks.swift in Sources */,
 				D2579553298ABB04008A1BE5 /* DatadogContextMock.swift in Sources */,
 				D24C9C6929A7CE06002057CF /* DDErrorMocks.swift in Sources */,
+				6167E7142B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				D2579558298ABB04008A1BE5 /* Encoding.swift in Sources */,
+				6167E7202B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2EBEE4829BA17C400B15732 /* NetworkInstrumentationMocks.swift in Sources */,
 				3C0D5DEF2A5442A900446CF9 /* EventMocks.swift in Sources */,
 				D24C9C5529A7C5F3002057CF /* DateProvider.swift in Sources */,
 				D2579559298ABB04008A1BE5 /* DDAssert.swift in Sources */,
 				D2579552298ABB04008A1BE5 /* FileWriterMock.swift in Sources */,
+				6167E7252B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				61AE74172AD7DA9B008DB9BB /* FeatureMessageMocks.swift in Sources */,
+				6167E71B2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				D2A7840329A536AD003B03BB /* PrintFunctionMock.swift in Sources */,
 				D2A7840D29A53A4B003B03BB /* TestsDirectory.swift in Sources */,
 				D2DA23CF298D5F2300C6C7E6 /* FeatureMessageReceiverMock.swift in Sources */,
@@ -8184,13 +8232,17 @@
 				D2579579298ABB83008A1BE5 /* FoundationMocks.swift in Sources */,
 				D257957A298ABB83008A1BE5 /* DatadogContextMock.swift in Sources */,
 				D24C9C6A29A7CE06002057CF /* DDErrorMocks.swift in Sources */,
+				6167E7152B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				D257957B298ABB83008A1BE5 /* Encoding.swift in Sources */,
+				6167E7212B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2EBEE4929BA17C400B15732 /* NetworkInstrumentationMocks.swift in Sources */,
 				3C0D5DF02A5442A900446CF9 /* EventMocks.swift in Sources */,
 				D24C9C5629A7C5F3002057CF /* DateProvider.swift in Sources */,
 				D257957C298ABB83008A1BE5 /* DDAssert.swift in Sources */,
 				D257957D298ABB83008A1BE5 /* FileWriterMock.swift in Sources */,
+				6167E7262B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				61AE74182AD7DA9B008DB9BB /* FeatureMessageMocks.swift in Sources */,
+				6167E71C2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				D2A7840429A536AD003B03BB /* PrintFunctionMock.swift in Sources */,
 				D2A7840E29A53A4B003B03BB /* TestsDirectory.swift in Sources */,
 				D2DA23D0298D5F2300C6C7E6 /* FeatureMessageReceiverMock.swift in Sources */,
@@ -8556,12 +8608,14 @@
 				D2CB6EEE27C520D400A62B57 /* DDErrorTests.swift in Sources */,
 				3C0D5DE32A543DC900446CF9 /* EventGeneratorTests.swift in Sources */,
 				D25CFAA229C8644E00E3A43D /* Casting+Tracing.swift in Sources */,
+				6167E71F2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2CB6EF227C520D400A62B57 /* KronosTimeStorageTests.swift in Sources */,
 				D2CB6EF427C520D400A62B57 /* FileWriterTests.swift in Sources */,
 				D2CB6EFE27C520D400A62B57 /* RUMMonitorConfigurationTests.swift in Sources */,
 				D2CB6F0027C520D400A62B57 /* RUMSessionMatcher.swift in Sources */,
 				A728ADB12934EB0C00397996 /* DDW3CHTTPHeadersWriter+apiTests.m in Sources */,
 				D2CB6F0127C520D400A62B57 /* DatadogPrivateMocks.swift in Sources */,
+				6167E7242B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				6167E6DE2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */,
 				D26C49B02886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */,
 				D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */,
@@ -8598,6 +8652,7 @@
 				61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */,
 				614798972A459AA80095CB02 /* DDTraceTests.swift in Sources */,
 				D2CB6F2627C520D400A62B57 /* DataUploadDelayTests.swift in Sources */,
+				6167E7132B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				D2CB6F2827C520D400A62B57 /* DataUploadWorkerTests.swift in Sources */,
 				D2CB6F2B27C520D400A62B57 /* CrashContextProviderTests.swift in Sources */,
 				49274907288048B800ECD49B /* InternalProxyTests.swift in Sources */,
@@ -8608,6 +8663,7 @@
 				D2CB6F3027C520D400A62B57 /* DatadogExtensions.swift in Sources */,
 				D2CB6F3227C520D400A62B57 /* JSONDataMatcher.swift in Sources */,
 				6136CB4B2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
+				6167E71A2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				D2CB6F3327C520D400A62B57 /* FilesOrchestratorTests.swift in Sources */,
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -313,22 +313,18 @@
 		6167E7072B82A9FD00C3CA2D /* GeneratingBacktraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7052B82A9FD00C3CA2D /* GeneratingBacktraceTests.swift */; };
 		6167E70E2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E70D2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift */; };
 		6167E70F2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E70D2B83502200C3CA2D /* DatadogCore+FeatureDirectoriesTests.swift */; };
-		6167E7122B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
-		6167E7132B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
 		6167E7142B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
 		6167E7152B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7112B837F0B00C3CA2D /* BacktraceReportingMocks.swift */; };
-		6167E7192B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
-		6167E71A2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
 		6167E71B2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
 		6167E71C2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */; };
-		6167E71E2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
-		6167E71F2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
 		6167E7202B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
 		6167E7212B837FB200C3CA2D /* DDThreadMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */; };
-		6167E7232B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
-		6167E7242B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
 		6167E7252B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
 		6167E7262B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */; };
+		6167E7292B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */; };
+		6167E72A2B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */; };
+		6167E72C2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */; };
+		6167E72D2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		6170DC1C25C18729003AED5C /* PLCrashReporterPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* PLCrashReporterPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
@@ -2203,6 +2199,8 @@
 		6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacktraceReportMocks.swift; sourceTree = "<group>"; };
 		6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDThreadMocks.swift; sourceTree = "<group>"; };
 		6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageMocks.swift; sourceTree = "<group>"; };
+		6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportMocks.swift; sourceTree = "<group>"; };
+		6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHelpers.swift; sourceTree = "<group>"; };
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfo.swift; sourceTree = "<group>"; };
 		616C0AA028573F6300C13264 /* RUMOperatingSystemInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfoTests.swift; sourceTree = "<group>"; };
@@ -4395,6 +4393,7 @@
 		6167E7172B837F6300C3CA2D /* CrashReporting */ = {
 			isa = PBXGroup;
 			children = (
+				6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */,
 				6167E7182B837F7A00C3CA2D /* BacktraceReportMocks.swift */,
 				6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */,
 				6167E71D2B837FB200C3CA2D /* DDThreadMocks.swift */,
@@ -5511,6 +5510,7 @@
 				D2F44FBB299AA36D0074B0D9 /* Decompression.swift */,
 				61133C462423990D00786299 /* TestsDirectory.swift */,
 				61C713D22A3DFB4900FA735A /* FuzzyHelpers.swift */,
+				6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -7478,7 +7478,6 @@
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
-				6167E7122B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				D2A434AC2A8E416F0028E329 /* DDSessionReplay+apiTests.m in Sources */,
 				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,
@@ -7584,11 +7583,9 @@
 				D20605B6287572640047275C /* DatadogContextProviderMock.swift in Sources */,
 				6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */,
 				61DA8CB828647A500074A606 /* InternalLoggerTests.swift in Sources */,
-				6167E71E2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2FB1257292E0F0E005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,
 				614B78F1296D7B63009C6B92 /* LowPowerModePublisherTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
-				6167E7232B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
 				61A2CC242A44454D0000FF25 /* DDRUMTests.swift in Sources */,
 				D2A1EE26287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
@@ -7598,7 +7595,6 @@
 				A7DA18042AB0C91200F76337 /* DDUIKitRUMViewsPredicateTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* TracingWithLoggingIntegrationTests.swift in Sources */,
 				D2A1EE3E2885D7EC00D28DFB /* LaunchTimePublisherTests.swift in Sources */,
-				6167E7192B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				61B5E42926DFB60A000B0A5F /* DDConfiguration+apiTests.m in Sources */,
 				D22743E429DEB933001A7EF9 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				3CCCA5C72ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */,
@@ -8199,6 +8195,7 @@
 				D24C9C5529A7C5F3002057CF /* DateProvider.swift in Sources */,
 				D2579559298ABB04008A1BE5 /* DDAssert.swift in Sources */,
 				D2579552298ABB04008A1BE5 /* FileWriterMock.swift in Sources */,
+				6167E72C2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */,
 				6167E7252B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				61AE74172AD7DA9B008DB9BB /* FeatureMessageMocks.swift in Sources */,
 				6167E71B2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
@@ -8212,6 +8209,7 @@
 				D2F44FBC299AA36D0074B0D9 /* Decompression.swift in Sources */,
 				D24C9C5229A7BD12002057CF /* SamplerMock.swift in Sources */,
 				D2579557298ABB04008A1BE5 /* AttributesMocks.swift in Sources */,
+				6167E7292B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C7298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
 				D2DA23CA298D5C1300C6C7E6 /* UIKitMocks.swift in Sources */,
 				6188900F2AC58B8C00D0B966 /* TelemetryReceiverMock.swift in Sources */,
@@ -8240,6 +8238,7 @@
 				D24C9C5629A7C5F3002057CF /* DateProvider.swift in Sources */,
 				D257957C298ABB83008A1BE5 /* DDAssert.swift in Sources */,
 				D257957D298ABB83008A1BE5 /* FileWriterMock.swift in Sources */,
+				6167E72D2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */,
 				6167E7262B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				61AE74182AD7DA9B008DB9BB /* FeatureMessageMocks.swift in Sources */,
 				6167E71C2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
@@ -8253,6 +8252,7 @@
 				D2F44FBD299AA36D0074B0D9 /* Decompression.swift in Sources */,
 				D24C9C5329A7BD12002057CF /* SamplerMock.swift in Sources */,
 				D257957F298ABB83008A1BE5 /* AttributesMocks.swift in Sources */,
+				6167E72A2B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C8298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
 				D2DA23CB298D5C1300C6C7E6 /* UIKitMocks.swift in Sources */,
 				618890102AC58B8C00D0B966 /* TelemetryReceiverMock.swift in Sources */,
@@ -8608,14 +8608,12 @@
 				D2CB6EEE27C520D400A62B57 /* DDErrorTests.swift in Sources */,
 				3C0D5DE32A543DC900446CF9 /* EventGeneratorTests.swift in Sources */,
 				D25CFAA229C8644E00E3A43D /* Casting+Tracing.swift in Sources */,
-				6167E71F2B837FB200C3CA2D /* DDThreadMocks.swift in Sources */,
 				D2CB6EF227C520D400A62B57 /* KronosTimeStorageTests.swift in Sources */,
 				D2CB6EF427C520D400A62B57 /* FileWriterTests.swift in Sources */,
 				D2CB6EFE27C520D400A62B57 /* RUMMonitorConfigurationTests.swift in Sources */,
 				D2CB6F0027C520D400A62B57 /* RUMSessionMatcher.swift in Sources */,
 				A728ADB12934EB0C00397996 /* DDW3CHTTPHeadersWriter+apiTests.m in Sources */,
 				D2CB6F0127C520D400A62B57 /* DatadogPrivateMocks.swift in Sources */,
-				6167E7242B837FF100C3CA2D /* BinaryImageMocks.swift in Sources */,
 				6167E6DE2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */,
 				D26C49B02886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */,
 				D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */,
@@ -8652,7 +8650,6 @@
 				61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */,
 				614798972A459AA80095CB02 /* DDTraceTests.swift in Sources */,
 				D2CB6F2627C520D400A62B57 /* DataUploadDelayTests.swift in Sources */,
-				6167E7132B837F0B00C3CA2D /* BacktraceReportingMocks.swift in Sources */,
 				D2CB6F2827C520D400A62B57 /* DataUploadWorkerTests.swift in Sources */,
 				D2CB6F2B27C520D400A62B57 /* CrashContextProviderTests.swift in Sources */,
 				49274907288048B800ECD49B /* InternalProxyTests.swift in Sources */,
@@ -8663,7 +8660,6 @@
 				D2CB6F3027C520D400A62B57 /* DatadogExtensions.swift in Sources */,
 				D2CB6F3227C520D400A62B57 /* JSONDataMatcher.swift in Sources */,
 				6136CB4B2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
-				6167E71A2B837F7A00C3CA2D /* BacktraceReportMocks.swift in Sources */,
 				D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				D2CB6F3327C520D400A62B57 /* FilesOrchestratorTests.swift in Sources */,
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -109,7 +109,9 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        installConsoleOutputInterceptor()
+        if Environment.isRunningInteractive() {
+            installConsoleOutputInterceptor()
+        }
         return true
     }
 

--- a/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
@@ -68,7 +68,7 @@ class GeneratingBacktraceTests: XCTestCase {
 
         // When
         XCTAssertTrue(Thread.current.isMainThread)
-        let threadID = core.backtraceReporter.currentThreadID()
+        let threadID = Thread.currentThreadID
         let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace(threadID: threadID))
 
         // Then
@@ -84,9 +84,9 @@ class GeneratingBacktraceTests: XCTestCase {
         let semaphore = DispatchSemaphore(value: 0)
         var threadID: ThreadID?
 
-        let thread = Thread { [weak self] in
+        let thread = Thread {
             XCTAssertFalse(Thread.current.isMainThread)
-            threadID = self?.core.backtraceReporter.currentThreadID()
+            threadID = Thread.currentThreadID
             semaphore.signal()
         }
 

--- a/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+import TestUtilities
 import DatadogCrashReporting
 @testable import DatadogInternal
 
@@ -23,10 +24,10 @@ class GeneratingBacktraceTests: XCTestCase {
         super.tearDown()
     }
 
-    func testGivenCrashReportingIsEnabled_thenCoreCanGenerateBacktrace() throws {
+    func testGeneratingBacktraceOfTheCurrentThread() throws {
         // Given
         CrashReporting.enable(in: core)
-        XCTAssertNotNil(core.get(feature: BacktraceReportingFeature.self), "`BacktraceReportingFeature` is registered")
+        XCTAssertNotNil(core.get(feature: BacktraceReportingFeature.self), "`BacktraceReportingFeature` must be registered")
 
         // When
         let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace())
@@ -59,5 +60,44 @@ class GeneratingBacktraceTests: XCTestCase {
             backtrace.binaryImages.contains(where: { $0.libraryName.hasPrefix("XCTest") }),
             "Backtrace should include the image for `XCTest`"
         )
+    }
+
+    func testGeneratingBacktraceOfTheMainThread() throws {
+        // Given
+        CrashReporting.enable(in: core)
+
+        // When
+        XCTAssertTrue(Thread.current.isMainThread)
+        let threadID = core.backtraceReporter.currentThreadID()
+        let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace(threadID: threadID))
+
+        // Then
+        XCTAssertFalse(backtrace.stack.isEmpty)
+        XCTAssertTrue(backtrace.stack.contains(uiKitLibraryName), "Main thread stack should include UIKit symbols")
+    }
+
+    func testGeneratingBacktraceOfSecondaryThread() throws {
+        // Given
+        CrashReporting.enable(in: core)
+
+        // When
+        let semaphore = DispatchSemaphore(value: 0)
+        var threadID: ThreadID?
+
+        let thread = Thread { [weak self] in
+            XCTAssertFalse(Thread.current.isMainThread)
+            threadID = self?.core.backtraceReporter.currentThreadID()
+            semaphore.signal()
+        }
+
+        thread.start()
+        XCTAssertEqual(semaphore.wait(timeout: .now() + 5), .success)
+        thread.cancel()
+
+        let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace(threadID: threadID!))
+
+        // Then
+        XCTAssertFalse(backtrace.stack.isEmpty)
+        XCTAssertFalse(backtrace.stack.contains(uiKitLibraryName), "Secondary thread stack should NOT include UIKit symbols")
     }
 }

--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -5,7 +5,9 @@
  */
 
 import XCTest
+import TestUtilities
 import DatadogInternal
+import DatadogCrashReporting
 @testable import DatadogRUM
 
 /// Test case covering scenarios of App Hangs monitoring in RUM.
@@ -22,7 +24,7 @@ class AppHangsMonitoringTests: XCTestCase {
         core = nil
     }
 
-    func testWhenMainThreadHangsAboveThreshold_itTracksAppHang() throws {
+    func testGivenRUMEnabledButCrashReportingNot_whenMainThreadHangs_itTracksAppHangWithNoStack() throws {
         let mainQueue = DispatchQueue(label: "main-queue", qos: .userInteractive)
         rumConfig.mainQueue = mainQueue
 
@@ -42,9 +44,48 @@ class AppHangsMonitoringTests: XCTestCase {
         let errors = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMErrorEvent.self)
         let appHangError = try XCTUnwrap(errors.first)
 
-        XCTAssertEqual(appHangError.error.message, "App Hang")
-        XCTAssertEqual(appHangError.error.type, "AppHang")
+        XCTAssertEqual(appHangError.error.message, AppHangsObserver.Constants.appHangErrorMessage)
+        XCTAssertEqual(appHangError.error.type, AppHangsObserver.Constants.appHangErrorType)
+        XCTAssertEqual(appHangError.error.stack, AppHangsObserver.Constants.appHangNoStackErrorMessage)
         XCTAssertEqual(appHangError.error.source, .source)
+        XCTAssertNil(appHangError.error.threads, "Threads should be unavailable as CrashReporting was not enabled")
+        XCTAssertNil(appHangError.error.binaryImages,  "Binary Images should be unavailable as CrashReporting was not enabled")
         XCTAssertGreaterThanOrEqual(appHangError.date, beforeHang.timeIntervalSince1970.toInt64Milliseconds)
+    }
+
+    func testGivenRUMAndCrashReportingEnabled_whenMainThreadHangs_itTracksAppHangWithMainThreadStack() throws {
+        // Given (no matter of RUM or CR initialization order)
+        oneOf([
+            {
+                RUM.enable(with: self.rumConfig, in: self.core)
+                CrashReporting.enable(in: self.core)
+            },
+            {
+                CrashReporting.enable(in: self.core)
+                RUM.enable(with: self.rumConfig, in: self.core)
+            },
+        ])
+
+        // When
+        let hangDuration = rumConfig.defaultAppHangThreshold * 1.25
+        let awaitMainThreadHang = expectation(description: "Wait until hang ends")
+        DispatchQueue.main.async {
+            Thread.sleep(forTimeInterval: hangDuration) // hang the main thread
+            DispatchQueue.main.async { awaitMainThreadHang.fulfill() } // hang ended, ready to run test assertions
+        }
+        waitForExpectations(timeout: rumConfig.defaultAppHangThreshold * 5)
+
+        // Then
+        RUMMonitor.shared(in: core).dd.flush() // flush RUM monitor to await hang processing
+
+        let appHangError = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMErrorEvent.self).first)
+        let mainThreadStack = try XCTUnwrap(appHangError.error.stack)
+
+        XCTAssertEqual(appHangError.error.message, AppHangsObserver.Constants.appHangErrorMessage)
+        XCTAssertEqual(appHangError.error.type, AppHangsObserver.Constants.appHangErrorType)
+        XCTAssertTrue(mainThreadStack.contains(uiKitLibraryName), "Main thread stack should include UIKit symbols")
+        XCTAssertEqual(appHangError.error.source, .source)
+        XCTAssertNotNil(appHangError.error.threads, "Other threads should be available")
+        XCTAssertNotNil(appHangError.error.binaryImages,  "Binary Images should be available for symbolication")
     }
 }

--- a/DatadogCrashReporting/Sources/Integrations/BacktraceReporter.swift
+++ b/DatadogCrashReporting/Sources/Integrations/BacktraceReporter.swift
@@ -9,11 +9,11 @@ import DatadogInternal
 internal struct BacktraceReporter: DatadogInternal.BacktraceReporting {
     let reporter: ThirdPartyCrashReporter
 
-    func generateBacktrace() -> DatadogInternal.BacktraceReport? {
+    func generateBacktrace(threadID: ThreadID) -> DatadogInternal.BacktraceReport? {
         do {
-            return try reporter.generateBacktrace()
+            return try reporter.generateBacktrace(threadID: threadID)
         } catch let error {
-            DD.logger.error("Encountered an error when generating backtrace", error: error)
+            DD.logger.error("Encountered an error when generating backtrace for thread ID: \(threadID)", error: error)
             return nil
         }
     }

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -60,7 +60,7 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     }
 
     func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport {
-        let liveReportData = crashReporter.generateLiveReport(withThread: threadID.thread_t)
+        let liveReportData = crashReporter.generateLiveReport(withThread: threadID)
         let liveReport = try PLCrashReport(data: liveReportData)
 
         // This is quite opportunistic - we map PLCR's live report through existing `DDCrashReport` builder to

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+import Foundation
 import DatadogInternal
 import CrashReporter
 
@@ -58,8 +59,8 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
         try crashReporter.purgePendingCrashReportAndReturnError()
     }
 
-    func generateBacktrace() throws -> BacktraceReport {
-        let liveReportData = try crashReporter.generateLiveReportAndReturnError()
+    func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport {
+        let liveReportData = crashReporter.generateLiveReport(withThread: threadID.thread_t)
         let liveReport = try PLCrashReport(data: liveReportData)
 
         // This is quite opportunistic - we map PLCR's live report through existing `DDCrashReport` builder to

--- a/DatadogCrashReporting/Sources/ThirdPartyCrashReporter.swift
+++ b/DatadogCrashReporting/Sources/ThirdPartyCrashReporter.swift
@@ -28,5 +28,5 @@ internal protocol ThirdPartyCrashReporter {
 
     // MARK: - Backtrace Generation
 
-    func generateBacktrace() throws -> BacktraceReport
+    func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport
 }

--- a/DatadogCrashReporting/Tests/Mocks.swift
+++ b/DatadogCrashReporting/Tests/Mocks.swift
@@ -50,43 +50,8 @@ internal class ThirdPartyCrashReporterMock: ThirdPartyCrashReporter {
         hasPurgedPendingCrashReport = true
     }
 
-    func generateBacktrace() throws -> BacktraceReport {
+    func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport {
         return generatedBacktrace
-    }
-}
-
-internal extension BacktraceReport {
-    static func mockAny() -> BacktraceReport {
-        return BacktraceReport(
-            stack: "any",
-            threads: [],
-            binaryImages: [],
-            wasTruncated: false
-        )
-    }
-}
-
-internal extension DDCrashReport {
-    static func mockAny() -> DDCrashReport {
-        return DDCrashReport(
-            date: Date(),
-            type: "any",
-            message: "any",
-            stack: "any",
-            threads: [],
-            binaryImages: [],
-            meta: .init(
-                incidentIdentifier: "any",
-                process: "any",
-                parentProcess: "any",
-                path: "any",
-                codeType: "any",
-                exceptionType: "any",
-                exceptionCodes: "any"
-            ),
-            wasTruncated: false,
-            context: "any".data(using: .utf8)
-        )
     }
 }
 

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -6,9 +6,14 @@
 
 import Foundation
 
-/// A type representing unique thread identifier for `BacktraceReport` generation.
-public struct ThreadID {
-    public let thread_t: thread_t
+/// A value identifying the thread for `BacktraceReport` generation.
+public typealias ThreadID = thread_t
+
+public extension Thread {
+    /// Obtains the `ThreadID` of the caller thread.
+    ///
+    /// Should be used in conjunction with `BacktraceReporting.generateBacktrace(threadID:)` to generate backtrace of particular thread.
+    static var currentThreadID: ThreadID { pthread_mach_thread_np(pthread_self()) }
 }
 
 /// A protocol for types capable of generating backtrace reports.
@@ -24,13 +29,6 @@ public protocol BacktraceReporting {
 }
 
 public extension BacktraceReporting {
-    /// Obtains the `ThreadID` of the caller thread. 
-    /// 
-    /// Should be used in conjunction with `generateBacktrace(threadID:)` to generate backtrace of particular thread.
-    func currentThreadID() -> ThreadID {
-        ThreadID(thread_t: pthread_mach_thread_np(pthread_self()))
-    }
-
     /// Generates a backtrace report for current thread.
     ///
     /// The caller thread will be promoted in the main stack of returned `BacktraceReport` (`report.stack`).
@@ -38,7 +36,7 @@ public extension BacktraceReporting {
     /// - Returns: A `BacktraceReport` starting on the current thread and containing information about all other threads
     ///            running in the process. Returns `nil` if the backtrace report cannot be generated.
     func generateBacktrace() -> BacktraceReport? {
-        let callerThreadID = currentThreadID()
+        let callerThreadID = Thread.currentThreadID
         return generateBacktrace(threadID: callerThreadID)
     }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -12,15 +12,11 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
 
     /// A type capable of generating backtrace reports.
-    private let reporter: BacktraceReporting
+    let reporter: BacktraceReporting
 
     /// Creates `BacktraceReportingFeature`.
     /// - Parameter reporter: An external implementation of a type capable of generating backtrace reports.
     init(reporter: BacktraceReporting) {
         self.reporter = reporter
-    }
-
-    internal func generateBacktrace() -> BacktraceReport? {
-        reporter.generateBacktrace()
     }
 }

--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /* Collection of mappings from various types to `RUMDataModel` format. */
 
@@ -76,5 +77,29 @@ internal extension RUMViewEvent {
     /// - Returns: The `Metadata` for the given `RUMViewEvent`.
     func metadata() -> Metadata {
         return Metadata(id: view.id, documentVersion: dd.documentVersion)
+    }
+}
+
+internal extension DDThread {
+    var toRUMDataFormat: RUMErrorEvent.Error.Threads {
+        return .init(
+            crashed: crashed,
+            name: name,
+            stack: stack,
+            state: nil
+        )
+    }
+}
+
+internal extension BinaryImage {
+    var toRUMDataFormat: RUMErrorEvent.Error.BinaryImages {
+        return .init(
+            arch: architecture,
+            isSystem: isSystemLibrary,
+            loadAddress: loadAddress,
+            maxAddress: maxAddress,
+            name: libraryName,
+            uuid: uuid
+        )
     }
 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -83,6 +83,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             appHangThreshold: configuration.defaultAppHangThreshold,
             mainQueue: configuration.mainQueue,
             dateProvider: configuration.dateProvider,
+            backtraceReporter: core.backtraceReporter,
             telemetry: core.telemetry
         )
         self.requestBuilder = RequestBuilder(

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
@@ -84,3 +84,14 @@ internal class AppHangsObserver: RUMCommandPublisher {
         subscriber?.process(command: command)
     }
 }
+
+extension AppHangsObserver {
+    /// Awaits the processing of pending app hang.
+    ///
+    /// Note: This method is synchronous and will block the caller thread, in worst case up for `appHangThreshold`.
+    func flush() {
+        let semaphore = DispatchSemaphore(value: 0)
+        watchdogThread.onBeforeSleep = { semaphore.signal() }
+        semaphore.wait()
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 
 internal class AppHangsObserver: RUMCommandPublisher {
-    private enum Constants {
+    enum Constants {
         /// The standardized `error.message` for RUM errors describing an app hang.
         static let appHangErrorMessage = "App Hang"
 
@@ -16,7 +16,7 @@ internal class AppHangsObserver: RUMCommandPublisher {
         static let appHangErrorType = "AppHang"
 
         /// The standardized `error.stack` when a backtrace couldn't be generated.
-        static let appHangErrorNoStackMessage = "Stack trace was not generated because `DatadogCrashReporting` was not enabled"
+        static let appHangNoStackErrorMessage = "Stack trace was not generated because `DatadogCrashReporting` was not enabled"
     }
 
     /// Watchdog thread that monitors the main queue for App Hangs.
@@ -73,13 +73,13 @@ internal class AppHangsObserver: RUMCommandPublisher {
                 time: appHang.date,
                 message: Constants.appHangErrorMessage,
                 type: Constants.appHangErrorType,
-                stack: Constants.appHangErrorNoStackMessage,
+                stack: Constants.appHangNoStackErrorMessage,
                 source: .source,
                 attributes: [:]
             )
         }
 
-        command.attributes = ["hang_duration": appHang.duration]
+        command.attributes["hang_duration"] = appHang.duration
 
         subscriber?.process(command: command)
     }

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsObserver.swift
@@ -16,6 +16,7 @@ internal class AppHangsObserver: RUMCommandPublisher {
     init(
         appHangThreshold: TimeInterval,
         observedQueue: DispatchQueue,
+        backtraceReporter: BacktraceReporting,
         dateProvider: DateProvider,
         telemetry: Telemetry
     ) {
@@ -23,6 +24,7 @@ internal class AppHangsObserver: RUMCommandPublisher {
             appHangThreshold: appHangThreshold,
             queue: observedQueue,
             dateProvider: dateProvider,
+            backtraceReporter: backtraceReporter,
             telemetry: telemetry
         )
         watchdogThread.onHangEnded = { [weak self] appHang in

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -85,7 +85,7 @@ internal final class AppHangsWatchdogThread: Thread {
 
         if Thread.isMainThread {
             // When initialization happens on the main thread, we can get its `ThreadID` right away, so startup hangs are covered
-            self.mainThreadID = backtraceReporter.currentThreadID()
+            self.mainThreadID = Thread.currentThreadID
             self.isMainThreadIDCached = true
         }
 
@@ -111,7 +111,7 @@ internal final class AppHangsWatchdogThread: Thread {
                 }
                 if self.isMainThreadIDCached == false {
                     // If initialization didin't happen on the main thread, capture and cache the `ThreadID` of the main thread.
-                    self.mainThreadID = backtraceReporter.currentThreadID()
+                    self.mainThreadID = Thread.currentThreadID
                     self.isMainThreadIDCached = true
                 }
                 mainThreadTask.signal()

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -41,6 +41,8 @@ internal final class AppHangsWatchdogThread: Thread {
     private let mainQueue: DispatchQueue
     /// SDK date provider.
     private let dateProvider: DateProvider
+    /// Backtrace reporter for hang's stack trace generation.
+    private let backtraceReporter: BacktraceReporting
     /// Telemetry interface.
     private let telemetry: Telemetry
     /// Closure to be notified when App Hang ends. It will be executed on the watchdog thread.
@@ -55,17 +57,20 @@ internal final class AppHangsWatchdogThread: Thread {
     ///   - appHangThreshold: Minimum duration of the `queue` hang to consider it an App Hang.
     ///   - queue: The queue to observe for hangs. (main queue)
     ///   - dateProvider: Date provider.
+    ///   - backtraceReporter: Backtrace reporter for hang's stack trace generation.
     ///   - telemetry: The handler to report issues through RUM Telemetry.
     init(
         appHangThreshold: TimeInterval,
         queue: DispatchQueue,
         dateProvider: DateProvider,
+        backtraceReporter: BacktraceReporting,
         telemetry: Telemetry
     ) {
         self.appHangThreshold = appHangThreshold
         self.idleInterval = appHangThreshold * Constants.tolerance
         self.mainQueue = queue
         self.dateProvider = dateProvider
+        self.backtraceReporter = backtraceReporter
         self.telemetry = telemetry
         super.init()
         self.name = "com.datadoghq.app-hang-watchdog"

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -58,6 +58,9 @@ internal final class AppHangsWatchdogThread: Thread {
     /// Closure to be notified when App Hang ends. It will be executed on the watchdog thread.
     @ReadWriteLock
     internal var onHangEnded: ((AppHang) -> Void)?
+    /// A block called after this thread finished its pass and will become idle.
+    @ReadWriteLock
+    internal var onBeforeSleep: (() -> Void)?
 
     /// Creates an instance of an App Hang watchdog thread.
     ///
@@ -98,7 +101,9 @@ internal final class AppHangsWatchdogThread: Thread {
 
         while !isCancelled {
             defer {
-                // Before continuing, sleep for a while, to reduce the CPU consumption by watchdog thread.
+                // Notify that thread finished its next pass and will be put to IDLE
+                onBeforeSleep?()
+                // Sleep (become idle) to reduce the CPU consumption by watchdog thread:
                 Thread.sleep(forTimeInterval: idleInterval)
             }
 

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -38,6 +38,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         appHangThreshold: TimeInterval,
         mainQueue: DispatchQueue,
         dateProvider: DateProvider,
+        backtraceReporter: BacktraceReporting,
         telemetry: Telemetry
     ) {
         // Always create views handler (we can't know if it will be used by SwiftUI instrumentation)
@@ -89,6 +90,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         self.appHangs = AppHangsObserver(
             appHangThreshold: appHangThreshold,
             observedQueue: mainQueue,
+            backtraceReporter: backtraceReporter,
             dateProvider: dateProvider,
             telemetry: telemetry
         )

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -161,24 +161,27 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     init(
         time: Date,
         message: String,
-        type: String,
-        backtrace: BacktraceReport,
-        source: RUMInternalErrorSource,
-        attributes: [AttributeKey: AttributeValue]
+        type: String? = nil,
+        stack: String? = nil,
+        source: RUMInternalErrorSource = .source,
+        errorSourceType: RUMErrorEvent.Error.SourceType = .ios,
+        isCrash: Bool = false,
+        threads: [DDThread]? = nil,
+        binaryImages: [BinaryImage]? = nil,
+        isStackTraceTruncated: Bool? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
     ) {
         self.time = time
-        self.source = source
         self.attributes = attributes
-
         self.message = message
         self.type = type
-        self.stack = backtrace.stack
-
-        self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
-        self.isCrash = false // backtrace reports are not crashes
-        self.threads = backtrace.threads
-        self.binaryImages = backtrace.binaryImages
-        self.isStackTraceTruncated = backtrace.wasTruncated
+        self.stack = stack
+        self.isCrash = isCrash
+        self.source = source
+        self.errorSourceType = errorSourceType
+        self.threads = threads
+        self.binaryImages = binaryImages
+        self.isStackTraceTruncated = isStackTraceTruncated
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -99,12 +99,18 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     let type: String?
     /// Error stacktrace.
     let stack: String?
-    /// Whether this error crashed the host application
+    /// Whether this error has crashed the host application
     let isCrash: Bool?
     /// The origin of this error.
     let source: RUMInternalErrorSource
     /// The platform type of the error (iOS, React Native, ...)
     let errorSourceType: RUMErrorEvent.Error.SourceType
+    /// An information about the threads currently running in the process.
+    let threads: [DDThread]?
+    /// The list of binary images referenced from `stack` and `threads`.
+    let binaryImages: [BinaryImage]?
+    /// Indicates whether any stack trace information in `stack` or `threads` was truncated due to stack trace minimization.
+    let isStackTraceTruncated: Bool?
 
     init(
         time: Date,
@@ -123,6 +129,10 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
 
         self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
         self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash)?.decoded()
+
+        self.threads = nil
+        self.binaryImages = nil
+        self.isStackTraceTruncated = nil
     }
 
     init(
@@ -142,6 +152,33 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
 
         self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
         self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash) as? Bool
+
+        self.threads = nil
+        self.binaryImages = nil
+        self.isStackTraceTruncated = nil
+    }
+
+    init(
+        time: Date,
+        message: String,
+        type: String,
+        backtrace: BacktraceReport,
+        source: RUMInternalErrorSource,
+        attributes: [AttributeKey: AttributeValue]
+    ) {
+        self.time = time
+        self.source = source
+        self.attributes = attributes
+
+        self.message = message
+        self.type = type
+        self.stack = backtrace.stack
+
+        self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
+        self.isCrash = false // backtrace reports are not crashes
+        self.threads = backtrace.threads
+        self.binaryImages = backtrace.binaryImages
+        self.isStackTraceTruncated = backtrace.wasTruncated
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -584,7 +584,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
             error: .init(
-                binaryImages: nil,
+                binaryImages: command.binaryImages?.compactMap { $0.toRUMDataFormat },
                 causes: nil,
                 handling: nil,
                 handlingStack: nil,
@@ -596,9 +596,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 source: command.source.toRUMDataFormat,
                 sourceType: command.errorSourceType,
                 stack: command.stack,
-                threads: nil,
+                threads: command.threads?.compactMap { $0.toRUMDataFormat },
                 type: command.type,
-                wasTruncated: nil
+                wasTruncated: command.isStackTraceTruncated
             ),
             featureFlags: .init(featureFlagsInfo: featureFlags),
             os: .init(context: context),

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
@@ -83,7 +83,7 @@ class AppHangsWatchdogThreadTests: XCTestCase {
         watchdogThread.cancel()
     }
 
-    func testItTracksHangDateAndDuration() {
+    func testItTracksHangDateStackAndDuration() {
         let trackHang = expectation(description: "track App Hang")
 
         // Given
@@ -95,11 +95,12 @@ class AppHangsWatchdogThreadTests: XCTestCase {
             appHangThreshold: appHangThreshold,
             queue: queue,
             dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
-            backtraceReporter: BacktraceReporterMock(),
+            backtraceReporter: BacktraceReporterMock(backtrace: .mockWith(stack: "Main thread stack")),
             telemetry: TelemetryMock()
         )
         watchdogThread.onHangEnded = { hang in
             XCTAssertEqual(hang.date, .mockDecember15th2019At10AMUTC())
+            XCTAssertEqual(hang.backtrace?.stack, "Main thread stack")
             XCTAssertGreaterThanOrEqual(hang.duration, hangDuration * (1 - AppHangsWatchdogThread.Constants.tolerance))
             XCTAssertLessThanOrEqual(hang.duration, hangDuration * (1 + AppHangsWatchdogThread.Constants.tolerance))
             trackHang.fulfill()

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
@@ -23,6 +23,7 @@ class AppHangsWatchdogThreadTests: XCTestCase {
             appHangThreshold: appHangThreshold,
             queue: queue,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: TelemetryMock()
         )
         watchdogThread.onHangEnded = { _ in
@@ -58,6 +59,7 @@ class AppHangsWatchdogThreadTests: XCTestCase {
             appHangThreshold: appHangThreshold,
             queue: queue,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: TelemetryMock()
         )
         watchdogThread.onHangEnded = { _ in
@@ -93,6 +95,7 @@ class AppHangsWatchdogThreadTests: XCTestCase {
             appHangThreshold: appHangThreshold,
             queue: queue,
             dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: TelemetryMock()
         )
         watchdogThread.onHangEnded = { hang in

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -21,6 +21,7 @@ class RUMInstrumentationTests: XCTestCase {
             appHangThreshold: .mockAny(),
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: NOPTelemetry()
         )
 
@@ -43,6 +44,7 @@ class RUMInstrumentationTests: XCTestCase {
             appHangThreshold: .mockAny(),
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: NOPTelemetry()
         )
 
@@ -62,6 +64,7 @@ class RUMInstrumentationTests: XCTestCase {
             appHangThreshold: .mockAny(),
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: NOPTelemetry()
         )
 
@@ -84,6 +87,7 @@ class RUMInstrumentationTests: XCTestCase {
             appHangThreshold: .mockAny(),
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: NOPTelemetry()
         )
 
@@ -102,6 +106,7 @@ class RUMInstrumentationTests: XCTestCase {
             appHangThreshold: .mockAny(),
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
             telemetry: NOPTelemetry()
         )
         let subscriber = RUMCommandSubscriberMock()

--- a/TestUtilities/Helpers/UIKitHelpers.swift
+++ b/TestUtilities/Helpers/UIKitHelpers.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+/// The library name for UIKit framework as it will appear in unsymbolicated stack trace.
+///
+/// This name may differ between OS runtimes.
+public var uiKitLibraryName: String {
+    let uiKitBundleURL = Bundle(for: UIViewController.self).bundleURL
+    let uiKitFrameworkName = uiKitBundleURL.lastPathComponent // 'UIKitCore.framework' on iOS 12+; 'UIKit.framework' on iOS 11
+    return String(uiKitFrameworkName.dropLast(".framework".count))
+}

--- a/TestUtilities/Mocks/BacktraceReportingMocks.swift
+++ b/TestUtilities/Mocks/BacktraceReportingMocks.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+import Foundation
 import DatadogInternal
 
 public struct BacktraceReporterMock: BacktraceReporting {
@@ -13,7 +14,7 @@ public struct BacktraceReporterMock: BacktraceReporting {
         self.backtrace = backtrace
     }
 
-    public func generateBacktrace() -> BacktraceReport? {
+    public func generateBacktrace(threadID: ThreadID) -> BacktraceReport? {
         return backtrace
     }
 }

--- a/TestUtilities/Mocks/BacktraceReportingMocks.swift
+++ b/TestUtilities/Mocks/BacktraceReportingMocks.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+public struct BacktraceReporterMock: BacktraceReporting {
+    public var backtrace: BacktraceReport?
+
+    public init(backtrace: BacktraceReport? = .mockAny()) {
+        self.backtrace = backtrace
+    }
+
+    public func generateBacktrace() -> BacktraceReport? {
+        return backtrace
+    }
+}

--- a/TestUtilities/Mocks/FeatureModels/CrashReporting/BacktraceReportMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/CrashReporting/BacktraceReportMocks.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+extension BacktraceReport: AnyMockable, RandomMockable {
+    public static func mockAny() -> BacktraceReport {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> BacktraceReport {
+        return BacktraceReport(
+            stack: .mockRandom(),
+            threads: .mockRandom(),
+            binaryImages: .mockRandom(),
+            wasTruncated: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        stack: String = .mockAny(),
+        threads: [DDThread] = .mockAny(),
+        binaryImages: [BinaryImage] = .mockAny(),
+        wasTruncated: Bool = .mockAny()
+    ) -> BacktraceReport {
+        return BacktraceReport(
+            stack: stack,
+            threads: threads,
+            binaryImages: binaryImages,
+            wasTruncated: wasTruncated
+        )
+    }
+}

--- a/TestUtilities/Mocks/FeatureModels/CrashReporting/BinaryImageMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/CrashReporting/BinaryImageMocks.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+extension BinaryImage: AnyMockable, RandomMockable {
+    public static func mockAny() -> BinaryImage {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> BinaryImage {
+        return BinaryImage(
+            libraryName: .mockRandom(),
+            uuid: .mockRandom(),
+            architecture: .mockRandom(),
+            isSystemLibrary: .mockRandom(),
+            loadAddress: .mockRandom(),
+            maxAddress: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        libraryName: String = .mockAny(),
+        uuid: String = .mockAny(),
+        architecture: String = .mockAny(),
+        isSystemLibrary: Bool = .mockAny(),
+        loadAddress: String = .mockAny(),
+        maxAddress: String = .mockAny()
+    ) -> BinaryImage {
+        return BinaryImage(
+            libraryName: libraryName,
+            uuid: uuid,
+            architecture: architecture,
+            isSystemLibrary: isSystemLibrary,
+            loadAddress: loadAddress,
+            maxAddress: maxAddress
+        )
+    }
+}

--- a/TestUtilities/Mocks/FeatureModels/CrashReporting/DDCrashReportMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/CrashReporting/DDCrashReportMocks.swift
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension DDCrashReport: AnyMockable, RandomMockable {
+    public static func mockAny() -> DDCrashReport {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> DDCrashReport {
+        return DDCrashReport(
+            date: .mockRandom(),
+            type: .mockRandom(),
+            message: .mockRandom(),
+            stack: .mockRandom(),
+            threads: .mockRandom(),
+            binaryImages: .mockRandom(),
+            meta: .mockRandom(),
+            wasTruncated: .mockRandom(),
+            context: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        date: Date? = .mockAny(),
+        type: String = .mockAny(),
+        message: String = .mockAny(),
+        stack: String = .mockAny(),
+        threads: [DDThread] = .mockAny(),
+        binaryImages: [BinaryImage] = .mockAny(),
+        meta: Meta = .mockAny(),
+        wasTruncated: Bool = .mockAny(),
+        context: Data? = .mockAny()
+    ) -> DDCrashReport {
+        return DDCrashReport(
+            date: date,
+            type: type,
+            message: message,
+            stack: stack,
+            threads: threads,
+            binaryImages: binaryImages,
+            meta: meta,
+            wasTruncated: wasTruncated,
+            context: context
+        )
+    }
+}
+
+extension DDCrashReport.Meta: AnyMockable, RandomMockable {
+    public static func mockAny() -> DDCrashReport.Meta {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> DDCrashReport.Meta {
+        return DDCrashReport.Meta(
+            incidentIdentifier: .mockRandom(),
+            process: .mockRandom(),
+            parentProcess: .mockRandom(),
+            path: .mockRandom(),
+            codeType: .mockRandom(),
+            exceptionType: .mockRandom(),
+            exceptionCodes: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        incidentIdentifier: String? = .mockAny(),
+        process: String? = .mockAny(),
+        parentProcess: String? = .mockAny(),
+        path: String? = .mockAny(),
+        codeType: String? = .mockAny(),
+        exceptionType: String? = .mockAny(),
+        exceptionCodes: String? = .mockAny()
+    ) -> DDCrashReport.Meta {
+        return DDCrashReport.Meta(
+            incidentIdentifier: incidentIdentifier,
+            process: process,
+            parentProcess: parentProcess,
+            path: path,
+            codeType: codeType,
+            exceptionType: exceptionType,
+            exceptionCodes: exceptionCodes
+        )
+    }
+}

--- a/TestUtilities/Mocks/FeatureModels/CrashReporting/DDThreadMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/CrashReporting/DDThreadMocks.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+extension DDThread: AnyMockable, RandomMockable {
+    public static func mockAny() -> DDThread {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> DDThread {
+        return DDThread(
+            name: .mockRandom(),
+            stack: .mockRandom(),
+            crashed: .mockRandom(),
+            state: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        name: String = .mockAny(),
+        stack: String = .mockAny(),
+        crashed: Bool = .mockAny(),
+        state: String? = .mockAny()
+    ) -> DDThread {
+        return DDThread(
+            name: name,
+            stack: stack,
+            crashed: crashed,
+            state: state
+        )
+    }
+}


### PR DESCRIPTION
### What and why?

📦 Following #1685 and #1687, this PR adds `error.stack`, `error.threads` and `error.binary_images` for App Hang RUM errors, so they can be later symbolicated in Datadog app:

<p align="center">
<img width="50%" alt="Screenshot 2024-02-20 at 14 30 12" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/9e7fa2ba-b092-4461-97ff-1d06733d6667">
</p>

### How?

This leverages the [`generateLiveReportWithThread:`](https://github.com/microsoft/plcrashreporter/blob/c071a07986a527d961383558e0604a456fb64b92/Source/PLCrashReporter.m#L675-L686) API from PLCR, to promote the main thread stack as the key one in produced Live Report. In our domain, it is called through convenience variant next to `generateBacktrace()` added earlier in #1687. To identify the thread, we use [`thread_t`](https://developer.apple.com/documentation/kernel/thread_t) aliased through  `DatadogInternal.ThreadID`.

The backtrace for the caller thread or and any thread can be generated as follows:
```swift
// current thread:
let backtrace = backtraceReporter.generateBacktrace()

// other thread:
Thread {
   threadID = Thread.currentThreadID()
}

let backtrace = backtraceReporter.generateBacktrace(threadID: threadID)
```

To achieve the goal of this PR, so generating main thread stack trace from App Hang watchdog thread, the `currentThreadID()` is obtained and cached in one of two ways:
- If SDK is initialized on the main thread, we resolve the value right away;
- Otherwise, the value is captured from the first main thread task dispatched by watchdog thread.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
