### PR TITLE
feat: Add ability to override `source_type` for crashes

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -344,6 +344,7 @@ extension DatadogContextProvider {
         buildId: String?,
         variant: String?,
         source: String,
+        nativeSourceOverride: String?,
         sdkVersion: String,
         ciAppOrigin: String?,
         applicationName: String,
@@ -370,6 +371,7 @@ extension DatadogContextProvider {
             applicationBundleIdentifier: applicationBundleIdentifier,
             sdkInitDate: dateProvider.now,
             device: device,
+            nativeSourceOverride: nativeSourceOverride,
             // this is a placeholder waiting for the `ApplicationStatePublisher`
             // to be initialized on the main thread, this value will be overrided
             // as soon as the subscription is made.

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -412,6 +412,7 @@ public enum Datadog {
         let variant = configuration.additionalConfiguration[CrossPlatformAttributes.variant] as? String
         let sdkVersion = configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String ?? __sdkVersion
         let buildId = configuration.additionalConfiguration[CrossPlatformAttributes.buildId] as? String
+        let nativeSourceType = configuration.additionalConfiguration[CrossPlatformAttributes.nativeSourceType] as? String
 
         let performance = PerformancePreset(
             batchSize: debug ? .small : configuration.batchSize,
@@ -441,6 +442,7 @@ public enum Datadog {
                 buildId: buildId,
                 variant: variant,
                 source: source,
+                nativeSourceOverride: nativeSourceType,
                 sdkVersion: sdkVersion,
                 ciAppOrigin: CITestIntegration.active?.origin,
                 applicationName: bundleName ?? bundleType.rawValue,

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -29,6 +29,19 @@ class CrashContextTests: XCTestCase {
         XCTAssertEqual(deserializedContext.trackingConsent, randomConsent)
     }
 
+    func testGivenContextWithCustomNativeSourceType_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        // Given
+        let randomSourceType: String = .mockRandom()
+        let context: CrashContext = .mockWith(nativeSourceTypeOverride: randomSourceType)
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        XCTAssertEqual(deserializedContext.nativeSourceTypeOverride, randomSourceType)
+    }
+
     func testGivenContextWithLastRUMViewEventSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
         let randomRUMViewEvent = AnyCodable(mockRandomAttributes())
 

--- a/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
@@ -369,12 +369,31 @@ class DatadogConfigurationTests: XCTestCase {
         var configuration = defaultConfig
         configuration.additionalConfiguration[CrossPlatformAttributes.buildId] = buildId
 
+        // When
         Datadog.initialize(with: configuration, trackingConsent: .mockRandom())
         defer { Datadog.flushAndDeinitialize() }
 
         let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
         let context = core.contextProvider.read()
 
+        // Then
         XCTAssertEqual(context.buildId, buildId)
+    }
+
+    func testGivenNativeSourceType_itSetsInContext() throws {
+        // Given
+        let nativeSourceType: String = .mockRandom()
+        var configuration = defaultConfig
+        configuration.additionalConfiguration[CrossPlatformAttributes.nativeSourceType] = nativeSourceType
+
+        // When
+        Datadog.initialize(with: configuration, trackingConsent: .mockRandom())
+        defer { Datadog.flushAndDeinitialize() }
+
+        let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
+        let context = core.contextProvider.read()
+
+        // Then
+        XCTAssertEqual(context.nativeSourceOverride, nativeSourceType)
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -143,7 +143,8 @@ extension CrashContext {
         carrierInfo: CarrierInfo? = .mockAny(),
         lastRUMViewEvent: AnyCodable? = nil,
         lastRUMSessionState: AnyCodable? = nil,
-        lastIsAppInForeground: Bool = .mockAny()
+        lastIsAppInForeground: Bool = .mockAny(),
+        nativeSourceTypeOverride: String? = nil
     ) -> Self {
         .init(
             serverTimeOffset: serverTimeOffset,
@@ -160,7 +161,8 @@ extension CrashContext {
             carrierInfo: carrierInfo,
             lastRUMViewEvent: lastRUMViewEvent,
             lastRUMSessionState: lastRUMSessionState,
-            lastIsAppInForeground: lastIsAppInForeground
+            lastIsAppInForeground: lastIsAppInForeground,
+            nativeSourceTypeOverride: nativeSourceTypeOverride
         )
     }
 
@@ -180,7 +182,8 @@ extension CrashContext {
             carrierInfo: .mockRandom(),
             lastRUMViewEvent: AnyCodable(mockRandomAttributes()),
             lastRUMSessionState: AnyCodable(mockRandomAttributes()),
-            lastIsAppInForeground: .mockRandom()
+            lastIsAppInForeground: .mockRandom(),
+            nativeSourceTypeOverride: RUMErrorSourceType.mockRandom().rawValue
         )
     }
 

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
@@ -69,6 +69,9 @@ internal struct CrashContext: Codable, Equatable {
     /// The last _"Is app in foreground?"_ information from crashed app process.
     let lastIsAppInForeground: Bool
 
+    /// The override for `source_type` for crashes.
+    let nativeSourceTypeOverride: String?
+
     // MARK: - Initialization
 
     init(
@@ -86,7 +89,8 @@ internal struct CrashContext: Codable, Equatable {
         carrierInfo: CarrierInfo?,
         lastRUMViewEvent: AnyCodable?,
         lastRUMSessionState: AnyCodable?,
-        lastIsAppInForeground: Bool
+        lastIsAppInForeground: Bool,
+        nativeSourceTypeOverride: String?
     ) {
         self.serverTimeOffset = serverTimeOffset
         self.service = service
@@ -103,6 +107,7 @@ internal struct CrashContext: Codable, Equatable {
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState
         self.lastIsAppInForeground = lastIsAppInForeground
+        self.nativeSourceTypeOverride = nativeSourceTypeOverride
     }
 
     init(
@@ -123,6 +128,7 @@ internal struct CrashContext: Codable, Equatable {
         self.networkConnectionInfo = context.networkConnectionInfo
         self.carrierInfo = context.carrierInfo
         self.lastIsAppInForeground = context.applicationStateHistory.currentSnapshot.state.isRunningInForeground
+        self.nativeSourceTypeOverride = context.nativeSourceOverride
 
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -149,6 +149,10 @@ public struct CrossPlatformAttributes {
     /// It sets the GraphQL varibles as a JSON string if they were defined by the developer.
     /// Expects `String` value.
     public static let graphqlVariables = "_dd.graphql.variables"
+
+    /// Override the `source_type` of errors reported by the native crash handler. This is used on
+    /// platforms that can supply extra steps or information on a native crash (such as Unity's IL2CPP
+    public static let nativeSourceType = "_dd.native_source_type"
 }
 
 public struct LaunchArguments {

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -39,6 +39,9 @@ public struct DatadogContext {
     ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
     public let source: String
 
+    /// Denotes the source type for  crashes.. This is used for platforms that provide additional symbolication steps for native crashes.
+    public let nativeSourceOverride: String?
+
     /// The version of Datadog iOS SDK.
     public let sdkVersion: String
 
@@ -124,6 +127,7 @@ public struct DatadogContext {
         applicationBundleIdentifier: String,
         sdkInitDate: Date,
         device: DeviceInfo,
+        nativeSourceOverride: String? = nil,
         userInfo: UserInfo? = nil,
         trackingConsent: TrackingConsent = .pending,
         launchTime: LaunchTime? = nil,
@@ -150,6 +154,7 @@ public struct DatadogContext {
         self.applicationBundleIdentifier = applicationBundleIdentifier
         self.sdkInitDate = sdkInitDate
         self.device = device
+        self.nativeSourceOverride = nativeSourceOverride
         self.userInfo = userInfo
         self.trackingConsent = trackingConsent
         self.launchTime = launchTime

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -173,6 +173,8 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
 
         /// The last RUM view in crashed app process.
         let lastRUMViewEvent: PartialRUMViewEvent?
+
+        let nativeSourceTypeOverride: String?
     }
 
     /// Time provider.
@@ -205,6 +207,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
             .addingTimeInterval(context.serverTimeOffset)
 
         var errorAttributes: [AttributeKey: AttributeValue] = [:]
+
         // Set crash attributes for the error
         errorAttributes[DDError.threads] = report.threads
         errorAttributes[DDError.binaryImages] = report.binaryImages
@@ -226,7 +229,8 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
             error: .init(
                 kind: report.type,
                 message: report.message,
-                stack: report.stack
+                stack: report.stack,
+                sourceType: context.nativeSourceTypeOverride ?? "ios"
             ),
             serviceName: context.service,
             environment: context.env,

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -71,6 +71,8 @@ public struct LogEvent: Encodable {
         public var message: String?
         /// The Log error stack
         public var stack: String?
+        /// The Log error source_type. Used by cross platform SDKs
+        public var sourceType: String = "ios"
     }
 
     /// Device information.
@@ -157,6 +159,7 @@ internal struct LogEventEncoder {
         case errorKind = "error.kind"
         case errorMessage = "error.message"
         case errorStack = "error.stack"
+        case errorSourceType = "error.source_type"
 
         // MARK: - Application info
 
@@ -218,6 +221,7 @@ internal struct LogEventEncoder {
             try container.encode(someError.kind, forKey: .errorKind)
             try container.encode(someError.message, forKey: .errorMessage)
             try container.encode(someError.stack, forKey: .errorStack)
+            try container.encode(someError.sourceType, forKey: .errorSourceType)
         }
 
         // Encode logger info

--- a/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
@@ -61,6 +61,7 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.error?.kind, randomError.type)
             XCTAssertEqual(log.error?.message, randomError.message)
             XCTAssertEqual(log.error?.stack, randomError.stack)
+            XCTAssertEqual(log.error?.sourceType, "ios")
             XCTAssertEqual(log.attributes, randomAttributes)
             XCTAssertEqual(log.tags.map { Set($0) }, randomTags)
             XCTAssertEqual(log.serviceName, randomService)

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -323,7 +323,7 @@ extension TrackingConsent {
 
 extension String {
     public static func mockAnySource() -> String {
-        return ["ios", "android", "browser", "ios", "react-native", "flutter"].randomElement()!
+        return ["ios", "android", "browser", "ios", "react-native", "flutter", "unity"].randomElement()!
     }
 }
 


### PR DESCRIPTION
### What and why?

Add the ability to pass the attribute `_dd.native_source_type` to override the source_type for native crashes. This is needed for platforms that can supply additional information from a native crash (specifically Unity with IL2CPP).

refs: RUM-2691

### How?

This added an extra item to `DatadogContext`: `nativeSourceOverride` that is set from the cross platform additional attribute `_dd.native_source_type`. This is used to add the same value to the CrashContext when the DatadogCrashReporting feature sends a message over the bus. That value is then read and serialized by the Logs and RUM feature to provide the correct value.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
