### PR TITLE
fix: pass through data when network request completes

### DIFF
--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -66,7 +66,11 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         RUM.enable(
             with: RUM.Configuration(
                 applicationID: Environment.readRUMApplicationID(),
-                urlSessionTracking: .init(firstPartyHostsTracing: .trace(hosts: [], sampleRate: 100)),
+                urlSessionTracking: .init(
+                    resourceAttributesProvider: { req, resp, data, err in
+                        print("⭐️ [Attributes Provider] data: \(data)")
+                        return [:]
+            }),
                 trackBackgroundEvents: true,
                 customEndpoint: Environment.readCustomRUMURL(),
                 telemetrySampleRate: 100

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -68,7 +68,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
                 applicationID: Environment.readRUMApplicationID(),
                 urlSessionTracking: .init(
                     resourceAttributesProvider: { req, resp, data, err in
-                        print("⭐️ [Attributes Provider] data: \(data)")
+                        print("⭐️ [Attributes Provider] data: \(String(describing: data))")
                         return [:]
             }),
                 trackBackgroundEvents: true,

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -199,7 +199,6 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
 
     class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {
         func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-            print(data)
         }
     }
 }

--- a/Datadog/IntegrationUnitTests/RUM/StartingRUMSessionTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/StartingRUMSessionTests.swift
@@ -143,14 +143,14 @@ class StartingRUMSessionTests: XCTestCase {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
         rumConfig.trackBackgroundEvents = .mockRandom() // no matter BET state
-        
+
         // When
         rumTime.now = sdkInitTime
         RUM.enable(with: rumConfig, in: core)
-        
+
         rumTime.now = firstRUMTime
         RUMMonitor.shared(in: core).startView(key: "key", name: "FirstView")
-        
+
         // Then
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
@@ -158,7 +158,7 @@ class StartingRUMSessionTests: XCTestCase {
 
         XCTAssertEqual(session.views.count, 1)
         XCTAssertTrue(try session.has(sessionPrecondition: .backgroundLaunch), "Session must be marked as 'background launch'")
-        
+
         let firstView = try XCTUnwrap(session.views.first)
         XCTAssertFalse(firstView.isApplicationLaunchView(), "Session should not begin with 'app launch' view")
         XCTAssertEqual(firstView.name, "FirstView")

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -92,7 +92,7 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
             interceptDidFinishCollecting: { [weak self] session, task, metrics in
                 self?.task(task, didFinishCollecting: metrics)
 
-                if #available(iOS 15, tvOS 15, *) {
+                if #available(iOS 15, tvOS 15, *), !task.dd.hasCompletion {
                     // iOS 15 and above, didCompleteWithError is not called hence we use task state to detect task completion
                     // while prior to iOS 15, task state doesn't change to completed hence we use didCompleteWithError to detect task completion
                     self?.task(task, didCompleteWithError: task.error)
@@ -113,6 +113,8 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
         try swizzler.swizzle(
             interceptCompletionHandler: { [weak self] task, _, error in
                 self?.task(task, didCompleteWithError: error)
+            }, didReceive: { [weak self] task, data in
+                self?.task(task, didReceive: data)
             }
         )
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -139,6 +139,7 @@ open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
             try swizzler.swizzle(
                 interceptCompletionHandler: { [weak self] task, _, error in
                     self?.interceptor?.task(task, didCompleteWithError: error)
+                }, didReceive: { _, _ in
                 }
             )
         } catch {

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/NetworkInstrumentationSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/NetworkInstrumentationSwizzler.swift
@@ -23,9 +23,13 @@ internal final class NetworkInstrumentationSwizzler {
 
     /// Swizzles `URLSession.dataTask(with:completionHandler:)` methods (with `URL` and `URLRequest`).
     func swizzle(
-        interceptCompletionHandler: @escaping (URLSessionTask, Data?, Error?) -> Void
+        interceptCompletionHandler: @escaping (URLSessionTask, Data?, Error?) -> Void,
+        didReceive: @escaping (URLSessionTask, Data) -> Void
     ) throws {
-        try urlSessionSwizzler.swizzle(interceptCompletionHandler: interceptCompletionHandler)
+        try urlSessionSwizzler.swizzle(
+            interceptCompletionHandler: interceptCompletionHandler,
+            didReceive: didReceive
+        )
     }
 
     /// Swizzles `URLSessionTask.resume()` method.

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTask+Tracking.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTask+Tracking.swift
@@ -33,4 +33,20 @@ extension DatadogExtension where ExtendedType: URLSessionTask {
 
         return session.delegate
     }
+
+    var hasCompletion: Bool {
+        get {
+            let value = objc_getAssociatedObject(type, &hasCompletionKey) as? Bool
+            return value == true
+        }
+        set {
+            if newValue {
+                objc_setAssociatedObject(type, &hasCompletionKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            } else {
+                objc_setAssociatedObject(type, &hasCompletionKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+        }
+    }
 }
+
+private var hasCompletionKey: Void?

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
@@ -10,6 +10,9 @@ import XCTest
 
 class URLSessionSwizzlerTests: XCTestCase {
     func testSwizzling_dataTaskWithCompletion() throws {
+        let didReceive = expectation(description: "didReceive")
+        didReceive.expectedFulfillmentCount = 2
+
         let didInterceptCompletion = expectation(description: "interceptCompletion")
         didInterceptCompletion.expectedFulfillmentCount = 2
 
@@ -18,6 +21,8 @@ class URLSessionSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptCompletionHandler: { _, _, _ in
                 didInterceptCompletion.fulfill()
+            }, didReceive: { _, _ in
+                didReceive.fulfill()
             }
         )
 
@@ -30,6 +35,6 @@ class URLSessionSwizzlerTests: XCTestCase {
         session.dataTask(with: url) { _, _, _ in }.resume() // not intercepted
         session.dataTask(with: URLRequest(url: url)) { _, _, _ in }.resume() // not intercepted
 
-        wait(for: [didInterceptCompletion], timeout: 5)
+        wait(for: [didReceive, didInterceptCompletion], timeout: 5)
     }
 }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -221,6 +221,8 @@ extension RUM {
             /// attributes for RUM resource based on the provided request, response, data, and error.
             /// Keep the implementation fast and do not make any assumptions on the thread used to run it.
             ///
+            /// Note: This is not supported for async-await APIs.
+            ///
             /// Default: `nil`.
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
 


### PR DESCRIPTION
### What and why?

Fixes #1680

### How?

This PR mimics the old behavior of the instrumentation.

When completion handler is provided in `URLSession` APIs, `urlSession(_:dataTask:didReceive:)` is not called, which means we can't buffer the data and in the called the Resource Attribute Provider.

This is not only true for the completion handler based APIs but also true for async-await APIs.

Meanwhile we use 	`urlSession(_:task:didFinishCollecting:)` to mark the completion of the network operation which is the only reliable API at this moment. We use this to mark completion for async-await APIs.

#### How did the regression happen?

For some APIs, both `urlSession(_:task:didFinishCollecting:)` and `urlSession(_:task:didCompleteWithError:)` are called. But there is not specific order guaranteed which one comes first, ie the one called first, marks the end of the network operation. In the breaking change, `urlSession(_:task:didFinishCollecting:)` and given `urlSession(_:dataTask:didReceive:)` was not called either, Resource Attribute Provider executes with nil data.

#### How does this PR fix it?

With this PR we make sure, if the API has a completion handler given, we are not going to use `urlSession(_:task:didFinishCollecting:)` as end of operation because we are sure  `urlSession(_:task:didCompleteWithError:)` will be called.

Along side, when the operation finishes, we also call handler for registering the data when the operation completes. The APIs guarantees from behavior that either `urlSession(_:dataTask:didReceive:)` is called or the compeltion handler, hence we don't register data two times.

#### Do we support async-await?

No, because they don't have completion handler, so experience remain broken with them.

#### Tested locally on

- [x] iOS 12.4
- [x] iOS 13.0
- [x] iOS 14.5
- [x] iOS 15.5

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
