### PR TITLE
[CIVIS-9278] Dogfood quality-gates in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - info
   - lint
   - test
+  - gate
 
 ENV info:
   stage: info
@@ -84,3 +85,13 @@ SDK integration tests (iOS):
     - ./tools/config/generate-http-server-mock-config.sh
     - xcodebuild -workspace "$TEST_WORKSPACE" -destination "$TEST_DESTINATION" -scheme "IntegrationScenarios" -testPlan DatadogIntegrationTests test | xcbeautify
     - xcodebuild -workspace "$TEST_WORKSPACE" -destination "$TEST_DESTINATION" -scheme "IntegrationScenarios" -testPlan DatadogCrashReportingIntegrationTests test | xcbeautify
+
+Gate:
+  stage: gate
+  allow_failure: true
+  script:
+    - curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+    - export DD_BETA_COMMANDS_ENABLED=true
+    - export DD_API_KEY=${DD_SDK_SWIFT_TESTING_APIKEY}
+    - export DD_APP_KEY=${DD_SDK_SWIFT_TESTING_APPLICATION_KEY}
+    - datadog-ci gate evaluate


### PR DESCRIPTION
This patch adds quality gates to the CI. All rules will be non-blocking

### What and why?

[Quality gates](https://docs.datadoghq.com/quality_gates/) is a new Datadog product. It allows for creating rules that will be evaluated during the CI process (it will block CI pipelines if there are code issues, e.g. new flaky tests).

We are testing a new code coverage rule that will fail if the code coverage of a feature branch decreases by more than a threshold compared to the default branch. It'd be very useful to also test this rule in this repo as it reports code coverage.

This patch integrates quality-gates into the CI, while marking the job as `allowed_to_fail`, meaning that **quality-gates will never block the CI**.

### How?

Adding a new stage to the CI pipeline that runs quality-gates.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
