### PR TITLE
RUM-2925 feat: Add public API for non-fatal App Hangs monitoring

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -20,8 +20,8 @@ class AppHangsMonitoringTests: XCTestCase {
 
     override func setUp() {
         rumConfig.mainQueue = mainQueue
-        rumConfig.defaultAppHangThreshold = 0.4
-        hangDuration = rumConfig.defaultAppHangThreshold * 1.25
+        rumConfig.appHangThreshold = 0.4
+        hangDuration = rumConfig.appHangThreshold! * 1.25
         core = DatadogCoreProxy()
     }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -80,7 +80,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             uiKitRUMViewsPredicate: configuration.uiKitViewsPredicate,
             uiKitRUMActionsPredicate: configuration.uiKitActionsPredicate,
             longTaskThreshold: configuration.longTaskThreshold,
-            appHangThreshold: configuration.defaultAppHangThreshold,
+            appHangThreshold: configuration.appHangThreshold,
             mainQueue: configuration.mainQueue,
             dateProvider: configuration.dateProvider,
             backtraceReporter: core.backtraceReporter,

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -94,18 +94,19 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
             }
         }
 
-        if let appHangThreshold = appHangThreshold {
-            if appHangThreshold >= Constants.minAppHangThreshold {
-                appHangs = AppHangsObserver(
-                    appHangThreshold: appHangThreshold,
-                    observedQueue: mainQueue,
-                    backtraceReporter: backtraceReporter,
-                    dateProvider: dateProvider,
-                    telemetry: telemetry
-                )
-            } else {
-                DD.logger.error("`RUM.Configuration.appHangThreshold` cannot be less than 0.1s. App Hangs monitoring will be disabled.")
+        if var appHangThreshold = appHangThreshold {
+            if appHangThreshold < Constants.minAppHangThreshold {
+                appHangThreshold = Constants.minAppHangThreshold
+                DD.logger.warn("`RUM.Configuration.appHangThreshold` cannot be less than \(Constants.minAppHangThreshold)s. A value of \(Constants.minAppHangThreshold)s will be used.")
             }
+
+            appHangs = AppHangsObserver(
+                appHangThreshold: appHangThreshold,
+                observedQueue: mainQueue,
+                backtraceReporter: backtraceReporter,
+                dateProvider: dateProvider,
+                telemetry: telemetry
+            )
         }
 
         self.viewsHandler = viewsHandler

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -118,6 +118,18 @@ extension RUM {
         /// Default: `0.1`.
         public var longTaskThreshold: TimeInterval?
 
+        /// Enables App Hangs monitoring with the given threshold (in seconds).
+        ///
+        /// Only App Hangs that last more than this threshold will be reported. The minimal allowed value for this option is `0.1` seconds.
+        /// To disable hangs monitoring, set this parameter to `nil`.
+        ///
+        /// - Note: Be cautious when setting the threshold to very small values, as it may lead to excessive reporting of hangs.
+        ///         The SDK implements a secondary thread for monitoring App Hangs. To reduce CPU utilization, it tracks hangs with a tolerance of 2.5%, meaning that
+        ///         some hangs lasting very close to this threshold may not be reported.
+        ///
+        /// - Default: `nil` (hangs monitoring disabled).
+        public var appHangThreshold: TimeInterval?
+
         /// Sets the preferred frequency for collecting RUM vitals.
         ///
         /// To disable RUM vitals monitoring, set `nil`.
@@ -258,8 +270,6 @@ extension RUM {
         internal var dateProvider: DateProvider = SystemDateProvider()
         /// The main queue, subject to App Hangs monitoring.
         internal var mainQueue: DispatchQueue = .main
-        /// The minimum main queue hang to be tracked as App Hang.
-        internal var defaultAppHangThreshold: TimeInterval = 2
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
         internal var debugViews: Bool = ProcessInfo.processInfo.arguments.contains("DD_DEBUG_RUM")
@@ -310,6 +320,7 @@ extension RUM.Configuration {
     ///   - trackFrustrations: Determines whether automatic tracking of user frustrations should be enabled. Default: `true`.
     ///   - trackBackgroundEvents: Determines whether RUM events should be tracked when no view is active. Default: `false`.
     ///   - longTaskThreshold: The threshold for RUM long tasks tracking (in seconds). Default: `0.1`.
+    ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
@@ -328,6 +339,7 @@ extension RUM.Configuration {
         trackFrustrations: Bool = true,
         trackBackgroundEvents: Bool = false,
         longTaskThreshold: TimeInterval? = 0.1,
+        appHangThreshold: TimeInterval? = nil,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
@@ -346,6 +358,7 @@ extension RUM.Configuration {
         self.trackFrustrations = trackFrustrations
         self.trackBackgroundEvents = trackBackgroundEvents
         self.longTaskThreshold = longTaskThreshold
+        self.appHangThreshold = appHangThreshold
         self.vitalsUpdateFrequency = vitalsUpdateFrequency
         self.viewEventMapper = viewEventMapper
         self.resourceEventMapper = resourceEventMapper

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -127,6 +127,8 @@ extension RUM {
         ///         The SDK implements a secondary thread for monitoring App Hangs. To reduce CPU utilization, it tracks hangs with a tolerance of 2.5%, meaning that
         ///         some hangs lasting very close to this threshold may not be reported.
         ///
+        /// - Note: App Hangs monitoring requires Datadog Crash Reporting to be enabled. Otherwise stack trace will be not reported in App Hang errors.
+        ///
         /// - Default: `nil` (hangs monitoring disabled).
         public var appHangThreshold: TimeInterval?
 

--- a/DatadogRUM/Tests/RUMConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfigurationTests.swift
@@ -22,6 +22,7 @@ class RUMConfigurationTests: XCTestCase {
         XCTAssertTrue(config.trackFrustrations)
         XCTAssertFalse(config.trackBackgroundEvents)
         XCTAssertEqual(config.longTaskThreshold, 0.1)
+        XCTAssertNil(config.appHangThreshold)
         XCTAssertEqual(config.vitalsUpdateFrequency, .average)
         XCTAssertNil(config.viewEventMapper)
         XCTAssertNil(config.resourceEventMapper)

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -101,6 +101,7 @@ class RUMTests: XCTestCase {
         config.uiKitViewsPredicate = UIKitRUMViewsPredicateMock()
         config.uiKitActionsPredicate = UIKitRUMActionsPredicateMock()
         config.longTaskThreshold = 0.5
+        config.appHangThreshold = 2
 
         // When
         RUM.enable(with: config, in: core)
@@ -111,6 +112,7 @@ class RUMTests: XCTestCase {
         XCTAssertIdentical(monitor, rum.instrumentation.viewsHandler.subscriber)
         XCTAssertIdentical(monitor, (rum.instrumentation.actionsHandler as? UIKitRUMUserActionsHandler)?.subscriber)
         XCTAssertIdentical(monitor, rum.instrumentation.longTasks?.subscriber)
+        XCTAssertIdentical(monitor, rum.instrumentation.appHangs?.subscriber)
     }
 
     func testWhenEnabledWithNoInstrumentations() throws {
@@ -118,6 +120,7 @@ class RUMTests: XCTestCase {
         config.uiKitViewsPredicate = nil
         config.uiKitActionsPredicate = nil
         config.longTaskThreshold = nil
+        config.appHangThreshold = nil
 
         // When
         RUM.enable(with: config, in: core)
@@ -132,6 +135,35 @@ class RUMTests: XCTestCase {
         )
         XCTAssertNil(rum.instrumentation.actionsHandler)
         XCTAssertNil(rum.instrumentation.longTasks)
+        XCTAssertNil(rum.instrumentation.appHangs)
+    }
+
+    func testWhenEnabledWithInvalidLongTasksThreshold() throws {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // Given
+        config.longTaskThreshold = -5
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        XCTAssertEqual(dd.logger.errorLog?.message, "`RUM.Configuration.longTaskThreshold` cannot be less than 0s. Long Tasks monitoring will be disabled.")
+    }
+
+    func testWhenEnabledWithInvalidAppHangThreshold() throws {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // Given
+        config.appHangThreshold = .mockRandom(min: -10, max: 0.0999)
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        XCTAssertEqual(dd.logger.errorLog?.message, "`RUM.Configuration.appHangThreshold` cannot be less than 0.1s. App Hangs monitoring will be disabled.")
     }
 
     func testWhenEnabledWithURLSessionTracking() throws {

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -163,7 +163,7 @@ class RUMTests: XCTestCase {
         RUM.enable(with: config, in: core)
 
         // Then
-        XCTAssertEqual(dd.logger.errorLog?.message, "`RUM.Configuration.appHangThreshold` cannot be less than 0.1s. App Hangs monitoring will be disabled.")
+        XCTAssertEqual(dd.logger.warnLog?.message, "`RUM.Configuration.appHangThreshold` cannot be less than 0.1s. A value of 0.1s will be used.")
     }
 
     func testWhenEnabledWithURLSessionTracking() throws {


### PR DESCRIPTION
### What and why?

📦 The final touch on https://github.com/DataDog/dd-sdk-ios/pull/1699. Adding public API for App Hangs monitoring in `RUM.Configuration`:

```swift
/// Enables App Hangs monitoring with the given threshold (in seconds).
///
/// Only App Hangs that last more than this threshold will be reported. The minimal allowed value for this option is `0.1` seconds.
/// To disable hangs monitoring, set this parameter to `nil`.
///
/// - Note: Be cautious when setting the threshold to very small values, as it may lead to excessive reporting of hangs.
///         The SDK implements a secondary thread for monitoring App Hangs. To reduce CPU utilization, it tracks hangs with a tolerance of 2.5%, meaning that
///         some hangs lasting very close to this threshold may not be reported.
///
/// - Note: App Hangs monitoring requires Datadog Crash Reporting to be enabled. Otherwise stack trace will be not reported in App Hang errors.
///
/// - Default: `nil` (hangs monitoring disabled).
public var appHangThreshold: TimeInterval?
```

This is limited to non-fatal hangs. Once fatal hangs monitoring is available, it will leverage this option and a new one will be introduced to select which kinds of hangs should be tracked. This follows the agreement from [ADR - App Hangs detection in iOS SDK](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3473147398/ADR+-+App+Hangs+detection+in+iOS+SDK) (internal).

### How?

Adding public API to condition hangs instrumentation.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
