### PR TITLE
Change SR code decorator to produce Int instead of Int64

### DIFF
--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -28,7 +28,7 @@ internal protocol StoragePerformancePreset {
     var maxFileAgeForRead: TimeInterval { get }
     /// Maximum number of serialized objects written to a single file.
     /// If number of objects in recently used file reaches this limit, new file is created for new data.
-    var maxObjectsInFile: Int { get }
+    var maxObjectsInFile: UInt64 { get }
     /// Maximum size of serialized object data (in bytes).
     /// If serialized object data exceeds this limit, it is skipped (not written to file and not uploaded).
     var maxObjectSize: UInt64 { get }
@@ -56,7 +56,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let maxFileAgeForWrite: TimeInterval
     let minFileAgeForRead: TimeInterval
     let maxFileAgeForRead: TimeInterval
-    let maxObjectsInFile: Int
+    let maxObjectsInFile: UInt64
     let maxObjectSize: UInt64
 
     // MARK: - UploadPerformancePreset

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/JSON/SegmentJSON.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/JSON/SegmentJSON.swift
@@ -39,13 +39,13 @@ internal struct SegmentJSON {
     /// The `source` of SDK in which the segment was recorded (e.g. `"ios"`).
     let source: String
     /// The timestamp of the earliest record.
-    let start: Int64
+    let start: Int
     /// The timestamp of the latest record.
-    let end: Int64
+    let end: Int
     /// Records to be sent in this segment.
     let records: [JSONObject]
     /// Number of records.
-    let recordsCount: Int64
+    let recordsCount: Int
     /// If there is a Full Snapshot among records.
     let hasFullSnapshot: Bool
 
@@ -54,10 +54,10 @@ internal struct SegmentJSON {
         sessionID: String,
         viewID: String,
         source: String,
-        start: Int64,
-        end: Int64,
+        start: Int,
+        end: Int,
         records: [JSONObject],
-        recordsCount: Int64,
+        recordsCount: Int,
         hasFullSnapshot: Bool
     ) {
         self.applicationID = applicationID
@@ -80,17 +80,17 @@ internal struct SegmentJSON {
         let json: JSONObject = try decode(data)
 
         self.records = try read(codingKey: .records, from: json)
-        self.recordsCount = Int64(records.count)
+        self.recordsCount = records.count
 
         var hasFullSnapshot = false
-        var start: Int64 = .max
-        var end: Int64 = .min
+        var start: Int = .max
+        var end: Int = .min
 
         // loop through the records to compute the
         // `start`, `end, and `has_full_snapshot` fieds
         // of the segment
         for record in records {
-            guard let timestamp = record[Constants.timestampKey] as? Int64 else {
+            guard let timestamp = record[Constants.timestampKey] as? Int else {
                 // records must contain a timestamp
                 throw InternalError(description: "Record is missing timestamp")
             }
@@ -98,7 +98,7 @@ internal struct SegmentJSON {
             start = min(timestamp, start)
             end = max(timestamp, end)
 
-            guard let type = record[Constants.typeKey] as? Int64 else {
+            guard let type = record[Constants.typeKey] as? Int else {
                 continue // ignore records with no type
             }
 

--- a/DatadogSessionReplay/Sources/Feature/SRContextPublisher.swift
+++ b/DatadogSessionReplay/Sources/Feature/SRContextPublisher.swift
@@ -22,7 +22,7 @@ internal class SRContextPublisher {
     }
 
     /// Notifies other Features on the state of Session Replay records count.
-    func setRecordsCountByViewID(_ value: [String: Int64]) {
+    func setRecordsCountByViewID(_ value: [String: Int]) {
         core?.set(baggage: value, forKey: RUMDependency.recordsCountByViewID)
     }
 }

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -18,19 +18,19 @@ public struct SRSegment: SRDataModel {
     public let application: Application
 
     /// The end UTC timestamp in milliseconds corresponding to the last record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-    public let end: Int64
+    public let end: Int
 
     /// Whether this Segment contains a full snapshot record or not.
     public let hasFullSnapshot: Bool?
 
     /// The index of this Segment in the segments list that was recorded for this view ID. Starts from 0.
-    public let indexInView: Int64?
+    public let indexInView: Int?
 
     /// The records contained by this Segment.
     public let records: [SRRecord]
 
     /// The number of records in this Segment.
-    public let recordsCount: Int64
+    public let recordsCount: Int
 
     /// Session properties
     public let session: Session
@@ -39,7 +39,7 @@ public struct SRSegment: SRDataModel {
     public let source: Source
 
     /// The start UTC timestamp in milliseconds corresponding to the first record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-    public let start: Int64
+    public let start: Int
 
     /// View properties
     public let view: View
@@ -107,7 +107,7 @@ public struct SRShapeBorder: Codable, Hashable {
     public let color: String
 
     /// The width of the border in pixels.
-    public let width: Int64
+    public let width: Int
 
     enum CodingKeys: String, CodingKey {
         case color = "color"
@@ -119,16 +119,16 @@ public struct SRShapeBorder: Codable, Hashable {
 @_spi(Internal)
 public struct SRContentClip: Codable, Hashable {
     /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
-    public let bottom: Int64?
+    public let bottom: Int?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
-    public let left: Int64?
+    public let left: Int?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
-    public let right: Int64?
+    public let right: Int?
 
     /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
-    public let top: Int64?
+    public let top: Int?
 
     enum CodingKeys: String, CodingKey {
         case bottom = "bottom"
@@ -167,10 +167,10 @@ public struct SRShapeWireframe: Codable, Hashable {
     public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    public let height: Int64
+    public let height: Int
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    public let id: Int64
+    public let id: Int
 
     /// The style of this wireframe.
     public let shapeStyle: SRShapeStyle?
@@ -179,13 +179,13 @@ public struct SRShapeWireframe: Codable, Hashable {
     public let type: String = "shape"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    public let width: Int64
+    public let width: Int
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let x: Int64
+    public let x: Int
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let y: Int64
+    public let y: Int
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
@@ -245,16 +245,16 @@ public struct SRTextPosition: Codable, Hashable {
     @_spi(Internal)
     public struct Padding: Codable, Hashable {
         /// The bottom padding in pixels. The default value is 0.
-        public let bottom: Int64?
+        public let bottom: Int?
 
         /// The left padding in pixels. The default value is 0.
-        public let left: Int64?
+        public let left: Int?
 
         /// The right padding in pixels. The default value is 0.
-        public let right: Int64?
+        public let right: Int?
 
         /// The top padding in pixels. The default value is 0.
-        public let top: Int64?
+        public let top: Int?
 
         enum CodingKeys: String, CodingKey {
             case bottom = "bottom"
@@ -275,7 +275,7 @@ public struct SRTextStyle: Codable, Hashable {
     public let family: String
 
     /// The font size in pixels.
-    public let size: Int64
+    public let size: Int
 
     enum CodingKeys: String, CodingKey {
         case color = "color"
@@ -294,10 +294,10 @@ public struct SRTextWireframe: Codable, Hashable {
     public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    public let height: Int64
+    public let height: Int
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    public let id: Int64
+    public let id: Int
 
     /// The style of this wireframe.
     public let shapeStyle: SRShapeStyle?
@@ -315,13 +315,13 @@ public struct SRTextWireframe: Codable, Hashable {
     public let type: String = "text"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    public let width: Int64
+    public let width: Int
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let x: Int64
+    public let x: Int
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let y: Int64
+    public let y: Int
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
@@ -352,10 +352,10 @@ public struct SRImageWireframe: Codable, Hashable {
     public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    public let height: Int64
+    public let height: Int
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    public let id: Int64
+    public let id: Int
 
     /// Flag describing an image wireframe that should render an empty state placeholder
     public var isEmpty: Bool?
@@ -373,13 +373,13 @@ public struct SRImageWireframe: Codable, Hashable {
     public let type: String = "image"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    public let width: Int64
+    public let width: Int
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let x: Int64
+    public let x: Int
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let y: Int64
+    public let y: Int
 
     enum CodingKeys: String, CodingKey {
         case base64 = "base64"
@@ -405,10 +405,10 @@ public struct SRPlaceholderWireframe: Codable, Hashable {
     public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    public let height: Int64
+    public let height: Int
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    public let id: Int64
+    public let id: Int
 
     /// Label of the placeholder
     public var label: String?
@@ -417,13 +417,13 @@ public struct SRPlaceholderWireframe: Codable, Hashable {
     public let type: String = "placeholder"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    public let width: Int64
+    public let width: Int
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let x: Int64
+    public let x: Int
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let y: Int64
+    public let y: Int
 
     enum CodingKeys: String, CodingKey {
         case clip = "clip"
@@ -447,10 +447,10 @@ public struct SRWebviewWireframe: Codable, Hashable {
     public let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-    public let height: Int64
+    public let height: Int
 
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    public let id: Int64
+    public let id: Int
 
     /// The style of this wireframe.
     public let shapeStyle: SRShapeStyle?
@@ -462,13 +462,13 @@ public struct SRWebviewWireframe: Codable, Hashable {
     public let type: String = "webview"
 
     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-    public let width: Int64
+    public let width: Int
 
     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let x: Int64
+    public let x: Int
 
     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-    public let y: Int64
+    public let y: Int
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
@@ -554,10 +554,10 @@ public struct SRFullSnapshotRecord: Codable {
     public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 10
+    public let type: Int = 10
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -583,10 +583,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
     public let data: Data
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 11
+    public let type: Int = 11
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -660,7 +660,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
             public let removes: [Removes]
 
             /// The source of this type of incremental data.
-            public let source: Int64 = 0
+            public let source: Int = 0
 
             /// Contains the updated wireframes mutations.
             public let updates: [Updates]
@@ -675,7 +675,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
             @_spi(Internal)
             public struct Adds: Codable {
                 /// The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively.
-                public let previousId: Int64?
+                public let previousId: Int?
 
                 /// Schema of a Wireframe type.
                 public let wireframe: SRWireframe
@@ -689,7 +689,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
             @_spi(Internal)
             public struct Removes: Codable {
                 /// The id of the wireframe that needs to be removed.
-                public let id: Int64
+                public let id: Int
 
                 enum CodingKeys: String, CodingKey {
                     case id = "id"
@@ -769,10 +769,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    public let height: Int64?
+                    public let height: Int?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    public let id: Int64
+                    public let id: Int
 
                     /// The style of this wireframe.
                     public let shapeStyle: SRShapeStyle?
@@ -790,13 +790,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let type: String = "text"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    public let width: Int64?
+                    public let width: Int?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let x: Int64?
+                    public let x: Int?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let y: Int64?
+                    public let y: Int?
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
@@ -824,10 +824,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    public let height: Int64?
+                    public let height: Int?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    public let id: Int64
+                    public let id: Int
 
                     /// The style of this wireframe.
                     public let shapeStyle: SRShapeStyle?
@@ -836,13 +836,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let type: String = "shape"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    public let width: Int64?
+                    public let width: Int?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let x: Int64?
+                    public let x: Int?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let y: Int64?
+                    public let y: Int?
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
@@ -870,10 +870,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    public let height: Int64?
+                    public let height: Int?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    public let id: Int64
+                    public let id: Int
 
                     /// Flag describing an image wireframe that should render an empty state placeholder
                     public var isEmpty: Bool?
@@ -891,13 +891,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let type: String = "image"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    public let width: Int64?
+                    public let width: Int?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let x: Int64?
+                    public let x: Int?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let y: Int64?
+                    public let y: Int?
 
                     enum CodingKeys: String, CodingKey {
                         case base64 = "base64"
@@ -923,10 +923,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    public let height: Int64?
+                    public let height: Int?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    public let id: Int64
+                    public let id: Int
 
                     /// Label of the placeholder
                     public var label: String?
@@ -935,13 +935,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let type: String = "placeholder"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    public let width: Int64?
+                    public let width: Int?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let x: Int64?
+                    public let x: Int?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let y: Int64?
+                    public let y: Int?
 
                     enum CodingKeys: String, CodingKey {
                         case clip = "clip"
@@ -965,10 +965,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
-                    public let height: Int64?
+                    public let height: Int?
 
                     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-                    public let id: Int64
+                    public let id: Int
 
                     /// The style of this wireframe.
                     public let shapeStyle: SRShapeStyle?
@@ -980,13 +980,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     public let type: String = "webview"
 
                     /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
-                    public let width: Int64?
+                    public let width: Int?
 
                     /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let x: Int64?
+                    public let x: Int?
 
                     /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
-                    public let y: Int64?
+                    public let y: Int?
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
@@ -1011,7 +1011,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
             public let positions: [Positions]?
 
             /// The source of this type of incremental data.
-            public let source: Int64 = 2
+            public let source: Int = 2
 
             enum CodingKeys: String, CodingKey {
                 case positions = "positions"
@@ -1021,16 +1021,16 @@ public struct SRIncrementalSnapshotRecord: Codable {
             @_spi(Internal)
             public struct Positions: Codable {
                 /// The touch id of the touch event this position corresponds to. In mobile it is possible to have multiple touch events (fingers touching the screen) happening at the same time.
-                public let id: Int64
+                public let id: Int
 
                 /// The UTC timestamp in milliseconds corresponding to the moment the position change was recorded. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.
-                public let timestamp: Int64
+                public let timestamp: Int
 
                 /// The x coordinate value of the position.
-                public let x: Int64
+                public let x: Int
 
                 /// The y coordinate value of the position.
-                public let y: Int64
+                public let y: Int
 
                 enum CodingKeys: String, CodingKey {
                     case id = "id"
@@ -1045,13 +1045,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
         @_spi(Internal)
         public struct ViewportResizeData: Codable {
             /// The new height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height is divided by 2 to get a normalized height.
-            public let height: Int64
+            public let height: Int
 
             /// The source of this type of incremental data.
-            public let source: Int64 = 4
+            public let source: Int = 4
 
             /// The new width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width is divided by 2 to get a normalized width.
-            public let width: Int64
+            public let width: Int
 
             enum CodingKeys: String, CodingKey {
                 case height = "height"
@@ -1067,13 +1067,13 @@ public struct SRIncrementalSnapshotRecord: Codable {
             public let pointerEventType: PointerEventType
 
             /// Id of the pointer of this PointerInteraction.
-            public let pointerId: Int64
+            public let pointerId: Int
 
             /// Schema of an PointerType
             public let pointerType: PointerType
 
             /// The source of this type of incremental data.
-            public let source: Int64 = 9
+            public let source: Int = 9
 
             /// X-axis coordinate for this PointerInteraction.
             public let x: Double
@@ -1119,10 +1119,10 @@ public struct SRMetaRecord: Codable {
     public let slotId: String?
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 4
+    public let type: Int = 4
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -1135,13 +1135,13 @@ public struct SRMetaRecord: Codable {
     @_spi(Internal)
     public struct Data: Codable {
         /// The height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized height is the current height divided by 2.
-        public let height: Int64
+        public let height: Int
 
         /// Browser-specific. URL of the view described by this record.
         public let href: String?
 
         /// The width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized width is the current width divided by 2.
-        public let width: Int64
+        public let width: Int
 
         enum CodingKeys: String, CodingKey {
             case height = "height"
@@ -1160,10 +1160,10 @@ public struct SRFocusRecord: Codable {
     public let slotId: String?
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 6
+    public let type: Int = 6
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -1190,10 +1190,10 @@ public struct SRViewEndRecord: Codable {
     public let slotId: String?
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 7
+    public let type: Int = 7
 
     enum CodingKeys: String, CodingKey {
         case slotId = "slotId"
@@ -1211,10 +1211,10 @@ public struct SRVisualViewportRecord: Codable {
     public let slotId: String?
 
     /// Defines the UTC time in milliseconds when this Record was performed.
-    public let timestamp: Int64
+    public let timestamp: Int
 
     /// The type of this Record.
-    public let type: Int64 = 8
+    public let type: Int = 8
 
     enum CodingKeys: String, CodingKey {
         case data = "data"
@@ -1322,4 +1322,4 @@ public enum SRRecord: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/c3747b3facf75e51cbad4c32f77ec3894f5a7249
+// Generated from https://github.com/DataDog/rum-events-format/tree/78f17559b7898dad5a6b3b4af2fe4ab4a5be6b54

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff.swift
@@ -7,7 +7,7 @@
 #if os(iOS)
 import Foundation
 
-internal typealias DiffableID = Int64
+internal typealias DiffableID = Int
 
 /// A base interface of array elements compared in `computeDiff(oldArray:newArray:)`.
 internal protocol Diffable {

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -26,12 +26,12 @@ internal class RecordsBuilder {
     func createMetaRecord(from snapshot: ViewTreeSnapshot) -> SRRecord {
         let record = SRMetaRecord(
             data: .init(
-                height: Int64(withNoOverflow: snapshot.viewportSize.height),
+                height: Int(withNoOverflow: snapshot.viewportSize.height),
                 href: nil,
-                width: Int64(withNoOverflow: snapshot.viewportSize.width)
+                width: Int(withNoOverflow: snapshot.viewportSize.width)
             ),
             slotId: nil,
-            timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+            timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
         )
         return .metaRecord(value: record)
     }
@@ -42,7 +42,7 @@ internal class RecordsBuilder {
         let record = SRFocusRecord(
             data: SRFocusRecord.Data(hasFocus: true),
             slotId: nil,
-            timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+            timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
         )
         return .focusRecord(value: record)
     }
@@ -53,7 +53,7 @@ internal class RecordsBuilder {
     func createFullSnapshotRecord(from snapshot: ViewTreeSnapshot, wireframes: [SRWireframe]) -> SRRecord {
         let record = SRFullSnapshotRecord(
             data: .init(wireframes: wireframes),
-            timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+            timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
         )
 
         return .fullSnapshotRecord(value: record)
@@ -95,7 +95,7 @@ internal class RecordsBuilder {
                     }
                 )
             ),
-            timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+            timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
         )
 
         return .incrementalSnapshotRecord(value: record)
@@ -119,7 +119,7 @@ internal class RecordsBuilder {
                         y: round(touch.position.y)
                     )
                 ),
-                timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+                timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
             )
             return .incrementalSnapshotRecord(value: record)
         }
@@ -136,11 +136,11 @@ internal class RecordsBuilder {
             value: SRIncrementalSnapshotRecord(
                 data: .viewportResizeData(
                     value: .init(
-                        height: Int64(withNoOverflow: snapshot.viewportSize.height),
-                        width: Int64(withNoOverflow: snapshot.viewportSize.width)
+                        height: Int(withNoOverflow: snapshot.viewportSize.height),
+                        width: Int(withNoOverflow: snapshot.viewportSize.width)
                     )
                 ),
-                timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+                timestamp: Int(snapshot.date.timeIntervalSince1970.toMilliseconds)
             )
         )
     }

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -57,12 +57,12 @@ public class SessionReplayWireframesBuilder {
         let wireframe = SRShapeWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
-            height: Int64(withNoOverflow: frame.height),
+            height: Int(withNoOverflow: frame.height),
             id: id,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
-            width: Int64(withNoOverflow: frame.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
+            width: Int(withNoOverflow: frame.width),
+            x: Int(withNoOverflow: frame.minX),
+            y: Int(withNoOverflow: frame.minY)
         )
 
         return .shapeWireframe(value: wireframe)
@@ -84,15 +84,15 @@ public class SessionReplayWireframesBuilder {
             base64: nil, // field deprecated - we should use resource endpoint instead
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
-            height: Int64(withNoOverflow: frame.height),
+            height: Int(withNoOverflow: frame.height),
             id: id,
             isEmpty: false, // field deprecated - we should use placeholder wireframe instead
             mimeType: mimeType,
             resourceId: resourceId,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
-            width: Int64(withNoOverflow: frame.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
+            width: Int(withNoOverflow: frame.width),
+            x: Int(withNoOverflow: frame.minX),
+            y: Int(withNoOverflow: frame.minY)
         )
         return .imageWireframe(value: wireframe)
     }
@@ -118,18 +118,18 @@ public class SessionReplayWireframesBuilder {
         let textPosition = SRTextPosition(
             alignment: textAlignment,
             padding: .init(
-                bottom: Int64(withNoOverflow: frame.maxY - textFrame.maxY),
-                left: Int64(withNoOverflow: textFrame.minX - frame.minX),
-                right: Int64(withNoOverflow: frame.maxX - textFrame.maxX),
-                top: Int64(withNoOverflow: textFrame.minY - frame.minY)
+                bottom: Int(withNoOverflow: frame.maxY - textFrame.maxY),
+                left: Int(withNoOverflow: textFrame.minX - frame.minX),
+                right: Int(withNoOverflow: frame.maxX - textFrame.maxX),
+                top: Int(withNoOverflow: textFrame.minY - frame.minY)
             )
         )
 
-        var fontSize = Int64(withNoOverflow: fontOverride?.size ?? font?.pointSize ?? Fallback.fontSize)
+        var fontSize = Int(withNoOverflow: fontOverride?.size ?? font?.pointSize ?? Fallback.fontSize)
         if text.count > 0, fontScalingEnabled {
             // Calculates the approximate font size for available text area √(frameArea / numberOfCharacters)
             let area = textFrame.width * textFrame.height
-            let calculatedFontSize = Int64(sqrt(area / CGFloat(text.count)))
+            let calculatedFontSize = Int(sqrt(area / CGFloat(text.count)))
             if calculatedFontSize < fontSize {
                 fontSize = calculatedFontSize
             }
@@ -145,40 +145,40 @@ public class SessionReplayWireframesBuilder {
         let wireframe = SRTextWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
-            height: Int64(withNoOverflow: frame.height),
+            height: Int(withNoOverflow: frame.height),
             id: id,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
             text: text,
             textPosition: textPosition,
             textStyle: textStyle,
-            width: Int64(withNoOverflow: frame.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
+            width: Int(withNoOverflow: frame.width),
+            x: Int(withNoOverflow: frame.minX),
+            y: Int(withNoOverflow: frame.minY)
         )
 
         return .textWireframe(value: wireframe)
     }
 
     public func createPlaceholderWireframe(
-        id: Int64,
+        id: Int,
         frame: CGRect,
         label: String,
         clip: SRContentClip? = nil
     ) -> SRWireframe {
         let wireframe = SRPlaceholderWireframe(
             clip: clip,
-            height: Int64(withNoOverflow: frame.size.height),
+            height: Int(withNoOverflow: frame.size.height),
             id: id,
             label: label,
-            width: Int64(withNoOverflow: frame.size.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
+            width: Int(withNoOverflow: frame.size.width),
+            x: Int(withNoOverflow: frame.minX),
+            y: Int(withNoOverflow: frame.minY)
         )
         return .placeholderWireframe(value: wireframe)
     }
 
     public func createWebViewWireframe(
-        id: Int64,
+        id: Int,
         frame: CGRect,
         slotId: String,
         clip: SRContentClip? = nil,
@@ -191,13 +191,13 @@ public class SessionReplayWireframesBuilder {
         let wireframe = SRWebviewWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
             clip: clip,
-            height: Int64(withNoOverflow: frame.height),
+            height: Int(withNoOverflow: frame.height),
             id: id,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
             slotId: slotId,
-            width: Int64(withNoOverflow: frame.size.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
+            width: Int(withNoOverflow: frame.size.width),
+            x: Int(withNoOverflow: frame.minX),
+            y: Int(withNoOverflow: frame.minY)
         )
 
         return .webviewWireframe(value: wireframe)
@@ -212,7 +212,7 @@ public class SessionReplayWireframesBuilder {
 
         return .init(
             color: hexString(from: borderColor) ?? Fallback.color,
-            width: Int64(withNoOverflow: borderWidth.rounded(.up))
+            width: Int(withNoOverflow: borderWidth.rounded(.up))
         )
     }
 
@@ -253,10 +253,10 @@ extension SRContentClip {
     /// This method is a convenience for exposing the internal default init.
     @_spi(Internal)
     public static func create(
-        bottom: Int64?,
-        left: Int64?,
-        right: Int64?,
-        top: Int64?
+        bottom: Int?,
+        left: Int?,
+        right: Int?,
+        top: Int?
     ) -> SRContentClip {
         return SRContentClip(
             bottom: bottom,

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -56,7 +56,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
 
     private var srContextPublisher: SRContextPublisher
 
-    private var recordsCountByViewID: [String: Int64] = [:]
+    private var recordsCountByViewID: [String: Int] = [:]
 
     init(
         queue: Queue,
@@ -126,7 +126,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
             // Transform `[SRRecord]` to `EnrichedRecord` so we can write it to `DatadogCore` and
             // later read it back (as `EnrichedRecordJSON`) for preparing upload request(s):
             let enrichedRecord = EnrichedRecord(context: viewTreeSnapshot.context, records: records)
-            trackRecord(key: enrichedRecord.viewID, value: Int64(records.count))
+            trackRecord(key: enrichedRecord.viewID, value: records.count)
 
             recordWriter.write(nextRecord: enrichedRecord)
         }
@@ -136,7 +136,7 @@ internal class SnapshotProcessor: SnapshotProcessing {
         lastWireframes = wireframes
     }
 
-    private func trackRecord(key: String, value: Int64) {
+    private func trackRecord(key: String, value: Int) {
         if let existingValue = recordsCountByViewID[key] {
             recordsCountByViewID[key] = existingValue + value
         } else {

--- a/DatadogSessionReplay/Sources/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchIdentifierGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchIdentifierGenerator.swift
@@ -12,7 +12,7 @@ import UIKit
 ///
 /// Ref.: https://developer.apple.com/documentation/uikit/uitouch
 /// > If you need to store information about a touch outside of a multi-touch sequence, copy that information from the touch.
-internal typealias TouchIdentifier = Int64
+internal typealias TouchIdentifier = Int
 
 /// Manages `TouchIdentifier` for `UITouch` instances.
 ///

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Single unique ID of a view in view-tree hierarchy.
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
 @_spi(Internal)
-public typealias NodeID = Int64
+public typealias NodeID = Int
 
 /// Manages `NodeIDs` for `UIView` instances.
 ///
@@ -27,7 +27,7 @@ public final class NodeIDGenerator {
     /// Tracks next `NodeID` to assign.
     private var currentID: NodeID
 
-    init(currentID: NodeID = 0, maxID: NodeID = Int64(Int32.max)) {
+    init(currentID: NodeID = 0, maxID: NodeID = .max) {
         self.currentID = currentID
         self.maxID = maxID
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -114,10 +114,10 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
         let bottom = max(contentFrame.height - (relativeIntersectedRect.height + top), 0)
         let right = max(contentFrame.width - (relativeIntersectedRect.width + left), 0)
         return SRContentClip(
-            bottom: Int64(withNoOverflow: bottom),
-            left: Int64(withNoOverflow: left),
-            right: Int64(withNoOverflow: right),
-            top: Int64(withNoOverflow: top)
+            bottom: Int(withNoOverflow: bottom),
+            left: Int(withNoOverflow: left),
+            right: Int(withNoOverflow: right),
+            top: Int(withNoOverflow: top)
         )
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -72,10 +72,10 @@ internal struct UITextViewWireframesBuilder: NodeWireframesBuilder {
         let bottom = max(contentRect.height - attributes.frame.height - top, 0)
         let right = max(contentRect.width - attributes.frame.width - left, 0)
         return SRContentClip(
-            bottom: Int64(withNoOverflow: bottom),
-            left: Int64(withNoOverflow: left),
-            right: Int64(withNoOverflow: right),
-            top: Int64(withNoOverflow: top)
+            bottom: Int(withNoOverflow: bottom),
+            left: Int(withNoOverflow: left),
+            right: Int(withNoOverflow: right),
+            top: Int(withNoOverflow: top)
         )
     }
 

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
@@ -116,8 +116,8 @@ class SegmentJSONTests: XCTestCase {
 
     // MARK: - Fuzzy Helpers
 
-    private func generateSegment(maxRecordsCount: Int64 = 100, source: SRSegment.Source = .mockRandom()) -> SRSegment {
-        let recordsCount: Int64 = .mockRandom(min: 1, max: maxRecordsCount)
+    private func generateSegment(maxRecordsCount: Int = 100, source: SRSegment.Source = .mockRandom()) -> SRSegment {
+        let recordsCount: Int = .mockRandom(min: 1, max: maxRecordsCount)
         let records: [SRRecord] = (0..<recordsCount).map { _ in .mockRandom() }
         let timestamps = records.map { $0.timestamp }
         let hasFullSnapshot = records.contains {

--- a/DatadogSessionReplay/Tests/Feature/SRContextPublisherTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/SRContextPublisherTests.swift
@@ -23,7 +23,7 @@ class SRContextPublisherTests: XCTestCase {
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
 
-        let recordsCountByViewID: [String: Int64] = ["view-id": 2]
+        let recordsCountByViewID: [String: Int] = ["view-id": 2]
         srContextPublisher.setRecordsCountByViewID(recordsCountByViewID)
 
         XCTAssertEqual(core.recordsCountByViewID, recordsCountByViewID)
@@ -32,7 +32,7 @@ class SRContextPublisherTests: XCTestCase {
     func testItDoesNotOverridePreviouslySetValue() throws {
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let recordsCountByViewID: [String: Int64] = ["view-id": 2]
+        let recordsCountByViewID: [String: Int] = ["view-id": 2]
 
         srContextPublisher.setHasReplay(true)
         srContextPublisher.setRecordsCountByViewID(recordsCountByViewID)
@@ -52,7 +52,7 @@ class SRContextPublisherTests: XCTestCase {
 private extension PassthroughCoreMock {
     var hasReplay: Bool? { try? context.baggages["sr_has_replay"]?.decode() }
 
-    var recordsCountByViewID: [String: Int64]? {
+    var recordsCountByViewID: [String: Int]? {
         try? context.baggages["sr_records_count_by_view_id"]?.decode()
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -39,16 +39,16 @@ extension SRTextWireframe: AnyMockable, RandomMockable {
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
         clip: SRContentClip? = .mockAny(),
-        height: Int64 = .mockAny(),
-        id: Int64 = .mockAny(),
+        height: Int = .mockAny(),
+        id: Int = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
         text: String = .mockAny(),
         textPosition: SRTextPosition? = .mockAny(),
         textStyle: SRTextStyle = .mockAny(),
         type: String = .mockAny(),
-        width: Int64 = .mockAny(),
-        x: Int64 = .mockAny(),
-        y: Int64 = .mockAny()
+        width: Int = .mockAny(),
+        x: Int = .mockAny(),
+        y: Int = .mockAny()
     ) -> SRTextWireframe {
         return SRTextWireframe(
             border: border,
@@ -82,7 +82,7 @@ extension SRTextStyle: AnyMockable, RandomMockable {
     static func mockWith(
         color: String = .mockAny(),
         family: String = .mockAny(),
-        size: Int64 = .mockAny()
+        size: Int = .mockAny()
     ) -> SRTextStyle {
         return SRTextStyle(
             color: color,
@@ -130,10 +130,10 @@ extension SRTextPosition.Padding: AnyMockable, RandomMockable {
     }
 
     static func mockWith(
-        bottom: Int64? = .mockAny(),
-        left: Int64? = .mockAny(),
-        right: Int64? = .mockAny(),
-        top: Int64? = .mockAny()
+        bottom: Int? = .mockAny(),
+        left: Int? = .mockAny(),
+        right: Int? = .mockAny(),
+        top: Int? = .mockAny()
     ) -> SRTextPosition.Padding {
         return SRTextPosition.Padding(
             bottom: bottom,
@@ -212,12 +212,12 @@ extension SRShapeWireframe: AnyMockable, RandomMockable {
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
         clip: SRContentClip? = .mockAny(),
-        height: Int64 = .mockAny(),
-        id: Int64 = .mockAny(),
+        height: Int = .mockAny(),
+        id: Int = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
-        width: Int64 = .mockAny(),
-        x: Int64 = .mockAny(),
-        y: Int64 = .mockAny()
+        width: Int = .mockAny(),
+        x: Int = .mockAny(),
+        y: Int = .mockAny()
     ) -> SRShapeWireframe {
         return SRShapeWireframe(
             border: border,
@@ -272,7 +272,7 @@ extension SRShapeBorder: AnyMockable, RandomMockable {
 
     static func mockWith(
         color: String = .mockAny(),
-        width: Int64 = .mockAny()
+        width: Int = .mockAny()
     ) -> SRShapeBorder {
         return SRShapeBorder(
             color: color,
@@ -296,10 +296,10 @@ extension SRContentClip: AnyMockable, RandomMockable {
     }
 
     static func mockWith(
-        bottom: Int64? = .mockAny(),
-        left: Int64? = .mockAny(),
-        right: Int64? = .mockAny(),
-        top: Int64? = .mockAny()
+        bottom: Int? = .mockAny(),
+        left: Int? = .mockAny(),
+        right: Int? = .mockAny(),
+        top: Int? = .mockAny()
     ) -> SRContentClip {
         return SRContentClip(
             bottom: bottom,
@@ -335,11 +335,11 @@ extension SRPlaceholderWireframe: AnyMockable, RandomMockable {
 
     static func mockWith(
         clip: SRContentClip? = .mockAny(),
-        height: Int64 = .mockAny(),
-        id: Int64 = .mockAny(),
-        width: Int64 = .mockAny(),
-        x: Int64 = .mockAny(),
-        y: Int64 = .mockAny()
+        height: Int = .mockAny(),
+        id: Int = .mockAny(),
+        width: Int = .mockAny(),
+        x: Int = .mockAny(),
+        y: Int = .mockAny()
     ) -> SRPlaceholderWireframe {
         return SRPlaceholderWireframe(
             clip: clip,
@@ -400,14 +400,14 @@ extension SRImageWireframe: AnyMockable, RandomMockable {
         base64: String? = .mockAny(),
         border: SRShapeBorder? = .mockAny(),
         clip: SRContentClip? = .mockAny(),
-        height: Int64 = .mockAny(),
-        id: Int64 = .mockAny(),
+        height: Int = .mockAny(),
+        id: Int = .mockAny(),
         isEmpty: Bool = .mockAny(),
         mimeType: String? = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
-        width: Int64 = .mockAny(),
-        x: Int64 = .mockAny(),
-        y: Int64 = .mockAny()
+        width: Int = .mockAny(),
+        x: Int = .mockAny(),
+        y: Int = .mockAny()
     ) -> SRImageWireframe {
         return SRImageWireframe(
             base64: base64,
@@ -492,7 +492,7 @@ extension SRVisualViewportRecord: AnyMockable, RandomMockable {
 
     static func mockWith(
         data: Data = .mockAny(),
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRVisualViewportRecord {
         return SRVisualViewportRecord(
             data: data,
@@ -553,7 +553,7 @@ extension SRViewEndRecord: AnyMockable, RandomMockable {
     }
 
     static func mockWith(
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRViewEndRecord {
         return SRViewEndRecord(
             slotId: .mockRandom(),
@@ -577,7 +577,7 @@ extension SRFocusRecord: AnyMockable, RandomMockable {
 
     static func mockWith(
         data: Data = .mockAny(),
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRFocusRecord {
         return SRFocusRecord(
             data: data,
@@ -622,7 +622,7 @@ extension SRMetaRecord: AnyMockable, RandomMockable {
 
     static func mockWith(
         data: Data = .mockAny(),
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRMetaRecord {
         return SRMetaRecord(
             data: data,
@@ -646,9 +646,9 @@ extension SRMetaRecord.Data: AnyMockable, RandomMockable {
     }
 
     static func mockWith(
-        height: Int64 = .mockAny(),
+        height: Int = .mockAny(),
         href: String? = .mockAny(),
-        width: Int64 = .mockAny()
+        width: Int = .mockAny()
     ) -> SRMetaRecord.Data {
         return SRMetaRecord.Data(
             height: height,
@@ -672,7 +672,7 @@ extension SRIncrementalSnapshotRecord: AnyMockable, RandomMockable {
 
     static func mockWith(
         data: Data = .mockAny(),
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRIncrementalSnapshotRecord {
         return SRIncrementalSnapshotRecord(
             data: data,
@@ -713,7 +713,7 @@ extension SRIncrementalSnapshotRecord.Data.PointerInteractionData: AnyMockable, 
 
     static func mockWith(
         pointerEventType: PointerEventType = .mockAny(),
-        pointerId: Int64 = .mockAny(),
+        pointerId: Int = .mockAny(),
         pointerType: PointerType = .mockAny(),
         x: Double = .mockAny(),
         y: Double = .mockAny()
@@ -769,8 +769,8 @@ extension SRIncrementalSnapshotRecord.Data.ViewportResizeData: AnyMockable, Rand
     }
 
     static func mockWith(
-        height: Int64 = .mockAny(),
-        width: Int64 = .mockAny()
+        height: Int = .mockAny(),
+        width: Int = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.ViewportResizeData {
         return SRIncrementalSnapshotRecord.Data.ViewportResizeData(
             height: height,
@@ -814,10 +814,10 @@ extension SRIncrementalSnapshotRecord.Data.TouchData.Positions: AnyMockable, Ran
     }
 
     static func mockWith(
-        id: Int64 = .mockAny(),
-        timestamp: Int64 = .mockAny(),
-        x: Int64 = .mockAny(),
-        y: Int64 = .mockAny()
+        id: Int = .mockAny(),
+        timestamp: Int = .mockAny(),
+        x: Int = .mockAny(),
+        y: Int = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.TouchData.Positions {
         return SRIncrementalSnapshotRecord.Data.TouchData.Positions(
             id: id,
@@ -888,12 +888,12 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUp
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
         clip: SRContentClip? = .mockAny(),
-        height: Int64? = .mockAny(),
-        id: Int64 = .mockAny(),
+        height: Int? = .mockAny(),
+        id: Int = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
-        width: Int64? = .mockAny(),
-        x: Int64? = .mockAny(),
-        y: Int64? = .mockAny()
+        width: Int? = .mockAny(),
+        x: Int? = .mockAny(),
+        y: Int? = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate(
             border: border,
@@ -932,15 +932,15 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpd
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
         clip: SRContentClip? = .mockAny(),
-        height: Int64? = .mockAny(),
-        id: Int64 = .mockAny(),
+        height: Int? = .mockAny(),
+        id: Int = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
         text: String? = .mockAny(),
         textPosition: SRTextPosition? = .mockAny(),
         textStyle: SRTextStyle? = .mockAny(),
-        width: Int64? = .mockAny(),
-        x: Int64? = .mockAny(),
-        y: Int64? = .mockAny()
+        width: Int? = .mockAny(),
+        x: Int? = .mockAny(),
+        y: Int? = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate(
             border: border,
@@ -970,7 +970,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Removes: AnyMockable, Ra
     }
 
     static func mockWith(
-        id: Int64 = .mockAny()
+        id: Int = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Removes {
         return SRIncrementalSnapshotRecord.Data.MutationData.Removes(
             id: id
@@ -991,7 +991,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Adds: AnyMockable, Rando
     }
 
     static func mockWith(
-        previousId: Int64? = .mockAny(),
+        previousId: Int? = .mockAny(),
         wireframe: SRWireframe = .mockAny()
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Adds {
         return SRIncrementalSnapshotRecord.Data.MutationData.Adds(
@@ -1015,7 +1015,7 @@ extension SRFullSnapshotRecord: AnyMockable, RandomMockable {
 
     static func mockWith(
         data: Data = .mockAny(),
-        timestamp: Int64 = .mockAny()
+        timestamp: Int = .mockAny()
     ) -> SRFullSnapshotRecord {
         return SRFullSnapshotRecord(
             data: data,
@@ -1068,14 +1068,14 @@ extension SRSegment: AnyMockable, RandomMockable {
 
     static func mockWith(
         application: Application = .mockAny(),
-        end: Int64 = .mockAny(),
+        end: Int = .mockAny(),
         hasFullSnapshot: Bool? = .mockAny(),
-        indexInView: Int64? = .mockAny(),
+        indexInView: Int? = .mockAny(),
         records: [SRRecord] = .mockAny(),
-        recordsCount: Int64 = .mockAny(),
+        recordsCount: Int = .mockAny(),
         session: Session = .mockAny(),
         source: Source = .mockAny(),
-        start: Int64 = .mockAny(),
+        start: Int = .mockAny(),
         view: View = .mockAny()
     ) -> SRSegment {
         return SRSegment(
@@ -1213,7 +1213,7 @@ internal extension SRRecord {
         }
     }
 
-    var timestamp: Int64 {
+    var timestamp: Int {
         switch self {
         case .fullSnapshotRecord(let record):           return record.timestamp
         case .incrementalSnapshotRecord(let record):    return record.timestamp

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -13,7 +13,7 @@ class DiffSRWireframes: XCTestCase {
     // MARK: - Diffable Conformance
 
     func testDiffID() {
-        let randomID: Int64 = .mockRandom()
+        let randomID: Int = .mockRandom()
         let wireframes: [SRWireframe] = [
             .shapeWireframe(value: .mockWith(id: randomID)),
             .textWireframe(value: .mockWith(id: randomID)),

--- a/DatadogSessionReplay/Tests/Processor/Diffing/DiffTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/DiffTests.swift
@@ -89,7 +89,7 @@ class DiffTests: XCTestCase {
 
     func testWhenApplyingDiffOnTopOfTheOriginalSequence_itShouldProduceTheOtherSequence() throws {
         // Test for short long sequences to cover more edge cases
-        let testedLengths: [Int64] = [2, 5, 500, 1_000]
+        let testedLengths: [Int] = [2, 5, 500, 1_000]
 
         try testedLengths.forEach { length in
             // Given

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -227,14 +227,15 @@ class SnapshotProcessorTests: XCTestCase {
             "Segment must start with 'meta' → 'focus' → 'full snapshot' records"
         )
 
-        try enrichedRecord.records[3..<13].forEach { record in
+        let remainingRecords = enrichedRecord.records[3..<13]
+        try remainingRecords.forEach { (record: SRRecord) in
             let pointerInteractionData = try XCTUnwrap(
                 record.incrementalSnapshot?.pointerInteractionData,
                 "Touch information must be send in 'incremental snapshot'"
             )
             XCTAssertEqual(pointerInteractionData.pointerType, .touch)
-            XCTAssertGreaterThanOrEqual(record.timestamp, earliestTouchTime.timeIntervalSince1970.toInt64Milliseconds)
-            XCTAssertLessThanOrEqual(record.timestamp, snapshotTime.timeIntervalSince1970.toInt64Milliseconds)
+            XCTAssertGreaterThanOrEqual(record.timestamp, Int(earliestTouchTime.timeIntervalSince1970.toMilliseconds))
+            XCTAssertLessThanOrEqual(record.timestamp, Int(snapshotTime.timeIntervalSince1970.toMilliseconds))
         }
 
         XCTAssertEqual(core.recordsCountByViewID, ["abc": 13])
@@ -342,7 +343,7 @@ class SnapshotProcessorTests: XCTestCase {
 }
 
 fileprivate extension PassthroughCoreMock {
-    var recordsCountByViewID: [String: Int64]? {
+    var recordsCountByViewID: [String: Int]? {
         return try? context.baggages["sr_records_count_by_view_id"]?.decode()
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
@@ -76,9 +76,9 @@ class WKWebViewRecorderTests: XCTestCase {
         XCTAssertEqual(wireframe.id, id)
         XCTAssertEqual(wireframe.slotId, String(slotId))
         XCTAssertNil(wireframe.clip)
-        XCTAssertEqual(wireframe.x, Int64(withNoOverflow: attributes.frame.minX))
-        XCTAssertEqual(wireframe.y, Int64(withNoOverflow: attributes.frame.minY))
-        XCTAssertEqual(wireframe.width, Int64(withNoOverflow: attributes.frame.width))
-        XCTAssertEqual(wireframe.height, Int64(withNoOverflow: attributes.frame.height))
+        XCTAssertEqual(wireframe.x, Int(withNoOverflow: attributes.frame.minX))
+        XCTAssertEqual(wireframe.y, Int(withNoOverflow: attributes.frame.minY))
+        XCTAssertEqual(wireframe.width, Int(withNoOverflow: attributes.frame.width))
+        XCTAssertEqual(wireframe.height, Int(withNoOverflow: attributes.frame.height))
     }
 }

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -47,14 +47,6 @@ public class SRCodeDecorator: SwiftCodeDecorator {
 
     // MARK: - Types customiation
 
-    override public func transform(primitive: SwiftPrimitiveType) -> SwiftPrimitiveType {
-        if primitive is SwiftPrimitive<Int> {
-            return SwiftPrimitive<Int64>() // Replace all `Int` with `Int64`
-        } else {
-            return super.transform(primitive: primitive)
-        }
-    }
-
     override public func transform(struct: SwiftStruct) throws -> SwiftStruct {
         var `struct` = try super.transform(struct: `struct`)
 


### PR DESCRIPTION
### What and why?

As discussed, during the platform meeting I explored idea of removing Int64 from SessionReplay.

Unfortunately we do use milisecond timestamp in SR, which overflows in tests after this change. Manual test using shopist went fine.

Looking for some feedback. I feel like we could either so a selective override of one model in SR (making the timestamp the only Int64 exception) or start talking with the backend.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
