### PR TITLE
RUM-1836 feat(otel-tracer): change default span kind to internal

### DIFF
--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -149,7 +149,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
             active: false,
             attributes: [:],
             parent: .currentSpan,
-            spanKind: .client,
+            spanKind: .internal,
             spanName: spanName,
             startTime: nil,
             tracer: self

--- a/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
@@ -169,7 +169,7 @@ final class OTelSpanTests: XCTestCase {
         XCTAssertEqual(recordedSpan.operationName, name)
         let expectedTags = [
             "key": "value",
-            "span.kind": "client",
+            "span.kind": "internal",
         ]
         DDAssertDictionariesEqual(recordedSpan.tags, expectedTags)
     }
@@ -276,7 +276,7 @@ final class OTelSpanTests: XCTestCase {
             "key2": "value2",
             "key3": "3",
             "key4": "4.0",
-            "span.kind": "client",
+            "span.kind": "internal",
         ]
         DDAssertDictionariesEqual(recordedSpan.tags, expectedTags)
     }


### PR DESCRIPTION
### What and why?

Client is not right value for the span kind as per definition of

>CLIENT Indicates that the span describes a request to some remote service. This span is usually the parent of a remote SERVER span and does not end until the response is received.

Source: https://opentelemetry.io/docs/specs/otel/trace/api/#spankind


### How?

Revert to default ie Internal.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
