### PR TITLE
RUM-3437 Inject Container to Browser Events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -871,6 +871,10 @@
 		D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */; };
 		D25085102976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */; };
 		D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */; };
+		D253EE962B988CA90010B589 /* ViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE952B988CA90010B589 /* ViewCache.swift */; };
+		D253EE972B988CA90010B589 /* ViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE952B988CA90010B589 /* ViewCache.swift */; };
+		D253EE9B2B98B37B0010B589 /* ViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE982B98B3690010B589 /* ViewCacheTests.swift */; };
+		D253EE9C2B98B37C0010B589 /* ViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE982B98B3690010B589 /* ViewCacheTests.swift */; };
 		D2553807288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553808288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553826288F0B1A00727FAD /* BatteryStatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */; };
@@ -2581,6 +2585,8 @@
 		D24C9C6629A7CBF0002057CF /* DDErrorMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorMocks.swift; sourceTree = "<group>"; };
 		D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoriesMock.swift; sourceTree = "<group>"; };
 		D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogRemoteFeatureMock.swift; sourceTree = "<group>"; };
+		D253EE952B988CA90010B589 /* ViewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCache.swift; sourceTree = "<group>"; };
+		D253EE982B98B3690010B589 /* ViewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCacheTests.swift; sourceTree = "<group>"; };
 		D2546BF029AF4F550054E00B /* DatadogTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTracer.swift; sourceTree = "<group>"; };
 		D2546C0329AF55AA0054E00B /* TraceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceFeature.swift; sourceTree = "<group>"; };
 		D2546C0729AF55E90054E00B /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
@@ -4192,6 +4198,7 @@
 			children = (
 				61C1510C25AC8C1B00362D4B /* ViewIdentifierTests.swift */,
 				61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */,
+				D253EE982B98B3690010B589 /* ViewCacheTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4252,6 +4259,7 @@
 			children = (
 				61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */,
 				61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */,
+				D253EE952B988CA90010B589 /* ViewCache.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -8069,6 +8077,7 @@
 				D23F8E5729DDCD28001CFAE8 /* RUMScopeDependencies.swift in Sources */,
 				D23F8E5829DDCD28001CFAE8 /* VitalMemoryReader.swift in Sources */,
 				D23F8E5929DDCD28001CFAE8 /* WebViewEventReceiver.swift in Sources */,
+				D253EE972B988CA90010B589 /* ViewCache.swift in Sources */,
 				D23F8E5A29DDCD28001CFAE8 /* RUMResourceScope.swift in Sources */,
 				D23F8E5C29DDCD28001CFAE8 /* RUMApplicationScope.swift in Sources */,
 				D23F8E5D29DDCD28001CFAE8 /* SwiftUIViewModifier.swift in Sources */,
@@ -8167,6 +8176,7 @@
 				D23F8EBE29DDCD38001CFAE8 /* WebViewEventReceiverTests.swift in Sources */,
 				D23F8EBF29DDCD38001CFAE8 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				D23F8EC029DDCD38001CFAE8 /* RUMEventSanitizerTests.swift in Sources */,
+				D253EE9C2B98B37C0010B589 /* ViewCacheTests.swift in Sources */,
 				6176C1732ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D23F8EC129DDCD38001CFAE8 /* RUMEventsMapperTests.swift in Sources */,
 				6167E6DB2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,
@@ -8344,6 +8354,7 @@
 				D29A9F5A29DD85BB005C54A4 /* RUMScopeDependencies.swift in Sources */,
 				D29A9F5B29DD85BB005C54A4 /* VitalMemoryReader.swift in Sources */,
 				D29A9F6229DD85BB005C54A4 /* WebViewEventReceiver.swift in Sources */,
+				D253EE962B988CA90010B589 /* ViewCache.swift in Sources */,
 				D29A9F8429DD85BB005C54A4 /* RUMResourceScope.swift in Sources */,
 				D29A9F7329DD85BB005C54A4 /* RUMApplicationScope.swift in Sources */,
 				D29A9F6A29DD85BB005C54A4 /* SwiftUIViewModifier.swift in Sources */,
@@ -8442,6 +8453,7 @@
 				D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */,
 				D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				D29A9FA229DDB483005C54A4 /* RUMEventSanitizerTests.swift in Sources */,
+				D253EE9B2B98B37B0010B589 /* ViewCacheTests.swift in Sources */,
 				6176C1722ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D29A9FB929DDB483005C54A4 /* RUMEventsMapperTests.swift in Sources */,
 				6167E6DA2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -39,11 +39,13 @@ extension WebViewEventReceiver: AnyMockable {
 
     static func mockWith(
         dateProvider: DateProvider = SystemDateProvider(),
-        commandSubscriber: RUMCommandSubscriber = RUMCommandSubscriberMock()
+        commandSubscriber: RUMCommandSubscriber = RUMCommandSubscriberMock(),
+        viewCache: ViewCache = ViewCache()
     ) -> Self {
         .init(
             dateProvider: dateProvider,
-            commandSubscriber: commandSubscriber
+            commandSubscriber: commandSubscriber,
+            viewCache: viewCache
         )
     }
 }
@@ -706,7 +708,8 @@ extension RUMScopeDependencies {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
-        onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener()
+        onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
+        viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             core: core,
@@ -720,7 +723,8 @@ extension RUMScopeDependencies {
             ciTest: ciTest,
             syntheticsTest: syntheticsTest,
             vitalsReaders: vitalsReaders,
-            onSessionStart: onSessionStart
+            onSessionStart: onSessionStart,
+            viewCache: viewCache
         )
     }
 
@@ -736,7 +740,8 @@ extension RUMScopeDependencies {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
-        onSessionStart: RUM.SessionListener? = nil
+        onSessionStart: RUM.SessionListener? = nil,
+        viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             core: self.core,
@@ -750,7 +755,8 @@ extension RUMScopeDependencies {
             ciTest: ciTest ?? self.ciTest,
             syntheticsTest: syntheticsTest ?? self.syntheticsTest,
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
-            onSessionStart: onSessionStart ?? self.onSessionStart
+            onSessionStart: onSessionStart ?? self.onSessionStart,
+            viewCache: viewCache ?? self.viewCache
         )
     }
 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -67,7 +67,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     telemetry: core.telemetry
                 )
             },
-            onSessionStart: configuration.onSessionStart
+            onSessionStart: configuration.onSessionStart,
+            viewCache: ViewCache()
         )
 
         self.monitor = Monitor(
@@ -101,7 +102,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
             ErrorMessageReceiver(monitor: monitor),
             WebViewEventReceiver(
                 dateProvider: configuration.dateProvider,
-                commandSubscriber: monitor
+                commandSubscriber: monitor,
+                viewCache: dependencies.viewCache
             ),
             CrashReportReceiver(
                 applicationID: configuration.applicationID,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -40,6 +40,7 @@ internal struct RUMScopeDependencies {
     let syntheticsTest: RUMSyntheticsTest?
     let vitalsReaders: VitalsReaders?
     let onSessionStart: RUM.SessionListener?
+    let viewCache: ViewCache
 
     var telemetry: Telemetry {
         core?.telemetry ?? NOPTelemetry()

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -124,11 +124,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 frequency: $0.frequency
             )
         }
-
-        // Notify Synthetics if needed
-        if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {
-            print("_dd.view.id=" + self.viewUUID.toRUMDataFormat)
-        }
     }
 
     // MARK: - RUMContextProvider

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ViewCache.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ViewCache.swift
@@ -33,7 +33,7 @@ internal final class ViewCache {
     ///   - capacity: The maximum number of ids to store.
     init(
         dateProvider: DateProvider = SystemDateProvider(),
-        ttl: TimeInterval = 3 * 60,
+        ttl: TimeInterval = 3.minutes,
         capacity: Int = 30
     ) {
         self.dateProvider = dateProvider

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ViewCache.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ViewCache.swift
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// The ``ViewCache``  keeps previous view ids in memory.
+///
+/// This class can be used to store and retrieve previous RUM views based
+/// on timestamp.
+internal final class ViewCache {
+    let dateProvider: DateProvider
+    let ttl: Int64
+    let capacity: Int
+
+    private struct View: Hashable {
+        let timestamp: Int64
+        let id: String
+        let hasReplay: Bool?
+    }
+
+    @ReadWriteLock
+    private var views: [View] = []
+
+    /// Create a view-cache instance.
+    ///
+    /// - Parameters:
+    ///   - dateProvider: The date provider.
+    ///   - ttl: The TTL of view ids in cache.
+    ///   - capacity: The maximum number of ids to store.
+    init(
+        dateProvider: DateProvider = SystemDateProvider(),
+        ttl: TimeInterval = 3 * 60,
+        capacity: Int = 30
+    ) {
+        self.dateProvider = dateProvider
+        self.ttl = ttl.toInt64Milliseconds
+        self.capacity = capacity
+        self.views.reserveCapacity(capacity)
+    }
+
+    /// Insert a view id in the cache.
+    ///
+    /// - Parameters:
+    ///   - id: The view id to cache.
+    ///   - timestamp: The view epoch timestamp in milliseconds.
+    ///   - hasReplay: `true` if the view has replay.
+    func insert(id: String, timestamp: Int64, hasReplay: Bool? = nil) {
+        _views.mutate { views in
+            let view = View(timestamp: timestamp, id: id, hasReplay: hasReplay)
+            // order views by desc epoch time
+            if let index = views.firstIndex(where: { $0.timestamp < timestamp }) {
+                views.insert(view, at: index)
+            } else {
+                views.append(view)
+            }
+        }
+
+        purge()
+    }
+
+    /// Gets the last view id before the specified timestamp.
+    ///
+    /// - Parameters:
+    ///   - timestamp: The requested epoch timestamp in milliseconds.
+    ///   - hasReplay: Specify `true` to get the last view with replay.
+    /// - Returns: The view id if found.
+    func lastView<Integer>(before timestamp: Integer, hasReplay: Bool? = nil) -> String? where Integer: BinaryInteger {
+        views.first(where: {
+            if $0.timestamp < timestamp {
+                guard let hasReplay = hasReplay else {
+                    return true
+                }
+
+                if $0.hasReplay == hasReplay {
+                    return true
+                }
+            }
+            return false
+        })?.id
+    }
+
+    private func purge() {
+        let now = dateProvider.now.timeIntervalSince1970.toInt64Milliseconds
+
+        _views.mutate {
+            var views = $0.prefix(capacity)
+
+            if let index = views.firstIndex(where: { now - $0.timestamp > ttl }) {
+                views = views.prefix(upTo: index)
+            }
+
+            $0 = Array(views)
+        }
+    }
+}

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -754,7 +754,8 @@ extension RUMScopeDependencies {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
-        onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener()
+        onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
+        viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             core: core,
@@ -768,7 +769,8 @@ extension RUMScopeDependencies {
             ciTest: ciTest,
             syntheticsTest: syntheticsTest,
             vitalsReaders: vitalsReaders,
-            onSessionStart: onSessionStart
+            onSessionStart: onSessionStart,
+            viewCache: viewCache
         )
     }
 
@@ -784,7 +786,8 @@ extension RUMScopeDependencies {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
-        onSessionStart: RUM.SessionListener? = nil
+        onSessionStart: RUM.SessionListener? = nil,
+        viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             core: self.core,
@@ -798,7 +801,8 @@ extension RUMScopeDependencies {
             ciTest: ciTest ?? self.ciTest,
             syntheticsTest: syntheticsTest ?? self.syntheticsTest,
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
-            onSessionStart: onSessionStart ?? self.onSessionStart
+            onSessionStart: onSessionStart ?? self.onSessionStart,
+            viewCache: viewCache ?? self.viewCache
         )
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/ViewCacheTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/ViewCacheTests.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+
+@testable import DatadogRUM
+
+class ViewCacheTests: XCTestCase {
+    func testRequestView_withReplay() {
+        let dateProvider = RelativeDateProvider()
+        let cache = ViewCache(dateProvider: DateProviderMock())
+
+        let viewId: String = .mockRandom()
+        cache.insert(
+            id: viewId,
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: true
+        )
+
+        dateProvider.advance(bySeconds: 1)
+
+        let timestamp = dateProvider.now.timeIntervalSince1970.toInt64Milliseconds
+        XCTAssertEqual(cache.lastView(before: timestamp), viewId)
+        XCTAssertEqual(cache.lastView(before: timestamp, hasReplay: true), viewId)
+        XCTAssertNil(cache.lastView(before: timestamp, hasReplay: false))
+    }
+
+    func testRequestView_withoutReplay() {
+        let dateProvider = RelativeDateProvider()
+        let cache = ViewCache(dateProvider: DateProviderMock())
+
+        let viewId: String = .mockRandom()
+        cache.insert(
+            id: viewId,
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: false
+        )
+
+        dateProvider.advance(bySeconds: 1)
+
+        let timestamp = dateProvider.now.timeIntervalSince1970.toInt64Milliseconds
+        XCTAssertEqual(cache.lastView(before: timestamp), viewId)
+        XCTAssertEqual(cache.lastView(before: timestamp, hasReplay: false), viewId)
+        XCTAssertNil(cache.lastView(before: timestamp, hasReplay: true))
+    }
+
+    func testPurge_whenExceedingCount() {
+        let dateProvider = RelativeDateProvider()
+        let capacity: Int = .mockRandom(min: 2, max: 30)
+        let cache = ViewCache(dateProvider: dateProvider, capacity: capacity)
+
+        let firstId: String = .mockRandom()
+        cache.insert(
+            id: firstId,
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: .mockRandom()
+        )
+
+        dateProvider.advance(bySeconds: 1)
+
+        let timestamp = dateProvider.now.timeIntervalSince1970.toInt64Milliseconds
+        XCTAssertEqual(cache.lastView(before: timestamp), firstId)
+
+        for _ in (0..<capacity - 1) {
+            dateProvider.advance(bySeconds: 1)
+            cache.insert(
+                id: .mockRandom(),
+                timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+                hasReplay: .mockRandom()
+            )
+        }
+
+        XCTAssertEqual(cache.lastView(before: timestamp), firstId)
+
+        dateProvider.advance(bySeconds: 1)
+        cache.insert(
+            id: .mockRandom(),
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: .mockRandom()
+        )
+
+        XCTAssertNil(cache.lastView(before: timestamp))
+    }
+
+    func testPurge_whenExceedingTTL() {
+        let dateProvider = RelativeDateProvider()
+        let cache = ViewCache(dateProvider: dateProvider, ttl: 30)
+
+        let firstId: String = .mockRandom()
+        cache.insert(
+            id: firstId,
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: .mockRandom()
+        )
+
+        dateProvider.advance(bySeconds: 10)
+
+        let timestamp = dateProvider.now.timeIntervalSince1970.toInt64Milliseconds
+        XCTAssertEqual(cache.lastView(before: timestamp), firstId)
+
+        dateProvider.advance(bySeconds: 30)
+
+        cache.insert(
+            id: .mockRandom(),
+            timestamp: dateProvider.now.timeIntervalSince1970.toInt64Milliseconds,
+            hasReplay: .mockRandom()
+        )
+
+        XCTAssertNil(cache.lastView(before: timestamp))
+    }
+}

--- a/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
@@ -16,13 +16,16 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
         let rumServerSession = server.obtainUniqueRecordingSession()
         // Server session recording Logs send to `HTTPServerMock`.
         let loggingServerSession = server.obtainUniqueRecordingSession()
+        // Server session recording Replays send to `HTTPServerMock`.
+        let srServerSession = server.obtainUniqueRecordingSession()
 
         let app = ExampleApplication()
         app.launchWith(
             testScenarioClassName: "WebViewTrackingScenario",
             serverConfiguration: HTTPServerMockConfiguration(
                 logsEndpoint: loggingServerSession.recordingURL,
-                rumEndpoint: rumServerSession.recordingURL
+                rumEndpoint: rumServerSession.recordingURL,
+                srEndpoint: srServerSession.recordingURL
             )
         )
 
@@ -55,6 +58,7 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
         let expectedBrowserServiceName = "shopist-web-ui"
         let expectedBrowserRUMApplicationID = nativeView.viewEvents[0].application.id
         let expectedBrowserSessionID = nativeView.viewEvents[0].session.id
+        let expectedBrowserContainerViewID = nativeView.viewEvents[0].view.id
 
         let browserView = session.views[2]
         XCTAssertNil(browserView.name, "Browser views should have no `name`")
@@ -66,6 +70,8 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(browserViewEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
             XCTAssertEqual(browserViewEvent.source, .browser, "Webview events should use Browser SDK `source`")
             XCTAssertEqual(browserViewEvent.dd.session?.plan, .plan1, "Webview events should use iOS SDK plan 1")
+            XCTAssertEqual(browserViewEvent.container?.source, .ios, "Webview events should include a container source")
+            XCTAssertEqual(browserViewEvent.container?.view.id, expectedBrowserContainerViewID, "Webview events should include a container view.id")
         }
         XCTAssertGreaterThan(browserView.resourceEvents.count, 0, "It should track some Webview resources")
         browserView.resourceEvents.forEach { browserResourceEvent in
@@ -74,6 +80,8 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(browserResourceEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
             XCTAssertEqual(browserResourceEvent.source, .browser, "Webview events should use Browser SDK `source`")
             XCTAssertEqual(browserResourceEvent.dd.session?.plan, .plan1, "Webview events should use iOS SDK plan 1")
+            XCTAssertEqual(browserResourceEvent.container?.source, .ios, "Webview events should use include a container view")
+            XCTAssertEqual(browserResourceEvent.container?.view.id, expectedBrowserContainerViewID, "Webview events should include a container view.id")
         }
 
         // Get `LogMatchers`

--- a/IntegrationTests/Runner/Scenarios/WebView/WebViewScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/WebView/WebViewScenarios.swift
@@ -8,6 +8,7 @@ import UIKit
 import DatadogCore
 import DatadogRUM
 import DatadogLogs
+import DatadogSessionReplay
 
 private struct WebViewTrackingScenarioPredicate: UIKitRUMViewsPredicate {
     private let defaultPredicate = DefaultUIKitRUMViewsPredicate()
@@ -25,10 +26,20 @@ final class WebViewTrackingScenario: TestScenario {
     static var storyboardName: String = "WebViewTrackingScenario"
 
     func configureFeatures() {
-        var config = RUM.Configuration(applicationID: "rum-application-id")
-        config.customEndpoint = Environment.serverMockConfiguration()?.rumEndpoint
-        config.uiKitViewsPredicate = WebViewTrackingScenarioPredicate()
-        RUM.enable(with: config)
+        RUM.enable(
+            with: RUM.Configuration(
+                applicationID: "rum-application-id",
+                uiKitViewsPredicate: WebViewTrackingScenarioPredicate(),
+                customEndpoint: Environment.serverMockConfiguration()?.rumEndpoint
+            )
+        )
+
+        SessionReplay.enable(
+            with: SessionReplay.Configuration(
+                replaySampleRate: 100,
+                customEndpoint: Environment.serverMockConfiguration()?.srEndpoint
+            )
+        )
 
         Logs.enable(
             with: Logs.Configuration(


### PR DESCRIPTION
### What and why?

As part of WebView Replay requirements, each Browser event should include a `container` field with the native source and `view.id`. As described in [_view-container-schema.json](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/_view-container-schema.json).

This field will help the player to retrieve the Browser RUM View contained in a native replay.

### How?

The Browser SDK sends views through the JS bridge asynchronously with delays, meaning that a browser event could come from a previous view. See the following user-journey:
```
View 1 (id: 1) -> View 2 (id: 2) -> Back to View 1 (id: 3)
```

Assuming that View 1 presents a web-view, we could receive Browser events contained in view.id 1 while being in view.id 3.

To assign the right container to the right Browser event, we need to keep previous view ids in cache so they can be fetch based on timestamp. This is the role of the introduced `ViewCache`.
The `ViewCache` class is a new RUM scope dependency that is used to store view ids when a new view starts. The `WebViewEventReceiver` can then use that cache to inject the right container to the Browser events.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
