### PR TITLE
RUM-1828 feat! (128 bit trace id) support 128 bit trace ids in distributed tracing, spans, rum and log events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		3C85D42A29F7C70300AFF894 /* TestUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D257953E298ABA65008A1BE5 /* TestUtilities.framework */; };
 		3C85D42C29F7C87D00AFF894 /* HostsSanitizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C85D42B29F7C87D00AFF894 /* HostsSanitizerMock.swift */; };
 		3C85D42D29F7C87D00AFF894 /* HostsSanitizerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C85D42B29F7C87D00AFF894 /* HostsSanitizerMock.swift */; };
+		3C9B27252B9F174700569C07 /* SpanID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B27242B9F174700569C07 /* SpanID.swift */; };
+		3C9B27262B9F174700569C07 /* SpanID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B27242B9F174700569C07 /* SpanID.swift */; };
 		3C9C6BB429F7C0C000581C43 /* DatadogInternal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D23039A5298D513C001A1FA3 /* DatadogInternal.framework */; };
 		3CBDE6742AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBDE6732AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift */; };
 		3CBDE6752AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBDE6732AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift */; };
@@ -1896,6 +1898,7 @@
 		3C1890132ABDE99200CE9E73 /* DDURLSessionInstrumentationTests+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDURLSessionInstrumentationTests+apiTests.m"; sourceTree = "<group>"; };
 		3C85D41429F7C59C00AFF894 /* WebViewTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewTracking.swift; sourceTree = "<group>"; };
 		3C85D42B29F7C87D00AFF894 /* HostsSanitizerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostsSanitizerMock.swift; sourceTree = "<group>"; };
+		3C9B27242B9F174700569C07 /* SpanID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanID.swift; sourceTree = "<group>"; };
 		3CBDE6732AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInstrumentation.swift; sourceTree = "<group>"; };
 		3CBDE6892AA0C47300F6A7B6 /* URLSessionTask+Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionTask+Tracking.swift"; sourceTree = "<group>"; };
 		3CCCA5C32ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionInstrumentation+objc.swift"; sourceTree = "<group>"; };
@@ -5829,6 +5832,7 @@
 				D2160C9829C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift */,
 				D2160CEC29C0E0E600FAA9A5 /* DatadogURLSessionHandler.swift */,
 				D2EBEDCC29B893D800B15732 /* TraceID.swift */,
+				3C9B27242B9F174700569C07 /* SpanID.swift */,
 				D2160C9429C0DE5600FAA9A5 /* FirstPartyHosts.swift */,
 				D2160C9729C0DE5700FAA9A5 /* HostsSanitizer.swift */,
 				D2160C9629C0DE5600FAA9A5 /* TracingHeaderType.swift */,
@@ -8018,6 +8022,7 @@
 				D2EBEE2329BA160F00B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D23039F8298D5236001A1FA3 /* InternalLogger.swift in Sources */,
 				D2303A01298D5236001A1FA3 /* DateFormatting.swift in Sources */,
+				3C9B27252B9F174700569C07 /* SpanID.swift in Sources */,
 				D2216EC02A94DE2900ADAEC8 /* FeatureBaggage.swift in Sources */,
 				D23039F1298D5236001A1FA3 /* AnyDecodable.swift in Sources */,
 				6167E6E22B81207200C3CA2D /* DDCrashReport.swift in Sources */,
@@ -8855,6 +8860,7 @@
 				D2EBEE3129BA161100B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D2DA236E298D57AA00C6C7E6 /* InternalLogger.swift in Sources */,
 				D2DA236F298D57AA00C6C7E6 /* DateFormatting.swift in Sources */,
+				3C9B27262B9F174700569C07 /* SpanID.swift in Sources */,
 				D2216EC12A94DE2900ADAEC8 /* FeatureBaggage.swift in Sources */,
 				D2DA2370298D57AA00C6C7E6 /* AnyDecodable.swift in Sources */,
 				6167E6E32B81207200C3CA2D /* DDCrashReport.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -44,6 +44,10 @@
 		3CCCA5C52ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C32ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift */; };
 		3CCCA5C72ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */; };
 		3CCCA5C82ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */; };
+		3CCECDAF2BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */; };
+		3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */; };
+		3CCECDB22BC68A0A0013C125 /* SpanIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */; };
+		3CCECDB32BC68A0A0013C125 /* SpanIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */; };
 		3CE11A1129F7BE0900202522 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
@@ -1903,6 +1907,8 @@
 		3CBDE6892AA0C47300F6A7B6 /* URLSessionTask+Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionTask+Tracking.swift"; sourceTree = "<group>"; };
 		3CCCA5C32ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionInstrumentation+objc.swift"; sourceTree = "<group>"; };
 		3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDURLSessionInstrumentationConfigurationTests.swift; sourceTree = "<group>"; };
+		3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanIDGeneratorTests.swift; sourceTree = "<group>"; };
+		3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanIDTests.swift; sourceTree = "<group>"; };
 		3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogWebViewTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
@@ -5855,7 +5861,9 @@
 				D2160CD329C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift */,
 				D2160CD229C0DF6700FAA9A5 /* URLSessionTaskInterceptionTests.swift */,
 				61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */,
+				3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */,
 				61B558D32469CDD8001460D3 /* TraceIDGeneratorTests.swift */,
+				3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */,
 				A79B0F5A292B7C06008742B3 /* B3HTTPHeadersWriterTests.swift */,
 				A79B0F60292BB071008742B3 /* B3HTTPHeadersReaderTests.swift */,
 				A728ADA22934DB5000397996 /* W3CHTTPHeadersWriterTests.swift */,
@@ -8909,6 +8917,7 @@
 				D2EBEE3C29BA163E00B15732 /* B3HTTPHeadersWriterTests.swift in Sources */,
 				D21AE6BC29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */,
 				D2DA23A3298D58F400C6C7E6 /* AnyEncodableTests.swift in Sources */,
+				3CCECDAF2BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB429DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
 				3C0D5DF52A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4429BA168200B15732 /* TraceIDTests.swift in Sources */,
@@ -8933,6 +8942,7 @@
 				D2160CE029C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,
 				D2EBEE3B29BA163E00B15732 /* B3HTTPHeadersReaderTests.swift in Sources */,
 				D2BEEDB82B3360F50065F3AC /* URLSessionTaskDelegateSwizzlerTests.swift in Sources */,
+				3CCECDB22BC68A0A0013C125 /* SpanIDTests.swift in Sources */,
 				D2181A8E2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */,
 				D2A783DA29A530EF003B03BB /* SwiftExtensionsTests.swift in Sources */,
 				D2D36DCB2AC6DCCA0021F28A /* DatadogCoreProtocolTests.swift in Sources */,
@@ -8952,6 +8962,7 @@
 				D2EBEE4029BA163F00B15732 /* B3HTTPHeadersWriterTests.swift in Sources */,
 				D21AE6BD29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */,
 				D2DA23B1298D59DC00C6C7E6 /* AnyEncodableTests.swift in Sources */,
+				3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB529DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
 				3C0D5DF62A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4629BA168400B15732 /* TraceIDTests.swift in Sources */,
@@ -8976,6 +8987,7 @@
 				D2160CE129C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,
 				D2EBEE3F29BA163F00B15732 /* B3HTTPHeadersReaderTests.swift in Sources */,
 				D2BEEDB92B3360F50065F3AC /* URLSessionTaskDelegateSwizzlerTests.swift in Sources */,
+				3CCECDB32BC68A0A0013C125 /* SpanIDTests.swift in Sources */,
 				D2181A8F2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */,
 				D2A783D929A530EF003B03BB /* SwiftExtensionsTests.swift in Sources */,
 				D2D36DCC2AC6DCCA0021F28A /* DatadogCoreProtocolTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -34,7 +34,8 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
                 )
             )
         )
-        config.traceIDGenerator = RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 1)
+        config.traceIDGenerator = RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100))
+        config.spanIDGenerator = RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 1)
 
         Trace.enable(
             with: config,
@@ -76,15 +77,15 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
 
         let matcher1 = try XCTUnwrap(matchers.first)
         try XCTAssertEqual(matcher1.operationName(), "root")
-        try XCTAssertEqual(matcher1.traceID(), "1")
-        try XCTAssertEqual(matcher1.spanID(), "2")
+        try XCTAssertEqual(matcher1.traceID(), "64")
+        try XCTAssertEqual(matcher1.spanID(), "64")
         try XCTAssertEqual(matcher1.metrics.isRootSpan(), 1)
 
         let matcher2 = try XCTUnwrap(matchers.last)
         try XCTAssertEqual(matcher2.operationName(), "urlsession.request")
-        try XCTAssertEqual(matcher2.traceID(), "1")
-        try XCTAssertEqual(matcher2.parentSpanID(), "2")
-        try XCTAssertEqual(matcher2.spanID(), "3")
+        try XCTAssertEqual(matcher2.traceID(), "64")
+        try XCTAssertEqual(matcher2.parentSpanID(), "64")
+        try XCTAssertEqual(matcher2.spanID(), "65")
     }
 
     class MockDelegate: NSObject, URLSessionDataDelegate {

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -77,15 +77,15 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
 
         let matcher1 = try XCTUnwrap(matchers.first)
         try XCTAssertEqual(matcher1.operationName(), "root")
-        try XCTAssertEqual(matcher1.traceID(), "64")
-        try XCTAssertEqual(matcher1.spanID(), "64")
+        try XCTAssertEqual(matcher1.traceID(), .init(idHi: 10, idLo: 100))
+        try XCTAssertEqual(matcher1.spanID(), .init(rawValue: 100))
         try XCTAssertEqual(matcher1.metrics.isRootSpan(), 1)
 
         let matcher2 = try XCTUnwrap(matchers.last)
         try XCTAssertEqual(matcher2.operationName(), "urlsession.request")
-        try XCTAssertEqual(matcher2.traceID(), "64")
-        try XCTAssertEqual(matcher2.parentSpanID(), "64")
-        try XCTAssertEqual(matcher2.spanID(), "65")
+        try XCTAssertEqual(matcher2.traceID(), .init(idHi: 10, idLo: 100))
+        try XCTAssertEqual(matcher2.parentSpanID(), .init(rawValue: 100))
+        try XCTAssertEqual(matcher2.spanID(), .init(rawValue: 101))
     }
 
     class MockDelegate: NSObject, URLSessionDataDelegate {

--- a/DatadogCore/Tests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
+++ b/DatadogCore/Tests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
@@ -33,7 +33,7 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
 
         // When
         integration.writeLog(
-            withSpanContext: .mockWith(traceID: 1, spanID: 2),
+            withSpanContext: .mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200),
             fields: [
                 OTLogFields.message: "hello",
                 "custom field": 123,
@@ -56,8 +56,8 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
         DDAssertJSONEqual(
             AnyEncodable(log.attributes.internalAttributes),
             AnyEncodable([
-                "dd.trace_id": "1",
-                "dd.span_id": "2"
+                "dd.trace_id": "a0000000000000064",
+                "dd.span_id": "c8"
             ])
         )
     }
@@ -110,7 +110,7 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
 
         // When
         integration.writeLog(
-            withSpanContext: .mockWith(traceID: 1, spanID: 2),
+            withSpanContext: .mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200),
             fields: ["custom field": 123],
             date: .mockDecember15th2019At10AMUTC(),
             else: {}
@@ -130,8 +130,8 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
         DDAssertJSONEqual(
             AnyEncodable(log.attributes.internalAttributes),
             AnyEncodable([
-                "dd.trace_id": "1",
-                "dd.span_id": "2"
+                "dd.trace_id": "a0000000000000064",
+                "dd.span_id": "c8"
             ])
         )
     }

--- a/DatadogCore/Tests/Datadog/LoggerTests.swift
+++ b/DatadogCore/Tests/Datadog/LoggerTests.swift
@@ -865,11 +865,11 @@ class LoggerTests: XCTestCase {
         let logMatchers = try core.waitAndReturnLogMatchers()
         logMatchers[0].assertValue(
             forKeyPath: "dd.trace_id",
-            equals: String(span.context.dd.traceID)
+            equals: span.context.dd.traceID.toString(representation: .hexadecimal)
         )
         logMatchers[0].assertValue(
             forKeyPath: "dd.span_id",
-            equals: String(span.context.dd.spanID)
+            equals: span.context.dd.spanID.toString(representation: .decimal)
         )
         logMatchers[1].assertNoValue(forKey: "dd.trace_id")
         logMatchers[1].assertNoValue(forKey: "dd.span_id")

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -313,15 +313,15 @@ extension RUMSpanContext: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> RUMSpanContext {
         return RUMSpanContext(
-            traceID: .mockRandom(),
-            spanID: .mockRandom(),
+            traceID: .mock(.mockRandom(), .mockRandom()),
+            spanID: .mock(.mockRandom()),
             samplingRate: .mockRandom()
         )
     }
 
     static func mockWith(
-        traceID: String = .mockAny(),
-        spanID: String = .mockAny(),
+        traceID: TraceID = .mockAny(),
+        spanID: SpanID = .mockAny(),
         samplingRate: Double = .mockAny()
     ) -> RUMSpanContext {
         return RUMSpanContext(
@@ -344,7 +344,11 @@ extension RUMStartResourceCommand: AnyMockable, RandomMockable {
             httpMethod: .mockRandom(),
             kind: .mockAny(),
             isFirstPartyRequest: .mockRandom(),
-            spanContext: .init(traceID: .mockRandom(), spanID: .mockRandom(), samplingRate: .mockAny())
+            spanContext: .init(
+                traceID: .mock(.mockRandom(), .mockRandom()),
+                spanID: .mock(.mockRandom()),
+                samplingRate: .mockAny()
+            )
         )
     }
 

--- a/DatadogCore/Tests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -84,8 +84,8 @@ extension DDSpanContext {
 
     static func mockWith(
         traceID: TraceID = .mockAny(),
-        spanID: TraceID = .mockAny(),
-        parentSpanID: TraceID? = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentSpanID: SpanID? = .mockAny(),
         baggageItems: BaggageItems = .mockAny()
     ) -> DDSpanContext {
         return DDSpanContext(
@@ -114,7 +114,8 @@ extension DatadogTracer {
         core: DatadogCoreProtocol,
         sampler: Sampler = .mockKeepAll(),
         tags: [String: Encodable] = [:],
-        tracingUUIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator(),
+        traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator(),
+        spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator(),
         dateProvider: DateProvider = SystemDateProvider(),
         spanEventBuilder: SpanEventBuilder = .mockAny(),
         loggingIntegration: TracingWithLoggingIntegration = .mockAny()
@@ -123,7 +124,8 @@ extension DatadogTracer {
             core: core,
             sampler: sampler,
             tags: tags,
-            tracingUUIDGenerator: tracingUUIDGenerator,
+            traceIDGenerator: traceIDGenerator,
+            spanIDGenerator: spanIDGenerator,
             dateProvider: dateProvider,
             loggingIntegration: loggingIntegration,
             spanEventBuilder: spanEventBuilder

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -44,7 +44,8 @@ class TracerTests: XCTestCase {
             applicationBundleIdentifier: "com.datadoghq.ios-sdk"
         )
         config.dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
-        config.traceIDGenerator = RelativeTracingUUIDGenerator(startingFrom: 1)
+        config.traceIDGenerator = RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100))
+        config.spanIDGenerator = RelativeSpanIDGenerator(startingFrom: 100)
 
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
@@ -58,8 +59,8 @@ class TracerTests: XCTestCase {
           "spans": [
             {
               "_dd.agent_psr": 1,
-              "trace_id": "1",
-              "span_id": "2",
+              "trace_id": "64",
+              "span_id": "64",
               "parent_id": "0",
               "name": "operation",
               "service": "default-service-name",
@@ -72,7 +73,8 @@ class TracerTests: XCTestCase {
               "meta.version": "1.0.0",
               "meta._dd.source": "abc",
               "metrics._top_level": 1,
-              "metrics._sampling_priority_v1": 1
+              "metrics._sampling_priority_v1": 1,
+              "meta._dd.p.tid": "a"
             }
           ],
           "env": "custom"
@@ -201,7 +203,8 @@ class TracerTests: XCTestCase {
         // Assert child-parent relationship
 
         XCTAssertEqual(try grandchildMatcher.operationName(), "grandchild operation")
-        XCTAssertEqual(try grandchildMatcher.traceID(), String(rootSpan.context.dd.traceID, representation: .hexadecimal))
+        XCTAssertEqual(try grandchildMatcher.traceID(), rootSpan.context.dd.traceID.idLoHex)
+        XCTAssertEqual(try grandchildMatcher.meta.tid(), rootSpan.context.dd.traceID.idHiHex)
         XCTAssertEqual(try grandchildMatcher.parentSpanID(), String(childSpan.context.dd.spanID, representation: .hexadecimal))
         XCTAssertNil(try? grandchildMatcher.metrics.isRootSpan())
         XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
@@ -211,7 +214,8 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.overwritten"), "b", "Tags should have higher priority than baggage items")
 
         XCTAssertEqual(try childMatcher.operationName(), "child operation")
-        XCTAssertEqual(try childMatcher.traceID(), String(rootSpan.context.dd.traceID, representation: .hexadecimal))
+        XCTAssertEqual(try childMatcher.traceID(), rootSpan.context.dd.traceID.idLoHex)
+        XCTAssertEqual(try childMatcher.meta.tid(), rootSpan.context.dd.traceID.idHiHex)
         XCTAssertEqual(try childMatcher.parentSpanID(), String(rootSpan.context.dd.spanID, representation: .hexadecimal))
         XCTAssertNil(try? childMatcher.metrics.isRootSpan())
         XCTAssertEqual(try childMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
@@ -559,8 +563,8 @@ class TracerTests: XCTestCase {
 
         regularLogMatcher.assertStatus(equals: "info")
         regularLogMatcher.assertMessage(equals: "hello")
-        regularLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID))
-        regularLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID))
+        regularLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID, representation: .hexadecimal))
+        regularLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID, representation: .hexadecimal))
         regularLogMatcher.assertValue(forKey: "custom.field", equals: "value")
 
         errorLogMatcher.assertStatus(equals: "error")
@@ -568,8 +572,8 @@ class TracerTests: XCTestCase {
         errorLogMatcher.assertValue(forKey: "error.kind", equals: "Swift error")
         errorLogMatcher.assertValue(forKey: "error.message", equals: "Ops!")
         errorLogMatcher.assertMessage(equals: "Ops!")
-        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID))
-        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID))
+        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID, representation: .hexadecimal))
+        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID, representation: .hexadecimal))
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
@@ -593,8 +597,8 @@ class TracerTests: XCTestCase {
         errorLogMatcher.assertValue(forKey: "error.kind", equals: "Swift error")
         errorLogMatcher.assertValue(forKey: "error.message", equals: "Ops!")
         errorLogMatcher.assertMessage(equals: "Ops!")
-        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID))
-        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID))
+        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID, representation: .hexadecimal))
+        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID, representation: .hexadecimal))
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
@@ -624,8 +628,8 @@ class TracerTests: XCTestCase {
         errorLogMatcher.assertValue(forKey: "error.kind", equals: "Tracer - 1")
         errorLogMatcher.assertValue(forKey: "error.message", equals: "Ops!")
         errorLogMatcher.assertMessage(equals: "Ops!")
-        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID))
-        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID))
+        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID, representation: .hexadecimal))
+        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID, representation: .hexadecimal))
     }
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
@@ -650,8 +654,8 @@ class TracerTests: XCTestCase {
         errorLogMatcher.assertValue(forKey: "error.kind", equals: "ErrorMock")
         errorLogMatcher.assertValue(forKey: "error.message", equals: "Ops!")
         errorLogMatcher.assertMessage(equals: "Ops!")
-        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID))
-        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID))
+        errorLogMatcher.assertValue(forKey: "dd.trace_id", equals: String(span.context.dd.traceID, representation: .hexadecimal))
+        errorLogMatcher.assertValue(forKey: "dd.span_id", equals: String(span.context.dd.spanID, representation: .hexadecimal))
     }
 
     // MARK: - Integration With RUM Feature
@@ -747,7 +751,7 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
         let spanContext2 = DDSpanContext(traceID: 3, spanID: 4, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockKeepAll())
@@ -758,8 +762,8 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "x-datadog-trace-id": "1",
-            "x-datadog-parent-id": "2",
+            "x-datadog-trace-id": "a0000000000000064",
+            "x-datadog-parent-id": "c8",
             "x-datadog-sampling-priority": "1",
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
@@ -779,7 +783,7 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingMultipleHeaders() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
         let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
         let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
 
@@ -791,8 +795,8 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "X-B3-TraceId": "00000000000000000000000000000001",
-            "X-B3-SpanId": "0000000000000002",
+            "X-B3-TraceId": "000000000000000a0000000000000064",
+            "X-B3-SpanId": "00000000000000c8",
             "X-B3-Sampled": "1",
             "X-B3-ParentSpanId": "0000000000000003"
         ]
@@ -825,7 +829,7 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
         let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
         let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
 
@@ -837,7 +841,7 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "b3": "00000000000000000000000000000001-0000000000000002-1-0000000000000003"
+            "b3": "000000000000000a0000000000000064-00000000000000c8-1-0000000000000003"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
 
@@ -863,7 +867,7 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockRejectAll())
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
@@ -881,7 +885,7 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingMultipleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockRejectAll(), injectEncoding: .multiple)
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
@@ -899,7 +903,7 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithW3CHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
         let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
         let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
 
@@ -916,8 +920,8 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "tracestate": "dd=o:rum;p:0000000000000002;s:1",
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-01"
+            "tracestate": "dd=o:rum;p:00000000000000c8;s:1",
+            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-01"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
 
@@ -945,7 +949,7 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithW3CHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = W3CHTTPHeadersWriter(
             sampler: .mockRejectAll(),
@@ -960,8 +964,8 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders = [
-            "tracestate": "dd=o:rum;p:0000000000000002;s:0",
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-00"
+            "tracestate": "dd=o:rum;p:00000000000000c8;s:0",
+            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-00"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -969,7 +973,7 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockRejectAll())
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
@@ -987,7 +991,7 @@ class TracerTests: XCTestCase {
     func testItExtractsSpanContextWithHTTPHeadersReader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockKeepAll())
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
@@ -1005,7 +1009,7 @@ class TracerTests: XCTestCase {
     func testItExtractsSpanContextWithB3HTTPHeadersReader_forMultipleHeaders() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
 
         let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .multiple)
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
@@ -1023,7 +1027,7 @@ class TracerTests: XCTestCase {
     func testItExtractsSpanContextWithB3HTTPHeadersReader_forSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
 
         let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .single)
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
@@ -1041,7 +1045,7 @@ class TracerTests: XCTestCase {
     func testItExtractsSpanContextWithW3CHTTPHeadersReader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
 
         let httpHeadersWriter = W3CHTTPHeadersWriter(
             sampler: .mockKeepAll(),

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -203,9 +203,8 @@ class TracerTests: XCTestCase {
         // Assert child-parent relationship
 
         XCTAssertEqual(try grandchildMatcher.operationName(), "grandchild operation")
-        XCTAssertEqual(try grandchildMatcher.traceID(), rootSpan.context.dd.traceID.idLoHex)
-        XCTAssertEqual(try grandchildMatcher.meta.tid(), rootSpan.context.dd.traceID.idHiHex)
-        XCTAssertEqual(try grandchildMatcher.parentSpanID(), String(childSpan.context.dd.spanID, representation: .hexadecimal))
+        XCTAssertEqual(try grandchildMatcher.traceID(), rootSpan.context.dd.traceID)
+        XCTAssertEqual(try grandchildMatcher.parentSpanID(), childSpan.context.dd.spanID)
         XCTAssertNil(try? grandchildMatcher.metrics.isRootSpan())
         XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
         XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.child-item"), "bar")
@@ -214,16 +213,15 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.overwritten"), "b", "Tags should have higher priority than baggage items")
 
         XCTAssertEqual(try childMatcher.operationName(), "child operation")
-        XCTAssertEqual(try childMatcher.traceID(), rootSpan.context.dd.traceID.idLoHex)
-        XCTAssertEqual(try childMatcher.meta.tid(), rootSpan.context.dd.traceID.idHiHex)
-        XCTAssertEqual(try childMatcher.parentSpanID(), String(rootSpan.context.dd.spanID, representation: .hexadecimal))
+        XCTAssertEqual(try childMatcher.traceID(), rootSpan.context.dd.traceID)
+        XCTAssertEqual(try childMatcher.parentSpanID(), rootSpan.context.dd.spanID)
         XCTAssertNil(try? childMatcher.metrics.isRootSpan())
         XCTAssertEqual(try childMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
         XCTAssertEqual(try childMatcher.meta.custom(keyPath: "meta.child-item"), "bar")
         XCTAssertNil(try? childMatcher.meta.custom(keyPath: "meta.grandchild-item"))
 
         XCTAssertEqual(try rootMatcher.operationName(), "root operation")
-        XCTAssertEqual(try rootMatcher.parentSpanID(), "0")
+        XCTAssertEqual(try rootMatcher.parentSpanID(), .invalid)
         XCTAssertEqual(try rootMatcher.metrics.isRootSpan(), 1)
         XCTAssertEqual(try rootMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
         XCTAssertNil(try? rootMatcher.meta.custom(keyPath: "meta.child-item"))
@@ -263,7 +261,7 @@ class TracerTests: XCTestCase {
         let child1Matcher = spanMatchers[1]
         let child2Matcher = spanMatchers[0]
 
-        XCTAssertEqual(try rootMatcher.parentSpanID(), "0")
+        XCTAssertEqual(try rootMatcher.parentSpanID(), .invalid)
         XCTAssertEqual(try child1Matcher.parentSpanID(), try rootMatcher.spanID())
         XCTAssertEqual(try child2Matcher.parentSpanID(), try rootMatcher.spanID())
     }
@@ -296,8 +294,8 @@ class TracerTests: XCTestCase {
 
         waitForExpectations(timeout: 5)
         let spanMatchers = try core.waitAndReturnSpanMatchers()
-        XCTAssertEqual(try spanMatchers[0].parentSpanID(), "0")
-        XCTAssertEqual(try spanMatchers[1].parentSpanID(), "0")
+        XCTAssertEqual(try spanMatchers[0].parentSpanID(), .invalid)
+        XCTAssertEqual(try spanMatchers[1].parentSpanID(), .invalid)
     }
 
     func testStartingRootActiveSpanInAsynchronousJobs() throws {
@@ -329,9 +327,9 @@ class TracerTests: XCTestCase {
         let request2Matcher = spanMatchers[3]
 
         XCTAssertEqual(try response1Matcher.parentSpanID(), try request1Matcher.spanID())
-        XCTAssertEqual(try request1Matcher.parentSpanID(), "0")
+        XCTAssertEqual(try request1Matcher.parentSpanID(), .invalid)
         XCTAssertEqual(try response2Matcher.parentSpanID(), try request2Matcher.spanID())
-        XCTAssertEqual(try request2Matcher.parentSpanID(), "0")
+        XCTAssertEqual(try request2Matcher.parentSpanID(), .invalid)
     }
 
     // MARK: - Sending user info

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -760,9 +760,10 @@ class TracerTests: XCTestCase {
 
         // Then
         let expectedHTTPHeaders1 = [
-            "x-datadog-trace-id": "a0000000000000064",
+            "x-datadog-trace-id": "64",
             "x-datadog-parent-id": "c8",
             "x-datadog-sampling-priority": "1",
+            "x-datadog-tags": "_dd.p.tid=a"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
 
@@ -774,6 +775,7 @@ class TracerTests: XCTestCase {
             "x-datadog-trace-id": "3",
             "x-datadog-parent-id": "4",
             "x-datadog-sampling-priority": "1",
+            "x-datadog-tags": "_dd.p.tid=0"
         ]
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
     }

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -28,7 +28,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         tracer = .mockWith(
             core: core,
-            tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0),
+            traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+            spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0),
             loggingIntegration: TracingWithLoggingIntegration(core: core, service: .mockAny(), networkInfoEnabled: .mockAny())
         )
 
@@ -121,15 +122,15 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(log.message, "network error")
         XCTAssertEqual(
             log.attributes.internalAttributes?["dd.trace_id"] as? AnyCodable,
-            AnyCodable(String(span.traceID))
+            AnyCodable(String(span.traceID, representation: .hexadecimal))
         )
         XCTAssertEqual(
             log.attributes.internalAttributes?["dd.trace_id"] as? AnyCodable,
-            AnyCodable(String(span.traceID))
+            AnyCodable(String(span.traceID, representation: .hexadecimal))
         )
         XCTAssertEqual(
             log.attributes.internalAttributes?["dd.span_id"] as? AnyCodable,
-            AnyCodable(String(span.spanID))
+            AnyCodable(String(span.spanID, representation: .hexadecimal))
         )
         XCTAssertEqual(log.error?.kind, "domain - 123")
         XCTAssertEqual(log.attributes.internalAttributes?.count, 2)
@@ -189,11 +190,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(log.message, "404 not found")
         DDAssertJSONEqual(
             AnyEncodable(log.attributes.internalAttributes?["dd.trace_id"]),
-            String(span.traceID)
+            String(span.traceID, representation: .hexadecimal)
         )
         DDAssertJSONEqual(
             AnyEncodable(log.attributes.internalAttributes?["dd.span_id"]),
-            String(span.spanID)
+            String(span.spanID, representation: .hexadecimal)
         )
         XCTAssertEqual(log.error?.kind, "HTTPURLResponse - 404")
         XCTAssertEqual(log.attributes.internalAttributes?.count, 2)
@@ -215,14 +216,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
             [
-                "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
-                "X-B3-SpanId": "0000000000000001",
+                "traceparent": "00-000000000000000a0000000000000064-0000000000000064-01",
+                "X-B3-SpanId": "0000000000000064",
                 "X-B3-Sampled": "1",
-                "X-B3-TraceId": "00000000000000000000000000000001",
-                "b3": "00000000000000000000000000000001-0000000000000001-1",
-                "x-datadog-trace-id": "1",
-                "tracestate": "dd=p:0000000000000001;s:1",
-                "x-datadog-parent-id": "1",
+                "X-B3-TraceId": "000000000000000a0000000000000064",
+                "b3": "000000000000000a0000000000000064-0000000000000064-1",
+                "x-datadog-trace-id": "a0000000000000064",
+                "tracestate": "dd=p:0000000000000064;s:1",
+                "x-datadog-parent-id": "64",
                 "x-datadog-sampling-priority": "1"
             ]
         )

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -221,7 +221,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "X-B3-Sampled": "1",
                 "X-B3-TraceId": "000000000000000a0000000000000064",
                 "b3": "000000000000000a0000000000000064-0000000000000064-1",
-                "x-datadog-trace-id": "a0000000000000064",
+                "x-datadog-trace-id": "64",
+                "x-datadog-tags": "_dd.p.tid=a",
                 "tracestate": "dd=p:0000000000000064;s:1",
                 "x-datadog-parent-id": "64",
                 "x-datadog-sampling-priority": "1"

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -200,15 +200,15 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDHTTPHeadersWriter(sampleRate: 100)
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "x-datadog-trace-id": "1",
-            "x-datadog-parent-id": "2",
+            "x-datadog-trace-id": "a0000000000000064",
+            "x-datadog-parent-id": "c8",
             "x-datadog-sampling-priority": "1",
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
@@ -218,7 +218,7 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDHTTPHeadersWriter(sampleRate: 0)
@@ -233,7 +233,7 @@ class DDTracerTests: XCTestCase {
     func testInjectingSpanContextToInvalidCarrierOrFormat() throws {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
-        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2))
+        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
         let objcValidWriter = DDHTTPHeadersWriter(sampleRate: 100)
         let objcInvalidFormat = "foo"
@@ -252,14 +252,14 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDB3HTTPHeadersWriter(sampleRate: 100)
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "b3": "00000000000000000000000000000001-0000000000000002-1-0000000000000000"
+            "b3": "000000000000000a0000000000000064-00000000000000c8-1-0000000000000000"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -268,7 +268,7 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDB3HTTPHeadersWriter(sampleRate: 0)
@@ -283,7 +283,7 @@ class DDTracerTests: XCTestCase {
     func testInjectingSpanContextToInvalidCarrierOrFormatForB3() throws {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
-        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2))
+        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
         let objcValidWriter = DDB3HTTPHeadersWriter(sampleRate: 100)
         let objcInvalidFormat = "foo"
@@ -302,15 +302,15 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDW3CHTTPHeadersWriter(sampleRate: 100)
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-01",
-            "tracestate": "dd=p:0000000000000002;s:1"
+            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-01",
+            "tracestate": "dd=p:00000000000000c8;s:1"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -319,15 +319,15 @@ class DDTracerTests: XCTestCase {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(
-            swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2)
+            swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
         let objcWriter = DDW3CHTTPHeadersWriter(sampleRate: 0)
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "traceparent": "00-00000000000000000000000000000001-0000000000000002-00",
-            "tracestate": "dd=p:0000000000000002;s:0"
+            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-00",
+            "tracestate": "dd=p:00000000000000c8;s:0"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }
@@ -335,7 +335,7 @@ class DDTracerTests: XCTestCase {
     func testInjectingSpanContextToInvalidCarrierOrFormatForW3C() throws {
         Trace.enable(with: config)
         let objcTracer = DDTracer.shared()
-        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: 1, spanID: 2))
+        let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
         let objcValidWriter = DDW3CHTTPHeadersWriter(sampleRate: 100)
         let objcInvalidFormat = "foo"

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -207,9 +207,10 @@ class DDTracerTests: XCTestCase {
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "x-datadog-trace-id": "a0000000000000064",
+            "x-datadog-trace-id": "64",
             "x-datadog-parent-id": "c8",
             "x-datadog-sampling-priority": "1",
+            "x-datadog-tags": "_dd.p.tid=a"
         ]
         XCTAssertEqual(objcWriter.traceHeaderFields, expectedHTTPHeaders)
     }

--- a/DatadogCore/Tests/Matchers/SpanMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SpanMatcher.swift
@@ -121,6 +121,7 @@ internal class SpanMatcher {
     struct Meta {
         fileprivate let matcher: SpanMatcher
 
+        func tid()                  throws -> String { try matcher.meta(forKeyPath: "meta._dd.p.tid") }
         func source()               throws -> String { try matcher.meta(forKeyPath: "meta._dd.source") }
         func applicationVersion()   throws -> String { try matcher.meta(forKeyPath: "meta.version") }
         func tracerVersion()        throws -> String { try matcher.meta(forKeyPath: "meta.tracer.version") }

--- a/DatadogCore/Tests/Matchers/SpanMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SpanMatcher.swift
@@ -86,7 +86,10 @@ internal class SpanMatcher {
         let idLoStr: String = try attribute(forKeyPath: "trace_id")
         let idLo = UInt64(idLoStr, radix: 16) ?? UInt64(0)
 
-        return .init(idLo: idLo)
+        let idHiStr: String = try meta.tid()
+        let idHi = UInt64(idHiStr, radix: 16) ?? UInt64(0)
+
+        return .init(idHi: idHi, idLo: idLo)
     }
 
     func spanID() throws -> SpanID? {

--- a/DatadogCore/Tests/Matchers/SpanMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SpanMatcher.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /// Implemented by types allowed to represent span attribute `.*` value in JSON.
 protocol AllowedSpanAttributeValue {}
@@ -81,9 +82,26 @@ internal class SpanMatcher {
 
     // MARK: - Attributes matching
 
-    func traceID()          throws -> String { try attribute(forKeyPath: "trace_id") }
-    func spanID()           throws -> String { try attribute(forKeyPath: "span_id") }
-    func parentSpanID()     throws -> String { try attribute(forKeyPath: "parent_id") }
+    func traceID() throws -> TraceID? {
+        let idLoStr: String = try attribute(forKeyPath: "trace_id")
+        let idHiStr = try dd.matcher.meta.tid()
+
+        let idHi = UInt64(idHiStr, radix: 16) ?? UInt64(0)
+        let idLo = UInt64(idLoStr, radix: 16) ?? UInt64(0)
+
+        return .init(idHi: idHi, idLo: idLo)
+    }
+
+    func spanID() throws -> SpanID? {
+        let spanId: String = try attribute(forKeyPath: "span_id")
+        return .init(spanId, representation: .hexadecimal)
+    }
+
+    func parentSpanID() throws -> SpanID? {
+        let spanId: String = try attribute(forKeyPath: "parent_id")
+        return .init(spanId, representation: .hexadecimal)
+    }
+
     func operationName()    throws -> String { try attribute(forKeyPath: "name") }
     func serviceName()      throws -> String { try attribute(forKeyPath: "service") }
     func resource()         throws -> String { try attribute(forKeyPath: "resource") }

--- a/DatadogCore/Tests/Matchers/SpanMatcher.swift
+++ b/DatadogCore/Tests/Matchers/SpanMatcher.swift
@@ -84,12 +84,9 @@ internal class SpanMatcher {
 
     func traceID() throws -> TraceID? {
         let idLoStr: String = try attribute(forKeyPath: "trace_id")
-        let idHiStr = try dd.matcher.meta.tid()
-
-        let idHi = UInt64(idHiStr, radix: 16) ?? UInt64(0)
         let idLo = UInt64(idLoStr, radix: 16) ?? UInt64(0)
 
-        return .init(idHi: idHi, idLo: idLo)
+        return .init(idLo: idLo)
     }
 
     func spanID() throws -> SpanID? {

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
@@ -20,12 +20,12 @@ public class B3HTTPHeadersReader: TracePropagationHeadersReader {
         if let traceIDValue = httpHeaderFields[B3HTTPHeaders.Multiple.traceIDField],
            let spanIDValue = httpHeaderFields[B3HTTPHeaders.Multiple.spanIDField],
            let traceID = TraceID(traceIDValue, representation: .hexadecimal),
-           let spanID = TraceID(spanIDValue, representation: .hexadecimal) {
+           let spanID = SpanID(spanIDValue, representation: .hexadecimal) {
             return (
                 traceID: traceID,
                 spanID: spanID,
                 parentSpanID: httpHeaderFields[B3HTTPHeaders.Multiple.parentSpanIDField]
-                    .flatMap { TraceID($0, representation: .hexadecimal) }
+                    .flatMap { SpanID($0, representation: .hexadecimal) }
             )
         }
 
@@ -35,11 +35,11 @@ public class B3HTTPHeadersReader: TracePropagationHeadersReader {
         if let traceIDValue = b3Value?[safe: 0],
            let spanIDValue = b3Value?[safe: 1],
            let traceID = TraceID(traceIDValue, representation: .hexadecimal),
-           let spanID = TraceID(spanIDValue, representation: .hexadecimal) {
+           let spanID = SpanID(spanIDValue, representation: .hexadecimal) {
             return (
                 traceID: traceID,
                 spanID: spanID,
-                parentSpanID: b3Value?[safe: 3].flatMap({ TraceID($0, representation: .hexadecimal) })
+                parentSpanID: b3Value?[safe: 3].flatMap({ SpanID($0, representation: .hexadecimal) })
             )
         }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -14,13 +14,28 @@ public class HTTPHeadersReader: TracePropagationHeadersReader {
     }
 
     public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
-        guard let traceIDValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
+        guard let traceIDLoValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
               let spanIDValue = httpHeaderFields[TracingHTTPHeaders.parentSpanIDField],
-              let traceID = TraceID(traceIDValue, representation: .hexadecimal),
               let spanID = SpanID(spanIDValue, representation: .hexadecimal)
         else {
             return nil
         }
+
+        // tags are comma separated key=value pairs
+        let tags = httpHeaderFields[TracingHTTPHeaders.tagsField]?.split(separator: ",")
+            .map { $0.split(separator: "=") }
+            .reduce(into: [String: String]()) { result, pair in
+                if pair.count == 2 {
+                    result[String(pair[0])] = String(pair[1])
+                }
+            } ?? [:]
+
+        let traceIDHiValue = tags[TracingHTTPHeaders.TagKeys.traceIDHi] ?? "0"
+
+        let traceID = TraceID(
+            idHi: UInt64(traceIDHiValue, radix: 16) ?? 0,
+            idLo: UInt64(traceIDLoValue, radix: 16) ?? 0
+        )
 
         return (
             traceID: traceID,

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -16,8 +16,8 @@ public class HTTPHeadersReader: TracePropagationHeadersReader {
     public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
         guard let traceIDValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
               let spanIDValue = httpHeaderFields[TracingHTTPHeaders.parentSpanIDField],
-              let traceID = TraceID(traceIDValue),
-              let spanID = TraceID(spanIDValue)
+              let traceID = TraceID(traceIDValue, representation: .hexadecimal),
+              let spanID = SpanID(spanIDValue, representation: .hexadecimal)
         else {
             return nil
         }

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -75,8 +75,9 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
         ]
 
         if samplingPriority {
-            traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceID, representation: .hexadecimal)
+            traceHeaderFields[TracingHTTPHeaders.traceIDField] = traceID.idLoHex
             traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(spanID, representation: .hexadecimal)
+            traceHeaderFields[TracingHTTPHeaders.tagsField] = "_dd.p.tid=\(traceID.idHiHex)"
         }
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -75,8 +75,8 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
         ]
 
         if samplingPriority {
-            traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceID)
-            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(spanID)
+            traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceID, representation: .hexadecimal)
+            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(spanID, representation: .hexadecimal)
         }
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/TracingHTTPHeaders.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/TracingHTTPHeaders.swift
@@ -26,4 +26,13 @@ public enum TracingHTTPHeaders {
     ///
     /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
     public static let originField = "x-datadog-origin"
+
+    /// The Datadog tags of the Trace.
+    public static let tagsField = "x-datadog-tags"
+
+    /// Keys for Datadog tags.
+    public enum TagKeys {
+        /// The Datadog tag key for the higher order 64 bits of the trace ID.
+        public static let traceIDHi = "_dd.p.tid"
+    }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/SpanID.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/SpanID.swift
@@ -1,0 +1,161 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public struct SpanID: RawRepresentable, Equatable, Hashable {
+    public static let invalidId: UInt64 = 0
+    public static let invalid = SpanID()
+
+    /// The `String` representation format of a `SpanID`.
+    public enum Representation {
+        case decimal
+        case hexadecimal
+        case hexadecimal16Chars
+        case hexadecimal32Chars
+    }
+
+    /// The unique integer (64-bit unsigned) ID of the trace containing this span.
+    /// - See also: [Datadog API Reference - Send Traces](https://docs.datadoghq.com/api/?lang=bash#send-traces)
+    public let rawValue: UInt64
+
+    /// Creates a new instance with the specified raw value.
+    ///
+    /// - Parameter rawValue: The raw value to use for the new instance.
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    public init() {
+        self.rawValue = Self.invalidId
+    }
+
+    public func toString(representation: Representation) -> String {
+        String(self, representation: representation)
+    }
+}
+
+extension SpanID {
+    /// Creates a `SpanID` from a `String` representation.
+    ///
+    /// - Parameters:
+    ///   - string: The `String` representation.
+    ///   - representation: The representation, `.decimal` by default.
+    public init?(_ string: String, representation: Representation = .decimal) {
+        switch representation {
+        case .decimal:
+            guard let rawValue = UInt64(string) else {
+                return nil
+            }
+
+            self.init(rawValue: rawValue)
+        case .hexadecimal, .hexadecimal16Chars, .hexadecimal32Chars:
+            guard let rawValue = UInt64(string, radix: 16) else {
+                return nil
+            }
+
+            self.init(rawValue: rawValue)
+        }
+    }
+}
+
+extension SpanID: ExpressibleByIntegerLiteral {
+    /// Creates an instance initialized to the specified integer value.
+    ///
+    /// Do not call this initializer directly. Instead, initialize a variable or
+    /// constant using an integer literal. For example:
+    ///
+    ///     let id: SpanID = 23
+    ///
+    /// In this example, the assignment to the `id` constant calls this integer
+    /// literal initializer behind the scenes.
+    ///
+    /// - Parameter value: The value to create.
+    public init(integerLiteral value: UInt64) {
+        self.init(rawValue: value)
+    }
+}
+
+extension String {
+    /// Creates a `String` representation of a `SpanID`.
+    ///
+    /// - Parameters:
+    ///   - spanID: The Trace ID
+    ///   - representation: The required representation. `.decimal` by default.
+    public init(_ spanID: SpanID, representation: SpanID.Representation = .decimal) {
+        switch representation {
+        case .decimal:
+            self.init(spanID.rawValue)
+        case .hexadecimal:
+            self.init(spanID.rawValue, radix: 16)
+        case .hexadecimal16Chars:
+            self.init(format: "%016llx", spanID.rawValue)
+        case .hexadecimal32Chars:
+            self.init(format: "%032llx", spanID.rawValue)
+        }
+    }
+}
+
+/// A `SpanID` generator interface.
+public protocol SpanIDGenerator {
+    /// Generates a new and unique `SpanID`.
+    ///
+    /// - Returns: The generated `SpanID`
+    func generate() -> SpanID
+}
+
+/// A Default `SpanID` genarator.
+public struct DefaultSpanIDGenerator: SpanIDGenerator {
+    /// Describes the lower and upper boundary of tracing ID generation.
+    ///
+    /// * Lower: starts with `1` as `0` is reserved for historical reason: 0 == "unset", ref: dd-trace-java:DDId.java.
+    /// * Upper: equals to `2 ^ 63 - 1` as some tracers can't handle the `2 ^ 64 -1` range, ref: dd-trace-java:DDId.java.
+    public static let defaultGenerationRange = (1...UInt64.max >> 1)
+
+    /// The generator's range.
+    let range: ClosedRange<UInt64>
+
+    /// Creates a default generator.
+    ///
+    /// - Parameter range: The generator's range.
+    public init(range: ClosedRange<UInt64> = Self.defaultGenerationRange) {
+        self.range = range
+    }
+
+    /// Generates a new and unique `SpanID`.
+    ///
+    /// The Trace ID will be generated within the range.
+    ///
+    /// - Returns: The generated `SpanID`
+    public func generate() -> SpanID {
+        var rawValue: UInt64
+        repeat {
+            rawValue = UInt64.random(in: range)
+        } while rawValue == SpanID.invalidId
+        return SpanID(rawValue: rawValue)
+   }
+}
+
+extension SpanID: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        do {
+            let rawValue = try container.decode(UInt64.self)
+            self.init(rawValue: rawValue)
+        } catch {
+            let rawValue = try container.decode(String.self)
+            guard let spanID = SpanID(rawValue, representation: .decimal) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid SpanID format: \(rawValue)")
+            }
+            self = spanID
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/TraceID.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TraceID.swift
@@ -225,7 +225,7 @@ public struct DefaultTraceIDGenerator: TraceIDGenerator {
         repeat {
             // 32-bit unix seconds + 32 bits of zero in decimal
             let seconds = UInt32(Date().timeIntervalSince1970)
-            idHi = UInt64("\(seconds)00000000") ?? TraceID.invalidId
+            idHi = UInt64(seconds) << 32
             idLo = UInt64.random(in: range)
         } while idHi == TraceID.invalidId && idLo == TraceID.invalidId
         return TraceID(idHi: idHi, idLo: idLo)

--- a/DatadogInternal/Sources/NetworkInstrumentation/TraceID.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TraceID.swift
@@ -6,8 +6,6 @@
 
 import Foundation
 
-public typealias SpanID = TraceID
-
 public struct TraceID: RawRepresentable, Equatable, Hashable {
     /// The `String` representation format of a `TraceID`.
     public enum Representation {
@@ -17,15 +15,86 @@ public struct TraceID: RawRepresentable, Equatable, Hashable {
         case hexadecimal32Chars
     }
 
-    /// The unique integer (64-bit unsigned) ID of the trace containing this span.
-    /// - See also: [Datadog API Reference - Send Traces](https://docs.datadoghq.com/api/?lang=bash#send-traces)
-    public let rawValue: UInt64
+    /// The unique 128-bit identifier for a trace.
+    public var rawValue: (UInt64, UInt64) {
+        get {
+            return (idHi, idLo)
+        }
+    }
+
+    /// Invalid trace ID with all bits set to `0`.
+    public static let invalidId: UInt64 = 0
+
+    /// Invalid trace ID.
+    public static let invalid = TraceID()
+
+    /// The unique integer (64-bit unsigned) ID of the trace
+    /// (high 64 bits of the 128-bit trace ID).
+    public private(set) var idHi: UInt64
+
+    /// The unique integer (64-bit unsigned) ID of the trace
+    /// (low 64 bits of the 128-bit trace ID).
+    public private(set) var idLo: UInt64
+
+    /// The `String` representation of high 64 bits of the trace ID.
+    public var idHiHex: String {
+        return String(format: "%llx", idHi)
+    }
+
+    /// The `String` representation of low 64 bits of the trace ID.
+    public var idLoHex: String {
+        return String(format: "%llx", idLo)
+    }
 
     /// Creates a new instance with the specified raw value.
-    ///
-    /// - Parameter rawValue: The raw value to use for the new instance.
-    public init(rawValue: UInt64) {
-        self.rawValue = rawValue
+    /// - Parameter rawValue: Tuple of two `UInt64` values representing high and
+    /// low 64 bits of the trace ID.
+    public init(rawValue: (UInt64, UInt64)) {
+        self.init(idHi: rawValue.0, idLo: rawValue.1)
+    }
+
+    /// Creates a new instance with the specified low 64 bits of the trace ID.
+    /// - Parameter idLo: The low 64 bits of the trace ID.
+    public init(idLo: UInt64) {
+        self.init(rawValue: (0, idLo))
+    }
+
+    /// Creates a new instance with the specified high and low 64 bits of the trace ID.
+    /// - Parameters:
+    ///   - idHi: High 64 bits of the trace ID.
+    ///   - idLo: Low 64 bits of the trace ID.
+    public init(idHi: UInt64, idLo: UInt64) {
+        self.idHi = idHi
+        self.idLo = idLo
+    }
+
+    /// Creates a new instance with invalid trace ID.
+    public init() {
+        self.idHi = Self.invalidId
+        self.idLo = Self.invalidId
+    }
+
+    /// Returns `String` representation of the trace ID.
+    /// - Parameter representation: The required representation.
+    /// - Returns: The `String` representation of the trace ID.
+    public func toString(representation: Representation) -> String {
+        String(self, representation: representation)
+    }
+}
+
+extension TraceID: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(toString(representation: .hexadecimal))
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        guard let traceID = TraceID(string, representation: .hexadecimal) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid TraceID")
+        }
+        self = traceID
     }
 }
 
@@ -38,17 +107,41 @@ extension TraceID {
     public init?(_ string: String, representation: Representation = .decimal) {
         switch representation {
         case .decimal:
-            guard let rawValue = UInt64(string) else {
+            guard let idLo = UInt64(string) else {
                 return nil
             }
 
-            self.init(rawValue: rawValue)
-        case .hexadecimal, .hexadecimal16Chars, .hexadecimal32Chars:
-            guard let rawValue = UInt64(string, radix: 16) else {
+            self.init(idLo: idLo)
+        case .hexadecimal16Chars:
+            guard let idLo = UInt64(string, radix: 16) else {
                 return nil
             }
 
-            self.init(rawValue: rawValue)
+            self.init(idLo: idLo)
+        case .hexadecimal32Chars:
+            guard let idLo = UInt64(string, radix: 16), let idHi = UInt64(string.prefix(16), radix: 16) else {
+                return nil
+            }
+
+            self.init(rawValue: (idHi, idLo))
+        case .hexadecimal:
+            if string.count > 16 && string.count <= 32 {
+                let strLo = string[string.index(string.endIndex, offsetBy: -16)...]
+                let strHi = string[string.startIndex..<string.index(string.endIndex, offsetBy: -16)]
+                guard let idLo = UInt64(strLo, radix: 16), let idHi = UInt64(strHi, radix: 16) else {
+                    return nil
+                }
+
+                self.init(rawValue: (idHi, idLo))
+            } else if string.count <= 16 {
+                guard let idLo = UInt64(string, radix: 16) else {
+                    return nil
+                }
+
+                self.init(idLo: idLo)
+            } else {
+                return nil
+            }
         }
     }
 }
@@ -66,26 +159,30 @@ extension TraceID: ExpressibleByIntegerLiteral {
     ///
     /// - Parameter value: The value to create.
     public init(integerLiteral value: UInt64) {
-        self.init(rawValue: value)
+        self.init(rawValue: (0, value))
     }
 }
 
 extension String {
     /// Creates a `String` representation of a `TraceID`.
-    ///
+    /// Leading zeros are not included.
     /// - Parameters:
     ///   - traceID: The Trace ID
     ///   - representation: The required representation. `.decimal` by default.
-    public init(_ traceID: TraceID, representation: TraceID.Representation = .decimal) {
+    public init(_ traceID: TraceID, representation: TraceID.Representation) {
         switch representation {
         case .decimal:
-            self.init(traceID.rawValue)
+            self.init(traceID.idLo)
         case .hexadecimal:
-            self.init(traceID.rawValue, radix: 16)
+            if traceID.idHi == TraceID.invalidId {
+                self.init(format: "%llx", traceID.idLo)
+            } else {
+                self.init(format: "%llx%016llx", traceID.idHi, traceID.idLo)
+            }
         case .hexadecimal16Chars:
-            self.init(format: "%016llx", traceID.rawValue)
+            self.init(format: "%016llx", traceID.idLo)
         case .hexadecimal32Chars:
-            self.init(format: "%032llx", traceID.rawValue)
+            self.init(format: "%016llx%016llx", traceID.idHi, traceID.idLo)
         }
     }
 }
@@ -110,7 +207,7 @@ public struct DefaultTraceIDGenerator: TraceIDGenerator {
     let range: ClosedRange<UInt64>
 
     /// Creates a default generator.
-    /// 
+    ///
     /// - Parameter range: The generator's range.
     public init(range: ClosedRange<UInt64> = Self.defaultGenerationRange) {
         self.range = range
@@ -122,6 +219,12 @@ public struct DefaultTraceIDGenerator: TraceIDGenerator {
     ///
     /// - Returns: The generated `TraceID`
     public func generate() -> TraceID {
-        return TraceID(rawValue: .random(in: range))
+        var idHi: UInt64
+        var idLo: UInt64
+        repeat {
+            idHi = UInt64.random(in: range)
+            idLo = UInt64.random(in: range)
+        } while idHi == TraceID.invalidId && idLo == TraceID.invalidId
+        return TraceID(idHi: idHi, idLo: idLo)
    }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
@@ -22,7 +22,7 @@ public class W3CHTTPHeadersReader: TracePropagationHeadersReader {
               let spanIDValue = values?[safe: 2],
               values?[safe: 3] != W3CHTTPHeaders.Constants.unsampledValue,
               let traceID = TraceID(traceIDValue, representation: .hexadecimal),
-              let spanID = TraceID(spanIDValue, representation: .hexadecimal)
+              let spanID = SpanID(spanIDValue, representation: .hexadecimal)
         else {
             return nil
         }

--- a/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersWriterTests.swift
@@ -16,13 +16,13 @@ class B3HTTPHeadersWriterTests: XCTestCase {
         )
 
         writer.write(
-            traceID: 1_234,
+            traceID: .init(idHi: 1_234, idLo: 1_234),
             spanID: 2_345,
             parentSpanID: 5_678
         )
 
         let headers = writer.traceHeaderFields
-        XCTAssertEqual(headers[B3HTTPHeaders.Single.b3Field], "000000000000000000000000000004d2-0000000000000929-1-000000000000162e")
+        XCTAssertEqual(headers[B3HTTPHeaders.Single.b3Field], "00000000000004d200000000000004d2-0000000000000929-1-000000000000162e")
     }
 
     func testItWritesSingleHeaderWithSampling() {
@@ -33,7 +33,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
         )
 
         writer.write(
-            traceID: 1_234,
+            traceID: .init(idHi: 1_234, idLo: 1_234),
             spanID: 2_345,
             parentSpanID: 5_678
         )
@@ -48,10 +48,13 @@ class B3HTTPHeadersWriterTests: XCTestCase {
             sampler: sampler,
             injectEncoding: .single
         )
-        writer.write(traceID: 1_234, spanID: 2_345)
+        writer.write(
+            traceID: .init(idHi: 1_234, idLo: 1_234),
+            spanID: 2_345
+        )
 
         let headers = writer.traceHeaderFields
-        XCTAssertEqual(headers[B3HTTPHeaders.Single.b3Field], "000000000000000000000000000004d2-0000000000000929-1")
+        XCTAssertEqual(headers[B3HTTPHeaders.Single.b3Field], "00000000000004d200000000000004d2-0000000000000929-1")
     }
 
     func testItWritesMultipleHeader() {
@@ -61,13 +64,13 @@ class B3HTTPHeadersWriterTests: XCTestCase {
             injectEncoding: .multiple
         )
         writer.write(
-            traceID: 1_234,
+            traceID: .init(idHi: 1_234, idLo: 1_234),
             spanID: 2_345,
             parentSpanID: 5_678
         )
 
         let headers = writer.traceHeaderFields
-        XCTAssertEqual(headers[B3HTTPHeaders.Multiple.traceIDField], "000000000000000000000000000004d2")
+        XCTAssertEqual(headers[B3HTTPHeaders.Multiple.traceIDField], "00000000000004d200000000000004d2")
         XCTAssertEqual(headers[B3HTTPHeaders.Multiple.spanIDField], "0000000000000929")
         XCTAssertEqual(headers[B3HTTPHeaders.Multiple.sampledField], "1")
         XCTAssertEqual(headers[B3HTTPHeaders.Multiple.parentSpanIDField], "000000000000162e")
@@ -80,7 +83,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
             injectEncoding: .multiple
         )
         writer.write(
-            traceID: 1_234,
+            traceID: .init(idHi: 1_234, idLo: 1_234),
             spanID: 2_345,
             parentSpanID: 5_678
         )
@@ -98,10 +101,13 @@ class B3HTTPHeadersWriterTests: XCTestCase {
             sampler: sampler,
             injectEncoding: .multiple
         )
-        writer.write(traceID: 1_234, spanID: 2_345)
+        writer.write(
+            traceID: .init(idHi: 1_234, idLo: 1_234),
+            spanID: 2_345
+        )
 
         let headers = writer.traceHeaderFields
-        XCTAssertEqual(headers[B3HTTPHeaders.Multiple.traceIDField], "000000000000000000000000000004d2")
+        XCTAssertEqual(headers[B3HTTPHeaders.Multiple.traceIDField], "00000000000004d200000000000004d2")
         XCTAssertEqual(headers[B3HTTPHeaders.Multiple.spanIDField], "0000000000000929")
         XCTAssertEqual(headers[B3HTTPHeaders.Multiple.sampledField], "1")
         XCTAssertNil(headers[B3HTTPHeaders.Multiple.parentSpanIDField])

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -473,10 +473,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = HTTPHeadersWriter(sampler: .mockKeepAll())
         handler.firstPartyHosts = .init(["test.com": [.datadog]])
-        handler.parentSpan = TraceContext(traceID: .mock(1), spanID: .mock(2))
+        handler.parentSpan = TraceContext(traceID: .mock(1, 1), spanID: .mock(2))
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(3))
+        writer.write(traceID: .mock(1, 1), spanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -486,7 +486,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Then
         let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1))
+        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
         XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
         XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
@@ -498,7 +498,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.firstPartyHosts = .init(["test.com": [.b3]])
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(3), parentSpanID: .mock(2))
+        writer.write(traceID: .mock(1, 1), spanID: .mock(3), parentSpanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -508,7 +508,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Then
         let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1))
+        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
         XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
         XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
@@ -520,7 +520,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.firstPartyHosts = .init(["test.com": [.b3multi]])
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(3), parentSpanID: .mock(2))
+        writer.write(traceID: .mock(1, 1), spanID: .mock(3), parentSpanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -530,7 +530,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Then
         let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1))
+        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
         XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
         XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }
@@ -545,10 +545,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             ]
         )
         handler.firstPartyHosts = .init(["test.com": [.tracecontext]])
-        handler.parentSpan = TraceContext(traceID: .mock(1), spanID: .mock(2))
+        handler.parentSpan = TraceContext(traceID: .mock(1, 1), spanID: .mock(2))
 
         // When
-        writer.write(traceID: .mock(1), spanID: .mock(3))
+        writer.write(traceID: .mock(1, 1), spanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
@@ -558,7 +558,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Then
         let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1))
+        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
         XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
         XCTAssertEqual(interception?.trace?.spanID, .mock(3))
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDGeneratorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDGeneratorTests.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogInternal
+
+class SpanIDGeneratorTests: XCTestCase {
+    func testDefaultGenerationBoundaries() {
+        let generator = DefaultSpanIDGenerator()
+        XCTAssertEqual(generator.range.lowerBound, 1)
+        XCTAssertEqual(generator.range.upperBound, 9_223_372_036_854_775_807) // 2 ^ 63 -1
+    }
+
+    func testItGeneratesUUIDsFromGivenBoundaries() {
+        let generator = DefaultSpanIDGenerator(range: 10...15)
+        var generatedUUIDs: Set<SpanID> = []
+
+        (0..<1_000).forEach { _ in
+            generatedUUIDs.insert(generator.generate())
+        }
+
+        XCTAssertEqual(generatedUUIDs, [10, 11, 12, 13, 14, 15])
+    }
+}

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
@@ -93,4 +93,46 @@ class SpanIDTests: XCTestCase {
         let json = try! encoder.encode(spanID)
         XCTAssertEqual(String(data: json, encoding: .utf8), "1234")
     }
+
+    func testToString() {
+        // hexadecimal
+        XCTAssertEqual(SpanID(rawValue: 0).toString(representation: .hexadecimal), "0")
+        XCTAssertEqual(SpanID(rawValue: 1).toString(representation: .hexadecimal), "1")
+        XCTAssertEqual(SpanID(rawValue: 15).toString(representation: .hexadecimal), "f")
+        XCTAssertEqual(SpanID(rawValue: 16).toString(representation: .hexadecimal), "10")
+        XCTAssertEqual(SpanID(rawValue: 123).toString(representation: .hexadecimal), "7b")
+        XCTAssertEqual(SpanID(rawValue: 123_456).toString(representation: .hexadecimal), "1e240")
+        XCTAssertEqual(SpanID(rawValue: .max).toString(representation: .hexadecimal), "ffffffffffffffff")
+
+        // hexadecimal16Chars
+        XCTAssertEqual(SpanID(rawValue: 0).toString(representation: .hexadecimal16Chars), "0000000000000000")
+        XCTAssertEqual(SpanID(rawValue: 1).toString(representation: .hexadecimal16Chars), "0000000000000001")
+        XCTAssertEqual(SpanID(rawValue: 15).toString(representation: .hexadecimal16Chars), "000000000000000f")
+        XCTAssertEqual(SpanID(rawValue: 16).toString(representation: .hexadecimal16Chars), "0000000000000010")
+        XCTAssertEqual(SpanID(rawValue: 123).toString(representation: .hexadecimal16Chars), "000000000000007b")
+        XCTAssertEqual(SpanID(rawValue: 123_456).toString(representation: .hexadecimal16Chars), "000000000001e240")
+        XCTAssertEqual(SpanID(rawValue: .max).toString(representation: .hexadecimal16Chars), "ffffffffffffffff")
+
+        // hexadecimal32Chars
+        XCTAssertEqual(SpanID(rawValue: 0).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000000")
+        XCTAssertEqual(SpanID(rawValue: 1).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000001")
+        XCTAssertEqual(SpanID(rawValue: 15).toString(representation: .hexadecimal32Chars), "0000000000000000000000000000000f")
+        XCTAssertEqual(SpanID(rawValue: 16).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000010")
+        XCTAssertEqual(SpanID(rawValue: 123).toString(representation: .hexadecimal32Chars), "0000000000000000000000000000007b")
+        XCTAssertEqual(SpanID(rawValue: 123_456).toString(representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
+        XCTAssertEqual(SpanID(rawValue: .max).toString(representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+
+        // decimal
+        XCTAssertEqual(SpanID(rawValue: 0).toString(representation: .decimal), "0")
+        XCTAssertEqual(SpanID(rawValue: 1).toString(representation: .decimal), "1")
+        XCTAssertEqual(SpanID(rawValue: 15).toString(representation: .decimal), "15")
+        XCTAssertEqual(SpanID(rawValue: 16).toString(representation: .decimal), "16")
+        XCTAssertEqual(SpanID(rawValue: 123).toString(representation: .decimal), "123")
+        XCTAssertEqual(SpanID(rawValue: 123_456).toString(representation: .decimal), "123456")
+        XCTAssertEqual(SpanID(rawValue: .max).toString(representation: .decimal), "\(UInt64.max)")
+    }
+
+    func testDefaultInit() {
+        XCTAssertEqual(SpanID(), 0)
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
@@ -82,7 +82,7 @@ class SpanIDTests: XCTestCase {
         XCTAssertEqual(spanID, SpanID(rawValue: 1_234))
     }
 
-    func testEncodableFromUnknownFormat() {
+    func testDecodableUnknownFormat() {
         let json = "1f"
         let decoder = JSONDecoder()
         XCTAssertThrowsError(try decoder.decode(SpanID.self, from: json.data(using: .utf8)!) as SpanID)

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
@@ -66,4 +66,31 @@ class SpanIDTests: XCTestCase {
         XCTAssertEqual(String(SpanID("123456")!, representation: .hexadecimal), "1e240")
         XCTAssertEqual(String(SpanID("\(UInt64.max)")!, representation: .hexadecimal), "ffffffffffffffff")
     }
+
+    func testEncodableFromDecimal() {
+        let json = "1234"
+        let decoder = JSONDecoder()
+        let spanID = try! decoder.decode(SpanID.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(spanID, SpanID(rawValue: 1_234))
+    }
+
+    func testEncodableFromString() {
+        let json = "\"1234\""
+        let decoder = JSONDecoder()
+        let spanID = try! decoder.decode(SpanID.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(spanID, SpanID(rawValue: 1_234))
+    }
+
+    func testEncodableFromUnknownFormat() {
+        let json = "1f"
+        let decoder = JSONDecoder()
+        XCTAssertThrowsError(try decoder.decode(SpanID.self, from: json.data(using: .utf8)!) as SpanID)
+    }
+
+    func testDecodable() {
+        let spanID = SpanID(rawValue: 1_234)
+        let encoder = JSONEncoder()
+        let json = try! encoder.encode(spanID)
+        XCTAssertEqual(String(data: json, encoding: .utf8), "1234")
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+
+class SpanIDTests: XCTestCase {
+    func testToHexadecimalStringConversion() {
+        XCTAssertEqual(String(SpanID(rawValue: 0), representation: .hexadecimal), "0")
+        XCTAssertEqual(String(SpanID(rawValue: 1), representation: .hexadecimal), "1")
+        XCTAssertEqual(String(SpanID(rawValue: 15), representation: .hexadecimal), "f")
+        XCTAssertEqual(String(SpanID(rawValue: 16), representation: .hexadecimal), "10")
+        XCTAssertEqual(String(SpanID(rawValue: 123), representation: .hexadecimal), "7b")
+        XCTAssertEqual(String(SpanID(rawValue: 123_456), representation: .hexadecimal), "1e240")
+        XCTAssertEqual(String(SpanID(rawValue: .max), representation: .hexadecimal), "ffffffffffffffff")
+    }
+
+    func testTo16CharHexadecimalStringConversion() {
+        XCTAssertEqual(String(SpanID(rawValue: 0), representation: .hexadecimal16Chars), "0000000000000000")
+        XCTAssertEqual(String(SpanID(rawValue: 1), representation: .hexadecimal16Chars), "0000000000000001")
+        XCTAssertEqual(String(SpanID(rawValue: 15), representation: .hexadecimal16Chars), "000000000000000f")
+        XCTAssertEqual(String(SpanID(rawValue: 16), representation: .hexadecimal16Chars), "0000000000000010")
+        XCTAssertEqual(String(SpanID(rawValue: 123), representation: .hexadecimal16Chars), "000000000000007b")
+        XCTAssertEqual(String(SpanID(rawValue: 123_456), representation: .hexadecimal16Chars), "000000000001e240")
+        XCTAssertEqual(String(SpanID(rawValue: .max), representation: .hexadecimal16Chars), "ffffffffffffffff")
+    }
+
+    func testTo32CharHexadecimalStringConversion() {
+        XCTAssertEqual(String(SpanID(rawValue: 0), representation: .hexadecimal32Chars), "00000000000000000000000000000000")
+        XCTAssertEqual(String(SpanID(rawValue: 1), representation: .hexadecimal32Chars), "00000000000000000000000000000001")
+        XCTAssertEqual(String(SpanID(rawValue: 15), representation: .hexadecimal32Chars), "0000000000000000000000000000000f")
+        XCTAssertEqual(String(SpanID(rawValue: 16), representation: .hexadecimal32Chars), "00000000000000000000000000000010")
+        XCTAssertEqual(String(SpanID(rawValue: 123), representation: .hexadecimal32Chars), "0000000000000000000000000000007b")
+        XCTAssertEqual(String(SpanID(rawValue: 123_456), representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
+        XCTAssertEqual(String(SpanID(rawValue: .max), representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+    }
+    func testToDecimalStringConversion() {
+        XCTAssertEqual(String(SpanID(rawValue: 0)), "0")
+        XCTAssertEqual(String(SpanID(rawValue: 1)), "1")
+        XCTAssertEqual(String(SpanID(rawValue: 15)), "15")
+        XCTAssertEqual(String(SpanID(rawValue: 16)), "16")
+        XCTAssertEqual(String(SpanID(rawValue: 123)), "123")
+        XCTAssertEqual(String(SpanID(rawValue: 123_456)), "123456")
+        XCTAssertEqual(String(SpanID(rawValue: .max)), "\(UInt64.max)")
+    }
+
+    func testInitializationFromHexadecimal() {
+        XCTAssertEqual(SpanID("0", representation: .hexadecimal), 0)
+        XCTAssertEqual(SpanID("1", representation: .hexadecimal), 1)
+        XCTAssertEqual(SpanID("f", representation: .hexadecimal), 15)
+        XCTAssertEqual(SpanID("10", representation: .hexadecimal), 16)
+        XCTAssertEqual(SpanID("7b", representation: .hexadecimal), 123)
+        XCTAssertEqual(SpanID("1e240", representation: .hexadecimal), 123_456)
+        XCTAssertEqual(SpanID("FFFFFFFFFFFFFFFF", representation: .hexadecimal), SpanID(rawValue: .max))
+    }
+
+    func testInitializationFromDecimal() {
+        XCTAssertEqual(String(SpanID("0")!, representation: .hexadecimal), "0")
+        XCTAssertEqual(String(SpanID("1")!, representation: .hexadecimal), "1")
+        XCTAssertEqual(String(SpanID("15")!, representation: .hexadecimal), "f")
+        XCTAssertEqual(String(SpanID("16")!, representation: .hexadecimal), "10")
+        XCTAssertEqual(String(SpanID("123")!, representation: .hexadecimal), "7b")
+        XCTAssertEqual(String(SpanID("123456")!, representation: .hexadecimal), "1e240")
+        XCTAssertEqual(String(SpanID("\(UInt64.max)")!, representation: .hexadecimal), "ffffffffffffffff")
+    }
+}

--- a/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/SpanIDTests.swift
@@ -37,6 +37,7 @@ class SpanIDTests: XCTestCase {
         XCTAssertEqual(String(SpanID(rawValue: 123_456), representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
         XCTAssertEqual(String(SpanID(rawValue: .max), representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
     }
+
     func testToDecimalStringConversion() {
         XCTAssertEqual(String(SpanID(rawValue: 0)), "0")
         XCTAssertEqual(String(SpanID(rawValue: 1)), "1")

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
@@ -26,17 +26,14 @@ class TraceIDGeneratorTests: XCTestCase {
             XCTAssertLessThanOrEqual(id.idLo, 15)
 
             let idHiStr = String(id.idHi, radix: 10)
+            let idHi = UInt64(idHiStr) ?? 0
 
-            // take 8 characters from the right
-            let idHiRight = idHiStr.suffix(8)
-            let zeros = UInt32(idHiRight, radix: 10)
-            XCTAssertEqual(zeros, 0)
-
-            // take 8 characters from right after the first 8
-            let idHiLeft = idHiStr.prefix(idHiStr.count - 8)
-            let seconds = UInt32(idHiLeft, radix: 10)!
+            let seconds = UInt32(idHi >> 32)
             XCTAssertGreaterThanOrEqual(seconds, lowerBound)
             XCTAssertLessThanOrEqual(seconds, upperBound)
+
+            let zeros = UInt32(idHi & 0xFFFFFFFF)
+            XCTAssertEqual(zeros, 0)
         }
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
@@ -7,6 +7,25 @@
 import XCTest
 @testable import DatadogInternal
 
+class SpanIDGeneratorTests: XCTestCase {
+    func testDefaultGenerationBoundaries() {
+        let generator = DefaultSpanIDGenerator()
+        XCTAssertEqual(generator.range.lowerBound, 1)
+        XCTAssertEqual(generator.range.upperBound, 9_223_372_036_854_775_807) // 2 ^ 63 -1
+    }
+
+    func testItGeneratesUUIDsFromGivenBoundaries() {
+        let generator = DefaultSpanIDGenerator(range: 10...15)
+        var generatedUUIDs: Set<SpanID> = []
+
+        (0..<1_000).forEach { _ in
+            generatedUUIDs.insert(generator.generate())
+        }
+
+        XCTAssertEqual(generatedUUIDs, [10, 11, 12, 13, 14, 15])
+    }
+}
+
 class TraceIDGeneratorTests: XCTestCase {
     func testDefaultGenerationBoundaries() {
         let generator = DefaultTraceIDGenerator()
@@ -16,12 +35,13 @@ class TraceIDGeneratorTests: XCTestCase {
 
     func testItGeneratesUUIDsFromGivenBoundaries() {
         let generator = DefaultTraceIDGenerator(range: 10...15)
-        var generatedUUIDs: Set<TraceID> = []
 
         (0..<1_000).forEach { _ in
-            generatedUUIDs.insert(generator.generate())
+            let id = generator.generate()
+            XCTAssertGreaterThanOrEqual(id.idLo, 10)
+            XCTAssertLessThanOrEqual(id.idLo, 15)
+            XCTAssertGreaterThanOrEqual(id.idHi, 10)
+            XCTAssertLessThanOrEqual(id.idHi, 15)
         }
-
-        XCTAssertEqual(generatedUUIDs, [10, 11, 12, 13, 14, 15])
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
@@ -30,18 +30,32 @@ class TraceIDGeneratorTests: XCTestCase {
     func testDefaultGenerationBoundaries() {
         let generator = DefaultTraceIDGenerator()
         XCTAssertEqual(generator.range.lowerBound, 1)
-        XCTAssertEqual(generator.range.upperBound, 9_223_372_036_854_775_807) // 2 ^ 63 -1
+        XCTAssertEqual(generator.range.upperBound, 18_446_744_073_709_551_615)
     }
 
     func testItGeneratesUUIDsFromGivenBoundaries() {
         let generator = DefaultTraceIDGenerator(range: 10...15)
 
+        let lowerBound = UInt32(Date().timeIntervalSince1970)
         (0..<1_000).forEach { _ in
             let id = generator.generate()
+            let upperBound = UInt32(Date().timeIntervalSince1970)
+
             XCTAssertGreaterThanOrEqual(id.idLo, 10)
             XCTAssertLessThanOrEqual(id.idLo, 15)
-            XCTAssertGreaterThanOrEqual(id.idHi, 10)
-            XCTAssertLessThanOrEqual(id.idHi, 15)
+
+            let idHiStr = String(id.idHi, radix: 10)
+
+            // take 8 characters from the right
+            let idHiRight = idHiStr.suffix(8)
+            let zeros = UInt32(idHiRight, radix: 10)
+            XCTAssertEqual(zeros, 0)
+
+            // take 8 characters from right after the first 8
+            let idHiLeft = idHiStr.prefix(idHiStr.count - 8)
+            let seconds = UInt32(idHiLeft, radix: 10)!
+            XCTAssertGreaterThanOrEqual(seconds, lowerBound)
+            XCTAssertLessThanOrEqual(seconds, upperBound)
         }
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDGeneratorTests.swift
@@ -7,25 +7,6 @@
 import XCTest
 @testable import DatadogInternal
 
-class SpanIDGeneratorTests: XCTestCase {
-    func testDefaultGenerationBoundaries() {
-        let generator = DefaultSpanIDGenerator()
-        XCTAssertEqual(generator.range.lowerBound, 1)
-        XCTAssertEqual(generator.range.upperBound, 9_223_372_036_854_775_807) // 2 ^ 63 -1
-    }
-
-    func testItGeneratesUUIDsFromGivenBoundaries() {
-        let generator = DefaultSpanIDGenerator(range: 10...15)
-        var generatedUUIDs: Set<SpanID> = []
-
-        (0..<1_000).forEach { _ in
-            generatedUUIDs.insert(generator.generate())
-        }
-
-        XCTAssertEqual(generatedUUIDs, [10, 11, 12, 13, 14, 15])
-    }
-}
-
 class TraceIDGeneratorTests: XCTestCase {
     func testDefaultGenerationBoundaries() {
         let generator = DefaultTraceIDGenerator()

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
@@ -9,52 +9,82 @@ import DatadogInternal
 
 class TraceIDTests: XCTestCase {
     func testToHexadecimalStringConversion() {
-        XCTAssertEqual(String(TraceID(rawValue: 0), representation: .hexadecimal), "0")
-        XCTAssertEqual(String(TraceID(rawValue: 1), representation: .hexadecimal), "1")
-        XCTAssertEqual(String(TraceID(rawValue: 15), representation: .hexadecimal), "f")
-        XCTAssertEqual(String(TraceID(rawValue: 16), representation: .hexadecimal), "10")
-        XCTAssertEqual(String(TraceID(rawValue: 123), representation: .hexadecimal), "7b")
-        XCTAssertEqual(String(TraceID(rawValue: 123_456), representation: .hexadecimal), "1e240")
-        XCTAssertEqual(String(TraceID(rawValue: .max), representation: .hexadecimal), "ffffffffffffffff")
+        // 64 bit or less
+        XCTAssertEqual(String(TraceID(rawValue: (0, 0)), representation: .hexadecimal), "0")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 1)), representation: .hexadecimal), "1")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 15)), representation: .hexadecimal), "f")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 16)), representation: .hexadecimal), "10")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123)), representation: .hexadecimal), "7b")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123_456)), representation: .hexadecimal), "1e240")
+        XCTAssertEqual(String(TraceID(rawValue: (0, .max)), representation: .hexadecimal), "ffffffffffffffff")
+
+        // 128 bit
+        XCTAssertEqual(String(TraceID(rawValue: (1, 0)), representation: .hexadecimal), "10000000000000000")
+        XCTAssertEqual(String(TraceID(rawValue: (1, 1)), representation: .hexadecimal), "10000000000000001")
+        XCTAssertEqual(String(TraceID(rawValue: (15, 15)), representation: .hexadecimal), "f000000000000000f")
+        XCTAssertEqual(String(TraceID(rawValue: (16, 16)), representation: .hexadecimal), "100000000000000010")
+        XCTAssertEqual(String(TraceID(rawValue: (123, 123)), representation: .hexadecimal), "7b000000000000007b")
+        XCTAssertEqual(String(TraceID(rawValue: (123_456, 123_456)), representation: .hexadecimal), "1e240000000000001e240")
+        XCTAssertEqual(String(TraceID(rawValue: (.max, .max)), representation: .hexadecimal), "ffffffffffffffffffffffffffffffff")
     }
 
     func testTo16CharHexadecimalStringConversion() {
-        XCTAssertEqual(String(TraceID(rawValue: 0), representation: .hexadecimal16Chars), "0000000000000000")
-        XCTAssertEqual(String(TraceID(rawValue: 1), representation: .hexadecimal16Chars), "0000000000000001")
-        XCTAssertEqual(String(TraceID(rawValue: 15), representation: .hexadecimal16Chars), "000000000000000f")
-        XCTAssertEqual(String(TraceID(rawValue: 16), representation: .hexadecimal16Chars), "0000000000000010")
-        XCTAssertEqual(String(TraceID(rawValue: 123), representation: .hexadecimal16Chars), "000000000000007b")
-        XCTAssertEqual(String(TraceID(rawValue: 123_456), representation: .hexadecimal16Chars), "000000000001e240")
-        XCTAssertEqual(String(TraceID(rawValue: .max), representation: .hexadecimal16Chars), "ffffffffffffffff")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 0)), representation: .hexadecimal16Chars), "0000000000000000")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 1)), representation: .hexadecimal16Chars), "0000000000000001")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 15)), representation: .hexadecimal16Chars), "000000000000000f")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 16)), representation: .hexadecimal16Chars), "0000000000000010")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123)), representation: .hexadecimal16Chars), "000000000000007b")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123_456)), representation: .hexadecimal16Chars), "000000000001e240")
+        XCTAssertEqual(String(TraceID(rawValue: (0, .max)), representation: .hexadecimal16Chars), "ffffffffffffffff")
     }
 
     func testTo32CharHexadecimalStringConversion() {
-        XCTAssertEqual(String(TraceID(rawValue: 0), representation: .hexadecimal32Chars), "00000000000000000000000000000000")
-        XCTAssertEqual(String(TraceID(rawValue: 1), representation: .hexadecimal32Chars), "00000000000000000000000000000001")
-        XCTAssertEqual(String(TraceID(rawValue: 15), representation: .hexadecimal32Chars), "0000000000000000000000000000000f")
-        XCTAssertEqual(String(TraceID(rawValue: 16), representation: .hexadecimal32Chars), "00000000000000000000000000000010")
-        XCTAssertEqual(String(TraceID(rawValue: 123), representation: .hexadecimal32Chars), "0000000000000000000000000000007b")
-        XCTAssertEqual(String(TraceID(rawValue: 123_456), representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
-        XCTAssertEqual(String(TraceID(rawValue: .max), representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+        // 64 bit
+        XCTAssertEqual(String(TraceID(rawValue: (0, 0)), representation: .hexadecimal32Chars), "00000000000000000000000000000000")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 1)), representation: .hexadecimal32Chars), "00000000000000000000000000000001")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 15)), representation: .hexadecimal32Chars), "0000000000000000000000000000000f")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 16)), representation: .hexadecimal32Chars), "00000000000000000000000000000010")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123)), representation: .hexadecimal32Chars), "0000000000000000000000000000007b")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123_456)), representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
+        XCTAssertEqual(String(TraceID(rawValue: (0, .max)), representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+
+        // 128 bit
+        XCTAssertEqual(String(TraceID(rawValue: (1, 0)), representation: .hexadecimal32Chars), "00000000000000010000000000000000")
+        XCTAssertEqual(String(TraceID(rawValue: (1, 1)), representation: .hexadecimal32Chars), "00000000000000010000000000000001")
+        XCTAssertEqual(String(TraceID(rawValue: (15, 15)), representation: .hexadecimal32Chars), "000000000000000f000000000000000f")
+        XCTAssertEqual(String(TraceID(rawValue: (16, 16)), representation: .hexadecimal32Chars), "00000000000000100000000000000010")
+        XCTAssertEqual(String(TraceID(rawValue: (123, 123)), representation: .hexadecimal32Chars), "000000000000007b000000000000007b")
+        XCTAssertEqual(String(TraceID(rawValue: (123_456, 123_456)), representation: .hexadecimal32Chars), "000000000001e240000000000001e240")
+        XCTAssertEqual(String(TraceID(rawValue: (.max, .max)), representation: .hexadecimal32Chars), "ffffffffffffffffffffffffffffffff")
     }
     func testToDecimalStringConversion() {
-        XCTAssertEqual(String(TraceID(rawValue: 0)), "0")
-        XCTAssertEqual(String(TraceID(rawValue: 1)), "1")
-        XCTAssertEqual(String(TraceID(rawValue: 15)), "15")
-        XCTAssertEqual(String(TraceID(rawValue: 16)), "16")
-        XCTAssertEqual(String(TraceID(rawValue: 123)), "123")
-        XCTAssertEqual(String(TraceID(rawValue: 123_456)), "123456")
-        XCTAssertEqual(String(TraceID(rawValue: .max)), "\(UInt64.max)")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 0)), representation: .decimal), "0")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 1)), representation: .decimal), "1")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 15)), representation: .decimal), "15")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 16)), representation: .decimal), "16")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123)), representation: .decimal), "123")
+        XCTAssertEqual(String(TraceID(rawValue: (0, 123_456)), representation: .decimal), "123456")
+        XCTAssertEqual(String(TraceID(rawValue: (0, .max)), representation: .decimal), "\(UInt64.max)")
     }
 
     func testInitializationFromHexadecimal() {
+        // 64 bit or less
         XCTAssertEqual(TraceID("0", representation: .hexadecimal), 0)
         XCTAssertEqual(TraceID("1", representation: .hexadecimal), 1)
         XCTAssertEqual(TraceID("f", representation: .hexadecimal), 15)
         XCTAssertEqual(TraceID("10", representation: .hexadecimal), 16)
         XCTAssertEqual(TraceID("7b", representation: .hexadecimal), 123)
         XCTAssertEqual(TraceID("1e240", representation: .hexadecimal), 123_456)
-        XCTAssertEqual(TraceID("FFFFFFFFFFFFFFFF", representation: .hexadecimal), TraceID(rawValue: .max))
+        XCTAssertEqual(TraceID("FFFFFFFFFFFFFFFF", representation: .hexadecimal), TraceID(rawValue: (0, .max)))
+
+        // 128 bit
+        XCTAssertEqual(TraceID("10000000000000000", representation: .hexadecimal), TraceID(rawValue: (1, 0)))
+        XCTAssertEqual(TraceID("10000000000000001", representation: .hexadecimal), TraceID(rawValue: (1, 1)))
+        XCTAssertEqual(TraceID("f000000000000000f", representation: .hexadecimal), TraceID(rawValue: (15, 15)))
+        XCTAssertEqual(TraceID("100000000000000010", representation: .hexadecimal), TraceID(rawValue: (16, 16)))
+        XCTAssertEqual(TraceID("7b000000000000007b", representation: .hexadecimal), TraceID(rawValue: (123, 123)))
+        XCTAssertEqual(TraceID("1e240000000000001e240", representation: .hexadecimal), TraceID(rawValue: (123_456, 123_456)))
+        XCTAssertEqual(TraceID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", representation: .hexadecimal), TraceID(rawValue: (.max, .max)))
     }
 
     func testInitializationFromDecimal() {

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
@@ -57,6 +57,7 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(String(TraceID(rawValue: (123_456, 123_456)), representation: .hexadecimal32Chars), "000000000001e240000000000001e240")
         XCTAssertEqual(String(TraceID(rawValue: (.max, .max)), representation: .hexadecimal32Chars), "ffffffffffffffffffffffffffffffff")
     }
+
     func testToDecimalStringConversion() {
         XCTAssertEqual(String(TraceID(rawValue: (0, 0)), representation: .decimal), "0")
         XCTAssertEqual(String(TraceID(rawValue: (0, 1)), representation: .decimal), "1")
@@ -85,6 +86,13 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(TraceID("7b000000000000007b", representation: .hexadecimal), TraceID(rawValue: (123, 123)))
         XCTAssertEqual(TraceID("1e240000000000001e240", representation: .hexadecimal), TraceID(rawValue: (123_456, 123_456)))
         XCTAssertEqual(TraceID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", representation: .hexadecimal), TraceID(rawValue: (.max, .max)))
+
+        // invalid
+        XCTAssertNil(TraceID("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFG", representation: .hexadecimal))
+        XCTAssertNil(TraceID("-1", representation: .hexadecimal))
+        XCTAssertNil(TraceID("FFFFFFFFFFFFFFFFG", representation: .hexadecimal))
+        XCTAssertNil(TraceID("1FFFFFFFFFFFFFFFF", representation: .hexadecimal16Chars))
+        XCTAssertNil(TraceID("1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", representation: .hexadecimal32Chars))
     }
 
     func testInitializationFromDecimal() {
@@ -95,6 +103,10 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(String(TraceID("123")!, representation: .hexadecimal), "7b")
         XCTAssertEqual(String(TraceID("123456")!, representation: .hexadecimal), "1e240")
         XCTAssertEqual(String(TraceID("\(UInt64.max)")!, representation: .hexadecimal), "ffffffffffffffff")
+
+        // invalid
+        XCTAssertNil(TraceID("-1"))
+        XCTAssertNil(TraceID("\(UInt64.max)0"))
     }
 
     func testDecodableFromHexadecimal() {

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
@@ -130,4 +130,54 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(TraceID(rawValue: (0, 123_456)).idLoHex, "1e240")
         XCTAssertEqual(TraceID(rawValue: (0, .max)).idLoHex, "ffffffffffffffff")
     }
+
+    func testToString() {
+        // hexadecimal
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).toString(representation: .hexadecimal), "0")
+        XCTAssertEqual(TraceID(rawValue: (0, 1)).toString(representation: .hexadecimal), "1")
+        XCTAssertEqual(TraceID(rawValue: (0, 15)).toString(representation: .hexadecimal), "f")
+        XCTAssertEqual(TraceID(rawValue: (0, 16)).toString(representation: .hexadecimal), "10")
+        XCTAssertEqual(TraceID(rawValue: (0, 123)).toString(representation: .hexadecimal), "7b")
+        XCTAssertEqual(TraceID(rawValue: (0, 123_456)).toString(representation: .hexadecimal), "1e240")
+        XCTAssertEqual(TraceID(rawValue: (0, .max)).toString(representation: .hexadecimal), "ffffffffffffffff")
+        XCTAssertEqual(TraceID(rawValue: (1, .max)).toString(representation: .hexadecimal), "1ffffffffffffffff")
+        XCTAssertEqual(TraceID(rawValue: (.max, .max)).toString(representation: .hexadecimal), "ffffffffffffffffffffffffffffffff")
+
+        // hexadecimal16Chars
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).toString(representation: .hexadecimal16Chars), "0000000000000000")
+        XCTAssertEqual(TraceID(rawValue: (0, 1)).toString(representation: .hexadecimal16Chars), "0000000000000001")
+        XCTAssertEqual(TraceID(rawValue: (0, 15)).toString(representation: .hexadecimal16Chars), "000000000000000f")
+        XCTAssertEqual(TraceID(rawValue: (0, 16)).toString(representation: .hexadecimal16Chars), "0000000000000010")
+        XCTAssertEqual(TraceID(rawValue: (0, 123)).toString(representation: .hexadecimal16Chars), "000000000000007b")
+        XCTAssertEqual(TraceID(rawValue: (0, 123_456)).toString(representation: .hexadecimal16Chars), "000000000001e240")
+        XCTAssertEqual(TraceID(rawValue: (0, .max)).toString(representation: .hexadecimal16Chars), "ffffffffffffffff")
+        XCTAssertEqual(TraceID(rawValue: (1, .max)).toString(representation: .hexadecimal16Chars), "ffffffffffffffff")
+        XCTAssertEqual(TraceID(rawValue: (.max, .max)).toString(representation: .hexadecimal16Chars), "ffffffffffffffff")
+
+        // hexadecimal32Chars
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000000")
+        XCTAssertEqual(TraceID(rawValue: (0, 1)).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000001")
+        XCTAssertEqual(TraceID(rawValue: (0, 15)).toString(representation: .hexadecimal32Chars), "0000000000000000000000000000000f")
+        XCTAssertEqual(TraceID(rawValue: (0, 16)).toString(representation: .hexadecimal32Chars), "00000000000000000000000000000010")
+        XCTAssertEqual(TraceID(rawValue: (0, 123)).toString(representation: .hexadecimal32Chars), "0000000000000000000000000000007b")
+        XCTAssertEqual(TraceID(rawValue: (0, 123_456)).toString(representation: .hexadecimal32Chars), "0000000000000000000000000001e240")
+        XCTAssertEqual(TraceID(rawValue: (0, .max)).toString(representation: .hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+        XCTAssertEqual(TraceID(rawValue: (1, .max)).toString(representation: .hexadecimal32Chars), "0000000000000001ffffffffffffffff")
+
+        // decimal
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).toString(representation: .decimal), "0")
+        XCTAssertEqual(TraceID(rawValue: (0, 1)).toString(representation: .decimal), "1")
+        XCTAssertEqual(TraceID(rawValue: (0, 15)).toString(representation: .decimal), "15")
+        XCTAssertEqual(TraceID(rawValue: (0, 16)).toString(representation: .decimal), "16")
+        XCTAssertEqual(TraceID(rawValue: (0, 123)).toString(representation: .decimal), "123")
+        XCTAssertEqual(TraceID(rawValue: (0, 123_456)).toString(representation: .decimal), "123456")
+        XCTAssertEqual(TraceID(rawValue: (0, .max)).toString(representation: .decimal), "\(UInt64.max)")
+        XCTAssertEqual(TraceID(rawValue: (1, .max)).toString(representation: .decimal), "\(UInt64.max)")
+        XCTAssertEqual(TraceID(rawValue: (.max, .max)).toString(representation: .decimal), "\(UInt64.max)")
+    }
+
+    func testDefaultInit() {
+        XCTAssertEqual(TraceID().rawValue.0, 0)
+        XCTAssertEqual(TraceID().rawValue.1, 0)
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
@@ -104,6 +104,12 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(traceID, TraceID(rawValue: (0, 123_456)))
     }
 
+    func testDecodableUnknownFormat() {
+        let json = "1234"
+        let decoder = JSONDecoder()
+        XCTAssertThrowsError(try decoder.decode(TraceID.self, from: json.data(using: .utf8)!) as TraceID)
+    }
+
     func testEncodableToHexadecimal() {
         let traceID = TraceID(rawValue: (0, 123_456))
         let encoder = JSONEncoder()

--- a/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/TraceIDTests.swift
@@ -96,4 +96,38 @@ class TraceIDTests: XCTestCase {
         XCTAssertEqual(String(TraceID("123456")!, representation: .hexadecimal), "1e240")
         XCTAssertEqual(String(TraceID("\(UInt64.max)")!, representation: .hexadecimal), "ffffffffffffffff")
     }
+
+    func testDecodableFromHexadecimal() {
+        let json = "\"1e240\""
+        let decoder = JSONDecoder()
+        let traceID = try! decoder.decode(TraceID.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(traceID, TraceID(rawValue: (0, 123_456)))
+    }
+
+    func testEncodableToHexadecimal() {
+        let traceID = TraceID(rawValue: (0, 123_456))
+        let encoder = JSONEncoder()
+        let json = try! encoder.encode(traceID)
+        XCTAssertEqual(String(data: json, encoding: .utf8), "\"1e240\"")
+    }
+
+    func testIdHiHex() {
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).idHiHex, "0")
+        XCTAssertEqual(TraceID(rawValue: (1, 0)).idHiHex, "1")
+        XCTAssertEqual(TraceID(rawValue: (15, 0)).idHiHex, "f")
+        XCTAssertEqual(TraceID(rawValue: (16, 0)).idHiHex, "10")
+        XCTAssertEqual(TraceID(rawValue: (123, 0)).idHiHex, "7b")
+        XCTAssertEqual(TraceID(rawValue: (123_456, 0)).idHiHex, "1e240")
+        XCTAssertEqual(TraceID(rawValue: (.max, 0)).idHiHex, "ffffffffffffffff")
+    }
+
+    func testIdLoHex() {
+        XCTAssertEqual(TraceID(rawValue: (0, 0)).idLoHex, "0")
+        XCTAssertEqual(TraceID(rawValue: (0, 1)).idLoHex, "1")
+        XCTAssertEqual(TraceID(rawValue: (0, 15)).idLoHex, "f")
+        XCTAssertEqual(TraceID(rawValue: (0, 16)).idLoHex, "10")
+        XCTAssertEqual(TraceID(rawValue: (0, 123)).idLoHex, "7b")
+        XCTAssertEqual(TraceID(rawValue: (0, 123_456)).idLoHex, "1e240")
+        XCTAssertEqual(TraceID(rawValue: (0, .max)).idLoHex, "ffffffffffffffff")
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
@@ -12,8 +12,8 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
         let w3cHTTPHeadersReader = W3CHTTPHeadersReader(httpHeaderFields: ["traceparent": "00-4d2-929-01"])
         let ids = w3cHTTPHeadersReader.read()
 
-        XCTAssertEqual(ids?.traceID, TraceID(rawValue: 1_234))
-        XCTAssertEqual(ids?.spanID, TraceID(rawValue: 2_345))
+        XCTAssertEqual(ids?.traceID, TraceID(idLo: 1_234))
+        XCTAssertEqual(ids?.spanID, SpanID(2_345))
         XCTAssertNil(ids?.parentSpanID)
     }
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -16,10 +16,10 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
         )
-        w3cHTTPHeadersWriter.write(traceID: 1_234, spanID: 2_345)
+        w3cHTTPHeadersWriter.write(traceID: .init(idHi: 1_234, idLo: 1_234), spanID: 2_345)
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
-        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-01")
+        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
     }
 
@@ -31,10 +31,10 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
         )
-        w3cHTTPHeadersWriter.write(traceID: 1_234, spanID: 2_345, parentSpanID: 5_678)
+        w3cHTTPHeadersWriter.write(traceID: .init(idHi: 1_234, idLo: 1_234), spanID: 2_345, parentSpanID: 5_678)
 
         let headers = w3cHTTPHeadersWriter.traceHeaderFields
-        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-000000000000000000000000000004d2-0000000000000929-00")
+        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-00")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
     }
 }

--- a/DatadogLogs/Sources/Feature/Baggages.swift
+++ b/DatadogLogs/Sources/Feature/Baggages.swift
@@ -58,8 +58,8 @@ internal struct SpanContext: Decodable {
         case spanID = "dd.span_id"
     }
 
-    let traceID: String?
-    let spanID: String?
+    let traceID: TraceID?
+    let spanID: SpanID?
 }
 
 /// The RUM context received from `DatadogCore`.

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -139,11 +139,11 @@ internal final class RemoteLogger: LoggerProtocol {
             }
 
             // When bundle with Trace is enabled, link RUM context (if available):
-            if self.activeSpanIntegration, let span = context.baggages[SpanContext.key] {
+            if self.activeSpanIntegration, let spanContext = context.baggages[SpanContext.key] {
                 do {
-                    let trace = try span.decode(type: SpanContext.self)
-                    internalAttributes[LogEvent.Attributes.Trace.traceID] = trace.traceID
-                    internalAttributes[LogEvent.Attributes.Trace.spanID] = trace.spanID
+                    let trace = try spanContext.decode(type: SpanContext.self)
+                    internalAttributes[LogEvent.Attributes.Trace.traceID] = trace.traceID?.toString(representation: .hexadecimal)
+                    internalAttributes[LogEvent.Attributes.Trace.spanID] = trace.spanID?.toString(representation: .decimal)
                 } catch {
                     self.core.telemetry
                         .error("Fails to decode Span context from Logs", error: error)

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -365,14 +365,14 @@ class RemoteLoggerTests: XCTestCase {
             activeSpanIntegration: true
         )
 
-        let traceID: String = .mockRandom()
-        let spanID: String = .mockRandom()
+        let traceID: TraceID = .mock(.mockRandom(), .mockRandom())
+        let spanID: SpanID = .mock(.mockRandom())
 
         // When
         core.set(
             baggage: [
-                "dd.trace_id": traceID,
-                "dd.span_id": spanID
+                "dd.trace_id": traceID.toString(representation: .hexadecimal),
+                "dd.span_id": spanID.toString(representation: .decimal)
             ],
             forKey: "span_context"
         )
@@ -386,8 +386,8 @@ class RemoteLoggerTests: XCTestCase {
         XCTAssertEqual(logs.count, 1)
 
         let log = try XCTUnwrap(logs.first)
-        XCTAssertEqual(log.attributes.internalAttributes?["dd.trace_id"] as? String, traceID)
-        XCTAssertEqual(log.attributes.internalAttributes?["dd.span_id"] as? String, spanID)
+        XCTAssertEqual(log.attributes.internalAttributes?["dd.trace_id"] as? String, traceID.toString(representation: .hexadecimal))
+        XCTAssertEqual(log.attributes.internalAttributes?["dd.span_id"] as? String, spanID.toString(representation: .decimal))
     }
 
     func testWhenActiveSpanIntegrationIsEnabled_withNoActiveSpan_itDoesNotSendTelemetryError() throws {

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -12,16 +12,19 @@ internal struct DistributedTracing {
     let sampler: Sampler
     /// The distributed tracing ID generator.
     let traceIDGenerator: TraceIDGenerator
+    let spanIDGenerator: SpanIDGenerator
     /// First party hosts defined by the user.
     let firstPartyHosts: FirstPartyHosts
 
     init(
         sampler: Sampler,
         firstPartyHosts: FirstPartyHosts,
-        traceIDGenerator: TraceIDGenerator
+        traceIDGenerator: TraceIDGenerator,
+        spanIDGenerator: SpanIDGenerator
     ) {
         self.sampler = sampler
         self.traceIDGenerator = traceIDGenerator
+        self.spanIDGenerator = spanIDGenerator
         self.firstPartyHosts = firstPartyHosts
     }
 }
@@ -147,7 +150,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 extension DistributedTracing {
     func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> URLRequest {
         let traceID = traceIDGenerator.generate()
-        let spanID = traceIDGenerator.generate()
+        let spanID = spanIDGenerator.generate()
 
         var request = request
         headerTypes.forEach {
@@ -195,11 +198,11 @@ extension DistributedTracing {
 
     func trace(from interception: DatadogInternal.URLSessionTaskInterception) -> RUMSpanContext? {
         return interception.trace.map {
-           .init(
-               traceID: String($0.traceID),
-               spanID: String($0.spanID),
-               samplingRate: Double(sampler.samplingRate) / 100.0
-           )
+            .init(
+                traceID: $0.traceID,
+                spanID: $0.spanID,
+                samplingRate: Double(sampler.samplingRate) / 100.0
+            )
         }
     }
 }

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -53,13 +53,15 @@ extension InternalExtension where ExtendedType == RUM {
             distributedTracing = DistributedTracing(
                 sampler: Sampler(samplingRate: rumConfiguration.debugSDK ? 100 : sampleRate),
                 firstPartyHosts: FirstPartyHosts(hosts),
-                traceIDGenerator: rumConfiguration.traceIDGenerator
+                traceIDGenerator: rumConfiguration.traceIDGenerator,
+                spanIDGenerator: rumConfiguration.spanIDGenerator
             )
         case let .traceWithHeaders(hostsWithHeaders, sampleRate):
             distributedTracing = DistributedTracing(
                 sampler: Sampler(samplingRate: rumConfiguration.debugSDK ? 100 : sampleRate),
                 firstPartyHosts: FirstPartyHosts(hostsWithHeaders),
-                traceIDGenerator: rumConfiguration.traceIDGenerator
+                traceIDGenerator: rumConfiguration.traceIDGenerator,
+                spanIDGenerator: rumConfiguration.spanIDGenerator
             )
         case .none:
             distributedTracing = nil

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -270,6 +270,7 @@ extension RUM {
         internal var uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
 
         internal var traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator()
+        internal var spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator()
 
         internal var dateProvider: DateProvider = SystemDateProvider()
         /// The main queue, subject to App Hangs monitoring.

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -253,9 +253,9 @@ internal protocol RUMResourceCommand: RUMCommand {
 /// in order to create the APM span. The actual `Span` is not send by the SDK.
 internal struct RUMSpanContext {
     /// The trace ID injected to `URLRequest` that issues RUM resource.
-    let traceID: String
+    let traceID: TraceID
     /// The span ID injected to `URLRequest` that issues RUM resource.
-    let spanID: String
+    let spanID: SpanID
     /// The sampling rate applied to the trace (a value between `0.0` and `1.0`).
     let samplingRate: Double
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -117,8 +117,20 @@ internal class RUMResourceScope: RUMScope {
         let size: Int64?
 
         // Check trace attributes
-        let traceId = (attributes.removeValue(forKey: CrossPlatformAttributes.traceID) as? String) ?? spanContext?.traceID
-        let spanId = (attributes.removeValue(forKey: CrossPlatformAttributes.spanID) as? String) ?? spanContext?.spanID
+        var traceId: TraceID? = nil
+        if let tid = attributes.removeValue(forKey: CrossPlatformAttributes.traceID) as? String {
+            traceId = .init(tid, representation: .hexadecimal)
+        } else {
+            traceId = spanContext?.traceID
+        }
+
+        var spanId: SpanID? = nil
+        if let sid = attributes.removeValue(forKey: CrossPlatformAttributes.spanID) as? String {
+            spanId = .init(sid, representation: .decimal)
+        } else {
+            spanId = spanContext?.spanID
+        }
+
         let traceSamplingRate = (attributes.removeValue(forKey: CrossPlatformAttributes.rulePSR) as? Double) ?? spanContext?.samplingRate
 
         // Check GraphQL attributes
@@ -162,8 +174,8 @@ internal class RUMResourceScope: RUMScope {
                     plan: .plan1,
                     sessionPrecondition: self.context.sessionPrecondition
                 ),
-                spanId: spanId,
-                traceId: traceId
+                spanId: spanId?.toString(representation: .decimal),
+                traceId: traceId?.toString(representation: .hexadecimal)
             ),
             action: self.context.activeUserActionID.map { rumUUID in
                 .init(id: .string(value: rumUUID.toRUMDataFormat))

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -46,7 +46,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField), "rum")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
@@ -483,10 +484,11 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
                 "X-B3-Sampled": "1",
                 "X-B3-TraceId": "000000000000000a0000000000000064",
                 "b3": "000000000000000a0000000000000064-0000000000000064-1",
-                "x-datadog-trace-id": "a0000000000000064",
+                "x-datadog-trace-id": "64",
                 "x-datadog-parent-id": "64",
                 "x-datadog-sampling-priority": "1",
-                "x-datadog-origin": "rum"
+                "x-datadog-origin": "rum",
+                "x-datadog-tags": "_dd.p.tid=a"
             ]
         )
     }

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -34,7 +34,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -45,8 +46,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField), "rum")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
 
@@ -56,7 +57,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -67,7 +69,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000001-1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000064-1")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectB3MultiTraceHeaders() throws {
@@ -76,7 +78,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -87,8 +90,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "00000000000000000000000000000001")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000001")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000064")
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
     }
@@ -99,7 +102,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -110,7 +114,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000001-01")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-01")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectDDTraceHeaders() throws {
@@ -119,7 +123,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockRejectAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -141,7 +146,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockRejectAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -161,7 +167,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockRejectAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -184,7 +191,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockRejectAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -195,7 +203,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000001-00")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-00")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itDoesNotOverwriteTraceHeaders() throws {
@@ -204,7 +212,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
 
@@ -277,14 +286,15 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: Sampler(samplingRate: Float(traceSamplingRate)),
                 firstPartyHosts: .init(),
-                traceIDGenerator: DefaultTraceIDGenerator()
+                traceIDGenerator: DefaultTraceIDGenerator(),
+                spanIDGenerator: DefaultSpanIDGenerator()
             )
         )
 
         let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random())
         taskInterception.register(trace: TraceContext(
-            traceID: 1,
-            spanID: 2,
+            traceID: 100,
+            spanID: 200,
             parentSpanID: nil
         ))
         XCTAssertNotNil(taskInterception.trace)
@@ -297,8 +307,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         let resourceStartCommand = try XCTUnwrap(commandSubscriber.lastReceivedCommand as? RUMStartResourceCommand)
         let spanContext = try XCTUnwrap(resourceStartCommand.spanContext)
-        XCTAssertEqual(spanContext.traceID, "1")
-        XCTAssertEqual(spanContext.spanID, "2")
+        XCTAssertEqual(spanContext.traceID, .init(idLo: 100))
+        XCTAssertEqual(spanContext.spanID, .init(rawValue: 200))
         XCTAssertEqual(spanContext.samplingRate, traceSamplingRate / 100, accuracy: 0.01)
     }
 
@@ -457,7 +467,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             distributedTracing: .init(
                 sampler: .mockKeepAll(),
                 firstPartyHosts: .init(),
-                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 0)
+                traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+                spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 0)
             )
         )
         let request: URLRequest = .mockWith(httpMethod: "GET")
@@ -466,14 +477,14 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
             [
-                "tracestate": "dd=o:rum;p:0000000000000001;s:1",
-                "traceparent": "00-00000000000000000000000000000001-0000000000000001-01",
-                "X-B3-SpanId": "0000000000000001",
+                "tracestate": "dd=o:rum;p:0000000000000064;s:1",
+                "traceparent": "00-000000000000000a0000000000000064-0000000000000064-01",
+                "X-B3-SpanId": "0000000000000064",
                 "X-B3-Sampled": "1",
-                "X-B3-TraceId": "00000000000000000000000000000001",
-                "b3": "00000000000000000000000000000001-0000000000000001-1",
-                "x-datadog-trace-id": "1",
-                "x-datadog-parent-id": "1",
+                "X-B3-TraceId": "000000000000000a0000000000000064",
+                "b3": "000000000000000a0000000000000064-0000000000000064-1",
+                "x-datadog-trace-id": "a0000000000000064",
+                "x-datadog-parent-id": "64",
                 "x-datadog-sampling-priority": "1",
                 "x-datadog-origin": "rum"
             ]

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -377,15 +377,15 @@ extension RUMSpanContext: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> RUMSpanContext {
         return RUMSpanContext(
-            traceID: .mockRandom(),
-            spanID: .mockRandom(),
+            traceID: .mock(.mockRandom(), .mockRandom()),
+            spanID: .mock(.mockRandom()),
             samplingRate: .mockRandom()
         )
     }
 
     static func mockWith(
-        traceID: String = .mockAny(),
-        spanID: String = .mockAny(),
+        traceID: TraceID = .mockAny(),
+        spanID: SpanID = .mockAny(),
         samplingRate: Double = .mockAny()
     ) -> RUMSpanContext {
         return RUMSpanContext(
@@ -408,7 +408,11 @@ extension RUMStartResourceCommand: AnyMockable, RandomMockable {
             httpMethod: .mockRandom(),
             kind: .mockAny(),
             isFirstPartyRequest: .mockRandom(),
-            spanContext: .init(traceID: .mockRandom(), spanID: .mockRandom(), samplingRate: .mockAny())
+            spanContext: .init(
+                traceID: .mock(.mockRandom(), .mockRandom()),
+                spanID: .mock(.mockRandom()),
+                samplingRate: .mockAny()
+            )
         )
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -68,7 +68,11 @@ class RUMResourceScopeTests: XCTestCase {
             url: "https://foo.com/resource/1",
             httpMethod: .post,
             resourceKindBasedOnRequest: nil,
-            spanContext: .init(traceID: "100", spanID: "200", samplingRate: 0.42)
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                samplingRate: 0.42
+            )
         )
 
         currentTime.addTimeInterval(2)
@@ -116,7 +120,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.download)
         XCTAssertEqual(try XCTUnwrap(event.action?.id.stringValue), rumContext.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.dd.traceId, "100")
+        XCTAssertEqual(event.dd.traceId, "64")
         XCTAssertEqual(event.dd.spanId, "200")
         XCTAssertEqual(event.dd.rulePsr, 0.42)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
@@ -145,7 +149,11 @@ class RUMResourceScopeTests: XCTestCase {
             url: "https://foo.com/resource/1",
             httpMethod: .post,
             resourceKindBasedOnRequest: nil,
-            spanContext: .init(traceID: "100", spanID: "200", samplingRate: 0.42)
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                samplingRate: 0.42
+            )
         )
 
         currentTime.addTimeInterval(2)
@@ -193,7 +201,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.download)
         XCTAssertEqual(try XCTUnwrap(event.action?.id.stringValue), rumContext.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.dd.traceId, "100")
+        XCTAssertEqual(event.dd.traceId, "64")
         XCTAssertEqual(event.dd.spanId, "200")
         XCTAssertEqual(event.dd.rulePsr, 0.42)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
@@ -224,7 +232,11 @@ class RUMResourceScopeTests: XCTestCase {
             url: "https://foo.com/resource/1",
             httpMethod: .post,
             resourceKindBasedOnRequest: nil,
-            spanContext: .init(traceID: "100", spanID: "200", samplingRate: 0.42)
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                samplingRate: 0.42
+            )
         )
 
         currentTime.addTimeInterval(2)
@@ -272,7 +284,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.download)
         XCTAssertEqual(try XCTUnwrap(event.action?.id.stringValue), rumContext.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.dd.traceId, "100")
+        XCTAssertEqual(event.dd.traceId, "64")
         XCTAssertEqual(event.dd.spanId, "200")
         XCTAssertEqual(event.dd.rulePsr, 0.42)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
@@ -292,7 +304,11 @@ class RUMResourceScopeTests: XCTestCase {
             context: rumContext,
             dependencies: dependencies,
             resourceKey: "/resource/1",
-            spanContext: .init(traceID: "100", spanID: "200", samplingRate: 0.42)
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                samplingRate: 0.42
+            )
         )
 
         // When
@@ -306,7 +322,7 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Then
         let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
-        XCTAssertEqual(event.dd.traceId, "100")
+        XCTAssertEqual(event.dd.traceId, "64")
         XCTAssertEqual(event.dd.spanId, "200")
         XCTAssertEqual(event.dd.rulePsr, 0.42)
     }

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -30,7 +30,8 @@ internal final class TraceFeature: DatadogRemoteFeature {
             core: core,
             sampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sampleRate),
             tags: configuration.tags ?? [:],
-            tracingUUIDGenerator: configuration.traceIDGenerator,
+            traceIDGenerator: configuration.traceIDGenerator,
+            spanIDGenerator: configuration.spanIDGenerator,
             dateProvider: configuration.dateProvider,
             loggingIntegration: TracingWithLoggingIntegration(
                 core: core,

--- a/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
+++ b/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
@@ -99,8 +99,8 @@ internal struct TracingWithLoggingIntegration {
                     networkInfoEnabled: networkInfoEnabled,
                     userAttributes: AnyEncodable(userAttributes),
                     internalAttributes: SpanCoreContext(
-                        traceID: String(spanContext.traceID),
-                        spanID: String(spanContext.spanID)
+                        traceID: String(spanContext.traceID, representation: .hexadecimal),
+                        spanID: String(spanContext.spanID, representation: .hexadecimal)
                     )
                 )
             ),

--- a/DatadogTrace/Sources/Span/SpanEventEncoder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventEncoder.swift
@@ -126,6 +126,8 @@ internal struct SpanEventEncoder {
 
         case origin = "meta._dd.origin"
 
+        case ptid = "meta._dd.p.tid"
+
         case userId = "meta.usr.id"
         case userName = "meta.usr.name"
         case userEmail = "meta.usr.email"
@@ -233,6 +235,8 @@ internal struct SpanEventEncoder {
             try container.encode(carrierInfo.radioAccessTechnology, forKey: .mobileNetworkCarrierRadioTechnology)
             try container.encode(carrierInfo.carrierAllowsVOIP ? "1" : "0", forKey: .mobileNetworkCarrierAllowsVoIP)
         }
+
+        try container.encode(span.traceID.idHiHex, forKey: .ptid)
     }
 
     /// Encodes `meta.*` attributes coming from user
@@ -247,8 +251,5 @@ internal struct SpanEventEncoder {
             let metaKey = "meta.\($0.key)"
             try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
         }
-
-        let metaDdPTid = "meta._dd.p.tid"
-        try container.encode(span.traceID.idHiHex, forKey: DynamicCodingKey(metaDdPTid))
     }
 }

--- a/DatadogTrace/Sources/Span/SpanEventEncoder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventEncoder.swift
@@ -154,10 +154,10 @@ internal struct SpanEventEncoder {
 
     func encode(_ span: SpanEvent, to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StaticCodingKeys.self)
-        try container.encode(String(span.traceID, representation: .hexadecimal), forKey: .traceID)
+        try container.encode(span.traceID.idLoHex, forKey: .traceID)
         try container.encode(String(span.spanID, representation: .hexadecimal), forKey: .spanID)
 
-        let parentSpanID = span.parentID ?? TraceID(rawValue: 0) // 0 is a reserved ID for a root span (ref: DDTracer.java#L600)
+        let parentSpanID = span.parentID ?? SpanID.invalid // 0 is a reserved ID for a root span (ref: DDTracer.java#L600)
         try container.encode(String(parentSpanID, representation: .hexadecimal), forKey: .parentID)
 
         try container.encode(span.operationName, forKey: .operationName)
@@ -247,5 +247,8 @@ internal struct SpanEventEncoder {
             let metaKey = "meta.\($0.key)"
             try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
         }
+
+        let metaDdPTid = "meta._dd.p.tid"
+        try container.encode(span.traceID.idHiHex, forKey: DynamicCodingKey(metaDdPTid))
     }
 }

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -123,6 +123,7 @@ extension Trace {
         // MARK: - Internal
 
         internal var traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator()
+        internal var spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator()
         internal var dateProvider: DateProvider = SystemDateProvider()
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
 

--- a/DatadogTrace/Tests/Span/SpanEventBuilderTests.swift
+++ b/DatadogTrace/Tests/Span/SpanEventBuilderTests.swift
@@ -17,8 +17,8 @@ class SpanEventBuilderTests: XCTestCase {
 
         let span = builder.createSpanEvent(
             context: context,
-            traceID: 1,
-            spanID: 2,
+            traceID: .init(idHi: 10, idLo: 100),
+            spanID: 200,
             parentSpanID: 1,
             operationName: "operation-name",
             startTime: .mockDecember15th2019At10AMUTC(),
@@ -33,8 +33,8 @@ class SpanEventBuilderTests: XCTestCase {
             logFields: []
         )
 
-        XCTAssertEqual(span.traceID, 1)
-        XCTAssertEqual(span.spanID, 2)
+        XCTAssertEqual(span.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(span.spanID, .init(rawValue: 200))
         XCTAssertEqual(span.parentID, 1)
         XCTAssertEqual(span.operationName, "operation-name")
         XCTAssertEqual(span.serviceName, "test-service-name")

--- a/DatadogTrace/Tests/TracingFeatureMocks.swift
+++ b/DatadogTrace/Tests/TracingFeatureMocks.swift
@@ -19,8 +19,8 @@ extension DDSpanContext {
 
     static func mockWith(
         traceID: TraceID = .mockAny(),
-        spanID: TraceID = .mockAny(),
-        parentSpanID: TraceID? = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentSpanID: SpanID? = .mockAny(),
         baggageItems: BaggageItems = .mockAny()
     ) -> DDSpanContext {
         return DDSpanContext(
@@ -91,8 +91,8 @@ extension DDSpan {
 extension SpanEvent: AnyMockable, RandomMockable {
     static func mockWith(
         traceID: TraceID = .mockAny(),
-        spanID: TraceID = .mockAny(),
-        parentID: TraceID? = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentID: SpanID? = .mockAny(),
         operationName: String = .mockAny(),
         serviceName: String = .mockAny(),
         resource: String = .mockAny(),
@@ -137,9 +137,9 @@ extension SpanEvent: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> SpanEvent {
         return SpanEvent(
-            traceID: .init(rawValue: .mockRandom()),
-            spanID: .init(rawValue: .mockRandom()),
-            parentID: .init(rawValue: .mockRandom()),
+            traceID: .mock(.mockRandom(), .mockRandom()),
+            spanID: .mock(.mockRandom()),
+            parentID: .mock(.mockRandom()),
             operationName: .mockRandom(),
             serviceName: .mockRandom(),
             resource: .mockRandom(),
@@ -198,7 +198,8 @@ extension DatadogTracer {
         core: DatadogCoreProtocol,
         sampler: Sampler = .mockKeepAll(),
         tags: [String: Encodable] = [:],
-        tracingUUIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator(),
+        traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator(),
+        spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator(),
         dateProvider: DateProvider = SystemDateProvider(),
         spanEventBuilder: SpanEventBuilder = .mockAny(),
         loggingIntegration: TracingWithLoggingIntegration = .mockAny()
@@ -207,7 +208,8 @@ extension DatadogTracer {
             core: core,
             sampler: sampler,
             tags: tags,
-            tracingUUIDGenerator: tracingUUIDGenerator,
+            traceIDGenerator: traceIDGenerator,
+            spanIDGenerator: spanIDGenerator,
             dateProvider: dateProvider,
             loggingIntegration: loggingIntegration,
             spanEventBuilder: spanEventBuilder

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -63,7 +63,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
@@ -172,7 +173,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         span.finish()
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "65")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -24,7 +24,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         tracer = .mockWith(
             core: core,
-            tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1, advancingByCount: 1)
+            traceIDGenerator: RelativeTracingUUIDGenerator(startingFrom: .init(idHi: 10, idLo: 100)),
+            spanIDGenerator: RelativeSpanIDGenerator(startingFrom: 100, advancingByCount: 1)
         )
 
         handler = TracingURLSessionHandler(
@@ -62,15 +63,15 @@ class TracingURLSessionHandlerTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "00000000000000000000000000000001")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000002")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000064")
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000002-1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000002-01")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000064-1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-01")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itDoesNotOverwriteTraceHeaders() throws {
@@ -143,7 +144,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "0")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "0")
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000002-00")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-00")
     }
 
     func testGivenFirstPartyInterception_withActiveSpan_itInjectParentSpanID() throws {
@@ -171,15 +172,15 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         span.finish()
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "3")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "65")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "00000000000000000000000000000001")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000003")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField), "0000000000000002")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000065")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField), "0000000000000064")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "00000000000000000000000000000001-0000000000000003-1-0000000000000002")
-        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-00000000000000000000000000000001-0000000000000003-01")
+        XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000065-1-0000000000000064")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000065-01")
     }
 
     func testGivenFirstPartyInterceptionWithSpanContext_whenInterceptionCompletes_itUsesInjectedSpanContext() throws {
@@ -214,8 +215,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let envelope: SpanEventsEnvelope? = core.events().last
         let span = try XCTUnwrap(envelope?.spans.first)
 
-        XCTAssertEqual(String(span.traceID), "100")
-        XCTAssertEqual(String(span.spanID), "200")
+        XCTAssertEqual(String(span.traceID, representation: .decimal), "100")
+        XCTAssertEqual(String(span.spanID, representation: .decimal), "200")
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertFalse(span.isError)
         XCTAssertEqual(span.duration, 1)
@@ -261,8 +262,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         span.setActive()
         // Then
         let context = handler.traceContext()
-        XCTAssertEqual(context?.traceID, TraceID(rawValue: 1))
-        XCTAssertEqual(context?.spanID, SpanID(rawValue: 2))
+        XCTAssertEqual(context?.traceID, TraceID(idHi: 10, idLo: 100))
+        XCTAssertEqual(context?.spanID, SpanID(100))
 
         // When
         span.finish()
@@ -283,12 +284,12 @@ class TracingURLSessionHandlerTests: XCTestCase {
         span.setActive()
         interception.register(trace: TraceContext(
             traceID: span.context.dd.traceID,
-            spanID: SpanID(rawValue: 3),
+            spanID: SpanID(300),
             parentSpanID: span.context.dd.spanID
         ))
         handler.interceptionDidStart(interception: interception)
         // Then
-        XCTAssertEqual(interception.trace?.parentSpanID?.rawValue, 2)
+        XCTAssertEqual(interception.trace?.parentSpanID?.rawValue, 100)
 
         // When
         span.finish()
@@ -309,14 +310,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let envelopes: [SpanEventsEnvelope] = core.events()
         let event1 = try XCTUnwrap(envelopes.first?.spans.first)
         XCTAssertEqual(event1.operationName, "root")
-        XCTAssertEqual(event1.traceID, TraceID(rawValue: 1))
-        XCTAssertEqual(event1.spanID, SpanID(rawValue: 2))
+        XCTAssertEqual(event1.traceID, TraceID(idHi: 10, idLo: 100))
+        XCTAssertEqual(event1.spanID, SpanID(100))
         XCTAssertNil(event1.parentID)
         let event2 = try XCTUnwrap(envelopes.last?.spans.first)
         XCTAssertEqual(event2.operationName, "urlsession.request")
-        XCTAssertEqual(event2.traceID, TraceID(rawValue: 1))
-        XCTAssertEqual(event2.parentID, SpanID(rawValue: 2))
-        XCTAssertEqual(event2.spanID, SpanID(rawValue: 3))
+        XCTAssertEqual(event2.traceID, TraceID(idHi: 10, idLo: 100))
+        XCTAssertEqual(event2.parentID, SpanID(100))
+        XCTAssertEqual(event2.spanID, SpanID(300))
     }
 
     func testGivenFirstPartyIncompleteInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
@@ -117,14 +117,6 @@ extension TracingCommonAsserts {
     }
 }
 
-extension String {
-    /// Tracing feature uses hexadecimal representation of trace and span IDs, while Logging uses decimals.
-    /// This helper converts hexadecimal string to decimal string for comparison.
-    var hexadecimalNumberToDecimal: String {
-        return "\(UInt64(self, radix: 16)!)"
-    }
-}
-
 extension SpanMatcher {
     class func from(requests: [HTTPServerMock.Request]) throws -> [SpanMatcher] {
         return try requests

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingManualInstrumentationScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingManualInstrumentationScenarioTests.swift
@@ -92,9 +92,9 @@ class TracingManualInstrumentationScenarioTests: IntegrationTests, TracingCommon
         logMatchers[1].assertValue(forKeyPath: "error.stack", matches: matcher)
 
         // Assert logs are linked to "data downloading" span
-        logMatchers[0].assertValue(forKey: "dd.trace_id", equals: try spanMatchers[0].traceID().hexadecimalNumberToDecimal)
-        logMatchers[0].assertValue(forKey: "dd.span_id", equals: try spanMatchers[0].spanID().hexadecimalNumberToDecimal)
-        logMatchers[1].assertValue(forKey: "dd.trace_id", equals: try spanMatchers[1].traceID().hexadecimalNumberToDecimal)
-        logMatchers[1].assertValue(forKey: "dd.span_id", equals: try spanMatchers[1].spanID().hexadecimalNumberToDecimal)
+        logMatchers[0].assertValue(forKey: "dd.trace_id", equals: try spanMatchers[0].traceID()?.toString(representation: .hexadecimal))
+        logMatchers[0].assertValue(forKey: "dd.span_id", equals: try spanMatchers[0].spanID()?.toString(representation: .hexadecimal))
+        logMatchers[1].assertValue(forKey: "dd.trace_id", equals: try spanMatchers[1].traceID()?.toString(representation: .hexadecimal))
+        logMatchers[1].assertValue(forKey: "dd.span_id", equals: try spanMatchers[1].spanID()?.toString(representation: .hexadecimal))
     }
 }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
@@ -238,7 +238,7 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
         XCTAssertEqual(firstPartyRequests.count, 1)
 
         let firstPartyRequest = firstPartyRequests[0]
-        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], try taskWithRequest.traceID()?.toString(representation: .hexadecimal))
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], try taskWithRequest.traceID()?.idLoHex)
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID()?.toString(representation: .hexadecimal))
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-sampling-priority"], "1")
         XCTAssertNil(firstPartyRequest.httpHeaders["x-datadog-origin"])

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
@@ -5,6 +5,7 @@
  */
 
 import HTTPServerMock
+import DatadogInternal
 import XCTest
 
 private extension ExampleApplication {
@@ -33,7 +34,7 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
             )
         )
     }
-    
+
     func testTracingURLSessionScenario_directWithGlobalFirstPartyHosts() throws {
         try runTest(
             for: "TracingURLSessionScenario",
@@ -237,8 +238,8 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
         XCTAssertEqual(firstPartyRequests.count, 1)
 
         let firstPartyRequest = firstPartyRequests[0]
-        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], try taskWithRequest.traceID().hexadecimalNumberToDecimal)
-        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID().hexadecimalNumberToDecimal)
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], try taskWithRequest.traceID()?.toString(representation: .hexadecimal))
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID()?.toString(representation: .hexadecimal))
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-sampling-priority"], "1")
         XCTAssertNil(firstPartyRequest.httpHeaders["x-datadog-origin"])
     }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
@@ -242,5 +242,7 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID()?.toString(representation: .hexadecimal))
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-sampling-priority"], "1")
         XCTAssertNil(firstPartyRequest.httpHeaders["x-datadog-origin"])
+        let tid = try taskWithRequest.meta.tid()
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-tags"], "_dd.p.tid=\(tid)")
     }
 }

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -55,9 +55,9 @@ public class RelativeTracingUUIDGenerator: TraceIDGenerator {
 }
 
 public class RelativeSpanIDGenerator: SpanIDGenerator {
+    @ReadWriteLock
     private(set) var uuid: SpanID
     internal let count: UInt64
-    private let queue = DispatchQueue(label: "queue-RelativeTracingUUIDGenerator-\(UUID().uuidString)")
 
     public init(startingFrom uuid: SpanID, advancingByCount count: UInt64 = 1) {
         self.uuid = uuid
@@ -65,10 +65,8 @@ public class RelativeSpanIDGenerator: SpanIDGenerator {
     }
 
     public func generate() -> SpanID {
-        return queue.sync {
-            defer { uuid = uuid + count }
-            return uuid
-        }
+        defer { uuid = uuid + count }
+        return uuid
     }
 }
 


### PR DESCRIPTION
### What and why?

RFC https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3545630931

### How?

This PR adds support for 128 bit trace ids in the SDK. There are several behind the scenes changes to support 128 bit trace ids which includes new TraceID type to keep the implementation decoupled from SpanID.

1. All distributed tracing headers are updated to support 128 bit trace ids
2. All span and rum events are updated to support 128 bit trace ids
3. All log events are updated to support 128 bit trace ids

Tests are updated accordingly and I changed trace and span ids to the values which are represented differently in hex and decimal unlike 1, 2. This forces us to make sure we are encoding the ids correctly where needed.

This is a breaking change as we are making changes in public types but in Internal module.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
