### PR TITLE
feat(logs): Add error fingerprint attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FIX] Propagate parent span in distributing tracing. See [#1627][]
 - [IMPROVEMENT] Add Device's Brand, Name, and Model in LogEvent. See [#1672][] (Thanks [@aldoKelvianto][])
 - [FEATURE] Improved image recording in Session Replay. See [#1592][]
+- [FEATURE] Allow custom error fingerprinting on logs with a special attribute. See [#1722][]
 
 # 2.7.1 / 12-02-2024
 
@@ -605,6 +606,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1685]: https://github.com/DataDog/dd-sdk-ios/pull/1685
 [#1656]: https://github.com/DataDog/dd-sdk-ios/pull/1656
 [#1666]: https://github.com/DataDog/dd-sdk-ios/pull/1666
+[#1722]: https://github.com/DataDog/dd-sdk-ios/pull/1722
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -68,6 +68,7 @@ internal struct LogMessageReceiver: FeatureMessageReceiver {
                     level: log.level,
                     message: log.message,
                     error: log.error,
+                    errorFingerprint: nil,
                     attributes: .init(
                         userAttributes: log.userAttributes ?? [:],
                         internalAttributes: log.internalAttributes

--- a/DatadogLogs/Sources/Log/LogEventBuilder.swift
+++ b/DatadogLogs/Sources/Log/LogEventBuilder.swift
@@ -45,6 +45,7 @@ internal struct LogEventBuilder {
         level: LogLevel,
         message: String,
         error: DDError?,
+        errorFingerprint: String?,
         attributes: LogEvent.Attributes,
         tags: Set<String>,
         context: DatadogContext,
@@ -62,7 +63,8 @@ internal struct LogEventBuilder {
                     kind: $0.type,
                     message: $0.message,
                     stack: $0.stack,
-                    sourceType: $0.sourceType
+                    sourceType: $0.sourceType,
+                    fingerprint: errorFingerprint
                 )
             },
             serviceName: service,

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -73,6 +73,8 @@ public struct LogEvent: Encodable {
         public var stack: String?
         /// The Log error source_type. Used by cross platform SDKs
         public var sourceType: String = "ios"
+        /// The custom fingerprint supplied for this error, if any
+        public var fingerprint: String?
     }
 
     /// Device information.
@@ -171,6 +173,7 @@ internal struct LogEventEncoder {
         case errorMessage = "error.message"
         case errorStack = "error.stack"
         case errorSourceType = "error.source_type"
+        case errorFingerprint = "error.fingerprint"
 
         // MARK: - Application info
 
@@ -233,6 +236,7 @@ internal struct LogEventEncoder {
             try container.encode(someError.message, forKey: .errorMessage)
             try container.encode(someError.stack, forKey: .errorStack)
             try container.encode(someError.sourceType, forKey: .errorSourceType)
+            try container.encode(someError.fingerprint, forKey: .errorFingerprint)
         }
 
         // Encode logger info

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -112,6 +112,13 @@ public enum Logs {
     }
 }
 
+extension Logs {
+    /// Attributes that can be added to logs that have special properies in Datadog.
+    public struct Attributes {
+        public static let errorFingerprint = "_dd.error.fingerprint"
+    }
+}
+
 extension Logs.Configuration: InternalExtended { }
 extension InternalExtension where ExtendedType == Logs.Configuration {
     /// Sets the custom mapper for `LogEvent`. This can be used to modify logs before they are sent to Datadog.

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -115,6 +115,7 @@ public enum Logs {
 extension Logs {
     /// Attributes that can be added to logs that have special properies in Datadog.
     public struct Attributes {
+        /// Add a custom fingerprint to the error in this log. Requires that the log be supplied with an Error.
         public static let errorFingerprint = "_dd.error.fingerprint"
     }
 }

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -115,7 +115,8 @@ public enum Logs {
 extension Logs {
     /// Attributes that can be added to logs that have special properies in Datadog.
     public struct Attributes {
-        /// Add a custom fingerprint to the error in this log. Requires that the log be supplied with an Error.
+        /// Add a custom fingerprint to the error in this log. Requires that the log is supplied with an Error.
+        /// The value of this attribute must be a `String`.
         public static let errorFingerprint = "_dd.error.fingerprint"
     }
 }

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -110,6 +110,7 @@ internal final class RemoteLogger: LoggerProtocol {
         let tags = self.tags
         var logAttributes = attributes
         let isCrash = logAttributes?.removeValue(forKey: CrossPlatformAttributes.errorLogIsCrash) as? Bool ?? false
+        let errorFingerprint = logAttributes?.removeValue(forKey: Logs.Attributes.errorFingerprint) as? String
         let userAttributes = self.attributes
             .merging(logAttributes ?? [:]) { $1 } // prefer message attributes
         let combinedAttributes: [String: any Encodable]
@@ -162,6 +163,7 @@ internal final class RemoteLogger: LoggerProtocol {
                 level: level,
                 message: message,
                 error: error,
+                errorFingerprint: errorFingerprint,
                 attributes: .init(
                     userAttributes: combinedAttributes,
                     internalAttributes: internalAttributes

--- a/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
@@ -17,6 +17,7 @@ class LogEventBuilderTests: XCTestCase {
         let randomLevel: LogLevel = .mockRandom()
         let randomMessage: String = .mockRandom()
         let randomError: DDError = .mockRandom()
+        let randomErrorFingerprint: String? = .mockRandom()
         let randomAttributes: LogEvent.Attributes = .mockRandom()
         let randomTags: Set<String> = .mockRandom()
         let randomService: String = .mockRandom()
@@ -43,6 +44,7 @@ class LogEventBuilderTests: XCTestCase {
             level: randomLevel,
             message: randomMessage,
             error: randomError,
+            errorFingerprint: randomErrorFingerprint,
             attributes: randomAttributes,
             tags: randomTags,
             context: .mockWith(
@@ -66,6 +68,7 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.error?.message, randomError.message)
             XCTAssertEqual(log.error?.stack, randomError.stack)
             XCTAssertEqual(log.error?.sourceType, "ios")
+            XCTAssertEqual(log.error?.fingerprint, randomErrorFingerprint)
             XCTAssertEqual(log.attributes, randomAttributes)
             XCTAssertEqual(log.tags.map { Set($0) }, randomTags)
             XCTAssertEqual(log.serviceName, randomService)
@@ -133,6 +136,7 @@ class LogEventBuilderTests: XCTestCase {
             level: .mockAny(),
             message: .mockAny(),
             error: .mockAny(),
+            errorFingerprint: .mockAny(),
             attributes: .mockAny(),
             tags: .mockAny(),
             context: randomSDKContext,
@@ -182,6 +186,7 @@ class LogEventBuilderTests: XCTestCase {
             level: .mockAny(),
             message: .mockAny(),
             error: .mockAny(),
+            errorFingerprint: .mockAny(),
             attributes: .mockAny(),
             tags: .mockAny(),
             context: randomSDKContext,
@@ -208,6 +213,7 @@ class LogEventBuilderTests: XCTestCase {
             level: .mockAny(),
             message: .mockAny(),
             error: .mockAny(),
+            errorFingerprint: .mockAny(),
             attributes: .mockAny(),
             tags: .mockAny(),
             context: .mockWith(
@@ -248,6 +254,7 @@ class LogEventBuilderTests: XCTestCase {
             level: .mockAny(),
             message: "original message",
             error: .mockAny(),
+            errorFingerprint: .mockAny(),
             attributes: .mockAny(),
             tags: .mockAny(),
             context: .mockAny(),
@@ -281,6 +288,7 @@ class LogEventBuilderTests: XCTestCase {
             level: .mockAny(),
             message: .mockAny(),
             error: .mockAny(),
+            errorFingerprint: .mockAny(),
             attributes: .mockAny(),
             tags: .mockAny(),
             context: .mockAny(),

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -57,7 +57,8 @@ public enum RUM {
 extension RUM {
     /// Attributes that can be added to RUM calls that have special properies in Datadog.
     public struct Attributes {
-        /// Add a custom fingerprint to the error in this log. Requires that the log be supplied with an Error.
+        /// Add a custom fingerprint to the RUM error.
+        /// The value of this attribute must be a `String`.
         public static let errorFingerprint = "_dd.error.fingerprint"
     }
 }

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -53,3 +53,11 @@ public enum RUM {
         rum.monitor.notifySDKInit()
     }
 }
+
+extension RUM {
+    /// Attributes that can be added to RUM calls that have special properies in Datadog.
+    public struct Attributes {
+        /// Add a custom fingerprint to the error in this log. Requires that the log be supplied with an Error.
+        public static let errorFingerprint = "_dd.error.fingerprint"
+    }
+}

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -253,6 +253,8 @@ internal class RUMResourceScope: RUMScope {
     private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand, context: DatadogContext, writer: Writer) {
         attributes.merge(rumCommandAttributes: command.attributes)
 
+        let errorFingerprint = attributes.removeValue(forKey: RUM.Attributes.errorFingerprint) as? String
+
         let errorEvent = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -278,6 +280,7 @@ internal class RUMResourceScope: RUMScope {
             error: .init(
                 binaryImages: nil,
                 category: .exception, // resource errors are categorised as "Exception"
+                fingerprint: errorFingerprint,
                 handling: nil,
                 handlingStack: nil,
                 id: nil,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -561,6 +561,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private func sendErrorEvent(on command: RUMErrorCommand, context: DatadogContext, writer: Writer) {
         errorsCount += 1
 
+        var commandAttributes = command.attributes
+        let errorFingerprint = commandAttributes.removeValue(forKey: RUM.Attributes.errorFingerprint) as? String
+
         let errorEvent = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -579,7 +582,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: command.attributes),
+            context: .init(contextInfo: commandAttributes),
             date: command.time.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -587,6 +590,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 binaryImages: command.binaryImages?.compactMap { $0.toRUMDataFormat },
                 category: command.category,
                 causes: nil,
+                fingerprint: errorFingerprint,
                 handling: nil,
                 handlingStack: nil,
                 id: nil,

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingScenarioTests.swift
@@ -54,11 +54,11 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
             // Don't check "attribute" because local attributes should override
         ])
 
-        logMatchers[7].assertStatus(equals: "errpr")
+        logMatchers[7].assertStatus(equals: "error")
         logMatchers[7].assertMessage(equals: "error with fingerprint")
         logMatchers[7].assertAttributes(equal: [
-            "error.message": "MockError",
-            "error.fingerprint": "global value",
+            "error.message": "Runner.SendLogsFixtureViewController.MockError",
+            "error.fingerprint": "custom_fingerprint",
         ])
 
 

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingScenarioTests.swift
@@ -21,7 +21,7 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
 
         // Get expected number of `LogMatchers`
         let recordedRequests = try loggingServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try LogMatcher.from(requests: requests).count >= 7
+            try LogMatcher.from(requests: requests).count >= 8
         }
         let logMatchers = try LogMatcher.from(requests: recordedRequests)
 
@@ -48,11 +48,17 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
 
         logMatchers[6].assertStatus(equals: "notice")
         logMatchers[6].assertMessage(equals: "notice message with global")
-
         logMatchers[6].assertAttributes(equal: [
             "global-attribute-1": "global value",
             "global-attribute-2": 1540
             // Don't check "attribute" because local attributes should override
+        ])
+
+        logMatchers[7].assertStatus(equals: "errpr")
+        logMatchers[7].assertMessage(equals: "error with fingerprint")
+        logMatchers[7].assertAttributes(equal: [
+            "error.message": "MockError",
+            "error.fingerprint": "global value",
         ])
 
 

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -128,6 +128,9 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertNotNil(view3.viewEvents.last?.device)
         XCTAssertEqual(view3.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.resource.count, 0)
-        XCTAssertEqual(view3.viewEvents.last?.view.error.count, 0)
+        XCTAssertEqual(view3.viewEvents.last?.view.error.count, 1)
+        let view3Error = try XCTUnwrap(view3.errorEvents[0])
+        XCTAssertEqual(view3Error.error.message, "Simulated view error with fingerprint")
+        XCTAssertEqual(view3Error.error.fingerprint, "fake-fingerprint")
     }
 }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -94,6 +94,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.errorEvents[0].error.resource?.url, "https://foo.com/resource/2")
         XCTAssertEqual(view1.errorEvents[0].error.resource?.method, .get)
         XCTAssertEqual(view1.errorEvents[0].error.resource?.statusCode, 400)
+        XCTAssertEqual(view1.errorEvents[0].error.fingerprint, "custom-fingerprint")
         let featureFlags = try XCTUnwrap(view1.viewEvents.last?.featureFlags)
         XCTAssertEqual(featureFlags.featureFlagsInfo.count, 0)
         RUMSessionMatcher.assertViewWasEventuallyInactive(view1)

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -1270,7 +1270,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1294,7 +1293,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1317,7 +1315,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1338,7 +1335,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1360,7 +1356,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1382,7 +1377,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -1270,6 +1270,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1293,6 +1294,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1315,6 +1317,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1335,6 +1338,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1356,6 +1360,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1377,6 +1382,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = IntegrationScenarios/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
@@ -42,7 +42,10 @@ internal class SendLogsFixtureViewController: UIViewController {
         logger?.error(
             "error with fingerprint",
             error: MockError(),
-            attributes: [Logs.Attributes.errorFingerprint: "custom_fingerprint"]
+            attributes: [
+                Logs.Attributes.errorFingerprint: "custom_fingerprint",
+                "attribute": "value"
+            ]
         )
     }
 }

--- a/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/Logging/ManualInstrumentation/SendLogsFixtureViewController.swift
@@ -8,6 +8,14 @@ import UIKit
 import DatadogLogs
 
 internal class SendLogsFixtureViewController: UIViewController {
+    class MockError: LocalizedError {
+        var title: String {
+            get { return "MockError" }
+        }
+        var code: Int {
+            get { return 406 }
+        }
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -31,5 +39,10 @@ internal class SendLogsFixtureViewController: UIViewController {
         Logs.addAttribute(forKey: "attribute", value: 20)
 
         logger?.notice("notice message with global", attributes: ["attribute": "value"])
+        logger?.error(
+            "error with fingerprint",
+            error: MockError(),
+            attributes: [Logs.Attributes.errorFingerprint: "custom_fingerprint"]
+        )
     }
 }

--- a/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture1ViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture1ViewController.swift
@@ -5,6 +5,7 @@
  */
 
 import UIKit
+import DatadogRUM
 
 internal class SendRUMFixture1ViewController: UIViewController {
     @IBOutlet weak var pushNextScreenButton: UIButton!
@@ -80,7 +81,10 @@ internal class SendRUMFixture1ViewController: UIViewController {
                     statusCode: 400,
                     httpVersion: nil,
                     headerFields: nil
-                )!
+                )!,
+                attributes: [
+                    RUM.Attributes.errorFingerprint: "custom-fingerprint"
+                ]
             )
 
             // Reveal the "Push Next Screen" button so UITest can continue

--- a/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
@@ -5,12 +5,22 @@
  */
 
 import UIKit
+import DatadogRUM
 
 internal class SendRUMFixture3ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         rumMonitor.startView(key: "fixture3-vc", name: "SendRUMFixture3View")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            rumMonitor.addError(
+                message: "Simulated view error with fingerprint",
+                source: .source, attributes: [
+                    RUM.Attributes.errorFingerprint: "fake-fingerprint"
+                ]
+            )
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
@@ -16,7 +16,8 @@ internal class SendRUMFixture3ViewController: UIViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             rumMonitor.addError(
                 message: "Simulated view error with fingerprint",
-                source: .source, attributes: [
+                source: .source, 
+                attributes: [
                     RUM.Attributes.errorFingerprint: "fake-fingerprint"
                 ]
             )


### PR DESCRIPTION
### What and why?

Allow users to provide custom error fingerprint attribute.

In Logs the attribute `Logs.Attributes.errorFingerprint` is added to any log call and added to the `LogEvent.Error.fingerprint` member. 

In RUM, the attribute `RUM.Attributes.errorFingterprint` is added to  `addError` calls and it is transferred to the `RUMError.finterprint` member

refs: RUM-2906

### How?

A special attribute (defined at `Logs.Attributes.errorFingerprint`) is read and moved during LogEvent creation

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
