### PR TITLE
RUM-1843 Method Call telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -531,6 +531,8 @@
 		A7EA11622AB0CE6C00C73970 /* DDUIKitRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA18062AB0CA4700F76337 /* DDUIKitRUMActionsPredicateTests.swift */; };
 		A7EA88562B17639A00FE2580 /* ResourcesWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EA88552B17639A00FE2580 /* ResourcesWriter.swift */; };
 		A7F651302B7655DE004B0EDB /* UIImageResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6512F2B7655DE004B0EDB /* UIImageResourceTests.swift */; };
+		A7FA98CE2BA1A6930018D6B5 /* SharedMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FA98CD2BA1A6930018D6B5 /* SharedMetrics.swift */; };
+		A7FA98CF2BA1A6930018D6B5 /* SharedMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FA98CD2BA1A6930018D6B5 /* SharedMetrics.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A4287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A6287476230047275C /* ServerOffsetPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A5287476230047275C /* ServerOffsetPublisher.swift */; };
@@ -2460,6 +2462,7 @@
 		A7F773D32924EA2D00AC1A62 /* B3HTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = B3HTTPHeaders.swift; sourceTree = "<group>"; };
 		A7F773DB29253F8B00AC1A62 /* B3HTTPHeadersWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersWriter.swift; sourceTree = "<group>"; };
 		A7F773DC29253F8B00AC1A62 /* B3HTTPHeadersReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = B3HTTPHeadersReader.swift; sourceTree = "<group>"; };
+		A7FA98CD2BA1A6930018D6B5 /* SharedMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMetrics.swift; sourceTree = "<group>"; };
 		B3BBBCB0265E71C600943419 /* VitalMemoryReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReader.swift; sourceTree = "<group>"; };
 		B3BBBCBB265E71D100943419 /* VitalMemoryReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReaderTests.swift; sourceTree = "<group>"; };
 		B3FC3C0626526EFF00DEED9E /* VitalInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalInfo.swift; sourceTree = "<group>"; };
@@ -5727,6 +5730,7 @@
 				D23039DC298D5235001A1FA3 /* DDError.swift */,
 				61133BBA2423979B00786299 /* SwiftExtensions.swift */,
 				D29A9F9429DDB1DB005C54A4 /* UIKitExtensions.swift */,
+				A7FA98CD2BA1A6930018D6B5 /* SharedMetrics.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -8028,6 +8032,7 @@
 				D2EBEE2229BA160F00B15732 /* TracePropagationHeadersReader.swift in Sources */,
 				D2303A02298D5236001A1FA3 /* ReadWriteLock.swift in Sources */,
 				D2EBEE2429BA160F00B15732 /* W3CHTTPHeadersReader.swift in Sources */,
+				A7FA98CE2BA1A6930018D6B5 /* SharedMetrics.swift in Sources */,
 				D23039E8298D5236001A1FA3 /* DatadogContext.swift in Sources */,
 				D23039FF298D5236001A1FA3 /* Foundation+Datadog.swift in Sources */,
 				D2F8235329915E12003C7E99 /* DatadogSite.swift in Sources */,
@@ -8865,6 +8870,7 @@
 				D2EBEE3029BA161100B15732 /* TracePropagationHeadersReader.swift in Sources */,
 				D2DA2373298D57AA00C6C7E6 /* ReadWriteLock.swift in Sources */,
 				D2EBEE3229BA161100B15732 /* W3CHTTPHeadersReader.swift in Sources */,
+				A7FA98CF2BA1A6930018D6B5 /* SharedMetrics.swift in Sources */,
 				D2DA2374298D57AA00C6C7E6 /* DatadogContext.swift in Sources */,
 				D2DA2375298D57AA00C6C7E6 /* Foundation+Datadog.swift in Sources */,
 				D2F8235429915E12003C7E99 /* DatadogSite.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/TelemetryCoreIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/TelemetryCoreIntegrationTests.swift
@@ -33,12 +33,15 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42])
+        core.telemetry.stopMethodCalled(
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+        )
 
         // Then
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
         let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
 
-        XCTAssertEqual(debugEvents.count, 2) // metrics are transported as debug events
+        XCTAssertEqual(debugEvents.count, 3) // metrics are transported as debug events
         XCTAssertEqual(errorEvents.count, 1)
 
         let debug = debugEvents[0]
@@ -51,6 +54,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         let metric = debugEvents[1]
         XCTAssertEqual(metric.telemetry.message, "[Mobile Metric] Metric Name")
         DDAssertReflectionEqual(metric.telemetry.telemetryInfo, ["metric.attribute": 42])
+
+        let methodCalledMetric = debugEvents[2]
+        XCTAssertEqual(methodCalledMetric.telemetry.message, "[Mobile Metric] Method Called")
     }
 
     func testGivenRUMEnabled_whenNoViewIsActive_telemetryEventsAreLinkedToSession() throws {
@@ -68,6 +74,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.stopMethodCalled(
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+        )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
         let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
@@ -89,6 +98,12 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         XCTAssertNotNil(metric.session?.id)
         XCTAssertNil(metric.view?.id)
         XCTAssertNil(metric.action?.id)
+
+        let methodCalledMetric = try XCTUnwrap(debugEvents.first(where: { $0.telemetry.message == "[Mobile Metric] Method Called" }))
+        XCTAssertEqual(methodCalledMetric.application?.id, "rum-app-id")
+        XCTAssertNotNil(methodCalledMetric.session?.id)
+        XCTAssertNil(methodCalledMetric.view?.id)
+        XCTAssertNil(methodCalledMetric.action?.id)
     }
 
     func testGivenRUMEnabled_whenViewIsActive_telemetryEventsAreLinkedToView() throws {
@@ -105,6 +120,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.stopMethodCalled(
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+        )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
         let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
@@ -126,6 +144,12 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         XCTAssertNotNil(metric.session?.id)
         XCTAssertNotNil(metric.view?.id)
         XCTAssertNil(metric.action?.id)
+
+        let methodCalledMetric = try XCTUnwrap(debugEvents.first(where: { $0.telemetry.message == "[Mobile Metric] Method Called" }))
+        XCTAssertEqual(methodCalledMetric.application?.id, "rum-app-id")
+        XCTAssertNotNil(methodCalledMetric.session?.id)
+        XCTAssertNotNil(methodCalledMetric.view?.id)
+        XCTAssertNil(methodCalledMetric.action?.id)
     }
 
     func testGivenRUMEnabled_whenActionIsActive_telemetryEventsAreLinkedToAction() throws {
@@ -143,6 +167,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.stopMethodCalled(
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+        )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
         let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
@@ -164,5 +191,11 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         XCTAssertNotNil(metric.session?.id)
         XCTAssertNotNil(metric.view?.id)
         XCTAssertNotNil(metric.action?.id)
+
+        let methodCalledMetric = try XCTUnwrap(debugEvents.first(where: { $0.telemetry.message == "[Mobile Metric] Method Called" }))
+        XCTAssertEqual(methodCalledMetric.application?.id, "rum-app-id")
+        XCTAssertNotNil(methodCalledMetric.session?.id)
+        XCTAssertNotNil(methodCalledMetric.view?.id)
+        XCTAssertNotNil(methodCalledMetric.action?.id)
     }
 }

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -229,7 +229,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         telemetry.metric(
             name: BatchDeletedMetric.name,
             attributes: [
-                BatchMetric.typeKey: BatchDeletedMetric.typeValue,
+                BasicMetric.typeKey: BatchDeletedMetric.typeValue,
                 BatchMetric.trackKey: metricsData.trackName,
                 BatchDeletedMetric.uploaderDelayKey: [
                     BatchDeletedMetric.uploaderDelayMinKey: metricsData.uploaderPerformance.minUploadDelay.toMilliseconds,
@@ -257,7 +257,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         telemetry.metric(
             name: BatchClosedMetric.name,
             attributes: [
-                BatchMetric.typeKey: BatchClosedMetric.typeValue,
+                BasicMetric.typeKey: BatchClosedMetric.typeValue,
                 BatchMetric.trackKey: metricsData.trackName,
                 BatchMetric.consentKey: metricsData.consentLabel,
                 BatchClosedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,

--- a/DatadogCore/Sources/Utils/CoreMetrics.swift
+++ b/DatadogCore/Sources/Utils/CoreMetrics.swift
@@ -8,8 +8,6 @@ import Foundation
 
 /// Common definitions for batch telemetries.
 internal enum BatchMetric {
-    /// Metric type key.
-    static let typeKey = "metric_type"
     /// Track name key
     static let trackKey = "track"
     /// Track name value.

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -87,7 +87,7 @@ public extension Telemetry {
     func startMethodCalled(
         operationName: String,
         callerClass: String,
-        samplingRate: Float
+        samplingRate: Float = 100.0
     ) -> MethodCalledTrace? {
         if Sampler(samplingRate: samplingRate).sample() {
             return MethodCalledTrace(
@@ -105,22 +105,10 @@ public extension Telemetry {
     /// - Parameters
     ///   - metric: The `MethodCalledTrace` instance.
     ///   - isSuccessful: A flag indicating if the method call was successful.
-    func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool) {
+    func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool = true) {
         if let metric = metric {
             send(telemetry: metric.asTelemetryMetric(isSuccessful: isSuccessful))
         }
-    }
-
-    /// Convenience method to start a method call with a default sampling rate of 100.
-    func startMethodCalled(
-        operationName: String,
-        callerClass: String
-    ) -> MethodCalledTrace? {
-        startMethodCalled(operationName: operationName, callerClass: callerClass, samplingRate: 100)
-    }
-    /// Convenience method to stop a method call that assumes success.
-    func stopMethodCalled(_ metric: MethodCalledTrace?) {
-        stopMethodCalled(metric, isSuccessful: true)
     }
 }
 

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -82,7 +82,7 @@ public protocol Telemetry {
     ///   - samplingRate: The sampling rate of the method call.
     ///
     /// - Returns: A `MethodCalledTrace` instance.
-    func startMethodCall(
+    func startMethodCalled(
         operationName: String,
         callerClass: String,
         samplingRate: Float
@@ -93,20 +93,20 @@ public protocol Telemetry {
     /// - Parameters
     ///   - metric: The `MethodCalledTrace` instance.
     ///   - isSuccessful: A flag indicating if the method call was successful.
-    func stopMethodCall(_ metric: MethodCalledTrace?, isSuccessful: Bool)
+    func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool)
 }
 
 extension Telemetry {
     /// Convenience method to start a method call with a default sampling rate of 100.
-    func startMethodCall(
+    func startMethodCalled(
         operationName: String,
         callerClass: String
     ) -> MethodCalledTrace? {
-        startMethodCall(operationName: operationName, callerClass: callerClass, samplingRate: 100)
+        startMethodCalled(operationName: operationName, callerClass: callerClass, samplingRate: 100)
     }
     /// Convenience method to stop a method call that assumes success.
-    func stopMethodCall(_ metric: MethodCalledTrace?) {
-        stopMethodCall(metric, isSuccessful: true)
+    func stopMethodCalled(_ metric: MethodCalledTrace?) {
+        stopMethodCalled(metric, isSuccessful: true)
     }
 }
 
@@ -116,8 +116,8 @@ public struct MethodCalledTrace {
     let callerClass: String
     let startTime = Date()
 
-    var exectutionTime: TimeInterval {
-        return startTime.timeIntervalSinceNow
+    var exectutionTime: Int64 {
+        return -startTime.timeIntervalSinceNow.toInt64Nanoseconds
     }
 
     func asTelemetryMetric(isSuccessful: Bool) -> TelemetryMessage {
@@ -125,7 +125,6 @@ public struct MethodCalledTrace {
             name: MethodCalledMetric.name,
             attributes: [
                 MethodCalledMetric.executionTime: exectutionTime,
-                MethodCalledMetric.startTime: startTime,
                 MethodCalledMetric.operationName: operationName,
                 MethodCalledMetric.callerClass: callerClass,
                 MethodCalledMetric.isSuccessful: isSuccessful,
@@ -360,8 +359,8 @@ public struct NOPTelemetry: Telemetry {
     public init() { }
     /// no-op
     public func send(telemetry: TelemetryMessage) { }
-    public func startMethodCall(operationName: String, callerClass: String, samplingRate: Float) -> MethodCalledTrace? { return nil }
-    public func stopMethodCall(_ metric: MethodCalledTrace?, isSuccessful: Bool) { }
+    public func startMethodCalled(operationName: String, callerClass: String, samplingRate: Float) -> MethodCalledTrace? { return nil }
+    public func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool) { }
 }
 
 internal struct CoreTelemetry: Telemetry {
@@ -396,7 +395,7 @@ internal struct CoreTelemetry: Telemetry {
     ///   - samplingRate: The sampling rate of the method call. Value between `0.0` and `100.0`, where `0.0` means NO event will be processed and `100.0` means ALL events will be processed. Note that this value is multiplicated by telemetry sampling (by default 20%) and metric events sampling (hardcoded to 15%). Making it effectively 3% sampling rate for sending events, when this value is set to `100`.
     ///
     /// - Returns: A `MethodCalledTrace` instance to be used to stop the method call and measure it's execution time. It can be `nil` if the method call is not sampled.
-    func startMethodCall(
+    func startMethodCalled(
         operationName: String,
         callerClass: String,
         samplingRate: Float
@@ -417,7 +416,7 @@ internal struct CoreTelemetry: Telemetry {
     /// - Parameters
     ///   - metric: The `MethodCalledTrace` instance.
     ///   - isSuccessful: A flag indicating if the method call was successful.
-    func stopMethodCall(_ metric: MethodCalledTrace?, isSuccessful: Bool) {
+    func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool) {
         if let metric = metric {
             send(telemetry: metric.asTelemetryMetric(isSuccessful: isSuccessful))
         }

--- a/DatadogInternal/Sources/Utils/SharedMetrics.swift
+++ b/DatadogInternal/Sources/Utils/SharedMetrics.swift
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Common definitions for telemetries.
+public enum BasicMetric {
+    /// Basic Metric type key.
+    public static let typeKey = "metric_type"
+}
+
+/// Definition of "Method Called" telemetry.
+public enum MethodCalledMetric {
+    /// The name of this metric, included in telemetry log.
+    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+    public static let name = "Method Called"
+    /// Metric type value.
+    public static let typeValue = "method called"
+
+    /// The key for operation name.
+    public static let operationName = "operation_name"
+    /// The key for caller class.
+    public static let callerClass = "caller_class"
+    /// The key for is successful.
+    public static let isSuccessful = "is_successful"
+    /// They key for start time.
+    public static let startTime = "start_time"
+    /// The key for execution time.
+    public static let executionTime = "execution_time"
+
+    public enum Device {
+        /// The key for device object.
+        public static let key = "device"
+
+        /// The key for device model name.
+        public static let model = "model"
+        /// The key for device brand.
+        public static let brand = "brand"
+        /// The key for CPU architecture.
+        public static let architecture = "architecture"
+    }
+
+    /// The key for OS object.
+    public enum OS {
+        /// The key for operating system object.
+        public static let key = "os"
+
+        /// The key for OS name.
+        public static let name = "name"
+        /// The key for OS version.
+        public static let version = "version"
+        /// The key for OS build.
+        public static let build = "build"
+    }
+}

--- a/DatadogInternal/Sources/Utils/SharedMetrics.swift
+++ b/DatadogInternal/Sources/Utils/SharedMetrics.swift
@@ -26,8 +26,6 @@ public enum MethodCalledMetric {
     public static let callerClass = "caller_class"
     /// The key for is successful.
     public static let isSuccessful = "is_successful"
-    /// They key for start time.
-    public static let startTime = "start_time"
     /// The key for execution time.
     public static let executionTime = "execution_time"
 

--- a/DatadogInternal/Sources/Utils/SharedMetrics.swift
+++ b/DatadogInternal/Sources/Utils/SharedMetrics.swift
@@ -54,3 +54,9 @@ public enum MethodCalledMetric {
         public static let build = "build"
     }
 }
+
+public extension [String: Encodable] {
+    var isMethodCallAttributes: Bool {
+        self[BasicMetric.typeKey] as? String == MethodCalledMetric.typeValue
+    }
+}

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -138,7 +138,7 @@ class TelemetryTests: XCTestCase {
         XCTAssertNotEqual(telemetry.configuration, initialConfiguration)
     }
 
-    func testWhenSendingTelemetryMessage_itForwardsToCore() {
+    func testWhenSendingTelemetryMessage_itForwardsToCore() throws {
         // Given
         class Receiver: FeatureMessageReceiver {
             var telemetry: TelemetryMessage?
@@ -182,6 +182,26 @@ class TelemetryTests: XCTestCase {
             return XCTFail("An error should be send to core.")
         }
         XCTAssertEqual(configuration.batchSize, 0)
+
+        // When
+        let operationName = String.mockRandom()
+        let callerClass = String.mockRandom()
+        let isSuccessful = Bool.random()
+        core.telemetry.stopMethodCalled(
+            core.telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, samplingRate: 100),
+            isSuccessful: isSuccessful
+        )
+
+        // Then
+        guard case .metric(let name, let attributes) = receiver.telemetry else {
+            return XCTFail("A debug should be send to core.")
+        }
+        XCTAssertEqual(name, MethodCalledMetric.name)
+        XCTAssertGreaterThan(try XCTUnwrap(attributes[MethodCalledMetric.executionTime] as? Int64), 0)
+        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.operationName] as? String), operationName)
+        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.callerClass] as? String), callerClass)
+        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.isSuccessful] as? Bool), isSuccessful)
+        XCTAssertEqual(try XCTUnwrap(attributes[BasicMetric.typeKey] as? String), MethodCalledMetric.typeValue)
     }
 }
 

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -211,7 +211,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
                 source: .init(rawValue: context.source) ?? .ios,
                 telemetry: .init(
                     message: "[Mobile Metric] \(name)",
-                    telemetryInfo: attributes.extended(with: context)
+                    telemetryInfo: attributes.enrichIfNeeded(with: context)
                 ),
                 version: context.sdkVersion,
                 view: rum?.viewID.map { .init(id: $0) }
@@ -255,11 +255,10 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 }
 
 fileprivate extension [String: Encodable] {
-    func extended(
+    func enrichIfNeeded(
         with context: DatadogContext
     ) -> [String: Encodable] {
-        /// Method Called metric needs to be enriched with device and os information, only available in the `DatadogContext`.
-        if let key = self[BasicMetric.typeKey] as? String, key == MethodCalledMetric.typeValue {
+        if isMethodCallAttributes {
             var attributes = self
             attributes[MethodCalledMetric.Device.key] = [
                 MethodCalledMetric.Device.model: context.device.model,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -259,7 +259,7 @@ fileprivate extension [String: Encodable] {
         with context: DatadogContext
     ) -> [String: Encodable] {
         /// Method Called metric needs to be enriched with device and os information, only available in the `DatadogContext`.
-        if let key = self[BasicMetric.key] as? String, key == MethodCalledMetric.type {
+        if let key = self[BasicMetric.typeKey] as? String, key == MethodCalledMetric.typeValue {
             var attributes = self
             attributes[MethodCalledMetric.Device.key] = [
                 MethodCalledMetric.Device.model: context.device.model,
@@ -272,8 +272,9 @@ fileprivate extension [String: Encodable] {
                 MethodCalledMetric.OS.build: context.device.osBuildNumber,
             ]
             return attributes
+        } else {
+            return self
         }
-        return self
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -64,8 +64,8 @@ public class Recorder: Recording {
     private let resourceProcessor: ResourceProcessing
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
-    /// The sampler for internal telemetry.
-    private let telemetrySampler: Sampler
+    /// The sampling rate for internal telemetry of method call.
+    private let methodCallTelemetrySamplingRate: Float
 
     convenience init(
         snapshotProcessor: SnapshotProcessing,
@@ -88,8 +88,7 @@ public class Recorder: Recording {
             touchSnapshotProducer: touchSnapshotProducer,
             snapshotProcessor: snapshotProcessor,
             resourceProcessor: resourceProcessor,
-            telemetry: telemetry,
-            telemetrySampler: Sampler(samplingRate: 0.005) // 0.5% of calls
+            telemetry: telemetry
         )
     }
 
@@ -100,7 +99,7 @@ public class Recorder: Recording {
         snapshotProcessor: SnapshotProcessing,
         resourceProcessor: ResourceProcessing,
         telemetry: Telemetry,
-        telemetrySampler: Sampler
+        methodCallTelemetrySamplingRate: Float = 15
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.viewTreeSnapshotProducer = viewTreeSnapshotProducer
@@ -108,7 +107,7 @@ public class Recorder: Recording {
         self.snapshotProcessor = snapshotProcessor
         self.resourceProcessor = resourceProcessor
         self.telemetry = telemetry
-        self.telemetrySampler = telemetrySampler
+        self.methodCallTelemetrySamplingRate = methodCallTelemetrySamplingRate
         uiApplicationSwizzler.swizzle()
     }
 
@@ -124,7 +123,7 @@ public class Recorder: Recording {
         let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
-            samplingRate: MethodCallConstants.captureRecordSampling // Effectively 3% * 15% = 0.45% of calls
+            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 15% = 0.45% of calls
         )
         var isSuccesful = true
         do {
@@ -149,7 +148,6 @@ public class Recorder: Recording {
     private enum MethodCallConstants {
         static let captureRecordOperationName = "Capture Record"
         static let className = "Recorder"
-        static let captureRecordSampling: Float = 15.0
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -99,7 +99,7 @@ public class Recorder: Recording {
         snapshotProcessor: SnapshotProcessing,
         resourceProcessor: ResourceProcessing,
         telemetry: Telemetry,
-        methodCallTelemetrySamplingRate: Float = 15
+        methodCallTelemetrySamplingRate: Float = 5
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.viewTreeSnapshotProducer = viewTreeSnapshotProducer
@@ -123,9 +123,9 @@ public class Recorder: Recording {
         let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
-            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 15% = 0.45% of calls
+            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 5% = 0.15% of calls
         )
-        var isSuccesful = true
+        var isSuccessful = true
         do {
             guard let viewTreeSnapshot = try viewTreeSnapshotProducer.takeSnapshot(with: recorderContext) else {
                 // There is nothing visible yet (i.e. the key window is not yet ready).
@@ -139,15 +139,17 @@ public class Recorder: Recording {
                 context: .init(recorderContext.applicationID)
             )
         } catch let error {
-            isSuccesful = false
+            isSuccessful = false
             telemetry.error("[SR] Failed to take snapshot", error: DDError(error: error))
         }
-        telemetry.stopMethodCalled(methodCalledTrace, isSuccessful: isSuccesful)
+        telemetry.stopMethodCalled(methodCalledTrace, isSuccessful: isSuccessful)
     }
 
     private enum MethodCallConstants {
         static let captureRecordOperationName = "Capture Record"
-        static let className = "Recorder"
+        static let className = {
+            String(reflecting: Recorder.self)
+        }()
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -121,7 +121,7 @@ public class Recorder: Recording {
     /// Initiates the capture of a next record.
     /// **Note**: This is called on the main thread.
     func captureNextRecord(_ recorderContext: Context) {
-        let methodCallTrace = telemetry.startMethodCall(
+        let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
             samplingRate: MethodCallConstants.captureRecordSampling // Effectively 3% * 15% = 0.45% of calls
@@ -143,7 +143,7 @@ public class Recorder: Recording {
             isSuccesful = false
             telemetry.error("[SR] Failed to take snapshot", error: DDError(error: error))
         }
-        telemetry.stopMethodCall(methodCallTrace, isSuccessful: isSuccesful)
+        telemetry.stopMethodCalled(methodCalledTrace, isSuccessful: isSuccesful)
     }
 
     private enum MethodCallConstants {


### PR DESCRIPTION
### What and why?

This PR adds telemetry for [Method Called (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3528197707/Method+Called+Telemetry+-+Spec).

This telemetry allows measuring execution time of methods + adds call side sampling for heavily called functions.

Along with these interfaces, we implement first function to utilise this: `SessionReplay.Recorder.captureNextRecord()`.

### How?

It's mostly reusing existing strategy for Batch metrics adding a little bit of convenience methods for measuring execution time. 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
