### PR TITLE
RUM-3291 Privacy Manifest - describe data use

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1110,6 +1110,8 @@
 		D2A7841029A53B2F003B03BB /* Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BAB2423979B00786299 /* Directory.swift */; };
 		D2A7841129A53B2F003B03BB /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BAC2423979B00786299 /* File.swift */; };
 		D2A7841229A53B2F003B03BB /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BAC2423979B00786299 /* File.swift */; };
+		D2A7A8FF2BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */; };
+		D2A7A9002BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */; };
 		D2B249942A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249952A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249972A45E10500DD4F9F /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249962A45E10500DD4F9F /* LoggerTests.swift */; };
@@ -2657,6 +2659,7 @@
 		D2A434AD2A8E426C0028E329 /* DDSessionReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSessionReplayTests.swift; sourceTree = "<group>"; };
 		D2A7840129A534F9003B03BB /* DatadogLogsTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogLogsTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A7840229A536AD003B03BB /* PrintFunctionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFunctionMock.swift; sourceTree = "<group>"; };
+		D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerProtocol+Internal.swift"; sourceTree = "<group>"; };
 		D2B249962A45E10500DD4F9F /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
@@ -5609,6 +5612,7 @@
 		D29A9F3529DD84AA005C54A4 /* DatadogRUM */ = {
 			isa = PBXGroup;
 			children = (
+				D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */,
 				61C713B82A3C935C00FA735A /* RUM.swift */,
 				49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */,
 				61C713A02A3B78F900FA735A /* RUMMonitorProtocol.swift */,
@@ -7039,6 +7043,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2A7A9002BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7089,6 +7094,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2A7A8FF2BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1112,6 +1112,8 @@
 		D2A7841229A53B2F003B03BB /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BAC2423979B00786299 /* File.swift */; };
 		D2A7A8FF2BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */; };
 		D2A7A9002BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */; };
+		D2A7A9022BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */; };
+		D2A7A9032BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */; };
 		D2B249942A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249952A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249972A45E10500DD4F9F /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249962A45E10500DD4F9F /* LoggerTests.swift */; };
@@ -2660,6 +2662,7 @@
 		D2A7840129A534F9003B03BB /* DatadogLogsTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogLogsTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A7840229A536AD003B03BB /* PrintFunctionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFunctionMock.swift; sourceTree = "<group>"; };
 		D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerProtocol+Internal.swift"; sourceTree = "<group>"; };
 		D2B249962A45E10500DD4F9F /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
@@ -4428,6 +4431,7 @@
 		6170DC1325C1864B003AED5C /* DatadogCrashReporting */ = {
 			isa = PBXGroup;
 			children = (
+				D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */,
 				6161247825CA9CA6009901BE /* CrashReporting.swift */,
 				61DE333525C8278A008E3EC2 /* CrashReportingPlugin.swift */,
 				D293302B2A137DAD0029C9EA /* CrashReportingFeature.swift */,
@@ -7001,6 +7005,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2A7A9022BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7152,6 +7157,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2A7A9032BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
                     "DatadogCore/Private/**/*.{h,m}"]
 
   s.resource_bundle = {
-    "DatadogPrivacyInfo" => "DatadogCore/Resources/PrivacyInfo.xcprivacy"
+    "DatadogCore" => "DatadogCore/Resources/PrivacyInfo.xcprivacy"
   }
 
   s.dependency 'DatadogInternal', s.version.to_s

--- a/DatadogCore/Resources/PrivacyInfo.xcprivacy
+++ b/DatadogCore/Resources/PrivacyInfo.xcprivacy
@@ -2,8 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>browser-intake-datadoghq.com</string>
+		<string>browser-intake-us3-datadoghq.com</string>
+		<string>browser-intake-us5-datadoghq.com</string>
+		<string>browser-intake-datadoghq.eu</string>
+		<string>browser-intake-ap1-datadoghq.com</string>
+		<string>browser-intake-ddog-gov.com</string>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -24,4 +24,8 @@ Pod::Spec.new do |s|
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
   s.dependency 'PLCrashReporter', '~> 1.11.1'
+
+  s.resource_bundle = {
+    "DatadogPrivacyInfo" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
+  }
 end

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.dependency 'PLCrashReporter', '~> 1.11.1'
 
   s.resource_bundle = {
-    "DatadogPrivacyInfo" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
+    "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
   }
 end

--- a/DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy
+++ b/DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.source_files = ["DatadogRUM/Sources/**/*.swift"]
 
   s.resource_bundle = {
-    "DatadogPrivacyInfo" => "DatadogRUM/Resources/PrivacyInfo.xcprivacy"
+    "DatadogRUM" => "DatadogRUM/Resources/PrivacyInfo.xcprivacy"
   }
 
   s.dependency 'DatadogInternal', s.version.to_s

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -22,6 +22,10 @@ Pod::Spec.new do |s|
   
   s.source_files = ["DatadogRUM/Sources/**/*.swift"]
 
+  s.resource_bundle = {
+    "DatadogPrivacyInfo" => "DatadogRUM/Resources/PrivacyInfo.xcprivacy"
+  }
+
   s.dependency 'DatadogInternal', s.version.to_s
 
 end

--- a/DatadogRUM/Resources/PrivacyInfo.xcprivacy
+++ b/DatadogRUM/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -27,4 +27,8 @@ Pod::Spec.new do |s|
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
   s.dependency 'PLCrashReporter', '~> 1.11.1'
+
+  s.resource_bundle = {
+    "DatadogPrivacyInfo" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
+  }
 end

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.dependency 'PLCrashReporter', '~> 1.11.1'
 
   s.resource_bundle = {
-    "DatadogPrivacyInfo" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
+    "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"
   }
 end

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,11 @@ let package = Package(
             dependencies: [
                 .target(name: "DatadogInternal"),
             ],
-            path: "DatadogRUM/Sources"
+            path: "DatadogRUM",
+            sources: ["Sources"],
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ]
         ),
         .testTarget(
             name: "DatadogRUMTests",

--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,11 @@ let package = Package(
                 .target(name: "DatadogInternal"),
                 .product(name: "CrashReporter", package: "PLCrashReporter"),
             ],
-            path: "DatadogCrashReporting/Sources"
+            path: "DatadogCrashReporting",
+            sources: ["Sources"],
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ]
         ),
         .testTarget(
             name: "DatadogCrashReportingTests",

--- a/dependency-manager-tests/carthage/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/carthage/App/PrivacyInfo.xcprivacy
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
 </plist>

--- a/dependency-manager-tests/cocoapods/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/cocoapods/App/PrivacyInfo.xcprivacy
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
 </plist>

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 				61B8C30026E0E278006EDF53 /* Frameworks */,
 				61B8C30126E0E278006EDF53 /* Resources */,
 				31384BB2056A865F3ED23F38 /* [CP] Embed Pods Frameworks */,
+				A242A29C234C1DB8379AA6B1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -539,6 +540,7 @@
 				D245424827C8D3200039E0A6 /* Frameworks */,
 				D245424A27C8D3200039E0A6 /* Resources */,
 				D245424D27C8D3200039E0A6 /* [CP] Embed Pods Frameworks */,
+				3BA7B0D961097BC82E5E9018 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -787,6 +789,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic iOS/Pods-Common-App Dynamic iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		3BA7B0D961097BC82E5E9018 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic tvOS/Pods-Common-App Dynamic tvOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic tvOS/Pods-Common-App Dynamic tvOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic tvOS/Pods-Common-App Dynamic tvOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		5645FD027BB938478818FE88 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -846,6 +865,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A242A29C234C1DB8379AA6B1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic iOS/Pods-Common-App Dynamic iOS-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic iOS/Pods-Common-App Dynamic iOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Common-App Dynamic iOS/Pods-Common-App Dynamic iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CC86EE069424642723D0C2E2 /* [CP] Copy Pods Resources */ = {

--- a/dependency-manager-tests/spm/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/spm/App/PrivacyInfo.xcprivacy
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
 </plist>

--- a/dependency-manager-tests/spm/Makefile
+++ b/dependency-manager-tests/spm/Makefile
@@ -24,5 +24,5 @@ create-src-from-xcodeproj:
 		rm -rf SPMProject.xcodeproj.src
 		cp -r SPMProject.xcodeproj SPMProject.xcodeproj.src
 		rm SPMProject.xcodeproj.src/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-		sed "s|\"${GIT_REFERENCE}\"|GIT_REFERENCE|g" SPMProject.xcodeproj/project.pbxproj > SPMProject.xcodeproj.src/project.pbxproj
+		sed "s|${GIT_REFERENCE}|GIT_REFERENCE|g" SPMProject.xcodeproj/project.pbxproj > SPMProject.xcodeproj.src/project.pbxproj
 		@echo "OK 👌"

--- a/dependency-manager-tests/xcframeworks/App/PrivacyInfo.xcprivacy
+++ b/dependency-manager-tests/xcframeworks/App/PrivacyInfo.xcprivacy
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
 </plist>


### PR DESCRIPTION
### What and why?

Add data use decription in Privacy Manifests for:
- `DatadogCore`
- `DatadogRUM`
- `DatadogCrashReporting`


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
