### PR TITLE
chore: Add unityVersion to telemetry objects

### DIFF
--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -46,6 +46,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let trackSessionAcrossSubdomains: Bool?
     public let trackUserInteractions: Bool?
     public let trackViewsManually: Bool?
+    public let unityVersion: String?
     public let useAllowedTracingOrigins: Bool?
     public let useAllowedTracingUrls: Bool?
     public let useBeforeSend: Bool?
@@ -278,6 +279,7 @@ extension Telemetry {
         trackSessionAcrossSubdomains: Bool? = nil,
         trackUserInteractions: Bool? = nil,
         trackViewsManually: Bool? = nil,
+        unityVersion: String? = nil,
         useAllowedTracingOrigins: Bool? = nil,
         useAllowedTracingUrls: Bool? = nil,
         useBeforeSend: Bool? = nil,
@@ -330,6 +332,7 @@ extension Telemetry {
             trackSessionAcrossSubdomains: trackSessionAcrossSubdomains,
             trackUserInteractions: trackUserInteractions,
             trackViewsManually: trackViewsManually,
+            unityVersion: unityVersion,
             useAllowedTracingOrigins: useAllowedTracingOrigins,
             useAllowedTracingUrls: useAllowedTracingUrls,
             useBeforeSend: useBeforeSend,
@@ -439,6 +442,7 @@ extension ConfigurationTelemetry {
             trackSessionAcrossSubdomains: other.trackSessionAcrossSubdomains ?? trackSessionAcrossSubdomains,
             trackUserInteractions: other.trackUserInteractions ?? trackUserInteractions,
             trackViewsManually: other.trackViewsManually ?? trackViewsManually,
+            unityVersion: other.unityVersion ?? unityVersion,
             useAllowedTracingOrigins: other.useAllowedTracingOrigins ?? useAllowedTracingOrigins,
             useAllowedTracingUrls: other.useAllowedTracingUrls ?? useAllowedTracingUrls,
             useBeforeSend: other.useBeforeSend ?? useBeforeSend,

--- a/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
@@ -50,6 +50,7 @@ extension ConfigurationTelemetry {
             trackSessionAcrossSubdomains: .mockRandom(),
             trackUserInteractions: .mockRandom(),
             trackViewsManually: .mockRandom(),
+            unityVersion: .mockRandom(),
             useAllowedTracingOrigins: .mockRandom(),
             useAllowedTracingUrls: .mockRandom(),
             useBeforeSend: .mockRandom(),

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -257,6 +257,7 @@ class TelemetryTest: Telemetry {
             trackSessionAcrossSubdomains: configuration.trackSessionAcrossSubdomains,
             trackUserInteractions: configuration.trackUserInteractions,
             trackViewsManually: configuration.trackViewsManually,
+            unityVersion: configuration.unityVersion,
             useAllowedTracingOrigins: configuration.useAllowedTracingOrigins,
             useAllowedTracingUrls: configuration.useAllowedTracingUrls,
             useBeforeSend: configuration.useBeforeSend,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -321,6 +321,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             trackResources: nil,
             trackSessionAcrossSubdomains: nil,
             trackViewsManually: configuration.trackViewsManually,
+            unityVersion: configuration.unityVersion,
             useAllowedTracingOrigins: nil,
             useAllowedTracingUrls: nil,
             useBeforeSend: nil,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -311,6 +311,7 @@ class TelemetryReceiverTests: XCTestCase {
         let trackNativeViews: Bool? = .mockRandom()
         let trackNetworkRequests: Bool? = .mockRandom()
         let trackViewsManually: Bool? = .mockRandom()
+        let unityVersion: String? = .mockRandom()
         let useFirstPartyHosts: Bool? = .mockRandom()
         let useLocalEncryption: Bool? = .mockRandom()
         let useProxy: Bool? = .mockRandom()
@@ -338,6 +339,7 @@ class TelemetryReceiverTests: XCTestCase {
             trackNativeViews: trackNativeViews,
             trackNetworkRequests: trackNetworkRequests,
             trackViewsManually: trackViewsManually,
+            unityVersion: unityVersion,
             useFirstPartyHosts: useFirstPartyHosts,
             useLocalEncryption: useLocalEncryption,
             useProxy: useProxy,
@@ -370,6 +372,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.telemetry.configuration.trackNativeViews, trackNativeViews)
         XCTAssertEqual(event?.telemetry.configuration.trackNetworkRequests, trackNetworkRequests)
         XCTAssertEqual(event?.telemetry.configuration.trackViewsManually, trackViewsManually)
+        XCTAssertEqual(event?.telemetry.configuration.unityVersion, unityVersion)
         XCTAssertEqual(event?.telemetry.configuration.useFirstPartyHosts, useFirstPartyHosts)
         XCTAssertEqual(event?.telemetry.configuration.useLocalEncryption, useLocalEncryption)
         XCTAssertEqual(event?.telemetry.configuration.useProxy, useProxy)


### PR DESCRIPTION
### What and why?

Add unityVersion to telemetry intermediate objects so they can be added to the RUMTelemetry event.

refs: RUM-3237

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
