### PR TITLE
Fix Swift Package Manager warning for Datadog.modulemap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,9 @@ let package = Package(
                 .target(name: "DatadogPrivate"),
             ],
             path: "DatadogCore",
+            exclude: [
+                "Sources/Datadog.modulemap"
+            ],
             sources: ["Sources"],
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")


### PR DESCRIPTION
### What and why?
Fix the Swift Package warning for unprocessable files. Issue #1739

### How?
Added the modulemap file to the package target's exclusion list.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
