### PR TITLE
feat: Support eventMapper on crashes for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [FEATURE] Support calling log event mapper for crashes.
+
 # 2.8.0 / 19-03-2024
 
 - [FEATURE] App Hangs are tracked as RUM errors. See [#1685][]

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -21,6 +21,12 @@ var rumMonitor: RUMMonitorProtocol { RUMMonitor.shared() }
 class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
+    func logEventMapper(event: LogEvent) -> LogEvent {
+        var event = event
+        event.error?.fingerprint = "mapped"
+        return event
+    }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if Environment.isRunningUnitTests() {
             return false
@@ -44,6 +50,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         // Enable Logs
         Logs.enable(
             with: Logs.Configuration(
+                eventMapper: logEventMapper,
                 customEndpoint: Environment.readCustomLogsURL()
             )
         )

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -21,12 +21,6 @@ var rumMonitor: RUMMonitorProtocol { RUMMonitor.shared() }
 class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func logEventMapper(event: LogEvent) -> LogEvent {
-        var event = event
-        event.error?.fingerprint = "mapped"
-        return event
-    }
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if Environment.isRunningUnitTests() {
             return false
@@ -50,7 +44,6 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         // Enable Logs
         Logs.enable(
             with: Logs.Configuration(
-                eventMapper: logEventMapper,
                 customEndpoint: Environment.readCustomLogsURL()
             )
         )

--- a/DatadogCore/Tests/Datadog/Mocks/LogsMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/LogsMocks.swift
@@ -60,7 +60,8 @@ extension CrashLogReceiver: AnyMockable {
         dateProvider: DateProvider = SystemDateProvider()
     ) -> Self {
         .init(
-            dateProvider: dateProvider
+            dateProvider: dateProvider,
+            logEventMapper: nil
         )
     }
 }

--- a/DatadogCore/Tests/Matchers/LogMatcher.swift
+++ b/DatadogCore/Tests/Matchers/LogMatcher.swift
@@ -56,6 +56,7 @@ internal class LogMatcher: JSONDataMatcher {
         static let errorKind = "error.kind"
         static let errorMessage = "error.message"
         static let errorStack = "error.stack"
+        static let errorFingerprint = "error.fingerprint"
 
         // MARK: - Dd info
         static let dd = "_dd"
@@ -135,6 +136,10 @@ internal class LogMatcher: JSONDataMatcher {
 
     func assertMessage(equals message: String, file: StaticString = #file, line: UInt = #line) {
         assertValue(forKey: JSONKey.message, equals: message, file: file, line: line)
+    }
+
+    func assertErrorFingerprint(equals fingerprint: String) {
+        assertValue(forKey: JSONKey.errorFingerprint, equals: fingerprint)
     }
 
     func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?)?, file: StaticString = #file, line: UInt = #line) {

--- a/DatadogLogs/Sources/Feature/LogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/LogsFeature.swift
@@ -36,7 +36,7 @@ internal struct LogsFeature: DatadogRemoteFeature {
             ),
             messageReceiver: CombinedFeatureMessageReceiver(
                 LogMessageReceiver(logEventMapper: logEventMapper),
-                CrashLogReceiver(dateProvider: dateProvider),
+                CrashLogReceiver(dateProvider: dateProvider, logEventMapper: logEventMapper),
                 WebViewLogReceiver()
             ),
             dateProvider: dateProvider

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -191,6 +191,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
 
     /// Time provider.
     let dateProvider: DateProvider
+    let logEventMapper: LogEventMapper?
 
     /// Process messages receives from the bus.
     ///
@@ -285,7 +286,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
                 tags: nil
             )
 
-            writer.write(value: event)
+            logEventMapper?.map(event: event, callback: writer.write) ?? writer.write(value: event)
         }
 
         return true

--- a/DatadogLogs/Tests/Mocks/LoggingFeatureMocks.swift
+++ b/DatadogLogs/Tests/Mocks/LoggingFeatureMocks.swift
@@ -76,7 +76,8 @@ extension CrashLogReceiver: AnyMockable {
         dateProvider: DateProvider = SystemDateProvider()
     ) -> Self {
         .init(
-            dateProvider: dateProvider
+            dateProvider: dateProvider,
+            logEventMapper: nil
         )
     }
 }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
@@ -106,5 +106,8 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
         crashLog.assertLoggerName(equals: "crash-reporter")
         crashLog.assertApplicationVersion(equals: "1.0")
         crashLog.assertApplicationBuildNumber(equals: "1")
+
+        // Assert mapped value
+        crashLog.assertErrorFingerprint(equals: "mapped fingerprint")
     }
 }

--- a/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -59,10 +59,17 @@ final class CrashReportingCollectOrSendWithRUMScenario: CrashReportingBaseScenar
 
 /// A `CrashReportingScenario` which uploads the crash report as "EMERGENCY" Log.
 final class CrashReportingCollectOrSendWithLoggingScenario: CrashReportingBaseScenario, TestScenario {
+    func logEventMapper(event: LogEvent) -> LogEvent? {
+        var event = event
+        event.error?.fingerprint = "mapped fingerprint"
+        return event
+    }
+
     func configureFeatures() {
         // Enable Logs
         Logs.enable(
             with: Logs.Configuration(
+                eventMapper: logEventMapper,
                 customEndpoint: Environment.serverMockConfiguration()?.logsEndpoint
             )
         )


### PR DESCRIPTION
### What and why?

This adds a call to the configured log event mapper when a crash is reported to the Logs feature.  It's tested in the integration test app by adding a fingerprint to the reported crash.

refs: RUM-2209

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
