### PR TITLE
feat: Allow crash reporting to use event mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [FEATURE] Call RUM's `errorEventMapper` for crashes.
+
 # 2.8.0 / 19-03-2024
 
 - [FEATURE] App Hangs are tracked as RUM errors. See [#1685][]

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -63,7 +63,8 @@ extension CrashReportReceiver: AnyMockable {
         uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
-        telemetry: Telemetry = NOPTelemetry()
+        telemetry: Telemetry = NOPTelemetry(),
+        eventsMapper: RUMEventsMapper = .mockNoOp()
     ) -> Self {
         .init(
             applicationID: applicationID,
@@ -73,7 +74,8 @@ extension CrashReportReceiver: AnyMockable {
             uuidGenerator: uuidGenerator,
             ciTest: ciTest,
             syntheticsTest: syntheticsTest,
-            telemetry: telemetry
+            telemetry: telemetry,
+            eventsMapper: eventsMapper
         )
     }
 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -25,6 +25,14 @@ internal final class RUMFeature: DatadogRemoteFeature {
         configuration: RUM.Configuration
     ) throws {
         self.configuration = configuration
+        let eventsMapper = RUMEventsMapper(
+            viewEventMapper: configuration.viewEventMapper,
+            errorEventMapper: configuration.errorEventMapper,
+            resourceEventMapper: configuration.resourceEventMapper,
+            actionEventMapper: configuration.actionEventMapper,
+            longTaskEventMapper: configuration.longTaskEventMapper,
+            telemetry: core.telemetry
+        )
 
         let dependencies = RUMScopeDependencies(
             core: core,
@@ -43,14 +51,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 }
             }(),
             eventBuilder: RUMEventBuilder(
-                eventsMapper: RUMEventsMapper(
-                    viewEventMapper: configuration.viewEventMapper,
-                    errorEventMapper: configuration.errorEventMapper,
-                    resourceEventMapper: configuration.resourceEventMapper,
-                    actionEventMapper: configuration.actionEventMapper,
-                    longTaskEventMapper: configuration.longTaskEventMapper,
-                    telemetry: core.telemetry
-                )
+                eventsMapper: eventsMapper
             ),
             rumUUIDGenerator: configuration.uuidGenerator,
             ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
@@ -119,7 +120,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
                         return nil
                     }
                 }(),
-                telemetry: core.telemetry
+                telemetry: core.telemetry,
+                eventsMapper: eventsMapper
             )
         )
 

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -206,6 +206,9 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 let rumError = createRUMError(from: crashReport, and: lastRUMViewEvent, crashDate: crashTimings.realCrashDate, sourceType: context.nativeSourceOverride)
                 if let mappedError = self.eventsMapper.map(event: rumError) {
                     writer.write(value: mappedError)
+                } else {
+                    DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
+                    writer.write(value: rumError)
                 }
             }
         }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -331,6 +331,9 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
 
             if let mappedError = self.eventsMapper.map(event: rumError) {
                 writer.write(value: mappedError)
+            } else {
+                DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
+                writer.write(value: rumError)
             }
             if let mappedView = self.eventsMapper.map(event: updatedRUMView) {
                 writer.write(value: self.eventsMapper.map(event: mappedView))

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -38,7 +38,8 @@ extension CrashReportReceiver: AnyMockable {
         uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
-        telemetry: Telemetry = NOPTelemetry()
+        telemetry: Telemetry = NOPTelemetry(),
+        eventsMapper: RUMEventsMapper = .mockNoOp()
     ) -> Self {
         .init(
             applicationID: applicationID,
@@ -48,7 +49,8 @@ extension CrashReportReceiver: AnyMockable {
             uuidGenerator: uuidGenerator,
             ciTest: ciTest,
             syntheticsTest: syntheticsTest,
-            telemetry: telemetry
+            telemetry: telemetry,
+            eventsMapper: eventsMapper
         )
     }
 }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
@@ -96,5 +96,8 @@ class CrashReportingWithRUMScenarioTests: IntegrationTests, RUMCommonAsserts {
         XCTAssertNotNil(try? lastRUMErrorEventJSON.value(forKeyPath: "error.meta") as [String: Any], "The error should include crash meta info")
         XCTAssertNotNil(try? lastRUMErrorEventJSON.value(forKeyPath: "error.threads") as [Any], "The error should include threads info")
         XCTAssertNotNil(try? lastRUMErrorEventJSON.value(forKeyPath: "error.binary_images") as [Any], "The error should include binary images info")
+
+        // Assert mapped value
+        XCTAssertEqual(crashRUMError.error.fingerprint, "mapped fingerprint", "Error should have a mapper supplied fingerprint value")
     }
 }

--- a/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -47,10 +47,18 @@ final class CrashReportingCollectOrSendWithRUMScenario: CrashReportingBaseScenar
         }
     }
 
+    func rumErrorEventMapper(event: RUMErrorEvent) -> RUMErrorEvent? {
+        var event = event
+        event.error.fingerprint = "mapped fingerprint"
+        return event
+    }
+
     func configureFeatures() {
         var rumConfig = RUM.Configuration(applicationID: "rum-application-id")
         rumConfig.customEndpoint = Environment.serverMockConfiguration()?.rumEndpoint
         rumConfig.uiKitViewsPredicate = CustomPredicate()
+        rumConfig.errorEventMapper = rumErrorEventMapper
+
         RUM.enable(with: rumConfig)
 
         CrashReporting.enable()


### PR DESCRIPTION
### What and why?

CrashReportReceiver now supports calling both the view and event mapper before writing the crash to storage.

refs: RUM-2206

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
