### PR TITLE
fix: Fix compilation problem in integration tests

### DIFF
--- a/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import XCTest
-@testable import DatadogInternal
+import DatadogInternal
 
 /// Passthrough core mocks feature-scope allowing recording events in **sync**.
 ///


### PR DESCRIPTION
### What and why?

🧰 Fixing CI which fails on `@testable import` (in `TestUtilities`) when running integration tests.

### How?

`@testable import DatadogInternal` → `import DatadogInternal` as `@testable` is not necessary.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
