### PR TITLE
RUM-3462 refactor: Make `FeatureScope` always available

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -265,6 +265,8 @@
 		613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E793A2577B6EE00DFCC17 /* DataReader.swift */; };
 		613F9C182BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F9C172BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift */; };
 		613F9C192BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F9C172BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift */; };
+		613F9C1B2BB03188007C7606 /* FeatureScopeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F9C1A2BB03188007C7606 /* FeatureScopeMock.swift */; };
+		613F9C1C2BB03188007C7606 /* FeatureScopeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F9C1A2BB03188007C7606 /* FeatureScopeMock.swift */; };
 		614396722A67D74F00197326 /* CoreMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614396712A67D74F00197326 /* CoreMetrics.swift */; };
 		614396732A67D74F00197326 /* CoreMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614396712A67D74F00197326 /* CoreMetrics.swift */; };
 		61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C0424616DE9003D8BB8 /* ExampleAppDelegate.swift */; };
@@ -2175,6 +2177,7 @@
 		613E81F625A743600084B751 /* RUMEventsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventsMapperTests.swift; sourceTree = "<group>"; };
 		613E820425A879AF0084B751 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		613F9C172BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogCore+FeatureDataStoreTests.swift"; sourceTree = "<group>"; };
+		613F9C1A2BB03188007C7606 /* FeatureScopeMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureScopeMock.swift; sourceTree = "<group>"; };
 		6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzler.swift; sourceTree = "<group>"; };
 		6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandler.swift; sourceTree = "<group>"; };
 		61410166251A661D00E3C2D9 /* UIApplicationSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzlerTests.swift; sourceTree = "<group>"; };
@@ -4897,6 +4900,7 @@
 				D257954A298ABB04008A1BE5 /* PassthroughCoreMock.swift */,
 				D2160CEF29C0EC4D00FAA9A5 /* SingleFeatureCoreMock.swift */,
 				61C713CF2A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift */,
+				613F9C1A2BB03188007C7606 /* FeatureScopeMock.swift */,
 			);
 			path = CoreMocks;
 			sourceTree = "<group>";
@@ -8364,6 +8368,7 @@
 				D2579557298ABB04008A1BE5 /* AttributesMocks.swift in Sources */,
 				6167E7292B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C7298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
+				613F9C1B2BB03188007C7606 /* FeatureScopeMock.swift in Sources */,
 				D2DA23CA298D5C1300C6C7E6 /* UIKitMocks.swift in Sources */,
 				6188900F2AC58B8C00D0B966 /* TelemetryReceiverMock.swift in Sources */,
 				61C713D02A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift in Sources */,
@@ -8407,6 +8412,7 @@
 				D257957F298ABB83008A1BE5 /* AttributesMocks.swift in Sources */,
 				6167E72A2B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C8298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
+				613F9C1C2BB03188007C7606 /* FeatureScopeMock.swift in Sources */,
 				D2DA23CB298D5C1300C6C7E6 /* UIKitMocks.swift in Sources */,
 				618890102AC58B8C00D0B966 /* TelemetryReceiverMock.swift in Sources */,
 				61C713D12A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift in Sources */,

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -337,7 +337,7 @@ internal class CoreFeatureScope<Feature>: FeatureScope where Feature: DatadogFea
 
         // (on user thread) request SDK context
         context { context in
-            // (on context thread)
+            // (on context thread) call the block
             let writer = storage.writer(for: bypassConsent ? .granted : context.trackingConsent)
             block(context, writer)
         }
@@ -352,8 +352,7 @@ internal class CoreFeatureScope<Feature>: FeatureScope where Feature: DatadogFea
     }
 
     var dataStore: DataStore {
-        // Data store is only available when core instance exists.
-        return (core != nil) ? store : NOPDataStore()
+        return (core != nil) ? store : NOPDataStore() // only available when the core exists
     }
 
     func send(message: FeatureMessage, else fallback: @escaping () -> Void) {

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -359,6 +359,18 @@ internal class CoreFeatureScope<Feature>: FeatureScope where Feature: DatadogFea
         // Data store is only available when core instance exists.
         return (core != nil) ? store : NOPDataStore()
     }
+
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
+        core?.send(message: message, else: fallback)
+    }
+
+    func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
+        core?.set(baggage: baggage, forKey: key)
+    }
+
+    var telemetry: Telemetry {
+        return core?.telemetry ?? NOPTelemetry()
+    }
 }
 
 extension DatadogContextProvider {

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDataStoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDataStoreTests.swift
@@ -45,8 +45,8 @@ class DatadogCore_FeatureDataStoreTests: XCTestCase {
         try core.register(feature: FeatureBMock())
 
         // When
-        let scopeA = try XCTUnwrap(core.scope(for: FeatureAMock.name))
-        let scopeB = try XCTUnwrap(core.scope(for: FeatureBMock.name))
+        let scopeA = core.scope(for: FeatureAMock.self)
+        let scopeB = core.scope(for: FeatureBMock.self)
 
         let commonKey = "key"
         scopeA.dataStore.setValue("feature A data".utf8Data, forKey: commonKey)
@@ -104,8 +104,8 @@ class DatadogCore_FeatureDataStoreTests: XCTestCase {
         try core2.register(feature: FeatureAMock())
 
         // When
-        let scope1 = try XCTUnwrap(core1.scope(for: FeatureAMock.name))
-        let scope2 = try XCTUnwrap(core2.scope(for: FeatureAMock.name))
+        let scope1 = core1.scope(for: FeatureAMock.self)
+        let scope2 = core2.scope(for: FeatureAMock.self)
 
         let commonKey = "key"
         scope1.dataStore.setValue("feature data in core 1".utf8Data, forKey: commonKey)

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -49,7 +49,7 @@ class DatadogCoreTests: XCTestCase {
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
+        let scope = core.scope(for: FeatureMock.self)
 
         // When
         core.set(trackingConsent: .notGranted)
@@ -95,7 +95,7 @@ class DatadogCoreTests: XCTestCase {
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
+        let scope = core.scope(for: FeatureMock.self)
 
         // When
         core.set(trackingConsent: .notGranted)
@@ -150,7 +150,7 @@ class DatadogCoreTests: XCTestCase {
 
         let feature = FeatureMock()
         try core.register(feature: feature)
-        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
+        let scope = core.scope(for: FeatureMock.self)
 
         // When
         let key = "key"
@@ -257,7 +257,7 @@ class DatadogCoreTests: XCTestCase {
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
         try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
+        let scope = core.scope(for: FeatureMock.self)
 
         // When
         core.stop()
@@ -267,7 +267,7 @@ class DatadogCoreTests: XCTestCase {
         }
 
         // Then
-        XCTAssertNil(core.scope(for: FeatureMock.name))
+        XCTAssertNil(core.get(feature: FeatureMock.self))
         core.flush()
         XCTAssertEqual(requestBuilderSpy.requestParameters.count, 0, "It should not send any request")
     }

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -127,7 +127,16 @@ private struct FeatureScopeProxy: FeatureScope {
         }
     }
 
+    var telemetry: Telemetry { proxy.telemetry }
     var dataStore: DataStore { proxy.dataStore }
+
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
+        proxy.send(message: message, else: fallback)
+    }
+
+    func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
+        proxy.set(baggage: baggage, forKey: key)
+    }
 }
 
 private class FeatureScopeInterceptor {

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -74,10 +74,11 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
         return core.get(feature: type)
     }
 
-    func scope(for feature: String) -> FeatureScope? {
-        return core.scope(for: feature).map { scope in
-            FeatureScopeProxy(proxy: scope, interceptor: featureScopeInterceptors[feature]!)
-        }
+    func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature {
+        return FeatureScopeProxy(
+            proxy: core.scope(for: featureType),
+            interceptor: featureScopeInterceptors[T.name]!
+        )
     }
 
     func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorConfigurationTests.swift
@@ -41,7 +41,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
         let monitor = RUMMonitor.shared(in: core).dd
 
         let dependencies = monitor.scopes.dependencies
-        monitor.core?.scope(for: RUMFeature.name)?.eventWriteContext { context, _ in
+        monitor.core?.scope(for: RUMFeature.self).eventWriteContext { context, _ in
             DDAssertReflectionEqual(context.userInfo, self.userIno)
             XCTAssertEqual(context.networkConnectionInfo, self.networkConnectionInfo)
             XCTAssertEqual(context.carrierInfo, self.carrierInfo)

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -278,11 +278,12 @@ public class NOPDatadogCore: DatadogCoreProtocol {
     public func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
 }
 
-internal struct NOPFeatureScope: FeatureScope {
+public struct NOPFeatureScope: FeatureScope {
+    public init() { }
     /// no-op
-    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) { }
+    public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) { }
     /// no-op
-    func context(_ block: @escaping (DatadogContext) -> Void) { }
+    public func context(_ block: @escaping (DatadogContext) -> Void) { }
     /// no-op
-    var dataStore: DataStore { NOPDataStore() }
+    public var dataStore: DataStore { NOPDataStore() }
 }

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -36,16 +36,14 @@ public protocol DatadogCoreProtocol: AnyObject {
     /// - Returns: The Feature if any.
     func get<T>(feature type: T.Type) -> T? where T: DatadogFeature
 
-    /// Retrieves a Feature Scope by its name.
+    /// Retrieves a Feature Scope for given feature type..
     ///
-    /// Feature Scope collects data to Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature retrieves
-    /// its `FeatureScope` interface for writing events to the core. The core will store and upload events efficiently
-    /// according to the performance presets defined on initialization.
+    /// TODO: RUM-3462 update API comment
     ///
     /// - Parameters:
-    ///   - feature: The Feature's name.
-    /// - Returns: The Feature scope if a Feature with given name was registered.
-    func scope(for feature: String) -> FeatureScope?
+    ///   - type: The Feature instance type.
+    /// - Returns: TODO: RUM-3462 update API comment
+    func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature
 
     /// Sets given baggage for a given Feature for sharing data through `DatadogContext`.
     ///
@@ -273,9 +271,18 @@ public class NOPDatadogCore: DatadogCoreProtocol {
     /// no-op
     public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
     /// no-op
-    public func scope(for feature: String) -> FeatureScope? { nil }
+    public func scope<T>(for featureType: T.Type) -> FeatureScope { NOPFeatureScope() }
     /// no-op
     public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) { }
     /// no-op
     public func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
+}
+
+internal struct NOPFeatureScope: FeatureScope {
+    /// no-op
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) { }
+    /// no-op
+    func context(_ block: @escaping (DatadogContext) -> Void) { }
+    /// no-op
+    var dataStore: DataStore { NOPDataStore() }
 }

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -51,7 +51,7 @@ public protocol DatadogCoreProtocol: AnyObject, MessageSending, BaggageSharing {
 }
 
 public protocol MessageSending {
-    /// Sends a message on the bus shared by features registered to the sam core..
+    /// Sends a message on the bus shared by features registered to the sam core.
     ///
     /// If the message could not be processed by any registered feature, the fallback closure
     /// will be invoked. Do not make any assumption on which thread the fallback is called.
@@ -97,7 +97,7 @@ public protocol BaggageSharing {
 }
 
 extension MessageSending {
-    /// Sends a message on the bus shared by features registered to the same core..
+    /// Sends a message on the bus shared by features registered to the same core.
     ///
     /// - Parameters:
     ///   - message: The message.
@@ -304,9 +304,9 @@ public struct NOPFeatureScope: FeatureScope {
     /// no-op
     public var dataStore: DataStore { NOPDataStore() }
     /// no-op
+    public var telemetry: Telemetry { NOPTelemetry() }
+    /// no-op
     public func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
     /// no-op
     public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) { }
-    /// no-op
-    public var telemetry: Telemetry { NOPTelemetry() }
 }

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -36,18 +36,22 @@ public protocol DatadogCoreProtocol: AnyObject, MessageSending, BaggageSharing {
     /// - Returns: The Feature if any.
     func get<T>(feature type: T.Type) -> T? where T: DatadogFeature
 
-    /// Retrieves a Feature Scope for given feature type..
+    /// Retrieves a Feature Scope for given feature type.
     ///
-    /// TODO: RUM-3462 update API comment
+    /// The scope manages the underlying core's reference in safe way, guaranteeing no reference leaks.
+    /// It is available right away even before the feature registration completes in the core, so some capabilities
+    /// might be not available before the feature is fully registered.
+    ///
+    /// If possible, feature implementation must to take dependency on `FeatureScope` rather than `DatadogCoreProtocol` itself.
     ///
     /// - Parameters:
     ///   - type: The Feature instance type.
-    /// - Returns: TODO: RUM-3462 update API comment
+    /// - Returns: The scope for requested feature type.
     func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature
 }
 
 public protocol MessageSending {
-    /// Sends a message on the bus shared by features registered in this core.
+    /// Sends a message on the bus shared by features registered to the sam core..
     ///
     /// If the message could not be processed by any registered feature, the fallback closure
     /// will be invoked. Do not make any assumption on which thread the fallback is called.
@@ -93,7 +97,7 @@ public protocol BaggageSharing {
 }
 
 extension MessageSending {
-    /// Sends a message on the bus shared by features registered in this core.
+    /// Sends a message on the bus shared by features registered to the same core..
     ///
     /// - Parameters:
     ///   - message: The message.
@@ -228,9 +232,14 @@ public protocol FeatureScope: MessageSending, BaggageSharing {
     /// - Parameter block: The block to execute; it is called on the context queue.
     func context(_ block: @escaping (DatadogContext) -> Void)
 
-    /// Data store configured for storing data for this feature.
+    /// Data store endpoint.
+    ///
+    /// Use this property to store data for this feature. Data will be persisted between app launches.
     var dataStore: DataStore { get }
 
+    /// Telemetry endpoint.
+    ///
+    /// Use this property to report any telemetry event to the core.
     var telemetry: Telemetry { get }
 }
 

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -55,7 +55,7 @@ internal struct LogMessageReceiver: FeatureMessageReceiver {
                 return false
             }
 
-            core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+            core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
                 let builder = LogEventBuilder(
                     service: log.service ?? context.service,
                     loggerName: log.logger,
@@ -237,7 +237,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
 
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
-        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: true) { context, writer in
+        core.scope(for: LogsFeature.self).eventWriteContext(bypassConsent: true) { context, writer in
             let event = LogEvent(
                 date: date,
                 status: .emergency,
@@ -309,7 +309,7 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
         let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
         let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
 
-        core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+        core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
             let ddTags = "\(versionKey):\(context.version),\(envKey):\(context.env)"
 
             if let tags = event[tagsKey] as? String, !tags.isEmpty {

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -122,7 +122,7 @@ internal final class RemoteLogger: LoggerProtocol {
 
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.
-        self.core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+        self.core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
             var internalAttributes: [String: Encodable] = [:]
 
             // When bundle with RUM is enabled, link RUM context (if available):

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -122,7 +122,7 @@ internal final class RemoteLogger: LoggerProtocol {
 
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.
-        self.core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
+        core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
             var internalAttributes: [String: Encodable] = [:]
 
             // When bundle with RUM is enabled, link RUM context (if available):

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -15,7 +15,7 @@ import DatadogInternal
 @available(iOS 13, *)
 internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     /// The SDK core instance.
-    let core: DatadogCoreProtocol
+    weak var core: DatadogCoreProtocol?
 
     /// The required number of taps to complete the tap action.
     let count: Int
@@ -29,6 +29,9 @@ internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     func body(content: Content) -> some View {
         content.simultaneousGesture(
             TapGesture(count: count).onEnded { _ in
+                guard let core = core else {
+                    return // core was deallocated
+                }
                 RUMMonitor.shared(in: core)
                     .addAction(type: .tap, name: name, attributes: attributes)
             }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -201,7 +201,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             // We know it is too late for sending RUM view to previous RUM session as it is now stale on backend.
             // To avoid inconsistency, we only send the RUM error.
             DD.logger.debug("Sending crash as RUM error.")
-            core.scope(for: RUMFeature.name)?.eventWriteContext(bypassConsent: true) { context, writer in
+            core.scope(for: RUMFeature.self).eventWriteContext(bypassConsent: true) { context, writer in
                 let rumError = createRUMError(from: crashReport, and: lastRUMViewEvent, crashDate: crashTimings.realCrashDate, sourceType: context.nativeSourceOverride)
                 writer.write(value: rumError)
             }
@@ -321,7 +321,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
 
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
-        core.scope(for: RUMFeature.name)?.eventWriteContext(bypassConsent: true) { context, writer in
+        core.scope(for: RUMFeature.self).eventWriteContext(bypassConsent: true) { context, writer in
             let rumError = createRUMError(from: crashReport, and: updatedRUMView, crashDate: realCrashDate, sourceType: context.nativeSourceOverride)
 
             writer.write(value: rumError)

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -222,14 +222,11 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     }
 
     private func record(event id: String?, in core: DatadogCoreProtocol, operation: @escaping (DatadogContext, Writer) -> Void) {
-        guard
-            let rum = core.scope(for: RUMFeature.name),
-            sampler.sample()
-        else {
+        guard sampler.sample() else {
             return
         }
 
-        rum.eventWriteContext { context, writer in
+        core.scope(for: RUMFeature.self).eventWriteContext { context, writer in
             // reset recorded events on session renewal
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -59,7 +59,7 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
             )
         )
 
-        core.scope(for: RUMFeature.name)?.eventWriteContext { [weak core] context, writer in
+        core.scope(for: RUMFeature.self).eventWriteContext { [weak core] context, writer in
             guard let rumBaggage = context.baggages[RUMFeature.name] else {
                 return // Drop event if RUM is not enabled or RUM session is not sampled
             }

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -134,7 +134,7 @@ internal class Monitor: RUMCommandSubscriber {
 
     func process(command: RUMCommand) {
         // process command in event context
-        core?.scope(for: RUMFeature.name)?.eventWriteContext { context, writer in
+        core?.scope(for: RUMFeature.self).eventWriteContext { context, writer in
             self.queue.sync {
                 let transformedCommand = self.transform(command: command)
 
@@ -218,7 +218,7 @@ extension Monitor: RUMMonitorProtocol {
         // Even though we're not writing anything, need to get the write context
         // to make sure we're returning the correct sessionId after all other
         // events have processed.
-        core?.scope(for: RUMFeature.name)?.eventWriteContext { _, _ in
+        core?.scope(for: RUMFeature.self).eventWriteContext { _, _ in
             self.queue.sync {
                 guard let sessionId = self.scopes.activeSession?.sessionUUID else {
                     completion(nil)

--- a/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/RecordWriter.swift
@@ -25,7 +25,7 @@ internal class RecordWriter: RecordWriting {
     // MARK: - Writing
 
     func write(nextRecord: EnrichedRecord) {
-        core?.scope(for: SessionReplayFeature.name)?.eventWriteContext { _, recordWriter in
+        core?.scope(for: SessionReplayFeature.self).eventWriteContext { _, recordWriter in
             recordWriter.write(value: nextRecord)
         }
     }

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -27,7 +27,7 @@ internal class ResourcesWriter: ResourcesWriting {
     // MARK: - Writing
 
     func write(resources: [EnrichedResource]) {
-        guard let scope = core?.scope(for: ResourcesFeature.name) else {
+        guard let scope = core?.scope(for: ResourcesFeature.self) else {
             return
         }
         scope.eventWriteContext { _, recordWriter in

--- a/DatadogTrace/Sources/Span/SpanWriteContext.swift
+++ b/DatadogTrace/Sources/Span/SpanWriteContext.swift
@@ -30,13 +30,13 @@ internal final class LazySpanWriteContext: SpanWriteContext {
         self.core = core
 
         // Capture the core context valid at the moment of initialization:
-        core.scope(for: TraceFeature.name)?.context { [weak self] context in
+        core.scope(for: TraceFeature.self).context { [weak self] context in
             self?.context = context
         }
     }
 
     func spanWriteContext(_ block: @escaping (DatadogContext, Writer) -> Void) {
-        guard let scope = core?.scope(for: TraceFeature.name) else {
+        guard let scope = core?.scope(for: TraceFeature.self) else {
             return
         }
 

--- a/TestUtilities/Mocks/CoreMocks/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/FeatureRegistrationCoreMock.swift
@@ -46,9 +46,8 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
 
     // MARK: - Unsupported
 
-    public func scope(for feature: String) -> FeatureScope? {
-        // not supported - use different type of core mock if you need this
-        return nil
+    public func scope<T>(for featureType: T.Type) -> FeatureScope where T : DatadogFeature {
+        return NOPFeatureScope()
     }
 
     public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {

--- a/TestUtilities/Mocks/CoreMocks/FeatureScopeMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/FeatureScopeMock.swift
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+public class FeatureScopeMock: FeatureScope {
+    struct EventWriterMock: Writer {
+        weak var scope: FeatureScopeMock?
+
+        func write<T, M>(value: T, metadata: M?) where T : Encodable, M : Encodable {
+            scope?.events.append((value, metadata))
+        }
+    }
+
+    @ReadWriteLock
+    public var contextMock: DatadogContext
+    @ReadWriteLock
+    private var events: [(event: Encodable, metadata: Encodable?)] = []
+    @ReadWriteLock
+    private var messages: [FeatureMessage] = []
+
+    public init(context: DatadogContext = .mockAny()) {
+        self.contextMock = context
+    }
+
+    public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+        block(contextMock, EventWriterMock(scope: self))
+    }
+    
+    public func context(_ block: @escaping (DatadogContext) -> Void) {
+        block(contextMock)
+    }
+
+    public var dataStore: DataStore { dataStoreMock }
+
+    public var telemetry: Telemetry { telemetryMock }
+
+    public func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
+        messages.append(message)
+    }
+    
+    public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
+        contextMock.baggages[key] = baggage()
+    }
+
+    // MARK: - Side Effects Observation
+
+    /// Retrieve events written through Even Write Context API.
+    public func eventsWritten<T>(ofType type: T.Type = T.self) -> [T] where T: Encodable {
+        return events.compactMap { $0.event as? T }
+    }
+
+    /// Retrieve data written in Data Store.
+    public let dataStoreMock: DataStore = NOPDataStore()
+
+    /// Retrieve telemetries sent to Telemetry endpoint.
+    public let telemetryMock = TelemetryMock()
+
+    /// Retrieve messages sent over Message Bus.
+    public func messagesSent() -> [FeatureMessage] {
+        return messages
+    }
+}

--- a/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
@@ -86,7 +86,7 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
     public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
 
     /// Always returns a feature-scope.
-    public func scope(for feature: String) -> FeatureScope? {
+    public func scope<T>(for featureType: T.Type) -> FeatureScope where T : DatadogFeature {
         self
     }
 

--- a/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
@@ -89,10 +89,10 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
         feature as? T
     }
 
-    public override func scope(for feature: String) -> FeatureScope? {
-        guard feature == Feature.name else {
-            return nil
+    public override func scope<T>(for featureType: T.Type) -> FeatureScope where T : DatadogFeature {
+        guard T.name == Feature.name else {
+            return NOPFeatureScope()
         }
-        return super.scope(for: feature)
+        return super.scope(for: featureType)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR straightens the `FeatureScope` interface, proposing it to become the main (and in most cases the only) dependency for features implementation. Instead of spreading the `core` reference across features and managing it in a `weak` manner, the implementation should take a strong dependency on `FeatureScope`.

There are 3 category of motivations behind this change:
- Short-term goal: Necessary for fatal App Hangs monitoring. This change is to ensure `DataStore` can be available in `AppHangsObserver` before `RUMFeature` is initialized. 
- Mid-term goal: We want features implementation to take dependency on `FeatureScope` rather than managing the `DatadogCoreProtocol` reference by themselves. As this PR proves, **manual management of the core reference is error-prone** and may sometimes lead to memory leaks due to capturing strong ref that surpasses core's lifecycle. With `FeatureScope` abstracting the `weak` reference we will enforce proper and safe implementation in all features 📈.
- Long-term goal: By iteratively replacing `DatadogCoreProtocol` dependency with `FeatureScope`, feature unit tests will be vastly simplified and become properly segregated. Features will no longer be able to make side-effects on core in unit tests, hence tests of one feature expecting side-effects in another feature will have to be moved to the integration-unit target.

### How?

Changed the feature scope retrieval API:
```diff
- func scope(for feature: String) -> FeatureScope?
+ func scope<Feature>(for featureType: Feature.Type) -> FeatureScope
```
- Only the scope of a known feature type can be requested. It means RUM can request its own scope, but it has no access to Logs or Session Replay scope.
- The scope is available right away, even before the feature's registration completed in core. It means the `FeatureScope` interface can be injected all across the feature implementation.
- The `FeatureScope` manages `weak var core: DatadogCoreProtocol?` reference. It is no longer required for feature implementation to deal with core's ref safety.

The `FeatureScope` interface was extended with all capabilities that feature needs to interact with the core. That includes baggage sharing, message sending (over MB) and an access to the `telemetry` endpoint:

<img width="980" alt="Screenshot 2024-03-25 at 09 44 43" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/92446271-5071-4d08-aa17-b10eb2df4bbd">

For backward-compatibility and to avoid large refactoring, all `FeatureScope` capabilities are still present in `DatadogCoreProtocol` in this PR:

<img width="456" alt="Screenshot 2024-03-25 at 09 47 54" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/04032104-23a4-4b09-956a-3e5a23fdc58e">

This is done by adding two composition protocols: `MessageSending` and `BaggageSharing` in `DatadogInternal` for sharing these aspects between core and scope:
```swift
protocol DatadogCoreProtocol: MessageSending, BaggageSharing
protocol FeatureScope: MessageSending, BaggageSharing
```
After all features are migrated to depend on `FeatureScope` the conformance to both protocols will be removed from `DatadogCoreProtocol`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
