### PR TITLE
chore: Add more context to `HTTPServerMock` errors

### DIFF
--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerSession.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerSession.swift
@@ -30,7 +30,12 @@ public class ServerSession {
 
     /// Actively fetches requests recorded by the server in this session until given `condition` evaluated to `true`.
     /// Throws an exception if given `timeout` is exceeded.
-    public func pullRecordedRequests(timeout: TimeInterval, until condition: ([Request]) throws -> Bool) throws -> [Request] {
+    public func pullRecordedRequests(
+        timeout: TimeInterval,
+        file: StaticString = #fileID,
+        line: UInt = #line,
+        until condition: ([Request]) throws -> Bool
+    ) throws -> [Request] {
         let timeoutTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
         timeoutTimer.setEventHandler { timeoutTimer.cancel() }
         timeoutTimer.schedule(deadline: .now() + timeout, leeway: .nanoseconds(0))
@@ -48,7 +53,11 @@ public class ServerSession {
 
         if timeoutTimer.isCancelled {
             throw Exception(
-                description: "Exceeded \(timeout)s timeout with pulling \(pulledRequests.count) requests and not meeting the `condition()`."
+                description: """
+                Exceeded \(timeout)s timeout with pulling \(pulledRequests.count) requests and not meeting the `condition()`.
+                - pulled endpoint: \(recordingURL.absoluteString)
+                - caller: \(file):\(line)
+                """
             )
         } else {
             timeoutTimer.cancel()

--- a/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
+++ b/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
@@ -124,9 +124,10 @@ final class HTTPServerMockTests: XCTestCase {
         XCTAssertThrowsError(
             try session.pullRecordedRequests(timeout: 1) { $0.count == 1 }
         ) { error in
-            XCTAssertEqual(
-                (error as? Exception)?.description,
-                "Exceeded 1.0s timeout with pulling 0 requests and not meeting the `condition()`."
+            let description = (error as? Exception)?.description ?? ""
+            XCTAssertTrue(
+                description.hasPrefix("Exceeded 1.0s timeout with pulling 0 requests and not meeting the `condition()`."),
+                "It must include expected description, got '\(description)' instead"
             )
         }
     }


### PR DESCRIPTION
### What and why?

📦 Adding more context to `HTTPServerMock` errors in UI testing.

This is ambiguous if we pull data from more than 2 endpoints in test:
<img width="826" alt="Screenshot 2024-03-25 at 14 06 27" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/2fd46103-a186-4a1b-8f5f-6e0414e6cc3a">

### How?

Added extra context on what endpoint is being pulled and what is the caller code.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
