### PR TITLE
RUM-3461 refactor: Replace `core` dependency in RUM with `FeatureScope`

### DIFF
--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -58,6 +58,7 @@ extension CrashReportReceiver: AnyMockable {
     }
 
     static func mockWith(
+        featureScope: FeatureScope = NOPFeatureScope(),
         applicationID: String = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         sessionSampler: Sampler = .mockKeepAll(),
@@ -68,14 +69,14 @@ extension CrashReportReceiver: AnyMockable {
         telemetry: Telemetry = NOPTelemetry()
     ) -> Self {
         .init(
+            featureScope: featureScope,
             applicationID: applicationID,
             dateProvider: dateProvider,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
             uuidGenerator: uuidGenerator,
             ciTest: ciTest,
-            syntheticsTest: syntheticsTest,
-            telemetry: telemetry
+            syntheticsTest: syntheticsTest
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -38,11 +38,13 @@ extension WebViewEventReceiver: AnyMockable {
     }
 
     static func mockWith(
+        featureScope: FeatureScope = NOPFeatureScope(),
         dateProvider: DateProvider = SystemDateProvider(),
         commandSubscriber: RUMCommandSubscriber = RUMCommandSubscriberMock(),
         viewCache: ViewCache = ViewCache()
     ) -> Self {
         .init(
+            featureScope: featureScope,
             dateProvider: dateProvider,
             commandSubscriber: commandSubscriber,
             viewCache: viewCache

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -700,7 +700,7 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
-        scope: FeatureScope = NOPFeatureScope(),
+        featureScope: FeatureScope = NOPFeatureScope(),
         rumApplicationID: String = .mockAny(),
         sessionSampler: Sampler = .mockKeepAll(),
         trackBackgroundEvents: Bool = .mockAny(),
@@ -715,7 +715,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            scope: scope,
+            featureScope: featureScope,
             rumApplicationID: rumApplicationID,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
@@ -747,7 +747,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            scope: self.scope,
+            featureScope: self.featureScope,
             rumApplicationID: rumApplicationID ?? self.rumApplicationID,
             sessionSampler: sessionSampler ?? self.sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents ?? self.trackBackgroundEvents,

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -697,7 +697,7 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
-        core: DatadogCoreProtocol = NOPDatadogCore(),
+        scope: FeatureScope = NOPFeatureScope(),
         rumApplicationID: String = .mockAny(),
         sessionSampler: Sampler = .mockKeepAll(),
         trackBackgroundEvents: Bool = .mockAny(),
@@ -712,7 +712,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            core: core,
+            scope: scope,
             rumApplicationID: rumApplicationID,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
@@ -744,7 +744,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            core: self.core,
+            scope: self.scope,
             rumApplicationID: rumApplicationID ?? self.rumApplicationID,
             sessionSampler: sessionSampler ?? self.sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents ?? self.trackBackgroundEvents,

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -12,67 +12,48 @@ import DatadogInternal
 @testable import DatadogCore
 
 class CrashReportReceiverTests: XCTestCase {
-    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
-
-    override func setUp() {
-        super.setUp()
-        core = PassthroughCoreMock()
-    }
-
-    override func tearDown() {
-        core = nil
-        super.tearDown()
-    }
+    private let featureScope = FeatureScopeMock()
 
     func testReceiveCrashEvent() throws {
         // Given
-        let core = PassthroughCoreMock(
-            bypassConsentExpectation: expectation(description: "Send Event Bypass Consent"),
-            messageReceiver: CrashReportReceiver.mockAny()
-        )
+        let receiver: CrashReportReceiver = .mockWith(featureScope: featureScope)
 
         // When
-        core.send(
-            message: .baggage(
-                key: CrashReportReceiver.MessageKeys.crash,
-                value: MessageBusSender.Crash(
-                    report: DDCrashReport.mockAny(),
-                    context: CrashContext.mockWith(lastRUMViewEvent: nil)
-                )
+        let message: FeatureMessage = .baggage(
+            key: CrashReportReceiver.MessageKeys.crash,
+            value: MessageBusSender.Crash(
+                report: DDCrashReport.mockAny(),
+                context: CrashContext.mockWith(lastRUMViewEvent: nil)
             )
         )
+        let result = receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1, "It should send error event")
+        XCTAssertTrue(result, "It must accept the message")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1, "It should send error event")
     }
 
     func testReceiveCrashAndViewEvent() throws {
         // Given
-        let core = PassthroughCoreMock(
-            bypassConsentExpectation: expectation(description: "Send Event Bypass Consent"),
-            messageReceiver: CrashReportReceiver.mockAny()
-        )
-
+        let receiver: CrashReportReceiver = .mockWith(featureScope: featureScope)
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // When
-        core.send(
-            message: .baggage(
-                key: CrashReportReceiver.MessageKeys.crash,
-                value: MessageBusSender.Crash(
-                    report: DDCrashReport.mockWith(date: Date()),
-                    context: CrashContext.mockWith(
-                        lastRUMViewEvent: AnyCodable(lastRUMViewEvent)
-                    )
+        let message: FeatureMessage = .baggage(
+            key: CrashReportReceiver.MessageKeys.crash,
+            value: MessageBusSender.Crash(
+                report: DDCrashReport.mockWith(date: Date()),
+                context: CrashContext.mockWith(
+                    lastRUMViewEvent: AnyCodable(lastRUMViewEvent)
                 )
             )
         )
+        let result = receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1, "It should send error event")
-        XCTAssertEqual(core.events(ofType: RUMViewEvent.self).count, 1, "It should send view event")
+        XCTAssertTrue(result, "It must accept the message")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1, "It should send error event")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1, "It should send view event")
     }
 
     // MARK: - Testing Conditional Uploads
@@ -92,6 +73,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: .mockRandom() // no matter BET
@@ -102,13 +84,13 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 2, "It must send both RUM error and RUM view")
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1)
-        XCTAssertEqual(core.events(ofType: RUMViewEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "It must send both RUM error and RUM view")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1)
     }
 
     func testGivenCrashDuringRUMSessionWithActiveViewCollectedLessThan4HoursAgoWithPreviousCrash_whenSending_itSendsNothing() throws {
@@ -126,6 +108,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: .mockRandom() // no matter BET
@@ -136,11 +119,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 0, "It must send no message")
+        XCTAssertEqual(featureScope.eventsWritten.count, 0, "It must send no message")
     }
 
     func testGivenCrashDuringRUMSessionWithActiveViewCollectedMoreThan4HoursAgo_whenSending_itSendsOnlyRUMError() throws {
@@ -158,6 +141,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: .mockRandom() // no matter BET
@@ -168,12 +152,12 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 1, "It must send only RUM error")
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must send only RUM error")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1)
     }
 
     func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
@@ -191,6 +175,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: true // BET enabled
@@ -201,13 +186,13 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 2, "It must send both RUM error and RUM view")
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1)
-        XCTAssertEqual(core.events(ofType: RUMViewEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "It must send both RUM error and RUM view")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1)
     }
 
     func testGivenCrashDuringApplicationLaunch_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
@@ -226,6 +211,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             trackBackgroundEvents: true // BET enabled
         )
@@ -235,13 +221,13 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 2, "It must send both RUM error and RUM view")
-        XCTAssertEqual(core.events(ofType: RUMCrashEvent.self).count, 1)
-        XCTAssertEqual(core.events(ofType: RUMViewEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "It must send both RUM error and RUM view")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMCrashEvent.self).count, 1)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1)
     }
 
     func testGivenCrashDuringAppLaunchAndNoSampling_whenSending_itIsDropped() throws {
@@ -258,6 +244,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: .mockRejectAll() // no sampling (no session should be sent)
         )
@@ -267,11 +254,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 0, "Crash must not be send as it is rejected by sampler")
+        XCTAssertEqual(featureScope.eventsWritten.count, 0, "Crash must not be send as it is rejected by sampler")
     }
 
     func testGivenCrashDuringAppLaunchInBackgroundAndBETDisabled_whenSending_itIsDropped() throws {
@@ -288,6 +275,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: crashDate),
             trackBackgroundEvents: false // BET disabled
         )
@@ -297,11 +285,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 0, "Crash must not be send as it happened in background and BET is disabled")
+        XCTAssertEqual(featureScope.eventsWritten.count, 0, "Crash must not be send as it happened in background and BET is disabled")
     }
 
     func testGivenCrashDuringSampledRUMSession_whenSending_itIsDropped() throws {
@@ -325,6 +313,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: currentDate),
             sessionSampler: .mockRandom(), // no matter current session sampling
             trackBackgroundEvents: .mockRandom()
@@ -335,11 +324,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        XCTAssertEqual(core.events.count, 0, "Crash must not be send as it the session was rejected by sampler")
+        XCTAssertEqual(featureScope.eventsWritten.count, 0, "Crash must not be send as it the session was rejected by sampler")
     }
 
     // MARK: - Testing Uploaded Data - Crashes During RUM Session With Active View
@@ -358,6 +347,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: crashDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: .mockRandom() // no matter BET
@@ -368,11 +358,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        let sendRUMViewEvent = core.events(ofType: RUMViewEvent.self)[0]
+        let sendRUMViewEvent = featureScope.eventsWritten(ofType: RUMViewEvent.self)[0]
 
         XCTAssertTrue(
             sendRUMViewEvent.application.id == lastRUMViewEvent.application.id
@@ -455,6 +445,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(
                 using: crashDate.addingTimeInterval(
                     .mockRandom(min: 10, max: 2 * CrashReportReceiver.Constants.viewEventAvailabilityThreshold) // simulate restarting app from 10s to 8h later
@@ -469,11 +460,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        let sendRUMErrorEvent = core.events(ofType: RUMCrashEvent.self)[0]
+        let sendRUMErrorEvent = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
 
         XCTAssertTrue(
             sendRUMErrorEvent.model.application.id == lastRUMViewEvent.application.id
@@ -527,9 +518,7 @@ class CrashReportReceiverTests: XCTestCase {
     }
 
     func testGivenCrashDuringRUMSessionWithActiveViewAndOverridenSourceType_whenSendingRUMViewEvent_itSendsOverrideSourceType() throws {
-        core = PassthroughCoreMock(
-            context: .mockWith(nativeSourceOverride: "ios+il2cpp")
-        )
+        featureScope.contextMock = .mockWith(nativeSourceOverride: "ios+il2cpp")
         let lastRUMViewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
 
         // Given
@@ -543,6 +532,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: crashDate),
             sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
             trackBackgroundEvents: .mockRandom() // no matter BET
@@ -553,11 +543,11 @@ class CrashReportReceiverTests: XCTestCase {
             receiver.receive(message: .baggage(
                 key: MessageBusSender.MessageKeys.crash,
                 value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-            ), from: core)
+            ), from: NOPDatadogCore())
         )
 
         // Then
-        let sendRUMErrorEvent = core.events(ofType: RUMCrashEvent.self)[0]
+        let sendRUMErrorEvent = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
         XCTAssertEqual(sendRUMErrorEvent.model.error.sourceType, .iosIl2cpp, "Must send overridden sourceType")
     }
 
@@ -581,14 +571,7 @@ class CrashReportReceiverTests: XCTestCase {
             expectViewName expectedViewName: String,
             expectViewURL expectedViewURL: String
         ) throws {
-            let core = PassthroughCoreMock(
-                messageReceiver: CrashReportReceiver.mockWith(
-                    applicationID: randomRUMAppID,
-                    sessionSampler: .mockKeepAll(),
-                    trackBackgroundEvents: backgroundEventsTrackingEnabled,
-                    uuidGenerator: DefaultRUMUUIDGenerator()
-                )
-            )
+            let featureScope = FeatureScopeMock()
 
             // Given
             let crashDate: Date = .mockDecember15th2019At10AMUTC()
@@ -613,10 +596,12 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             let receiver: CrashReportReceiver = .mockWith(
+                featureScope: featureScope,
                 applicationID: randomRUMAppID,
                 dateProvider: RelativeDateProvider(using: crashDate),
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
-                trackBackgroundEvents: backgroundEventsTrackingEnabled
+                trackBackgroundEvents: backgroundEventsTrackingEnabled,
+                uuidGenerator: DefaultRUMUUIDGenerator()
             )
 
             // When
@@ -624,12 +609,12 @@ class CrashReportReceiverTests: XCTestCase {
                 receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-                ), from: core)
+                ), from: NOPDatadogCore())
             )
 
             // Then
-            let sentRUMView = core.events(ofType: RUMViewEvent.self)[0]
-            let sentRUMError = core.events(ofType: RUMCrashEvent.self)[0]
+            let sentRUMView = featureScope.eventsWritten(ofType: RUMViewEvent.self)[0]
+            let sentRUMError = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
 
             // Assert RUM view properties
             XCTAssertTrue(
@@ -722,15 +707,8 @@ class CrashReportReceiverTests: XCTestCase {
             backgroundEventsTrackingEnabled: Bool
         ) throws {
             let mockApplicationId: String = .mockRandom(among: .alphanumerics)
-            let core = PassthroughCoreMock(
-                context: .mockWith(nativeSourceOverride: "ios+il2cpp"),
-                messageReceiver: CrashReportReceiver.mockWith(
-                    applicationID: mockApplicationId,
-                    sessionSampler: .mockKeepAll(),
-                    trackBackgroundEvents: backgroundEventsTrackingEnabled,
-                    uuidGenerator: DefaultRUMUUIDGenerator()
-                )
-            )
+            let featureScope = FeatureScopeMock()
+            featureScope.contextMock = .mockWith(nativeSourceOverride: "ios+il2cpp")
 
             // Given
             let crashDate: Date = .mockDecember15th2019At10AMUTC()
@@ -755,10 +733,12 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             let receiver: CrashReportReceiver = .mockWith(
-                applicationID: .mockRandom(among: .alphanumerics),
+                featureScope: featureScope,
+                applicationID: mockApplicationId,
                 dateProvider: RelativeDateProvider(using: crashDate),
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
-                trackBackgroundEvents: backgroundEventsTrackingEnabled
+                trackBackgroundEvents: backgroundEventsTrackingEnabled,
+                uuidGenerator: DefaultRUMUUIDGenerator()
             )
 
             // When
@@ -766,11 +746,11 @@ class CrashReportReceiverTests: XCTestCase {
                 receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-                ), from: core)
+                ), from: NOPDatadogCore())
             )
 
             // Then
-            let sentRUMError = core.events(ofType: RUMCrashEvent.self)[0]
+            let sentRUMError = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
             XCTAssertEqual(sentRUMError.model.error.sourceType, .iosIl2cpp, "Must send overridden sourceType")
         }
 
@@ -802,14 +782,7 @@ class CrashReportReceiverTests: XCTestCase {
             expectViewName expectedViewName: String,
             expectViewURL expectedViewURL: String
         ) throws {
-            let core = PassthroughCoreMock(
-                messageReceiver: CrashReportReceiver.mockWith(
-                    applicationID: randomRUMAppID,
-                    sessionSampler: .mockKeepAll(),
-                    trackBackgroundEvents: backgroundEventsTrackingEnabled,
-                    uuidGenerator: DefaultRUMUUIDGenerator()
-                )
-            )
+            let featureScope = FeatureScopeMock()
 
             // Given
             let crashDate: Date = .mockDecember15th2019At10AMUTC()
@@ -831,9 +804,11 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             let receiver: CrashReportReceiver = .mockWith(
+                featureScope: featureScope,
                 applicationID: randomRUMAppID,
                 dateProvider: RelativeDateProvider(using: crashDate),
-                trackBackgroundEvents: backgroundEventsTrackingEnabled
+                trackBackgroundEvents: backgroundEventsTrackingEnabled,
+                uuidGenerator: DefaultRUMUUIDGenerator()
             )
 
             // When
@@ -841,12 +816,12 @@ class CrashReportReceiverTests: XCTestCase {
                 receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-                ), from: core)
+                ), from: NOPDatadogCore())
             )
 
             // Then
-            let sentRUMView = core.events(ofType: RUMViewEvent.self)[0]
-            let sentRUMError = core.events(ofType: RUMCrashEvent.self)[0]
+            let sentRUMView = featureScope.eventsWritten(ofType: RUMViewEvent.self)[0]
+            let sentRUMError = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
 
             // Assert RUM view properties
             XCTAssertTrue(
@@ -930,15 +905,8 @@ class CrashReportReceiverTests: XCTestCase {
             expectViewName expectedViewName: String,
             expectViewURL expectedViewURL: String
         ) throws {
-            let core = PassthroughCoreMock(
-                context: .mockWith(nativeSourceOverride: "ios+il2cpp"),
-                messageReceiver: CrashReportReceiver.mockWith(
-                    applicationID: .mockRandom(among: .alphanumerics),
-                    sessionSampler: .mockKeepAll(),
-                    trackBackgroundEvents: backgroundEventsTrackingEnabled,
-                    uuidGenerator: DefaultRUMUUIDGenerator()
-                )
-            )
+            let featureScope = FeatureScopeMock()
+            featureScope.contextMock = .mockWith(nativeSourceOverride: "ios+il2cpp")
 
             // Given
             let crashDate: Date = .mockDecember15th2019At10AMUTC()
@@ -960,9 +928,11 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             let receiver: CrashReportReceiver = .mockWith(
+                featureScope: featureScope,
                 applicationID: .mockRandom(),
                 dateProvider: RelativeDateProvider(using: crashDate),
-                trackBackgroundEvents: backgroundEventsTrackingEnabled
+                trackBackgroundEvents: backgroundEventsTrackingEnabled,
+                uuidGenerator: DefaultRUMUUIDGenerator()
             )
 
             // When
@@ -970,11 +940,11 @@ class CrashReportReceiverTests: XCTestCase {
                 receiver.receive(message: .baggage(
                     key: MessageBusSender.MessageKeys.crash,
                     value: MessageBusSender.Crash(report: crashReport, context: crashContext)
-                ), from: core)
+                ), from: NOPDatadogCore())
             )
 
             // Then
-            let sentRUMError = core.events(ofType: RUMCrashEvent.self)[0]
+            let sentRUMError = featureScope.eventsWritten(ofType: RUMCrashEvent.self)[0]
 
             XCTAssertEqual(sentRUMError.model.error.sourceType, .iosIl2cpp, "Must send overridden sourceType")
         }

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorConfigurationTests.swift
@@ -41,7 +41,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
         let monitor = RUMMonitor.shared(in: core).dd
 
         let dependencies = monitor.scopes.dependencies
-        monitor.core?.scope(for: RUMFeature.self).eventWriteContext { context, _ in
+        monitor.featureScope.eventWriteContext { context, _ in
             DDAssertReflectionEqual(context.userInfo, self.userIno)
             XCTAssertEqual(context.networkConnectionInfo, self.networkConnectionInfo)
             XCTAssertEqual(context.carrierInfo, self.carrierInfo)

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -12,6 +12,10 @@ import Foundation
 /// Any reference to `DatadogCoreProtocol` must be captured as `weak` within a Feature. This is to avoid
 /// retain cycle of core holding the Feature and vice-versa.
 public protocol DatadogCoreProtocol: AnyObject, MessageSending, BaggageSharing {
+    // TODO: RUM-3717 
+    // Remove `DatadogCoreProtocol` conformance to `MessageSending` and `BaggageSharing` once
+    // all features are migrated to depend on `FeatureScope` interface.
+
     /// Registers a Feature instance.
     ///
     /// Feature can interact with the core and other Feature through the message bus. Some specific Features

--- a/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
@@ -27,6 +27,9 @@ public protocol FeatureMessageReceiver {
     /// - Returns: `true` if the message was processed by the receiver;`false` if it was ignored.
     @discardableResult
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool
+    // ^ TODO: RUM-3717
+    // Remove `core:` parameter from this API once all features are migrated to depend on `FeatureScope` interface
+    // instead of depending on directly on `core`.
 }
 
 public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -108,6 +108,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 viewCache: dependencies.viewCache
             ),
             CrashReportReceiver(
+                featureScope: featureScope,
                 applicationID: configuration.applicationID,
                 dateProvider: configuration.dateProvider,
                 sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
@@ -120,8 +121,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     } else {
                         return nil
                     }
-                }(),
-                telemetry: core.telemetry
+                }()
             )
         )
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -26,8 +26,9 @@ internal final class RUMFeature: DatadogRemoteFeature {
     ) throws {
         self.configuration = configuration
 
+        let featureScope = core.scope(for: RUMFeature.self)
         let dependencies = RUMScopeDependencies(
-            core: core,
+            scope: featureScope,
             rumApplicationID: configuration.applicationID,
             sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
             trackBackgroundEvents: configuration.trackBackgroundEvents,
@@ -72,7 +73,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
 
         self.monitor = Monitor(
-            core: core,
+            featureScope: featureScope,
             dependencies: dependencies,
             dateProvider: configuration.dateProvider
         )

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -95,6 +95,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
         self.messageReceiver = CombinedFeatureMessageReceiver(
             TelemetryReceiver(
+                featureScope: featureScope,
                 dateProvider: configuration.dateProvider,
                 sampler: Sampler(samplingRate: configuration.telemetrySampleRate),
                 configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate),

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -28,7 +28,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
         let featureScope = core.scope(for: RUMFeature.self)
         let dependencies = RUMScopeDependencies(
-            scope: featureScope,
+            featureScope: featureScope,
             rumApplicationID: configuration.applicationID,
             sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
             trackBackgroundEvents: configuration.trackBackgroundEvents,
@@ -73,7 +73,6 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
 
         self.monitor = Monitor(
-            featureScope: featureScope,
             dependencies: dependencies,
             dateProvider: configuration.dateProvider
         )

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -100,7 +100,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate),
                 metricsExtraSampler: Sampler(samplingRate: configuration.metricsTelemetrySampleRate)
             ),
-            ErrorMessageReceiver(monitor: monitor),
+            ErrorMessageReceiver(
+                featureScope: featureScope,
+                monitor: monitor
+            ),
             WebViewEventReceiver(
                 featureScope: featureScope,
                 dateProvider: configuration.dateProvider,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -102,6 +102,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             ),
             ErrorMessageReceiver(monitor: monitor),
             WebViewEventReceiver(
+                featureScope: featureScope,
                 dateProvider: configuration.dateProvider,
                 commandSubscriber: monitor,
                 viewCache: dependencies.viewCache

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -100,6 +100,8 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         let realDateNow: Date
     }
 
+    /// RUM feature scope.
+    let featureScope: FeatureScope
     let applicationID: String
     let dateProvider: DateProvider
     let sessionSampler: Sampler
@@ -109,21 +111,20 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
     let ciTest: RUMCITest?
     /// Integration with Synthetics tests. It contains the Synthetics test context when active.
     let syntheticsTest: RUMSyntheticsTest?
-    /// Telemetry interface.
-    let telemetry: Telemetry
 
     // MARK: - Initialization
 
     init(
+        featureScope: FeatureScope,
         applicationID: String,
         dateProvider: DateProvider,
         sessionSampler: Sampler,
         trackBackgroundEvents: Bool,
         uuidGenerator: RUMUUIDGenerator,
         ciTest: RUMCITest?,
-        syntheticsTest: RUMSyntheticsTest?,
-        telemetry: Telemetry
+        syntheticsTest: RUMSyntheticsTest?
     ) {
+        self.featureScope = featureScope
         self.applicationID = applicationID
         self.dateProvider = dateProvider
         self.sessionSampler = sessionSampler
@@ -131,7 +132,6 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         self.uuidGenerator = uuidGenerator
         self.ciTest = ciTest
         self.syntheticsTest = syntheticsTest
-        self.telemetry = telemetry
     }
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
@@ -140,16 +140,16 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 return false
             }
 
-            return send(report: crash.report, with: crash.context, to: core)
+            return send(report: crash.report, with: crash.context)
         } catch {
-            core.telemetry
+            featureScope.telemetry
                 .error("Fails to decode crash from RUM", error: error)
         }
 
         return false
     }
 
-    private func send(report: CrashReport, with context: CrashContext, to core: DatadogCoreProtocol) -> Bool {
+    private func send(report: CrashReport, with context: CrashContext) -> Bool {
         // The `crashReport.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
         // to the server time before processing. Following use of the current correction is not ideal (it's not the correction
         // from the moment of crash), but this is the best approximation we can get.
@@ -168,17 +168,16 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 sendCrashReportLinkedToLastViewInPreviousSession(
                     report,
                     lastRUMViewEventInPreviousSession: lastRUMViewEvent,
-                    using: adjustedCrashTimings,
-                    to: core
+                    using: adjustedCrashTimings
                 )
             } else {
                 DD.logger.debug("There was a crash in previous session, but it is ignored due to another crash already present in the last view.")
                 return false
             }
         } else if let lastRUMSessionState = context.lastRUMSessionState {
-            sendCrashReportToPreviousSession(report, crashContext: context, lastRUMSessionStateInPreviousSession: lastRUMSessionState, using: adjustedCrashTimings, to: core)
+            sendCrashReportToPreviousSession(report, crashContext: context, lastRUMSessionStateInPreviousSession: lastRUMSessionState, using: adjustedCrashTimings)
         } else if sessionSampler.sample() { // before producing a new RUM session, we must consider sampling
-            sendCrashReportToNewSession(report, crashContext: context, using: adjustedCrashTimings, to: core)
+            sendCrashReportToNewSession(report, crashContext: context, using: adjustedCrashTimings)
         } else {
             DD.logger.debug("There was a crash in previous session, but it is ignored due to sampling.")
             return false
@@ -192,16 +191,15 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
     private func sendCrashReportLinkedToLastViewInPreviousSession(
         _ crashReport: CrashReport,
         lastRUMViewEventInPreviousSession lastRUMViewEvent: RUMViewEvent,
-        using crashTimings: AdjustedCrashTimings,
-        to core: DatadogCoreProtocol
+        using crashTimings: AdjustedCrashTimings
     ) {
         if crashTimings.realDateNow.timeIntervalSince(crashTimings.realCrashDate) < Constants.viewEventAvailabilityThreshold {
-            send(crashReport: crashReport, to: lastRUMViewEvent, using: crashTimings.realCrashDate, to: core)
+            send(crashReport: crashReport, to: lastRUMViewEvent, using: crashTimings.realCrashDate)
         } else {
             // We know it is too late for sending RUM view to previous RUM session as it is now stale on backend.
             // To avoid inconsistency, we only send the RUM error.
             DD.logger.debug("Sending crash as RUM error.")
-            core.scope(for: RUMFeature.self).eventWriteContext(bypassConsent: true) { context, writer in
+            featureScope.eventWriteContext(bypassConsent: true) { context, writer in
                 let rumError = createRUMError(from: crashReport, and: lastRUMViewEvent, crashDate: crashTimings.realCrashDate, sourceType: context.nativeSourceOverride)
                 writer.write(value: rumError)
             }
@@ -215,8 +213,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         _ crashReport: CrashReport,
         crashContext: CrashContext,
         lastRUMSessionStateInPreviousSession lastRUMSessionState: RUMSessionState,
-        using crashTimings: AdjustedCrashTimings,
-        to core: DatadogCoreProtocol
+        using crashTimings: AdjustedCrashTimings
     ) {
         let handlingRule = RUMOffViewEventsHandlingRule(
             sessionState: lastRUMSessionState,
@@ -256,7 +253,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         }
 
         if let newRUMView = newRUMView {
-            send(crashReport: crashReport, to: newRUMView, using: crashTimings.realCrashDate, to: core)
+            send(crashReport: crashReport, to: newRUMView, using: crashTimings.realCrashDate)
         }
     }
 
@@ -265,8 +262,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
     private func sendCrashReportToNewSession(
         _ crashReport: CrashReport,
         crashContext: CrashContext,
-        using crashTimings: AdjustedCrashTimings,
-        to core: DatadogCoreProtocol
+        using crashTimings: AdjustedCrashTimings
     ) {
         // We can ignore `sessionState` for building the rule as we can assume there was no session sent - otherwise,
         // the `lastRUMSessionState` would have been set in `CrashContext` and we could be sending the crash to previous session
@@ -310,18 +306,18 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         }
 
         if let newRUMView = newRUMView {
-            send(crashReport: crashReport, to: newRUMView, using: crashTimings.realCrashDate, to: core)
+            send(crashReport: crashReport, to: newRUMView, using: crashTimings.realCrashDate)
         }
     }
 
     /// Sends given `CrashReport` by linking it to given `rumView` and updating view counts accordingly.
-    private func send(crashReport: CrashReport, to rumView: RUMViewEvent, using realCrashDate: Date, to core: DatadogCoreProtocol) {
+    private func send(crashReport: CrashReport, to rumView: RUMViewEvent, using realCrashDate: Date) {
         DD.logger.debug("Updating RUM view with crash report.")
         let updatedRUMView = updateRUMViewWithNewError(rumView, crashDate: realCrashDate)
 
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
-        core.scope(for: RUMFeature.self).eventWriteContext(bypassConsent: true) { context, writer in
+        featureScope.eventWriteContext(bypassConsent: true) { context, writer in
             let rumError = createRUMError(from: crashReport, and: updatedRUMView, crashDate: realCrashDate, sourceType: context.nativeSourceOverride)
 
             writer.write(value: rumError)
@@ -537,7 +533,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             container: nil,
             context: nil,
             date: startDate.timeIntervalSince1970.toInt64Milliseconds,
-            device: .init(device: context.device, telemetry: telemetry),
+            device: .init(device: context.device, telemetry: featureScope.telemetry),
             display: nil,
             // RUMM-2197: In very rare cases, the OS info computed below might not be exactly the one
             // that the app crashed on. This would correspond to a scenario when the device OS was upgraded

--- a/DatadogRUM/Sources/Integrations/ErrorMessageReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/ErrorMessageReceiver.swift
@@ -25,6 +25,8 @@ internal struct ErrorMessageReceiver: FeatureMessageReceiver {
         let attributes: [String: AnyCodable]?
     }
 
+    /// RUM feature scope.
+    let featureScope: FeatureScope
     let monitor: Monitor
 
     /// Adds RUM Error with given message and stack to current RUM View.
@@ -46,7 +48,7 @@ internal struct ErrorMessageReceiver: FeatureMessageReceiver {
 
             return true
         } catch {
-            core.telemetry
+            featureScope.telemetry
                 .error("Fails to decode error message", error: error)
             return false
         }

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -11,6 +11,8 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     /// Maximum number of telemetry events allowed per RUM  sessions.
     static let maxEventsPerSessions: Int = 100
 
+    /// RUM feature scope.
+    let featureScope: FeatureScope
     let dateProvider: DateProvider
 
     let sampler: Sampler
@@ -33,16 +35,19 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     /// Creates a RUM Telemetry instance.
     ///
     /// - Parameters:
+    ///   - featureScope: RUM feature scope.
     ///   - dateProvider: Current device time provider.
     ///   - sampler: Telemetry events sampler.
     ///   - configurationExtraSampler: Extra sampler for configuration events (applied on top of `sampler`).
     ///   - metricsExtraSampler: Extra sampler for metric events (applied on top of `sampler`).
     init(
+        featureScope: FeatureScope,
         dateProvider: DateProvider,
         sampler: Sampler,
         configurationExtraSampler: Sampler,
         metricsExtraSampler: Sampler
     ) {
+        self.featureScope = featureScope
         self.dateProvider = dateProvider
         self.sampler = sampler
         self.configurationExtraSampler = configurationExtraSampler
@@ -62,23 +67,23 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
             return false
         }
 
-        return receive(telemetry: telemetry, from: core)
+        return receive(telemetry: telemetry)
     }
 
     /// Receives a Telemetry message from the bus.
     ///
     /// - Parameter telemetry: The telemetry message to consume.
     /// - Returns: Always `true`.
-    func receive(telemetry: TelemetryMessage, from core: DatadogCoreProtocol) -> Bool {
+    private func receive(telemetry: TelemetryMessage) -> Bool {
         switch telemetry {
         case let .debug(id, message, attributes):
-            debug(id: id, message: message, attributes: attributes, in: core)
+            debug(id: id, message: message, attributes: attributes)
         case let .error(id, message, kind, stack):
-            error(id: id, message: message, kind: kind, stack: stack, in: core)
+            error(id: id, message: message, kind: kind, stack: stack)
         case .configuration(let configuration):
-            send(configuration: configuration, in: core)
+            send(configuration: configuration)
         case let .metric(name, attributes):
-            metric(name: name, attributes: attributes, in: core)
+            metric(name: name, attributes: attributes)
         }
 
         return true
@@ -94,10 +99,10 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///   - id: Identity of the debug log, this can be used to prevent duplicates.
     ///   - message: The debug message.
     ///   - attributes: Custom attributes attached to the log (optional).
-    private func debug(id: String, message: String, attributes: [String: Encodable]?, in core: DatadogCoreProtocol) {
+    private func debug(id: String, message: String, attributes: [String: Encodable]?) {
         let date = dateProvider.now
 
-        record(event: id, in: core) { context, writer in
+        record(event: id) { context, writer in
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 
             let event = TelemetryDebugEvent(
@@ -132,10 +137,10 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///   - message: Body of the log
     ///   - kind: The error type or kind (or code in some cases).
     ///   - stack: The stack trace or the complementary information about the error.
-    private func error(id: String, message: String, kind: String?, stack: String?, in core: DatadogCoreProtocol) {
+    private func error(id: String, message: String, kind: String?, stack: String?) {
         let date = dateProvider.now
 
-        record(event: id, in: core) { context, writer in
+        record(event: id) { context, writer in
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 
             let event = TelemetryErrorEvent(
@@ -162,14 +167,14 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     /// configuration for lazy initialization of the SDK.
     ///
     /// - Parameter configuration: The SDK configuration.
-    private func send(configuration: DatadogInternal.ConfigurationTelemetry, in core: DatadogCoreProtocol) {
+    private func send(configuration: DatadogInternal.ConfigurationTelemetry) {
         guard configurationExtraSampler.sample() else {
             return
         }
 
         let date = dateProvider.now
 
-        self.record(event: "_dd.configuration", in: core) { context, writer in
+        self.record(event: "_dd.configuration") { context, writer in
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 
             let event = TelemetryConfigurationEvent(
@@ -190,14 +195,14 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
         }
     }
 
-    private func metric(name: String, attributes: [String: Encodable], in core: DatadogCoreProtocol) {
+    private func metric(name: String, attributes: [String: Encodable]) {
         guard metricsExtraSampler.sample() else {
             return
         }
 
         let date = dateProvider.now
 
-        record(event: nil, in: core) { context, writer in
+        record(event: nil) { context, writer in
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 
             let event = TelemetryDebugEvent(
@@ -221,12 +226,12 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
         }
     }
 
-    private func record(event id: String?, in core: DatadogCoreProtocol, operation: @escaping (DatadogContext, Writer) -> Void) {
+    private func record(event id: String?, operation: @escaping (DatadogContext, Writer) -> Void) {
         guard sampler.sample() else {
             return
         }
 
-        core.scope(for: RUMFeature.self).eventWriteContext { context, writer in
+        featureScope.eventWriteContext { context, writer in
             // reset recorded events on session renewal
             let rum = try? context.baggages[RUMFeature.name]?.decode(type: RUMCoreContext.self)
 

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -110,6 +110,7 @@ internal enum RUMInternalErrorSource: String, Decodable {
 internal typealias RUMErrorCategory = RUMErrorEvent.Error.Category
 
 internal class Monitor: RUMCommandSubscriber {
+    /// RUM feature scope.
     let featureScope: FeatureScope
     let scopes: RUMApplicationScope
     let dateProvider: DateProvider

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -124,11 +124,10 @@ internal class Monitor: RUMCommandSubscriber {
     private var attributes: [AttributeKey: AttributeValue] = [:]
 
     init(
-        featureScope: FeatureScope,
         dependencies: RUMScopeDependencies,
         dateProvider: DateProvider
     ) {
-        self.featureScope = featureScope
+        self.featureScope = dependencies.featureScope
         self.scopes = RUMApplicationScope(dependencies: dependencies)
         self.dateProvider = dateProvider
     }

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -110,6 +110,7 @@ internal enum RUMInternalErrorSource: String, Decodable {
 internal typealias RUMErrorCategory = RUMErrorEvent.Error.Category
 
 internal class Monitor: RUMCommandSubscriber {
+    let featureScope: FeatureScope
     let scopes: RUMApplicationScope
     let dateProvider: DateProvider
     let queue = DispatchQueue(
@@ -117,24 +118,23 @@ internal class Monitor: RUMCommandSubscriber {
         target: .global(qos: .userInteractive)
     )
 
-    private(set) weak var core: DatadogCoreProtocol?
     private(set) var debugging: RUMDebugging? = nil
 
     private var attributes: [AttributeKey: AttributeValue] = [:]
 
     init(
-        core: DatadogCoreProtocol,
+        featureScope: FeatureScope,
         dependencies: RUMScopeDependencies,
         dateProvider: DateProvider
     ) {
-        self.core = core
+        self.featureScope = featureScope
         self.scopes = RUMApplicationScope(dependencies: dependencies)
         self.dateProvider = dateProvider
     }
 
     func process(command: RUMCommand) {
         // process command in event context
-        core?.scope(for: RUMFeature.self).eventWriteContext { context, writer in
+        featureScope.eventWriteContext { context, writer in
             self.queue.sync {
                 let transformedCommand = self.transform(command: command)
 
@@ -147,7 +147,7 @@ internal class Monitor: RUMCommandSubscriber {
         }
 
         // update the core context with rum context
-        core?.set(
+        featureScope.set(
             baggage: {
                 self.queue.sync { () -> RUMCoreContext? in
                     let context = self.scopes.activeSession?.viewScopes.last?.context ??
@@ -218,7 +218,7 @@ extension Monitor: RUMMonitorProtocol {
         // Even though we're not writing anything, need to get the write context
         // to make sure we're returning the correct sessionId after all other
         // events have processed.
-        core?.scope(for: RUMFeature.self).eventWriteContext { _, _ in
+        featureScope.eventWriteContext { _, _ in
             self.queue.sync {
                 guard let sessionId = self.scopes.activeSession?.sessionUUID else {
                     completion(nil)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -28,7 +28,7 @@ internal struct VitalsReaders {
 /// Dependency container for injecting components to `RUMScopes` hierarchy.
 internal struct RUMScopeDependencies {
     /// The RUM feature scope to interact with core.
-    let scope: FeatureScope
+    let featureScope: FeatureScope
     let rumApplicationID: String
     let sessionSampler: Sampler
     let trackBackgroundEvents: Bool
@@ -43,7 +43,7 @@ internal struct RUMScopeDependencies {
     let onSessionStart: RUM.SessionListener?
     let viewCache: ViewCache
 
-    var telemetry: Telemetry { scope.telemetry }
+    var telemetry: Telemetry { featureScope.telemetry }
 
     var sessionType: RUMSessionType {
         if ciTest != nil {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -27,7 +27,8 @@ internal struct VitalsReaders {
 
 /// Dependency container for injecting components to `RUMScopes` hierarchy.
 internal struct RUMScopeDependencies {
-    weak var core: DatadogCoreProtocol?
+    /// The RUM feature scope to interact with core.
+    let scope: FeatureScope
     let rumApplicationID: String
     let sessionSampler: Sampler
     let trackBackgroundEvents: Bool
@@ -42,9 +43,7 @@ internal struct RUMScopeDependencies {
     let onSessionStart: RUM.SessionListener?
     let viewCache: ViewCache
 
-    var telemetry: Telemetry {
-        core?.telemetry ?? NOPTelemetry()
-    }
+    var telemetry: Telemetry { scope.telemetry }
 
     var sessionType: RUMSessionType {
         if ciTest != nil {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -46,7 +46,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// Information about this session state, shared with `CrashContext`.
     private var state: RUMSessionState {
         didSet {
-            dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+            dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
         }
     }
 
@@ -118,7 +118,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
 
         // Update `CrashContext` with recent RUM session state:
-        dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+        dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && sessionUUID != .nullUUID {
@@ -219,7 +219,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             // We also want to send this as a session is being stopped.
             // It means that with Background Events Tracking disabled, eventual off-view crashes will be dropped
             // similar to how we drop other events.
-            dependencies.core?.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
+            dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
         }
 
         return isActive || !viewScopes.isEmpty

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -46,7 +46,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// Information about this session state, shared with `CrashContext`.
     private var state: RUMSessionState {
         didSet {
-            dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+            dependencies.featureScope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
         }
     }
 
@@ -118,7 +118,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
 
         // Update `CrashContext` with recent RUM session state:
-        dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
+        dependencies.featureScope.send(message: .baggage(key: RUMBaggageKeys.sessionState, value: state))
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && sessionUUID != .nullUUID {
@@ -219,7 +219,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             // We also want to send this as a session is being stopped.
             // It means that with Background Events Tracking disabled, eventual off-view crashes will be dropped
             // similar to how we drop other events.
-            dependencies.scope.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
+            dependencies.featureScope.send(message: .baggage(key: RUMBaggageKeys.viewReset, value: true))
         }
 
         return isActive || !viewScopes.isEmpty

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -542,7 +542,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
             // Update `CrashContext` with recent RUM view (no matter sampling - we want to always
             // have recent information if process is interrupted by crash):
-            dependencies.scope.send(
+            dependencies.featureScope.send(
                 message: .baggage(
                     key: RUMBaggageKeys.viewEvent,
                     value: event

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -542,7 +542,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
             // Update `CrashContext` with recent RUM view (no matter sampling - we want to always
             // have recent information if process is interrupted by crash):
-            dependencies.core?.send(
+            dependencies.scope.send(
                 message: .baggage(
                     key: RUMBaggageKeys.viewEvent,
                     value: event

--- a/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
@@ -18,8 +18,7 @@ class ErrorMessageReceiverTests: XCTestCase {
         receiver = ErrorMessageReceiver(
             featureScope: featureScope,
             monitor: Monitor(
-                featureScope: featureScope,
-                dependencies: .mockAny(),
+                dependencies: .mockWith(featureScope: featureScope),
                 dateProvider: SystemDateProvider()
             )
         )

--- a/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
@@ -16,6 +16,7 @@ class ErrorMessageReceiverTests: XCTestCase {
 
     override func setUp() {
         receiver = ErrorMessageReceiver(
+            featureScope: featureScope,
             monitor: Monitor(
                 featureScope: featureScope,
                 dependencies: .mockAny(),

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -10,6 +10,7 @@ import DatadogInternal
 @testable import DatadogRUM
 
 class WebViewEventReceiverTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
     /// Creates random RUM Browser event.
     /// Both mobile and browser events conform to the same schema, so we can consider mobile events browser-compatible.
     private func randomWebEvent() -> JSON { try! randomRUMEvent().toJSONObject() }
@@ -123,11 +124,11 @@ class WebViewEventReceiverTests: XCTestCase {
     }
 
     func testWhenReceivingWebViewTrackingMessageWithValidEvent_itAcknowledgesTheMessageAndKeepsRUMSessionAlive() throws {
-        let core = PassthroughCoreMock()
         let commandsSubscriberMock = RUMCommandSubscriberMock()
 
         // Given
         let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
             dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
             commandSubscriber: commandsSubscriberMock,
             viewCache: ViewCache()
@@ -135,7 +136,7 @@ class WebViewEventReceiverTests: XCTestCase {
 
         // When
         let message = webViewTrackingMessage(with: randomWebEvent())
-        let result = receiver.receive(message: message, from: core)
+        let result = receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
         XCTAssertTrue(result, "It must acknowledge the message")
@@ -144,10 +145,9 @@ class WebViewEventReceiverTests: XCTestCase {
     }
 
     func testWhenReceivingOtherMessage_itRejectsIt() throws {
-        let core = PassthroughCoreMock()
-
         // Given
         let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
             dateProvider: DateProviderMock(),
             commandSubscriber: RUMCommandSubscriberMock(),
             viewCache: ViewCache()
@@ -155,7 +155,7 @@ class WebViewEventReceiverTests: XCTestCase {
 
         // When
         let otherMessage: FeatureMessage = .baggage(key: "message to other receiver", value: String.mockRandom())
-        let result = receiver.receive(message: otherMessage, from: core)
+        let result = receiver.receive(message: otherMessage, from: NOPDatadogCore())
 
         // Then
         XCTAssertFalse(result, "It must reject messages addressed to other receivers")
@@ -164,19 +164,19 @@ class WebViewEventReceiverTests: XCTestCase {
     // MARK: - Modifying Web Events
 
     func testGivenRUMContextAvailable_whenReceivingWebEvent_itGetsEnrichedWithOtherMobileContextAndWritten() throws {
-        let core = PassthroughCoreMock(
-            context: .mockWith(
-                source: "react-native",
-                serverTimeOffset: .mockRandom(min: -10, max: 10).rounded()
-            )
+        // Given
+        let dateProvider = RelativeDateProvider()
+        let rumContext: RUMCoreContext = .mockRandom()
+        featureScope.contextMock = .mockWith(
+            source: "react-native",
+            serverTimeOffset: .mockRandom(min: -10, max: 10).rounded(),
+            baggages: [
+                RUMFeature.name: FeatureBaggage(rumContext)
+            ]
         )
 
-        // Given
-        let rumContext: RUMCoreContext = .mockRandom()
-        core.set(baggage: rumContext, forKey: RUMFeature.name)
-        let dateProvider = RelativeDateProvider()
-
         let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
             dateProvider: DateProviderMock(),
             commandSubscriber: RUMCommandSubscriberMock(),
             viewCache: ViewCache(dateProvider: dateProvider)
@@ -203,7 +203,7 @@ class WebViewEventReceiverTests: XCTestCase {
 
         // When
 
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: core)
+        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
 
         // Then
         let expectedWebEventWritten: JSON = [
@@ -219,58 +219,59 @@ class WebViewEventReceiverTests: XCTestCase {
             "application": ["id": rumContext.applicationID],
             "session": ["id": rumContext.sessionID],
             "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
-            "date": date + core.context.serverTimeOffset.toInt64Milliseconds,
+            "date": date + featureScope.contextMock.serverTimeOffset.toInt64Milliseconds,
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
         XCTAssertTrue(result, "It must accept the message")
-        XCTAssertEqual(core.events.count, 1, "It must write web event to core")
-        let actualWebEventWritten = try XCTUnwrap(core.events.first)
+        XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
+        let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
     }
 
     func testGivenRUMContextNotAvailable_whenReceivingWebEvent_itIsDropped() throws {
-        let core = PassthroughCoreMock()
-
         // Given
-        XCTAssertNil(core.context.baggages[RUMFeature.name])
+        XCTAssertNil(featureScope.contextMock.baggages[RUMFeature.name])
 
         let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
             dateProvider: DateProviderMock(),
             commandSubscriber: RUMCommandSubscriberMock(),
             viewCache: ViewCache()
         )
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: randomWebEvent()), from: core)
+        let result = receiver.receive(message: webViewTrackingMessage(with: randomWebEvent()), from: NOPDatadogCore())
 
         // Then
         XCTAssertTrue(result, "It must accept the message")
-        XCTAssertTrue(core.events.isEmpty, "The event must be dropped")
+        XCTAssertTrue(featureScope.eventsWritten.isEmpty, "The event must be dropped")
     }
 
     func testGivenInvalidRUMContext_whenReceivingEvent_itSendsErrorTelemetry() throws {
         struct InvalidRUMContext: Codable {
             var foo = "bar"
         }
-        let telemetryReceiver = TelemetryReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: telemetryReceiver)
 
         // Given
-        core.set(baggage: InvalidRUMContext(), forKey: RUMFeature.name)
-        XCTAssertNotNil(core.context.baggages[RUMFeature.name])
+        featureScope.contextMock = .mockWith(
+            baggages: [
+                RUMFeature.name: FeatureBaggage(InvalidRUMContext())
+            ]
+        )
 
         let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
             dateProvider: DateProviderMock(),
             commandSubscriber: RUMCommandSubscriberMock(),
             viewCache: ViewCache()
         )
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: randomWebEvent()), from: core)
+        let result = receiver.receive(message: webViewTrackingMessage(with: randomWebEvent()), from: NOPDatadogCore())
 
         // Then
         XCTAssertTrue(result, "It should accept the message")
-        let errorTelemetry = try XCTUnwrap(telemetryReceiver.messages.firstError(), "It must send error telemetry")
+        let errorTelemetry = try XCTUnwrap(featureScope.telemetryMock.messages.firstError(), "It must send error telemetry")
         XCTAssertTrue(errorTelemetry.message.hasPrefix("Failed to decode `RUMCoreContext`"))
     }
 }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -743,7 +743,7 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
-        core: DatadogCoreProtocol = NOPDatadogCore(),
+        scope: FeatureScope = NOPFeatureScope(),
         rumApplicationID: String = .mockAny(),
         sessionSampler: Sampler = .mockKeepAll(),
         trackBackgroundEvents: Bool = .mockAny(),
@@ -758,7 +758,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            core: core,
+            scope: scope,
             rumApplicationID: rumApplicationID,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
@@ -790,7 +790,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            core: self.core,
+            scope: self.scope,
             rumApplicationID: rumApplicationID ?? self.rumApplicationID,
             sessionSampler: sessionSampler ?? self.sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents ?? self.trackBackgroundEvents,

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -745,7 +745,7 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
-        scope: FeatureScope = NOPFeatureScope(),
+        featureScope: FeatureScope = NOPFeatureScope(),
         rumApplicationID: String = .mockAny(),
         sessionSampler: Sampler = .mockKeepAll(),
         trackBackgroundEvents: Bool = .mockAny(),
@@ -760,7 +760,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            scope: scope,
+            featureScope: featureScope,
             rumApplicationID: rumApplicationID,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
@@ -792,7 +792,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
-            scope: self.scope,
+            featureScope: self.featureScope,
             rumApplicationID: rumApplicationID ?? self.rumApplicationID,
             sessionSampler: sessionSampler ?? self.sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents ?? self.trackBackgroundEvents,

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -59,12 +59,14 @@ extension TelemetryReceiver: AnyMockable {
     public static func mockAny() -> Self { .mockWith() }
 
     static func mockWith(
+        featureScope: FeatureScope = NOPFeatureScope(),
         dateProvider: DateProvider = SystemDateProvider(),
         sampler: Sampler = .mockKeepAll(),
         configurationExtraSampler: Sampler = .mockKeepAll(),
         metricsExtraSampler: Sampler = .mockKeepAll()
     ) -> Self {
         .init(
+            featureScope: featureScope,
             dateProvider: dateProvider,
             sampler: sampler,
             configurationExtraSampler: configurationExtraSampler,

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -31,24 +31,24 @@ extension CrashReportReceiver: AnyMockable {
     }
 
     static func mockWith(
+        featureScope: FeatureScope = NOPFeatureScope(),
         applicationID: String = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         sessionSampler: Sampler = .mockKeepAll(),
         trackBackgroundEvents: Bool = true,
         uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         ciTest: RUMCITest? = nil,
-        syntheticsTest: RUMSyntheticsTest? = nil,
-        telemetry: Telemetry = NOPTelemetry()
+        syntheticsTest: RUMSyntheticsTest? = nil
     ) -> Self {
         .init(
+            featureScope: featureScope,
             applicationID: applicationID,
             dateProvider: dateProvider,
             sessionSampler: sessionSampler,
             trackBackgroundEvents: trackBackgroundEvents,
             uuidGenerator: uuidGenerator,
             ciTest: ciTest,
-            syntheticsTest: syntheticsTest,
-            telemetry: telemetry
+            syntheticsTest: syntheticsTest
         )
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
@@ -10,17 +10,7 @@ import DatadogInternal
 @testable import DatadogRUM
 
 class MonitorTests: XCTestCase {
-    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
-
-    override func setUp() {
-        super.setUp()
-        core = PassthroughCoreMock()
-    }
-
-    override func tearDown() {
-        core = nil
-        super.tearDown()
-    }
+    private let scope = FeatureScopeMock()
 
     func testWhenSessionIsSampled_itSetsRUMContextInCore() throws {
         // Given
@@ -28,8 +18,8 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            core: core,
-            dependencies: .mockWith(core: core, sessionSampler: sampler),
+            featureScope: scope,
+            dependencies: .mockWith(scope: scope, sessionSampler: sampler),
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
@@ -37,7 +27,7 @@ class MonitorTests: XCTestCase {
 
         // Then
         let expectedContext = monitor.currentRUMContext
-        let rumBaggage = try XCTUnwrap(core.context.baggages[RUMFeature.name])
+        let rumBaggage = try XCTUnwrap(scope.contextMock.baggages[RUMFeature.name])
         let rumContext = try rumBaggage.decode(type: RUMCoreContext.self)
         XCTAssertEqual(rumContext.applicationID, expectedContext.rumApplicationID)
         XCTAssertEqual(rumContext.sessionID, expectedContext.sessionID.toRUMDataFormat)
@@ -50,15 +40,15 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            core: core,
-            dependencies: .mockWith(core: core, sessionSampler: sampler),
+            featureScope: scope,
+            dependencies: .mockWith(scope: scope, sessionSampler: sampler),
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
         monitor.flush()
 
         // Then
-        XCTAssertNil(core.context.baggages[RUMFeature.name])
+        XCTAssertNil(scope.contextMock.baggages[RUMFeature.name])
     }
 
     func testStartView_withViewController_itUsesClassNameAsViewName() throws {
@@ -67,8 +57,8 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            core: core,
-            dependencies: .mockWith(core: core, sessionSampler: .mockKeepAll()),
+            featureScope: scope,
+            dependencies: .mockWith(scope: scope, sessionSampler: .mockKeepAll()),
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc)
@@ -85,8 +75,8 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            core: core,
-            dependencies: .mockWith(core: core, sessionSampler: .mockKeepAll()),
+            featureScope: scope,
+            dependencies: .mockWith(scope: scope, sessionSampler: .mockKeepAll()),
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc, name: "Some View")

--- a/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 @testable import DatadogRUM
 
 class MonitorTests: XCTestCase {
-    private let scope = FeatureScopeMock()
+    private let featureScope = FeatureScopeMock()
 
     func testWhenSessionIsSampled_itSetsRUMContextInCore() throws {
         // Given
@@ -18,8 +18,7 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            featureScope: scope,
-            dependencies: .mockWith(scope: scope, sessionSampler: sampler),
+            dependencies: .mockWith(featureScope: featureScope, sessionSampler: sampler),
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
@@ -27,7 +26,7 @@ class MonitorTests: XCTestCase {
 
         // Then
         let expectedContext = monitor.currentRUMContext
-        let rumBaggage = try XCTUnwrap(scope.contextMock.baggages[RUMFeature.name])
+        let rumBaggage = try XCTUnwrap(featureScope.contextMock.baggages[RUMFeature.name])
         let rumContext = try rumBaggage.decode(type: RUMCoreContext.self)
         XCTAssertEqual(rumContext.applicationID, expectedContext.rumApplicationID)
         XCTAssertEqual(rumContext.sessionID, expectedContext.sessionID.toRUMDataFormat)
@@ -40,15 +39,14 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            featureScope: scope,
-            dependencies: .mockWith(scope: scope, sessionSampler: sampler),
+            dependencies: .mockWith(featureScope: featureScope, sessionSampler: sampler),
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
         monitor.flush()
 
         // Then
-        XCTAssertNil(scope.contextMock.baggages[RUMFeature.name])
+        XCTAssertNil(featureScope.contextMock.baggages[RUMFeature.name])
     }
 
     func testStartView_withViewController_itUsesClassNameAsViewName() throws {
@@ -57,8 +55,7 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            featureScope: scope,
-            dependencies: .mockWith(scope: scope, sessionSampler: .mockKeepAll()),
+            dependencies: .mockWith(featureScope: featureScope, sessionSampler: .mockKeepAll()),
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc)
@@ -75,8 +72,7 @@ class MonitorTests: XCTestCase {
 
         // When
         let monitor = Monitor(
-            featureScope: scope,
-            dependencies: .mockWith(scope: scope, sessionSampler: .mockKeepAll()),
+            dependencies: .mockWith(featureScope: featureScope, sessionSampler: .mockKeepAll()),
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc, name: "Some View")

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -348,7 +348,7 @@ class RUMSessionScopeTests: XCTestCase {
             isInitialSession: randomIsInitialSession,
             parent: parent,
             dependencies: .mockWith(
-                scope: featureScope,
+                featureScope: featureScope,
                 sessionSampler: .mockRandom() // no matter if sampled or not
             ),
             hasReplay: randomIsReplayBeingRecorded
@@ -377,7 +377,7 @@ class RUMSessionScopeTests: XCTestCase {
             isInitialSession: randomIsInitialSession,
             parent: parent,
             startTime: sessionStartTime,
-            dependencies: .mockWith(scope: featureScope),
+            dependencies: .mockWith(featureScope: featureScope),
             hasReplay: randomIsReplayBeingRecorded
         )
 
@@ -406,7 +406,7 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             parent: parent,
             startTime: sessionStartTime,
-            dependencies: .mockWith(scope: featureScope)
+            dependencies: .mockWith(featureScope: featureScope)
         )
 
         // When
@@ -564,7 +564,7 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             parent: parent,
             startTime: Date(),
-            dependencies: .mockWith(scope: featureScope)
+            dependencies: .mockWith(featureScope: featureScope)
         )
 
         let command = RUMStartViewCommand.mockWith(time: Date(), identity: .mockViewIdentifier(), name: "ActiveView")
@@ -593,7 +593,7 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             parent: parent,
             startTime: Date(),
-            dependencies: .mockWith(scope: featureScope)
+            dependencies: .mockWith(featureScope: featureScope)
         )
 
         let startViewCommand = RUMStartViewCommand.mockWith(time: Date(), identity: .mockViewIdentifier())

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2448,7 +2448,7 @@ class RUMViewScopeTests: XCTestCase {
         let scope = RUMViewScope(
             isInitialView: .mockRandom(),
             parent: parent,
-            dependencies: .mockWith(scope: featureScope),
+            dependencies: .mockWith(featureScope: featureScope),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
             name: "ViewController",

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2439,25 +2439,16 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.dd.documentVersion, 1, "It should record only one view update")
     }
 
-    // MARK: Integration with Crash Context
+    // MARK: - Sending Messages Over Message Bus
 
-    func testWhenViewIsStarted_thenItUpdatesLastRUMViewEventInCrashContext() throws {
-        var viewEvent: RUMViewEvent? = nil
-        let messageReciever = FeatureMessageReceiverMock { message in
-            if case let .baggage(label, baggage) = message, label == RUMBaggageKeys.viewEvent {
-                viewEvent = try? baggage.decode()
-            }
-        }
-
-        let core = PassthroughCoreMock(
-            messageReceiver: messageReciever
-        )
+    func testWhenViewIsStarted_itSendsViewEventMessages() throws {
+        let featureScope = FeatureScopeMock()
 
         // Given
         let scope = RUMViewScope(
             isInitialView: .mockRandom(),
             parent: parent,
-            dependencies: .mockWith(core: core),
+            dependencies: .mockWith(scope: featureScope),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
             name: "ViewController",
@@ -2468,18 +2459,18 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         // When
-        core.eventWriteContext { context, writer in
-            XCTAssertTrue(
-                scope.process(
-                    command: RUMStartViewCommand.mockWith(identity: .mockViewIdentifier()),
-                    context: context,
-                    writer: writer
-                )
+        featureScope.eventWriteContext { context, writer in
+            _ = scope.process(
+                command: RUMStartViewCommand.mockWith(identity: .mockViewIdentifier()),
+                context: context,
+                writer: writer
             )
         }
 
         // Then
-        let rumViewSent = try XCTUnwrap(core.events(ofType: RUMViewEvent.self).last, "It should send view event")
-        DDAssertReflectionEqual(viewEvent, rumViewSent, "It must inject sent event to crash context")
+        let rumViewWritten = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last, "It should send view event")
+        let baggageSent = try XCTUnwrap(featureScope.messagesSent().firstBaggage(withKey: RUMBaggageKeys.viewEvent))
+        let rumViewSent: RUMViewEvent = try baggageSent.decode()
+        DDAssertReflectionEqual(rumViewSent, rumViewWritten, "It must sent written event over message bus")
     }
 }

--- a/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
@@ -17,7 +17,6 @@ class RUMMonitorProtocol_ConvenienceTests: XCTestCase {
     func testCallingExtensionMethodsIsSafe() {
         // Given
         let monitor = Monitor(
-            featureScope: NOPFeatureScope(),
             dependencies: .mockAny(),
             dateProvider: SystemDateProvider()
         )

--- a/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
@@ -17,7 +17,7 @@ class RUMMonitorProtocol_ConvenienceTests: XCTestCase {
     func testCallingExtensionMethodsIsSafe() {
         // Given
         let monitor = Monitor(
-            core: PassthroughCoreMock(),
+            featureScope: NOPFeatureScope(),
             dependencies: .mockAny(),
             dateProvider: SystemDateProvider()
         )

--- a/DatadogRUM/Tests/RUMMonitorProtocol+InternalTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+InternalTests.swift
@@ -15,7 +15,6 @@ class RUMMonitorProtocol_InternalTests: XCTestCase {
 
         // When
         monitor = Monitor(
-            featureScope: NOPFeatureScope(),
             dependencies: .mockAny(),
             dateProvider: SystemDateProvider()
         )

--- a/DatadogRUM/Tests/RUMMonitorProtocol+InternalTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+InternalTests.swift
@@ -15,7 +15,7 @@ class RUMMonitorProtocol_InternalTests: XCTestCase {
 
         // When
         monitor = Monitor(
-            core: PassthroughCoreMock(),
+            featureScope: NOPFeatureScope(),
             dependencies: .mockAny(),
             dateProvider: SystemDateProvider()
         )

--- a/TestUtilities/Mocks/CoreMocks/FeatureScopeMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/FeatureScopeMock.swift
@@ -49,7 +49,10 @@ public class FeatureScopeMock: FeatureScope {
 
     // MARK: - Side Effects Observation
 
-    /// Retrieve events written through Even Write Context API.
+    /// Retrieve anonymous events written through Even Write Context API.
+    public var eventsWritten: [Encodable] { events.map { $0.event } }
+
+    /// Retrieve typed events written through Even Write Context API.
     public func eventsWritten<T>(ofType type: T.Type = T.self) -> [T] where T: Encodable {
         return events.compactMap { $0.event as? T }
     }

--- a/TestUtilities/Mocks/FeatureMessageMocks.swift
+++ b/TestUtilities/Mocks/FeatureMessageMocks.swift
@@ -13,6 +13,11 @@ public extension Array where Element == FeatureMessage {
         return compactMap({ $0.asBaggage }).filter({ $0.key == key }).first?.baggage
     }
 
+    /// Unpacks the last "baggage message" with given key in this array.
+    func lastBaggage(withKey key: String) -> FeatureBaggage? {
+        return compactMap({ $0.asBaggage }).filter({ $0.key == key }).last?.baggage
+    }
+
     /// Unpacks the first "baggage message" with given key in this array.
     var firstWebViewMessage: WebViewMessage? {
         return lazy.compactMap { $0.asWebViewMessage }.first


### PR DESCRIPTION
### What and why?

📦 Utilizing the change from #1744, this PR updates the whole RUM to depend on `FeatureScope` interface rather than `DatadogCoreProtocol` directly.

This will be leveraged in fatal App Hangs monitoring, where `AppHangObserver` will take a dependency on `FeatureScope` to access DataStore, Event Write Context and Telemetry.

### How?

With `FeatureScope` being available during RUM feature registration (https://github.com/DataDog/dd-sdk-ios/pull/1744), it is now injected into all downstream components in RUM including the `Monitor` and all message receivers.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
