### PR TITLE
RUM-2813 Add support for `internal_telemetry` from browser

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -911,6 +911,9 @@
 		D253EE972B988CA90010B589 /* ViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE952B988CA90010B589 /* ViewCache.swift */; };
 		D253EE9B2B98B37B0010B589 /* ViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE982B98B3690010B589 /* ViewCacheTests.swift */; };
 		D253EE9C2B98B37C0010B589 /* ViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE982B98B3690010B589 /* ViewCacheTests.swift */; };
+		D2552AF32BBC47D300A45725 /* WebRecordIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52F2B84F71200B63F36 /* WebRecordIntegrationTests.swift */; };
+		D2552AF52BBC492400A45725 /* WebEventIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */; };
+		D2552AF62BBC492600A45725 /* WebEventIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */; };
 		D2553807288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553808288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553826288F0B1A00727FAD /* BatteryStatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */; };
@@ -2648,6 +2651,7 @@
 		D2546C0329AF55AA0054E00B /* TraceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceFeature.swift; sourceTree = "<group>"; };
 		D2546C0729AF55E90054E00B /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		D2546C0A29AF56270054E00B /* MessageReceivers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivers.swift; sourceTree = "<group>"; };
+		D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEventIntegrationTests.swift; sourceTree = "<group>"; };
 		D2553806288AA84F00727FAD /* UploadMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMock.swift; sourceTree = "<group>"; };
 		D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisher.swift; sourceTree = "<group>"; };
 		D2553828288F0B2300727FAD /* LowPowerModePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowPowerModePublisher.swift; sourceTree = "<group>"; };
@@ -5006,6 +5010,7 @@
 			children = (
 				61E8C5072B28898800E709B4 /* StartingRUMSessionTests.swift */,
 				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
+				D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -7694,6 +7699,7 @@
 				61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */,
 				D2A1EE442886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */,
 				D29A9FD029DDC58E005C54A4 /* RUMFeatureTests.swift in Sources */,
+				D2552AF52BBC492400A45725 /* WebEventIntegrationTests.swift in Sources */,
 				61F930C82BA1C51C005F0EE2 /* Storage+TLVTests.swift in Sources */,
 				3C1890152ABDE9BF00CE9E73 /* DDURLSessionInstrumentationTests+apiTests.m in Sources */,
 				D28F836529C9E69E00EF8EA2 /* DatadogTraceFeatureTests.swift in Sources */,
@@ -8763,6 +8769,7 @@
 				D24C9C4E29A7BA41002057CF /* LogsMocks.swift in Sources */,
 				D2CB6EDE27C520D400A62B57 /* RUMEventMatcher.swift in Sources */,
 				D2CB6EE027C520D400A62B57 /* SpanMatcher.swift in Sources */,
+				D2552AF32BBC47D300A45725 /* WebRecordIntegrationTests.swift in Sources */,
 				6179DB572B6022EA00E9E04E /* SendingCrashReportTests.swift in Sources */,
 				61112F8F2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */,
 				D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */,
@@ -8824,6 +8831,7 @@
 				D2CB6F2827C520D400A62B57 /* DataUploadWorkerTests.swift in Sources */,
 				D2CB6F2B27C520D400A62B57 /* CrashContextProviderTests.swift in Sources */,
 				49274907288048B800ECD49B /* InternalProxyTests.swift in Sources */,
+				D2552AF62BBC492600A45725 /* WebEventIntegrationTests.swift in Sources */,
 				D29A9FC529DDB719005C54A4 /* RUMInternalProxyTests.swift in Sources */,
 				D22743EA29DEC9A9001A7EF9 /* RUMDataModelMocks.swift in Sources */,
 				D22743E529DEB934001A7EF9 /* UIViewControllerSwizzlerTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
@@ -1,0 +1,276 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+#if !os(tvOS)
+import WebKit
+
+import TestUtilities
+@testable import DatadogRUM
+@testable import DatadogWebViewTracking
+
+class WebEventIntegrationTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var controller: WKUserContentControllerMock!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() {
+        core = DatadogCoreProxy(
+            context: .mockWith(
+                env: "test",
+                version: "1.1.1",
+                serverTimeOffset: 123
+            )
+        )
+
+        controller = WKUserContentControllerMock()
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        WebViewTracking.enable(webView: webView, in: core)
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        controller = nil
+    }
+
+    func testWebEventIntegration() throws {
+        // Given
+        let randomApplicationID: String = .mockRandom()
+        let randomUUID: UUID = .mockRandom()
+
+        RUM.enable(with: .mockWith(applicationID: randomApplicationID) {
+            $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
+        }, in: core)
+
+        let body = """
+        {
+          "eventType": "view",
+          "event": {
+            "application": {
+              "id": "xxx"
+            },
+            "date": \(1635932927012),
+            "service": "super",
+            "session": {
+              "id": "0110cab4-7471-480e-aa4e-7ce039ced355",
+              "type": "user"
+            },
+            "type": "view",
+            "view": {
+              "action": {
+                "count": 0
+              },
+              "cumulative_layout_shift": 0,
+              "dom_complete": 152800000,
+              "dom_content_loaded": 118300000,
+              "dom_interactive": 116400000,
+              "error": {
+                "count": 0
+              },
+              "first_contentful_paint": 121300000,
+              "id": "64308fd4-83f9-48cb-b3e1-1e91f6721230",
+              "in_foreground_periods": [],
+              "is_active": true,
+              "largest_contentful_paint": 121299000,
+              "load_event": 152800000,
+              "loading_time": 152800000,
+              "loading_type": "initial_load",
+              "long_task": {
+                "count": 0
+              },
+              "referrer": "",
+              "resource": {
+                "count": 3
+              },
+              "time_spent": 3120000000,
+              "url": "http://localhost:8080/test.html"
+            },
+            "_dd": {
+              "document_version": 2,
+              "drift": 0,
+              "format_version": 2,
+              "session": {
+                "plan": 2
+              }
+            }
+          },
+          "tags": [
+            "browser_sdk_version:3.6.13"
+          ]
+        }
+        """
+
+        // When
+        RUMMonitor.shared(in: core).startView(key: "web-view")
+        controller.send(body: body)
+        controller.flush()
+
+        // Then
+        let expectedUUID = randomUUID.uuidString.lowercased()
+        let rumMatcher = try XCTUnwrap(core.waitAndReturnRUMEventMatchers().last)
+        try rumMatcher.assertItFullyMatches(jsonString: """
+        {
+            "application": {
+              "id": "\(randomApplicationID)"
+            },
+            "date": \(1_635_932_927_012 + 123.toInt64Milliseconds),
+            "service": "super",
+            "session": {
+              "id": "\(expectedUUID)",
+              "type": "user"
+            },
+            "type": "view",
+            "view": {
+              "action": {
+                "count": 0
+              },
+              "cumulative_layout_shift": 0,
+              "dom_complete": 152800000,
+              "dom_content_loaded": 118300000,
+              "dom_interactive": 116400000,
+              "error": {
+                "count": 0
+              },
+              "first_contentful_paint": 121300000,
+              "id": "64308fd4-83f9-48cb-b3e1-1e91f6721230",
+              "in_foreground_periods": [],
+              "is_active": true,
+              "largest_contentful_paint": 121299000,
+              "load_event": 152800000,
+              "loading_time": 152800000,
+              "loading_type": "initial_load",
+              "long_task": {
+                "count": 0
+              },
+              "referrer": "",
+              "resource": {
+                "count": 3
+              },
+              "time_spent": 3120000000,
+              "url": "http://localhost:8080/test.html"
+            },
+            "_dd": {
+              "document_version": 2,
+              "drift": 0,
+              "format_version": 2,
+              "session": {
+                "plan": 1
+              }
+            }
+        }
+        """
+        )
+    }
+
+    func testWebTelemetryIntegration() throws {
+        // Given
+        let randomApplicationID: String = .mockRandom()
+        let randomUUID: UUID = .mockRandom()
+
+        RUM.enable(with: .mockWith(applicationID: randomApplicationID) {
+            $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
+        }, in: core)
+
+        let body = """
+        {
+          "eventType": "internal_telemetry",
+          "event":
+            {
+              "type": "telemetry",
+              "date": 1712069357432,
+              "service": "browser-rum-sdk",
+              "version": "5.2.0-b93ed472a4f14fbf2bcd1bc2c9faacb4abbeed82",
+              "source": "browser",
+              "_dd": { "format_version": 2 },
+              "telemetry":
+                {
+                  "type": "configuration",
+                  "configuration":
+                    {
+                      "session_replay_sample_rate": 100,
+                      "use_allowed_tracing_urls": false,
+                      "selected_tracing_propagators": [],
+                      "default_privacy_level": "allow",
+                      "use_excluded_activity_urls": false,
+                      "use_worker_url": false,
+                      "track_user_interactions": true,
+                      "track_resources": true,
+                      "track_long_task": true,
+                      "session_sample_rate": 100,
+                      "telemetry_sample_rate": 100,
+                      "use_before_send": false,
+                      "use_proxy": false,
+                      "allow_fallback_to_local_storage": false,
+                      "store_contexts_across_pages": false,
+                      "allow_untrusted_events": false
+                    },
+                  "runtime_env": { "is_local_file": false, "is_worker": false }
+                },
+              "experimental_features": [],
+              "application": { "id": "00000000-aaaa-0000-aaaa-000000000000" },
+              "session": { "id": "00000000-aaaa-0000-aaaa-000000000000" },
+              "view": {},
+              "action": { "id": [] }
+            }
+        }
+        """
+
+        // When
+        RUMMonitor.shared(in: core).startView(key: "web-view")
+        controller.send(body: body)
+        controller.flush()
+
+        // Then
+        let expectedUUID = randomUUID.uuidString.lowercased()
+        let rumMatcher = try XCTUnwrap(core.waitAndReturnRUMEventMatchers().last)
+        try rumMatcher.assertItFullyMatches(jsonString: """
+        {
+          "type": "telemetry",
+          "date": \(1_712_069_357_432 + 123.toInt64Milliseconds),
+          "service": "browser-rum-sdk",
+          "version": "5.2.0-b93ed472a4f14fbf2bcd1bc2c9faacb4abbeed82",
+          "source": "browser",
+          "_dd": { "format_version": 2 },
+          "telemetry":
+            {
+              "type": "configuration",
+              "configuration":
+                {
+                  "session_replay_sample_rate": 100,
+                  "use_allowed_tracing_urls": false,
+                  "selected_tracing_propagators": [],
+                  "default_privacy_level": "allow",
+                  "use_excluded_activity_urls": false,
+                  "use_worker_url": false,
+                  "track_user_interactions": true,
+                  "track_resources": true,
+                  "track_long_task": true,
+                  "session_sample_rate": 100,
+                  "telemetry_sample_rate": 100,
+                  "use_before_send": false,
+                  "use_proxy": false,
+                  "allow_fallback_to_local_storage": false,
+                  "store_contexts_across_pages": false,
+                  "allow_untrusted_events": false
+                },
+              "runtime_env": { "is_local_file": false, "is_worker": false }
+            },
+          "experimental_features": [],
+          "application": { "id": "\(randomApplicationID)" },
+          "session": { "id": "\(expectedUUID)" },
+          "view": {},
+          "action": { "id": [] }
+        }
+        """
+        )
+    }
+}
+
+#endif

--- a/DatadogInternal/Sources/Models/WebViewTracking/WebViewMessage.swift
+++ b/DatadogInternal/Sources/Models/WebViewTracking/WebViewMessage.swift
@@ -21,6 +21,7 @@ public enum WebViewMessage {
         case error
         case longTask = "long_task"
         case record
+        case telemetry = "internal_telemetry"
     }
 
     /// Raw event dictionary.
@@ -34,6 +35,8 @@ public enum WebViewMessage {
     case log(Event)
     /// A browser rum event.
     case rum(Event)
+    /// A browser telemetry event.
+    case telemetry(Event)
     /// A browser session-replay record.
     case record(Event, View)
 }
@@ -65,6 +68,8 @@ extension WebViewMessage: Decodable {
             self = .log(event)
         case .rum, .view, .action, .resource, .error, .longTask:
             self = .rum(event)
+        case .telemetry:
+            self = .telemetry(event)
         case .record:
             let view = try container.decode(View.self, forKey: .view)
             self = .record(event, view)

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -49,9 +49,9 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         switch message {
         case let .webview(.rum(event)):
-            receive(rum: event, from: core)
+            receive(rum: event)
         case let .webview(.telemetry(event)):
-            receive(telemetry: event, from: core)
+            receive(telemetry: event)
         default:
             return false
         }
@@ -59,7 +59,7 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
         return true
     }
 
-    private func receive(rum event: JSON, from core: DatadogCoreProtocol) {
+    private func receive(rum event: JSON) {
         commandSubscriber.process(
             command: RUMKeepSessionAliveCommand(
                 time: dateProvider.now,
@@ -115,9 +115,9 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
         }
     }
 
-    private func receive(telemetry event: JSON, from core: DatadogCoreProtocol) {
+    private func receive(telemetry event: JSON) {
         // RUM-2866: Update with dedicated telemetry track
-        featureScope.eventWriteContext { [weak core] context, writer in
+        featureScope.eventWriteContext { [featureScope] context, writer in
             guard let rumBaggage = context.baggages[RUMFeature.name] else {
                 return // Drop event if RUM is not enabled or RUM session is not sampled
             }
@@ -142,7 +142,7 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
 
                 writer.write(value: AnyEncodable(event))
             } catch {
-                core?.telemetry.error("Failed to decode `RUMCoreContext`", error: error)
+                featureScope.telemetry.error("Failed to decode `RUMCoreContext`", error: error)
             }
         }
     }

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -39,23 +39,27 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
         self.viewCache = viewCache
     }
 
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .webview(.rum(event)) = message else {
-            return false
-        }
-
-        write(event: event)
-        return true
-    }
-
     /// Writes a Browser RUM event to the core.
     ///
     /// The receiver will inject current RUM context and apply server-time offset to the event.
     ///
     /// - Parameters:
-    ///   - event: The Browser RUM event.
+    ///   - message: The message containing the Browser RUM event.
     ///   - core: The core to write the event.
-    private func write(event: JSON) {
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        switch message {
+        case let .webview(.rum(event)):
+            receive(rum: event, from: core)
+        case let .webview(.telemetry(event)):
+            receive(telemetry: event, from: core)
+        default:
+            return false
+        }
+
+        return true
+    }
+
+    private func receive(rum event: JSON, from core: DatadogCoreProtocol) {
         commandSubscriber.process(
             command: RUMKeepSessionAliveCommand(
                 time: dateProvider.now,
@@ -107,6 +111,38 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                 writer.write(value: AnyEncodable(event))
             } catch {
                 featureScope.telemetry.error("Failed to decode `RUMCoreContext`", error: error)
+            }
+        }
+    }
+
+    private func receive(telemetry event: JSON, from core: DatadogCoreProtocol) {
+        // RUM-2866: Update with dedicated telemetry track
+        featureScope.eventWriteContext { [weak core] context, writer in
+            guard let rumBaggage = context.baggages[RUMFeature.name] else {
+                return // Drop event if RUM is not enabled or RUM session is not sampled
+            }
+
+            do {
+                let rum: RUMCoreContext = try rumBaggage.decode()
+                var event = event
+
+                if let date = event["date"] as? Int {
+                    event["date"] = Int64(date) + context.serverTimeOffset.toInt64Milliseconds
+                }
+
+                if var application = event["application"] as? JSON {
+                    application["id"] = rum.applicationID
+                    event["application"] = application
+                }
+
+                if var session = event["session"] as? JSON {
+                    session["id"] = rum.sessionID
+                    event["session"] = session
+                }
+
+                writer.write(value: AnyEncodable(event))
+            } catch {
+                core?.telemetry.error("Failed to decode `RUMCoreContext`", error: error)
             }
         }
     }

--- a/DatadogWebViewTracking/Sources/MessageEmitter.swift
+++ b/DatadogWebViewTracking/Sources/MessageEmitter.swift
@@ -45,13 +45,13 @@ internal final class MessageEmitter: InternalExtension<WebViewTracking>.Abstract
             }
 
             let decoder = JSONDecoder()
-            let event = try decoder.decode(WebViewMessage.self, from: data)
+            let message = try decoder.decode(WebViewMessage.self, from: data)
 
-            switch event {
+            switch message {
             case .log:
-                send(log: event, in: core)
-            case .rum:
-                send(rum: event, in: core)
+                send(log: message, in: core)
+            case .rum, .telemetry:
+                send(rum: message, in: core)
             case let .record(event, view):
                 send(record: event, view: view, slotId: slotId, in: core)
             }


### PR DESCRIPTION
### What and why?

Following #1691, the telemetry events coming from Browser were no longer forwarded to RUM track.

### How?

Support `internal_telemetry` message type and forward them to RUM.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
