### PR TITLE
RUM-2916 fix: Crash in `NetworkInstrumentationFeature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Call RUM's `errorEventMapper` for crashes. See [#1742][]
 * [FEATURE] Support calling log event mapper for crashes. See [#1741][]
+* [FIX] Fix crash in `NetworkInstrumentationFeature`. See [#1767][]
 
 # 2.8.0 / 19-03-2024
 
@@ -575,6 +576,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1315]: https://github.com/DataDog/dd-sdk-ios/pull/1315
 [#1331]: https://github.com/DataDog/dd-sdk-ios/pull/1331
 [#1328]: https://github.com/DataDog/dd-sdk-ios/pull/1328
+[#1767]: https://github.com/DataDog/dd-sdk-ios/pull/1767
 [#1355]: https://github.com/DataDog/dd-sdk-ios/pull/1355
 [#1410]: https://github.com/DataDog/dd-sdk-ios/pull/1410
 [#1412]: https://github.com/DataDog/dd-sdk-ios/pull/1412

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -51,7 +51,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation = expectation(description: "Send span")
 
         // Given
-        let request: URLRequest = .mockWith(httpMethod: "POST")
+        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
         interception.register(metrics: .mockAny())
         interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
@@ -74,12 +74,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation?.expectedFulfillmentCount = 2
 
         // Given
-        let request: URLRequest = .mockWith(
-            url: "http://www.example.com",
-            queryParams: [
-                URLQueryItem(name: "foo", value: "42"),
-                URLQueryItem(name: "lang", value: "en")
-            ],
+        let request: ImmutableRequest = .mockWith(
+            url: URL(string: "http://www.example.com")!,
             httpMethod: "GET"
         )
         let error = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
@@ -149,7 +145,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation?.expectedFulfillmentCount = 2
 
         // Given
-        let request: URLRequest = .mockWith(httpMethod: "GET")
+        let request: ImmutableRequest = .mockWith(httpMethod: "GET")
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
         interception.register(response: .mockResponseWith(statusCode: 404), error: nil)
         interception.register(

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -11,7 +11,7 @@ public class URLSessionTaskInterception {
     public let identifier: UUID
     /// The initial request send during this interception. It is, the request send from `URLSession`, not the one
     /// given by the user (as the request could have been modified in `URLSessionSwizzler`).
-    public private(set) var request: URLRequest
+    public private(set) var request: ImmutableRequest
     /// Tells if the `request` is send to a 1st party host.
     public let isFirstPartyRequest: Bool
     /// Task metrics collected during this interception.
@@ -28,7 +28,7 @@ public class URLSessionTaskInterception {
     /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
     public private(set) var origin: String?
 
-    init(request: URLRequest, isFirstParty: Bool) {
+    init(request: ImmutableRequest, isFirstParty: Bool) {
         self.identifier = UUID()
         self.request = request
         self.isFirstPartyRequest = isFirstParty
@@ -46,7 +46,7 @@ public class URLSessionTaskInterception {
         }
     }
 
-    func register(request: URLRequest) {
+    func register(request: ImmutableRequest) {
         self.request = request
     }
 
@@ -94,6 +94,20 @@ public struct ResourceCompletion {
     public init(response: URLResponse?, error: Error?) {
         self.httpResponse = response as? HTTPURLResponse
         self.error = error
+    }
+}
+
+public struct ImmutableRequest {
+    public let url: URL?
+    public let httpMethod: String?
+    public let allHTTPHeaderFields: [String: String]?
+    public let unsafeOriginal: URLRequest
+
+    public init(request: URLRequest) {
+        self.url = request.url
+        self.httpMethod = request.httpMethod
+        self.allHTTPHeaderFields = request.allHTTPHeaderFields
+        self.unsafeOriginal = request
     }
 }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -97,10 +97,20 @@ public struct ResourceCompletion {
     }
 }
 
+/// An immutable version of `URLRequest`.
+///
+/// Introduced in response to concerns raised in https://github.com/DataDog/dd-sdk-ios/issues/1638 
+/// it makes a copy of request attributes, safeguarding against potential thread safety issues arising from concurrent 
+/// mutations (see more context in https://github.com/DataDog/dd-sdk-ios/pull/1767 ).
 public struct ImmutableRequest {
+    /// The URL of the request.
     public let url: URL?
+    /// The HTTP method of the request.
     public let httpMethod: String?
+    /// The HTTP header fields of the request.
     public let allHTTPHeaderFields: [String: String]?
+    /// A reference to the original `URLRequest` object provided during initialization. Direct use is discouraged
+    /// due to thread safety concerns. Instead, necessary attributes should be accessed through `ImmutableRequest` fields.
     public let unsafeOriginal: URLRequest
 
     public init(request: URLRequest) {

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -81,7 +81,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                 attributes: [:],
                 url: url,
                 httpMethod: RUMMethod(httpMethod: interception.request.httpMethod),
-                kind: RUMResourceType(request: interception.request),
+                kind: RUMResourceType(request: interception.request.unsafeOriginal),
                 spanContext: distributedTracing?.trace(from: interception)
             )
         )
@@ -99,7 +99,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 
         // Get RUM Resource attributes from the user.
         let userAttributes = rumAttributesProvider?(
-            interception.request,
+            interception.request.unsafeOriginal,
             interception.completion?.httpResponse,
             interception.data,
             interception.completion?.error

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -246,8 +246,10 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         commandSubscriber.onCommandReceived = { _ in receiveCommand.fulfill() }
 
         // Given
-        var request = URLRequest(url: .mockRandom())
-        request.httpMethod = ["GET", "POST", "PUT", "DELETE"].randomElement()!
+        let request: ImmutableRequest = .mockWith(
+            url: .mockRandom(),
+            httpMethod: ["GET", "POST", "PUT", "DELETE"].randomElement()!
+        )
         let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random())
         XCTAssertNil(taskInterception.trace)
 
@@ -391,13 +393,13 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let mockRequest: URLRequest = .mockAny()
+        let mockRequest: ImmutableRequest = .mockAny()
         let mockResponse: URLResponse = .mockAny()
         let mockData: Data = .mockRandom()
         let mockAttributes: [AttributeKey: AttributeValue] = mockRandomAttributes()
 
         let handler = createHandler { request, response, data, error in
-            XCTAssertEqual(request, mockRequest)
+            XCTAssertEqual(request, mockRequest.unsafeOriginal)
             XCTAssertEqual(response, mockResponse)
             XCTAssertEqual(data, mockData)
             XCTAssertNil(error)
@@ -428,12 +430,12 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let mockRequest: URLRequest = .mockAny()
+        let mockRequest: ImmutableRequest = .mockAny()
         let mockError = ErrorMock()
         let mockAttributes: [AttributeKey: AttributeValue] = mockRandomAttributes()
 
         let handler = createHandler { request, response, data, error in
-            XCTAssertEqual(request, mockRequest)
+            XCTAssertEqual(request, mockRequest.unsafeOriginal)
             XCTAssertNil(response)
             XCTAssertNil(data)
             XCTAssertTrue(error is ErrorMock)

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -225,7 +225,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation = expectation(description: "Send span")
 
         // Given
-        let request: URLRequest = .mockWith(httpMethod: "POST")
+        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
         interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
         interception.register(
@@ -275,7 +275,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation?.expectedFulfillmentCount = 2
 
         // Given
-        let request: URLRequest = .mockWith(httpMethod: "POST")
+        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
 
         // When
@@ -364,8 +364,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.expectation?.isInverted = true
 
         // Given
-        var request: URLRequest = .mockAny()
-        request.setValue("rum", forHTTPHeaderField: TracingHTTPHeaders.originField)
+        let request: ImmutableRequest = .mockWith(
+            allHTTPHeaderFields: [TracingHTTPHeaders.originField: "rum"]
+        )
         let interception = URLSessionTaskInterception(request: request, isFirstParty: false)
         interception.register(response: .mockAny(), error: nil)
 

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -65,7 +65,7 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     }
 
     public func interception(for request: URLRequest) -> URLSessionTaskInterception? {
-        interceptions.values.first { $0.request == request }
+        interceptions.values.first { $0.request.unsafeOriginal == request }
     }
 
     public func interception(for url: URL) -> URLSessionTaskInterception? {
@@ -102,6 +102,22 @@ extension ResourceCompletion: AnyMockable {
         error: Error? = nil
     ) -> Self {
         return ResourceCompletion(response: response, error: error)
+    }
+}
+
+extension ImmutableRequest: AnyMockable {
+    public static func mockAny() -> ImmutableRequest {
+        return .mockWith()
+    }
+    public static func mockWith(
+        url: URL = .mockAny(),
+        httpMethod: String = "GET",
+        allHTTPHeaderFields: [String: String] = .mockAny()
+    ) -> ImmutableRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        request.allHTTPHeaderFields = allHTTPHeaderFields
+        return ImmutableRequest(request: request)
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR addresses the crashes reported in #1638 by implementing extra thread safety measures.

```
Thread 10 Crashed:
0   CoreFoundation                  0x31fe4ac54         CF_IS_OBJC
1   CoreFoundation                  0x31fe694e4         [inlined] CFDictionaryGetCount
2   CoreFoundation                  0x31fe694e4         CFDictionaryGetCount
3   CFNetwork                       0x3221fb2b8         _CFHTTPServerResponseEnqueue
4   CFNetwork                       0x3221e2be0         CFHTTPCookieStorageUnscheduleFromRunLoop
5   Foundation                      0x31e1a2718         URLRequest.allHTTPHeaderFields.getter
6   <AppName>                         0x104ec81c4         NetworkInstrumentationFeature.extractTrace (NetworkInstrumentationFeature.swift:246)
7   <AppName>                         0x104ec6ba4         [inlined] NetworkInstrumentationFeature.extractTrace
8   <AppName>                         0x104ec6ba4         NetworkInstrumentationFeature.intercept (NetworkInstrumentationFeature.swift:169)
9   <AppName>                         0x104ec6dbc         thunk for closure
```

I couldn't reproduce the issue, so the fix is based on the following considerations:

- There might be a thread safety issue when accessing `task.currentRequest` from a private queue.
- There could be a data race when reading `request.allHTTPHeaderFields` from a private queue, possibly due to underlying `CFDictionary` operations.
- It's possible that a combination of the above scenarios is occurring, as suggested by multiple different stack traces reported in #1638.

### How?


Two main changes to resolve the issue:
- `let currentRequest = task.currentRequest` has been moved from the private queue to the `URLSession` thread to ensure safe access.
- A new type, `ImmutableRequest`, has been introduced. This type captures an immutable copy of the necessary fields from `URLRequest`, thereby avoiding direct referencing of underlying Foundation objects from the private queue.

### Reproducibility

While attempting to reproduce the problem in our codebase, I encountered several key findings:

- Modifying `URLRequest` from multiple concurrent threads causes thread safety issues. This arises from `URLRequest` being a Swift struct backed by an underlying Foundation object, as it conforms to [ReferenceConvertible](https://developer.apple.com/documentation/foundation/referenceconvertible):
```swift
// 🔥 Thread 12: EXC_BAD_ACCESS
// #0 ___lldb_unnamed_symbol6147 ()
// #1 ___lldb_unnamed_symbol6175 ()
// #2 CFURLRequestSetHTTPHeaderFieldValue ()
// #3 specialized URLRequest._applyMutation<τ_0_0>(_:) ()
// #4 closure #1 in CrashInNetworkFeatureExperiment.testRequestMutation() at CrashInNetworkFeatureExperiment.swift:28
// #5 partial apply for closure #1 in CrashInNetworkFeatureExperiment.testRequestMutation() ()
// #6 partial apply for thunk for @callee_guaranteed (@unowned Int) -> () ()
// #7 thunk for @escaping @callee_guaranteed (@unowned Int) -> () ()
// #8 __wrap_dispatch_apply_block_invoke ()
func testRequestMutation() {
    var request = URLRequest(url: URL(string: "https://example.com/")!)

    DispatchQueue.concurrentPerform(iterations: 10_000) { idx in
        request.setValue("header-\(idx)", forHTTPHeaderField: "field") // #28
        _ = request.allHTTPHeaderFields?["field"]
    }
}
``` 

- It appears safe [to modify](https://github.com/DataDog/dd-sdk-ios/blob/5334eab9cb5f9de2f47f62d9a951b3b05230938e/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTask%2BTracking.swift#L19) `task.currentRequest` between threads, even if the request undergoes multiple redirections.
```swift
// ✅ no crash
func testTaskMutation() {
    let request = URLRequest(url: URL(string: "https://httpbin.org/redirect/10")!)
    let task = session.dataTask(with: request)
    task.resume()

    DispatchQueue.concurrentPerform(iterations: 10_000) { idx in
        let otherRequest = URLRequest(url: URL(string: "https://httpbin.org/redirect/\(idx)")!)
        task.setValue(otherRequest, forKey: "currentRequest")
        _ = task.currentRequest
    }
}
```

- Isolating our `NetworkInstrumentationFeature` code and subjecting it to stress testing with simultaneous thread access did not reveal any issues.
```swift
// ✅ no crash
func testNetworkInstrumentationFeature() {
    let swizzler = NetworkInstrumentationSwizzler()

    try! swizzler.swizzle(
        interceptResume: { task in
            var modifiedRequest = URLRequest(url: URL(string: "https://httpbin.org/redirect/15")!)
            modifiedRequest.setValue("header-value", forHTTPHeaderField: "header-field")
            task.dd.override(currentRequest: modifiedRequest)
        }
    )

    let request = URLRequest(url: URL(string: "https://httpbin.org/redirect/10")!)
    let task = session.dataTask(with: request)
    task.resume()

    DispatchQueue.concurrentPerform(iterations: 10_000) { idx in
        _ = task.currentRequest?.allHTTPHeaderFields
        _ = task.currentRequest?.allHTTPHeaderFields?["header-field"]
    }
}
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
