### PR TITLE
RUM-3853 feat(otel-tracer): remove support for event API

### DIFF
--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -137,19 +137,19 @@ internal class OTelSpan: OpenTelemetryApi.Span {
     }
 
     func addEvent(name: String) {
-        // not supported
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
     func addEvent(name: String, timestamp: Date) {
-        // not supported
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue]) {
-        // not supported
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
-        // not supported
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
     func end() {

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -136,42 +136,20 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         )
     }
 
-    /// Sends a span event which is akin to a log in Datadog
-    /// - Parameter name: name of the event
     func addEvent(name: String) {
-        addEvent(name: name, timestamp: .init())
+        // not supported
     }
 
-    /// Sends a span event which is akin to a log in Datadog
-    /// - Parameters:
-    ///   - name: name of the event
-    ///   - timestamp: timestamp of the event
     func addEvent(name: String, timestamp: Date) {
-        addEvent(name: name, attributes: .init(), timestamp: timestamp)
+        // not supported
     }
 
-    /// Sends a span event which is akin to a log in Datadog
-    /// - Parameters:
-    ///   - name: name of the event
-    ///   - attributes: attributes of the event
-    ///   - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue]) {
-        addEvent(name: name, attributes: attributes, timestamp: .init())
+        // not supported
     }
 
-    /// Sends a span event which is akin to a log in Datadog
-    /// - Parameters:
-    ///   - name: name of the event
-    ///   - attributes: attributes of the event
-    ///   - timestamp: timestamp of the event
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
-        guard isRecording else {
-            return
-        }
-
-        // There is no need to lock here, because `DDSpan` is thread-safe
-
-        ddSpan.log(message: name, fields: attributes.tags, timestamp: timestamp)
+        // not supported
     }
 
     func end() {


### PR DESCRIPTION
### What and why?

`event` is not supported. 

### How?

- Make event API not supported
- Test case for logs integration

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
