### PR TITLE
RUM-3185 feat(otel-tracer): use DatadogSDKTesting as SPM dependency

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		3CCCA5C52ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C32ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift */; };
 		3CCCA5C72ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */; };
 		3CCCA5C82ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */; };
+		3CDA3F7E2BCD866D005D2C13 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3CDA3F7D2BCD866D005D2C13 /* DatadogSDKTesting */; };
+		3CDA3F802BCD8687005D2C13 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3CDA3F7F2BCD8687005D2C13 /* DatadogSDKTesting */; };
 		3CE11A1129F7BE0900202522 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
@@ -3004,6 +3006,7 @@
 			files = (
 				D26F741129ACBDA100D25622 /* DatadogInternal.framework in Frameworks */,
 				D2579592298ABCED008A1BE5 /* XCTest.framework in Frameworks */,
+				3CDA3F7E2BCD866D005D2C13 /* DatadogSDKTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3013,6 +3016,7 @@
 			files = (
 				D26F741229ACBDAD00D25622 /* DatadogInternal.framework in Frameworks */,
 				D230399E298D50F1001A1FA3 /* XCTest.framework in Frameworks */,
+				3CDA3F802BCD8687005D2C13 /* DatadogSDKTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6560,6 +6564,9 @@
 				3C41694229FBF6100042B9D2 /* PBXTargetDependency */,
 			);
 			name = "TestUtilities iOS";
+			packageProductDependencies = (
+				3CDA3F7D2BCD866D005D2C13 /* DatadogSDKTesting */,
+			);
 			productName = TestUtilities;
 			productReference = D257953E298ABA65008A1BE5 /* TestUtilities.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6579,6 +6586,9 @@
 				D26F741529ACBDAD00D25622 /* PBXTargetDependency */,
 			);
 			name = "TestUtilities tvOS";
+			packageProductDependencies = (
+				3CDA3F7F2BCD8687005D2C13 /* DatadogSDKTesting */,
+			);
 			productName = TestUtilities;
 			productReference = D257958B298ABB83008A1BE5 /* TestUtilities.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6598,6 +6608,8 @@
 				D2C1A51129C4C4EF00946C31 /* PBXTargetDependency */,
 			);
 			name = "DatadogTrace iOS";
+			packageProductDependencies = (
+			);
 			productName = DatadogTrace;
 			productReference = D25EE93429C4C3C300CE3839 /* DatadogTrace.framework */;
 			productType = "com.apple.product-type.framework";
@@ -6616,6 +6628,8 @@
 				D25EE93E29C4C3C300CE3839 /* PBXTargetDependency */,
 			);
 			name = "DatadogTraceTests iOS";
+			packageProductDependencies = (
+			);
 			productName = DatadogTraceTests;
 			productReference = D25EE93B29C4C3C300CE3839 /* DatadogTraceTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -6966,6 +6980,9 @@
 				Base,
 			);
 			mainGroup = 61133B78242393DE00786299;
+			packageReferences = (
+				3CDA3F6C2BCD8429005D2C13 /* XCRemoteSwiftPackageReference "dd-sdk-swift-testing" */,
+			);
 			productRefGroup = 61133B83242393DE00786299 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13140,6 +13157,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		3CDA3F6C2BCD8429005D2C13 /* XCRemoteSwiftPackageReference "dd-sdk-swift-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/DataDog/dd-sdk-swift-testing.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3CDA3F7D2BCD866D005D2C13 /* DatadogSDKTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3CDA3F6C2BCD8429005D2C13 /* XCRemoteSwiftPackageReference "dd-sdk-swift-testing" */;
+			productName = DatadogSDKTesting;
+		};
+		3CDA3F7F2BCD8687005D2C13 /* DatadogSDKTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3CDA3F6C2BCD8429005D2C13 /* XCRemoteSwiftPackageReference "dd-sdk-swift-testing" */;
+			productName = DatadogSDKTesting;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 61133B79242393DE00786299 /* Project object */;
 }

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
@@ -196,11 +196,6 @@
                BlueprintName = "DatadogCoreTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "OTelSpanTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
@@ -182,11 +182,6 @@
                BlueprintName = "DatadogCoreTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "OTelSpanTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
@@ -40,23 +40,7 @@ final class OTelSpanTests: XCTestCase {
 
         // Then
         let logs: [LogEvent] = core.waitAndReturnEvents(ofFeature: LogsFeature.name, ofType: LogEvent.self)
-        XCTAssertEqual(logs.count, 1)
-
-        let expectedAttributes: [String: Encodable] = [
-            "string": "value",
-            "bool": "true",
-            "int": "2",
-            "double": "2.0",
-            "stringArray.0": "value1",
-            "stringArray.1": "value2",
-            "boolArray.0": "true",
-            "boolArray.1": "false",
-            "intArray.0": "1",
-            "intArray.1": "2",
-            "doubleArray.0": "1.0",
-            "doubleArray.1": "2.0"
-        ]
-        DDAssertJSONEqual(AnyEncodable(expectedAttributes), AnyEncodable(logs[0].attributes.userAttributes))
+        XCTAssertEqual(logs.count, 0)
     }
 
     func testContextProviderSetActive_givenParentSpan() throws {

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,6 @@
 all: dependencies templates
 
-# The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 2.3.2
-DD_DISABLE_TEST_INSTRUMENTING = false
-
 define DD_SDK_TESTING_XCCONFIG_CI
-DD_SDK_TESTING_PATH=$$(DD_SDK_TESTING_OVERRIDE_PATH:default=$$(SRCROOT)/../instrumented-tests/)\n
-FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(DD_SDK_TESTING_PATH)/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
-OTHER_LDFLAGS[sdk=iphonesimulator*]=$$(inherited) -framework DatadogSDKTesting\n
-OTHER_LDFLAGS[sdk=appletvsimulator*]=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n
 DD_SDK_SWIFT_TESTING_APIKEY=${DD_SDK_SWIFT_TESTING_APIKEY}\n
@@ -72,12 +61,6 @@ ifeq (${ci}, true)
 		@echo $$DD_SDK_DATADOG_XCCONFIG_CI > xcconfigs/Datadog.local.xcconfig;
 ifndef DD_DISABLE_TEST_INSTRUMENTING
 		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;
-		@rm -rf instrumented-tests/DatadogSDKTesting.xcframework
-		@rm -rf instrumented-tests/DatadogSDKTesting.zip
-		@rm -rf instrumented-tests/LICENSE
-		@gh release download ${DD_SDK_SWIFT_TESTING_VERSION} -D instrumented-tests -R https://github.com/DataDog/dd-sdk-swift-testing -p "DatadogSDKTesting.zip"
-		@unzip -q instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
-		@[ -e "instrumented-tests/DatadogSDKTesting.xcframework" ] && echo "DatadogSDKTesting.xcframework - OK" || { echo "DatadogSDKTesting.xcframework - missing"; exit 1; }
 endif
 
 endif


### PR DESCRIPTION
### What and why?

DatadogSDKTesting is not enabled on otel-tracer branch.

### How?

There is a history why? It is mainly because `OpenTelemetryApi` package is imported by both `DatadogTrace` and `DatadogSDKTesting`. Linker is not intelligent enough to decide which one to use and it randomly select one. This random from the experience is frameworks ordered by name and then whichever comes first.

I had success with two solutions.

1. Use `OpenTelemetryApi` and `DatadogSDKTesting` as SPM. But we have big limitation, lack of iOS 12 support https://github.com/open-telemetry/opentelemetry-swift/issues/521
2. Use `OpenTelemetryApi` as xcframework and `DatadogSDKTesting` as SPM which worked as well and hence this PR.

<img width="1025" alt="image" src="https://github.com/DataDog/dd-sdk-ios/assets/8882380/2ec7f1d4-83d0-462d-8720-c36bda8099f8">

One thing to notice here, now the `DatadogSDKTesting` SDK will be added to the workspace. It is no longer dynamically injected which is good and bad. Good, we can now bump the version and maintain better. Bad, it has to be downloaded in our development cycle.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [x] Run tests for `tools/`
