### PR TITLE
[#1549] Address Swift 6 concurrency warning by synchronizing access to verbosityLevel.

### DIFF
--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -231,7 +231,14 @@ public enum Datadog {
     /// Verbosity level of Datadog SDK. Can be used for debugging purposes.
     /// If set, internal events occuring inside SDK will be printed to debugger console if their level is equal or greater than `verbosityLevel`.
     /// Default is `nil`.
-    public static var verbosityLevel: CoreLoggerLevel? = nil
+    public static var verbosityLevel: CoreLoggerLevel? {
+        get { _verbosityLevel.wrappedValue }
+        set { _verbosityLevel.wrappedValue = newValue }
+    }
+
+    /// The backing storage for `verbosityLevel`, ensuring efficient synchronized
+    /// read/write access to the shared value.
+    private static let _verbosityLevel = ReadWriteLock<CoreLoggerLevel?>(wrappedValue: nil)
 
     /// Returns `true` if the Datadog SDK is already initialized, `false` otherwise.
     ///

--- a/DatadogInternal/Sources/Concurrency/ReadWriteLock.swift
+++ b/DatadogInternal/Sources/Concurrency/ReadWriteLock.swift
@@ -13,7 +13,7 @@ import Foundation
 /// An additional method `mutate` allow to safely mutate the value in-place (to read it
 /// and write it while obtaining the lock only once).
 @propertyWrapper
-public final class ReadWriteLock<Value> {
+public final class ReadWriteLock<Value>: @unchecked Sendable {
     /// The wrapped value.
     private var value: Value
 


### PR DESCRIPTION
### What and why?

When building a host application target that imports the Datadog iOS SDK and has `complete` concurrency checking enabled on the application target, `Datadog.verbosityLevel` emits the following warning:

> Static property 'verbosityLevel' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6

This PR addresses the defect using an existing synchronization utility within _DatadogInternal_.

### How?

By downgrading `Datadog.verbosityLevel` to a computed property, backed by a private property using an instance of `ReadWriteStorage<Value>` to ensure efficient synchronization, the concurrency checker warning is fully resolved.

The warning that the concurrency checker emits, according to the setup described above, is a valid one. It's an example of the tooling doing exactly what it was designed to address, among other types of violations: shared mutable state not protected via explicit synchronization or actor isolation. Since this property has been and must continue to be readable and writable from any thread, and without regard to actor isolation, the most appropriate change is to wrap access to the property in a synchronization mechanism.

The ReadWriteLock class is the right tool for the job. It was missing only one key ingredient: an explicit declaration that it conforms to Sendable. It cannot directly conform to Sendable because it contains a `private var` property, mutable state. But the maintainers of the Datadog SDK know that it was designed to be Sendable before Sendable was a term, through the use of a POSIX reader/writer lock. Therefore it can be reasonably declared `@unchecked Sendable`, satisfying the concurrency checker through years of peer review and production exercise.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) *Existing tests that exercise verbosityLevel should suffice.*
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference #1549 
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
