### PR TITLE
RUM-3470 feat: Head-based sampling for local and (automatic) distributed tracing

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		617247B825DAB0E2007085B3 /* DDCrashReportBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617247B725DAB0E2007085B3 /* DDCrashReportBuilder.swift */; };
 		6175922B2A6FA8EE0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
 		6175922D2A6FADDD0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
+		6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175C3502BCE66DB006FAAB0 /* TraceContext.swift */; };
+		6175C3522BCE66DB006FAAB0 /* TraceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175C3502BCE66DB006FAAB0 /* TraceContext.swift */; };
 		617699182A860D9D0030022B /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617699172A860D9D0030022B /* HTTPClient.swift */; };
 		617699192A860D9D0030022B /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617699172A860D9D0030022B /* HTTPClient.swift */; };
 		6176991B2A86121B0030022B /* HTTPClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176991A2A86121B0030022B /* HTTPClientMock.swift */; };
@@ -2299,6 +2301,7 @@
 		617247AD25DA9BEA007085B3 /* CrashReportingObjcHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReportingObjcHelpers.h; sourceTree = "<group>"; };
 		617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrashReportingObjcHelpers.m; sourceTree = "<group>"; };
 		617247B725DAB0E2007085B3 /* DDCrashReportBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportBuilder.swift; sourceTree = "<group>"; };
+		6175C3502BCE66DB006FAAB0 /* TraceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceContext.swift; sourceTree = "<group>"; };
 		617699172A860D9D0030022B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		6176991A2A86121B0030022B /* HTTPClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientMock.swift; sourceTree = "<group>"; };
 		6176991D2A8791880030022B /* Datadog+MultipleInstancesIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Datadog+MultipleInstancesIntegrationTests.swift"; sourceTree = "<group>"; };
@@ -6017,6 +6020,7 @@
 			children = (
 				D2160C9829C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift */,
 				D2160CEC29C0E0E600FAA9A5 /* DatadogURLSessionHandler.swift */,
+				6175C3502BCE66DB006FAAB0 /* TraceContext.swift */,
 				D2EBEDCC29B893D800B15732 /* TraceID.swift */,
 				3C9B27242B9F174700569C07 /* SpanID.swift */,
 				D2160C9429C0DE5600FAA9A5 /* FirstPartyHosts.swift */,
@@ -8215,6 +8219,7 @@
 				D2EBEE2A29BA160F00B15732 /* TracingHTTPHeaders.swift in Sources */,
 				D21A94F22B8397CA00AC4256 /* WebViewMessage.swift in Sources */,
 				D23039EC298D5236001A1FA3 /* LaunchTime.swift in Sources */,
+				6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */,
 				D23039EE298D5236001A1FA3 /* FeatureMessageReceiver.swift in Sources */,
 				D23039DE298D5235001A1FA3 /* Writer.swift in Sources */,
 				D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */,
@@ -9097,6 +9102,7 @@
 				D2EBEE3829BA161100B15732 /* TracingHTTPHeaders.swift in Sources */,
 				D21A94F32B8397CA00AC4256 /* WebViewMessage.swift in Sources */,
 				D2DA2364298D57AA00C6C7E6 /* LaunchTime.swift in Sources */,
+				6175C3522BCE66DB006FAAB0 /* TraceContext.swift in Sources */,
 				D2DA2365298D57AA00C6C7E6 /* FeatureMessageReceiver.swift in Sources */,
 				D2DA2366298D57AA00C6C7E6 /* Writer.swift in Sources */,
 				D2DA2367298D57AA00C6C7E6 /* Telemetry.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
@@ -198,22 +198,22 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSamplingLocalTrace()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSamplingLocalTraceWithImplicitParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent_throughURLSessionInstrumentationAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent_throughURLSessionInstrumentationAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithNoParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithNoParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithParent_throughTracerAPI()">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore tvOS.xcscheme
@@ -184,22 +184,22 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSamplingLocalTrace()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSamplingLocalTraceWithImplicitParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent_throughURLSessionInstrumentationAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithNoParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent_throughURLSessionInstrumentationAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithNoParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithNoParent_throughTracerAPI()">
                </Test>
                <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithParent()">
+                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithParent_throughTracerAPI()">
                </Test>
             </SkippedTests>
          </TestableReference>
@@ -232,11 +232,6 @@
                BlueprintName = "DatadogTraceTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "DatadogTracer_SamplingTests/testWhenRootSpanIsSampled_thenAllChildSpansMustBeSampledTheSameWay()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -30,9 +30,15 @@ class HeadBasedSamplingTests: XCTestCase {
 
     // MARK: - Local Tracing
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported
     func testSamplingLocalTrace() throws {
-        let localTraceSampling: Float = 50
+        /*
+         This is the basic situation of local trace with 3 spans:
+
+         client-ios-app:     [-------- parent -----------]   |
+         client-ios-app:        [----- child --------]       | all 3: keep or drop
+         client-ios-app:           [-- grandchild --]        |
+         */
+        let localTraceSampling: Float = 50 // keep or drop
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -54,9 +60,14 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertTrue(allKept || allDropped, "All spans must be either kept or dropped")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported
     func testSamplingLocalTraceWithImplicitParent() throws {
-        let localTraceSampling: Float = 50
+        /*
+         This is the situation of local trace with active span as a parent:
+
+         client-ios-app:     [-------- active.span -----]   |
+         client-ios-app:       [- child1 -][- child2 -]     | all 3: keep or drop
+         */
+        let localTraceSampling: Float = 50 // keep or drop
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -65,8 +76,8 @@ class HeadBasedSamplingTests: XCTestCase {
         // When
         let parent = Tracer.shared(in: core).startSpan(operationName: "parent").setActive()
         let child1 = Tracer.shared(in: core).startSpan(operationName: "child 1")
-        let child2 = Tracer.shared(in: core).startSpan(operationName: "child 2")
         child1.finish()
+        let child2 = Tracer.shared(in: core).startSpan(operationName: "child 2")
         child2.finish()
         parent.finish()
 
@@ -78,10 +89,9 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertTrue(allKept || allDropped, "All spans must be either kept or dropped")
     }
 
-    // MARK: - Distributed Tracing
+    // MARK: - Distributed Tracing (through network instrumentation API)
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported
-    func testSendingSampledDistributedTraceWithNoParent() throws {
+    func testSendingSampledDistributedTraceWithNoParent_throughURLSessionInstrumentationAPI() throws {
         /*
          This is the situation where distributed trace starts with the span created with DatadogTrace network
          instrumentation (with no parent):
@@ -111,15 +121,17 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertTrue(span.isKept, "Span must be sampled")
 
         // Then
-        let expectedTraceIDField = String(span.traceID, representation: .decimal)
-        let expectedSpanIDField = String(span.spanID, representation: .decimal)
+        let expectedTraceIDField = span.traceID.idLoHex
+        let expectedSpanIDField = String(span.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(span.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
 
     // TODO: RUM-3535 Enable this test when trace context injection control is implemented
-    func testSendingDroppedDistributedTraceWithNoParent() throws {
+    func testSendingDroppedDistributedTraceWithNoParent_throughURLSessionInstrumentationAPI() throws {
         /*
          This is the situation where distributed trace starts with the span created with DatadogTrace network
          instrumentation (with no parent):
@@ -149,15 +161,16 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertFalse(span.isKept, "Span must be dropped")
 
         // Then
-        let expectedTraceIDField = String(span.traceID, representation: .decimal)
-        let expectedSpanIDField = String(span.spanID, representation: .decimal)
+        let expectedTraceIDField = span.traceID.idLoHex
+        let expectedSpanIDField = String(span.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(span.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported
-    func testSendingSampledDistributedTraceWithParent() throws {
+    func testSendingSampledDistributedTraceWithParent_throughURLSessionInstrumentationAPI() throws {
         /*
          This is the situation where distributed trace starts with an active local span and is continued with the span
          created with DatadogTrace network instrumentation:
@@ -196,15 +209,17 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(urlsessionSpan.parentID, activeSpan.spanID)
 
         // Then
-        let expectedTraceIDField = String(activeSpan.traceID, representation: .decimal)
-        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .decimal)
+        let expectedTraceIDField = activeSpan.traceID.idLoHex
+        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
 
     // TODO: RUM-3535 Enable this test when trace context injection control is implemented
-    func testSendingDroppedDistributedTraceWithParent() throws {
+    func testSendingDroppedDistributedTraceWithParent_throughURLSessionInstrumentationAPI() throws {
         /*
          This is the situation where distributed trace starts with an active local span and is continued with the span
          created with DatadogTrace network instrumentation:
@@ -243,11 +258,195 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(urlsessionSpan.parentID, activeSpan.spanID)
 
         // Then
-        let expectedTraceIDField = String(activeSpan.traceID, representation: .decimal)
-        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .decimal)
+        let expectedTraceIDField = activeSpan.traceID.idLoHex
+        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
+    }
+
+    // MARK: - Distributed Tracing (through Tracer API)
+
+    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    func testSendingSampledDistributedTraceWithNoParent_throughTracerAPI() throws {
+        /*
+         This is the situation where distributed trace starts with the span created with Datadog tracer:
+
+         client-ios-app:     [------ network.span ------]   keep
+         client backend:        [--- backend span ---]      keep
+         */
+
+        let localTraceSampling: Float = 100 // keep all
+        let distributedTraceSampling: Float = 0 // drop all
+
+        // Given
+        traceConfig.sampleRate = localTraceSampling
+        Trace.enable(with: traceConfig, in: core)
+
+        // When
+        var request: URLRequest = .mockAny()
+        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
+        Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
+        writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
+        span.finish()
+
+        // Then
+        let networkSpan = try XCTUnwrap(core.waitAndReturnSpanEvents().first, "It should send span event")
+        XCTAssertEqual(networkSpan.operationName, "network.span")
+        XCTAssertEqual(networkSpan.samplingRate, 1, "Span must use local trace sample rate")
+        XCTAssertTrue(networkSpan.isKept, "Span must be sampled")
+
+        // Then
+        let expectedTraceIDField = networkSpan.traceID.idLoHex
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(networkSpan.traceID.idHiHex)"
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
+    }
+
+    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    func testSendingDroppedDistributedTraceWithNoParent_throughTracerAPI() throws {
+        /*
+         This is the situation where distributed trace starts with the span created with Datadog tracer:
+
+         client-ios-app:     [------ network.span ------]   drop
+         client backend:        [--- backend span ---]      drop
+         */
+
+        let localTraceSampling: Float = 0 // drop all
+        let distributedTraceSampling: Float = 100 // keep all
+
+        // Given
+        traceConfig.sampleRate = localTraceSampling
+        Trace.enable(with: traceConfig, in: core)
+
+        // When
+        var request: URLRequest = .mockAny()
+        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
+        Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
+        writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
+        span.finish()
+
+        // Then
+        let networkSpan = try XCTUnwrap(core.waitAndReturnSpanEvents().first, "It should send span event")
+        XCTAssertEqual(networkSpan.operationName, "network.span")
+        XCTAssertEqual(networkSpan.samplingRate, 0, "Span must use local trace sample rate")
+        XCTAssertFalse(networkSpan.isKept, "Span must be dropped")
+
+        // Then
+        let expectedTraceIDField = networkSpan.traceID.idLoHex
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(networkSpan.traceID.idHiHex)"
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
+    }
+
+    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    func testSendingSampledDistributedTraceWithParent_throughTracerAPI() throws {
+        /*
+         This is the situation where distributed trace starts with an active local span and is continued with the span
+         created with Datadog tracer:
+
+         client-ios-app:     [-------- active.span -----------]   keep
+         client-ios-app:         [------ network.span ------]     keep
+         client backend:            [--- backend span ---]        keep
+         */
+
+        let localTraceSampling: Float = 100 // keep all
+        let distributedTraceSampling: Float = 0 // drop all
+
+        // Given
+        traceConfig.sampleRate = localTraceSampling
+        Trace.enable(with: traceConfig, in: core)
+
+        // When
+        var request: URLRequest = .mockAny()
+        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
+        let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
+        Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
+        writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
+        span.finish()
+        parentSpan.finish()
+
+        // Then
+        let spanEvents = core.waitAndReturnSpanEvents()
+        let activeSpan = try XCTUnwrap(spanEvents.first(where: { $0.operationName == "active.span" }))
+        let networkSpan = try XCTUnwrap(spanEvents.first(where: { $0.operationName == "network.span" }))
+
+        XCTAssertEqual(activeSpan.samplingRate, 1, "Span must use local trace sample rate")
+        XCTAssertTrue(activeSpan.isKept, "Span must be sampled")
+        XCTAssertEqual(networkSpan.samplingRate, 1, "Span must use local trace sample rate")
+        XCTAssertTrue(networkSpan.isKept, "Span must be sampled")
+        XCTAssertEqual(networkSpan.traceID, activeSpan.traceID)
+        XCTAssertEqual(networkSpan.parentID, activeSpan.spanID)
+
+        // Then
+        let expectedTraceIDField = activeSpan.traceID.idLoHex
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
+    }
+
+    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    func testSendingDroppedDistributedTraceWithParent_throughTracerAPI() throws {
+        /*
+         This is the situation where distributed trace starts with an active local span and is continued with the span
+         created with Datadog tracer:
+
+         client-ios-app:     [-------- active.span -----------]   drop
+         client-ios-app:         [------ network.span ------]     drop
+         client backend:            [--- backend span ---]        drop
+         */
+
+        let localTraceSampling: Float = 0 // drop all
+        let distributedTraceSampling: Float = 100 // keep all
+
+        // Given
+        traceConfig.sampleRate = localTraceSampling
+        Trace.enable(with: traceConfig, in: core)
+
+        // When
+        var request: URLRequest = .mockAny()
+        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
+        let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
+        Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
+        writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
+        span.finish()
+        parentSpan.finish()
+
+        // Then
+        let spanEvents = core.waitAndReturnSpanEvents()
+        let activeSpan = try XCTUnwrap(spanEvents.first(where: { $0.operationName == "active.span" }))
+        let networkSpan = try XCTUnwrap(spanEvents.first(where: { $0.operationName == "network.span" }))
+
+        XCTAssertEqual(activeSpan.samplingRate, 0, "Span must use local trace sample rate")
+        XCTAssertFalse(activeSpan.isKept, "Span must be dropped")
+        XCTAssertEqual(networkSpan.samplingRate, 0, "Span must use local trace sample rate")
+        XCTAssertFalse(networkSpan.isKept, "Span must be dropped")
+        XCTAssertEqual(networkSpan.traceID, activeSpan.traceID)
+        XCTAssertEqual(networkSpan.parentID, activeSpan.spanID)
+
+        // Then
+        let expectedTraceIDField = activeSpan.traceID.idLoHex
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), expectedTagsField)
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
     }
 
     // MARK: - Helpers

--- a/DatadogCore/Tests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -86,13 +86,17 @@ extension DDSpanContext {
         traceID: TraceID = .mockAny(),
         spanID: SpanID = .mockAny(),
         parentSpanID: SpanID? = .mockAny(),
-        baggageItems: BaggageItems = .mockAny()
+        baggageItems: BaggageItems = .mockAny(),
+        sampleRate: Float = .mockAny(),
+        isKept: Bool = .mockAny()
     ) -> DDSpanContext {
         return DDSpanContext(
             traceID: traceID,
             spanID: spanID,
             parentSpanID: parentSpanID,
-            baggageItems: baggageItems
+            baggageItems: baggageItems,
+            sampleRate: sampleRate,
+            isKept: isKept
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -728,10 +728,10 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
-        let spanContext2 = DDSpanContext(traceID: 3, spanID: 4, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext2 = DDSpanContext(traceID: 3, spanID: 4, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockKeepAll())
+        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockKeepAll())
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -762,11 +762,11 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingMultipleHeaders() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .multiple)
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .multiple)
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -808,11 +808,11 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .single)
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .single)
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -846,9 +846,9 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockRejectAll())
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockRejectAll())
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -864,9 +864,9 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingMultipleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockRejectAll(), injectEncoding: .multiple)
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockRejectAll(), injectEncoding: .multiple)
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -882,12 +882,12 @@ class TracerTests: XCTestCase {
     func testItInjectsSpanContextWithW3CHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny())
+        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
+        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
         let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: .mockKeepAll(),
+            sampler: Sampler.mockKeepAll(),
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
@@ -928,10 +928,10 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithW3CHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
         let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: .mockRejectAll(),
+            sampler: Sampler.mockRejectAll(),
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
@@ -952,9 +952,9 @@ class TracerTests: XCTestCase {
     func testItInjectsRejectedSpanContextWithHTTPHeadersWriter() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockRejectAll())
+        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockRejectAll())
         XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
 
         // When
@@ -970,9 +970,9 @@ class TracerTests: XCTestCase {
     func testItExtractsSpanContextWithHTTPHeadersReader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: .mockKeepAll())
+        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockKeepAll())
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
 
         let httpHeadersReader = HTTPHeadersReader(
@@ -983,14 +983,15 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
         XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
         XCTAssertNil(extractedSpanContext?.dd.parentSpanID)
+        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
     }
 
     func testItExtractsSpanContextWithB3HTTPHeadersReader_forMultipleHeaders() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .multiple)
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .multiple)
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
 
         let httpHeadersReader = B3HTTPHeadersReader(
@@ -1001,14 +1002,15 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
         XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
         XCTAssertEqual(extractedSpanContext?.dd.parentSpanID, injectedSpanContext.dd.parentSpanID)
+        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
     }
 
     func testItExtractsSpanContextWithB3HTTPHeadersReader_forSingleHeader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .single)
+        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .single)
         tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
 
         let httpHeadersReader = B3HTTPHeadersReader(
@@ -1019,15 +1021,16 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
         XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
         XCTAssertEqual(extractedSpanContext?.dd.parentSpanID, injectedSpanContext.dd.parentSpanID)
+        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
     }
 
     func testItExtractsSpanContextWithW3CHTTPHeadersReader() {
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny())
+        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
 
         let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: .mockKeepAll(),
+            sampler: Sampler.mockKeepAll(),
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
@@ -1042,6 +1045,7 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
         XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
         XCTAssertNil(extractedSpanContext?.dd.parentSpanID)
+        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
     }
 
     // MARK: - Span Dates Correction

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -209,7 +209,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
     func testGivenAllTracingHeaderTypes_itUsesTheSameIds() throws {
         let request: URLRequest = .mockWith(httpMethod: "GET")
-        let modifiedRequest = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
+        let (modifiedRequest, _) = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
 
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
@@ -12,9 +12,6 @@ public typealias OTelHTTPHeadersReader = B3HTTPHeadersReader
 public class B3HTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
-    @ReadWriteLock
-    public var tracerSampleRate: Float? = nil
-
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
@@ -12,6 +12,9 @@ public typealias OTelHTTPHeadersReader = B3HTTPHeadersReader
 public class B3HTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
+    @ReadWriteLock
+    public var tracerSampleRate: Float? = nil
+
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
@@ -41,6 +44,16 @@ public class B3HTTPHeadersReader: TracePropagationHeadersReader {
                 spanID: spanID,
                 parentSpanID: b3Value?[safe: 3].flatMap({ SpanID($0, representation: .hexadecimal) })
             )
+        }
+
+        return nil
+    }
+
+    public var sampled: Bool? {
+        if let single = httpHeaderFields[B3HTTPHeaders.Single.b3Field] {
+            return single != B3HTTPHeaders.Constants.unsampledValue
+        } else if let multiple = httpHeaderFields[B3HTTPHeaders.Multiple.sampledField] {
+            return multiple == B3HTTPHeaders.Constants.sampledValue
         }
 
         return nil

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
@@ -61,7 +61,7 @@ public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// The sample rate determines the `X-B3-Sampled` header field value
     /// and whether `X-B3-TraceId`, `X-B3-SpanId`, and `X-B3-ParentSpanId` are propagated.
-    private let sampler: Sampler
+    private let sampler: Sampling
 
     /// The telemetry header encoding used by the writer.
     private let injectEncoding: InjectEncoding
@@ -97,7 +97,7 @@ public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
     /// - Parameter sampler: The sampler used for headers injection.
     /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
     public init(
-        sampler: Sampler,
+        sampler: Sampling,
         injectEncoding: InjectEncoding = .single
     ) {
         self.sampler = sampler

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -9,6 +9,9 @@ import Foundation
 public class HTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
+    @ReadWriteLock
+    public var tracerSampleRate: Float? = nil
+
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
@@ -42,5 +45,12 @@ public class HTTPHeadersReader: TracePropagationHeadersReader {
             spanID: spanID,
             parentSpanID: nil
         )
+    }
+
+    public var sampled: Bool? {
+        if let sampling = httpHeaderFields[TracingHTTPHeaders.samplingPriorityField] {
+            return sampling == "1"
+        }
+        return nil
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -9,9 +9,6 @@ import Foundation
 public class HTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
-    @ReadWriteLock
-    public var tracerSampleRate: Float? = nil
-
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -38,7 +38,7 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// This value will decide of the `x-datadog-sampling-priority` header field value
     /// and if `x-datadog-trace-id` and `x-datadog-parent-id` are propagated.
-    private let sampler: Sampler
+    private let sampler: Sampling
 
     /// Initializes the headers writer.
     ///
@@ -58,7 +58,7 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     /// Initializes the headers writer.
     ///
     /// - Parameter sampler: The sampler used for headers injection.
-    public init(sampler: Sampler) {
+    public init(sampler: Sampling) {
         self.sampler = sampler
     }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
@@ -8,35 +8,33 @@ import Foundation
 
 /// An interface for processing `URLSession` task interceptions.
 public protocol DatadogURLSessionHandler {
-    /// The interceptor's first party hosts
+    /// The first party hosts configured for this handler.
     var firstPartyHosts: FirstPartyHosts { get }
 
-    /// Tells the interceptor to modify a URL request.
+    /// Modifies the provided request by injecting trace headers.
     ///
     /// - Parameters:
-    ///   - request: The request to intercept.
-    ///   - additionalFirstPartyHosts: Additional 1st-party hosts.
-    /// - Returns: The modified request.
-    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest
+    ///   - request: The request to be modified.
+    ///   - headerTypes: The types of tracing headers to inject into the request.
+    /// - Returns: A tuple containing the modified request and the injected TraceContext. If no trace is injected (e.g., due to sampling),
+    ///            the returned request remains unmodified, and the trace context will be nil.
+    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> (URLRequest, TraceContext?)
 
-    /// Returns the trace of the current execution context.
-    func traceContext() -> TraceContext?
-
-    /// Tells the interceptor that the session did start.
+    /// Notifies the handler that the interception has started.
     ///
-    /// - Parameter interception: The URLSession interception.
+    /// - Parameter interception: The URLSession task interception.
     func interceptionDidStart(interception: URLSessionTaskInterception)
 
-    /// Tells the interceptor that the session did complete.
+    /// Notifies the handler that the interception has completed.
     ///
-    /// - Parameter interception: The URLSession interception.
+    /// - Parameter interception: The URLSession task interception.
     func interceptionDidComplete(interception: URLSessionTaskInterception)
 }
 
 extension DatadogCoreProtocol {
     /// Core extension for registering `URLSession` handlers.
     ///
-    /// - Parameter urlSessionHandler: The `URLSession` handlers to register.
+    /// - Parameter urlSessionHandler: The `URLSession` handler to register.
     public func register(urlSessionHandler: DatadogURLSessionHandler) throws {
         let feature = get(feature: NetworkInstrumentationFeature.self) ?? .init()
         feature.handlers.append(urlSessionHandler)

--- a/DatadogInternal/Sources/NetworkInstrumentation/TraceContext.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TraceContext.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A context used to propagate trace through HTTP request headers.
+public struct TraceContext: Equatable {
+    /// The unique identifier for the trace.
+    public let traceID: TraceID
+    /// The unique identifier for the span.
+    public let spanID: SpanID
+    /// The unique identifier for the parent span, if any.
+    public let parentSpanID: SpanID?
+    /// The sample rate used for injecting the span into a request.
+    ///
+    /// It is a value between `0.0` (drop) and `100.0` (keep), determined by the local or distributed trace sampler.
+    public let sampleRate: Float
+    /// Indicates whether this span was sampled or rejected by the sampler.
+    public let isKept: Bool
+
+    /// Initializes a `TraceContext` instance with the provided parameters.
+    ///
+    /// - Parameters:
+    ///   - traceID: The unique identifier for the trace.
+    ///   - spanID: The unique identifier for the span.
+    ///   - parentSpanID: The unique identifier for the parent span, if any.
+    ///   - sampleRate: The sample rate used for injecting the span into a request.
+    ///   - isKept: A boolean indicating whether this span was sampled or rejected by the sampler.
+    public init(
+        traceID: TraceID,
+        spanID: SpanID,
+        parentSpanID: SpanID?,
+        sampleRate: Float,
+        isKept: Bool
+    ) {
+        self.traceID = traceID
+        self.spanID = spanID
+        self.parentSpanID = parentSpanID
+        self.sampleRate = sampleRate
+        self.isKept = isKept
+    }
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersReader.swift
@@ -16,7 +16,4 @@ public protocol TracePropagationHeadersReader {
 
     /// Indicates whether the trace was sampled based on the provided headers.
     var sampled: Bool? { get }
-
-    /// The sample rate used to sample this trace.
-    var tracerSampleRate: Float? { set get }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersReader.swift
@@ -13,4 +13,10 @@ public protocol TracePropagationHeadersReader {
         spanID: SpanID,
         parentSpanID: SpanID?
     )?
+
+    /// Indicates whether the trace was sampled based on the provided headers.
+    var sampled: Bool? { get }
+
+    /// The sample rate used to sample this trace.
+    var tracerSampleRate: Float? { set get }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -127,12 +127,15 @@ open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
                         return
                     }
 
+                    var injectedTraceContexts: [TraceContext]?
+
                     if let currentRequest = task.currentRequest {
-                        let request = feature.intercept(request: currentRequest, additionalFirstPartyHosts: firstPartyHosts)
+                        let (request, traceContexts) = feature.intercept(request: currentRequest, additionalFirstPartyHosts: firstPartyHosts)
                         task.dd.override(currentRequest: request)
+                        injectedTraceContexts = traceContexts
                     }
 
-                    feature.intercept(task: task, additionalFirstPartyHosts: firstPartyHosts)
+                    feature.intercept(task: task, with: injectedTraceContexts ?? [], additionalFirstPartyHosts: firstPartyHosts)
                 }
             )
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -71,22 +71,6 @@ public class URLSessionTaskInterception {
     }
 }
 
-public struct TraceContext {
-    public let traceID: TraceID
-    public let spanID: SpanID
-    public let parentSpanID: SpanID?
-
-    public init(
-        traceID: TraceID,
-        spanID: SpanID,
-        parentSpanID: SpanID? = nil
-    ) {
-        self.traceID = traceID
-        self.spanID = spanID
-        self.parentSpanID = parentSpanID
-    }
-}
-
 public struct ResourceCompletion {
     public let httpResponse: HTTPURLResponse?
     public let error: Error?

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
@@ -9,6 +9,9 @@ import Foundation
 public class W3CHTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
+    @ReadWriteLock
+    public var tracerSampleRate: Float? = nil
+
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
@@ -32,5 +35,16 @@ public class W3CHTTPHeadersReader: TracePropagationHeadersReader {
             spanID: spanID,
             parentSpanID: nil
         )
+    }
+
+    public var sampled: Bool? {
+        if let traceparent = httpHeaderFields[W3CHTTPHeaders.traceparent] {
+            guard let sampled = traceparent.components(separatedBy: W3CHTTPHeaders.Constants.separator).last else {
+                return nil
+            }
+            return sampled == W3CHTTPHeaders.Constants.sampledValue
+        }
+
+        return nil
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
@@ -9,9 +9,6 @@ import Foundation
 public class W3CHTTPHeadersReader: TracePropagationHeadersReader {
     private let httpHeaderFields: [String: String]
 
-    @ReadWriteLock
-    public var tracerSampleRate: Float? = nil
-
     public init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -42,7 +42,7 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// This value will decide of the `FLAG_SAMPLED` header field value
     /// and if `trace-id`, `span-id` are propagated.
-    private let sampler: Sampler
+    private let sampler: Sampling
 
     /// Initializes the headers writer.
     ///
@@ -65,7 +65,7 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// - Parameter sampler: The sampler used for headers injection.
     /// - Parameter tracestate: The tracestate to be injected.
-    public init(sampler: Sampler, tracestate: [String: String]) {
+    public init(sampler: Sampling, tracestate: [String: String]) {
         self.sampler = sampler
         self.tracestate = tracestate
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersReaderTests.swift
@@ -85,6 +85,7 @@ class B3HTTPHeadersReaderTests: XCTestCase {
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
+        XCTAssertEqual(reader.sampled, true)
     }
 
     func testReadingNotSampledTraceContext() {
@@ -94,5 +95,6 @@ class B3HTTPHeadersReaderTests: XCTestCase {
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")
+        XCTAssertEqual(reader.sampled, false)
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersReaderTests.swift
@@ -14,6 +14,7 @@ class HTTPHeadersReaderTests: XCTestCase {
 
         let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
+        XCTAssertEqual(reader.sampled, true)
     }
 
     func testReadingNotSampledTraceContext() {
@@ -22,5 +23,6 @@ class HTTPHeadersReaderTests: XCTestCase {
 
         let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")
+        XCTAssertEqual(reader.sampled, false)
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -466,101 +466,23 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
     }
 
-    // MARK: - URLRequest Interception
+    // MARK: - URLSessionTask Interception
 
-    func testGivenOpenTracing_whenInterceptingRequests_itInjectsTrace() throws {
-        // Given
-        var request: URLRequest = .mockWith(url: "https://test.com")
-        let writer = HTTPHeadersWriter(sampler: .mockKeepAll())
-        handler.firstPartyHosts = .init(["test.com": [.datadog]])
-        handler.parentSpan = TraceContext(traceID: .mock(1, 1), spanID: .mock(2))
+    func testWhenInterceptingTaskWithMultipleTraceContexts_itTakesTheFirstContext() throws {
+        let traceContexts = [
+            TraceContext(traceID: .mock(1, 1), spanID: .mock(2), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
+            TraceContext(traceID: .mock(2, 2), spanID: .mock(3), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
+            TraceContext(traceID: .mock(3, 3), spanID: .mock(4), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
+        ]
 
         // When
-        writer.write(traceID: .mock(1, 1), spanID: .mock(3))
-        request.allHTTPHeaderFields = writer.traceHeaderFields
-
-        let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
         let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
-        feature.intercept(task: task, additionalFirstPartyHosts: nil)
+        feature.intercept(task: .mockAny(), with: traceContexts, additionalFirstPartyHosts: nil)
         feature.flush()
 
         // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
-    }
-
-    func testGivenOpenTelemetry_b3single_whenInterceptingRequests_itInjectsTrace() throws {
-        // Given
-        var request: URLRequest = .mockWith(url: "https://test.com")
-        let writer = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .single)
-        handler.firstPartyHosts = .init(["test.com": [.b3]])
-
-        // When
-        writer.write(traceID: .mock(1, 1), spanID: .mock(3), parentSpanID: .mock(2))
-        request.allHTTPHeaderFields = writer.traceHeaderFields
-
-        let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
-        feature.intercept(task: task, additionalFirstPartyHosts: nil)
-        feature.flush()
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
-    }
-
-    func testGivenOpenTelemetry_b3multi_whenInterceptingRequests_itInjectsTrace() throws {
-        // Given
-        var request: URLRequest = .mockWith(url: "https://test.com")
-        let writer = B3HTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .multiple)
-        handler.firstPartyHosts = .init(["test.com": [.b3multi]])
-
-        // When
-        writer.write(traceID: .mock(1, 1), spanID: .mock(3), parentSpanID: .mock(2))
-        request.allHTTPHeaderFields = writer.traceHeaderFields
-
-        let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
-        feature.intercept(task: task, additionalFirstPartyHosts: nil)
-        feature.flush()
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
-    }
-
-    func testGivenW3C_whenInterceptingRequests_itInjectsTrace() throws {
-        // Given
-        var request: URLRequest = .mockWith(url: "https://test.com")
-        let writer = W3CHTTPHeadersWriter(
-            sampler: .mockKeepAll(),
-            tracestate: [
-                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
-            ]
-        )
-        handler.firstPartyHosts = .init(["test.com": [.tracecontext]])
-        handler.parentSpan = TraceContext(traceID: .mock(1, 1), spanID: .mock(2))
-
-        // When
-        writer.write(traceID: .mock(1, 1), spanID: .mock(3))
-        request.allHTTPHeaderFields = writer.traceHeaderFields
-
-        let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
-        feature.intercept(task: task, additionalFirstPartyHosts: nil)
-        feature.flush()
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertEqual(interception?.trace?.traceID, .mock(1, 1))
-        XCTAssertEqual(interception?.trace?.parentSpanID, .mock(2))
-        XCTAssertEqual(interception?.trace?.spanID, .mock(3))
+        let interception = try XCTUnwrap(handler.interceptions.first?.value)
+        XCTAssertEqual(interception.trace, traceContexts.first, "It should register first injected Trace Context")
     }
 
     // MARK: - First Party Hosts
@@ -700,7 +622,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             closures: [
                 { feature.handlers = [self.handler] },
                 { _ = feature.intercept(request: requests.randomElement()!, additionalFirstPartyHosts: nil) },
-                { feature.intercept(task: tasks.randomElement()!, additionalFirstPartyHosts: nil) },
+                { feature.intercept(task: tasks.randomElement()!, with: [], additionalFirstPartyHosts: nil) },
                 { feature.task(tasks.randomElement()!, didReceive: .mockRandom()) },
                 { feature.task(tasks.randomElement()!, didFinishCollecting: .mockAny()) },
                 { feature.task(tasks.randomElement()!, didCompleteWithError: nil) },

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
@@ -32,6 +32,7 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
 
         let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
+        XCTAssertEqual(reader.sampled, true)
     }
 
     func testReadingNotSampledTraceContext() {
@@ -40,5 +41,6 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
 
         let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")
+        XCTAssertEqual(reader.sampled, false)
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -40,7 +40,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.datadog]
         )
@@ -50,6 +50,13 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 100)
+        XCTAssertNil(injectedTraceContext.parentSpanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, 100)
+        XCTAssertTrue(injectedTraceContext.isKept)
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectB3TraceHeaders() throws {
@@ -64,13 +71,20 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.b3]
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000064-1")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 100)
+        XCTAssertNil(injectedTraceContext.parentSpanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, 100)
+        XCTAssertTrue(injectedTraceContext.isKept)
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectB3MultiTraceHeaders() throws {
@@ -85,7 +99,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.b3multi]
         )
@@ -95,6 +109,13 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000064")
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 100)
+        XCTAssertNil(injectedTraceContext.parentSpanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, 100)
+        XCTAssertTrue(injectedTraceContext.isKept)
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectW3CTraceHeaders() throws {
@@ -109,13 +130,20 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.tracecontext]
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-01")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 100)
+        XCTAssertNil(injectedTraceContext.parentSpanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, 100)
+        XCTAssertTrue(injectedTraceContext.isKept)
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectDDTraceHeaders() throws {
@@ -130,7 +158,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.datadog]
         )
@@ -139,6 +167,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField))
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectB3TraceHeaders() throws {
@@ -153,13 +183,15 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.b3]
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "0")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectB3MultiTraceHeaders() throws {
@@ -174,7 +206,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.b3multi]
         )
@@ -184,6 +216,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField))
         XCTAssertNil(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField))
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "0")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectW3CTraceHeaders() throws {
@@ -198,13 +232,15 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [.tracecontext]
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-00")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itDoesNotOverwriteTraceHeaders() throws {
@@ -219,19 +255,21 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         // When
-        var request: URLRequest = .mockWith(url: "https://www.example.com")
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
-        request.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
+        var orgRequest: URLRequest = .mockWith(url: "https://www.example.com")
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.tagsField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
+        orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
+        orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.tracestate)
 
-        request = handler.modify(
-            request: request,
+        let (request, traceContext) = handler.modify(
+            request: orgRequest,
             headerTypes: [
                 .datadog,
                 .b3,
@@ -241,6 +279,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "custom")
@@ -249,6 +288,9 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.tracestate), "custom")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenTaskInterceptionWithNoSpanContext_whenInterceptionStarts_itStartsRUMResource() throws {
@@ -298,7 +340,9 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         taskInterception.register(trace: TraceContext(
             traceID: 100,
             spanID: 200,
-            parentSpanID: nil
+            parentSpanID: nil,
+            sampleRate: .mockAny(),
+            isKept: .mockAny()
         ))
         XCTAssertNotNil(taskInterception.trace)
 
@@ -475,7 +519,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             )
         )
         let request: URLRequest = .mockWith(httpMethod: "GET")
-        let modifiedRequest = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
+        let (modifiedRequest, _) = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
 
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,

--- a/DatadogTrace/Sources/DDFormat.swift
+++ b/DatadogTrace/Sources/DDFormat.swift
@@ -39,8 +39,12 @@ extension TracePropagationHeadersReader where Self: OTFormatReader {
             spanID: ids.spanID,
             parentSpanID: ids.parentSpanID,
             baggageItems: BaggageItems(),
-            sampleRate: tracerSampleRate ?? 0, // unreachable default: sample rate is set by the tracer during extraction
-            isKept: sampled ?? false // unreachable default: we got trace ID, so this request must have been instrumented
+            // RUM-3470: The `0` sample rate set here is only a placeholder value. It is overwritten with
+            // the actual value in the caller: `Tracer.extract(reader)`.
+            sampleRate: 0,
+            // RUM-3470: The `false` default will be never reached. As we got trace and span ID,
+            // it means that the request has been instrumented, so sampling decision was read as well.
+            isKept: sampled ?? false
         )
     }
 }

--- a/DatadogTrace/Sources/DDFormat.swift
+++ b/DatadogTrace/Sources/DDFormat.swift
@@ -38,7 +38,9 @@ extension TracePropagationHeadersReader where Self: OTFormatReader {
             traceID: ids.traceID,
             spanID: ids.spanID,
             parentSpanID: ids.parentSpanID,
-            baggageItems: BaggageItems()
+            baggageItems: BaggageItems(),
+            sampleRate: tracerSampleRate ?? 0, // unreachable default: sample rate is set by the tracer during extraction
+            isKept: sampled ?? false // unreachable default: we got trace ID, so this request must have been instrumented
         )
     }
 }

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -137,8 +137,8 @@ internal final class DDSpan: OTSpan {
                 operationName: self.operationName,
                 startTime: self.startTime,
                 finishTime: finishTime,
-                samplingRate: sampler.samplingRate / 100.0,
-                isKept: sampler.sample(),
+                samplingRate: self.ddContext.sampleRate / 100.0,
+                isKept: self.ddContext.isKept,
                 tags: self.tags,
                 baggageItems: self.ddContext.baggageItems.all,
                 logFields: self.logFields

--- a/DatadogTrace/Sources/DDSpanContext.swift
+++ b/DatadogTrace/Sources/DDSpanContext.swift
@@ -16,6 +16,12 @@ internal struct DDSpanContext: OTSpanContext {
     let parentSpanID: SpanID?
     /// The baggage items of this span.
     let baggageItems: BaggageItems
+    /// The sample rate used for sampling this span.
+    ///
+    /// It is a value between `0.0` (drop) and `100.0` (keep), determined by the local or distributed trace sampler.
+    let sampleRate: Float
+    /// Whether this span was sampled or rejected by the sampler.
+    let isKept: Bool
 
     // MARK: - Open Tracing interface
 

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -79,7 +79,7 @@ internal class DatadogTracer: OTTracer {
     func startSpan(operationName: String, references: [OTReference]? = nil, tags: [String: Encodable]? = nil, startTime: Date? = nil) -> OTSpan {
         let parentSpanContext = references?.compactMap { $0.context.dd }.last ?? activeSpan?.context as? DDSpanContext
         return startSpan(
-            spanContext: createSpanContext(parentSpanContext: parentSpanContext),
+            spanContext: createSpanContext(parentSpanContext: parentSpanContext, using: localTraceSampler),
             operationName: operationName,
             tags: tags,
             startTime: startTime
@@ -88,7 +88,7 @@ internal class DatadogTracer: OTTracer {
 
     func startRootSpan(operationName: String, tags: [String: Encodable]? = nil, startTime: Date? = nil) -> OTSpan {
         return startSpan(
-            spanContext: createSpanContext(parentSpanContext: nil),
+            spanContext: createSpanContext(parentSpanContext: nil, using: localTraceSampler),
             operationName: operationName,
             tags: tags,
             startTime: startTime
@@ -101,7 +101,9 @@ internal class DatadogTracer: OTTracer {
 
     func extract(reader: OTFormatReader) -> OTSpanContext? {
         // TODO: RUMM-385 - make `HTTPHeadersReader` available in public API
-        reader.extract()
+        var reader = reader as? TracePropagationHeadersReader
+        reader?.tracerSampleRate = localTraceSampler.samplingRate
+        return (reader as? OTFormatReader)?.extract()
     }
 
     var activeSpan: OTSpan? {
@@ -110,12 +112,14 @@ internal class DatadogTracer: OTTracer {
 
     // MARK: - Internal
 
-    internal func createSpanContext(parentSpanContext: DDSpanContext? = nil) -> DDSpanContext {
+    internal func createSpanContext(parentSpanContext: DDSpanContext?, using sampler: Sampler) -> DDSpanContext {
         return DDSpanContext(
             traceID: parentSpanContext?.traceID ?? traceIDGenerator.generate(),
             spanID: spanIDGenerator.generate(),
             parentSpanID: parentSpanContext?.spanID,
-            baggageItems: BaggageItems(parent: parentSpanContext?.baggageItems)
+            baggageItems: BaggageItems(parent: parentSpanContext?.baggageItems),
+            sampleRate: parentSpanContext?.sampleRate ?? sampler.samplingRate,
+            isKept: parentSpanContext?.isKept ?? sampler.sample()
         )
     }
 

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -101,9 +101,18 @@ internal class DatadogTracer: OTTracer {
 
     func extract(reader: OTFormatReader) -> OTSpanContext? {
         // TODO: RUMM-385 - make `HTTPHeadersReader` available in public API
-        var reader = reader as? TracePropagationHeadersReader
-        reader?.tracerSampleRate = localTraceSampler.samplingRate
-        return (reader as? OTFormatReader)?.extract()
+        guard let context = reader.extract() as? DDSpanContext else {
+            return nil
+        }
+
+        return DDSpanContext(
+            traceID: context.traceID,
+            spanID: context.spanID,
+            parentSpanID: context.parentSpanID,
+            baggageItems: context.baggageItems,
+            sampleRate: localTraceSampler.samplingRate,
+            isKept: context.isKept
+        )
     }
 
     var activeSpan: OTSpan? {

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -29,63 +29,61 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         self.firstPartyHosts = firstPartyHosts
     }
 
-    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> URLRequest {
+    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> (URLRequest, TraceContext?) {
         guard let tracer = tracer else {
-            return request
+            return (request, nil)
         }
 
         // Use the current active span as parent if the propagation
         // headers support it.
         let parentSpanContext = tracer.activeSpan?.context as? DDSpanContext
-        let spanContext = tracer.createSpanContext(parentSpanContext: parentSpanContext)
+        let spanContext = tracer.createSpanContext(parentSpanContext: parentSpanContext, using: distributedTraceSampler)
+        let injectedSpanContext = TraceContext(
+            traceID: spanContext.traceID,
+            spanID: spanContext.spanID,
+            parentSpanID: spanContext.parentSpanID,
+            sampleRate: spanContext.sampleRate,
+            isKept: spanContext.isKept
+        )
 
+        let sampler = DeterministicSampler(shouldSample: spanContext.isKept, samplingRate: spanContext.sampleRate)
         var request = request
+        var hasSetAnyHeader = false
         headerTypes.forEach {
             let writer: TracePropagationHeadersWriter
             switch $0 {
             case .datadog:
-                writer = HTTPHeadersWriter(sampler: distributedTraceSampler)
+                writer = HTTPHeadersWriter(sampler: sampler)
             case .b3:
                 writer = B3HTTPHeadersWriter(
-                    sampler: distributedTraceSampler,
+                    sampler: sampler,
                     injectEncoding: .single
                 )
             case .b3multi:
                 writer = B3HTTPHeadersWriter(
-                    sampler: distributedTraceSampler,
+                    sampler: sampler,
                     injectEncoding: .multiple
                 )
             case .tracecontext:
-                writer = W3CHTTPHeadersWriter(sampler: distributedTraceSampler, tracestate: [:])
+                writer = W3CHTTPHeadersWriter(sampler: sampler, tracestate: [:])
             }
 
             writer.write(
-                traceID: spanContext.traceID,
-                spanID: spanContext.spanID,
-                parentSpanID: spanContext.parentSpanID
+                traceID: injectedSpanContext.traceID,
+                spanID: injectedSpanContext.spanID,
+                parentSpanID: injectedSpanContext.parentSpanID
             )
 
             writer.traceHeaderFields.forEach { field, value in
                 // do not overwrite existing header
                 if request.value(forHTTPHeaderField: field) == nil {
+                    hasSetAnyHeader = true
                     request.setValue(value, forHTTPHeaderField: field)
                 }
             }
         }
 
-        return request
-    }
-
-    func traceContext() -> DatadogInternal.TraceContext? {
-        guard let context = tracer?.activeSpan?.context as? DDSpanContext else {
-            return nil
-        }
-
-        return TraceContext(
-            traceID: context.traceID,
-            spanID: context.spanID,
-            parentSpanID: context.parentSpanID
-        )
+        return (request, (hasSetAnyHeader && injectedSpanContext.isKept) ? injectedSpanContext : nil)
     }
 
     func interceptionDidStart(interception: DatadogInternal.URLSessionTaskInterception) {
@@ -110,7 +108,9 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
                 traceID: trace.traceID,
                 spanID: trace.spanID,
                 parentSpanID: trace.parentSpanID,
-                baggageItems: .init()
+                baggageItems: .init(),
+                sampleRate: trace.sampleRate,
+                isKept: trace.isKept
             )
 
             span = tracer.startSpan(

--- a/DatadogTrace/Tests/DatadogTracer+SamplingTests.swift
+++ b/DatadogTrace/Tests/DatadogTracer+SamplingTests.swift
@@ -81,7 +81,6 @@ class DatadogTracer_SamplingTests: XCTestCase {
         XCTAssertEqual(events.filter({ $0.samplingRate == 0.42 }).count, 3, "All spans must encode the same sample rate")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported
     func testWhenRootSpanIsSampled_thenAllChildSpansMustBeSampledTheSameWay() throws {
         // When
         let tracer = createTracer(sampleRate: 50)

--- a/DatadogTrace/Tests/TracingFeatureMocks.swift
+++ b/DatadogTrace/Tests/TracingFeatureMocks.swift
@@ -21,13 +21,17 @@ extension DDSpanContext {
         traceID: TraceID = .mockAny(),
         spanID: SpanID = .mockAny(),
         parentSpanID: SpanID? = .mockAny(),
-        baggageItems: BaggageItems = .mockAny()
+        baggageItems: BaggageItems = .mockAny(),
+        sampleRate: Float = .mockAny(),
+        isKept: Bool = .mockAny()
     ) -> DDSpanContext {
         return DDSpanContext(
             traceID: traceID,
             spanID: spanID,
             parentSpanID: parentSpanID,
-            baggageItems: baggageItems
+            baggageItems: baggageItems,
+            sampleRate: sampleRate,
+            isKept: isKept
         )
     }
 }

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -53,7 +53,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [
                 .datadog,
@@ -73,6 +73,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000064-1")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-01")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.tracestate), "dd=p:0000000000000064;s:1")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 100)
+        XCTAssertNil(injectedTraceContext.parentSpanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, 100)
+        XCTAssertTrue(injectedTraceContext.isKept)
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itDoesNotOverwriteTraceHeaders() throws {
@@ -85,19 +93,21 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         // When
-        var request: URLRequest = .mockWith(url: "https://www.example.com")
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
-        request.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField)
-        request.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
-        request.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
+        var orgRequest: URLRequest = .mockWith(url: "https://www.example.com")
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.tagsField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.parentSpanIDField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField)
+        orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
+        orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
+        orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.tracestate)
 
-        request = handler.modify(
-            request: request,
+        let (request, traceContext) = handler.modify(
+            request: orgRequest,
             headerTypes: [
                 .datadog,
                 .b3,
@@ -107,6 +117,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "custom")
@@ -115,6 +126,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.tracestate), "custom")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectTraceHeaders() throws {
@@ -127,7 +141,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [
                 .datadog,
@@ -146,6 +160,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "0")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "0")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000064-00")
+
+        XCTAssertNil(traceContext, "It must return no trace context")
     }
 
     func testGivenFirstPartyInterception_withActiveSpan_itInjectParentSpanID() throws {
@@ -161,7 +177,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         span.setActive()
 
         // When
-        let request = handler.modify(
+        let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
             headerTypes: [
                 .datadog,
@@ -183,10 +199,19 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.sampledField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "000000000000000a0000000000000064-0000000000000065-1-0000000000000064")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "00-000000000000000a0000000000000064-0000000000000065-01")
+
+        let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
+        XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
+        XCTAssertEqual(injectedTraceContext.spanID, 101)
+        XCTAssertEqual(injectedTraceContext.parentSpanID, span.context.dd.spanID)
+        XCTAssertEqual(injectedTraceContext.sampleRate, span.context.dd.sampleRate)
+        XCTAssertEqual(injectedTraceContext.isKept, span.context.dd.isKept)
     }
 
     func testGivenFirstPartyInterceptionWithSpanContext_whenInterceptionCompletes_itUsesInjectedSpanContext() throws {
         core.expectation = expectation(description: "Send span")
+        let sampleRate: Float = .mockRandom(min: 1, max: 100)
+        let isKept: Bool = .mockRandom()
 
         // Given
         let interception = URLSessionTaskInterception(
@@ -205,7 +230,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
         interception.register(trace: TraceContext(
             traceID: 100,
             spanID: 200,
-            parentSpanID: nil
+            parentSpanID: nil,
+            sampleRate: sampleRate,
+            isKept: isKept
         ))
 
         // When
@@ -222,6 +249,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertFalse(span.isError)
         XCTAssertEqual(span.duration, 1)
+        XCTAssertEqual(span.samplingRate, sampleRate / 100)
+        XCTAssertEqual(span.isKept, isKept)
     }
 
     func testGivenFirstPartyInterceptionWithNoError_whenInterceptionCompletes_itEncodesRequestInfoInSpan() throws {
@@ -256,70 +285,6 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
         XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
         XCTAssertEqual(span.tags.count, 5)
-    }
-
-    func testTraceContext_whenInterceptionStarts_withActiveSpan_itReturnCurrentSpan() {
-        // When
-        let span = tracer.startRootSpan(operationName: "root")
-        span.setActive()
-        // Then
-        let context = handler.traceContext()
-        XCTAssertEqual(context?.traceID, TraceID(idHi: 10, idLo: 100))
-        XCTAssertEqual(context?.spanID, SpanID(100))
-
-        // When
-        span.finish()
-        // Then
-        XCTAssertNil(handler.traceContext())
-    }
-
-    func testGivenFirstPartyInterception_whenInterceptionStarts_withActiveSpan_itSendParentSpanID() throws {
-        core.expectation = expectation(description: "Send span")
-        core.expectation?.expectedFulfillmentCount = 2
-
-        // Given
-        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
-
-        // When
-        let span = tracer.startRootSpan(operationName: "root")
-        span.setActive()
-        interception.register(trace: TraceContext(
-            traceID: span.context.dd.traceID,
-            spanID: SpanID(300),
-            parentSpanID: span.context.dd.spanID
-        ))
-        handler.interceptionDidStart(interception: interception)
-        // Then
-        XCTAssertEqual(interception.trace?.parentSpanID?.rawValue, 100)
-
-        // When
-        span.finish()
-        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
-        interception.register(
-            metrics: .mockWith(
-                fetch: .init(
-                    start: .mockDecember15th2019At10AMUTC(),
-                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2)
-                )
-            )
-        )
-        handler.interceptionDidComplete(interception: interception)
-
-        // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
-
-        let envelopes: [SpanEventsEnvelope] = core.events()
-        let event1 = try XCTUnwrap(envelopes.first?.spans.first)
-        XCTAssertEqual(event1.operationName, "root")
-        XCTAssertEqual(event1.traceID, TraceID(idHi: 10, idLo: 100))
-        XCTAssertEqual(event1.spanID, SpanID(100))
-        XCTAssertNil(event1.parentID)
-        let event2 = try XCTUnwrap(envelopes.last?.spans.first)
-        XCTAssertEqual(event2.operationName, "urlsession.request")
-        XCTAssertEqual(event2.traceID, TraceID(idHi: 10, idLo: 100))
-        XCTAssertEqual(event2.parentID, SpanID(100))
-        XCTAssertEqual(event2.spanID, SpanID(300))
     }
 
     func testGivenFirstPartyIncompleteInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {

--- a/TestUtilities/Mocks/FoundationMocks.swift
+++ b/TestUtilities/Mocks/FoundationMocks.swift
@@ -620,7 +620,7 @@ extension URLSessionTask {
         return URLSessionDataTaskMock(request: .mockAny(), response: .mockAny())
     }
 
-    public static func mockWith(request: URLRequest, response: HTTPURLResponse) -> URLSessionDataTask {
+    public static func mockWith(request: URLRequest = .mockAny(), response: HTTPURLResponse = .mockAny()) -> URLSessionDataTask {
         return URLSessionDataTaskMock(request: request, response: response)
     }
 }

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -88,7 +88,7 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     public var firstPartyHosts: FirstPartyHosts
 
     public var modifiedRequest: URLRequest?
-    public var parentSpan: TraceContext?
+    public var injectedTraceContext: TraceContext?
     public var shouldInterceptRequest: ((URLRequest) -> Bool)?
 
     public var onRequestMutation: ((URLRequest, Set<TracingHeaderType>) -> Void)?
@@ -111,13 +111,9 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
         interceptions.values.first { $0.request.url == url }
     }
 
-    public func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest {
+    public func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> (URLRequest, TraceContext?) {
         onRequestMutation?(request, headerTypes)
-        return modifiedRequest ?? request
-    }
-
-    public func traceContext() -> TraceContext? {
-        parentSpan
+        return (modifiedRequest ?? request, injectedTraceContext)
     }
 
     public func interceptionDidStart(interception: URLSessionTaskInterception) {


### PR DESCRIPTION
### What and why?

📦 This PR implements head-based sampling for the scenarios defined earlier in https://github.com/DataDog/dd-sdk-ios/pull/1772. It also adds tests for one more class of scenarios: using distributed trace created manually with `OTFormatWriter` API. 

<details><summary> See all scenarios for head-based sampling vs their support level:</summary>
<p>

- ✅ Local trace with explicit parent:
```
client-ios-app:     [---- custom.span.1 -----]
client-ios-app:       [-- custom.span.2 ---]
client-ios-app:         [- custom.span.3 -]
```
- ✅ Local trace with implicit parent:
```
client-ios-app:     [----- active.span ------]
client-ios-app:       [-- custom.span.1 ---]
client-ios-app:         [- custom.span.2 -]
```
- ✅ Distributed trace sent via `URLSessionInstrumentation`:
```
dd-sdk-ios:         [--- urlsession.request ---]
client backend:        [--- backend span ---]
```
- ✅ Distributed trace sent via `URLSessionInstrumentation` with implicit parent:
```
client-ios-app:     [-------- active.span ---------]
dd-sdk-ios:           [--- urlsession.request ---]
client backend:          [--- backend span ---]
```
- ❌ Distributed trace sent via Tracer API (`*HTTPHeadersWriter`):
```
client-ios-app:     [------ network.span -------]
client backend:         [--- backend span ---]
```
- ❌ Distributed trace sent via Tracer API (`*HTTPHeadersWriter`) with implicit parent:
```
client-ios-app:     [------ active.span -------]
client-ios-app:       [---- network.span ----]
client backend:         [-- backend span --]
```
The last 2 scenarios are defined as failing (and disabled) tests. They will be supported and enabled in next PR.

</p>
</details>

### How?

I did few changes that enable this feature.

#### The sampling decision is now a part of `DDSpanContext`

In OT, creating child span requires passing the `OTSpanContext` of the parent. This makes a good place for propagating the sampling decision for head-based sampling. For that reason, `sampleRate` and `isKept` are added to `DDSpanContext`.

```
DDSpanContext (parent): {traceID, spanID, nil, isKept, sampleRate}

                                   ↓

DDSpanContext (child):  {parent.traceID, spanID, parent.spanID, parent.isKept, parent.sampleRate}
```

Note: While `isKept` is crucial for sampling the whole trace equally, the `sampleRate` is not. We need to propagate it, so it can be later sent [in `SpanEvent`](https://github.com/DataDog/dd-sdk-ios/blob/973fb6eb1820faca459e1c14fe4391284ca8290d/DatadogTrace/Sources/Span/SpanEventEncoder.swift#L60) for computing BE-side metrics.

#### The `OTFormatReader` implementations can now extract the sampling decision

Because the `OTTracer` can encode and decode the `OTSpanContext`:
```swift
// OTTracer
func inject(spanContext: OTSpanContext, writer: OTFormatWriter)
func extract(reader: OTFormatReader) -> OTSpanContext?
```
the implementations of HTTP header readers (DD, W3C and B3) were extended to extract the `isKept` and `sampleRate`.

Note: The `sampleRate` is not encoded as header so it needs to be supplied by the `tracer` in `extract(reader:)`.

#### `NetworkInstrumentationFeature` no longer decodes `TraceContext` from request headers

I enhanced the implementation of passing `TraceContext` between task interception methods. It now avoids coding it through request headers, which enables passing extra information not available in standard headers (the `sampleRate`).

Before:
```swift
// NetworkInstrumentationFeature
let request = self.intercept(request: currentRequest, ...) // <-- encode TraceContext in request headers
self.intercept(task: task, ...) // <-- decode TraceContext from task.currentRequest headers
```
Now:
```swift
let (request, traceContexts) = self.intercept(request: currentRequest, ...)
self.intercept(task: task, with: traceContexts, ...)
```

Note: This simplifies and enhances task interception in the main flow. However, it required additional changes in `URLSessionInterceptor` which is required for Alamofire Extension. 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
