### PR TITLE
Fix color SR identifier

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -42,10 +42,7 @@ extension UIColor {
         var b: CGFloat = 0
         var a: CGFloat = 0
         getRed(&r, green: &g, blue: &b, alpha: &a)
-        return String(
-            format: "%02X%02X%02X%02X",
-            Int(round(r * 255)), Int(round(g * 255)), Int(round(b * 255)), Int(round(a * 255))
-        )
+        return String(format: "%02X%02X%02X%02X", Int(round(r * 255)), Int(round(g * 255)), Int(round(b * 255)), Int(round(a * 255)))
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -37,7 +37,15 @@ extension DatadogExtension where ExtendedType: UIImage {
 
 extension UIColor {
     var srIdentifier: String {
-        return "\(hash)"
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(
+            format: "%02X%02X%02X%02X",
+            Int(round(r * 255)), Int(round(g * 255)), Int(round(b * 255)), Int(round(a * 255))
+        )
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -43,7 +43,8 @@ internal class ResourcesWriter: ResourcesWriting {
         self.decoder = decoder
         self.scope.dataStore.value(forKey: Constants.storeCreationKey) { [weak self]  result in
             do {
-                if let storeCreation = try result.data()?.asTimeInterval(), Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
+                if let storeCreation = try result.data(expectedVersion: Constants.currentStoreVersion)?.asTimeInterval(),
+                   Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
                     self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
                         switch result {
                         case .value(let data, let version) where version == Constants.currentStoreVersion:

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -25,7 +25,8 @@ internal class ResourcesWriter: ResourcesWriting {
             if let knownIdentifiers = knownIdentifiers.asData(encoder) {
                 scope.dataStore.setValue(
                     knownIdentifiers,
-                    forKey: Constants.knownResourcesKey
+                    forKey: Constants.knownResourcesKey,
+                    version: Constants.currentStoreVersion
                 )
             }
         }
@@ -45,7 +46,7 @@ internal class ResourcesWriter: ResourcesWriting {
                 if let storeCreation = try result.data()?.asTimeInterval(), Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
                     self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
                         switch result {
-                        case .value(let data, _):
+                        case .value(let data, let version) where version == Constants.currentStoreVersion:
                             do {
                                 if let knownIdentifiers = try data.asKnownIdentifiers(decoder) {
                                     self?.knownIdentifiers.formUnion(knownIdentifiers)
@@ -60,7 +61,8 @@ internal class ResourcesWriter: ResourcesWriting {
                 } else { // Reset if store was created more than 30 days ago
                     self?.scope.dataStore.setValue(
                         Date().timeIntervalSince1970.asData(),
-                        forKey: Constants.storeCreationKey
+                        forKey: Constants.storeCreationKey,
+                        version: Constants.currentStoreVersion
                     )
                     self?.scope.dataStore.removeValue(forKey: Constants.knownResourcesKey)
                 }
@@ -85,6 +87,7 @@ internal class ResourcesWriter: ResourcesWriting {
     enum Constants {
         static let knownResourcesKey = "known-resources"
         static let storeCreationKey = "store-creation"
+        static let currentStoreVersion = UInt16(1)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
@@ -20,7 +20,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = createSinglePixelImage()
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertNotEqual(imageResource.calculateIdentifier(), "")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -29,7 +29,8 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertNotEqual(imageResource.calculateIdentifier(), "")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
+        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -38,7 +39,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = UIImage(systemName: "circle.fill")!
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertNotEqual(imageResource.calculateIdentifier(), "")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -48,7 +49,8 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertNotEqual(imageResource.calculateIdentifier(), "")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
+        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
@@ -20,7 +20,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = createSinglePixelImage()
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
+        XCTAssertEqual(imageResource.calculateIdentifier(), "eab6bf754eb6a790cc1240262c1c3a29")
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -29,8 +29,7 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
-        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
+        XCTAssertEqual(imageResource.calculateIdentifier(), "eab6bf754eb6a790cc1240262c1c3a29FF0000FF")
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -39,7 +38,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = UIImage(systemName: "circle.fill")!
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
+        XCTAssertEqual(imageResource.calculateIdentifier(), "d918588dd612a9e8a13d9eedb5b57f78")
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -49,8 +48,7 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
-        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
+        XCTAssertEqual(imageResource.calculateIdentifier(), "d918588dd612a9e8a13d9eedb5b57f78FF0000FF")
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
@@ -20,7 +20,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = createSinglePixelImage()
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertEqual(imageResource.calculateIdentifier(), "eab6bf754eb6a790cc1240262c1c3a29")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -29,7 +29,8 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertEqual(imageResource.calculateIdentifier(), "eab6bf754eb6a790cc1240262c1c3a29FF0000FF")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
+        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -38,7 +39,7 @@ final class UIImageResourceTests: XCTestCase {
         let image = UIImage(systemName: "circle.fill")!
         let imageResource = UIImageResource(image: image, tintColor: nil)
 
-        XCTAssertEqual(imageResource.calculateIdentifier(), "d918588dd612a9e8a13d9eedb5b57f78")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 32)
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
@@ -48,7 +49,8 @@ final class UIImageResourceTests: XCTestCase {
         let tintColor = UIColor.red
         let imageResource = UIImageResource(image: image, tintColor: tintColor)
 
-        XCTAssertEqual(imageResource.calculateIdentifier(), "d918588dd612a9e8a13d9eedb5b57f78FF0000FF")
+        XCTAssertEqual(imageResource.calculateIdentifier().count, 40)
+        XCTAssertTrue(imageResource.calculateIdentifier().contains("FF0000FF"))
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 


### PR DESCRIPTION
### What and why?

Fixes the SR color identifier, which is causing unnecessary upload of resources.

### How?

Previous implementation was relying on UIColor (NSObject) hash. It appears to be stable only in the developer environment, but it feels random on production.

Testing is tricky, because different versions of iOS produce different images, and hashes.
Improved tests to check if length of the identifier, as well as if it contains color for tinted images.

Also, it resets the store version.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
