### PR TITLE
RUM-3284 Extension file lock crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+- [FIX] Fix crash when extension targets. See [#1789][]
 - [IMPROVEMENT] Add image duplicate detection between sessions. See [#1747][]
 - [FEATURE] Add support for 128 bit trace IDs. See [#1721][]
 - [FEATURE] Fatal App Hangs are tracked in RUM. See [#1763][]
@@ -637,6 +637,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1767]: https://github.com/DataDog/dd-sdk-ios/pull/1767
 [#1721]: https://github.com/DataDog/dd-sdk-ios/pull/1721
 [#1747]: https://github.com/DataDog/dd-sdk-ios/pull/1747
+[#1789]: https://github.com/DataDog/dd-sdk-ios/pull/1789
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -387,6 +387,7 @@ extension DatadogContextProvider {
         applicationBundleIdentifier: String,
         applicationVersion: String,
         sdkInitDate: Date,
+        isExtension: Bool,
         device: DeviceInfo,
         dateProvider: DateProvider,
         serverDateProvider: ServerDateProvider
@@ -411,7 +412,8 @@ extension DatadogContextProvider {
             // this is a placeholder waiting for the `ApplicationStatePublisher`
             // to be initialized on the main thread, this value will be overrided
             // as soon as the subscription is made.
-            applicationStateHistory: .active(since: dateProvider.now)
+            applicationStateHistory: .active(since: dateProvider.now),
+            isExtension: isExtension
         )
 
         self.init(context: context)

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -72,6 +72,10 @@ internal class DataUploadWorker: DataUploadWorkerType {
                 return
             }
             let context = contextProvider.read()
+            guard !context.isExtension else {
+                // Prevent uploading from app extensions
+                return
+            }
             let blockersForUpload = uploadConditions.blockersForUpload(with: context)
             let isSystemReady = blockersForUpload.isEmpty
             let files = isSystemReady ? fileReader.readFiles(limit: maxBatchesPerUpload) : nil

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -416,8 +416,7 @@ public enum Datadog {
 
         let performance = PerformancePreset(
             batchSize: debug ? .small : configuration.batchSize,
-            uploadFrequency: debug ? .frequent : configuration.uploadFrequency,
-            bundleType: bundleType
+            uploadFrequency: debug ? .frequent : configuration.uploadFrequency
         )
 
         // Set default `DatadogCore`:

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -449,6 +449,7 @@ public enum Datadog {
                 applicationBundleIdentifier: bundleIdentifier,
                 applicationVersion: applicationVersion,
                 sdkInitDate: configuration.dateProvider.now,
+                isExtension: bundleType == .iOSAppExtension,
                 device: DeviceInfo(),
                 dateProvider: configuration.dateProvider,
                 serverDateProvider: configuration.serverDateProvider

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -70,44 +70,31 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
 internal extension PerformancePreset {
     init(
         batchSize: Datadog.Configuration.BatchSize,
-        uploadFrequency: Datadog.Configuration.UploadFrequency,
-        bundleType: BundleType
+        uploadFrequency: Datadog.Configuration.UploadFrequency
     ) {
         let meanFileAgeInSeconds: TimeInterval = {
-            switch (bundleType, batchSize) {
-            case (.iOSApp, .small): return 3
-            case (.iOSApp, .medium): return 10
-            case (.iOSApp, .large): return 35
-            case (.iOSAppExtension, _): return 1
+            switch batchSize {
+            case .small: return 3
+            case .medium: return 10
+            case .large: return 35
             }
         }()
 
         let minUploadDelayInSeconds: TimeInterval = {
-            switch (bundleType, uploadFrequency) {
-            case (.iOSApp, .frequent): return 0.5
-            case (.iOSApp, .average): return 2
-            case (.iOSApp, .rare): return 5
-            case (.iOSAppExtension, _): return 0.5
+            switch uploadFrequency {
+            case .frequent: return 0.5
+            case .average: return 2
+            case .rare: return 5
             }
         }()
 
         let uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double) = {
-            switch bundleType {
-            case .iOSApp:
-                return (
-                    initial: 5,
-                    min: 1,
-                    max: 10,
-                    changeRate: 0.1
-                )
-            case .iOSAppExtension:
-                return (
-                    initial: 0.5, // ensures the the first upload is checked quickly after starting the short-lived app extension
-                    min: 1,
-                    max: 5,
-                    changeRate: 0.5 // if batches are found, reduces interval significantly for more uploads in short-lived app extension
-                )
-            }
+            return (
+                initial: 5,
+                min: 1,
+                max: 10,
+                changeRate: 0.1
+            )
         }()
 
         self.init(

--- a/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
@@ -11,84 +11,43 @@ import DatadogInternal
 
 class PerformancePresetTests: XCTestCase {
     func testIOSAppPresets() {
-        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom())
         XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 2.85, accuracy: 0.01)
         XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 3.15, accuracy: 0.01)
         XCTAssertEqual(smallBatchAnyFrequency.uploaderWindow, 3.0)
         assertPresetCommonValues(in: smallBatchAnyFrequency)
 
-        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom())
         XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 9.5)
         XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 10.5)
         XCTAssertEqual(mediumBatchAnyFrequency.uploaderWindow, 10.0)
         assertPresetCommonValues(in: mediumBatchAnyFrequency)
 
-        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom())
         XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 33.25)
         XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 36.75)
         XCTAssertEqual(largeBatchAnyFrequency.uploaderWindow, 35)
         assertPresetCommonValues(in: largeBatchAnyFrequency)
 
-        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSApp)
+        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent)
         XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 2.5)
         XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 5.0)
         XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.1)
         assertPresetCommonValues(in: frequentUploadAnyBatch)
 
-        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSApp)
+        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average)
         XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 10.0)
         XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 2.0)
         XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 20.0)
         XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.1)
         assertPresetCommonValues(in: averageUploadAnyBatch)
 
-        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSApp)
+        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare)
         XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 25.0)
         XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 5.0)
         XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 50.0)
         XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.1)
-        assertPresetCommonValues(in: rareUploadAnyBatch)
-    }
-
-    func testIOSAppExtensionPresets() {
-        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
-        XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 0.95)
-        XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 1.05)
-        XCTAssertEqual(smallBatchAnyFrequency.uploaderWindow, 1)
-        assertPresetCommonValues(in: smallBatchAnyFrequency)
-
-        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
-        XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 0.95, accuracy: 0.01)
-        XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 1.05, accuracy: 0.01)
-        XCTAssertEqual(mediumBatchAnyFrequency.uploaderWindow, 1)
-        assertPresetCommonValues(in: mediumBatchAnyFrequency)
-
-        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
-        XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 0.95, accuracy: 0.01)
-        XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 1.05, accuracy: 0.01)
-        XCTAssertEqual(largeBatchAnyFrequency.uploaderWindow, 1)
-        assertPresetCommonValues(in: largeBatchAnyFrequency)
-
-        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSAppExtension)
-        XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 0.25)
-        XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
-        XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 2.5)
-        XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.5)
-        assertPresetCommonValues(in: frequentUploadAnyBatch)
-
-        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSAppExtension)
-        XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 0.25)
-        XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 0.5)
-        XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 2.5)
-        XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.5)
-        assertPresetCommonValues(in: averageUploadAnyBatch)
-
-        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSAppExtension)
-        XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 0.25)
-        XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 0.5)
-        XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 2.5)
-        XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.5)
         assertPresetCommonValues(in: rareUploadAnyBatch)
     }
 
@@ -103,8 +62,7 @@ class PerformancePresetTests: XCTestCase {
     func testPresetsConsistency() {
         let allPossiblePresets: [PerformancePreset] = BatchSize.allCases
             .combined(with: UploadFrequency.allCases)
-            .combined(with: BundleType.allCases)
-            .map { PerformancePreset(batchSize: $0.0, uploadFrequency: $0.1, bundleType: $1) }
+            .map { PerformancePreset(batchSize: $0.0, uploadFrequency: $0.1) }
 
         allPossiblePresets.forEach { preset in
             XCTAssertLessThan(
@@ -157,7 +115,7 @@ class PerformancePresetTests: XCTestCase {
         )
 
         // When
-        let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom())
+        let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom())
         let updatedPreset = preset.updated(
             with: PerformancePresetOverride(
                 maxFileSize: maxFileSizeOverride,

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -200,11 +200,11 @@ extension BundleType: AnyMockable, RandomMockable {
 
 extension PerformancePreset: AnyMockable, RandomMockable {
     public static func mockAny() -> Self {
-        PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp)
+        PerformancePreset(batchSize: .medium, uploadFrequency: .average)
     }
 
     public static func mockRandom() -> Self {
-        PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom())
+        PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom())
     }
 
     static func combining(storagePerformance storage: StoragePerformanceMock, uploadPerformance upload: UploadPerformanceMock) -> Self {

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -106,6 +106,9 @@ public struct DatadogContext {
     /// `true` if the Low Power Mode is enabled.
     public var isLowPowerModeEnabled = false
 
+    /// Flag that determines if SDK is run from the iOS extension.
+    public var isExtension: Bool
+
     /// Type-less context baggages.
     public var baggages: [String: FeatureBaggage] = [:]
 
@@ -136,6 +139,7 @@ public struct DatadogContext {
         carrierInfo: CarrierInfo? = nil,
         batteryStatus: BatteryStatus? = nil,
         isLowPowerModeEnabled: Bool = false,
+        isExtension: Bool,
         baggages: [String: FeatureBaggage] = [:]
     ) {
         self.site = site
@@ -163,6 +167,7 @@ public struct DatadogContext {
         self.carrierInfo = carrierInfo
         self.batteryStatus = batteryStatus
         self.isLowPowerModeEnabled = isLowPowerModeEnabled
+        self.isExtension = isExtension
         self.baggages = baggages
     }
     // swiftlint:enable function_default_parameter_at_end

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -36,6 +36,7 @@ extension DatadogContext: AnyMockable {
         carrierInfo: CarrierInfo? = .mockAny(),
         batteryStatus: BatteryStatus? = .mockAny(),
         isLowPowerModeEnabled: Bool = false,
+        isExtension: Bool = false,
         baggages: [String: FeatureBaggage] = [:]
     ) -> DatadogContext {
         .init(
@@ -63,7 +64,8 @@ extension DatadogContext: AnyMockable {
             networkConnectionInfo: networkConnectionInfo,
             carrierInfo: carrierInfo,
             batteryStatus: batteryStatus,
-            isLowPowerModeEnabled: isLowPowerModeEnabled,
+            isLowPowerModeEnabled: isLowPowerModeEnabled, 
+            isExtension: isExtension,
             baggages: baggages
         )
     }
@@ -94,6 +96,7 @@ extension DatadogContext: AnyMockable {
             carrierInfo: .mockRandom(),
             batteryStatus: nil,
             isLowPowerModeEnabled: .mockRandom(),
+            isExtension: .mockRandom(),
             baggages: .mockRandom()
         )
     }


### PR DESCRIPTION
### What and why?

As mentioned in the: https://github.com/DataDog/dd-sdk-ios/issues/1690

It appears that we are dealing with https://developer.apple.com/documentation/xcode/sigkill

Quote:
0xdead10cc (3735883980) — pronounced “dead lock”
The operating system terminated the app because it held on to a file lock or SQLite database lock during suspension. Request additional background execution time on the main thread with beginBackgroundTask(withName:expirationHandler:). Make this request well before starting to write to the file in order to complete those operations and relinquish the lock before the app suspends. In an app extension, use beginActivity(options:reason:) to manage this work.

Using the `beginActivity(options:reason:)` could work, but is very likely to fail anyway due to short-lived nature of extensions. The other brainstormed option is preventing SDK from from uploading when run from widget/extension (it would only store events and let the app to the upload work next time it's opened).

### How?

PR pursues option 2, which is more likely to succeed in the long run without bigger refactor.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
