### PR TITLE
RUM-3470 feat: Head-based sampling for manual distributed tracing

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -356,6 +356,8 @@
 		6167E72A2B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */; };
 		6167E72C2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */; };
 		6167E72D2B84C72B00C3CA2D /* UIKitHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */; };
+		616AAA6D2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616AAA6C2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift */; };
+		616AAA6E2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616AAA6C2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		616F8C272BB1CD990061EA53 /* ProcessIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F8C262BB1CD990061EA53 /* ProcessIdentifier.swift */; };
 		616F8C282BB1CD990061EA53 /* ProcessIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F8C262BB1CD990061EA53 /* ProcessIdentifier.swift */; };
@@ -2294,6 +2296,7 @@
 		6167E7222B837FF100C3CA2D /* BinaryImageMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageMocks.swift; sourceTree = "<group>"; };
 		6167E7282B84C11900C3CA2D /* DDCrashReportMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportMocks.swift; sourceTree = "<group>"; };
 		6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHelpers.swift; sourceTree = "<group>"; };
+		616AAA6C2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TraceSamplingStrategy+objc.swift"; sourceTree = "<group>"; };
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfo.swift; sourceTree = "<group>"; };
 		616C0AA028573F6300C13264 /* RUMOperatingSystemInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOperatingSystemInfoTests.swift; sourceTree = "<group>"; };
@@ -4258,6 +4261,7 @@
 		6132BF4A24A49C7200D7BD17 /* Propagation */ = {
 			isa = PBXGroup;
 			children = (
+				616AAA6C2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift */,
 				6132BF4B24A49C8F00D7BD17 /* HTTPHeadersWriter+objc.swift */,
 				A79B0F5E292BA435008742B3 /* B3HTTPHeadersWriter+objc.swift */,
 				A728ADAA2934EA2100397996 /* W3CHTTPHeadersWriter+objc.swift */,
@@ -7864,6 +7868,7 @@
 				6132BF4C24A49C8F00D7BD17 /* HTTPHeadersWriter+objc.swift in Sources */,
 				6132BF4724A498D800D7BD17 /* DDSpan+objc.swift in Sources */,
 				615A4A8B24A3568900233986 /* OTSpan+objc.swift in Sources */,
+				616AAA6D2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift in Sources */,
 				611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */,
 				9E55407C25812D1C00F6E3AD /* RUM+objc.swift in Sources */,
 				D2A434AA2A8E40A20028E329 /* SessionReplay+objc.swift in Sources */,
@@ -9029,6 +9034,7 @@
 				3CCCA5C52ABAF0F80029D7BD /* DDURLSessionInstrumentation+objc.swift in Sources */,
 				D2CB6FA027C5217A00A62B57 /* Trace+objc.swift in Sources */,
 				D2CB6FA127C5217A00A62B57 /* HTTPHeadersWriter+objc.swift in Sources */,
+				616AAA6E2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift in Sources */,
 				D2CB6FA227C5217A00A62B57 /* DDSpan+objc.swift in Sources */,
 				D2CB6FA327C5217A00A62B57 /* OTSpan+objc.swift in Sources */,
 				D2CB6FA427C5217A00A62B57 /* DDURLSessionDelegate+objc.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -300,6 +300,10 @@
 		614CADD72510BAC000B93D2D /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADD62510BAC000B93D2D /* Environment.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		614ED36C260352DC00C8C519 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
+		615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */; };
+		615192CE2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */; };
+		615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */; };
+		615192D12BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */; };
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		615A4A8324A3431600233986 /* Trace+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8224A3431600233986 /* Trace+objc.swift */; };
 		615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8824A34FD700233986 /* DDTracerTests.swift */; };
@@ -2244,6 +2248,8 @@
 		614CADD62510BAC000B93D2D /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		614ED36B260352DC00C8C519 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../Carthage/Build/CrashReporter.xcframework; sourceTree = "<group>"; };
+		615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersWriterTests.swift; sourceTree = "<group>"; };
+		615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogTracer+InjectAndExtract.swift"; sourceTree = "<group>"; };
 		6152C84224BE2165006A1679 /* MockServerAddress.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockServerAddress.local.xcconfig; sourceTree = "<group>"; };
 		615519252461BCE7002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519262461BCE7002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -5735,6 +5741,7 @@
 				619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
 				61F3E3622BC5556D00C7881E /* DatadogTracer+SamplingTests.swift */,
+				615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */,
 				61C5A89824509C1100DA608C /* DDSpanTests.swift */,
 				61F1A620249A45E400075390 /* DDSpanContextTests.swift */,
 				D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */,
@@ -6049,6 +6056,7 @@
 				61B558D32469CDD8001460D3 /* TraceIDGeneratorTests.swift */,
 				3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */,
 				61F3E3652BC595F600C7881E /* HTTPHeadersReaderTests.swift */,
+				615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */,
 				A79B0F5A292B7C06008742B3 /* B3HTTPHeadersWriterTests.swift */,
 				A79B0F60292BB071008742B3 /* B3HTTPHeadersReaderTests.swift */,
 				A728ADA22934DB5000397996 /* W3CHTTPHeadersWriterTests.swift */,
@@ -8561,6 +8569,7 @@
 				61F3E3632BC5556D00C7881E /* DatadogTracer+SamplingTests.swift in Sources */,
 				D2C1A51C29C4C75700946C31 /* ContextMessageReceiverTests.swift in Sources */,
 				619CE7612A458D66005588CB /* TraceTests.swift in Sources */,
+				615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A52029C4C75700946C31 /* DDSpanTests.swift in Sources */,
 				D2C1A51B29C4C75700946C31 /* DDSpanContextTests.swift in Sources */,
 				D2C1A52729C4C7D000946C31 /* TracingFeatureMocks.swift in Sources */,
@@ -8764,6 +8773,7 @@
 				61F3E3642BC5556D00C7881E /* DatadogTracer+SamplingTests.swift in Sources */,
 				D2C1A56529C4F2E800946C31 /* ContextMessageReceiverTests.swift in Sources */,
 				619CE7622A458D66005588CB /* TraceTests.swift in Sources */,
+				615192D12BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A56629C4F2E800946C31 /* DDSpanTests.swift in Sources */,
 				D2C1A56729C4F2E800946C31 /* DDSpanContextTests.swift in Sources */,
 				D2C1A56829C4F2E800946C31 /* TracingFeatureMocks.swift in Sources */,
@@ -9193,6 +9203,7 @@
 				D2160CE929C0E00200FAA9A5 /* MethodSwizzlerTests.swift in Sources */,
 				D2216EC32A96649500ADAEC8 /* FeatureBaggageTests.swift in Sources */,
 				D2160CDC29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
+				615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */,
 				D2F44FB8299AA1DA0074B0D9 /* DataCompressionTests.swift in Sources */,
 				D2160CE029C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,
 				D2EBEE3B29BA163E00B15732 /* B3HTTPHeadersReaderTests.swift in Sources */,
@@ -9239,6 +9250,7 @@
 				D2EBEE4229BA163F00B15732 /* W3CHTTPHeadersReaderTests.swift in Sources */,
 				D2216EC42A96649700ADAEC8 /* FeatureBaggageTests.swift in Sources */,
 				D2160CDD29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
+				615192CE2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */,
 				D2F44FB9299AA1DB0074B0D9 /* DataCompressionTests.swift in Sources */,
 				D2160CE129C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift in Sources */,
 				D2EBEE3F29BA163F00B15732 /* B3HTTPHeadersReaderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCore iOS.xcscheme
@@ -209,12 +209,6 @@
                <Test
                   Identifier = "HeadBasedSamplingTests/testSendingDroppedDistributedTraceWithParent_throughURLSessionInstrumentationAPI()">
                </Test>
-               <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithNoParent_throughTracerAPI()">
-               </Test>
-               <Test
-                  Identifier = "HeadBasedSamplingTests/testSendingSampledDistributedTraceWithParent_throughTracerAPI()">
-               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference

--- a/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
+++ b/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
@@ -107,22 +107,19 @@ internal struct DebugManualTraceInjectionView: View {
 
         switch selectedTraceHeaderType {
         case .datadog:
-            let writer = HTTPHeadersWriter(sampleRate: sampleRate)
+            let writer = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: sampleRate))
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         case .w3c:
-            let writer = W3CHTTPHeadersWriter(
-                sampleRate: sampleRate,
-                tracestate: [:]
-            )
+            let writer = W3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: sampleRate), tracestate: [:])
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         case .b3Single:
-            let writer = B3HTTPHeadersWriter(sampleRate: sampleRate, injectEncoding: .single)
+            let writer = B3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: sampleRate), injectEncoding: .single)
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         case .b3Multiple:
-            let writer = B3HTTPHeadersWriter(sampleRate: sampleRate, injectEncoding: .multiple)
+            let writer = B3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: sampleRate), injectEncoding: .multiple)
             Tracer.shared().inject(spanContext: span.context, writer: writer)
             writer.traceHeaderFields.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         }

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -269,7 +269,6 @@ class HeadBasedSamplingTests: XCTestCase {
 
     // MARK: - Distributed Tracing (through Tracer API)
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
     func testSendingSampledDistributedTraceWithNoParent_throughTracerAPI() throws {
         /*
          This is the situation where distributed trace starts with the span created with Datadog tracer:
@@ -279,7 +278,6 @@ class HeadBasedSamplingTests: XCTestCase {
          */
 
         let localTraceSampling: Float = 100 // keep all
-        let distributedTraceSampling: Float = 0 // drop all
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -287,7 +285,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
         writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
@@ -309,7 +307,7 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    // TODO: RUM-3535 Enable this test when trace context injection control is implemented
     func testSendingDroppedDistributedTraceWithNoParent_throughTracerAPI() throws {
         /*
          This is the situation where distributed trace starts with the span created with Datadog tracer:
@@ -319,7 +317,6 @@ class HeadBasedSamplingTests: XCTestCase {
          */
 
         let localTraceSampling: Float = 0 // drop all
-        let distributedTraceSampling: Float = 100 // keep all
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -327,7 +324,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
         writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
@@ -349,7 +346,6 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
     func testSendingSampledDistributedTraceWithParent_throughTracerAPI() throws {
         /*
          This is the situation where distributed trace starts with an active local span and is continued with the span
@@ -361,7 +357,6 @@ class HeadBasedSamplingTests: XCTestCase {
          */
 
         let localTraceSampling: Float = 100 // keep all
-        let distributedTraceSampling: Float = 0 // drop all
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -369,7 +364,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
         let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
@@ -399,7 +394,7 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
     }
 
-    // TODO: RUM-3470 Enable this test when head-based sampling is supported for distributed tracing through Tracer API
+    // TODO: RUM-3535 Enable this test when trace context injection control is implemented
     func testSendingDroppedDistributedTraceWithParent_throughTracerAPI() throws {
         /*
          This is the situation where distributed trace starts with an active local span and is continued with the span
@@ -411,7 +406,6 @@ class HeadBasedSamplingTests: XCTestCase {
          */
 
         let localTraceSampling: Float = 0 // drop all
-        let distributedTraceSampling: Float = 100 // keep all
 
         // Given
         traceConfig.sampleRate = localTraceSampling
@@ -419,7 +413,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(sampleRate: distributedTraceSampling)
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
         let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -285,7 +285,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
         writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
@@ -324,7 +324,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
         writer.traceHeaderFields.forEach { field, value in request.setValue(value, forHTTPHeaderField: field) }
@@ -364,7 +364,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
         let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)
@@ -413,7 +413,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         var request: URLRequest = .mockAny()
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
         let parentSpan = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
         let span = Tracer.shared(in: core).startSpan(operationName: "network.span")
         Tracer.shared(in: core).inject(spanContext: span.context, writer: writer)

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -732,7 +732,7 @@ class TracerTests: XCTestCase {
         let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
         tracer.inject(spanContext: injectedContext, writer: writer)
 
         let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
@@ -753,7 +753,7 @@ class TracerTests: XCTestCase {
         let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        let writer = B3HTTPHeadersWriter(samplingStrategy: .auto, injectEncoding: .single)
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .headBased, injectEncoding: .single)
         tracer.inject(spanContext: injectedContext, writer: writer)
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
@@ -774,7 +774,7 @@ class TracerTests: XCTestCase {
         let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        let writer = B3HTTPHeadersWriter(samplingStrategy: .auto, injectEncoding: .multiple)
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .headBased, injectEncoding: .multiple)
         tracer.inject(spanContext: injectedContext, writer: writer)
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
@@ -795,7 +795,7 @@ class TracerTests: XCTestCase {
         let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        let writer = W3CHTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = W3CHTTPHeadersWriter(samplingStrategy: .headBased)
         tracer.inject(spanContext: injectedContext, writer: writer)
 
         let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -725,327 +725,88 @@ class TracerTests: XCTestCase {
 
     // MARK: - Injecting span context into carrier
 
-    func testItInjectsSpanContextWithHTTPHeadersWriter() {
+    func testInjectingAndExtractingSpanContextUsingDatadogCarrier() {
+        // Given
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext2 = DDSpanContext(traceID: 3, spanID: 4, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockKeepAll())
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
+        let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        tracer.inject(spanContext: spanContext1, writer: httpHeadersWriter)
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        tracer.inject(spanContext: injectedContext, writer: writer)
+
+        let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
+        let extractedContext = tracer.extract(reader: reader)!
 
         // Then
-        let expectedHTTPHeaders1 = [
-            "x-datadog-trace-id": "64",
-            "x-datadog-parent-id": "c8",
-            "x-datadog-sampling-priority": "1",
-            "x-datadog-tags": "_dd.p.tid=a"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
-
-        // When
-        tracer.inject(spanContext: spanContext2, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders2 = [
-            "x-datadog-trace-id": "3",
-            "x-datadog-parent-id": "4",
-            "x-datadog-sampling-priority": "1",
-            "x-datadog-tags": "_dd.p.tid=0"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
+        XCTAssertEqual(injectedContext.dd.traceID, extractedContext.dd.traceID)
+        XCTAssertEqual(injectedContext.dd.spanID, extractedContext.dd.spanID)
+        XCTAssertEqual(injectedContext.dd.parentSpanID, extractedContext.dd.parentSpanID)
+        XCTAssertEqual(injectedContext.dd.sampleRate, extractedContext.dd.sampleRate)
+        XCTAssertEqual(injectedContext.dd.isKept, extractedContext.dd.isKept)
     }
 
-    func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingMultipleHeaders() {
+    func testInjectingAndExtractingSpanContextUsingB3SingleCarrier() {
+        // Given
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .multiple)
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
+        let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        tracer.inject(spanContext: spanContext1, writer: httpHeadersWriter)
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .auto, injectEncoding: .single)
+        tracer.inject(spanContext: injectedContext, writer: writer)
+
+        let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
+        let extractedContext = tracer.extract(reader: reader)!
 
         // Then
-        let expectedHTTPHeaders1 = [
-            "X-B3-TraceId": "000000000000000a0000000000000064",
-            "X-B3-SpanId": "00000000000000c8",
-            "X-B3-Sampled": "1",
-            "X-B3-ParentSpanId": "0000000000000003"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
-
-        // When
-        tracer.inject(spanContext: spanContext2, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders2 = [
-            "X-B3-TraceId": "00000000000000000000000000000004",
-            "X-B3-SpanId": "0000000000000005",
-            "X-B3-Sampled": "1",
-            "X-B3-ParentSpanId": "0000000000000006"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
-
-        // When
-        tracer.inject(spanContext: spanContext3, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders3 = [
-            "X-B3-TraceId": "0000000000000000000000000000004d",
-            "X-B3-SpanId": "0000000000000058",
-            "X-B3-Sampled": "1"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
+        XCTAssertEqual(injectedContext.dd.traceID, extractedContext.dd.traceID)
+        XCTAssertEqual(injectedContext.dd.spanID, extractedContext.dd.spanID)
+        XCTAssertEqual(injectedContext.dd.parentSpanID, extractedContext.dd.parentSpanID)
+        XCTAssertEqual(injectedContext.dd.sampleRate, extractedContext.dd.sampleRate)
+        XCTAssertEqual(injectedContext.dd.isKept, extractedContext.dd.isKept)
     }
 
-    func testItInjectsSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
+    func testInjectingAndExtractingSpanContextUsingB3MultipleCarrier() {
+        // Given
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .single)
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
+        let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        tracer.inject(spanContext: spanContext1, writer: httpHeadersWriter)
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .auto, injectEncoding: .multiple)
+        tracer.inject(spanContext: injectedContext, writer: writer)
+
+        let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
+        let extractedContext = tracer.extract(reader: reader)!
 
         // Then
-        let expectedHTTPHeaders1 = [
-            "b3": "000000000000000a0000000000000064-00000000000000c8-1-0000000000000003"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
-
-        // When
-        tracer.inject(spanContext: spanContext2, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders2 = [
-            "b3": "00000000000000000000000000000004-0000000000000005-1-0000000000000006"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
-
-        // When
-        tracer.inject(spanContext: spanContext3, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders3 = [
-            "b3": "0000000000000000000000000000004d-0000000000000058-1"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
+        XCTAssertEqual(injectedContext.dd.traceID, extractedContext.dd.traceID)
+        XCTAssertEqual(injectedContext.dd.spanID, extractedContext.dd.spanID)
+        XCTAssertEqual(injectedContext.dd.parentSpanID, extractedContext.dd.parentSpanID)
+        XCTAssertEqual(injectedContext.dd.sampleRate, extractedContext.dd.sampleRate)
+        XCTAssertEqual(injectedContext.dd.isKept, extractedContext.dd.isKept)
     }
 
-    func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingSingleHeader() {
+    func testInjectingAndExtractingSpanContextUsingW3CCarrier() {
+        // Given
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockRejectAll())
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
+        let injectedContext = tracer.startSpan(operationName: .mockAny()).context
 
         // When
-        tracer.inject(spanContext: spanContext, writer: httpHeadersWriter)
+        let writer = W3CHTTPHeadersWriter(samplingStrategy: .auto)
+        tracer.inject(spanContext: injectedContext, writer: writer)
+
+        let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
+        let extractedContext = tracer.extract(reader: reader)!
 
         // Then
-        let expectedHTTPHeaders = [
-            "b3": "0"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
-    }
-
-    func testItInjectsRejectedSpanContextWithB3HTTPHeadersWriter_usingMultipleHeader() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockRejectAll(), injectEncoding: .multiple)
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
-
-        // When
-        tracer.inject(spanContext: spanContext, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders = [
-            "X-B3-Sampled": "0"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
-    }
-
-    func testItInjectsSpanContextWithW3CHTTPHeadersWriter() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let spanContext1 = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext2 = DDSpanContext(traceID: 4, spanID: 5, parentSpanID: 6, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-        let spanContext3 = DDSpanContext(traceID: 77, spanID: 88, parentSpanID: nil, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: Sampler.mockKeepAll(),
-            tracestate: [
-                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
-            ]
-        )
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
-
-        // When
-        tracer.inject(spanContext: spanContext1, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders1 = [
-            "tracestate": "dd=o:rum;p:00000000000000c8;s:1",
-            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-01"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders1)
-
-        // When
-        tracer.inject(spanContext: spanContext2, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders2 = [
-            "tracestate": "dd=o:rum;p:0000000000000005;s:1",
-            "traceparent": "00-00000000000000000000000000000004-0000000000000005-01"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders2)
-
-        // When
-        tracer.inject(spanContext: spanContext3, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders3 = [
-            "tracestate": "dd=o:rum;p:0000000000000058;s:1",
-            "traceparent": "00-0000000000000000000000000000004d-0000000000000058-01"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders3)
-    }
-
-    func testItInjectsRejectedSpanContextWithW3CHTTPHeadersWriter() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: Sampler.mockRejectAll(),
-            tracestate: [
-                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
-            ]
-        )
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
-
-        // When
-        tracer.inject(spanContext: spanContext, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders = [
-            "tracestate": "dd=o:rum;p:00000000000000c8;s:0",
-            "traceparent": "00-000000000000000a0000000000000064-00000000000000c8-00"
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
-    }
-
-    func testItInjectsRejectedSpanContextWithHTTPHeadersWriter() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let spanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockRejectAll())
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, [:])
-
-        // When
-        tracer.inject(spanContext: spanContext, writer: httpHeadersWriter)
-
-        // Then
-        let expectedHTTPHeaders = [
-            "x-datadog-sampling-priority": "0",
-        ]
-        XCTAssertEqual(httpHeadersWriter.traceHeaderFields, expectedHTTPHeaders)
-    }
-
-    func testItExtractsSpanContextWithHTTPHeadersReader() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: .mockAny(), baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = HTTPHeadersWriter(sampler: Sampler.mockKeepAll())
-        tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
-
-        let httpHeadersReader = HTTPHeadersReader(
-            httpHeaderFields: httpHeadersWriter.traceHeaderFields
-        )
-        let extractedSpanContext = tracer.extract(reader: httpHeadersReader)
-
-        XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
-        XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
-        XCTAssertNil(extractedSpanContext?.dd.parentSpanID)
-        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
-    }
-
-    func testItExtractsSpanContextWithB3HTTPHeadersReader_forMultipleHeaders() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .multiple)
-        tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
-
-        let httpHeadersReader = B3HTTPHeadersReader(
-            httpHeaderFields: httpHeadersWriter.traceHeaderFields
-        )
-        let extractedSpanContext = tracer.extract(reader: httpHeadersReader)
-
-        XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
-        XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
-        XCTAssertEqual(extractedSpanContext?.dd.parentSpanID, injectedSpanContext.dd.parentSpanID)
-        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
-    }
-
-    func testItExtractsSpanContextWithB3HTTPHeadersReader_forSingleHeader() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = B3HTTPHeadersWriter(sampler: Sampler.mockKeepAll(), injectEncoding: .single)
-        tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
-
-        let httpHeadersReader = B3HTTPHeadersReader(
-            httpHeaderFields: httpHeadersWriter.traceHeaderFields
-        )
-        let extractedSpanContext = tracer.extract(reader: httpHeadersReader)
-
-        XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
-        XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
-        XCTAssertEqual(extractedSpanContext?.dd.parentSpanID, injectedSpanContext.dd.parentSpanID)
-        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
-    }
-
-    func testItExtractsSpanContextWithW3CHTTPHeadersReader() {
-        Trace.enable(with: config, in: core)
-        let tracer = Tracer.shared(in: core)
-        let injectedSpanContext = DDSpanContext(traceID: .init(idHi: 10, idLo: 100), spanID: 200, parentSpanID: 3, baggageItems: .mockAny(), sampleRate: .mockRandom(), isKept: .mockRandom())
-
-        let httpHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: Sampler.mockKeepAll(),
-            tracestate: [
-                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
-            ]
-        )
-        tracer.inject(spanContext: injectedSpanContext, writer: httpHeadersWriter)
-
-        let httpHeadersReader = W3CHTTPHeadersReader(
-            httpHeaderFields: httpHeadersWriter.traceHeaderFields
-        )
-        let extractedSpanContext = tracer.extract(reader: httpHeadersReader)
-
-        XCTAssertEqual(extractedSpanContext?.dd.traceID, injectedSpanContext.dd.traceID)
-        XCTAssertEqual(extractedSpanContext?.dd.spanID, injectedSpanContext.dd.spanID)
-        XCTAssertNil(extractedSpanContext?.dd.parentSpanID)
-        XCTAssertEqual(extractedSpanContext?.dd.sampleRate, config.sampleRate)
+        XCTAssertEqual(injectedContext.dd.traceID, extractedContext.dd.traceID)
+        XCTAssertEqual(injectedContext.dd.spanID, extractedContext.dd.spanID)
+        XCTAssertEqual(injectedContext.dd.parentSpanID, extractedContext.dd.parentSpanID)
+        XCTAssertEqual(injectedContext.dd.sampleRate, extractedContext.dd.sampleRate)
+        XCTAssertEqual(injectedContext.dd.isKept, extractedContext.dd.isKept)
     }
 
     // MARK: - Span Dates Correction

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -203,7 +203,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDHTTPHeadersWriter(sampleRate: 100)
+        let objcWriter = DDHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -222,7 +222,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDHTTPHeadersWriter(sampleRate: 0)
+        let objcWriter = DDHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -236,7 +236,7 @@ class DDTracerTests: XCTestCase {
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
-        let objcValidWriter = DDHTTPHeadersWriter(sampleRate: 100)
+        let objcValidWriter = DDHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         let objcInvalidFormat = "foo"
         XCTAssertThrowsError(
             try objcTracer.inject(objcSpanContext, format: objcInvalidFormat, carrier: objcValidWriter)
@@ -256,7 +256,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDB3HTTPHeadersWriter(sampleRate: 100)
+        let objcWriter = DDB3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -272,7 +272,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDB3HTTPHeadersWriter(sampleRate: 0)
+        let objcWriter = DDB3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -286,7 +286,7 @@ class DDTracerTests: XCTestCase {
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
-        let objcValidWriter = DDB3HTTPHeadersWriter(sampleRate: 100)
+        let objcValidWriter = DDB3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         let objcInvalidFormat = "foo"
         XCTAssertThrowsError(
             try objcTracer.inject(objcSpanContext, format: objcInvalidFormat, carrier: objcValidWriter)
@@ -306,7 +306,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDW3CHTTPHeadersWriter(sampleRate: 100)
+        let objcWriter = DDW3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -323,7 +323,7 @@ class DDTracerTests: XCTestCase {
             swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200)
         )
 
-        let objcWriter = DDW3CHTTPHeadersWriter(sampleRate: 0)
+        let objcWriter = DDW3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
@@ -338,7 +338,7 @@ class DDTracerTests: XCTestCase {
         let objcTracer = DDTracer.shared()
         let objcSpanContext = DDSpanContextObjc(swiftSpanContext: DDSpanContext.mockWith(traceID: .init(idHi: 10, idLo: 100), spanID: 200))
 
-        let objcValidWriter = DDW3CHTTPHeadersWriter(sampleRate: 100)
+        let objcValidWriter = DDW3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
         let objcInvalidFormat = "foo"
         XCTAssertThrowsError(
             try objcTracer.inject(objcSpanContext, format: objcInvalidFormat, carrier: objcValidWriter)

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDB3HTTPHeadersWriter+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDB3HTTPHeadersWriter+apiTests.m
@@ -19,7 +19,10 @@
 #pragma clang diagnostic ignored "-Wunused-value"
 
 - (void)testInitWithSamplingRate {
-    [[DDB3HTTPHeadersWriter alloc] initWithSampleRate:100 injectEncoding:DDInjectEncodingSingle];
+    [[DDB3HTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy headBased]
+                                             injectEncoding:DDInjectEncodingSingle];
+    [[DDB3HTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy customWithSampleRate:50]
+                                             injectEncoding:DDInjectEncodingMultiple];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDHTTPHeadersWriter+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDHTTPHeadersWriter+apiTests.m
@@ -19,7 +19,8 @@
 #pragma clang diagnostic ignored "-Wunused-value"
 
 - (void)testInitWithSamplingRate {
-    [[DDHTTPHeadersWriter alloc] initWithSampleRate:50];
+    [[DDHTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy headBased]];
+    [[DDHTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy customWithSampleRate:50]];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDW3CHTTPHeadersWriter+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDW3CHTTPHeadersWriter+apiTests.m
@@ -19,7 +19,9 @@
 #pragma clang diagnostic ignored "-Wunused-value"
 
 - (void)testInitWithSamplingRate {
-    [[DDW3CHTTPHeadersWriter alloc] initWithSampleRate:50];
+    [[DDW3CHTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy headBased]];
+    [[DDW3CHTTPHeadersWriter alloc] initWithSamplingStrategy:[DDTraceSamplingStrategy customWithSampleRate:50]];
+
 }
 
 #pragma clang diagnostic pop

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -34,16 +34,12 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     public private(set) var traceHeaderFields: [String: String] = [:]
 
-    /// The tracing sampler.
-    ///
-    /// This value will decide of the `x-datadog-sampling-priority` header field value
-    /// and if `x-datadog-trace-id` and `x-datadog-parent-id` are propagated.
-    private let sampler: Sampling
+    private let samplingStrategy: TraceSamplingStrategy
 
     /// Initializes the headers writer.
     ///
     /// - Parameter samplingRate: The sampling rate applied for headers injection.
-    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(samplingRate: Float) {
         self.init(sampleRate: samplingRate)
     }
@@ -51,15 +47,16 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     /// Initializes the headers writer.
     ///
     /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(sampleRate: Float = 20) {
-        self.init(sampler: Sampler(samplingRate: sampleRate))
+        self.init(samplingStrategy: .custom(sampleRate: sampleRate))
     }
 
     /// Initializes the headers writer.
     ///
-    /// - Parameter sampler: The sampler used for headers injection.
-    public init(sampler: Sampling) {
-        self.sampler = sampler
+    /// - Parameter samplingStrategy: The strategy for sampling trace propagation headers.
+    public init(samplingStrategy: TraceSamplingStrategy) {
+        self.samplingStrategy = samplingStrategy
     }
 
     /// Writes the trace ID, span ID, and optional parent span ID into the trace propagation headers.
@@ -67,17 +64,18 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     /// - Parameter traceID: The trace ID.
     /// - Parameter spanID: The span ID.
     /// - Parameter parentSpanID: The parent span ID, if applicable.
-    public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
-        let samplingPriority = sampler.sample()
+    public func write(traceContext: TraceContext) {
+        let sampler = samplingStrategy.sampler(for: traceContext)
+        let sampled = sampler.sample()
 
         traceHeaderFields = [
-            TracingHTTPHeaders.samplingPriorityField: samplingPriority ? "1" : "0"
+            TracingHTTPHeaders.samplingPriorityField: sampled ? "1" : "0"
         ]
 
-        if samplingPriority {
-            traceHeaderFields[TracingHTTPHeaders.traceIDField] = traceID.idLoHex
-            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(spanID, representation: .hexadecimal)
-            traceHeaderFields[TracingHTTPHeaders.tagsField] = "_dd.p.tid=\(traceID.idHiHex)"
+        if sampled {
+            traceHeaderFields[TracingHTTPHeaders.traceIDField] = traceContext.traceID.idLoHex
+            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(traceContext.spanID, representation: .hexadecimal)
+            traceHeaderFields[TracingHTTPHeaders.tagsField] = "_dd.p.tid=\(traceContext.traceID.idHiHex)"
         }
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersWriter.swift
@@ -13,7 +13,7 @@ public enum TraceSamplingStrategy {
     /// Use this option to leverage head-based sampling, where the decision to keep or drop the trace
     /// is determined from the first span of the trace, the head, when the trace is created. With `.auto`
     /// strategy, this decision is propagated through the request context to downstream services.
-    case auto
+    case headBased
     /// Trace propagation headers will be sampled independently from sampling decision in propagated span.
     ///
     /// Use this option to apply the provided `sampleRate` for determining the decision to keep or drop the trace
@@ -22,7 +22,7 @@ public enum TraceSamplingStrategy {
 
     internal func sampler(for traceContext: TraceContext) -> Sampling {
         switch self {
-        case .auto:
+        case .headBased:
             return DeterministicSampler(shouldSample: traceContext.isKept, samplingRate: traceContext.sampleRate)
         case .custom(let sampleRate):
             return Sampler(samplingRate: sampleRate)

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -38,17 +38,13 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     /// This value will be merged with the tracestate from the trace context.
     private let tracestate: [String: String]
 
-    /// The tracing sampler.
-    ///
-    /// This value will decide of the `FLAG_SAMPLED` header field value
-    /// and if `trace-id`, `span-id` are propagated.
-    private let sampler: Sampling
+    private let samplingStrategy: TraceSamplingStrategy
 
     /// Initializes the headers writer.
     ///
     /// - Parameter samplingRate: The sampling rate applied for headers injection.
     /// - Parameter tracestate: The tracestate to be injected.
-    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(samplingRate: Float) {
         self.init(sampleRate: samplingRate, tracestate: [:])
     }
@@ -57,16 +53,17 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
     /// - Parameter tracestate: The tracestate to be injected.
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(sampleRate: Float = 20, tracestate: [String: String] = [:]) {
-        self.init(sampler: Sampler(samplingRate: sampleRate), tracestate: tracestate)
+        self.init(samplingStrategy: .custom(sampleRate: sampleRate), tracestate: tracestate)
     }
 
     /// Initializes the headers writer.
     ///
-    /// - Parameter sampler: The sampler used for headers injection.
+    /// - Parameter samplingStrategy: The strategy for sampling trace propagation headers.
     /// - Parameter tracestate: The tracestate to be injected.
-    public init(sampler: Sampling, tracestate: [String: String]) {
-        self.sampler = sampler
+    public init(samplingStrategy: TraceSamplingStrategy, tracestate: [String: String] = [:]) {
+        self.samplingStrategy = samplingStrategy
         self.tracestate = tracestate
     }
 
@@ -75,15 +72,16 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     /// - Parameter traceID: The trace ID.
     /// - Parameter spanID: The span ID.
     /// - Parameter parentSpanID: The parent span ID, if applicable.
-    public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
+    public func write(traceContext: TraceContext) {
         typealias Constants = W3CHTTPHeaders.Constants
 
+        let sampler = samplingStrategy.sampler(for: traceContext)
         let sampled = sampler.sample()
 
         traceHeaderFields[W3CHTTPHeaders.traceparent] = [
             Constants.version,
-            String(traceID, representation: .hexadecimal32Chars),
-            String(spanID, representation: .hexadecimal16Chars),
+            String(traceContext.traceID, representation: .hexadecimal32Chars),
+            String(traceContext.spanID, representation: .hexadecimal16Chars),
             sampled ? Constants.sampledValue : Constants.unsampledValue
         ]
         .joined(separator: Constants.separator)
@@ -92,7 +90,7 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
         // over the ones from the trace context
         let tracestate: [String: String] = [
             Constants.sampling: "\(sampled ? 1 : 0)",
-            Constants.parentId: String(spanID, representation: .hexadecimal16Chars)
+            Constants.parentId: String(traceContext.spanID, representation: .hexadecimal16Chars)
         ].merging(tracestate) { old, new in
             return new
         }

--- a/DatadogInternal/Sources/Utils/Sampler.swift
+++ b/DatadogInternal/Sources/Utils/Sampler.swift
@@ -32,23 +32,16 @@ public struct Sampler: Sampling {
 }
 
 /// A sampler that determines sampling decisions deterministically (the same each time).
-public struct DeterministicSampler: Sampling {
+internal struct DeterministicSampler: Sampling {
     /// Value between `0.0` and `100.0`, where `0.0` means NO event will be sent and `100.0` means ALL events will be sent.
-    public let samplingRate: Float
+    let samplingRate: Float
     /// Persisted sampling decision.
     private let shouldSample: Bool
 
-    public init(sampler: Sampler) {
-        self.init(
-            shouldSample: sampler.sample(),
-            samplingRate: sampler.samplingRate
-        )
-    }
-
-    public init(shouldSample: Bool, samplingRate: Float) {
+    init(shouldSample: Bool, samplingRate: Float) {
         self.samplingRate = samplingRate
         self.shouldSample = shouldSample
     }
 
-    public func sample() -> Bool { shouldSample }
+    func sample() -> Bool { shouldSample }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersReaderTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+import TestUtilities
 import DatadogInternal
 
 class B3HTTPHeadersReaderTests: XCTestCase {
@@ -80,8 +81,8 @@ class B3HTTPHeadersReaderTests: XCTestCase {
 
     func testReadingSampledTraceContext() {
         let encoding: B3HTTPHeadersWriter.InjectEncoding = [.multiple, .single].randomElement()!
-        let writer = B3HTTPHeadersWriter(sampleRate: 100, injectEncoding: encoding)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100), injectEncoding: encoding)
+        writer.write(traceContext: .mockRandom())
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
@@ -90,8 +91,8 @@ class B3HTTPHeadersReaderTests: XCTestCase {
 
     func testReadingNotSampledTraceContext() {
         let encoding: B3HTTPHeadersWriter.InjectEncoding = [.multiple, .single].randomElement()!
-        let writer = B3HTTPHeadersWriter(sampleRate: 0, injectEncoding: encoding)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = B3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0), injectEncoding: encoding)
+        writer.write(traceContext: .mockRandom())
 
         let reader = B3HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")

--- a/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/B3HTTPHeadersWriterTests.swift
@@ -11,7 +11,7 @@ import DatadogInternal
 class B3HTTPHeadersWriterTests: XCTestCase {
     func testWritingSampledTraceContext_withSingleEncoding_andAutoSamplingStrategy() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .single
         )
 
@@ -30,7 +30,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
 
     func testWritingDroppedTraceContext_withSingleEncoding_andAutoSamplingStrategy() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .single
         )
 
@@ -87,7 +87,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
 
     func testItWritesSingleHeaderWithoutOptionalValues() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .single
         )
 
@@ -105,7 +105,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
 
     func testWritingSampledTraceContext_withMultipleEncoding_andAutoSamplingStrategy() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .multiple
         )
 
@@ -127,7 +127,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
 
     func testWritingDroppedTraceContext_withMultipleEncoding_andAutoSamplingStrategy() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .multiple
         )
 
@@ -193,7 +193,7 @@ class B3HTTPHeadersWriterTests: XCTestCase {
 
     func testItWritesMultipleHeaderWithoutOptionalValues() {
         let writer = B3HTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             injectEncoding: .multiple
         )
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersReaderTests.swift
@@ -5,12 +5,13 @@
  */
 
 import XCTest
+import TestUtilities
 @testable import DatadogInternal
 
 class HTTPHeadersReaderTests: XCTestCase {
     func testReadingSampledTraceContext() {
-        let writer = HTTPHeadersWriter(sampleRate: 100)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
+        writer.write(traceContext: .mockRandom())
 
         let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
@@ -18,8 +19,8 @@ class HTTPHeadersReaderTests: XCTestCase {
     }
 
     func testReadingNotSampledTraceContext() {
-        let writer = HTTPHeadersWriter(sampleRate: 0)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
+        writer.write(traceContext: .mockRandom())
 
         let reader = HTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 
 class HTTPHeadersWriterTests: XCTestCase {
     func testWritingSampledTraceContext_withAutoSamplingStrategy() {
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
 
         writer.write(
             traceContext: .mockWith(
@@ -28,7 +28,7 @@ class HTTPHeadersWriterTests: XCTestCase {
     }
 
     func testWritingDroppedTraceContext_withAutoSamplingStrategy() {
-        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+        let writer = HTTPHeadersWriter(samplingStrategy: .headBased)
 
         writer.write(
             traceContext: .mockWith(

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+class HTTPHeadersWriterTests: XCTestCase {
+    func testWritingSampledTraceContext_withAutoSamplingStrategy() {
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: true
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "1")
+        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "4d2")
+        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "929")
+        XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
+    }
+
+    func testWritingDroppedTraceContext_withAutoSamplingStrategy() {
+        let writer = HTTPHeadersWriter(samplingStrategy: .auto)
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: false
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "0")
+        XCTAssertNil(headers[TracingHTTPHeaders.traceIDField])
+        XCTAssertNil(headers[TracingHTTPHeaders.parentSpanIDField])
+        XCTAssertNil(headers[TracingHTTPHeaders.tagsField])
+    }
+
+    func testWritingSampledTraceContext_withCustomSamplingStrategy() {
+        let writer = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: .random()
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "1")
+        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "4d2")
+        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "929")
+        XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
+    }
+
+    func testWritingDroppedTraceContext_withCustomSamplingStrategy() {
+        let writer = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: .random()
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "0")
+        XCTAssertNil(headers[TracingHTTPHeaders.traceIDField])
+        XCTAssertNil(headers[TracingHTTPHeaders.parentSpanIDField])
+        XCTAssertNil(headers[TracingHTTPHeaders.tagsField])
+    }
+}

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersReaderTests.swift
@@ -27,8 +27,8 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
     }
 
     func testReadingSampledTraceContext() {
-        let writer = W3CHTTPHeadersWriter(sampleRate: 100)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = W3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100))
+        writer.write(traceContext: .mockRandom())
 
         let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNotNil(reader.read(), "When sampled, it should return trace context")
@@ -36,8 +36,8 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
     }
 
     func testReadingNotSampledTraceContext() {
-        let writer = W3CHTTPHeadersWriter(sampleRate: 0)
-        writer.write(traceID: .mockAny(), spanID: .mockAny(), parentSpanID: .mockAny())
+        let writer = W3CHTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 0))
+        writer.write(traceContext: .mockRandom())
 
         let reader = W3CHTTPHeadersReader(httpHeaderFields: writer.traceHeaderFields)
         XCTAssertNil(reader.read(), "When not sampled, it should return no trace context")

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -5,35 +5,92 @@
  */
 
 import XCTest
-@testable import DatadogInternal
+import TestUtilities
+import DatadogInternal
 
 class W3CHTTPHeadersWriterTests: XCTestCase {
-    func testW3CHTTPHeadersWriterWritesSingleHeader() {
-        let sampler: Sampler = .mockKeepAll()
-        let w3cHTTPHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: sampler,
+    func testWritingSampledTraceContext_withAutoSamplingStrategy() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .auto,
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
         )
-        w3cHTTPHeadersWriter.write(traceID: .init(idHi: 1_234, idLo: 1_234), spanID: 2_345)
 
-        let headers = w3cHTTPHeadersWriter.traceHeaderFields
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: true
+            )
+        )
+
+        let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
     }
 
-    func testW3CHTTPHeadersWriterWritesSingleHeaderWithSampling() {
-        let sampler: Sampler = .mockRejectAll()
-        let w3cHTTPHeadersWriter = W3CHTTPHeadersWriter(
-            sampler: sampler,
+    func testWritingDroppedTraceContext_withAutoSamplingStrategy() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .auto,
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
         )
-        w3cHTTPHeadersWriter.write(traceID: .init(idHi: 1_234, idLo: 1_234), spanID: 2_345, parentSpanID: 5_678)
 
-        let headers = w3cHTTPHeadersWriter.traceHeaderFields
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                parentSpanID: 5_678,
+                isKept: false
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-00")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
+    }
+
+    func testWritingSampledTraceContext_withCustomSamplingStrategy() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: 100),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: .random()
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
+    }
+
+    func testWritingDroppedTraceContext_withCustomSamplingStrategy() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: 0),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ]
+        )
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                parentSpanID: 5_678,
+                isKept: .random()
+            )
+        )
+
+        let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-00")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -11,7 +11,7 @@ import DatadogInternal
 class W3CHTTPHeadersWriterTests: XCTestCase {
     func testWritingSampledTraceContext_withAutoSamplingStrategy() {
         let writer = W3CHTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]
@@ -32,7 +32,7 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
 
     func testWritingDroppedTraceContext_withAutoSamplingStrategy() {
         let writer = W3CHTTPHeadersWriter(
-            samplingStrategy: .auto,
+            samplingStrategy: .headBased,
             tracestate: [
                 W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
             ]

--- a/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
@@ -51,7 +51,7 @@ public class DDB3HTTPHeadersWriter: NSObject {
         injectEncoding: DDInjectEncoding = .single
     ) {
         swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(
-            sampleRate: sampleRate,
+            samplingStrategy: .custom(sampleRate: sampleRate),
             injectEncoding: .init(injectEncoding)
         )
     }

--- a/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
@@ -37,7 +37,7 @@ public class DDB3HTTPHeadersWriter: NSObject {
     }
 
     @objc
-    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:injectEncoding:)` instead.")
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(
         samplingRate: Float,
         injectEncoding: DDInjectEncoding = .single
@@ -46,12 +46,24 @@ public class DDB3HTTPHeadersWriter: NSObject {
     }
 
     @objc
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public init(
         sampleRate: Float = 20,
         injectEncoding: DDInjectEncoding = .single
     ) {
         swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate),
+            injectEncoding: .init(injectEncoding)
+        )
+    }
+
+    @objc
+    public init(
+        samplingStrategy: DDTraceSamplingStrategy,
+        injectEncoding: DDInjectEncoding = .single
+    ) {
+        swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(
+            samplingStrategy: samplingStrategy.swiftType,
             injectEncoding: .init(injectEncoding)
         )
     }

--- a/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -23,6 +23,8 @@ public class DDHTTPHeadersWriter: NSObject {
 
     @objc
     public init(sampleRate: Float = 20) {
-        swiftHTTPHeadersWriter = HTTPHeadersWriter(sampleRate: sampleRate)
+        swiftHTTPHeadersWriter = HTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: sampleRate)
+        )
     }
 }

--- a/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -16,15 +16,23 @@ public class DDHTTPHeadersWriter: NSObject {
     }
 
     @objc
-    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(samplingRate: Float) {
         self.init(sampleRate: samplingRate)
     }
 
     @objc
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public init(sampleRate: Float = 20) {
         swiftHTTPHeadersWriter = HTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate)
+        )
+    }
+
+    @objc
+    public init(samplingStrategy: DDTraceSamplingStrategy) {
+        swiftHTTPHeadersWriter = HTTPHeadersWriter(
+            samplingStrategy: samplingStrategy.swiftType
         )
     }
 }

--- a/DatadogObjc/Sources/Tracing/Propagation/TraceSamplingStrategy+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/TraceSamplingStrategy+objc.swift
@@ -1,38 +1,37 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019-2020 Datadog, Inc.
+ * Copyright 2019-Present Datadog, Inc.
  */
 
 import Foundation
+import DatadogInternal
 
 /// Available strategies for sampling trace propagation headers.
-public enum TraceSamplingStrategy {
+@objc
+public class DDTraceSamplingStrategy: NSObject {
+    internal let swiftType: DatadogInternal.TraceSamplingStrategy
+
     /// Trace propagation headers will be sampled same as propagated span.
     ///
     /// Use this option to leverage head-based sampling, where the decision to keep or drop the trace
     /// is determined from the first span of the trace, the head, when the trace is created. With `.headBased`
     /// strategy, this decision is propagated through the request context to downstream services.
-    case headBased
+    @objc
+    public static func headBased() -> DDTraceSamplingStrategy {
+        return DDTraceSamplingStrategy(swiftType: .headBased)
+    }
+
     /// Trace propagation headers will be sampled independently from sampling decision in propagated span.
     ///
     /// Use this option to apply the provided `sampleRate` for determining the decision to keep or drop the trace
     /// in downstream services independently of sampling their parent span.
-    case custom(sampleRate: Float)
-
-    internal func sampler(for traceContext: TraceContext) -> Sampling {
-        switch self {
-        case .headBased:
-            return DeterministicSampler(shouldSample: traceContext.isKept, samplingRate: traceContext.sampleRate)
-        case .custom(let sampleRate):
-            return Sampler(samplingRate: sampleRate)
-        }
+    @objc
+    public static func custom(sampleRate: Float) -> DDTraceSamplingStrategy {
+        return DDTraceSamplingStrategy(swiftType: .custom(sampleRate: sampleRate))
     }
-}
 
-/// Write interface for a custom carrier
-public protocol TracePropagationHeadersWriter {
-    var traceHeaderFields: [String: String] { get }
-
-    func write(traceContext: TraceContext)
+    private init(swiftType: DatadogInternal.TraceSamplingStrategy) {
+        self.swiftType = swiftType
+    }
 }

--- a/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
@@ -23,6 +23,9 @@ public class DDW3CHTTPHeadersWriter: NSObject {
 
     @objc
     public init(sampleRate: Float = 20) {
-        swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(sampleRate: sampleRate, tracestate: [:])
+        swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: sampleRate),
+            tracestate: [:]
+        )
     }
 }

--- a/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
@@ -16,15 +16,26 @@ public class DDW3CHTTPHeadersWriter: NSObject {
     }
 
     @objc
-    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(samplingRate: Float) {
         self.init(sampleRate: samplingRate)
     }
 
     @objc
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public init(sampleRate: Float = 20) {
         swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate),
+            tracestate: [:]
+        )
+    }
+
+    @objc
+    public init(
+        samplingStrategy: DDTraceSamplingStrategy
+    ) {
+        swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(
+            samplingStrategy: samplingStrategy.swiftType,
             tracestate: [:]
         )
     }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -161,22 +161,22 @@ extension DistributedTracing {
             let writer: TracePropagationHeadersWriter
             switch $0 {
             case .datadog:
-                writer = HTTPHeadersWriter(samplingStrategy: .auto)
+                writer = HTTPHeadersWriter(samplingStrategy: .headBased)
                 // To make sure the generated traces from RUM don’t affect APM Index Spans counts.
                 request.setValue("rum", forHTTPHeaderField: TracingHTTPHeaders.originField)
             case .b3:
                 writer = B3HTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     injectEncoding: .single
                 )
             case .b3multi:
                 writer = B3HTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     injectEncoding: .multiple
                 )
             case .tracecontext:
                 writer = W3CHTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     tracestate: [
                         W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
                     ]

--- a/DatadogTrace/Sources/DDFormat.swift
+++ b/DatadogTrace/Sources/DDFormat.swift
@@ -20,11 +20,14 @@ extension TracePropagationHeadersWriter where Self: OTFormatWriter {
         guard let spanContext = spanContext.dd else {
             return
         }
-
         write(
-            traceID: spanContext.traceID,
-            spanID: spanContext.spanID,
-            parentSpanID: spanContext.parentSpanID
+            traceContext: TraceContext(
+                traceID: spanContext.traceID,
+                spanID: spanContext.spanID,
+                parentSpanID: spanContext.parentSpanID,
+                sampleRate: spanContext.sampleRate,
+                isKept: spanContext.isKept
+            )
         )
     }
 }

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -55,20 +55,20 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             let writer: TracePropagationHeadersWriter
             switch $0 {
             case .datadog:
-                writer = HTTPHeadersWriter(samplingStrategy: .auto)
+                writer = HTTPHeadersWriter(samplingStrategy: .headBased)
             case .b3:
                 writer = B3HTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     injectEncoding: .single
                 )
             case .b3multi:
                 writer = B3HTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     injectEncoding: .multiple
                 )
             case .tracecontext:
                 writer = W3CHTTPHeadersWriter(
-                    samplingStrategy: .auto,
+                    samplingStrategy: .headBased,
                     tracestate: [:]
                 )
             }

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -17,6 +17,7 @@ import DatadogInternal
 @_exported import class DatadogInternal.HTTPHeadersWriter
 @_exported import class DatadogInternal.B3HTTPHeadersWriter
 @_exported import class DatadogInternal.W3CHTTPHeadersWriter
+@_exported import enum DatadogInternal.TraceSamplingStrategy
 // swiftlint:enable duplicate_imports
 
 extension Trace {

--- a/DatadogTrace/Tests/DDNoopTracerTests.swift
+++ b/DatadogTrace/Tests/DDNoopTracerTests.swift
@@ -20,7 +20,7 @@ class DDNoopTracerTests: XCTestCase {
 
         // When
         let context = DDSpanContext.mockAny()
-        noop.inject(spanContext: context, writer: HTTPHeadersWriter())
+        noop.inject(spanContext: context, writer: HTTPHeadersWriter(samplingStrategy: .auto))
         _ = noop.extract(reader: HTTPHeadersReader(httpHeaderFields: [:]))
         let root = noop.startRootSpan(operationName: "root operation").setActive()
         let child = noop.startSpan(operationName: "child operation")

--- a/DatadogTrace/Tests/DDNoopTracerTests.swift
+++ b/DatadogTrace/Tests/DDNoopTracerTests.swift
@@ -20,7 +20,7 @@ class DDNoopTracerTests: XCTestCase {
 
         // When
         let context = DDSpanContext.mockAny()
-        noop.inject(spanContext: context, writer: HTTPHeadersWriter(samplingStrategy: .auto))
+        noop.inject(spanContext: context, writer: HTTPHeadersWriter(samplingStrategy: .headBased))
         _ = noop.extract(reader: HTTPHeadersReader(httpHeaderFields: [:]))
         let root = noop.startRootSpan(operationName: "root operation").setActive()
         let child = noop.startSpan(operationName: "child operation")

--- a/DatadogTrace/Tests/DatadogTracer+InjectAndExtract.swift
+++ b/DatadogTrace/Tests/DatadogTracer+InjectAndExtract.swift
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogTrace
+
+private class MockWriter: OTFormatWriter, TracePropagationHeadersWriter {
+    var traceHeaderFields: [String: String] = [:]
+    var injectedTraceContext: TraceContext?
+    func write(traceContext: TraceContext) { injectedTraceContext = traceContext }
+}
+
+private class MockReader: OTFormatReader, TracePropagationHeadersReader {
+    var extractedIDs: (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? = nil
+    var extractedIsKept: Bool? = nil
+
+    func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? { extractedIDs }
+    var sampled: Bool? { extractedIsKept }
+}
+
+class DatadogTracer_InjectAndExtract: XCTestCase {
+    private func createTracer(sampleRate: Float) -> DatadogTracer {
+        return DatadogTracer(
+            featureScope: NOPFeatureScope(),
+            localTraceSampler: Sampler(samplingRate: sampleRate),
+            tags: [:],
+            traceIDGenerator: DefaultTraceIDGenerator(),
+            spanIDGenerator: DefaultSpanIDGenerator(),
+            dateProvider: DateProviderMock(),
+            loggingIntegration: .mockAny(),
+            spanEventBuilder: .mockAny()
+        )
+    }
+
+    func testInjectingSpanContextIntoWriter() {
+        // Given
+        let spanContext = DDSpanContext(
+            traceID: .mockRandom(),
+            spanID: .mockRandom(),
+            parentSpanID: .mockRandom(),
+            baggageItems: .mockAny(),
+            sampleRate: .mockRandom(min: 0, max: 100),
+            isKept: .random()
+        )
+
+        let tracer = createTracer(sampleRate: 42)
+        let writer = MockWriter()
+        XCTAssertNil(writer.injectedTraceContext)
+
+        // When
+        tracer.inject(spanContext: spanContext, writer: writer)
+
+        // Then
+        let expectedTraceContext = TraceContext(
+            traceID: spanContext.traceID,
+            spanID: spanContext.spanID,
+            parentSpanID: spanContext.parentSpanID,
+            sampleRate: spanContext.sampleRate,
+            isKept: spanContext.isKept
+        )
+        XCTAssertEqual(writer.injectedTraceContext, expectedTraceContext)
+    }
+
+    func testExtractnigSpanContextFromReader() throws {
+        // Given
+        let tracer = createTracer(sampleRate: 42)
+        let reader = MockReader()
+        let ids: (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) = (.mockRandom(), .mockRandom(), .mockRandom())
+        let isKept: Bool = .mockRandom()
+        reader.extractedIDs = ids
+        reader.extractedIsKept = isKept
+
+        // When
+        let spanContext = try XCTUnwrap(tracer.extract(reader: reader) as? DDSpanContext)
+
+        // Then
+        XCTAssertEqual(spanContext.traceID, ids.traceID)
+        XCTAssertEqual(spanContext.spanID, ids.spanID)
+        XCTAssertEqual(spanContext.parentSpanID, ids.parentSpanID)
+        XCTAssertEqual(spanContext.sampleRate, 42)
+        XCTAssertEqual(spanContext.isKept, isKept)
+    }
+
+    func testExtractsEmptySpanContextFromReader() throws {
+        // Given
+        let tracer = createTracer(sampleRate: 42)
+        let reader = MockReader()
+        reader.extractedIDs = nil
+        reader.extractedIsKept = nil
+
+        // When
+        XCTAssertNil(tracer.extract(reader: reader))
+    }
+}

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -7,9 +7,13 @@
 import Foundation
 import DatadogInternal
 
-extension SpanID {
+extension SpanID: AnyMockable, RandomMockable {
     public static func mockAny() -> SpanID {
         return SpanID(rawValue: .mockAny())
+    }
+
+    public static func mockRandom() -> SpanID {
+        return SpanID(rawValue: .mockRandom())
     }
 
     public static func mock(_ rawValue: UInt64) -> SpanID {
@@ -18,9 +22,13 @@ extension SpanID {
 }
 
 
-extension TraceID {
+extension TraceID: AnyMockable, RandomMockable {
     public static func mockAny() -> TraceID {
         return TraceID(rawValue: (.mockAny(), .mockAny()))
+    }
+
+    public static func mockRandom() -> TraceID {
+        return TraceID(idHi: .mockRandom(), idLo: .mockRandom())
     }
 
     public static func mock(_ rawValue: (UInt64, UInt64)) -> TraceID {
@@ -33,6 +41,38 @@ extension TraceID {
 
     public static func mock(_ idLo: UInt64) -> TraceID {
         return TraceID(idLo: idLo)
+    }
+}
+
+extension TraceContext: AnyMockable, RandomMockable {
+    public static func mockAny() -> TraceContext {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> TraceContext {
+        return .mockWith(
+            traceID: .mockRandom(),
+            spanID: .mockRandom(),
+            parentSpanID: .mockRandom(),
+            sampleRate: .mockRandom(min: 0, max: 100),
+            isKept: .random()
+        )
+    }
+
+    public static func mockWith(
+        traceID: TraceID = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentSpanID: SpanID? = nil,
+        sampleRate: Float = .mockAny(),
+        isKept: Bool = .mockAny()
+    ) -> TraceContext {
+        return TraceContext(
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentSpanID,
+            sampleRate: sampleRate,
+            isKept: isKept
+        )
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR continues the efforts from #1783 and earlier #1772. It adds support to head-based sampling for distributed traces created manually with Tracer API:

- ✅ Distributed trace sent via Tracer API (`*HTTPHeadersWriter`):
```
client-ios-app:     [------ network.span -------]
client backend:         [--- backend span ---]
```
- ✅ Distributed trace sent via Tracer API (`*HTTPHeadersWriter`) with implicit parent:
```
client-ios-app:     [------ active.span -------]
client-ios-app:       [---- network.span ----]
client backend:         [-- backend span --]
```

### How?

In head-based sampling mode, headers must be sampled the same as the injected span context (`spanContext.isKept`). However, this contradicts with existing `init(sampleRate:...)` constructors. To accommodate this change, a new initializer (init(samplingStrategy: TraceSamplingStrategy)) was added to each headers writer. Additionally, existing constructors have been deprecated to encourage migration. Users should now consciously choose between arbitrary sampling or the new head-based approach:
```swift
// in HTTPHeadersWriter:
public init(sampleRate: Float = 20) // 🟨 now: deprecated
public init(samplingStrategy: TraceSamplingStrategy)


// in B3HTTPHeadersWriter:
public init(sampleRate: Float = 20, injectEncoding: InjectEncoding = .single) // 🟨 now: deprecated
public init(samplingStrategy: TraceSamplingStrategy, injectEncoding: InjectEncoding = .single) 

// in W3CHTTPHeadersWriter:
public init(sampleRate: Float = 20, tracestate: [String: String] = [:]) // 🟨 now: deprecated
public init(samplingStrategy: TraceSamplingStrategy, tracestate: [String: String] = [:])
```

The `TraceSamplingStrategy` enum enables both the new behavior (`.auto`) and the previous one (`.custom(sampleRate:)`):

```swift
/// Available strategies for sampling trace propagation headers.
public enum TraceSamplingStrategy {
    /// Trace propagation headers will be sampled same as propagated span.
    ///
    /// Use this option to leverage head-based sampling, where the decision to keep or drop the trace
    /// is determined from the first span of the trace, the head, when the trace is created. With `.auto`
    /// strategy, this decision is propagated through the request context to downstream services.
    case auto
    /// Trace propagation headers will be sampled independently from sampling decision in propagated span.
    ///
    /// Use this option to apply the provided `sampleRate` for determining the decision to keep or drop the trace
    /// in downstream services independently of sampling their parent span.
    case custom(sampleRate: Float)
}
```

### 💡 Alternatives Considered

Another option was introducing new types for head-based sampling, but this approach would require solving the `RUM-3535: Trace Context injection control` issue first. It would simplify things, notably the uniformity of setting trace propagation headers across writers which varies: 
- only if "keep" [in `HTTPHeadersWriter`](https://github.com/DataDog/dd-sdk-ios/blob/3c7ef1416ca6ce6d155094c3552237cf1ffcff9d/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift#L77) and [in `B3HTTPHeadersWriter`](https://github.com/DataDog/dd-sdk-ios/blob/3c7ef1416ca6ce6d155094c3552237cf1ffcff9d/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift#L123)
- "always" [in `W3CHTTPHeadersWriter`](https://github.com/DataDog/dd-sdk-ios/blob/3c7ef1416ca6ce6d155094c3552237cf1ffcff9d/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift#L87)

Adopting head-based sampling in existing writers was chosen to avoid this complexity.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
