### PR TITLE
Add `addUserExtraInfo` method to ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] `DatadogTrace` now supports head-based sampling. See [#1794][]
 - [FEATURE] Support WebView recording in Session Replay. See [#1776][]
+- [IMPROVEMENT] Add `addUserExtraInfo` method to ObjC API. See [#1799][]
 
 # 2.10.0 / 23-04-2024
 

--- a/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
@@ -92,6 +92,7 @@ class DDDatadogTests: XCTestCase {
                 "attribute-string": "string value"
             ]
         )
+        DDDatadog.addUserExtraInfo(["foo": "bar"])
         XCTAssertEqual(userInfo.current.id, "id")
         XCTAssertEqual(userInfo.current.name, "name")
         XCTAssertEqual(userInfo.current.email, "email")
@@ -99,6 +100,7 @@ class DDDatadogTests: XCTestCase {
         XCTAssertEqual(extraInfo["attribute-int"]?.value as? Int, 42)
         XCTAssertEqual(extraInfo["attribute-double"]?.value as? Double, 42.5)
         XCTAssertEqual(extraInfo["attribute-string"]?.value as? String, "string value")
+        XCTAssertEqual(extraInfo["foo"]?.value as? String, "bar")
 
         DDDatadog.setUserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
         XCTAssertNil(userInfo.current.id)

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDDatadog+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDDatadog+apiTests.m
@@ -33,6 +33,7 @@
     [DDDatadog setVerbosityLevel:verbosity];
 
     [DDDatadog setUserInfoWithId:@"" name:@"" email:@"" extraInfo:@{}];
+    [DDDatadog addUserExtraInfo:@{}];
     [DDDatadog setTrackingConsentWithConsent:[DDTrackingConsent notGranted]];
 
     [DDDatadog clearAllData];

--- a/DatadogObjc/Sources/Datadog+objc.swift
+++ b/DatadogObjc/Sources/Datadog+objc.swift
@@ -71,6 +71,11 @@ public class DDDatadog: NSObject {
     }
 
     @objc
+    public static func addUserExtraInfo(_ extraInfo: [String: Any]) {
+        Datadog.addUserExtraInfo(castAttributesToSwift(extraInfo))
+    }
+
+    @objc
     public static func setTrackingConsent(consent: DDTrackingConsent) {
         Datadog.set(trackingConsent: consent.sdkConsent)
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -25,6 +25,7 @@ public class DDDatadog: NSObject
     public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel)
     public static func verbosityLevel() -> DDSDKVerbosityLevel
     public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
+    public static func addUserExtraInfo(_ extraInfo: [String: Any])
     public static func setTrackingConsent(consent: DDTrackingConsent)
     public static func clearAllData()
 public class DDSite: NSObject


### PR DESCRIPTION
### What and why?

This method was missing in ObjC API, despite being present in Swift.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
