### PR TITLE
Add `isInitialized` and `stopInstance` methods to ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] `DatadogTrace` now supports head-based sampling. See [#1794][]
 - [FEATURE] Support WebView recording in Session Replay. See [#1776][]
+- [IMPROVEMENT] Add `isInitialized` and `stopInstance` methods to ObjC API. See [#1800][]
 - [IMPROVEMENT] Add `addUserExtraInfo` method to ObjC API. See [#1799][]
 
 # 2.10.0 / 23-04-2024

--- a/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
@@ -24,7 +24,7 @@ class DDDatadogTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Initializing with configuration
+    // MARK: - SDK initialization / stop lifecycle
 
     func testItForwardsInitializationToSwift() throws {
         let config = DDConfiguration(
@@ -46,6 +46,49 @@ class DDDatadogTests: XCTestCase {
         XCTAssertEqual(context.env, "tests")
 
         Datadog.flushAndDeinitialize()
+
+        XCTAssertNil(CoreRegistry.default.get(feature: LogsFeature.self))
+    }
+
+    func testItReflectsInitializationStatus() throws {
+        let config = DDConfiguration(
+            clientToken: "abcefghi",
+            env: "tests"
+        )
+
+        config.bundle = .mockWith(CFBundleExecutable: "app-name")
+        XCTAssertFalse(DDDatadog.isInitialized())
+
+        DDDatadog.initialize(
+            configuration: config,
+            trackingConsent: randomConsent().objc
+        )
+
+        XCTAssertTrue(DDDatadog.isInitialized())
+
+        Datadog.flushAndDeinitialize()
+
+        XCTAssertNil(CoreRegistry.default.get(feature: LogsFeature.self))
+    }
+
+    func testItForwardsStopInstanceToSwift() throws {
+        let config = DDConfiguration(
+            clientToken: "abcefghi",
+            env: "tests"
+        )
+
+        config.bundle = .mockWith(CFBundleExecutable: "app-name")
+
+        DDDatadog.initialize(
+            configuration: config,
+            trackingConsent: randomConsent().objc
+        )
+
+        XCTAssertTrue(Datadog.isInitialized())
+
+        DDDatadog.stopInstance()
+
+        XCTAssertFalse(Datadog.isInitialized())
 
         XCTAssertNil(CoreRegistry.default.get(feature: LogsFeature.self))
     }

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDDatadog+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDDatadog+apiTests.m
@@ -29,6 +29,8 @@
 
     [DDDatadog initializeWithConfiguration:configuration trackingConsent:[DDTrackingConsent notGranted]];
 
+    [DDDatadog isInitialized];
+
     DDSDKVerbosityLevel verbosity = [DDDatadog verbosityLevel];
     [DDDatadog setVerbosityLevel:verbosity];
 
@@ -37,7 +39,7 @@
     [DDDatadog setTrackingConsentWithConsent:[DDTrackingConsent notGranted]];
 
     [DDDatadog clearAllData];
-    [DDDatadog flushAndDeinitialize];
+    [DDDatadog stopInstance];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogObjc/Sources/Datadog+objc.swift
+++ b/DatadogObjc/Sources/Datadog+objc.swift
@@ -81,6 +81,16 @@ public class DDDatadog: NSObject {
     }
 
     @objc
+    public static func isInitialized() -> Bool {
+        return Datadog.isInitialized()
+    }
+
+    @objc
+    public static func stopInstance() {
+        Datadog.stopInstance()
+    }
+
+    @objc
     public static func clearAllData() {
         Datadog.clearAllData()
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -27,6 +27,8 @@ public class DDDatadog: NSObject
     public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
     public static func addUserExtraInfo(_ extraInfo: [String: Any])
     public static func setTrackingConsent(consent: DDTrackingConsent)
+    public static func isInitialized() -> Bool
+    public static func stopInstance()
     public static func clearAllData()
 public class DDSite: NSObject
     public static func us1() -> DDSite


### PR DESCRIPTION
### What and why?

This PR adds `isInitialized` and `stopInstance` methods to ObjC API which were missing, but exist in Swift API.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
