### PR TITLE
chore: Fix nightly tests build failure

### DIFF
--- a/Datadog/E2ETests/Tracing/TracerE2ETests.swift
+++ b/Datadog/E2ETests/Tracing/TracerE2ETests.swift
@@ -51,7 +51,7 @@ class TracerE2ETests: E2ETests {
     /// ```
     func test_trace_tracer_inject_span_context() {
         let anySpan = tracer.startSpan(operationName: .mockRandom()) // this span is never sent
-        let anyWriter = HTTPHeadersWriter()
+        let anyWriter = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 20))
 
         measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             tracer.inject(spanContext: anySpan.context, writer: anyWriter)


### PR DESCRIPTION
### What and why?

📦 🧰 Fixes build failure in (nightly) E2E tests:
```
Failed to execute Step:
  command failed with exit status 65 (xcodebuild "-workspace" "/Users/vagrant/git/Datadog.xcworkspace" "-scheme" "E2ETests" "test" "-destination" "id=3B2CA806-D170-4AFA-A9B9-032CDF42BEAB" "-resultBundlePath" "/var/folders/yy/6kcn9mkd5svdbqnznwf474f00000gn/T/XCUITestOutput565255057/Test-E2ETests.xcresult" "-xcconfig" "/var/folders/yy/6kcn9mkd5svdbqnznwf474f00000gn/T/3094384847/temp.xcconfig"):
    /Users/vagrant/git/Datadog/E2ETests/Tracing/TracerE2ETests.swift:54:25: error: 'init(sampleRate:)' is deprecated: This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.
```

The `HTTPHeadersWriter()` initializer was deprecated in #1794. Because we treat warnings as errors, this produced build failure for E2E tests that use deprecated constructor.

### How?

Used replacement `init(samplingStrategy:)`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
