### PR TITLE
RUM-4310: Add `DDConfiguration#additionalConfiguration` property to ObjC API

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
@@ -69,11 +69,14 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcConfig.sdkConfiguration.batchProcessingLevel, .high)
 
         objcConfig.proxyConfiguration = [kCFNetworkProxiesHTTPEnable: true, kCFNetworkProxiesHTTPPort: 123, kCFNetworkProxiesHTTPProxy: "www.example.com", kCFProxyUsernameKey: "proxyuser", kCFProxyPasswordKey: "proxypass" ]
+        objcConfig.additionalConfiguration = ["additional": "config"]
+
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable] as? Bool, true)
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPPort] as? Int, 123)
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
         XCTAssertEqual(objcConfig.sdkConfiguration.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
+        XCTAssertEqual(objcConfig.sdkConfiguration._internal.additionalConfiguration["additional"] as? String, "config")
 
         class ObjCDataEncryption: DDDataEncryption {
             func encrypt(data: Data) throws -> Data { data }

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -63,6 +63,7 @@
     configuration.bundle = [NSBundle mainBundle];
     configuration.batchSize = DDBatchSizeMedium;
     configuration.uploadFrequency = DDUploadFrequencyAverage;
+    configuration.additionalConfiguration = @{@"additional": @"config"};
     [configuration setEncryption:[CustomDDDataEncryption new]];
 }
 

--- a/DatadogObjc/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogObjc/Sources/DatadogConfiguration+objc.swift
@@ -256,6 +256,13 @@ public class DDConfiguration: NSObject {
         set { sdkConfiguration.bundle = newValue }
     }
 
+    /// Sets additional configuration attributes.
+    /// This can be used to tweak internal features of the SDK and shouldn't be considered as a part of public API.
+    @objc public var additionalConfiguration: [String: Any] {
+        get { sdkConfiguration._internal.additionalConfiguration }
+        set { sdkConfiguration._internal_mutation { $0.additionalConfiguration = newValue } }
+    }
+
     /// Creates a Datadog SDK Configuration object.
     ///
     /// - Parameters:

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -71,6 +71,7 @@ public class DDConfiguration: NSObject
     public func setEncryption(_ encryption: DDDataEncryption)
     public func setServerDateProvider(_ serverDateProvider: DDServerDateProvider)
     @objc public var bundle: Bundle
+    @objc public var additionalConfiguration: [String: Any]
     public init(clientToken: String, env: String)
 public enum DDSDKVerbosityLevel: Int
     case none
@@ -1760,14 +1761,20 @@ public class DDB3HTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float,injectEncoding: DDInjectEncoding = .single)
     public init(sampleRate: Float = 20,injectEncoding: DDInjectEncoding = .single)
+    public init(samplingStrategy: DDTraceSamplingStrategy,injectEncoding: DDInjectEncoding = .single)
 public class DDHTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float)
     public init(sampleRate: Float = 20)
+    public init(samplingStrategy: DDTraceSamplingStrategy)
+public class DDTraceSamplingStrategy: NSObject
+    public static func headBased() -> DDTraceSamplingStrategy
+    public static func custom(sampleRate: Float) -> DDTraceSamplingStrategy
 public class DDW3CHTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float)
     public init(sampleRate: Float = 20)
+    public init(samplingStrategy: DDTraceSamplingStrategy)
 public class DDTraceConfiguration: NSObject
     override public init()
     @objc public var sampleRate: Float

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1567,7 +1567,14 @@ public static func enable()
 # ----------------------------------
 
 public enum WebViewTracking
-    public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: Float = 100,in core: DatadogCoreProtocol = CoreRegistry.default)
+    public struct SessionReplayConfiguration
+        public enum PrivacyLevel: String
+            case allow
+            case mask
+            case maskUserInput = "mask_user_input"
+        public var privacyLevel: PrivacyLevel
+        public init(privacyLevel: PrivacyLevel = .mask)
+    public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: Float = 100,sessionReplayConfiguration: SessionReplayConfiguration? = nil,in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter
@@ -1689,6 +1696,7 @@ public struct SRWebviewWireframe: Codable, Hashable
     public let clip: SRContentClip?
     public let height: Int64
     public let id: Int64
+    public let isVisible: Bool?
     public let shapeStyle: SRShapeStyle?
     public let slotId: String
     public let type: String = "webview"
@@ -1789,6 +1797,7 @@ public struct SRIncrementalSnapshotRecord: Codable
                     public let clip: SRContentClip?
                     public let height: Int64?
                     public let id: Int64
+                    public let isVisible: Bool?
                     public let shapeStyle: SRShapeStyle?
                     public let slotId: String
                     public let type: String = "webview"
@@ -1864,11 +1873,6 @@ public enum SRRecord: Codable
     case visualViewportRecord(value: SRVisualViewportRecord)
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws
-[?] extension SRImageWireframe
-    public static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool
-    public func hash(into hasher: inout Hasher)
-public protocol SessionReplayTextObfuscating
-    func mask(text: String) -> String
 public typealias WireframeID = NodeID
 public class SessionReplayWireframesBuilder
     public struct FontOverride
@@ -1877,9 +1881,14 @@ public class SessionReplayWireframesBuilder
     public func createImageWireframe(resourceId: String,id: WireframeID,frame: CGRect,mimeType: String = "png",clip: SRContentClip? = nil,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
     public func createTextWireframe(id: WireframeID,frame: CGRect,text: String,textFrame: CGRect? = nil,textAlignment: SRTextPosition.Alignment? = nil,clip: SRContentClip? = nil,textColor: CGColor? = nil,font: UIFont? = nil,fontOverride: FontOverride? = nil,fontScalingEnabled: Bool = false,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
     public func createPlaceholderWireframe(id: Int64,frame: CGRect,label: String,clip: SRContentClip? = nil) -> SRWireframe
-    public func createWebViewWireframe(id: Int64,frame: CGRect,slotId: String,clip: SRContentClip? = nil,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
+    public func visibleWebViewWireframe(id: Int,frame: CGRect,clip: SRContentClip? = nil,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
 [?] extension SRContentClip
     public static func create(bottom: Int64?,left: Int64?,right: Int64?,top: Int64?) -> SRContentClip
+[?] extension SRImageWireframe
+    public static func == (lhs: SRImageWireframe, rhs: SRImageWireframe) -> Bool
+    public func hash(into hasher: inout Hasher)
+public protocol SessionReplayTextObfuscating
+    func mask(text: String) -> String
 public typealias SessionReplayPrivacyLevel = SessionReplay.Configuration.PrivacyLevel
 public extension SessionReplay.Configuration.PrivacyLevel
     var sensitiveTextObfuscator: SessionReplayTextObfuscating


### PR DESCRIPTION
### What and why?

This PR adds missing `DDConfiguration#additionalConfiguration` property to ObjC API. It is made public there instead of creating ObjC analog of `InternalExtended` type because of interop with Kotlin Multiplatform - I'm not sure such extended type will be visible there. Anyway, this property is public in Android SDK.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
