### PR TITLE
GH-1797 fix: use trace and span id as decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FEATURE] Support WebView recording in Session Replay. See [#1776][]
 - [IMPROVEMENT] Add `isInitialized` and `stopInstance` methods to ObjC API. See [#1800][]
 - [IMPROVEMENT] Add `addUserExtraInfo` method to ObjC API. See [#1799][]
+- [FIX] Use trace and span id as decimal. See [#1807][]
 
 # 2.10.0 / 23-04-2024
 
@@ -648,6 +649,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1763]: https://github.com/DataDog/dd-sdk-ios/pull/1763
 [#1767]: https://github.com/DataDog/dd-sdk-ios/pull/1767
 [#1776]: https://github.com/DataDog/dd-sdk-ios/pull/1776
+[#1807]: https://github.com/DataDog/dd-sdk-ios/pull/1807
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -121,8 +121,8 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertTrue(span.isKept, "Span must be sampled")
 
         // Then
-        let expectedTraceIDField = span.traceID.idLoHex
-        let expectedSpanIDField = String(span.spanID, representation: .hexadecimal)
+        let expectedTraceIDField = String(span.traceID.idLo)
+        let expectedSpanIDField = String(span.spanID, representation: .decimal)
         let expectedTagsField = "_dd.p.tid=\(span.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
@@ -209,8 +209,8 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(urlsessionSpan.parentID, activeSpan.spanID)
 
         // Then
-        let expectedTraceIDField = activeSpan.traceID.idLoHex
-        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .hexadecimal)
+        let expectedTraceIDField = String(activeSpan.traceID.idLo)
+        let expectedSpanIDField = String(urlsessionSpan.spanID, representation: .decimal)
         let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
@@ -298,8 +298,8 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertTrue(networkSpan.isKept, "Span must be sampled")
 
         // Then
-        let expectedTraceIDField = networkSpan.traceID.idLoHex
-        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTraceIDField = String(networkSpan.traceID.idLo)
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .decimal)
         let expectedTagsField = "_dd.p.tid=\(networkSpan.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)
@@ -385,8 +385,8 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertEqual(networkSpan.parentID, activeSpan.spanID)
 
         // Then
-        let expectedTraceIDField = activeSpan.traceID.idLoHex
-        let expectedSpanIDField = String(networkSpan.spanID, representation: .hexadecimal)
+        let expectedTraceIDField = String(activeSpan.traceID.idLo)
+        let expectedSpanIDField = String(networkSpan.spanID, representation: .decimal)
         let expectedTagsField = "_dd.p.tid=\(activeSpan.traceID.idHiHex)"
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), expectedTraceIDField)
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), expectedSpanIDField)

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -219,10 +219,10 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "X-B3-Sampled": "1",
                 "X-B3-TraceId": "000000000000000a0000000000000064",
                 "b3": "000000000000000a0000000000000064-0000000000000064-1",
-                "x-datadog-trace-id": "64",
+                "x-datadog-trace-id": "100",
                 "x-datadog-tags": "_dd.p.tid=a",
                 "tracestate": "dd=p:0000000000000064;s:1",
-                "x-datadog-parent-id": "64",
+                "x-datadog-parent-id": "100",
                 "x-datadog-sampling-priority": "1"
             ]
         )

--- a/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDTracerTests.swift
@@ -207,8 +207,8 @@ class DDTracerTests: XCTestCase {
         try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
-            "x-datadog-trace-id": "64",
-            "x-datadog-parent-id": "c8",
+            "x-datadog-trace-id": "100",
+            "x-datadog-parent-id": "200",
             "x-datadog-sampling-priority": "1",
             "x-datadog-tags": "_dd.p.tid=a"
         ]

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -16,7 +16,7 @@ public class HTTPHeadersReader: TracePropagationHeadersReader {
     public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
         guard let traceIDLoValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
               let spanIDValue = httpHeaderFields[TracingHTTPHeaders.parentSpanIDField],
-              let spanID = SpanID(spanIDValue, representation: .hexadecimal)
+              let spanID = SpanID(spanIDValue, representation: .decimal)
         else {
             return nil
         }
@@ -34,7 +34,7 @@ public class HTTPHeadersReader: TracePropagationHeadersReader {
 
         let traceID = TraceID(
             idHi: UInt64(traceIDHiValue, radix: 16) ?? 0,
-            idLo: UInt64(traceIDLoValue, radix: 16) ?? 0
+            idLo: UInt64(traceIDLoValue, radix: 10) ?? 0
         )
 
         return (

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -73,8 +73,8 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
         ]
 
         if sampled {
-            traceHeaderFields[TracingHTTPHeaders.traceIDField] = traceContext.traceID.idLoHex
-            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(traceContext.spanID, representation: .hexadecimal)
+            traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceContext.traceID.idLo)
+            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(traceContext.spanID, representation: .decimal)
             traceHeaderFields[TracingHTTPHeaders.tagsField] = "_dd.p.tid=\(traceContext.traceID.idHiHex)"
         }
     }

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
@@ -22,8 +22,8 @@ class HTTPHeadersWriterTests: XCTestCase {
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "1")
-        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "4d2")
-        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "929")
+        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "1234")
+        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "2345")
         XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
     }
 
@@ -58,8 +58,8 @@ class HTTPHeadersWriterTests: XCTestCase {
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[TracingHTTPHeaders.samplingPriorityField], "1")
-        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "4d2")
-        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "929")
+        XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "1234")
+        XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "2345")
         XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
     }
 

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -46,9 +46,9 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField), "rum")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
 
         let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
@@ -530,8 +530,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
                 "X-B3-Sampled": "1",
                 "X-B3-TraceId": "000000000000000a0000000000000064",
                 "b3": "000000000000000a0000000000000064-0000000000000064-1",
-                "x-datadog-trace-id": "64",
-                "x-datadog-parent-id": "64",
+                "x-datadog-trace-id": "100",
+                "x-datadog-parent-id": "100",
                 "x-datadog-sampling-priority": "1",
                 "x-datadog-origin": "rum",
                 "x-datadog-tags": "_dd.p.tid=a"

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -63,9 +63,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000064")
@@ -189,9 +189,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         span.finish()
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "64")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
-        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "65")
+        XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "101")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.traceIDField), "000000000000000a0000000000000064")
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Multiple.spanIDField), "0000000000000065")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -409,14 +409,14 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         
         return .init(
             idHi: UInt64(traceIDHiValue, radix: 16) ?? 0,
-            idLo: UInt64(traceIDLoValue, radix: 16) ?? 0
+            idLo: UInt64(traceIDLoValue, radix: 10) ?? 0
         )
     }
     private func getSpanID(from request: Request) -> SpanID? {
         guard let spanId = request.httpHeaders["x-datadog-parent-id"] else {
             return nil
         }
-        return .init(spanId, representation: .hexadecimal)
+        return .init(spanId, representation: .decimal)
     }
     private func isValid(sampleRate: Double) -> Bool { sampleRate >= 0 && sampleRate <= 1 }
 }

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
@@ -238,8 +238,9 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
         XCTAssertEqual(firstPartyRequests.count, 1)
 
         let firstPartyRequest = firstPartyRequests[0]
-        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], try taskWithRequest.traceID()?.idLoHex)
-        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID()?.toString(representation: .hexadecimal))
+        let traceId = try taskWithRequest.traceID() ?? .invalid
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-trace-id"], String(traceId.idLo))
+        XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-parent-id"], try taskWithRequest.spanID()?.toString(representation: .decimal))
         XCTAssertEqual(firstPartyRequest.httpHeaders["x-datadog-sampling-priority"], "1")
         XCTAssertNil(firstPartyRequest.httpHeaders["x-datadog-origin"])
         let tid = try taskWithRequest.meta.tid()


### PR DESCRIPTION
### What and why?

Fixes #1797

### How?

With 128 bit id support, the trace id and span id for datadog headers were changed to hex format which was wrong. These must stay in decimal format and the higher 64 bits must be in hex.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
