### PR TITLE
Remove unused `sampleRate` parameter from `DDLogsConfiguration` object

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDLogsTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDLogsTests.swift
@@ -40,13 +40,11 @@ class DDLogsTests: XCTestCase {
 
     func testConfigurationOverrides() throws {
         // Given
-        let sampleRate: Float = .random(in: 0...100)
         let customEndpoint: URL = .mockRandom()
 
         // When
         DDLogs.enable(
             with: DDLogsConfiguration(
-                sampleRate: sampleRate,
                 customEndpoint: customEndpoint
             )
         )

--- a/DatadogObjc/Sources/Logs/Logs+objc.swift
+++ b/DatadogObjc/Sources/Logs/Logs+objc.swift
@@ -62,11 +62,9 @@ public class DDLogsConfiguration: NSObject {
     /// Creates a Logs configuration object.
     ///
     /// - Parameters:
-    ///   - sampleRate: The sampling rate for logging.
     ///   - customEndpoint: Overrides the custom server endpoint where Logs are sent.
     @objc
     public init(
-        sampleRate: Float = 100,
         customEndpoint: URL? = nil
     ) {
         configuration = .init(

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -88,7 +88,7 @@ public enum DDLogLevel: Int
     case critical
 public class DDLogsConfiguration: NSObject
     @objc public var customEndpoint: URL?
-    public init(sampleRate: Float = 100,customEndpoint: URL? = nil)
+    public init(customEndpoint: URL? = nil)
 public class DDLogs: NSObject
     public static func enable(with configuration: DDLogsConfiguration = .init())
 public class DDLoggerConfiguration: NSObject


### PR DESCRIPTION
### What and why?

`sampleRate` parameter wasn't actually used in the constructor `DDLogsConfiguration` object and underlying `Logs.Configuration` has no space for it.

It is a breaking change, but even if build will be broken on the customer side using `DatadogObjC`, it is easy to address that, this parameter had no effect anyway.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
