### PR TITLE
RUM-4418: Add missing global `addAttribute`/`removeAttribute` Logs API in ObjC

### DIFF
--- a/DatadogObjc/Sources/Logs/Logs+objc.swift
+++ b/DatadogObjc/Sources/Logs/Logs+objc.swift
@@ -81,6 +81,16 @@ public class DDLogs: NSObject {
     ) {
         Logs.enable(with: configuration.configuration)
     }
+
+    @objc
+    public static func addAttribute(forKey key: String, value: Any) {
+        Logs.addAttribute(forKey: key, value: AnyEncodable(value))
+    }
+
+    @objc
+    public static func removeAttribute(forKey key: String) {
+        Logs.removeAttribute(forKey: key)
+    }
 }
 
 @objc

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -91,6 +91,8 @@ public class DDLogsConfiguration: NSObject
     public init(customEndpoint: URL? = nil)
 public class DDLogs: NSObject
     public static func enable(with configuration: DDLogsConfiguration = .init())
+    public static func addAttribute(forKey key: String, value: Any)
+    public static func removeAttribute(forKey key: String)
 public class DDLoggerConfiguration: NSObject
     @objc public var service: String?
     @objc public var name: String?


### PR DESCRIPTION
### What and why?

`Logs.removeAttribute` / `Logs.addAttribute` API is missing in ObjC, while it exists in Swift. This PR adds the missing.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
