### PR TITLE
Refactor: Replace RUM monitor `queue` with `@ReadWriteLock`

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -143,7 +143,5 @@ class AppHangsMonitoringTests: XCTestCase {
         // and it is idle:
         let hangObserver = try XCTUnwrap(core.get(feature: RUMFeature.self)?.instrumentation.appHangs)
         hangObserver.flush()
-
-        RUMMonitor.shared(in: core).dd.flush() // flush also RUMMonitor so it ends processing hangs flushed from `hangObserver`
     }
 }

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -1220,7 +1220,7 @@ class RUMMonitorTests: XCTestCase {
             case 10: monitor.addAction(type: .tap, name: .mockRandom())
             case 11: monitor.addAttribute(forKey: String.mockRandom(), value: String.mockRandom())
             case 12: monitor.removeAttribute(forKey: String.mockRandom())
-            case 13: monitor.dd.debug = .mockRandom()
+            case 13: monitor.debug = .mockRandom()
             default: break
             }
         }

--- a/DatadogRUM/Sources/Debugging/RUMDebugging.swift
+++ b/DatadogRUM/Sources/Debugging/RUMDebugging.swift
@@ -28,11 +28,8 @@ private struct RUMDebugInfo {
 }
 
 internal class RUMDebugging {
-    private lazy var canvas: UIView = {
-        let view = RUMDebugView(frame: .zero)
-        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        return view
-    }()
+    /// An overlay view renderd on top of the app content. It is created lazily on first draw.
+    private var canvas: UIView? = nil
 
     // MARK: - Initialization
 
@@ -52,9 +49,8 @@ internal class RUMDebugging {
     }
 
     deinit {
-        let canvas = self.canvas
-        DispatchQueue.main.async {
-            canvas.removeFromSuperview()
+        DispatchQueue.main.async { [weak canvas] in
+            canvas?.removeFromSuperview()
             UIDevice.current.endGeneratingDeviceOrientationNotifications()
         }
 
@@ -69,9 +65,8 @@ internal class RUMDebugging {
     }
 
     deinit {
-        let canvas = self.canvas
-        DispatchQueue.main.async {
-            canvas.removeFromSuperview()
+        DispatchQueue.main.async { [weak canvas] in
+            canvas?.removeFromSuperview()
         }
     }
     #endif
@@ -91,6 +86,15 @@ internal class RUMDebugging {
     // MARK: - Private
 
     private func renderOnMainThread(rumDebugInfo: RUMDebugInfo) {
+        if canvas == nil {
+            canvas = RUMDebugView(frame: .zero)
+            canvas?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
+
+        guard let canvas = canvas else {
+            return
+        }
+
         canvas.subviews.forEach { view in
             view.removeFromSuperview()
         }
@@ -118,7 +122,7 @@ internal class RUMDebugging {
 
     @objc
     private func updateLayout() {
-        canvas.subviews.forEach { $0.setNeedsLayout() }
+        canvas?.subviews.forEach { $0.setNeedsLayout() }
     }
 }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -159,7 +159,7 @@ extension RUMFeature: Flushable {
     ///
     /// **blocks the caller thread**
     func flush() {
-        monitor.flush()
+        instrumentation.appHangs?.flush()
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -114,13 +114,11 @@ internal class Monitor: RUMCommandSubscriber {
     let featureScope: FeatureScope
     let scopes: RUMApplicationScope
     let dateProvider: DateProvider
-    let queue = DispatchQueue(
-        label: "com.datadoghq.rum-monitor",
-        target: .global(qos: .userInteractive)
-    )
 
+    @ReadWriteLock
     private(set) var debugging: RUMDebugging? = nil
 
+    @ReadWriteLock
     private var attributes: [AttributeKey: AttributeValue] = [:]
 
     init(
@@ -135,38 +133,34 @@ internal class Monitor: RUMCommandSubscriber {
     func process(command: RUMCommand) {
         // process command in event context
         featureScope.eventWriteContext { context, writer in
-            self.queue.sync {
-                let transformedCommand = self.transform(command: command)
+            let transformedCommand = self.transform(command: command)
 
-                _ = self.scopes.process(command: transformedCommand, context: context, writer: writer)
+            _ = self.scopes.process(command: transformedCommand, context: context, writer: writer)
 
-                if let debugging = self.debugging {
-                    debugging.debug(applicationScope: self.scopes)
-                }
+            if let debugging = self.debugging {
+                debugging.debug(applicationScope: self.scopes)
             }
         }
 
         // update the core context with rum context
         featureScope.set(
-            baggage: {
-                self.queue.sync { () -> RUMCoreContext? in
-                    let context = self.scopes.activeSession?.viewScopes.last?.context ??
-                                    self.scopes.activeSession?.context ??
-                                    self.scopes.context
+            baggage: { () -> RUMCoreContext? in
+                let context = self.scopes.activeSession?.viewScopes.last?.context ??
+                                self.scopes.activeSession?.context ??
+                                self.scopes.context
 
-                    guard context.sessionID != .nullUUID else {
-                        // if Session was sampled or not yet started
-                        return nil
-                    }
-
-                    return RUMCoreContext(
-                        applicationID: context.rumApplicationID,
-                        sessionID: context.sessionID.rawValue.uuidString.lowercased(),
-                        viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
-                        userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
-                        viewServerTimeOffset: self.scopes.activeSession?.viewScopes.last?.serverTimeOffset
-                    )
+                guard context.sessionID != .nullUUID else {
+                    // if Session was sampled or not yet started
+                    return nil
                 }
+
+                return RUMCoreContext(
+                    applicationID: context.rumApplicationID,
+                    sessionID: context.sessionID.rawValue.uuidString.lowercased(),
+                    viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
+                    userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
+                    viewServerTimeOffset: self.scopes.activeSession?.viewScopes.last?.serverTimeOffset
+                )
             },
             forKey: RUMFeature.name
         )
@@ -201,37 +195,30 @@ extension Monitor: RUMMonitorProtocol {
     // MARK: - attributes
 
     func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
-        queue.async {
-            self.attributes[key] = value
-        }
+        attributes[key] = value
     }
 
     func removeAttribute(forKey key: AttributeKey) {
-        queue.async {
-            self.attributes[key] = nil
-        }
+        attributes[key] = nil
     }
 
     // MARK: - session
 
     func currentSessionID(completion: @escaping (String?) -> Void) {
-        // Even though we're not writing anything, need to get the write context
-        // to make sure we're returning the correct sessionId after all other
-        // events have processed.
-        featureScope.eventWriteContext { _, _ in
-            self.queue.sync {
-                guard let sessionId = self.scopes.activeSession?.sessionUUID else {
-                    completion(nil)
-                    return
-                }
-
-                var sessionIdValue: String? = nil
-                if sessionId != RUMUUID.nullUUID {
-                    sessionIdValue = sessionId.rawValue.uuidString
-                }
-
-                completion(sessionIdValue)
+        // Synchronise it through the context thread to make sure we return the correct
+        // sessionID after all other events have been processed (also on the context thread):
+        featureScope.context { _ in
+            guard let sessionId = self.scopes.activeSession?.sessionUUID else {
+                completion(nil)
+                return
             }
+
+            var sessionIdValue: String? = nil
+            if sessionId != RUMUUID.nullUUID {
+                sessionIdValue = sessionId.rawValue.uuidString
+            }
+
+            completion(sessionIdValue)
         }
     }
 
@@ -500,15 +487,19 @@ extension Monitor: RUMMonitorProtocol {
 
     var debug: Bool {
         set {
-            queue.async {
-                self.debugging = newValue ? RUMDebugging() : nil
-                self.debugging?.debug(applicationScope: self.scopes)
+            debugging = newValue ? RUMDebugging() : nil
+
+            // Synchronise `debug(applicationScope:)` through the context thread to make sure it can safely
+            // read `scopes` after all events have been processed (also on the context thread):
+            featureScope.context { [weak self] _ in
+                guard let self = self else {
+                    return
+                }
+                debugging?.debug(applicationScope: scopes)
             }
         }
         get {
-            queue.sync {
-                self.debugging != nil
-            }
+            debugging != nil
         }
     }
 }
@@ -539,10 +530,5 @@ extension Monitor {
                 attributes: attributes
             )
         )
-    }
-
-    /// Completes all asynchronous operations with blocking the caller thread.
-    func flush() {
-        queue.sync { }
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
@@ -22,7 +22,6 @@ class MonitorTests: XCTestCase {
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
-        monitor.flush()
 
         // Then
         let expectedContext = monitor.currentRUMContext
@@ -43,7 +42,6 @@ class MonitorTests: XCTestCase {
             dateProvider: DateProviderMock()
         )
         monitor.startView(key: "foo")
-        monitor.flush()
 
         // Then
         XCTAssertNil(featureScope.contextMock.baggages[RUMFeature.name])
@@ -59,7 +57,6 @@ class MonitorTests: XCTestCase {
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc)
-        monitor.flush()
 
         // Then
         XCTAssertEqual(monitor.scopes.sessionScopes.first?.viewScopes.first?.viewName, "SomeViewController")
@@ -76,7 +73,6 @@ class MonitorTests: XCTestCase {
             dateProvider: DateProviderMock()
         )
         monitor.startView(viewController: vc, name: "Some View")
-        monitor.flush()
 
         // Then
         XCTAssertEqual(monitor.scopes.sessionScopes.first?.viewScopes.first?.viewName, "Some View")


### PR DESCRIPTION
### What and why?

📦 This PR removes the internal `queue` used in `RUM.Monitor`. This is to ease the upcoming work on sending view updates on RUM attributes change (`RUM-3588`) by simplifying internal state management in monitor's implementation.

As an extra benefit, this change reduces the number of threads consumed by RUM. It has no performance impact, as the removed queue was called with `.sync {}` anyway.

### How?
`RUM.Monitor` state that is now synchronised using **`@ReadWriteLock`**:
- Global RUM attributes.
- The `monitor.debug` flag.

`RUM.Monitor` operations that are now synchronised using **SDK context thread**:
- Events processing through `RUMScopes` (already using context thread before).
- Executing current sessionID callback (already using context thread before).
- Managing `monitor.debug` utility (using the `queue` before).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
