### PR TITLE
RUM-3588 chore: Add tests for global RUM attributes

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -489,6 +489,8 @@
 		61C713D12A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C713CF2A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift */; };
 		61C713D32A3DFB4900FA735A /* FuzzyHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C713D22A3DFB4900FA735A /* FuzzyHelpers.swift */; };
 		61C713D42A3DFB4900FA735A /* FuzzyHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C713D22A3DFB4900FA735A /* FuzzyHelpers.swift */; };
+		61CE2E5F2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */; };
+		61CE2E602BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */; };
 		61CE585A2B48174D00479510 /* SpanWriteContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CE58592B48174D00479510 /* SpanWriteContext.swift */; };
 		61CE585B2B48174D00479510 /* SpanWriteContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CE58592B48174D00479510 /* SpanWriteContext.swift */; };
 		61D03BE0273404E700367DE0 /* RUMDataModels+objcTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D03BDF273404E700367DE0 /* RUMDataModels+objcTests.swift */; };
@@ -2450,6 +2452,7 @@
 		61C713C92A3DC22700FA735A /* RUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTests.swift; sourceTree = "<group>"; };
 		61C713CF2A3DEFF900FA735A /* FeatureRegistrationCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureRegistrationCoreMock.swift; sourceTree = "<group>"; };
 		61C713D22A3DFB4900FA735A /* FuzzyHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyHelpers.swift; sourceTree = "<group>"; };
+		61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Monitor+GlobalAttributesTests.swift"; sourceTree = "<group>"; };
 		61CE58592B48174D00479510 /* SpanWriteContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanWriteContext.swift; sourceTree = "<group>"; };
 		61D03BDF273404E700367DE0 /* RUMDataModels+objcTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objcTests.swift"; sourceTree = "<group>"; };
 		61D3E0C8277B23F0008BE766 /* KronosInternetAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KronosInternetAddress.swift; sourceTree = "<group>"; };
@@ -4679,6 +4682,7 @@
 				618DCFDE24C75FD300589570 /* RUMScopeTests.swift */,
 				618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */,
 				6176C1712ABDBA2E00131A70 /* MonitorTests.swift */,
+				61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */,
 			);
 			path = RUMMonitor;
 			sourceTree = "<group>";
@@ -8428,6 +8432,7 @@
 				D23F8EAB29DDCD38001CFAE8 /* RUMDataModelMocks.swift in Sources */,
 				D23F8EAC29DDCD38001CFAE8 /* RUMDataModelsMappingTests.swift in Sources */,
 				D23F8EAD29DDCD38001CFAE8 /* RUMEventBuilderTests.swift in Sources */,
+				61CE2E602BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */,
 				D23F8EAE29DDCD38001CFAE8 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D23F8EAF29DDCD38001CFAE8 /* RUMScopeTests.swift in Sources */,
 				D23F8EB029DDCD38001CFAE8 /* SessionReplayDependencyTests.swift in Sources */,
@@ -8719,6 +8724,7 @@
 				D29A9FC629DDBA8A005C54A4 /* RUMDataModelMocks.swift in Sources */,
 				D29A9FD529DDC624005C54A4 /* RUMDataModelsMappingTests.swift in Sources */,
 				D29A9FBE29DDB483005C54A4 /* RUMEventBuilderTests.swift in Sources */,
+				61CE2E5F2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */,
 				D29A9FCC29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -116,6 +116,24 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.attribute(forKey: "attribute2"), "value2")
     }
 
+    func testUpdatingGlobalAttributesAfterSDKInit_thenStartingAndStoppingView() throws {
+        // Given
+        monitor.notifySDKInit()
+
+        // When
+        monitor.addAttribute(forKey: "attribute", value: "value")
+        monitor.addAttribute(forKey: "attribute", value: "new-value")
+        monitor.removeAttribute(forKey: "unknown-attribute")
+        monitor.startView(key: "View")
+        monitor.stopView(key: "View")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertEqual(lastView.attribute(forKey: "attribute"), "new-value")
+        XCTAssertEqual(lastView.numberOfAttributes, 1)
+    }
+
     // MARK: - Changing Global Attributes After Starting View
 
     func testAddingGlobalAttributeAfterViewIsStarted() throws {
@@ -242,6 +260,39 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView2.attribute(forKey: "attribute3"), "value3")
 
         XCTAssertNil(lastView3.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute3"), "value3")
+    }
+
+    func testAddingGlobalAttributesAfterViewIsStarted_thenStartingNextViewsWhileUpdatingAttributes() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View1")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+        monitor.addAttribute(forKey: "attribute3", value: "value3")
+
+        // When
+        monitor.startView(key: "View2")
+        monitor.addAttribute(forKey: "attribute1", value: "new-value1")
+        monitor.startView(key: "View3")
+        monitor.addAttribute(forKey: "attribute2", value: "new-value1")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastView1 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View1" }))
+        let lastView2 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View2" }))
+        let lastView3 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View3" }))
+
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute3"), "value3")
+
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute1"), "new-value1")
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute3"), "value3")
+
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute1"), "new-value1")
         XCTAssertEqual(lastView3.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(lastView3.attribute(forKey: "attribute3"), "value3")
     }
@@ -382,6 +433,34 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(resourceEvent.context?.contextInfo["attribute2"] as? String, "value2")
     }
 
+    func testUpdatingGlobalAttributeInActiveView_thenCollectingViewEvents() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+        monitor.addAttribute(forKey: "attribute", value: "value")
+        monitor.addAttribute(forKey: "attribute", value: "new-value")
+
+        // When
+        monitor.addError(message: "error event")
+        monitor.addAction(type: .custom, name: "custom action event")
+        monitor.startResource(resourceKey: "resource", url: .mockAny())
+        monitor.stopResource(resourceKey: "resource", response: .mockAny())
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let errorEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
+        let actionEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMActionEvent.self).last)
+        let resourceEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMResourceEvent.self).last)
+
+        XCTAssertEqual(lastView.view.error.count, 1)
+        XCTAssertEqual(lastView.view.action.count, 1)
+        XCTAssertEqual(lastView.view.resource.count, 1)
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        XCTAssertEqual(errorEvent.context?.contextInfo["attribute"] as? String, "new-value")
+        XCTAssertEqual(actionEvent.context?.contextInfo["attribute"] as? String, "new-value")
+        XCTAssertEqual(resourceEvent.context?.contextInfo["attribute"] as? String, "new-value")
+    }
+
     func testAddingGlobalAttributesToActiveView_thenCollectingViewTimingsAndRemovingAttribute() throws {
         // Given
         monitor.notifySDKInit()
@@ -415,5 +494,9 @@ private extension RUMViewEvent {
 
     func attribute<T: Equatable>(forKey key: String) -> T? {
         return context?.contextInfo[key] as? T
+    }
+
+    var numberOfAttributes: Int {
+        return context?.contextInfo.count ?? 0
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -1,0 +1,419 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class Monitor_GlobalAttributesTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+    private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope),
+            dateProvider: SystemDateProvider()
+        )
+    }
+
+    override func tearDown() {
+        monitor = nil
+    }
+
+    // MARK: - Changing Global Attributes After SDK Init
+
+    func testAddingGlobalAttributeAfterSDKInit() throws {
+        // When
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+    }
+
+    func testAddingGlobalAttributeAfterSDKInit_thenStartingView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // When
+        monitor.startView(key: "View")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let appLaunchView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }))
+        XCTAssertEqual(appLaunchView.attribute(forKey: "attribute"), "value")
+    }
+
+    func testAddingGlobalAttributeAfterSDKInit_thenSendingInteractiveEvent() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // When
+        monitor.addAction(type: .custom, name: "custom action")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+    }
+
+    func testAddingGlobalAttributesAfterSDKInit_thenRemovingAttribute() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastView.attribute(forKey: "attribute2"))
+    }
+
+    func testAddingGlobalAttributeAfterSDKInit_thenRemovingAttributeAndStartingView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.startView(key: "View")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView.attribute(forKey: "attribute2"), "value2")
+    }
+
+    func testAddingGlobalAttributeAfterSDKInit_thenRemovingAttributeAndStartingAndStoppingView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.startView(key: "View")
+        monitor.stopView(key: "View")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView.attribute(forKey: "attribute2"), "value2")
+    }
+
+    // MARK: - Changing Global Attributes After Starting View
+
+    func testAddingGlobalAttributeAfterViewIsStarted() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View")
+
+        // When
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+    }
+
+    func testAddingGlobalAttributeAfterViewIsStarted_thenSendingInteractiveEvent() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View")
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // When
+        monitor.addAction(type: .custom, name: "custom action")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+    }
+
+    func testAddingGlobalAttributesAfterViewIsStarted_thenRemovingAttribute() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastView.attribute(forKey: "attribute2"))
+    }
+
+    func testAddingGlobalAttributesAfterViewIsStarted_thenRemovingAttributeAndStoppingView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.stopView(key: "View")
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(lastView.view.name, "View")
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView.attribute(forKey: "attribute2"), "value2")
+    }
+
+    func testAddingGlobalAttributeAfterViewIsStarted_thenStartingNextViewsWhileAddingAttributes() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View1")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+
+        // When
+        monitor.startView(key: "View2")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+        monitor.startView(key: "View3")
+        monitor.addAttribute(forKey: "attribute3", value: "value3")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastView1 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View1" }))
+        let lastView2 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View2" }))
+        let lastView3 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View3" }))
+
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute1"), "value1")
+        XCTAssertNil(lastView1.attribute(forKey: "attribute2"))
+        XCTAssertNil(lastView1.attribute(forKey: "attribute3"))
+
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute2"), "value2")
+        XCTAssertNil(lastView2.attribute(forKey: "attribute3"))
+
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute2"), "value2")
+        XCTAssertNil(lastView2.attribute(forKey: "attribute3"))
+    }
+
+    func testAddingGlobalAttributesAfterViewIsStarted_thenStartingNextViewsWhileRemovingAttributes() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "View1")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+        monitor.addAttribute(forKey: "attribute3", value: "value3")
+
+        // When
+        monitor.startView(key: "View2")
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.startView(key: "View3")
+        monitor.removeAttribute(forKey: "attribute2")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastView1 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View1" }))
+        let lastView2 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View2" }))
+        let lastView3 = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "View3" }))
+
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView1.attribute(forKey: "attribute3"), "value3")
+
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute3"), "value3")
+
+        XCTAssertNil(lastView3.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(lastView3.attribute(forKey: "attribute3"), "value3")
+    }
+
+    // MARK: - Changing Global Attributes While There Is An Inactive View
+
+    func testAddingGlobalAttributeWhileInactiveView_thenImplicitlyStoppingInactiveView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "InactiveView")
+        monitor.startResource(resourceKey: "pending resource", url: .mockAny())
+        monitor.startView(key: "ActiveView")
+
+        // When
+        monitor.addAttribute(forKey: "attribute", value: "value")
+        monitor.stopResource(resourceKey: "pending resource", response: .mockAny())
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastInactiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "InactiveView" }))
+        let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
+
+        XCTAssertEqual(lastInactiveView.view.resource.count, 1)
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute"))
+        XCTAssertNil(lastActiveView.attribute(forKey: "attribute"))
+    }
+
+    func testAddingGlobalAttributesWhileInactiveView_thenRemovingAttributeAndImplicitlyStoppingInactiveView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "InactiveView")
+        monitor.startResource(resourceKey: "pending resource", url: .mockAny())
+        monitor.startView(key: "ActiveView")
+
+        // When
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.stopResource(resourceKey: "pending resource", response: .mockAny())
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastInactiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "InactiveView" }))
+        let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
+
+        XCTAssertEqual(lastInactiveView.view.resource.count, 1)
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
+        XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastActiveView.attribute(forKey: "attribute2"))
+    }
+
+    func testAddingGlobalAttributesWhileInactiveView_thenRemovingAttributeAndImplicitlyStoppingInactiveViewAndStoppingActiveView() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "InactiveView")
+        monitor.startResource(resourceKey: "pending resource", url: .mockAny())
+        monitor.startView(key: "ActiveView")
+
+        // When
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.stopResource(resourceKey: "pending resource", response: .mockAny())
+        monitor.stopView(key: "ActiveView")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let lastInactiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "InactiveView" }))
+        let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
+
+        XCTAssertEqual(lastInactiveView.view.resource.count, 1)
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
+        XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastActiveView.attribute(forKey: "attribute2"), "value2")
+    }
+
+    // MARK: - Including Up-to-date Global Attributes In Events
+
+    func testAddingGlobalAttributeToActiveView_thenCollectingViewEvents() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+        monitor.addAttribute(forKey: "attribute", value: "value")
+
+        // When
+        monitor.addError(message: "error event")
+        monitor.addAction(type: .custom, name: "custom action event")
+        monitor.startResource(resourceKey: "resource", url: .mockAny())
+        monitor.stopResource(resourceKey: "resource", response: .mockAny())
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let errorEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
+        let actionEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMActionEvent.self).last)
+        let resourceEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMResourceEvent.self).last)
+
+        XCTAssertEqual(lastView.view.error.count, 1)
+        XCTAssertEqual(lastView.view.action.count, 1)
+        XCTAssertEqual(lastView.view.resource.count, 1)
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        XCTAssertEqual(errorEvent.context?.contextInfo["attribute"] as? String, "value")
+        XCTAssertEqual(actionEvent.context?.contextInfo["attribute"] as? String, "value")
+        XCTAssertEqual(resourceEvent.context?.contextInfo["attribute"] as? String, "value")
+    }
+
+    func testAddingGlobalAttributesToActiveView_thenRemovingAttributeAndCollectingViewEvents() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.addError(message: "error event")
+        monitor.addAction(type: .custom, name: "custom action event")
+        monitor.startResource(resourceKey: "resource", url: .mockAny())
+        monitor.stopResource(resourceKey: "resource", response: .mockAny())
+
+        // Then
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let errorEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
+        let actionEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMActionEvent.self).last)
+        let resourceEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMResourceEvent.self).last)
+
+        XCTAssertEqual(lastView.view.error.count, 1)
+        XCTAssertEqual(lastView.view.action.count, 1)
+        XCTAssertEqual(lastView.view.resource.count, 1)
+        XCTAssertNil(lastView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastView.attribute(forKey: "attribute2"))
+        XCTAssertNil(errorEvent.context?.contextInfo["attribute1"])
+        XCTAssertEqual(errorEvent.context?.contextInfo["attribute2"] as? String, "value2")
+        XCTAssertNil(actionEvent.context?.contextInfo["attribute1"])
+        XCTAssertEqual(actionEvent.context?.contextInfo["attribute2"] as? String, "value2")
+        XCTAssertNil(resourceEvent.context?.contextInfo["attribute1"])
+        XCTAssertEqual(resourceEvent.context?.contextInfo["attribute2"] as? String, "value2")
+    }
+
+    func testAddingGlobalAttributesToActiveView_thenCollectingViewTimingsAndRemovingAttribute() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+        monitor.addAttribute(forKey: "attribute1", value: "value1")
+        monitor.addAttribute(forKey: "attribute2", value: "value2")
+
+        // When
+        monitor.addTiming(name: "timing1")
+        monitor.removeAttribute(forKey: "attribute1")
+        monitor.addTiming(name: "timing2")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
+        let viewAfterFirstTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.count == 1 }))
+        let viewAfterSecondTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.count == 2 }))
+
+        XCTAssertEqual(viewAfterFirstTiming.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(viewAfterFirstTiming.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
+    }
+}
+
+// MARK: - Helpers
+
+private extension RUMViewEvent {
+    func attribute(forKey key: String) -> Any? {
+        return context?.contextInfo[key]
+    }
+
+    func attribute<T: Equatable>(forKey key: String) -> T? {
+        return context?.contextInfo[key] as? T
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adds tests to existing RUM global attributes logic. This is to increase unit tests coverage in different scenarios:
- changing attributes right after SDK init;
- changing attributes after view is started;
- changing attributes while inactive view (view with pending resource).

### How?

Defined new **unit test** suite in `DatadogRUMTests` - asserting all existing behaviours for global RUM attributes handling.

I'm not yet removing the [existing RUM attributes **integration tests** in `DatadogCoreTests`](https://github.com/DataDog/dd-sdk-ios/blob/2e74021bfd7a1fd52a7e1c89a9da26eca776b580/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift#L1426-L1446) as they cover also the situation logic of merging command-specific attributes with global ones.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
