### PR TITLE
[CIVIS-9813] fix for test sdk integration

### DIFF
--- a/DatadogCore/Sources/FeaturesIntegration/CITestIntegration.swift
+++ b/DatadogCore/Sources/FeaturesIntegration/CITestIntegration.swift
@@ -83,6 +83,6 @@ internal class CITestIntegration {
     /// Creates a ID for message port. If UUID is provided joins name with UUID.
     /// Fallbacks to name if UUID is nil for backward compatibility
     private func messagePortId(name: String) -> CFString {
-        (messageChannelUUID.map{"\(name)-\($0)"} ?? name) as CFString
+        (messageChannelUUID.map { "\(name)-\($0)" } ?? name) as CFString
     }
 }

--- a/DatadogCore/Sources/FeaturesIntegration/CITestIntegration.swift
+++ b/DatadogCore/Sources/FeaturesIntegration/CITestIntegration.swift
@@ -20,12 +20,15 @@ internal class CITestIntegration {
     let testExecutionId: String
     /// Tag that must be added to spans and headers when running inside a CIApp test
     let origin = "ciapp-test"
+    // UUID for test process message channel
+    private let messageChannelUUID: String?
 
     private init?(processInfo: ProcessInfo = .processInfo) {
         guard let testID = processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"] else {
             return nil
         }
         self.testExecutionId = testID
+        self.messageChannelUUID = processInfo.environment["CI_VISIBILITY_MESSAGE_CHANNEL_UUID"]
     }
 
     /// Entry point for running all the tasks needed for CIApp integration
@@ -38,7 +41,10 @@ internal class CITestIntegration {
     /// created in the CIApp framework
     private func notifyRUMSession() {
         let timeout: CFTimeInterval = 1.0
-        guard let remotePort = CFMessagePortCreateRemote(nil, "DatadogTestingPort" as CFString) else {
+        
+        guard let remotePort = CFMessagePortCreateRemote(
+            nil, messagePortId(name: "DatadogTestingPort")
+        ) else {
             return
         }
         CFMessagePortSendRequest(
@@ -65,10 +71,18 @@ internal class CITestIntegration {
             return nil
         }
 
-        guard let port = CFMessagePortCreateLocal(nil, "DatadogRUMTestingPort" as CFString, attributeCallback, nil, nil) else {
+        guard let port = CFMessagePortCreateLocal(
+            nil, messagePortId(name: "DatadogRUMTestingPort"), attributeCallback, nil, nil
+        ) else {
             return
         }
         let runLoopSource = CFMessagePortCreateRunLoopSource(nil, port, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
+    }
+    
+    /// Creates a ID for message port. If UUID is provided joins name with UUID.
+    /// Fallbacks to name if UUID is nil for backward compatibility
+    private func messagePortId(name: String) -> CFString {
+        (messageChannelUUID.map{"\(name)-\($0)"} ?? name) as CFString
     }
 }


### PR DESCRIPTION
### What and why?

Swift testing library is using MachPorts to communicate with this library. They are unique for OS kernel, so each process should have a unique name for them. Right now we are using hardcoded names, so two running test processes will fail.

### How?

Testing library sets `CI_VISIBILITY_MESSAGE_CHANNEL_UUID` variable which is used for name generation for MachPorts.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
