### PR TITLE
RUM-3588 fix: Always update crash context with RUM attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVEMENT] Crash errors now include up-to-date global RUM attributes. See [#1834][]
 - [FEATURE] `DatadogTrace` now supports OpenTelemetry. See [#1828][]
 
 # 2.11.0 / 08-05-2024
@@ -659,6 +660,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1767]: https://github.com/DataDog/dd-sdk-ios/pull/1767
 [#1798]: https://github.com/DataDog/dd-sdk-ios/pull/1798
 [#1776]: https://github.com/DataDog/dd-sdk-ios/pull/1776
+[#1834]: https://github.com/DataDog/dd-sdk-ios/pull/1834
 [#1721]: https://github.com/DataDog/dd-sdk-ios/pull/1721
 [#1803]: https://github.com/DataDog/dd-sdk-ios/pull/1803
 [#1807]: https://github.com/DataDog/dd-sdk-ios/pull/1807

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -266,6 +266,8 @@
 		61133C702423993200786299 /* DatadogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* DatadogCore.framework */; };
 		6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
+		61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */; };
+		61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */; };
 		6121627C247D220500AC5D67 /* TracingWithLoggingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* TracingWithLoggingIntegrationTests.swift */; };
 		61216B762666DDA10089DCD1 /* LoggerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B752666DDA10089DCD1 /* LoggerConfigurationTests.swift */; };
 		61216B7B2667A9AE0089DCD1 /* LogsConfigurationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7A2667A9AE0089DCD1 /* LogsConfigurationE2ETests.swift */; };
@@ -2250,6 +2252,7 @@
 		611529A425E3DD51004F740E /* ValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValuePublisher.swift; sourceTree = "<group>"; };
 		611529AD25E3E429004F740E /* ValuePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValuePublisherTests.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
+		61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorContextNotifierTests.swift; sourceTree = "<group>"; };
 		611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* TracingWithLoggingIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithLoggingIntegration.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* TracingWithLoggingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithLoggingIntegrationTests.swift; sourceTree = "<group>"; };
@@ -4799,6 +4802,7 @@
 				6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */,
 				61494CB424C864680082C633 /* RUMResourceScopeTests.swift */,
 				617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */,
+				61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -8561,6 +8565,7 @@
 				D23F8EB129DDCD38001CFAE8 /* RUMViewScopeTests.swift in Sources */,
 				D224431029E977A100274EC7 /* TelemetryReceiverTests.swift in Sources */,
 				D23F8EB229DDCD38001CFAE8 /* ValuePublisherTests.swift in Sources */,
+				61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BD2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C12A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
@@ -8870,6 +8875,7 @@
 				D29A9FB829DDB483005C54A4 /* RUMViewScopeTests.swift in Sources */,
 				D224430F29E9779F00274EC7 /* TelemetryReceiverTests.swift in Sources */,
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
+				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BC2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -469,6 +469,8 @@
 		619CE75F2A458CE1005588CB /* TraceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */; };
 		619CE7612A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
 		619CE7622A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
+		619F5CEC2BF5089C004BFE70 /* GlobalRUMAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F5CEA2BF5089B004BFE70 /* GlobalRUMAttributes.swift */; };
+		619F5CED2BF508A4004BFE70 /* GlobalRUMAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F5CEA2BF5089B004BFE70 /* GlobalRUMAttributes.swift */; };
 		61A1A44929643254007909E7 /* DatadogCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A44829643254007909E7 /* DatadogCoreProxy.swift */; };
 		61A1A44A29643254007909E7 /* DatadogCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A44829643254007909E7 /* DatadogCoreProxy.swift */; };
 		61A2CC212A443D330000FF25 /* DDRUMConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */; };
@@ -2450,6 +2452,7 @@
 		61993672265BC029009D7EA8 /* E2ETests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2ETests.xcconfig; sourceTree = "<group>"; };
 		619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceConfigurationTests.swift; sourceTree = "<group>"; };
 		619CE7602A458D66005588CB /* TraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTests.swift; sourceTree = "<group>"; };
+		619F5CEA2BF5089B004BFE70 /* GlobalRUMAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalRUMAttributes.swift; sourceTree = "<group>"; };
 		61A1A44829643254007909E7 /* DatadogCoreProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreProxy.swift; sourceTree = "<group>"; };
 		61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMConfigurationTests.swift; sourceTree = "<group>"; };
 		61A2CC232A44454D0000FF25 /* DDRUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMTests.swift; sourceTree = "<group>"; };
@@ -4641,6 +4644,8 @@
 		6167E6DF2B81203A00C3CA2D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				619F5CEB2BF5089B004BFE70 /* RUM */,
+				D25C834D2B88A261008E73B1 /* WebViewTracking */,
 				6167E6E02B81204B00C3CA2D /* CrashReporting */,
 			);
 			path = Models;
@@ -4954,6 +4959,14 @@
 				61133C282423990D00786299 /* FileReaderTests.swift */,
 			);
 			path = Reading;
+			sourceTree = "<group>";
+		};
+		619F5CEB2BF5089B004BFE70 /* RUM */ = {
+			isa = PBXGroup;
+			children = (
+				619F5CEA2BF5089B004BFE70 /* GlobalRUMAttributes.swift */,
+			);
+			path = RUM;
 			sourceTree = "<group>";
 		};
 		61AE74112AD6EE7E008DB9BB /* Matchers */ = {
@@ -5551,14 +5564,6 @@
 			path = Swizzling;
 			sourceTree = "<group>";
 		};
-		D21A94F02B838CCD00AC4256 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				D25C834D2B88A261008E73B1 /* WebViewTracking */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
 		D21AE6BA29E5ED7D0064BF29 /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
@@ -5606,7 +5611,6 @@
 				D23039D1298D5235001A1FA3 /* Upload */,
 				D2A783D329A53049003B03BB /* Utils */,
 				D2160CE229C0DFED00FAA9A5 /* Swizzling */,
-				D21A94F02B838CCD00AC4256 /* Models */,
 				D2EBEE1D29BA15BC00B15732 /* NetworkInstrumentation */,
 			);
 			name = DatadogInternal;
@@ -8373,6 +8377,7 @@
 				D23039E9298D5236001A1FA3 /* TrackingConsent.swift in Sources */,
 				D2EBEE2629BA160F00B15732 /* B3HTTPHeaders.swift in Sources */,
 				D23354FC2A42E32000AFCAE2 /* InternalExtended.swift in Sources */,
+				619F5CEC2BF5089C004BFE70 /* GlobalRUMAttributes.swift in Sources */,
 				D23039F3298D5236001A1FA3 /* DynamicCodingKey.swift in Sources */,
 				D2BEEDB22B335DA90065F3AC /* URLSessionTaskDelegateSwizzler.swift in Sources */,
 				D23039FE298D5236001A1FA3 /* FeatureRequestBuilder.swift in Sources */,
@@ -9298,6 +9303,7 @@
 				D2DA235A298D57AA00C6C7E6 /* TrackingConsent.swift in Sources */,
 				D2EBEE3429BA161100B15732 /* B3HTTPHeaders.swift in Sources */,
 				D23354FD2A42E32000AFCAE2 /* InternalExtended.swift in Sources */,
+				619F5CED2BF508A4004BFE70 /* GlobalRUMAttributes.swift in Sources */,
 				D2DA235B298D57AA00C6C7E6 /* DynamicCodingKey.swift in Sources */,
 				D2BEEDB32B335DA90065F3AC /* URLSessionTaskDelegateSwizzler.swift in Sources */,
 				D2DA235C298D57AA00C6C7E6 /* FeatureRequestBuilder.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -302,6 +302,7 @@ class CrashContextProviderTests: XCTestCase {
     // MARK: - Helpers
 
     private func DDAssert(crashContext: CrashContext, includes sdkContext: DatadogContext, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(crashContext.appLaunchDate, sdkContext.launchTime?.launchDate, file: file, line: line)
         XCTAssertEqual(crashContext.serverTimeOffset, sdkContext.serverTimeOffset, file: file, line: line)
         XCTAssertEqual(crashContext.service, sdkContext.service, file: file, line: line)
         XCTAssertEqual(crashContext.env, sdkContext.env, file: file, line: line)

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -66,6 +66,40 @@ class CrashContextTests: XCTestCase {
         )
     }
 
+    func testGivenContextWithLastRUMAttributesSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomRUMAttributes = Bool.random() ? GlobalRUMAttributes(attributes: mockRandomAttributes()) : nil
+
+        // Given
+        let context: CrashContext = .mockWith(lastRUMAttributes: randomRUMAttributes)
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        DDAssertJSONEqual(
+            deserializedContext.lastRUMAttributes,
+            randomRUMAttributes
+        )
+    }
+
+    func testGivenContextWithLastLogttributesSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomLogAttributes = Bool.random() ? AnyCodable(mockRandomAttributes()) : nil
+
+        // Given
+        let context: CrashContext = .mockWith(lastLogAttributes: randomLogAttributes)
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        DDAssertJSONEqual(
+            deserializedContext.lastLogAttributes,
+            randomLogAttributes
+        )
+    }
+
     func testGivenContextWithUserInfoSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
         let randomUserInfo: UserInfo = .mockRandom()
 

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -144,8 +144,9 @@ extension CrashContext {
         lastRUMViewEvent: AnyCodable? = nil,
         lastRUMSessionState: AnyCodable? = nil,
         lastIsAppInForeground: Bool = .mockAny(),
-        lastLogAttributes: AnyCodable? = nil,
-        appLaunchDate: Date? = .mockRandomInThePast()
+        appLaunchDate: Date? = .mockRandomInThePast(),
+        lastRUMAttributes: GlobalRUMAttributes? = nil,
+        lastLogAttributes: AnyCodable? = nil
     ) -> Self {
         .init(
             serverTimeOffset: serverTimeOffset,
@@ -160,11 +161,12 @@ extension CrashContext {
             userInfo: userInfo,
             networkConnectionInfo: networkConnectionInfo,
             carrierInfo: carrierInfo,
+            lastIsAppInForeground: lastIsAppInForeground,
+            appLaunchDate: appLaunchDate,
             lastRUMViewEvent: lastRUMViewEvent,
             lastRUMSessionState: lastRUMSessionState,
-            lastIsAppInForeground: lastIsAppInForeground,
-            lastLogAttributes: lastLogAttributes,
-            appLaunchDate: appLaunchDate
+            lastRUMAttributes: lastRUMAttributes,
+            lastLogAttributes: lastLogAttributes
         )
     }
 
@@ -182,11 +184,12 @@ extension CrashContext {
             userInfo: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
             carrierInfo: .mockRandom(),
+            lastIsAppInForeground: .mockRandom(),
+            appLaunchDate: .mockRandomInThePast(),
             lastRUMViewEvent: AnyCodable(mockRandomAttributes()),
             lastRUMSessionState: AnyCodable(mockRandomAttributes()),
-            lastIsAppInForeground: .mockRandom(),
-            lastLogAttributes: AnyCodable(mockRandomAttributes()),
-            appLaunchDate: .mockRandomInThePast()
+            lastRUMAttributes: GlobalRUMAttributes(attributes: mockRandomAttributes()),
+            lastLogAttributes: AnyCodable(mockRandomAttributes())
         )
     }
 

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -702,6 +702,7 @@ func mockNoOpSessionListener() -> RUM.SessionListener {
 internal class FatalErrorContextNotifierMock: FatalErrorContextNotifying {
     var sessionState: RUMSessionState?
     var view: RUMViewEvent?
+    var globalAttributes: [String: Encodable] = [:]
 }
 
 extension RUMScopeDependencies {

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -699,6 +699,11 @@ func mockNoOpSessionListener() -> RUM.SessionListener {
     return { _, _ in }
 }
 
+internal class FatalErrorContextNotifierMock: FatalErrorContextNotifying {
+    var sessionState: RUMSessionState?
+    var view: RUMViewEvent?
+}
+
 extension RUMScopeDependencies {
     static func mockAny() -> RUMScopeDependencies {
         return mockWith()
@@ -718,7 +723,8 @@ extension RUMScopeDependencies {
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
-        viewCache: ViewCache = ViewCache()
+        viewCache: ViewCache = ViewCache(),
+        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -734,7 +740,8 @@ extension RUMScopeDependencies {
             syntheticsTest: syntheticsTest,
             vitalsReaders: vitalsReaders,
             onSessionStart: onSessionStart,
-            viewCache: viewCache
+            viewCache: viewCache,
+            fatalErrorContext: fatalErrorContext
         )
     }
 
@@ -752,7 +759,8 @@ extension RUMScopeDependencies {
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: RUM.SessionListener? = nil,
-        viewCache: ViewCache? = nil
+        viewCache: ViewCache? = nil,
+        fatalErrorContext: FatalErrorContextNotifying? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -768,7 +776,8 @@ extension RUMScopeDependencies {
             syntheticsTest: syntheticsTest ?? self.syntheticsTest,
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
             onSessionStart: onSessionStart ?? self.onSessionStart,
-            viewCache: viewCache ?? self.viewCache
+            viewCache: viewCache ?? self.viewCache,
+            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -401,7 +401,6 @@ class CrashReportReceiverTests: XCTestCase {
         DDAssertReflectionEqual(sendRUMViewEvent.os, lastRUMViewEvent.os)
     }
 
-    //
     func testGivenCrashDuringRUMSessionWithActiveView_whenSendingRUMErrorEvent_itIsLinkedToPreviousRUMSessionAndIncludesCrashInformation() throws {
         let lastRUMViewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
 
@@ -720,6 +719,41 @@ class CrashReportReceiverTests: XCTestCase {
         DDAssertJSONEqual(sendRUMErrorEvent.error.wasTruncated, crashReport.wasTruncated)
     }
 
+    func testGivenCrashDuringRUMSessionWithActiveViewAndLastRUMAttributesAvailable_itSendsEventsWithOverridingAttributes() throws {
+        let lastRUMViewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        let lastRUMAttributes = GlobalRUMAttributes(attributes: mockRandomAttributes())
+
+        // Given
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: AnyCodable(lastRUMViewEvent),
+            lastRUMAttributes: lastRUMAttributes
+        )
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+            trackBackgroundEvents: .mockRandom() // no matter BET
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .baggage(
+                key: MessageBusSender.MessageKeys.crash,
+                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMViewAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self)[0].context?.contextInfo)
+        let sentRUMErrorAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self)[0].context?.contextInfo)
+        DDAssertJSONEqual(sentRUMViewAttributes, lastRUMAttributes.attributes)
+        DDAssertJSONEqual(sentRUMErrorAttributes, lastRUMAttributes.attributes)
+    }
+
     // MARK: - Testing Uploaded Data - Crashes During RUM Session With No Active View
 
     func testGivenCrashDuringRUMSessionWithNoActiveView_whenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {
@@ -1002,6 +1036,74 @@ class CrashReportReceiverTests: XCTestCase {
 
             let sentRUMError = featureScope.eventsWritten(ofType: RUMErrorEvent.self)[0]
             XCTAssertEqual(sentRUMError.error.fingerprint, errorFingerprint, "Must send mapped RUMError event")
+        }
+
+        try test(
+            lastRUMSessionState: .mockWith(isInitialSession: true, hasTrackedAnyView: false), // when initial session with no views history
+            launchInForeground: true, // launch in foreground
+            backgroundEventsTrackingEnabled: .mockRandom() // no matter BET
+        )
+
+        try test(
+            lastRUMSessionState: .mockRandom(), // any sampled session
+            launchInForeground: false, // launch in background
+            backgroundEventsTrackingEnabled: true // BET enabled
+        )
+    }
+
+    func testGivenCrashDuringRUMSessionWithNoActiveViewAndLastRUMAttributesAvailable_itSendsEventsWithOverridingAttributes() throws {
+        func test(
+            lastRUMSessionState: RUMSessionState,
+            launchInForeground: Bool,
+            backgroundEventsTrackingEnabled: Bool
+        ) throws {
+            let featureScope = FeatureScopeMock()
+
+            // Given
+            let lastRUMAttributes = GlobalRUMAttributes(attributes: mockRandomAttributes())
+            let crashDate: Date = .mockDecember15th2019At10AMUTC()
+            let crashReport: DDCrashReport = .mockWith(
+                date: crashDate,
+                type: .mockRandom()
+            )
+            let dateCorrectionOffset: TimeInterval = .mockRandom()
+            let crashContext: CrashContext = .mockWith(
+                serverTimeOffset: dateCorrectionOffset,
+                service: .mockRandom(),
+                version: .mockRandom(),
+                buildNumber: .mockRandom(),
+                source: .mockRandom(),
+                trackingConsent: .granted,
+                userInfo: .mockRandom(),
+                networkConnectionInfo: .mockRandom(),
+                carrierInfo: .mockRandom(),
+                lastRUMViewEvent: nil, // means there was no active RUM view
+                lastRUMSessionState: AnyCodable(lastRUMSessionState), // means there was RUM session (sampled)
+                lastIsAppInForeground: launchInForeground,
+                lastRUMAttributes: lastRUMAttributes
+            )
+
+            let receiver: CrashReportReceiver = .mockWith(
+                featureScope: featureScope,
+                applicationID: .mockRandom(among: .alphanumerics),
+                dateProvider: RelativeDateProvider(using: crashDate),
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                trackBackgroundEvents: backgroundEventsTrackingEnabled
+            )
+
+            // When
+            XCTAssertTrue(
+                receiver.receive(message: .baggage(
+                    key: MessageBusSender.MessageKeys.crash,
+                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                ), from: NOPDatadogCore())
+            )
+
+            // Then
+            let sentRUMViewAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self)[0].context?.contextInfo)
+            let sentRUMErrorAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self)[0].context?.contextInfo)
+            DDAssertJSONEqual(sentRUMViewAttributes, lastRUMAttributes.attributes)
+            DDAssertJSONEqual(sentRUMErrorAttributes, lastRUMAttributes.attributes)
         }
 
         try test(
@@ -1314,6 +1416,63 @@ class CrashReportReceiverTests: XCTestCase {
             backgroundEventsTrackingEnabled: true, // BET enabled
             expectViewName: RUMOffViewEventsHandlingRule.Constants.backgroundViewName,
             expectViewURL: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL
+        )
+    }
+
+    func testGivenCrashDuringAppLaunchAndLastRUMAttributesAvailable_itSendsEventsWithOverridingAttributes() throws {
+        func test(
+            launchInForeground: Bool,
+            backgroundEventsTrackingEnabled: Bool
+        ) throws {
+            let featureScope = FeatureScopeMock()
+            let lastRUMAttributes = GlobalRUMAttributes(attributes: mockRandomAttributes())
+
+            // Given
+            let crashDate: Date = .mockDecember15th2019At10AMUTC()
+            let crashReport: DDCrashReport = .mockWith(
+                date: crashDate,
+                type: .mockRandom()
+            )
+
+            let crashContext: CrashContext = .mockWith(
+                trackingConsent: .granted,
+                lastRUMViewEvent: nil, // means there was no RUM session (it crashed during app launch)
+                lastRUMSessionState: nil, // means there was no RUM session (it crashed during app launch)
+                lastIsAppInForeground: launchInForeground,
+                lastRUMAttributes: lastRUMAttributes
+            )
+
+            let mappedViewName = String.mockRandom()
+            let receiver: CrashReportReceiver = .mockWith(
+                featureScope: featureScope,
+                applicationID: .mockRandom(),
+                dateProvider: RelativeDateProvider(using: crashDate),
+                trackBackgroundEvents: backgroundEventsTrackingEnabled
+            )
+
+            // When
+            XCTAssertTrue(
+                receiver.receive(message: .baggage(
+                    key: MessageBusSender.MessageKeys.crash,
+                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                ), from: NOPDatadogCore())
+            )
+
+            // Then
+            let sentRUMViewAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self)[0].context?.contextInfo)
+            let sentRUMErrorAttributes = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self)[0].context?.contextInfo)
+            DDAssertJSONEqual(sentRUMViewAttributes, lastRUMAttributes.attributes)
+            DDAssertJSONEqual(sentRUMErrorAttributes, lastRUMAttributes.attributes)
+        }
+
+        try test(
+            launchInForeground: true, // launch in foreground
+            backgroundEventsTrackingEnabled: .mockRandom() // no matter BET
+        )
+
+        try test(
+            launchInForeground: false, // launch in background
+            backgroundEventsTrackingEnabled: true // BET enabled
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -1442,7 +1442,6 @@ class CrashReportReceiverTests: XCTestCase {
                 lastRUMAttributes: lastRUMAttributes
             )
 
-            let mappedViewName = String.mockRandom()
             let receiver: CrashReportReceiver = .mockWith(
                 featureScope: featureScope,
                 applicationID: .mockRandom(),

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
@@ -63,17 +63,20 @@ internal struct CrashContext: Codable, Equatable {
     /// not support telephony services.
     let carrierInfo: CarrierInfo?
 
+    /// The last _"Is app in foreground?"_ information from crashed app process.
+    let lastIsAppInForeground: Bool
+
     /// The last RUM view in crashed app process.
     var lastRUMViewEvent: AnyCodable?
 
     /// State of the last RUM session in crashed app process.
     var lastRUMSessionState: AnyCodable?
 
-    /// The last _"Is app in foreground?"_ information from crashed app process.
-    let lastIsAppInForeground: Bool
-
     /// Last global log attributes, set with Logs.addAttribute / Logs.removeAttribute
     var lastLogAttributes: AnyCodable?
+
+    /// Last global RUM attributes. It gets updated with adding or removing attributes on `RUMMonitor`.
+    var lastRUMAttributes: GlobalRUMAttributes?
 
     // MARK: - Initialization
 
@@ -90,11 +93,12 @@ internal struct CrashContext: Codable, Equatable {
         userInfo: UserInfo?,
         networkConnectionInfo: NetworkConnectionInfo?,
         carrierInfo: CarrierInfo?,
+        lastIsAppInForeground: Bool,
+        appLaunchDate: Date?,
         lastRUMViewEvent: AnyCodable?,
         lastRUMSessionState: AnyCodable?,
-        lastIsAppInForeground: Bool,
-        lastLogAttributes: AnyCodable?,
-        appLaunchDate: Date?
+        lastRUMAttributes: GlobalRUMAttributes?,
+        lastLogAttributes: AnyCodable?
     ) {
         self.serverTimeOffset = serverTimeOffset
         self.service = service
@@ -108,17 +112,19 @@ internal struct CrashContext: Codable, Equatable {
         self.userInfo = userInfo
         self.networkConnectionInfo = networkConnectionInfo
         self.carrierInfo = carrierInfo
+        self.lastIsAppInForeground = lastIsAppInForeground
+        self.appLaunchDate = appLaunchDate
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState
-        self.lastIsAppInForeground = lastIsAppInForeground
+        self.lastRUMAttributes = lastRUMAttributes
         self.lastLogAttributes = lastLogAttributes
-        self.appLaunchDate = appLaunchDate
     }
 
     init(
         _ context: DatadogContext,
         lastRUMViewEvent: AnyCodable?,
         lastRUMSessionState: AnyCodable?,
+        lastRUMAttributes: GlobalRUMAttributes?,
         lastLogAttributes: AnyCodable?
     ) {
         self.serverTimeOffset = context.serverTimeOffset
@@ -137,6 +143,7 @@ internal struct CrashContext: Codable, Equatable {
 
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState
+        self.lastRUMAttributes = lastRUMAttributes
         self.lastLogAttributes = lastLogAttributes
 
         self.appLaunchDate = context.launchTime?.launchDate

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContextProvider.swift
@@ -105,7 +105,11 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     ///
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) {
-        queue.async {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
             let crashContext = CrashContext(
                 context,
                 lastRUMViewEvent: self.viewEvent,
@@ -121,9 +125,9 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func updateRUMView(with baggage: FeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async { [weak core] in
+        queue.async { [weak core, weak self] in
             do {
-                self.viewEvent = try baggage.decode(type: AnyCodable.self)
+                self?.viewEvent = try baggage.decode(type: AnyCodable.self)
             } catch {
                 core?.telemetry
                     .error("Fails to decode RUM view event from Crash Reporting", error: error)
@@ -132,10 +136,10 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func resetRUMView(with baggage: FeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async { [weak core] in
+        queue.async { [weak core, weak self] in
             do {
                 if try baggage.decode(type: Bool.self) {
-                    self.viewEvent = nil
+                    self?.viewEvent = nil
                 }
             } catch {
                 core?.telemetry
@@ -145,9 +149,9 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func updateSessionState(with baggage: FeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async { [weak core] in
+        queue.async { [weak core, weak self] in
             do {
-                self.sessionState = try baggage.decode(type: AnyCodable.self)
+                self?.sessionState = try baggage.decode(type: AnyCodable.self)
             } catch {
                 core?.telemetry
                     .error("Fails to decode RUM session state from Crash Reporting", error: error)
@@ -156,9 +160,9 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func updateLogAttributes(with baggage: FeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async { [weak core] in
+        queue.async { [weak core, weak self] in
             do {
-                self.logAttributes = try baggage.decode(type: AnyCodable.self)
+                self?.logAttributes = try baggage.decode(type: AnyCodable.self)
             } catch {
                 core?.telemetry
                     .error("Fails to decode log attributes from Crash Reporting", error: error)
@@ -167,9 +171,9 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     }
 
     private func updateRUMAttributes(with baggage: FeatureBaggage, to core: DatadogCoreProtocol) {
-        queue.async { [weak core] in
+        queue.async { [weak core, weak self] in
             do {
-                self.rumAttributes = try baggage.decode(type: GlobalRUMAttributes.self)
+                self?.rumAttributes = try baggage.decode(type: GlobalRUMAttributes.self)
             } catch {
                 core?.telemetry
                     .error("Fails to decode log attributes from Crash Reporting", error: error)

--- a/DatadogInternal/Sources/Models/RUM/GlobalRUMAttributes.swift
+++ b/DatadogInternal/Sources/Models/RUM/GlobalRUMAttributes.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct GlobalRUMAttributes: Codable, PassthroughAnyCodable {
+    public let attributes: [AttributeKey: AttributeValue]
+
+    public init(attributes: [AttributeKey: AttributeValue]) {
+        self.attributes = attributes
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try attributes.forEach {
+            try container.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        attributes = try container.allKeys
+            .reduce(into: [:]) { acc, next in acc[next.stringValue] = try container.decode(AnyCodable.self, forKey: next) }
+    }
+}

--- a/DatadogLogs/Tests/LogsTests.swift
+++ b/DatadogLogs/Tests/LogsTests.swift
@@ -136,7 +136,7 @@ class LogsTests: XCTestCase {
         XCTAssertEqual((baggage.attributes[attributeKey] as? AnyCodable)?.value as? String, attributeValue)
     }
 
-    func testItSendsGlobalLogUpdates_whenRemovettribute() throws {
+    func testItSendsGlobalLogUpdates_whenRemoveAttribute() throws {
         // Given
         let mockMessageReciever = FeatureMessageReceiverMock()
         let core = SingleFeatureCoreMock<LogsFeature>(

--- a/DatadogRUM/Sources/Feature/RUMBaggageKeys.swift
+++ b/DatadogRUM/Sources/Feature/RUMBaggageKeys.swift
@@ -18,4 +18,8 @@ internal enum RUMBaggageKeys {
     /// The key references RUM session state.
     /// The state associated with the key conforms to `Codable`.
     static let sessionState = "rum-session-state"
+
+    /// The key references ``DatadogInternal.GlobalRUMAttributes`` value holding RUM attributes.
+    /// It is sent after each change to RUM attributes in `RUMMonitor`.
+    static let attributes = "global-rum-attributes"
 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -71,7 +71,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 )
             },
             onSessionStart: configuration.onSessionStart,
-            viewCache: ViewCache()
+            viewCache: ViewCache(),
+            fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope)
         )
 
         self.monitor = Monitor(

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
@@ -31,7 +31,7 @@ internal final class AppHangsMonitor {
         appHangThreshold: TimeInterval,
         observedQueue: DispatchQueue,
         backtraceReporter: BacktraceReporting,
-        fatalErrorContext: FatalErrorContextNotifier,
+        fatalErrorContext: FatalErrorContextNotifying,
         dateProvider: DateProvider,
         processID: UUID
     ) {
@@ -53,7 +53,7 @@ internal final class AppHangsMonitor {
     init(
         featureScope: FeatureScope,
         watchdogThread: AppHangsObservingThread,
-        fatalErrorContext: FatalErrorContextNotifier,
+        fatalErrorContext: FatalErrorContextNotifying,
         processID: UUID,
         dateProvider: DateProvider
     ) {

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
@@ -11,7 +11,7 @@ internal final class FatalAppHangsHandler {
     /// RUM feature scope.
     private let featureScope: FeatureScope
     /// RUM context for fatal App Hangs monitoring.
-    private let fatalErrorContext: FatalErrorContextNotifier
+    private let fatalErrorContext: FatalErrorContextNotifying
     /// An ID of the current process.
     private let processID: UUID
     /// Device date provider.
@@ -19,7 +19,7 @@ internal final class FatalAppHangsHandler {
 
     init(
         featureScope: FeatureScope,
-        fatalErrorContext: FatalErrorContextNotifier,
+        fatalErrorContext: FatalErrorContextNotifying,
         processID: UUID,
         dateProvider: DateProvider
     ) {

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -47,7 +47,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         mainQueue: DispatchQueue,
         dateProvider: DateProvider,
         backtraceReporter: BacktraceReporting,
-        fatalErrorContext: FatalErrorContextNotifier,
+        fatalErrorContext: FatalErrorContextNotifying,
         processID: UUID
     ) {
         // Always create views handler (we can't know if it will be used by SwiftUI instrumentation)

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -138,7 +138,6 @@ internal class Monitor: RUMCommandSubscriber {
     }
 
     func process(command: RUMCommand) {
-        let start = Date()
         // process command in event context
         featureScope.eventWriteContext { [weak self] context, writer in
             guard let self = self else {
@@ -152,10 +151,6 @@ internal class Monitor: RUMCommandSubscriber {
             if let debugging = self.debugging {
                 debugging.debug(applicationScope: self.scopes)
             }
-
-            let stop = Date()
-            let diffMs = stop.timeIntervalSince(start) * 1_000
-            print("⭐️ RUM latency (ms): \(diffMs)")
         }
 
         // update the core context with rum context

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -204,10 +204,16 @@ extension Monitor: RUMMonitorProtocol {
 
     func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
         attributes[key] = value
+        process(
+            command: RUMUpdateViewAttributesCommand(time: dateProvider.now)
+        )
     }
 
     func removeAttribute(forKey key: AttributeKey) {
         attributes[key] = nil
+        process(
+            command: RUMUpdateViewAttributesCommand(time: dateProvider.now)
+        )
     }
 
     // MARK: - session

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -14,7 +14,7 @@ internal protocol RUMCommand {
     /// Attributes associated with the command.
     var attributes: [AttributeKey: AttributeValue] { set get }
     /// Whether or not receiving this command should start the "Background" view if no view is active
-    /// and ``Datadog.Configuration.Builder.trackBackgroundEvents(_:)`` is enabled.
+    /// and ``RUM.Configuration.trackBackgroundEvents`` is enabled.
     var canStartBackgroundView: Bool { get }
     /// Whether or not this command is considered a user intaraction
     var isUserInteraction: Bool { get }
@@ -241,6 +241,15 @@ internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAtt
     /// measured since the start of the View.
     let timingName: String
 }
+
+internal struct RUMUpdateViewAttributesCommand: RUMCommand {
+    let canStartBackgroundView = false
+    let isUserInteraction = false
+
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue] = [:]
+}
+
 
 // MARK: - RUM Resource related commands
 

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -242,14 +242,6 @@ internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAtt
     let timingName: String
 }
 
-internal struct RUMUpdateViewAttributesCommand: RUMCommand {
-    let canStartBackgroundView = false
-    let isUserInteraction = false
-
-    var time: Date
-    var attributes: [AttributeKey: AttributeValue] = [:]
-}
-
 // MARK: - RUM Resource related commands
 
 internal protocol RUMResourceCommand: RUMCommand {

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -250,7 +250,6 @@ internal struct RUMUpdateViewAttributesCommand: RUMCommand {
     var attributes: [AttributeKey: AttributeValue] = [:]
 }
 
-
 // MARK: - RUM Resource related commands
 
 internal protocol RUMResourceCommand: RUMCommand {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/FatalErrorContextNotifier.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/FatalErrorContextNotifier.swift
@@ -7,9 +7,19 @@
 import Foundation
 import DatadogInternal
 
-/// Manages RUM information necessary for building context for fatal errors such as Crashes or Fatal App Hangs.
+/// A type managing RUM information necessary for building context of fatal errors such as Crashes or Fatal App Hangs.
+internal protocol FatalErrorContextNotifying: AnyObject {
+    /// The state of the current RUM session.
+    /// Can be `nil` if no session was yet started. Never gets `nil` after starting first session.
+    var sessionState: RUMSessionState? { set get }
+    /// The active RUM view in current session.
+    /// Can be `nil` if no view is yet started. Will become `nil` if view was stopped without starting the new one.
+    var view: RUMViewEvent? { set get }
+}
+
+/// Manages RUM information necessary for building context of fatal errors such as Crashes or Fatal App Hangs.
 /// It tracks value changes and notifies updates on message bus.
-internal final class FatalErrorContextNotifier {
+internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     /// Message bus interface to send context updates to Crash Reporting.
     private let messageBus: MessageSending
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -44,7 +44,7 @@ internal struct RUMScopeDependencies {
     let onSessionStart: RUM.SessionListener?
     let viewCache: ViewCache
     /// The RUM context necessary for tracking fatal errors like Crashes or fatal App Hangs.
-    let fatalErrorContext: FatalErrorContextNotifier
+    let fatalErrorContext: FatalErrorContextNotifying
     /// Telemetry endpoint.
     let telemetry: Telemetry
     let sessionType: RUMSessionType
@@ -63,7 +63,8 @@ internal struct RUMScopeDependencies {
         syntheticsTest: RUMSyntheticsTest?,
         vitalsReaders: VitalsReaders?,
         onSessionStart: RUM.SessionListener?,
-        viewCache: ViewCache
+        viewCache: ViewCache,
+        fatalErrorContext: FatalErrorContextNotifying
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID
@@ -79,7 +80,7 @@ internal struct RUMScopeDependencies {
         self.vitalsReaders = vitalsReaders
         self.onSessionStart = onSessionStart
         self.viewCache = viewCache
-        self.fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        self.fatalErrorContext = fatalErrorContext
         self.telemetry = featureScope.telemetry
 
         if ciTest != nil {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -196,8 +196,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMAddViewTimingCommand where isActiveView:
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true
-        case _ as RUMUpdateViewAttributesCommand where isActiveView:
-            needsViewUpdate = true
 
         // Resource commands
         case let command as RUMStartResourceCommand where isActiveView:
@@ -439,8 +437,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         // RUMM-3133 Don't override View attributes with commands that are not view related.
         if command is RUMViewScopePropagatableAttributes {
             attributes.merge(rumCommandAttributes: command.attributes)
-        } else if command is RUMUpdateViewAttributesCommand {
-            attributes = command.attributes
         }
 
         let isCrash = (command as? RUMErrorCommand).map { $0.isCrash ?? false } ?? false
@@ -547,9 +543,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         )
 
         if let event = dependencies.eventBuilder.build(from: viewEvent) {
-            if !(command is RUMUpdateViewAttributesCommand) {
-                writer.write(value: event, metadata: event.metadata())
-            }
+            writer.write(value: event, metadata: event.metadata())
 
             // Update fatal error context with recent RUM view:
             dependencies.fatalErrorContext.view = event

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -23,7 +23,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -48,7 +48,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -70,7 +70,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -95,7 +95,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -116,7 +116,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -137,7 +137,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
 
@@ -158,7 +158,7 @@ class RUMInstrumentationTests: XCTestCase {
             mainQueue: .main,
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
-            fatalErrorContext: .mockAny(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
             processID: .mockAny()
         )
         let subscriber = RUMCommandSubscriberMock()

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -748,6 +748,7 @@ func mockNoOpSessionListener() -> RUM.SessionListener {
 internal class FatalErrorContextNotifierMock: FatalErrorContextNotifying {
     var sessionState: RUMSessionState?
     var view: RUMViewEvent?
+    var globalAttributes: [String: Encodable] = [:]
 }
 
 extension RUMScopeDependencies {

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -745,12 +745,9 @@ func mockNoOpSessionListener() -> RUM.SessionListener {
     return { _, _ in }
 }
 
-extension FatalErrorContextNotifier: AnyMockable {
-    public static func mockAny() -> FatalErrorContextNotifier {
-        return FatalErrorContextNotifier(
-            messageBus: NOPFeatureScope()
-        )
-    }
+internal class FatalErrorContextNotifierMock: FatalErrorContextNotifying {
+    var sessionState: RUMSessionState?
+    var view: RUMViewEvent?
 }
 
 extension RUMScopeDependencies {
@@ -772,7 +769,8 @@ extension RUMScopeDependencies {
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
-        viewCache: ViewCache = ViewCache()
+        viewCache: ViewCache = ViewCache(),
+        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -788,7 +786,8 @@ extension RUMScopeDependencies {
             syntheticsTest: syntheticsTest,
             vitalsReaders: vitalsReaders,
             onSessionStart: onSessionStart,
-            viewCache: viewCache
+            viewCache: viewCache,
+            fatalErrorContext: fatalErrorContext
         )
     }
 
@@ -806,7 +805,8 @@ extension RUMScopeDependencies {
         syntheticsTest: RUMSyntheticsTest? = nil,
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: RUM.SessionListener? = nil,
-        viewCache: ViewCache? = nil
+        viewCache: ViewCache? = nil,
+        fatalErrorContext: FatalErrorContextNotifying? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -822,7 +822,8 @@ extension RUMScopeDependencies {
             syntheticsTest: syntheticsTest ?? self.syntheticsTest,
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
             onSessionStart: onSessionStart ?? self.onSessionStart,
-            viewCache: viewCache ?? self.viewCache
+            viewCache: viewCache ?? self.viewCache,
+            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext
         )
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -62,7 +62,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Then
         let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(lastView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
-        XCTAssertEqual(lastView.attribute(forKey: "attribute"), "value")
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
     }
 
     func testAddingGlobalAttributesAfterSDKInit_thenRemovingAttribute() throws {
@@ -162,7 +162,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Then
         let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(lastView.view.name, "View")
-        XCTAssertEqual(lastView.attribute(forKey: "attribute"), "value")
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
     }
 
     func testAddingGlobalAttributesAfterViewIsStarted_thenRemovingAttribute() throws {
@@ -255,7 +255,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView1.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(lastView1.attribute(forKey: "attribute3"), "value3")
 
-        XCTAssertNil(lastView2.attribute(forKey: "attribute1"))
+        XCTAssertEqual(lastView2.attribute(forKey: "attribute1"), "value1")
         XCTAssertEqual(lastView2.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(lastView2.attribute(forKey: "attribute3"), "value3")
 
@@ -394,7 +394,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.view.error.count, 1)
         XCTAssertEqual(lastView.view.action.count, 1)
         XCTAssertEqual(lastView.view.resource.count, 1)
-        XCTAssertEqual(lastView.attribute(forKey: "attribute"), "value")
+        XCTAssertNil(lastView.attribute(forKey: "attribute"))
         XCTAssertEqual(errorEvent.context?.contextInfo["attribute"] as? String, "value")
         XCTAssertEqual(actionEvent.context?.contextInfo["attribute"] as? String, "value")
         XCTAssertEqual(resourceEvent.context?.contextInfo["attribute"] as? String, "value")
@@ -424,7 +424,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.view.action.count, 1)
         XCTAssertEqual(lastView.view.resource.count, 1)
         XCTAssertNil(lastView.attribute(forKey: "attribute1"))
-        XCTAssertEqual(lastView.attribute(forKey: "attribute2"), "value2")
+        XCTAssertNil(lastView.attribute(forKey: "attribute2"))
         XCTAssertNil(errorEvent.context?.contextInfo["attribute1"])
         XCTAssertEqual(errorEvent.context?.contextInfo["attribute2"] as? String, "value2")
         XCTAssertNil(actionEvent.context?.contextInfo["attribute1"])
@@ -486,7 +486,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
 
     // MARK: - Updating Fatal Error Context With Global Attributes
 
-    func testGivenSDKInitialized_whenGlobalAttributeIsAdded_thenFatalErrorContextIsUpdatedWithNewView() throws {
+    func testGivenSDKInitialized_whenGlobalAttributeIsAdded_thenFatalErrorContextIsUpdatedWithNewAttributes() throws {
         let fatalErrorContext = FatalErrorContextNotifierMock()
 
         // Given
@@ -500,12 +500,11 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.addAttribute(forKey: "attribute", value: "value")
 
         // Then
-        let fatalErrorContextView = try XCTUnwrap(fatalErrorContext.view)
-        XCTAssertEqual(fatalErrorContextView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
-        XCTAssertEqual(fatalErrorContextView.attribute(forKey: "attribute"), "value")
+        XCTAssertEqual(fatalErrorContext.globalAttributes["attribute"] as? String, "value")
+        XCTAssertEqual(fatalErrorContext.globalAttributes.count, 1)
     }
 
-    func testGivenSDKInitialized_whenGlobalAttributesAreAddedAndRemoved_thenFatalErrorContextIsUpdatedWithNewView() throws {
+    func testGivenSDKInitialized_whenGlobalAttributesAreAddedAndRemoved_thenFatalErrorContextIsUpdatedWithNewAttributes() throws {
         let fatalErrorContext = FatalErrorContextNotifierMock()
 
         // Given
@@ -521,53 +520,8 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.removeAttribute(forKey: "attribute1")
 
         // Then
-        let fatalErrorContextView = try XCTUnwrap(fatalErrorContext.view)
-        XCTAssertEqual(fatalErrorContextView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
-        XCTAssertNil(fatalErrorContextView.attribute(forKey: "attribute1"))
-        XCTAssertEqual(fatalErrorContextView.attribute(forKey: "attribute2"), "value2")
-    }
-
-    func testGivenSDKInitializedAndViewStarted_whenGlobalAttributeIsAdded_thenFatalErrorContextIsUpdatedWithNewView() throws {
-        let fatalErrorContext = FatalErrorContextNotifierMock()
-
-        // Given
-        monitor = Monitor(
-            dependencies: .mockWith(featureScope: featureScope, fatalErrorContext: fatalErrorContext),
-            dateProvider: SystemDateProvider()
-        )
-        monitor.notifySDKInit()
-        monitor.startView(key: "View")
-
-        // When
-        monitor.addAttribute(forKey: "attribute", value: "value")
-
-        // Then
-        let fatalErrorContextView = try XCTUnwrap(fatalErrorContext.view)
-        XCTAssertEqual(fatalErrorContextView.view.name, "View")
-        XCTAssertEqual(fatalErrorContextView.attribute(forKey: "attribute"), "value")
-    }
-
-    func testGivenSDKInitializedAndViewStarted_whenGlobalAttributesAreAddedAndRemoved_thenFatalErrorContextIsUpdatedWithNewView() throws {
-        let fatalErrorContext = FatalErrorContextNotifierMock()
-
-        // Given
-        monitor = Monitor(
-            dependencies: .mockWith(featureScope: featureScope, fatalErrorContext: fatalErrorContext),
-            dateProvider: SystemDateProvider()
-        )
-        monitor.notifySDKInit()
-        monitor.startView(key: "View")
-
-        // When
-        monitor.addAttribute(forKey: "attribute1", value: "value1")
-        monitor.addAttribute(forKey: "attribute2", value: "value2")
-        monitor.removeAttribute(forKey: "attribute1")
-
-        // Then
-        let fatalErrorContextView = try XCTUnwrap(fatalErrorContext.view)
-        XCTAssertEqual(fatalErrorContextView.view.name, "View")
-        XCTAssertNil(fatalErrorContextView.attribute(forKey: "attribute1"))
-        XCTAssertEqual(fatalErrorContextView.attribute(forKey: "attribute2"), "value2")
+        XCTAssertEqual(fatalErrorContext.globalAttributes["attribute2"] as? String, "value2")
+        XCTAssertEqual(fatalErrorContext.globalAttributes.count, 1)
     }
 }
 

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -483,6 +483,8 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
     }
+
+    // MARK: - Updating Fatal Error Context
 }
 
 // MARK: - Helpers

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
@@ -76,4 +76,21 @@ class FatalErrorContextNotifierTests: XCTestCase {
         let viewResetMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.viewReset))
         XCTAssertTrue(try viewResetMessage.decode(type: Bool.self))
     }
+
+    // MARK: - Changing Global Attributes
+
+    func testWhenGlobalAttributesAreSet_itSendsAttributesMessage() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let newGlobalAttributes = mockRandomAttributes()
+
+        // When
+        fatalErrorContext.globalAttributes = newGlobalAttributes
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 1)
+        let attributesMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.attributes))
+        DDAssertJSONEqual(newGlobalAttributes, try attributesMessage.decode(type: GlobalRUMAttributes.self).attributes)
+    }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+@testable import DatadogRUM
+
+class FatalErrorContextNotifierTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+
+    // MARK: - Changing Session State
+
+    func testWhenSessionStateIsSet_itSendsSessionStateMessage() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let newSessionState: RUMSessionState = .mockRandom()
+
+        // When
+        fatalErrorContext.sessionState = newSessionState
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 1)
+        let sessionStateMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.sessionState))
+        XCTAssertEqual(newSessionState, try sessionStateMessage.decode())
+    }
+
+    func testWhenSessionStateIsReset_itDoesNotSendNextSessionStateMessage() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let originalSessionState: RUMSessionState = .mockRandom()
+        fatalErrorContext.sessionState = originalSessionState
+
+        // When
+        fatalErrorContext.sessionState = nil
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 1)
+        let sessionStateMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.sessionState))
+        XCTAssertEqual(originalSessionState, try sessionStateMessage.decode())
+    }
+
+    // MARK: - Changing View State
+
+    func testWhenViewIsSet_itSendsViewEventMessage() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let newViewEvent: RUMViewEvent = .mockRandom()
+
+        // When
+        fatalErrorContext.view = newViewEvent
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 1)
+        let viewEventMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.viewEvent))
+        DDAssertJSONEqual(newViewEvent, try viewEventMessage.decode(type: RUMViewEvent.self))
+    }
+
+    func testWhenViewIsReset_itSendsViewResetMessage() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        fatalErrorContext.view = .mockRandom()
+
+        // When
+        fatalErrorContext.view = nil
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 2)
+        let viewResetMessage = try XCTUnwrap(messages.lastBaggage(withKey: RUMBaggageKeys.viewReset))
+        XCTAssertTrue(try viewResetMessage.decode(type: Bool.self))
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2551,16 +2551,17 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.dd.documentVersion, 1, "It should record only one view update")
     }
 
-    // MARK: - Sending Messages Over Message Bus
+    // MARK: - Updating Fatal Error Context
 
-    func testWhenViewIsStarted_itSendsViewEventMessages() throws {
+    func testWhenViewIsStarted_itUpdatesFatalErrorContextWithView() throws {
         let featureScope = FeatureScopeMock()
+        let fatalErrorContext = FatalErrorContextNotifierMock()
 
         // Given
         let scope = RUMViewScope(
             isInitialView: .mockRandom(),
             parent: parent,
-            dependencies: .mockWith(featureScope: featureScope),
+            dependencies: .mockWith(featureScope: featureScope, fatalErrorContext: fatalErrorContext),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
             name: "ViewController",
@@ -2581,8 +2582,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Then
         let rumViewWritten = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last, "It should send view event")
-        let baggageSent = try XCTUnwrap(featureScope.messagesSent().firstBaggage(withKey: RUMBaggageKeys.viewEvent))
-        let rumViewSent: RUMViewEvent = try baggageSent.decode()
-        DDAssertReflectionEqual(rumViewSent, rumViewWritten, "It must sent written event over message bus")
+        let rumViewInFatalErrorContext = try XCTUnwrap(fatalErrorContext.view)
+        DDAssertReflectionEqual(rumViewWritten, rumViewInFatalErrorContext, "It must update fatal error context with the view event written")
     }
 }

--- a/TestUtilities/Helpers/DDAssert.swift
+++ b/TestUtilities/Helpers/DDAssert.swift
@@ -8,6 +8,7 @@
  */
 
 import Foundation
+import DatadogInternal
 import XCTest
 
 public enum DDAssertError: Error {
@@ -144,6 +145,12 @@ private func _DDAssertJSONEqual<T, U>(_ expression1: @autoclosure () throws -> T
     let string2 = data2.utf8String
     guard string1 == string2 else {
         throw DDAssertError.expectedFailure("(\"\(string1)\") is not equal to (\"\(string2)\")")
+    }
+}
+
+public func DDAssertJSONEqual(_ expression1: @autoclosure () throws -> Any, _ expression2: @autoclosure () throws -> Any, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+    _DDEvaluateAssertion(message: message(), file: file, line: line) {
+        try _DDAssertJSONEqual(AnyCodable(expression1()), AnyCodable(expression2()))
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 With this PR, RUM error and RUM view sent after crash will always include up-to-date attributes set on `RUMMonitor`.

Because we don't update crash context with the "last RUM view" info on every change to global attributes, the global RUM attributes held in "last view" were not always correct. Global attributes change that happened during the last active view was never included in the crash error.

### How?

The `RUM.FatalErrorContextNotifier` is updated with `globalAttributes` property. Upon change, it sends a baggage over message bus holding `DatadogInternal.GlobalRUMAttributes` (new type). It is received in `DatadogCrashReporting` and gets encoded into `CrashContext`. 

Upon restarting the app from crash, the value is decoded to `RUM.CrashContext` on regular basis.

🎁 On testing front, I separated tests for updating the `FatalErrorContextNotifier` (1 and 2) from sending encoded baggage over message bus (3 and 4):

<p align="center">
<img width="80%" alt="Screenshot 2024-05-16 at 18 19 42" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/d7f56caf-1343-4dec-b224-8a06e07aab7c">
</p>

#### ♻️ Considered Alternative Approach

In my initial attempt, I tried a simpler approach of updating `crashContext.lastRUMView` with latest RUM attributes. That only required producing view updates on every global attribute change and [updating the view event in `FatalErrorContext`](https://github.com/DataDog/dd-sdk-ios/blob/c044ef9c69369a44c772d395c838d8c6951c2ab3/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift#L548-L549) inside `RUMViewScope`. This however added a linear backpressure to the RUM queue (red line), growing with the number of calls to `monitor.addAttribute(forKey:)`. With lack of "add multiple attribute**s**" API, this perf hit is not acceptable.

The solution implemented in this PR adds much less to the RUM backpressure (yellow line). The impact is related to message bus communication which is done on shared thread. 

<p align="center">
<img width="50%" alt="Screenshot 2024-05-16 at 18 33 20" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/39d11d4b-45f6-4c8b-8ad7-0e3bd3c4889c">
</p>



### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
