### PR TITLE
fix: Remove `WKWebView` instance in tests

### DIFF
--- a/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
@@ -7,7 +7,8 @@
 import XCTest
 
 #if !os(tvOS)
-import WebKit
+
+import DatadogInternal
 
 @testable import DatadogLogs
 @testable import DatadogRUM
@@ -29,10 +30,15 @@ class WebLogIntegrationTests: XCTestCase {
         )
 
         controller = WKUserContentControllerMock()
-        let configuration = WKWebViewConfiguration()
-        configuration.userContentController = controller
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        WebViewTracking.enable(webView: webView, in: core)
+
+        WebViewTracking.enable(
+            tracking: controller,
+            hosts: [],
+            hostsSanitizer: HostsSanitizer(),
+            logsSampleRate: 100,
+            sessionReplayConfiguration: nil,
+            in: core
+        )
     }
 
     override func tearDown() {

--- a/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
@@ -6,9 +6,10 @@
 
 import XCTest
 #if !os(tvOS)
-import WebKit
 
+import DatadogInternal
 import TestUtilities
+
 @testable import DatadogRUM
 @testable import DatadogWebViewTracking
 
@@ -28,10 +29,15 @@ class WebEventIntegrationTests: XCTestCase {
         )
 
         controller = WKUserContentControllerMock()
-        let configuration = WKWebViewConfiguration()
-        configuration.userContentController = controller
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        WebViewTracking.enable(webView: webView, in: core)
+        
+        WebViewTracking.enable(
+            tracking: controller,
+            hosts: [],
+            hostsSanitizer: HostsSanitizer(),
+            logsSampleRate: 100,
+            sessionReplayConfiguration: nil,
+            in: core
+        )
     }
 
     override func tearDown() {


### PR DESCRIPTION
### What and why?

Newly introduced webview tests were flaky. It seems that instantiated a `WKWebView` is sporadically retaining a core after the end of the test. **I'm not able to find any retain**, the core is always `weak`.

### How?
Enabe webview tracking on the `WKUserContentController` in tests, instead of a parent `WKWebView`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
