### PR TITLE
fix: Remove flaky assertion due to upload at init

### DIFF
--- a/DatadogCore/Tests/Datadog/DatadogTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogTests.swift
@@ -330,6 +330,7 @@ class DatadogTests: XCTestCase {
         // mock data is written only after this operation completes - otherwise, migration may delete mocked files.
         core.readWriteQueue.sync {}
 
+        // Given
         let featureDirectories: [FeatureDirectories] = [
             try core.directory.getFeatureDirectories(forFeatureNamed: "logging"),
             try core.directory.getFeatureDirectories(forFeatureNamed: "tracing"),
@@ -337,10 +338,6 @@ class DatadogTests: XCTestCase {
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }
         try allDirectories.forEach { directory in _ = try directory.createFile(named: .mockRandom()) }
-
-        // Given
-        let numberOfFiles = try allDirectories.reduce(0, { acc, nextDirectory in return try acc + nextDirectory.files().count })
-        XCTAssertEqual(numberOfFiles, 4, "Each feature stores 2 files - one authorised and one unauthorised")
 
         // When
         Datadog.clearAllData()


### PR DESCRIPTION
### What and why?

The upload at init could pick files in the authorized folder, so we cannot guarantee that the files will be there while running the test.

The assertion can be removed as we only need to assert that the `clearAllData` removes all files.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
