### PR TITLE
fix: WebView leak in test

### DIFF
--- a/Datadog/IntegrationUnitTests/SessionReplay/WebRecordIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/SessionReplay/WebRecordIntegrationTests.swift
@@ -15,7 +15,8 @@ import TestUtilities
 
 class WebRecordIntegrationTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
-    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var core: DatadogCoreProxy!
+    private var webView: WKWebView!
     private var controller: WKUserContentControllerMock!
     // swiftlint:enable implicitly_unwrapped_optional
 
@@ -30,20 +31,22 @@ class WebRecordIntegrationTests: XCTestCase {
 
         controller = WKUserContentControllerMock()
         let configuration = WKWebViewConfiguration()
+        configuration.processPool = WKProcessPool() // do not share cookies between instances: prevent leak
         configuration.userContentController = controller
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView = WKWebView(frame: .zero, configuration: configuration)
         WebViewTracking.enable(webView: webView, in: core)
     }
 
     override func tearDown() {
+        WebViewTracking.disable(webView: webView)
         core.flushAndTearDown()
         core = nil
+        webView = nil
         controller = nil
     }
 
     func testWebRecordIntegration() throws {
         // Given
-        let webView = WKWebView()
         let randomApplicationID: String = .mockRandom()
         let randomUUID: UUID = .mockRandom()
         let randomBrowserViewID: UUID = .mockRandom()


### PR DESCRIPTION
### What and why?

Yet another fix for flakiness introduced by a webview test:
Prevent sharing cookies between webview instances by setting a new `WKProcessPool`. It is possible that the cookie storage creates leak.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
