### PR TITLE
RUM-4440 feat: Upgrade PLCR to `1.11.2`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "microsoft/plcrashreporter" ~> 1.11.1
+github "microsoft/plcrashreporter" ~> 1.11.2
 binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" ~> 1.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.6.0"
-github "microsoft/plcrashreporter" "1.11.1"
+github "microsoft/plcrashreporter" "1.11.2"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'PLCrashReporter', '~> 1.11.1'
+  s.dependency 'PLCrashReporter', '~> 1.11.2'
 
   s.resource_bundle = {
     "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'PLCrashReporter', '~> 1.11.1'
+  s.dependency 'PLCrashReporter', '~> 1.11.2'
 
   s.resource_bundle = {
     "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.1"),
+        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2"),
         .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "1.6.0")
     ],
     targets: [


### PR DESCRIPTION
### What and why?

📦 Upgrading the PLCR dependency to [1.11.2](https://github.com/microsoft/plcrashreporter/releases/tag/1.11.2).

PLCR changelog:
```
[Improvement] Update PLCrashReporter to include privacy manifest.
[Improvement] Increase the maximum report size to 1MB.
```

### How?

Updated PLCR version for SPM, CP and CT.

Even tho PLCR now ships the privacy manifest which was earlier duplicated for `DatadogCrashReporting`, we decide to keep our manifest. There should be no harm in this setup:
- [our manifest](https://github.com/DataDog/dd-sdk-ios/blob/develop/DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy)
- [same fields in PLCR’s manifest](https://github.com/microsoft/plcrashreporter/blob/1.11.2/Resources/PrivacyInfo.xcprivacy#L13-L24)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [x] Run smoke tests
- [ ] Run tests for `tools/`
