### PR TITLE
chore: add support for Package.resolved V3

### DIFF
--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -29,9 +29,9 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
     dd_sdk_ios_package = PackageResolvedFile(path=f'{dd_sdk_package_path}/Package.resolved')
     dd_sdk_ios_package.print()
 
-    if dd_sdk_ios_package.version > 2:
+    if dd_sdk_ios_package.version > 3:
         raise Exception(
-            f'`dogfood.py` expects the `package.resolved` in `dd-sdk-ios` to use version <= 2 ' +
+            f'`dogfood.py` expects the `package.resolved` in `dd-sdk-ios` to use version <= 3 ' +
             f'but version {dd_sdk_ios_package.version} was detected. Update `dogfood.py` to use this version.'
         )
 

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -384,9 +384,5 @@ class PackageResolvedContentV3(PackageResolvedContentV2):
     Check https://github.com/apple/swift-package-manager/blob/e5123e483c18bff7afdc3b2029f9e1924779bbc8/Sources/Workspace/Workspace%2BDependencies.swift#L280
     """
 
-    def __init__(self, path: str, json_content: dict):
-        self.path = path
-        self.packages = json_content
-
     def origin_hash(self):
         return self.packages['originHash']

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -88,6 +88,8 @@ class PackageResolvedFile(PackageResolvedContent):
                 self.wrapped = PackageResolvedContentV1(self.path, self.packages)
             elif self.version == 2:
                 self.wrapped = PackageResolvedContentV2(self.path, self.packages)
+            elif self.version == 3:
+                self.wrapped = PackageResolvedContentV3(self.path, self.packages)
             else:
                 raise Exception(
                     f'{path} uses version {self.version} but `PackageResolvedFile` only supports ' +
@@ -131,6 +133,15 @@ class PackageResolvedFile(PackageResolvedContent):
 
     def read_dependency(self, package_id: PackageID) -> dict:
         return self.wrapped.read_dependency(package_id)
+
+    def origin_hash(self) -> str:
+        if self.version == 3:
+            return self.wrapped.origin_hash()
+        else:
+            raise Exception(
+                f'{self.path} does not contain `originHash` property. ' +
+                f'Check if the `package.resolved` file is in version 3.'
+            )
 
 
 class PackageResolvedContentV1(PackageResolvedContent):
@@ -346,3 +357,36 @@ class PackageResolvedContentV2(PackageResolvedContent):
 
         package_pin_index = package_pins[0]
         return self.packages['pins'][package_pin_index]
+
+
+class PackageResolvedContentV3(PackageResolvedContentV2):
+    """
+    Example of `package.resolved` in version `2` looks this::
+
+        {
+            "originHash" : "b47de6af98c4a9811a8d2af11d70b960dfc66b7c8e4944b35bb74c8f8bb9c487",
+            "pins" : [
+                {
+                    "identity" : "dd-sdk-ios",
+                    "kind" : "remoteSourceControl",
+                    "location" : "https://github.com/DataDog/dd-sdk-ios",
+                    "state" : {
+                        "branch" : "dogfooding",
+                        "revision" : "6f662103771eb4523164e64f7f936bf9276f6bd0"
+                    }
+                },
+                ...
+            ]
+            "version" : 3
+        }
+
+    In v3 new property origin hash has been added which SHA256 hash of the repository content.
+    Check https://github.com/apple/swift-package-manager/blob/e5123e483c18bff7afdc3b2029f9e1924779bbc8/Sources/Workspace/Workspace%2BDependencies.swift#L280
+    """
+
+    def __init__(self, path: str, json_content: dict):
+        self.path = path
+        self.packages = json_content
+
+    def origin_hash(self):
+        return self.packages['originHash']

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -93,7 +93,7 @@ class PackageResolvedFile(PackageResolvedContent):
             else:
                 raise Exception(
                     f'{path} uses version {self.version} but `PackageResolvedFile` only supports ' +
-                    f'versions `1` and `2`. Update `PackageResolvedFile` to support new version.'
+                    f'versions `1`, `2` and `3`. Update `PackageResolvedFile` to support new version.'
                 )
 
     def save(self):


### PR DESCRIPTION
### What and why?

```
 Failed to dogfood: .package.resolved uses version 3 but `PackageResolvedFile` only supports versions `1` and `2`. Update `PackageResolvedFile` to support new version.`
```

### How?

Added V3 version which basically same as V2 with extra field originHash. We are not using it.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
