### PR TITLE
fix: RUM to S8S context

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -46,7 +46,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil {
-            print("_dd.application.id=" + dependencies.rumApplicationID)
+            NSLog("_dd.application.id=" + dependencies.rumApplicationID)
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -122,7 +122,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && sessionUUID != .nullUUID {
-            print("_dd.session.id=" + sessionUUID.toRUMDataFormat)
+            NSLog("_dd.session.id=" + sessionUUID.toRUMDataFormat)
         }
     }
 
@@ -283,11 +283,6 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             timestamp: startTime.timeIntervalSince1970.toInt64Milliseconds,
             hasReplay: hasReplay
         )
-
-        // Notify Synthetics if needed
-        if dependencies.syntheticsTest != nil && sessionUUID != .nullUUID {
-            print("_dd.view.id=" + id)
-        }
     }
 
     private func startApplicationLaunchView(on command: RUMApplicationStartCommand, context: DatadogContext, writer: Writer) {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -127,7 +127,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {
-            print("_dd.view.id=" + self.viewUUID.toRUMDataFormat)
+            NSLog("_dd.view.id=" + self.viewUUID.toRUMDataFormat)
         }
     }
 


### PR DESCRIPTION
### What and why?

Synthetics reads RUM context shared on the device Console but the `print` function only prints to the Xcode console, while `NSLog` also prints entries into Console.

Follow up #1602

### How?

Replace `print` with `NSLog`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
