### PR TITLE
RUM-789 fix: Fix `batch_size` in configuration telemetry

### DIFF
--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -474,7 +474,7 @@ public enum Datadog {
         core.telemetry.configuration(
             backgroundTasksEnabled: configuration.backgroundTasksEnabled,
             batchProcessingLevel: Int64(exactly: configuration.batchProcessingLevel.maxBatchesPerUpload),
-            batchSize: Int64(exactly: performance.maxFileSize),
+            batchSize: performance.uploaderWindow.toInt64Milliseconds,
             batchUploadFrequency: performance.minUploadDelay.toInt64Milliseconds,
             useLocalEncryption: configuration.encryption != nil,
             useProxy: configuration.proxyConfiguration != nil


### PR DESCRIPTION
### What and why?

🐞 🔭 This PR fixes wrong value of the `batch_size` reported in RUM telemetry.

### How?

The previous value was set to "max file size", leading to reporting constant `4194304` bytes.

It is now fixed to report the [`uploaderWindow` value](https://github.com/DataDog/dd-sdk-ios/blob/61ec70ff47462095c90522f5da529eb5e7f441f7/DatadogCore/Sources/PerformancePreset.swift#L48) which is computed from the [SDK's configuration `batchSize`](https://github.com/DataDog/dd-sdk-ios/blob/61ec70ff47462095c90522f5da529eb5e7f441f7/DatadogCore/Sources/Datadog.swift#L37-L46) option (`3`, `10` or `35` seconds depending on the setting).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
