### PR TITLE
RUM-347 fix: Fix `batch_duration` in "Batch Closed" metric

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -55,17 +55,20 @@ class FilesOrchestratorTests: XCTestCase {
     }
 
     func testWhenSameWritableFileWasUsedMaxNumberOfTimes_itCreatesNewFile() throws {
-        let orchestrator = configureOrchestrator(using: RelativeDateProvider(advancingBySeconds: 0.001))
+        let dateProvider = DateProviderMock()
+        let orchestrator = configureOrchestrator(using: dateProvider)
         var previousFile: WritableFile = try orchestrator.getWritableFile(writeSize: 1) // first use of a new file
         var nextFile: WritableFile
 
         for _ in (0..<5) {
             for _ in (0 ..< performance.maxObjectsInFile).dropLast() { // skip first use
+                dateProvider.now.addTimeInterval(0.001)
                 nextFile = try orchestrator.getWritableFile(writeSize: 1)
                 XCTAssertEqual(nextFile.name, previousFile.name, "It should reuse the file \(performance.maxObjectsInFile) times")
                 previousFile = nextFile
             }
 
+            dateProvider.now.addTimeInterval(0.001)
             nextFile = try orchestrator.getWritableFile(writeSize: 1) // first use of a new file
             XCTAssertNotEqual(nextFile.name, previousFile.name, "It should create a new file when previous one is used \(performance.maxObjectsInFile) times")
             previousFile = nextFile


### PR DESCRIPTION
### What and why?

📦 🔭 This PR fixes the wrong value reported in `batch_duration` for "Batch Closed" metrics.

For 1w data, Android SDK reports it as 1.41s in p50 and 9.42s in p90, whereas for iOS SDK it is respectively ~30s and ~3min. 

### How?

Now we measure `batch_duration` in the same way [as Android SDK does](https://github.com/DataDog/dd-sdk-android/blob/a0e05c37a8ec3ee78415e082fb18f8e3a10668e2/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt#L49C17-L49C40) - by marking the last writable access to the batch and computing `batch_duration` as the duration from batch creation to last access.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
