### PR TITLE
RUM-4315 feat: Add missing RUM APIs for Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] `DatadogTrace` now supports OpenTelemetry. See [#1828][]
+- [FEATURE] RUM "stop session", "get session ID" and "evaluate feature flag" APIs are now available for Obj-C. See [#1853][]
 
 # 2.11.0 / 08-05-2024
 
@@ -661,6 +662,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1776]: https://github.com/DataDog/dd-sdk-ios/pull/1776
 [#1721]: https://github.com/DataDog/dd-sdk-ios/pull/1721
 [#1803]: https://github.com/DataDog/dd-sdk-ios/pull/1803
+[#1853]: https://github.com/DataDog/dd-sdk-ios/pull/1853
 [#1807]: https://github.com/DataDog/dd-sdk-ios/pull/1807
 [#1828]: https://github.com/DataDog/dd-sdk-ios/pull/1828
 [@00fa9a]: https://github.com/00FA9A

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -52,6 +52,9 @@
     UIViewController *anyVC = [UIViewController new];
 
     DDRUMMonitor *monitor = [DDRUMMonitor shared];
+    [monitor currentSessionIDWithCompletion:^(NSString * _Nullable sessionID) {}];
+    [monitor stopSession];
+
     [monitor startViewWithViewController:anyVC name:@"" attributes:@{}];
     [monitor stopViewWithViewController:anyVC attributes:@{}];
     [monitor startViewWithKey:@"" name:nil attributes:@{}];
@@ -72,6 +75,10 @@
     [monitor stopActionWithType:DDRUMActionTypeSwipe name:nil attributes:@{}];
     [monitor addActionWithType:DDRUMActionTypeTap name:@"" attributes:@{}];
     [monitor addAttributeForKey:@"" value:@""];
+    [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
+
+    [monitor setDebug:YES];
+    [monitor setDebug:NO];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -453,6 +453,16 @@ public class DDRUMMonitor: NSObject {
     }
 
     @objc
+    public func currentSessionID(completion: @escaping (String?) -> Void) {
+        swiftRUMMonitor.currentSessionID(completion: completion)
+    }
+
+    @objc
+    public func stopSession() {
+        swiftRUMMonitor.stopSession()
+    }
+
+    @objc
     public func startView(
         viewController: UIViewController,
         name: String?,
@@ -632,5 +642,15 @@ public class DDRUMMonitor: NSObject {
     @objc
     public func removeAttribute(forKey key: String) {
         swiftRUMMonitor.removeAttribute(forKey: key)
+    }
+
+    @objc
+    public func addFeatureFlagEvaluation(name: String, value: Any) {
+        swiftRUMMonitor.addFeatureFlagEvaluation(name: name, value: AnyEncodable(value))
+    }
+
+    @objc public var debug: Bool {
+        set { swiftRUMMonitor.debug = newValue }
+        get { swiftRUMMonitor.debug }
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds missing RUM APIs for Objective-C SDK.

### How?

The list includes:
- `[monitor currentSessionIDWithCompletion:]`
- `[monitor stopSession]`
- `[monitor addFeatureFlagEvaluationWithName:value:]`
- `[monitor setDebug:]`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
