### PR TITLE
chore: Fix generating rum models

### DIFF
--- a/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
@@ -26,6 +26,8 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
                 "RUMOperatingSystem",
                 "RUMActionID",
                 "RUMSessionPrecondition",
+                "RUMTelemetryDevice",
+                "RUMTelemetryOperatingSystem",
             ]
         )
     }
@@ -104,11 +106,25 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
         }
 
         if fixedName == "Device" {
-            fixedName = "RUMDevice"
+            if context.parent?.typeName == "telemetry" {
+                // The `telemetry.device` added in https://github.com/DataDog/rum-events-format/pull/200 has different schema
+                // than `*.device` in common schema: https://github.com/DataDog/rum-events-format/blob/dcd62e58566b9d158c404f3588edc62c041262dd/schemas/rum/_common-schema.json#L264-L295
+                // For that reason, we generate it under different name, so the `RUMTelemetryDevice` can be shared between telemetry events.
+                fixedName = "RUMTelemetryDevice"
+            } else {
+                fixedName = "RUMDevice"
+            }
         }
 
         if fixedName == "OS" {
-            fixedName = "RUMOperatingSystem"
+            if context.parent?.typeName == "telemetry" {
+                // The `telemetry.os` added in https://github.com/DataDog/rum-events-format/pull/200 has different schema
+                // than `*.os` in common schema: https://github.com/DataDog/rum-events-format/blob/dcd62e58566b9d158c404f3588edc62c041262dd/schemas/rum/_common-schema.json#L237-L262
+                // For that reason, we generate it under different name, so the `RUMTelemetryOperatingSystem` can be shared between telemetry events.
+                fixedName = "RUMTelemetryOperatingSystem"
+            } else {
+                fixedName = "RUMOperatingSystem"
+            }
         }
 
         // Since https://github.com/DataDog/rum-events-format/pull/57 `action.id` can be either

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/JSONSchema.swift
@@ -209,6 +209,12 @@ internal class JSONSchema: Decodable {
             let schema = try reader.read(url)
             merge(with: schema)
         }
+
+        // TODO: RUM-4571 [iOS] Generate RUM models for Usage Telemetry
+        // With addition of the "usage telemetry" the RUM schema was updated with unsupported constructs.
+        // To avoid `🚧 Unimplemented: "Building `SwiftAssociatedTypeEnum` case label for JSONObject is not supported` failure
+        // here we explicitly ignore the "usage" sub-schema.
+        oneOf = oneOf?.filter { $0.ref != "telemetry/usage-schema.json" }
     }
 
     // MARK: - Schemas Merging


### PR DESCRIPTION
### What and why?

🧰 This PR updates `rum-model-generator` so we can generate models from latest commits in [rum-events-format](https://github.com/DataDog/rum-events-format).

### How?

There were two breaking commits in `rum-events-format`:

**✨[RUM-4029 bootstrap telemetry usage schema](https://github.com/DataDog/rum-events-format/pull/197)** adding a whole new root-level schema for "usage telemetry". It requires generating polymorphic Swift types at nested level which isn't yet supported. Generation fails with:
```
🚧 Unimplemented: Building `SwiftAssociatedTypeEnum` case label for JSONObject is not supported
```
Because we don't yet leverage this feature, this PR explicitly ignores this subschema. The actual work to add this support is moved to `RUM-4571`.

**[RUM-1844: Add device and os info to telemetry events](https://github.com/DataDog/rum-events-format/pull/200)** introducing `telemetry.os` and `telemetry.device` objects. Because definition of these objects is different (although similar) from `*.os` and `*.device` in regular RUM events it was raising the [exception on being unable to share model definition](https://github.com/DataDog/dd-sdk-ios/blob/5bfb43af7411129d0366f0045368b210cebccf05/tools/rum-models-generator/Sources/CodeGeneration/Decorate/SwiftCodeDecorator.swift#L209-L213). To avoid this, `telemetry.os` and `telemetry.device` types are shared using different name.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [x] Run tests for `tools/`


[RUM-4029]: https://datadoghq.atlassian.net/browse/RUM-4029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ