### PR TITLE
fix: set traceContextInjection param for E2E test case

### DIFF
--- a/Datadog/E2ETests/Tracing/TracerE2ETests.swift
+++ b/Datadog/E2ETests/Tracing/TracerE2ETests.swift
@@ -51,7 +51,7 @@ class TracerE2ETests: E2ETests {
     /// ```
     func test_trace_tracer_inject_span_context() {
         let anySpan = tracer.startSpan(operationName: .mockRandom()) // this span is never sent
-        let anyWriter = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 20))
+        let anyWriter = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 20), traceContextInjection: .all)
 
         measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             tracer.inject(spanContext: anySpan.context, writer: anyWriter)


### PR DESCRIPTION
### What and why?

```
❌ /Users/vagrant/git/Datadog/E2ETests/Tracing/TracerE2ETests.swift:54:84: missing argument for parameter 'traceContextInjection' in call
        let anyWriter = HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 20))
```

### How?

Set arg value.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [x] Run smoke tests
- [x] Run tests for `tools/`
