### PR TITLE
refactor: Make `error.kind` and `error.stack` non-optional in SDK errors

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -223,8 +223,8 @@
 		61054FD32A6EE1BA00AAA894 /* MultipartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F902A6EE1BA00AAA894 /* MultipartFormDataTests.swift */; };
 		61054FD42A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F912A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift */; };
 		61054FD52A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F932A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift */; };
-		610ABD4C2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */; };
-		610ABD4D2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */; };
+		610ABD4C2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
+		610ABD4D2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
 		61112F8E2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
 		61112F8F2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
 		6111C58225C0081F00F5C4A2 /* RUMDataModels+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */; };
@@ -416,6 +416,8 @@
 		6174D6062BFB9D6400EC7469 /* DDWebViewTracking+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */; };
 		6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
 		6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
+		6174D61D2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
+		6174D61E2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
 		6175922B2A6FA8EE0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
 		6175922D2A6FADDD0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
 		6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175C3502BCE66DB006FAAB0 /* TraceContext.swift */; };
@@ -2197,7 +2199,7 @@
 		61054F902A6EE1BA00AAA894 /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		61054F912A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentRequestBuilderTests.swift; sourceTree = "<group>"; };
 		61054F932A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssertRectsEqual.swift; sourceTree = "<group>"; };
-		610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryCoreIntegrationTests.swift; sourceTree = "<group>"; };
+		610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTelemetryIntegrationTests.swift; sourceTree = "<group>"; };
 		61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDRUM+apiTests.m"; sourceTree = "<group>"; };
 		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
@@ -2398,6 +2400,7 @@
 		6174D6032BFB9AB600EC7469 /* WebViewTracking+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewTracking+objc.swift"; sourceTree = "<group>"; };
 		6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDWebViewTracking+apiTests.m"; sourceTree = "<group>"; };
 		6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKMetricFields.swift; sourceTree = "<group>"; };
+		6174D61C2C007B3300EC7469 /* ModuleName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleName.swift; sourceTree = "<group>"; };
 		6175C3502BCE66DB006FAAB0 /* TraceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceContext.swift; sourceTree = "<group>"; };
 		617699172A860D9D0030022B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		6176991A2A86121B0030022B /* HTTPClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientMock.swift; sourceTree = "<group>"; };
@@ -3883,7 +3886,7 @@
 			isa = PBXGroup;
 			children = (
 				6176991D2A8791880030022B /* Datadog+MultipleInstancesIntegrationTests.swift */,
-				610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */,
+				610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */,
 				D20FD9D52ACC0934004D3569 /* WebLogIntegrationTests.swift */,
 				D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */,
 			);
@@ -5886,6 +5889,7 @@
 				61133C462423990D00786299 /* TestsDirectory.swift */,
 				61C713D22A3DFB4900FA735A /* FuzzyHelpers.swift */,
 				6167E72B2B84C72B00C3CA2D /* UIKitHelpers.swift */,
+				6174D61C2C007B3300EC7469 /* ModuleName.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -8005,7 +8009,7 @@
 				6128F57B2BA35D6200D35B08 /* FeatureDataStoreTests.swift in Sources */,
 				D29A9FCE29DDC4BA005C54A4 /* RUMFeatureMocks.swift in Sources */,
 				61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */,
-				610ABD4C2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */,
+				610ABD4C2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */,
 				A79B0F64292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */,
 				D2B3F052282E827700C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */,
 				D20605B92875729E0047275C /* ContextValuePublisherMock.swift in Sources */,
@@ -8678,6 +8682,7 @@
 				D2A7840329A536AD003B03BB /* PrintFunctionMock.swift in Sources */,
 				D2A7840D29A53A4B003B03BB /* TestsDirectory.swift in Sources */,
 				D2DA23CF298D5F2300C6C7E6 /* FeatureMessageReceiverMock.swift in Sources */,
+				6174D61D2C007B3300EC7469 /* ModuleName.swift in Sources */,
 				D2160CF029C0EC4D00FAA9A5 /* SingleFeatureCoreMock.swift in Sources */,
 				D2579554298ABB04008A1BE5 /* FeatureBaggageMock.swift in Sources */,
 				3C85D42C29F7C87D00AFF894 /* HostsSanitizerMock.swift in Sources */,
@@ -8723,6 +8728,7 @@
 				D2A7840429A536AD003B03BB /* PrintFunctionMock.swift in Sources */,
 				D2A7840E29A53A4B003B03BB /* TestsDirectory.swift in Sources */,
 				D2DA23D0298D5F2300C6C7E6 /* FeatureMessageReceiverMock.swift in Sources */,
+				6174D61E2C007B3300EC7469 /* ModuleName.swift in Sources */,
 				D2160CF129C0EC4D00FAA9A5 /* SingleFeatureCoreMock.swift in Sources */,
 				D257957E298ABB83008A1BE5 /* FeatureBaggageMock.swift in Sources */,
 				3C85D42D29F7C87D00AFF894 /* HostsSanitizerMock.swift in Sources */,
@@ -9135,7 +9141,7 @@
 				D2CB6EE527C520D400A62B57 /* DataUploadConditionsTests.swift in Sources */,
 				D2CB6EE627C520D400A62B57 /* DateFormattingTests.swift in Sources */,
 				D2CB6EE727C520D400A62B57 /* FileTests.swift in Sources */,
-				610ABD4D2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */,
+				610ABD4D2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */,
 				D2CB6EEA27C520D400A62B57 /* LogMatcher.swift in Sources */,
 				D2CB6EEC27C520D400A62B57 /* CustomObjcViewController.m in Sources */,
 				D2EFA876286E011900F1FAA6 /* DatadogContextProviderTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
@@ -31,7 +31,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
 
         // When
         core.telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
+        #sourceLocation(file: "File.swift", line: 42)
         core.telemetry.error("Error Telemetry")
+        #sourceLocation()
         core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42])
         core.telemetry.stopMethodCalled(
             core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
@@ -50,6 +52,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
 
         let error = errorEvents[0]
         XCTAssertEqual(error.telemetry.message, "Error Telemetry")
+        XCTAssertEqual(error.telemetry.error?.kind, "\(moduleName())/FileError")
+        XCTAssertEqual(error.telemetry.error?.stack, "\(moduleName())/File.swift:42")
 
         let metric = debugEvents[1]
         XCTAssertEqual(metric.telemetry.message, "[Mobile Metric] Metric Name")

--- a/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
@@ -52,7 +52,7 @@ class CoreTelemetryIntegrationTests: XCTestCase {
 
         let error = errorEvents[0]
         XCTAssertEqual(error.telemetry.message, "Error Telemetry")
-        XCTAssertEqual(error.telemetry.error?.kind, "\(moduleName())/FileError")
+        XCTAssertEqual(error.telemetry.error?.kind, "\(moduleName())/File.swift")
         XCTAssertEqual(error.telemetry.error?.stack, "\(moduleName())/File.swift:42")
 
         let metric = debugEvents[1]

--- a/DatadogCore/Sources/Datadog+Internal.swift
+++ b/DatadogCore/Sources/Datadog+Internal.swift
@@ -43,7 +43,7 @@ public struct _TelemetryProxy {
 
     /// See Telementry.error
     public func error(id: String, message: String, kind: String?, stack: String?) {
-        telemetry.error(id: id, message: message, kind: kind, stack: stack)
+        telemetry.error(id: id, message: message, kind: kind ?? "unknown", stack: stack ?? "unknown")
     }
 }
 

--- a/DatadogCore/Tests/Datadog/OpenTracing/OTSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/OpenTracing/OTSpanTests.swift
@@ -44,12 +44,6 @@ private extension Dictionary where Key == String, Value == Encodable {
 }
 
 class OTSpanTests: XCTestCase {
-    #if os(iOS)
-    private let testModuleName = "DatadogCoreTests_iOS"
-    #elseif os(tvOS)
-    private let testModuleName = "DatadogCoreTests_tvOS"
-    #endif
-
     // MARK: - Test Error Conveniences
 
     func testWhenSettingErrorFromSwiftError_itLogsErrorFields() throws {
@@ -71,7 +65,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            \(testModuleName)/File.swift:42
+            \(moduleName())/File.swift:42
             swift error description
             """
         )
@@ -123,7 +117,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            \(testModuleName)/File.swift:42
+            \(moduleName())/File.swift:42
             Error Domain=DDSpan Code=1 "ns error description" UserInfo={NSLocalizedDescription=ns error description}
             """
         )
@@ -147,7 +141,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            \(testModuleName)/File.swift:42
+            \(moduleName())/File.swift:42
             """
         )
     }
@@ -175,7 +169,7 @@ class OTSpanTests: XCTestCase {
         XCTAssertEqual(
             try span.logs[0].otStack(),
             """
-            \(testModuleName)/File.swift:42
+            \(moduleName())/File.swift:42
             Thread 0 Crashed:
             0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
             1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620

--- a/DatadogCore/Tests/Datadog/RUM/TelemetryReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/TelemetryReceiverTests.swift
@@ -29,7 +29,7 @@ class TelemetryReceiverTests: XCTestCase {
         callConcurrently(
             closures: [
                 { core.telemetry.debug(id: .mockRandom(), message: "telemetry debug") },
-                { core.telemetry.error(id: .mockRandom(), message: "telemetry error", kind: nil, stack: nil) },
+                { core.telemetry.error(id: .mockRandom(), message: "telemetry error", kind: "error.kind", stack: "error.stack") },
                 { core.telemetry.configuration(batchSize: .mockRandom()) },
                 {
                     core.set(

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -186,19 +186,11 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ message: String, kind: String? = nil, stack: String? = nil, file: String = #fileID, line: Int = #line) {
-        func defaultKind(fileID: String) -> String {
-            // e.g. `DatadogInternal/Telemetry.swift` -> `DatadogInternal/TelemetryError`
-            return "\(fileID.hasSuffix(".swift") ? String(fileID.dropLast(6)) : fileID)Error"
-        }
-        func defaultStack(fileID: String, line: Int) -> String {
-            "\(fileID):\(line)"
-        }
-
         error(
             id: "\(file):\(line):\(message)",
             message: message,
-            kind: kind ?? defaultKind(fileID: file),
-            stack: stack ?? defaultStack(fileID: file, line: line)
+            kind: kind ?? "\(file)",
+            stack: stack ?? "\(file):\(line)"
         )
     }
 

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -48,14 +48,14 @@ class TelemetryTests: XCTestCase {
     func testSendingErrorTelemetry_whenNoKindAndNoStack() throws {
         // When
         #sourceLocation(file: "File.swift", line: 1)
-        telemetry.error("error message", kind: nil, stack: nil)
+        telemetry.error("error message")
         #sourceLocation()
 
         // Then
         let error = try XCTUnwrap(telemetry.messages.firstError())
         XCTAssertEqual(error.id, "\(moduleName())/File.swift:1:error message")
         XCTAssertEqual(error.message, "error message")
-        XCTAssertEqual(error.kind, "\(moduleName())/FileError")
+        XCTAssertEqual(error.kind, "\(moduleName())/File.swift")
         XCTAssertEqual(error.stack, "\(moduleName())/File.swift:1")
         XCTAssertEqual(telemetry.messages.count, 1)
     }

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -5,267 +5,179 @@
  */
 
 import XCTest
+import Foundation
 import TestUtilities
-
 @testable import DatadogInternal
 
 class TelemetryTests: XCTestCase {
-    func testTelemetryDebug() {
-        // Given
-        class TelemetryTest: Telemetry {
-            var debug: (id: String, message: String, attributes: [String: Encodable]?)?
+    private let telemetry = TelemetryMock()
 
-            func send(telemetry: DatadogInternal.TelemetryMessage) {
-                guard case let .debug(id, message, attributes) = telemetry else {
-                    return
-                }
+    // MARK: - Debug Telemetry
 
-                debug = (id: id, message: message, attributes: attributes)
-            }
-        }
-
-        let telemetry = TelemetryTest()
-
-        struct SwiftError: Error {
-            let description = "error description"
-        }
-
+    func testSendingDebugTelemetry() throws {
         // When
         #sourceLocation(file: "File.swift", line: 1)
         telemetry.debug("debug message", attributes: ["foo": "bar"])
         #sourceLocation()
 
         // Then
-        XCTAssertEqual(telemetry.debug?.id, "File.swift:1:debug message")
-        XCTAssertEqual(telemetry.debug?.message, "debug message")
-        XCTAssertEqual(telemetry.debug?.attributes as? [String: String], ["foo": "bar"])
+        let debug = try XCTUnwrap(telemetry.messages.firstDebug())
+        XCTAssertEqual(debug.id, "\(moduleName())/File.swift:1:debug message")
+        XCTAssertEqual(debug.message, "debug message")
+        XCTAssertEqual(debug.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(telemetry.messages.count, 1)
     }
 
-    func testTelemetryErrorFormatting() {
+    // MARK: - Error Telemetry
+
+    func testSendingErrorTelemetry() throws {
+        // When
+        #sourceLocation(file: "File.swift", line: 1)
+        telemetry.error("error message", kind: "error.kind", stack: "error.stack")
+        #sourceLocation()
+
+        // Then
+        let error = try XCTUnwrap(telemetry.messages.firstError())
+        XCTAssertEqual(error.id, "\(moduleName())/File.swift:1:error message")
+        XCTAssertEqual(error.message, "error message")
+        XCTAssertEqual(error.kind, "error.kind")
+        XCTAssertEqual(error.stack, "error.stack")
+        XCTAssertEqual(telemetry.messages.count, 1)
+    }
+
+    func testSendingErrorTelemetry_whenNoKindAndNoStack() throws {
+        // When
+        #sourceLocation(file: "File.swift", line: 1)
+        telemetry.error("error message", kind: nil, stack: nil)
+        #sourceLocation()
+
+        // Then
+        let error = try XCTUnwrap(telemetry.messages.firstError())
+        XCTAssertEqual(error.id, "\(moduleName())/File.swift:1:error message")
+        XCTAssertEqual(error.message, "error message")
+        XCTAssertEqual(error.kind, "\(moduleName())/FileError")
+        XCTAssertEqual(error.stack, "\(moduleName())/File.swift:1")
+        XCTAssertEqual(telemetry.messages.count, 1)
+    }
+
+    func testSendingErrorTelemetry_withSwiftError() throws {
         // Given
-        class TelemetryTest: Telemetry {
-            var error: (id: String, message: String, kind: String?, stack: String?)?
-
-            func send(telemetry: DatadogInternal.TelemetryMessage) {
-                guard case let .error(id, message, kind, stack) = telemetry else {
-                    return
-                }
-
-                error = (id: id, message: message, kind: kind, stack: stack)
-            }
-        }
-
-        let telemetry = TelemetryTest()
-
         struct SwiftError: Error {
             let description = "error description"
         }
-
         let swiftError = SwiftError()
 
+        // When
+        telemetry.error(swiftError)
+        telemetry.error("custom message", error: swiftError)
+
+        // Then
+        let errors = telemetry.messages.compactMap({ $0.asError })
+        XCTAssertEqual(telemetry.messages.count, 2)
+        XCTAssertEqual(errors[0].message, #"SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[0].kind, "SwiftError")
+        XCTAssertEqual(errors[0].stack, #"SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[1].message, #"custom message - SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[1].kind, "SwiftError")
+        XCTAssertEqual(errors[1].stack, #"SwiftError(description: "error description")"#)
+    }
+
+    func testSendingErrorTelemetry_withNSError() throws {
+        // Given
         let nsError = NSError(
             domain: "custom-domain",
             code: 10,
-            userInfo: [
-                NSLocalizedDescriptionKey: "error description"
-            ]
+            userInfo: [NSLocalizedDescriptionKey: "error description"]
         )
 
         // When
-        #sourceLocation(file: "File.swift", line: 1)
-        telemetry.error(swiftError)
-        #sourceLocation()
-
-        // Then
-        XCTAssertEqual(telemetry.error?.id, #"File.swift:1:SwiftError(description: "error description")"#)
-        XCTAssertEqual(telemetry.error?.message, #"SwiftError(description: "error description")"#)
-        XCTAssertEqual(telemetry.error?.kind, "SwiftError")
-        XCTAssertEqual(telemetry.error?.stack, #"SwiftError(description: "error description")"#)
-
-        // When
-        #sourceLocation(file: "File.swift", line: 2)
         telemetry.error(nsError)
-        #sourceLocation()
+        telemetry.error("custom message", error: nsError)
 
         // Then
-        XCTAssertEqual(telemetry.error?.id, "File.swift:2:error description")
-        XCTAssertEqual(telemetry.error?.message, "error description")
-        XCTAssertEqual(telemetry.error?.kind, "custom-domain - 10")
-        XCTAssertEqual(
-            telemetry.error?.stack,
-            """
-            Error Domain=custom-domain Code=10 "error description" UserInfo={NSLocalizedDescription=error description}
-            """
-        )
-
-        // When
-        telemetry.error("swift error", error: swiftError)
-        // Then
-        XCTAssertEqual(telemetry.error?.message, #"swift error - SwiftError(description: "error description")"#)
-
-        // When
-        telemetry.error("ns error", error: nsError)
-        // Then
-        XCTAssertEqual(telemetry.error?.message, "ns error - error description")
+        let errors = telemetry.messages.compactMap({ $0.asError })
+        XCTAssertEqual(telemetry.messages.count, 2)
+        XCTAssertEqual(errors[0].message, "error description")
+        XCTAssertEqual(errors[0].kind, "custom-domain - 10")
+        XCTAssertEqual(errors[0].stack, #"Error Domain=custom-domain Code=10 "error description" UserInfo={NSLocalizedDescription=error description}"#)
+        XCTAssertEqual(errors[1].message, "custom message - error description")
+        XCTAssertEqual(errors[1].kind, "custom-domain - 10")
+        XCTAssertEqual(errors[1].stack, #"Error Domain=custom-domain Code=10 "error description" UserInfo={NSLocalizedDescription=error description}"#)
     }
 
-    func testTelemetryConfiguration() {
-        // Given
-        let expectedConfiguration: ConfigurationTelemetry = .mockRandom()
+    // MARK: - Configuration Telemetry
 
-        let telemetry = TelemetryTest()
-
+    func testSendingConfigurationTelemetry() throws {
         // When
-        telemetry.applyConfiguration(configuration: expectedConfiguration)
+        telemetry.configuration(batchSize: 123, batchUploadFrequency: 456) // only some values
 
         // Then
-        XCTAssertEqual(telemetry.configuration, expectedConfiguration)
+        let configuration = try XCTUnwrap(telemetry.messages.firstConfiguration())
+        XCTAssertEqual(configuration.batchSize, 123)
+        XCTAssertEqual(configuration.batchUploadFrequency, 456)
     }
 
-    func testTelemetryConfigurationMerge() {
-        // Given
-        let initialConfiguration: ConfigurationTelemetry = .mockRandom()
-        let expectedConfiguration: ConfigurationTelemetry = .mockRandom()
+    // MARK: - Metric Telemetry
 
-        let telemetry = TelemetryTest()
-
+    func testSendingMetricTelemetry() throws {
         // When
-        telemetry.applyConfiguration(configuration: initialConfiguration)
-        telemetry.applyConfiguration(configuration: expectedConfiguration)
+        telemetry.metric(name: "metric name", attributes: ["attribute": "value"])
 
         // Then
-        XCTAssertEqual(telemetry.configuration, expectedConfiguration)
-        XCTAssertNotEqual(telemetry.configuration, initialConfiguration)
+        let metric = try XCTUnwrap(telemetry.messages.compactMap({ $0.asMetric }).first)
+        XCTAssertEqual(metric.name, "metric name")
+        XCTAssertEqual(metric.attributes as? [String: String], ["attribute": "value"])
     }
 
-    func testWhenSendingTelemetryMessage_itForwardsToCore() throws {
-        // Given
-        class Receiver: FeatureMessageReceiver {
-            var telemetry: TelemetryMessage?
+    func testStartingMethodCalledMetricTrace_whenSampled() throws {
+        XCTAssertNotNil(telemetry.startMethodCalled(operationName: .mockAny(), callerClass: .mockAny(), samplingRate: 100))
+    }
 
-            func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-                guard case .telemetry(let telemetry) = message else {
-                    return false
-                }
+    func testStartingMethodCalledMetricTrace_whenNotSampled() throws {
+        XCTAssertNil(telemetry.startMethodCalled(operationName: .mockAny(), callerClass: .mockAny(), samplingRate: 0))
+    }
 
-                self.telemetry = telemetry
-                return true
-            }
-        }
+    func testTrackingMethodCallMetricTelemetry() throws {
+        let operationName: String = .mockRandom()
+        let callerClass: String = .mockRandom()
+        let isSuccessful: Bool = .random()
 
-        let receiver = Receiver()
+        // When
+        let metricTrace = telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, samplingRate: 100)
+        Thread.sleep(forTimeInterval: 0.05)
+        telemetry.stopMethodCalled(metricTrace, isSuccessful: isSuccessful)
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: MethodCalledMetric.name))
+        XCTAssertEqual(metric.attributes[SDKMetricFields.typeKey] as? String, MethodCalledMetric.typeValue)
+        XCTAssertEqual(metric.attributes[MethodCalledMetric.operationName] as? String, operationName)
+        XCTAssertEqual(metric.attributes[MethodCalledMetric.callerClass] as? String, callerClass)
+        XCTAssertEqual(metric.attributes[MethodCalledMetric.isSuccessful] as? Bool, isSuccessful)
+        let executionTime = try XCTUnwrap(metric.attributes[MethodCalledMetric.executionTime] as? Int64)
+        XCTAssertGreaterThan(executionTime, 0)
+        XCTAssertLessThan(executionTime, TimeInterval(1).toInt64Nanoseconds)
+    }
+
+    // MARK: - Integration with Core
+
+    func testWhenUsingCoreTelemetry_itSendsTelemetryToMessageReceiver() throws {
+        let receiver = FeatureMessageReceiverMock()
         let core = PassthroughCoreMock(messageReceiver: receiver)
 
-        // When
-        core.telemetry.debug("debug")
+        core.telemetry.debug("debug message")
+        XCTAssertEqual(receiver.messages.lastTelemetry?.asDebug?.message, "debug message")
 
-        // Then
-        guard case .debug(_, let message, _) = receiver.telemetry else {
-            return XCTFail("A debug should be send to core.")
-        }
-        XCTAssertEqual(message, "debug")
+        core.telemetry.error("error message")
+        XCTAssertEqual(receiver.messages.lastTelemetry?.asError?.message, "error message")
 
-        // When
-        core.telemetry.error("error")
+        core.telemetry.configuration(batchSize: 123)
+        XCTAssertEqual(receiver.messages.lastTelemetry?.asConfiguration?.batchSize, 123)
 
-        // Then
-        guard case .error(_, let message, _, _) = receiver.telemetry else {
-            return XCTFail("An error should be send to core.")
-        }
-        XCTAssertEqual(message, "error")
+        core.telemetry.metric(name: "metric name", attributes: [:])
+        XCTAssertEqual(receiver.messages.lastTelemetry?.asMetric?.name, "metric name")
 
-        // When
-        core.telemetry.configuration(batchSize: 0)
-
-        // Then
-        guard case .configuration(let configuration) = receiver.telemetry else {
-            return XCTFail("An error should be send to core.")
-        }
-        XCTAssertEqual(configuration.batchSize, 0)
-
-        // When
-        let operationName = String.mockRandom()
-        let callerClass = String.mockRandom()
-        let isSuccessful = Bool.random()
-        core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, samplingRate: 100),
-            isSuccessful: isSuccessful
-        )
-
-        // Then
-        guard case .metric(let name, let attributes) = receiver.telemetry else {
-            return XCTFail("A debug should be send to core.")
-        }
-        XCTAssertEqual(name, MethodCalledMetric.name)
-        XCTAssertGreaterThan(try XCTUnwrap(attributes[MethodCalledMetric.executionTime] as? Int64), 0)
-        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.operationName] as? String), operationName)
-        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.callerClass] as? String), callerClass)
-        XCTAssertEqual(try XCTUnwrap(attributes[MethodCalledMetric.isSuccessful] as? Bool), isSuccessful)
-        XCTAssertEqual(try XCTUnwrap(attributes[SDKMetricFields.typeKey] as? String), MethodCalledMetric.typeValue)
-    }
-}
-
-class TelemetryTest: Telemetry {
-    var configuration: ConfigurationTelemetry?
-
-    func send(telemetry: DatadogInternal.TelemetryMessage) {
-        guard case .configuration(let configuration) = telemetry else {
-            return
-        }
-
-        self.configuration = configuration
-    }
-
-    internal func applyConfiguration(configuration: ConfigurationTelemetry) {
-        self.configuration(
-            actionNameAttribute: configuration.actionNameAttribute,
-            allowFallbackToLocalStorage: configuration.allowFallbackToLocalStorage,
-            allowUntrustedEvents: configuration.allowUntrustedEvents,
-            appHangThreshold: configuration.appHangThreshold,
-            backgroundTasksEnabled: configuration.backgroundTasksEnabled,
-            batchProcessingLevel: configuration.batchProcessingLevel,
-            batchSize: configuration.batchSize,
-            batchUploadFrequency: configuration.batchUploadFrequency,
-            dartVersion: configuration.dartVersion,
-            defaultPrivacyLevel: configuration.defaultPrivacyLevel,
-            forwardErrorsToLogs: configuration.forwardErrorsToLogs,
-            initializationType: configuration.initializationType,
-            mobileVitalsUpdatePeriod: configuration.mobileVitalsUpdatePeriod,
-            reactNativeVersion: configuration.reactNativeVersion,
-            reactVersion: configuration.reactVersion,
-            sessionReplaySampleRate: configuration.sessionReplaySampleRate,
-            sessionSampleRate: configuration.sessionSampleRate,
-            silentMultipleInit: configuration.silentMultipleInit,
-            startSessionReplayRecordingManually: configuration.startSessionReplayRecordingManually,
-            telemetryConfigurationSampleRate: configuration.telemetryConfigurationSampleRate,
-            telemetrySampleRate: configuration.telemetrySampleRate,
-            tracerAPI: configuration.tracerAPI,
-            tracerAPIVersion: configuration.tracerAPIVersion,
-            traceSampleRate: configuration.traceSampleRate,
-            trackBackgroundEvents: configuration.trackBackgroundEvents,
-            trackCrossPlatformLongTasks: configuration.trackCrossPlatformLongTasks,
-            trackErrors: configuration.trackErrors,
-            trackFlutterPerformance: configuration.trackFlutterPerformance,
-            trackFrustrations: configuration.trackFrustrations,
-            trackLongTask: configuration.trackLongTask,
-            trackNativeErrors: configuration.trackNativeErrors,
-            trackNativeLongTasks: configuration.trackNativeLongTasks,
-            trackNativeViews: configuration.trackNativeViews,
-            trackNetworkRequests: configuration.trackNetworkRequests,
-            trackResources: configuration.trackResources,
-            trackSessionAcrossSubdomains: configuration.trackSessionAcrossSubdomains,
-            trackUserInteractions: configuration.trackUserInteractions,
-            trackViewsManually: configuration.trackViewsManually,
-            unityVersion: configuration.unityVersion,
-            useAllowedTracingUrls: configuration.useAllowedTracingUrls,
-            useBeforeSend: configuration.useBeforeSend,
-            useExcludedActivityUrls: configuration.useExcludedActivityUrls,
-            useFirstPartyHosts: configuration.useFirstPartyHosts,
-            useLocalEncryption: configuration.useLocalEncryption,
-            useProxy: configuration.useProxy,
-            useSecureSessionCookie: configuration.useSecureSessionCookie,
-            useTracing: configuration.useTracing,
-            useWorkerUrl: configuration.useWorkerUrl
-        )
+        let metricTrace = core.telemetry.startMethodCalled(operationName: .mockAny(), callerClass: .mockAny())
+        core.telemetry.stopMethodCalled(metricTrace)
+        XCTAssertEqual(receiver.messages.lastTelemetry?.asMetric?.name, MethodCalledMetric.name)
     }
 }

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -137,7 +137,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///   - message: Body of the log
     ///   - kind: The error type or kind (or code in some cases).
     ///   - stack: The stack trace or the complementary information about the error.
-    private func error(id: String, message: String, kind: String?, stack: String?) {
+    private func error(id: String, message: String, kind: String, stack: String) {
         let date = dateProvider.now
 
         record(event: id) { context, writer in

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -129,7 +129,7 @@ class TelemetryReceiverTests: XCTestCase {
 
         // When
         telemetry.debug(id: "0", message: "telemetry debug 0")
-        telemetry.error(id: "0", message: "telemetry debug 1", kind: nil, stack: nil)
+        telemetry.error(id: "0", message: "telemetry debug 1", kind: "error.kind", stack: "error.stack")
         telemetry.debug(id: "0", message: "telemetry debug 2")
         telemetry.debug(id: "1", message: "telemetry debug 3")
 

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -247,12 +247,13 @@ class SegmentRequestBuilderTests: XCTestCase {
         _ = try builder.request(for: mockEvents, with: .mockWith(source: "invalid source"))
 
         // Then
-        XCTAssertEqual(
-            telemetry.description,
-            """
-            Telemetry logs:
-             - [error] [SR] Could not create segment source from provided string 'invalid source', kind: nil, stack: nil
-            """
+        XCTAssertTrue(
+            telemetry.description.hasPrefix(
+                """
+                Telemetry logs:
+                 - [error] [SR] Could not create segment source from provided string 'invalid source'
+                """
+            )
         )
     }
 }

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -84,10 +84,9 @@ class SessionReplayTests: XCTestCase {
         )
 
         // Then
-        let message = messageReceiver.messages.firstTelemetry()
-        let configuration = message?.asConfiguration
-        XCTAssertEqual(configuration?.sessionReplaySampleRate, sampleRate)
-        XCTAssertEqual(configuration?.defaultPrivacyLevel, privacyLevel.rawValue)
+        let configuration = try XCTUnwrap(messageReceiver.messages.firstTelemetry?.asConfiguration)
+        XCTAssertEqual(configuration.sessionReplaySampleRate, sampleRate)
+        XCTAssertEqual(configuration.defaultPrivacyLevel, privacyLevel.rawValue)
     }
 
     func testWhenEnabledWithReplaySampleRate() throws {

--- a/TestUtilities/Helpers/ModuleName.swift
+++ b/TestUtilities/Helpers/ModuleName.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Returns the name of current module.
+/// - Returns: The name of caller module.
+public func moduleName(file: String = #fileID) -> String {
+    guard let url = URL(string: file) else {
+        return "unknown"
+    }
+    return url.pathComponents.first ?? "unknown"
+}

--- a/TestUtilities/Mocks/FeatureMessageMocks.swift
+++ b/TestUtilities/Mocks/FeatureMessageMocks.swift
@@ -29,8 +29,13 @@ public extension Array where Element == FeatureMessage {
     }
 
     /// Unpacks the first "telemetry message" in this array.
-    func firstTelemetry() -> TelemetryMessage? {
-        return compactMap({ $0.asTelemetry }).first
+    var firstTelemetry: TelemetryMessage? {
+        compactMap({ $0.asTelemetry }).first
+    }
+
+    /// Unpacks the last "telemetry message" in this array.
+    var lastTelemetry: TelemetryMessage? {
+        compactMap({ $0.asTelemetry }).last
     }
 }
 

--- a/TestUtilities/Mocks/TelemetryMocks.swift
+++ b/TestUtilities/Mocks/TelemetryMocks.swift
@@ -73,7 +73,7 @@ public class TelemetryMock: Telemetry, CustomStringConvertible {
             let attributesString = attributes.map({ ", \($0)" }) ?? ""
             description.append("\n- [debug] \(message)" + attributesString)
         case .error(_, let message, let kind, let stack):
-            description.append("\n - [error] \(message), kind: \(kind ?? "nil"), stack: \(stack ?? "nil")")
+            description.append("\n - [error] \(message), kind: \(kind), stack: \(stack)")
         case .configuration(let configuration):
             description.append("\n- [configuration] \(configuration)")
         case let .metric(name, attributes):
@@ -89,9 +89,19 @@ public extension Array where Element == TelemetryMessage {
         return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).first
     }
 
-    /// Returns attributes of the first ERROR telemetry in this array.
+    /// Returns attributes of the first debug telemetry in this array.
+    func firstDebug() -> (id: String, message: String, attributes: [String: Encodable]?)? {
+        return compactMap { $0.asDebug }.first
+    }
+
+    /// Returns attributes of the first error telemetry in this array.
     func firstError() -> (id: String, message: String, kind: String?, stack: String?)? {
         return compactMap { $0.asError }.first
+    }
+
+    /// Returns the first configuration telemetry in this array.
+    func firstConfiguration() -> ConfigurationTelemetry? {
+        return compactMap { $0.asConfiguration }.first
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR changes the `error.kind` (and also `error.stack`) in SDK error telemetry to be non-optional (always set).

This serves two purposes:
- adds more context to SDK errors and avoid having error logs with no `error.kind`,
- increases the `error.kind` cardinality for later aggregating SDK errors by their kind in "RUM Session Ended" metric.

### How?

The `error.kind` now defaults to the `#fileID`:
```
e.g. `DatadogSR/Recorder.swift`
```
This will increase the cardinality of `error.kind` in SDK errors telemetry.

The `error.stack` now defaults to `#fileID` and `#line`:
```
e.g. `DatadogSR/Recorder.swift:42
```
This will add more clarity on SDK errors origin in certain SDK version.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
