### PR TITLE
RUM-917 Improve telemetry of type mismatch

### DIFF
--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -497,21 +497,6 @@ public enum SRWireframe: Codable {
     case placeholderWireframe(value: SRPlaceholderWireframe)
     case webviewWireframe(value: SRWebviewWireframe)
 
-    var type: String {
-        switch self {
-        case let (.shapeWireframe(value)):
-            return value.type
-        case let (.textWireframe(value)):
-            return value.type
-        case let (.imageWireframe(value)):
-            return value.type
-        case let (.placeholderWireframe(value)):
-            return value.type
-        case let (.webviewWireframe(value)):
-            return value.type
-        }
-    }
-
     // MARK: - Codable
 
     public func encode(to encoder: Encoder) throws {

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -497,6 +497,21 @@ public enum SRWireframe: Codable {
     case placeholderWireframe(value: SRPlaceholderWireframe)
     case webviewWireframe(value: SRWebviewWireframe)
 
+    var type: String {
+        switch self {
+        case let (.shapeWireframe(value)):
+            return value.type
+        case let (.textWireframe(value)):
+            return value.type
+        case let (.imageWireframe(value)):
+            return value.type
+        case let (.placeholderWireframe(value)):
+            return value.type
+        case let (.webviewWireframe(value)):
+            return value.type
+        }
+    }
+
     // MARK: - Codable
 
     public func encode(to encoder: Encoder) throws {

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -41,6 +41,21 @@ extension SRWireframe: Diffable {
             return true
         }
     }
+
+    var type: String {
+        switch self {
+        case let (.shapeWireframe(value)):
+            return value.type
+        case let (.textWireframe(value)):
+            return value.type
+        case let (.imageWireframe(value)):
+            return value.type
+        case let (.placeholderWireframe(value)):
+            return value.type
+        case let (.webviewWireframe(value)):
+            return value.type
+        }
+    }
 }
 
 // MARK: - Resolving Mutations

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -47,11 +47,11 @@ extension SRWireframe: Diffable {
 
 internal typealias WireframeMutation = SRIncrementalSnapshotRecord.Data.MutationData.Updates
 
-internal enum WireframeMutationError: Error {
+internal enum WireframeMutationError: Error, Equatable {
     /// Indicates an attempt of computing mutation for wireframes that have different `id`.
     case idMismatch
     /// Indicates an attempt of computing mutation for wireframes that have different type.
-    case typeMismatch
+    case typeMismatch(fromType: String, toType: String)
 }
 
 internal protocol MutableWireframe {
@@ -84,8 +84,13 @@ extension SRWireframe: MutableWireframe {
 extension SRShapeWireframe: MutableWireframe {
     func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
         guard case .shapeWireframe(let other) = otherWireframe else {
-            throw WireframeMutationError.typeMismatch
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
         }
+        // print string of enum of otherWireframe
+
         guard other.id == id else {
             throw WireframeMutationError.idMismatch
         }
@@ -108,7 +113,10 @@ extension SRShapeWireframe: MutableWireframe {
 extension SRPlaceholderWireframe: MutableWireframe {
     func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
         guard case .placeholderWireframe(let other) = otherWireframe else {
-            throw WireframeMutationError.typeMismatch
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
         }
         guard other.id == id else {
             throw WireframeMutationError.idMismatch
@@ -130,7 +138,10 @@ extension SRPlaceholderWireframe: MutableWireframe {
 extension SRImageWireframe: MutableWireframe {
     func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
         guard case .imageWireframe(let other) = otherWireframe else {
-            throw WireframeMutationError.typeMismatch
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
         }
         guard other.id == id else {
             throw WireframeMutationError.idMismatch
@@ -157,7 +168,10 @@ extension SRImageWireframe: MutableWireframe {
 extension SRTextWireframe: MutableWireframe {
     func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
         guard case .textWireframe(let other) = otherWireframe else {
-            throw WireframeMutationError.typeMismatch
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
         }
         guard other.id == id else {
             throw WireframeMutationError.idMismatch
@@ -184,7 +198,10 @@ extension SRTextWireframe: MutableWireframe {
 extension SRWebviewWireframe: MutableWireframe {
     func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
         guard case .webviewWireframe(let other) = otherWireframe else {
-            throw WireframeMutationError.typeMismatch
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
         }
         guard other.id == id, other.slotId == slotId else {
             throw WireframeMutationError.idMismatch

--- a/DatadogSessionReplay/Tests/Processor/Builders/RecordsBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Builders/RecordsBuilderTests.swift
@@ -97,7 +97,7 @@ class RecordsBuilderTests: XCTestCase {
             telemetry.description,
             """
             Telemetry logs:
-             - [error] [SR] Failed to create incremental record - typeMismatch, kind: WireframeMutationError, stack: typeMismatch
+             - [error] [SR] Failed to create incremental record - typeMismatch(fromType: "shape", toType: "text"), kind: WireframeMutationError, stack: typeMismatch(fromType: "shape", toType: "text")
             """
         )
     }

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -117,7 +117,13 @@ class DiffSRWireframes: XCTestCase {
         try wireframes.forEach { wireframeA, wireframeB in
             XCTAssertThrowsError(try wireframeB.mutations(from: wireframeA)) { error in
                 // Then
-                XCTAssertEqual(error as? WireframeMutationError, WireframeMutationError.typeMismatch)
+                XCTAssertEqual(
+                    error as? WireframeMutationError,
+                    WireframeMutationError.typeMismatch(
+                        fromType: wireframeA.type,
+                        toType: wireframeB.type
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
### What and why?

Adds extra telemetry info to to help resolving type mismatch error in Session Replay.

### How?

Expands error type to contain from and to types of the wireframe that conflicted.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
