### PR TITLE
RUM-1660 chore: Send "RUM Session Ended" telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -533,6 +533,8 @@
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
 		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
+		61C4534A2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C453492C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift */; };
+		61C4534B2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C453492C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift */; };
 		61C5A89624509BF600DA608C /* TracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89524509BF600DA608C /* TracerTests.swift */; };
 		61C713A32A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C713A02A3B78F900FA735A /* RUMMonitorProtocol.swift */; };
 		61C713A42A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C713A02A3B78F900FA735A /* RUMMonitorProtocol.swift */; };
@@ -2542,6 +2544,7 @@
 		61C3E63824BF19B4008053F2 /* RUMContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContext.swift; sourceTree = "<group>"; };
 		61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommand.swift; sourceTree = "<group>"; };
 		61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScope.swift; sourceTree = "<group>"; };
+		61C453492C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryInterceptorTests.swift; sourceTree = "<group>"; };
 		61C5A87824509A0C00DA608C /* DDSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpan.swift; sourceTree = "<group>"; };
 		61C5A87924509A0C00DA608C /* DDNoOps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDNoOps.swift; sourceTree = "<group>"; };
 		61C5A87C24509A0C00DA608C /* Casting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Casting.swift; sourceTree = "<group>"; };
@@ -5846,6 +5849,7 @@
 				D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */,
 				9E53889B2773C4B300A7DC42 /* WebViewEventReceiverTests.swift */,
 				D248ED4728081B9B00B315B4 /* TelemetryReceiverTests.swift */,
+				61C453492C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -8693,6 +8697,7 @@
 				6188697D2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
 				61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				D23F8EA029DDCD38001CFAE8 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
+				61C4534B2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */,
 				D23F8EA229DDCD38001CFAE8 /* RUMSessionScopeTests.swift in Sources */,
 				D23F8EA329DDCD38001CFAE8 /* RUMUserActionScopeTests.swift in Sources */,
 				615B0F8C2BB33C2800E9ED6C /* AppHangsMonitorTests.swift in Sources */,
@@ -9012,6 +9017,7 @@
 				6188697C2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
 				61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				D29A9FA629DDB483005C54A4 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
+				61C4534A2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */,
 				D29A9FBD29DDB483005C54A4 /* RUMSessionScopeTests.swift in Sources */,
 				D29A9FAB29DDB483005C54A4 /* RUMUserActionScopeTests.swift in Sources */,
 				615B0F8B2BB33C2800E9ED6C /* AppHangsMonitorTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -423,12 +423,18 @@
 		6174D6062BFB9D6400EC7469 /* DDWebViewTracking+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */; };
 		6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
 		6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
+		6174D6102BFDEA4600EC7469 /* SessionEndedMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */; };
+		6174D6112BFDEA4600EC7469 /* SessionEndedMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */; };
 		6174D6132BFDF16C00EC7469 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6122BFDF16C00EC7469 /* BundleType.swift */; };
 		6174D6142BFDF16C00EC7469 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6122BFDF16C00EC7469 /* BundleType.swift */; };
 		6174D6162BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */; };
 		6174D6172BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */; };
+		6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */; };
+		6174D61B2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */; };
 		6174D61D2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
 		6174D61E2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
+		6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */; };
+		6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */; };
 		6175922B2A6FA8EE0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
 		6175922D2A6FADDD0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
 		6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175C3502BCE66DB006FAAB0 /* TraceContext.swift */; };
@@ -2417,9 +2423,12 @@
 		6174D6032BFB9AB600EC7469 /* WebViewTracking+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewTracking+objc.swift"; sourceTree = "<group>"; };
 		6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDWebViewTracking+apiTests.m"; sourceTree = "<group>"; };
 		6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKMetricFields.swift; sourceTree = "<group>"; };
+		6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetric.swift; sourceTree = "<group>"; };
 		6174D6122BFDF16C00EC7469 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTypeTests.swift; sourceTree = "<group>"; };
+		6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetricTests.swift; sourceTree = "<group>"; };
 		6174D61C2C007B3300EC7469 /* ModuleName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleName.swift; sourceTree = "<group>"; };
+		6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetricController.swift; sourceTree = "<group>"; };
 		6175C3502BCE66DB006FAAB0 /* TraceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceContext.swift; sourceTree = "<group>"; };
 		617699172A860D9D0030022B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		6176991A2A86121B0030022B /* HTTPClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientMock.swift; sourceTree = "<group>"; };
@@ -4818,6 +4827,23 @@
 			path = SDKMetrics;
 			sourceTree = "<group>";
 		};
+		6174D60E2BFDEA1F00EC7469 /* SDKMetrics */ = {
+			isa = PBXGroup;
+			children = (
+				6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */,
+				6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */,
+			);
+			path = SDKMetrics;
+			sourceTree = "<group>";
+		};
+		6174D6182BFE447600EC7469 /* SDKMetrics */ = {
+			isa = PBXGroup;
+			children = (
+				6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */,
+			);
+			path = SDKMetrics;
+			sourceTree = "<group>";
+		};
 		617699162A8608C20030022B /* Context */ = {
 			isa = PBXGroup;
 			children = (
@@ -6042,6 +6068,7 @@
 				615950EC291C057D00470E0C /* Integrations */,
 				61B22E5824F3E6A700DC26D2 /* Debugging */,
 				D29A9F8B29DD860A005C54A4 /* Utils */,
+				6174D60E2BFDEA1F00EC7469 /* SDKMetrics */,
 			);
 			name = DatadogRUM;
 			path = ../DatadogRUM/Sources;
@@ -6066,6 +6093,7 @@
 				61411B0E24EC15940012EAB2 /* Utils */,
 				61C713C92A3DC22700FA735A /* RUMTests.swift */,
 				6188697B2A4376F700E8996B /* RUMConfigurationTests.swift */,
+				6174D6182BFE447600EC7469 /* SDKMetrics */,
 			);
 			name = DatadogRUMTests;
 			path = ../DatadogRUM/Tests;
@@ -8603,6 +8631,7 @@
 				6194B92E2BB43F9C00179430 /* FatalErrorContextNotifier.swift in Sources */,
 				6167E6D72B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */,
 				61C713A42A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */,
+				6174D6112BFDEA4600EC7469 /* SessionEndedMetric.swift in Sources */,
 				3C0D5DED2A54405A00446CF9 /* RUMViewEventsFilter.swift in Sources */,
 				D23F8E7629DDCD28001CFAE8 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D23F8E7729DDCD28001CFAE8 /* UIKitRUMViewsPredicate.swift in Sources */,
@@ -8628,6 +8657,7 @@
 				D23F8E8A29DDCD28001CFAE8 /* RUMEventsMapper.swift in Sources */,
 				D23F8E8B29DDCD28001CFAE8 /* RUMContext.swift in Sources */,
 				D23F8E8C29DDCD28001CFAE8 /* RUMBaggageKeys.swift in Sources */,
+				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
@@ -8659,6 +8689,7 @@
 				D23F8EB129DDCD38001CFAE8 /* RUMViewScopeTests.swift in Sources */,
 				D224431029E977A100274EC7 /* TelemetryReceiverTests.swift in Sources */,
 				D23F8EB229DDCD38001CFAE8 /* ValuePublisherTests.swift in Sources */,
+				6174D61B2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BD2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
@@ -8917,6 +8948,7 @@
 				6194B92D2BB43F9C00179430 /* FatalErrorContextNotifier.swift in Sources */,
 				6167E6D62B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */,
 				61C713A32A3B78F900FA735A /* RUMMonitorProtocol.swift in Sources */,
+				6174D6102BFDEA4600EC7469 /* SessionEndedMetric.swift in Sources */,
 				3C0D5DEC2A54405A00446CF9 /* RUMViewEventsFilter.swift in Sources */,
 				D29A9F5829DD85BB005C54A4 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D29A9F5E29DD85BB005C54A4 /* UIKitRUMViewsPredicate.swift in Sources */,
@@ -8942,6 +8974,7 @@
 				D29A9F7D29DD85BB005C54A4 /* RUMEventsMapper.swift in Sources */,
 				D29A9F5029DD85BA005C54A4 /* RUMContext.swift in Sources */,
 				D29A9F8329DD85BB005C54A4 /* RUMBaggageKeys.swift in Sources */,
+				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
@@ -8973,6 +9006,7 @@
 				D29A9FB829DDB483005C54A4 /* RUMViewScopeTests.swift in Sources */,
 				D224430F29E9779F00274EC7 /* TelemetryReceiverTests.swift in Sources */,
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
+				6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BC2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -594,6 +594,10 @@
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
 		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
+		61DCC84A2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */; };
+		61DCC84B2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */; };
+		61DCC84E2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */; };
+		61DCC84F2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
@@ -2589,6 +2593,8 @@
 		61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomObjcViewController.h; sourceTree = "<group>"; };
 		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
 		61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetricControllerTests.swift; sourceTree = "<group>"; };
+		61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionEndedMetricIntegrationTests.swift; sourceTree = "<group>"; };
+		61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryInterecptor.swift; sourceTree = "<group>"; };
 		61DE333525C8278A008E3EC2 /* CrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingPlugin.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventBuilderTests.swift; sourceTree = "<group>"; };
@@ -4635,6 +4641,7 @@
 				D236BE2729520FED00676E67 /* CrashReportReceiver.swift */,
 				D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */,
 				D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */,
+				61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -5259,6 +5266,14 @@
 			path = NTP;
 			sourceTree = "<group>";
 		};
+		61DCC84C2C05D4E500CB59E5 /* SDKMetrics */ = {
+			isa = PBXGroup;
+			children = (
+				61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */,
+			);
+			path = SDKMetrics;
+			sourceTree = "<group>";
+		};
 		61E45BD02450F64100F2C652 /* Span */ = {
 			isa = PBXGroup;
 			children = (
@@ -5317,6 +5332,7 @@
 				61E8C5072B28898800E709B4 /* StartingRUMSessionTests.swift */,
 				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
 				D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */,
+				61DCC84C2C05D4E500CB59E5 /* SDKMetrics */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -8034,6 +8050,7 @@
 				D24C9C7129A7D57A002057CF /* DirectoriesMock.swift in Sources */,
 				D22743E329DEB90B001A7EF9 /* RUMDebuggingTests.swift in Sources */,
 				614798992A459B2E0095CB02 /* DDTraceConfigurationTests.swift in Sources */,
+				61DCC84A2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */,
 				61133C5F2423990D00786299 /* DataUploaderTests.swift in Sources */,
 				D2A1EE36287EB8DB00D28DFB /* ServerOffsetPublisherTests.swift in Sources */,
 				61BBD19724ED50040023E65F /* DatadogConfigurationTests.swift in Sources */,
@@ -8665,6 +8682,7 @@
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
+				61DCC84F2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8983,6 +9001,7 @@
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
+				61DCC84E2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9221,6 +9240,7 @@
 				A7EA11622AB0CE6C00C73970 /* DDUIKitRUMActionsPredicateTests.swift in Sources */,
 				D2CB6EE527C520D400A62B57 /* DataUploadConditionsTests.swift in Sources */,
 				D2CB6EE627C520D400A62B57 /* DateFormattingTests.swift in Sources */,
+				61DCC84B2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */,
 				D2CB6EE727C520D400A62B57 /* FileTests.swift in Sources */,
 				610ABD4D2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */,
 				D2CB6EEA27C520D400A62B57 /* LogMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -351,7 +351,6 @@
 		614B78F1296D7B63009C6B92 /* LowPowerModePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B78EC296D7B63009C6B92 /* LowPowerModePublisherTests.swift */; };
 		614B78F2296D7B63009C6B92 /* LowPowerModePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B78EC296D7B63009C6B92 /* LowPowerModePublisherTests.swift */; };
 		614CADD72510BAC000B93D2D /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADD62510BAC000B93D2D /* Environment.swift */; };
-		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		614ED36C260352DC00C8C519 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
 		615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */; };
 		615192CE2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */; };
@@ -424,6 +423,10 @@
 		6174D6062BFB9D6400EC7469 /* DDWebViewTracking+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */; };
 		6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
 		6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */; };
+		6174D6132BFDF16C00EC7469 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6122BFDF16C00EC7469 /* BundleType.swift */; };
+		6174D6142BFDF16C00EC7469 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6122BFDF16C00EC7469 /* BundleType.swift */; };
+		6174D6162BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */; };
+		6174D6172BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */; };
 		6174D61D2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
 		6174D61E2C007B3300EC7469 /* ModuleName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6174D61C2C007B3300EC7469 /* ModuleName.swift */; };
 		6175922B2A6FA8EE0073F431 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
@@ -1395,7 +1398,6 @@
 		D2CB6E9B27C50EAE00A62B57 /* FilesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA92423979B00786299 /* FilesOrchestrator.swift */; };
 		D2CB6EA727C50EAE00A62B57 /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
 		D2CB6EA827C50EAE00A62B57 /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BB22423979B00786299 /* URLSessionClient.swift */; };
-		D2CB6EAF27C50EAE00A62B57 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		D2CB6EB327C50EAE00A62B57 /* KronosNTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D3E0CE277B23F0008BE766 /* KronosNTPClient.swift */; };
 		D2CB6EBA27C50EAE00A62B57 /* DataUploadConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BAF2423979B00786299 /* DataUploadConditions.swift */; };
 		D2CB6EBF27C50EAE00A62B57 /* KronosData+Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D3E0CD277B23F0008BE766 /* KronosData+Bytes.swift */; };
@@ -2350,7 +2352,6 @@
 		614B78EA296D7B63009C6B92 /* DatadogCoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogCoreTests.swift; sourceTree = "<group>"; };
 		614B78EC296D7B63009C6B92 /* LowPowerModePublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowPowerModePublisherTests.swift; sourceTree = "<group>"; };
 		614CADD62510BAC000B93D2D /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		614ED36B260352DC00C8C519 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../Carthage/Build/CrashReporter.xcframework; sourceTree = "<group>"; };
 		615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersWriterTests.swift; sourceTree = "<group>"; };
 		615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogTracer+InjectAndExtract.swift"; sourceTree = "<group>"; };
@@ -2416,6 +2417,8 @@
 		6174D6032BFB9AB600EC7469 /* WebViewTracking+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewTracking+objc.swift"; sourceTree = "<group>"; };
 		6174D6052BFB9D5500EC7469 /* DDWebViewTracking+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDWebViewTracking+apiTests.m"; sourceTree = "<group>"; };
 		6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKMetricFields.swift; sourceTree = "<group>"; };
+		6174D6122BFDF16C00EC7469 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
+		6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTypeTests.swift; sourceTree = "<group>"; };
 		6174D61C2C007B3300EC7469 /* ModuleName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleName.swift; sourceTree = "<group>"; };
 		6175C3502BCE66DB006FAAB0 /* TraceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceContext.swift; sourceTree = "<group>"; };
 		617699172A860D9D0030022B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -4032,7 +4035,6 @@
 				D286626D2A43487500852CE3 /* Datadog.swift */,
 				D2FB125C292FBB56005B13F8 /* Datadog+Internal.swift */,
 				E1D5AEA624B4D45A007F194B /* Versioning.swift */,
-				614E9EB2244719FA007EE3E1 /* BundleType.swift */,
 				61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */,
 				61133B9E2423979B00786299 /* Core */,
 				61216277247D1F2100AC5D67 /* FeaturesIntegration */,
@@ -5709,6 +5711,7 @@
 				D23039BC298D5235001A1FA3 /* DeviceInfo.swift */,
 				D23039BE298D5235001A1FA3 /* LaunchTime.swift */,
 				D2F8235229915E12003C7E99 /* DatadogSite.swift */,
+				6174D6122BFDF16C00EC7469 /* BundleType.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -6238,6 +6241,7 @@
 			children = (
 				D2DA239D298D58F300C6C7E6 /* AppStateHistoryTests.swift */,
 				D2DA239E298D58F300C6C7E6 /* DeviceInfoTests.swift */,
+				6174D6152BFDF29B00EC7469 /* BundleTypeTests.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -7916,7 +7920,6 @@
 				61DA8CAF28620C760074A606 /* Cryptography.swift in Sources */,
 				E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */,
 				61133BD82423979B00786299 /* URLSessionClient.swift in Sources */,
-				614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */,
 				61D3E0D8277B23F1008BE766 /* KronosNTPClient.swift in Sources */,
 				D20605B22874E1660047275C /* CarrierInfoPublisher.swift in Sources */,
 				D2A1EE32287DA51900D28DFB /* UserInfoPublisher.swift in Sources */,
@@ -8502,6 +8505,7 @@
 				D23039EA298D5236001A1FA3 /* DeviceInfo.swift in Sources */,
 				D2EBEE2329BA160F00B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D23039F8298D5236001A1FA3 /* InternalLogger.swift in Sources */,
+				6174D6132BFDF16C00EC7469 /* BundleType.swift in Sources */,
 				D2303A01298D5236001A1FA3 /* DateFormatting.swift in Sources */,
 				3C9B27252B9F174700569C07 /* SpanID.swift in Sources */,
 				D2216EC02A94DE2900ADAEC8 /* FeatureBaggage.swift in Sources */,
@@ -9147,7 +9151,6 @@
 				D20605A4287464F40047275C /* ContextValuePublisher.swift in Sources */,
 				D2CB6EA727C50EAE00A62B57 /* Versioning.swift in Sources */,
 				D2CB6EA827C50EAE00A62B57 /* URLSessionClient.swift in Sources */,
-				D2CB6EAF27C50EAE00A62B57 /* BundleType.swift in Sources */,
 				D2CB6EB327C50EAE00A62B57 /* KronosNTPClient.swift in Sources */,
 				D2CB6EBA27C50EAE00A62B57 /* DataUploadConditions.swift in Sources */,
 				D2CB6EBF27C50EAE00A62B57 /* KronosData+Bytes.swift in Sources */,
@@ -9437,6 +9440,7 @@
 				D2DA236D298D57AA00C6C7E6 /* DeviceInfo.swift in Sources */,
 				D2EBEE3129BA161100B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				D2DA236E298D57AA00C6C7E6 /* InternalLogger.swift in Sources */,
+				6174D6142BFDF16C00EC7469 /* BundleType.swift in Sources */,
 				D2DA236F298D57AA00C6C7E6 /* DateFormatting.swift in Sources */,
 				3C9B27262B9F174700569C07 /* SpanID.swift in Sources */,
 				D2216EC12A94DE2900ADAEC8 /* FeatureBaggage.swift in Sources */,
@@ -9495,6 +9499,7 @@
 				D2DA23A3298D58F400C6C7E6 /* AnyEncodableTests.swift in Sources */,
 				3CCECDAF2BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB429DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
+				6174D6162BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,
 				3C0D5DF52A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4429BA168200B15732 /* TraceIDTests.swift in Sources */,
 				D2EBEE4329BA168200B15732 /* TraceIDGeneratorTests.swift in Sources */,
@@ -9543,6 +9548,7 @@
 				D2DA23B1298D59DC00C6C7E6 /* AnyEncodableTests.swift in Sources */,
 				3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB529DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
+				6174D6172BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,
 				3C0D5DF62A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4629BA168400B15732 /* TraceIDTests.swift in Sources */,
 				D2EBEE4529BA168400B15732 /* TraceIDGeneratorTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -598,8 +598,8 @@
 		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
 		61DCC84A2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */; };
 		61DCC84B2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */; };
-		61DCC84E2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */; };
-		61DCC84F2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */; };
+		61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
+		61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
@@ -2597,7 +2597,7 @@
 		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
 		61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetricControllerTests.swift; sourceTree = "<group>"; };
 		61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionEndedMetricIntegrationTests.swift; sourceTree = "<group>"; };
-		61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryInterecptor.swift; sourceTree = "<group>"; };
+		61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryInterceptor.swift; sourceTree = "<group>"; };
 		61DE333525C8278A008E3EC2 /* CrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingPlugin.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventBuilderTests.swift; sourceTree = "<group>"; };
@@ -4644,7 +4644,7 @@
 				D236BE2729520FED00676E67 /* CrashReportReceiver.swift */,
 				D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */,
 				D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */,
-				61DCC84D2C071DCD00CB59E5 /* TelemetryInterecptor.swift */,
+				61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -8686,7 +8686,7 @@
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
-				61DCC84F2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */,
+				61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9006,7 +9006,7 @@
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
-				61DCC84E2C071DCD00CB59E5 /* TelemetryInterecptor.swift in Sources */,
+				61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -592,6 +592,8 @@
 		61DA8CB828647A500074A606 /* InternalLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB728647A500074A606 /* InternalLoggerTests.swift */; };
 		61DA8CB928647A500074A606 /* InternalLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB728647A500074A606 /* InternalLoggerTests.swift */; };
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
+		61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
+		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
@@ -2586,6 +2588,7 @@
 		61DA8CB728647A500074A606 /* InternalLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalLoggerTests.swift; sourceTree = "<group>"; };
 		61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomObjcViewController.h; sourceTree = "<group>"; };
 		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
+		61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndedMetricControllerTests.swift; sourceTree = "<group>"; };
 		61DE333525C8278A008E3EC2 /* CrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingPlugin.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventBuilderTests.swift; sourceTree = "<group>"; };
@@ -4840,6 +4843,7 @@
 			isa = PBXGroup;
 			children = (
 				6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */,
+				61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */,
 			);
 			path = SDKMetrics;
 			sourceTree = "<group>";
@@ -8669,6 +8673,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6188697D2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
+				61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				D23F8EA029DDCD38001CFAE8 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
 				D23F8EA229DDCD38001CFAE8 /* RUMSessionScopeTests.swift in Sources */,
 				D23F8EA329DDCD38001CFAE8 /* RUMUserActionScopeTests.swift in Sources */,
@@ -8986,6 +8991,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6188697C2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
+				61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				D29A9FA629DDB483005C54A4 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
 				D29A9FBD29DDB483005C54A4 /* RUMSessionScopeTests.swift in Sources */,
 				D29A9FAB29DDB483005C54A4 /* RUMUserActionScopeTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -163,7 +163,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
             monitor.startView(key: "key2", name: "View2")
             dateProvider.now += 5.seconds
             monitor.stopView(key: "key2")
-            
+
             // Simulate app in background:
             core.context = .mockWith(applicationStateHistory: .mockAppInBackground(since: dateProvider.now))
 

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -1,0 +1,231 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogRUM
+
+class RUMSessionEndedMetricIntegrationTests: XCTestCase {
+    private let dateProvider = DateProviderMock()
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var rumConfig: RUM.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy()
+        core.context = .mockWith(
+            launchTime: .mockWith(launchDate: dateProvider.now),
+            applicationStateHistory: .mockAppInForeground(since: dateProvider.now)
+        )
+        rumConfig = RUM.Configuration(applicationID: .mockAny())
+        rumConfig.telemetrySampleRate = 100
+        rumConfig.metricsTelemetrySampleRate = 100
+        rumConfig.dateProvider = dateProvider
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        rumConfig = nil
+        super.tearDown()
+    }
+
+    // MARK: - Conditions For Sending The Metric
+
+    func testWhenSessionEndsWithStopAPI() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertTrue(metricAttributes.wasStopped)
+    }
+
+    func testWhenSessionEndsDueToInactivityTimeout() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key1", name: "View1")
+
+        // When
+        dateProvider.now += RUMSessionScope.Constants.sessionTimeoutDuration + 1.seconds
+        monitor.startView(key: "key2", name: "View2")
+
+        // Then
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertFalse(metricAttributes.wasStopped)
+    }
+
+    func testWhenSessionReachesMaxDuration() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+
+        // When
+        let deadline = dateProvider.now + RUMSessionScope.Constants.sessionMaxDuration * 1.5
+        while dateProvider.now < deadline {
+            monitor.addAction(type: .custom, name: "action")
+            dateProvider.now += RUMSessionScope.Constants.sessionTimeoutDuration - 1.seconds
+        }
+
+        // Then
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertFalse(metricAttributes.wasStopped)
+    }
+
+    func testWhenSessionIsNotSampled_thenMetricIsNotSent() throws {
+        rumConfig.sessionSampleRate = 0
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let events = core.waitAndReturnEventsData(ofFeature: RUMFeature.name, timeout: .now() + 0.5)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    // MARK: - Reporting Session Attributes
+
+    func testReportingSessionID() throws {
+        var currentSessionID: String?
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+        monitor.currentSessionID { currentSessionID = $0 }
+        monitor.stopView(key: "key")
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let metric = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent())
+        let expectedSessionID = try XCTUnwrap(currentSessionID)
+        XCTAssertEqual(metric.session?.id, expectedSessionID.lowercased())
+    }
+
+    func testTrackingSessionDuration() throws {
+        let startTime = dateProvider.now
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        dateProvider.now += 5.seconds
+        monitor.startView(key: "key1", name: "View1")
+        dateProvider.now += 5.seconds
+        monitor.startView(key: "key2", name: "View2")
+        dateProvider.now += 5.seconds
+        monitor.startView(key: "key3", name: "View3")
+        dateProvider.now += 5.seconds
+        monitor.stopView(key: "key3")
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let expectedDuration = dateProvider.now.timeIntervalSince(startTime)
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertEqual(metricAttributes.duration, expectedDuration.toInt64Nanoseconds)
+    }
+
+    func testTrackingViewsCount() throws {
+        rumConfig.trackBackgroundEvents = true // enable tracking "Background" view
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        (0..<3).forEach { _ in
+            // Simulate app in foreground:
+            core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: dateProvider.now))
+
+            // Track 2 distinct views:
+            dateProvider.now += 5.seconds
+            monitor.startView(key: "key1", name: "View1")
+            dateProvider.now += 5.seconds
+            monitor.startView(key: "key2", name: "View2")
+            dateProvider.now += 5.seconds
+            monitor.stopView(key: "key2")
+            
+            // Simulate app in background:
+            core.context = .mockWith(applicationStateHistory: .mockAppInBackground(since: dateProvider.now))
+
+            // Track resource without view:
+            dateProvider.now += 1.seconds
+            monitor.startResource(resourceKey: "resource", url: .mockAny())
+            dateProvider.now += 1.seconds
+            monitor.stopResource(resourceKey: "resource", response: .mockAny())
+        }
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertEqual(metricAttributes.viewsCount.total, 10)
+        XCTAssertEqual(metricAttributes.viewsCount.applicationLaunch, 1)
+        XCTAssertEqual(metricAttributes.viewsCount.background, 3)
+    }
+
+    func testTrackingSDKErrors() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+
+        core.flush()
+        (0..<9).forEach { _ in core.telemetry.error(id: "id1", message: .mockAny(), kind: "kind1", stack: .mockAny()) }
+        (0..<8).forEach { _ in core.telemetry.error(id: "id2", message: .mockAny(), kind: "kind2", stack: .mockAny()) }
+        (0..<7).forEach { _ in core.telemetry.error(id: "id3", message: .mockAny(), kind: "kind3", stack: .mockAny()) }
+        (0..<6).forEach { _ in core.telemetry.error(id: "id4", message: .mockAny(), kind: "kind4", stack: .mockAny()) }
+        (0..<5).forEach { _ in core.telemetry.error(id: "id5", message: .mockAny(), kind: "kind5", stack: .mockAny()) }
+        (0..<4).forEach { _ in core.telemetry.error(id: "id6", message: .mockAny(), kind: "kind6", stack: .mockAny()) }
+        core.flush()
+
+        // When
+        monitor.stopSession()
+
+        // Then
+        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        XCTAssertEqual(metricAttributes.sdkErrorsCount.total, 39, "It should count all SDK errors")
+        XCTAssertEqual(
+            metricAttributes.sdkErrorsCount.byKind,
+            ["kind1": 9, "kind2": 8, "kind3": 7, "kind4": 6, "kind5": 5],
+            "It should report TOP 5 error kinds"
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private extension DatadogCoreProxy {
+    func waitAndReturnSessionEndedMetricEvent() -> TelemetryDebugEvent? {
+        let events = waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        return events.first(where: { $0.telemetry.message == "[Mobile Metric] \(SessionEndedMetric.Constants.name)" })
+    }
+}
+
+private extension TelemetryDebugEvent {
+    var attributes: SessionEndedMetric.Attributes? {
+        return telemetry.telemetryInfo[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes
+    }
+}
+

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -14,7 +14,6 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
     private var rumConfig: RUM.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
-        super.setUp()
         core = DatadogCoreProxy()
         core.context = .mockWith(
             launchTime: .mockWith(launchDate: dateProvider.now),
@@ -30,7 +29,6 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         core.flushAndTearDown()
         core = nil
         rumConfig = nil
-        super.tearDown()
     }
 
     // MARK: - Conditions For Sending The Metric

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -109,7 +109,6 @@ internal final class DatadogCore {
         self.isRunFromExtension = isRunFromExtension
         self.applicationVersionPublisher = ApplicationVersionPublisher(version: applicationVersion)
         self.consentPublisher = TrackingConsentPublisher(consent: initialConsent)
-
         self.contextProvider.subscribe(\.userInfo, to: userInfoPublisher)
         self.contextProvider.subscribe(\.version, to: applicationVersionPublisher)
         self.contextProvider.subscribe(\.trackingConsent, to: consentPublisher)
@@ -391,6 +390,7 @@ extension DatadogContextProvider {
         ciAppOrigin: String?,
         applicationName: String,
         applicationBundleIdentifier: String,
+        applicationBundleType: BundleType,
         applicationVersion: String,
         sdkInitDate: Date,
         device: DeviceInfo,
@@ -411,6 +411,7 @@ extension DatadogContextProvider {
             ciAppOrigin: ciAppOrigin,
             applicationName: applicationName,
             applicationBundleIdentifier: applicationBundleIdentifier,
+            applicationBundleType: applicationBundleType,
             sdkInitDate: dateProvider.now,
             device: device,
             nativeSourceOverride: nativeSourceOverride,

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -416,7 +416,7 @@ public enum Datadog {
             ?? "0"
 
         let bundleName = configuration.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
-        let bundleType: BundleType = configuration.bundle.bundlePath.hasSuffix(".appex") ? .iOSAppExtension : .iOSApp
+        let bundleType = BundleType(bundle: configuration.bundle)
         let bundleIdentifier = configuration.bundle.bundleIdentifier ?? "unknown"
         let service = configuration.service ?? configuration.bundle.bundleIdentifier ?? "ios"
         let source = configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String ?? "ios"
@@ -459,6 +459,7 @@ public enum Datadog {
                 ciAppOrigin: CITestIntegration.active?.origin,
                 applicationName: bundleName ?? bundleType.rawValue,
                 applicationBundleIdentifier: bundleIdentifier,
+                applicationBundleType: bundleType,
                 applicationVersion: applicationVersion,
                 sdkInitDate: configuration.dateProvider.now,
                 device: DeviceInfo(),

--- a/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
@@ -316,6 +316,36 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertEqual(context.applicationBundleIdentifier, "unknown")
     }
 
+    func testiOSAppBundleType() throws {
+        var configuration = defaultConfig
+        configuration.bundle = .mockWith(bundlePath: "bundle.path.app")
+
+        Datadog.initialize(
+            with: configuration,
+            trackingConsent: .mockRandom()
+        )
+        defer { Datadog.flushAndDeinitialize() }
+
+        let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
+        let context = core.contextProvider.read()
+        XCTAssertEqual(context.applicationBundleType, .iOSApp)
+    }
+
+    func testiOSAppExtensionBundleType() throws {
+        var configuration = defaultConfig
+        configuration.bundle = .mockWith(bundlePath: "bundle.path.appex")
+
+        Datadog.initialize(
+            with: configuration,
+            trackingConsent: .mockRandom()
+        )
+        defer { Datadog.flushAndDeinitialize() }
+
+        let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
+        let context = core.contextProvider.read()
+        XCTAssertEqual(context.applicationBundleType, .iOSAppExtension)
+    }
+
     func testEnvironment() throws {
         func verify(validEnv env: String) throws {
             Datadog.initialize(

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -188,16 +188,6 @@ extension UploadPerformanceMock {
     }
 }
 
-extension BundleType: AnyMockable, RandomMockable {
-    public static func mockAny() -> BundleType {
-        return .iOSApp
-    }
-
-    public static func mockRandom() -> BundleType {
-        return [.iOSApp, .iOSAppExtension].randomElement()!
-    }
-}
-
 extension PerformancePreset: AnyMockable, RandomMockable {
     public static func mockAny() -> Self {
         PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp)

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -725,7 +725,8 @@ extension RUMScopeDependencies {
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
         viewCache: ViewCache = ViewCache(),
-        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock()
+        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry())
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -742,7 +743,8 @@ extension RUMScopeDependencies {
             vitalsReaders: vitalsReaders,
             onSessionStart: onSessionStart,
             viewCache: viewCache,
-            fatalErrorContext: fatalErrorContext
+            fatalErrorContext: fatalErrorContext,
+            sessionEndedMetric: sessionEndedMetric
         )
     }
 
@@ -761,7 +763,8 @@ extension RUMScopeDependencies {
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: RUM.SessionListener? = nil,
         viewCache: ViewCache? = nil,
-        fatalErrorContext: FatalErrorContextNotifying? = nil
+        fatalErrorContext: FatalErrorContextNotifying? = nil,
+        sessionEndedMetric: SessionEndedMetricController? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -778,7 +781,8 @@ extension RUMScopeDependencies {
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
             onSessionStart: onSessionStart ?? self.onSessionStart,
             viewCache: viewCache ?? self.viewCache,
-            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext
+            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
+            sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric
         )
     }
 }
@@ -800,6 +804,7 @@ extension RUMSessionScope {
         parent: RUMContextProvider = RUMContextProviderMock(),
         startTime: Date = .mockAny(),
         startPrecondition: RUMSessionPrecondition? = .userAppLaunch,
+        context: DatadogContext = .mockAny(),
         dependencies: RUMScopeDependencies = .mockAny(),
         hasReplay: Bool? = .mockAny()
     ) -> RUMSessionScope {
@@ -808,8 +813,8 @@ extension RUMSessionScope {
             parent: parent,
             startTime: startTime,
             startPrecondition: startPrecondition,
-            dependencies: dependencies,
-            hasReplay: hasReplay
+            context: context,
+            dependencies: dependencies
         )
     }
 }

--- a/DatadogInternal/Sources/Context/BundleType.swift
+++ b/DatadogInternal/Sources/Context/BundleType.swift
@@ -6,8 +6,13 @@
 
 import Foundation
 
-/// A type of the bundle running the SDK.
-internal enum BundleType: String {
+public enum BundleType: String {
+    /// An iOS application.
     case iOSApp
+    /// An iOS app extension.
     case iOSAppExtension
+
+    public init(bundle: Bundle) {
+        self = bundle.bundlePath.hasSuffix(".appex") ? .iOSAppExtension : .iOSApp
+    }
 }

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -62,6 +62,9 @@ public struct DatadogContext {
     /// The bundle identifier, read from `Info.plist` (`CFBundleIdentifier`).
     public let applicationBundleIdentifier: String
 
+    /// The type of the bundle running the SDK.
+    public let applicationBundleType: BundleType
+
     /// Date of SDK initialization measured in device time (without NTP correction).
     public let sdkInitDate: Date
 
@@ -125,6 +128,7 @@ public struct DatadogContext {
         serverTimeOffset: TimeInterval = .zero,
         applicationName: String,
         applicationBundleIdentifier: String,
+        applicationBundleType: BundleType,
         sdkInitDate: Date,
         device: DeviceInfo,
         nativeSourceOverride: String? = nil,
@@ -152,6 +156,7 @@ public struct DatadogContext {
         self.serverTimeOffset = serverTimeOffset
         self.applicationName = applicationName
         self.applicationBundleIdentifier = applicationBundleIdentifier
+        self.applicationBundleType = applicationBundleType
         self.sdkInitDate = sdkInitDate
         self.device = device
         self.nativeSourceOverride = nativeSourceOverride

--- a/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
+++ b/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
@@ -8,6 +8,12 @@ import Foundation
 
 /// Common fields in SDK metrics.
 public enum SDKMetricFields {
-    /// Metric type key.
+    /// Metric type key. It expects `String` value.
     public static let typeKey = "metric_type"
+
+    /// Key referencing the session ID (`String`) that the metric should be sent with. It expects `String` value.
+    ///
+    /// When attached to metric attributes, the value of this key (session ID) will be used to replace
+    /// the ID of session that the metric was collected in. The key itself is dropped before the metric is sent.
+    public static let sessionIDOverrideKey = "session_id_override"
 }

--- a/DatadogInternal/Tests/Context/BundleTypeTests.swift
+++ b/DatadogInternal/Tests/Context/BundleTypeTests.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+
+class BundleTypeTests: XCTestCase {
+    func testiOSAppBundleType() {
+        let bundle: Bundle = .mockWith(bundlePath: "bundle.path.app")
+        let bundleType = BundleType(bundle: bundle)
+        XCTAssertEqual(bundleType, .iOSApp)
+    }
+
+    func testiOSAppExtensionBundleType() {
+        let bundle: Bundle = .mockWith(bundlePath: "bundle.path.appex")
+        let bundleType = BundleType(bundle: bundle)
+        XCTAssertEqual(bundleType, .iOSAppExtension)
+    }
+}

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -100,6 +100,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             telemetry: core.telemetry
         )
         self.messageReceiver = CombinedFeatureMessageReceiver(
+            TelemetryInterecptor(sessionEndedMetric: sessionEndedMetric),
             TelemetryReceiver(
                 featureScope: featureScope,
                 dateProvider: configuration.dateProvider,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -100,7 +100,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             telemetry: core.telemetry
         )
         self.messageReceiver = CombinedFeatureMessageReceiver(
-            TelemetryInterecptor(sessionEndedMetric: sessionEndedMetric),
+            TelemetryInterceptor(sessionEndedMetric: sessionEndedMetric),
             TelemetryReceiver(
                 featureScope: featureScope,
                 dateProvider: configuration.dateProvider,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -35,6 +35,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
 
         let featureScope = core.scope(for: RUMFeature.self)
+        let sessionEndedMetric = SessionEndedMetricController(telemetry: core.telemetry)
         let dependencies = RUMScopeDependencies(
             featureScope: featureScope,
             rumApplicationID: configuration.applicationID,
@@ -72,7 +73,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
             },
             onSessionStart: configuration.onSessionStart,
             viewCache: ViewCache(),
-            fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope)
+            fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope),
+            sessionEndedMetric: sessionEndedMetric
         )
 
         self.monitor = Monitor(

--- a/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 
 /// Intercepts telemetry events sent through message bus.
-internal struct TelemetryInterecptor: FeatureMessageReceiver {
+internal struct TelemetryInterceptor: FeatureMessageReceiver {
     /// "RUM Session Ended" controller to count SDK errors.
     let sessionEndedMetric: SessionEndedMetricController
 

--- a/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
@@ -28,6 +28,6 @@ internal struct TelemetryInterecptor: FeatureMessageReceiver {
     }
 
     private func interceptError(id: String, message: String, kind: String, stack: String) {
-        sessionEndedMetric.latestMetric?.track(sdkErrorKind: kind)
+        sessionEndedMetric.track(sdkErrorKind: kind, in: nil) // `nil` - track in current session
     }
 }

--- a/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+internal struct TelemetryInterecptor: FeatureMessageReceiver {
+    let sessionEndedMetric: SessionEndedMetricController
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case .telemetry(let telemetry) = message else {
+            return false
+        }
+
+        switch telemetry {
+        case .error(let id, let message, let kind, let stack):
+            interceptError(id: id, message: message, kind: kind, stack: stack)
+        default:
+            break
+        }
+
+        return false // do not consume, pass to next receivers
+    }
+
+    private func interceptError(id: String, message: String, kind: String, stack: String) {
+        sessionEndedMetric.latestMetric?.track(sdkErrorKind: kind)
+    }
+}

--- a/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterecptor.swift
@@ -7,7 +7,9 @@
 import Foundation
 import DatadogInternal
 
+/// Intercepts telemetry events sent through message bus.
 internal struct TelemetryInterecptor: FeatureMessageReceiver {
+    /// "RUM Session Ended" controller to count SDK errors.
     let sessionEndedMetric: SessionEndedMetricController
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {

--- a/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
@@ -8,6 +8,9 @@ import Foundation
 import DatadogInternal
 
 internal protocol RUMScope: AnyObject {
+    /// Container bundling dependencies for this scope.
+    var dependencies: RUMScopeDependencies { get }
+
     /// Processes given command. Returns:
     /// * `true` if the scope should be kept open.
     /// * `false` if the scope should be closed.
@@ -20,6 +23,13 @@ extension RUMScope {
     /// Returns `self`  to be kept open, `nil` if it requests to close.
     func scope(byPropagating command: RUMCommand, context: DatadogContext, writer: Writer) -> Self? {
         process(command: command, context: context, writer: writer) ? self : nil
+    }
+}
+
+extension RUMScope where Self: RUMContextProvider {
+    /// The "RUM Session Ended" metric tracking the session that this `RUMScope` belongs to.
+    var sessionEndedMetric: SessionEndedMetric? {
+        dependencies.sessionEndedMetric.metric(for: context.sessionID.toRUMDataFormat)
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
@@ -26,13 +26,6 @@ extension RUMScope {
     }
 }
 
-extension RUMScope where Self: RUMContextProvider {
-    /// The "RUM Session Ended" metric tracking the session that this `RUMScope` belongs to.
-    var sessionEndedMetric: SessionEndedMetric? {
-        dependencies.sessionEndedMetric.metric(for: context.sessionID.toRUMDataFormat)
-    }
-}
-
 extension Array where Element: RUMScope {
     /// Propagates given `command` through this array of scopes and manages their lifecycle by
     /// filtering scopes that get closed.

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -102,7 +102,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
             // proccss(command:context:writer) returned false, so the scope will be deallocated at the end of
             // this execution context. End the "RUM Session Ended" metric:
-            defer { dependencies.sessionEndedMetric.endMetric(sessionID: scope.sessionUUID.toRUMDataFormat) }
+            defer { dependencies.sessionEndedMetric.endMetric(sessionID: scope.sessionUUID) }
 
             // proccss(command:context:writer) returned false, but if the scope is still active
             // it means the session reached one of the end reasons

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -30,6 +30,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     // MARK: - Initialization
 
+    /// Container bundling dependencies for this scope.
     let dependencies: RUMScopeDependencies
 
     init(dependencies: RUMScopeDependencies) {
@@ -98,6 +99,10 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
                 // as it it still has work to do.
                 return scope
             }
+
+            // proccss(command:context:writer) returned false, so the scope will be deallocated at the end of
+            // this execution context. End the "RUM Session Ended" metric:
+            defer { dependencies.sessionEndedMetric.endMetric(sessionID: scope.sessionUUID.toRUMDataFormat) }
 
             // proccss(command:context:writer) returned false, but if the scope is still active
             // it means the session reached one of the end reasons

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -156,8 +156,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             parent: self,
             startTime: context.sdkInitDate,
             startPrecondition: startPrecondition,
-            dependencies: dependencies,
-            hasReplay: context.hasReplay
+            context: context,
+            dependencies: dependencies
         )
 
         lastSessionEndReason = nil
@@ -210,8 +210,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             parent: self,
             startTime: command.time,
             startPrecondition: startPrecondition,
+            context: context,
             dependencies: dependencies,
-            hasReplay: context.hasReplay,
             resumingViewScope: resumingViewScope
         )
         lastActiveView = nil

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -11,7 +11,9 @@ internal class RUMResourceScope: RUMScope {
     // MARK: - Initialization
 
     let context: RUMContext
-    private let dependencies: RUMScopeDependencies
+
+    /// Container bundling dependencies for this scope.
+    let dependencies: RUMScopeDependencies
 
     /// This Resource's UUID.
     let resourceUUID: RUMUUID

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -48,6 +48,7 @@ internal struct RUMScopeDependencies {
     /// Telemetry endpoint.
     let telemetry: Telemetry
     let sessionType: RUMSessionType
+    let sessionEndedMetric: SessionEndedMetricController
 
     init(
         featureScope: FeatureScope,
@@ -64,7 +65,8 @@ internal struct RUMScopeDependencies {
         vitalsReaders: VitalsReaders?,
         onSessionStart: RUM.SessionListener?,
         viewCache: ViewCache,
-        fatalErrorContext: FatalErrorContextNotifying
+        fatalErrorContext: FatalErrorContextNotifying,
+        sessionEndedMetric: SessionEndedMetricController
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID
@@ -82,6 +84,7 @@ internal struct RUMScopeDependencies {
         self.viewCache = viewCache
         self.fatalErrorContext = fatalErrorContext
         self.telemetry = featureScope.telemetry
+        self.sessionEndedMetric = sessionEndedMetric
 
         if ciTest != nil {
             self.sessionType = .ciTest

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -106,7 +106,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Start tracking "RUM Session Ended" metric for this session
         dependencies.sessionEndedMetric.startMetric(
-            sessionID: sessionUUID.toRUMDataFormat,
+            sessionID: sessionUUID,
             precondition: startPrecondition,
             context: context
         )
@@ -202,7 +202,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         var deactivating = false
         if isActive {
             if command is RUMStopSessionCommand {
-                sessionEndedMetric?.trackWasStopped()
+                dependencies.sessionEndedMetric.trackWasStopped(sessionID: self.context.sessionID)
                 endReason = .stopAPI
                 deactivating = true
             } else if let startApplicationCommand = command as? RUMApplicationStartCommand {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -19,7 +19,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     // MARK: - Initialization
 
     private unowned let parent: RUMContextProvider
-    private let dependencies: RUMScopeDependencies
+
+    /// Container bundling dependencies for this scope.
+    let dependencies: RUMScopeDependencies
 
     /// The type of this User Action.
     internal let actionType: RUMActionType

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -554,7 +554,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = event
 
             // Track this view in Session Ended metric:
-            sessionEndedMetric?.track(view: event)
+            dependencies.sessionEndedMetric.track(view: event, in: self.context.sessionID)
         } else { // if event was dropped by mapper
             version -= 1
         }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -25,7 +25,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Initialization
 
     private unowned let parent: RUMContextProvider
-    private let dependencies: RUMScopeDependencies
+
+    /// Container bundling dependencies for this scope.
+    let dependencies: RUMScopeDependencies
+
     /// If this is the very first view created in the current app process.
     private let isInitialView: Bool
 
@@ -549,6 +552,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
             // Update fatal error context with recent RUM view:
             dependencies.fatalErrorContext.view = event
+
+            // Track this view in Session Ended metric:
+            sessionEndedMetric?.track(view: event)
         } else { // if event was dropped by mapper
             version -= 1
         }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -1,0 +1,253 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// An object tracking the state of RUM session and exporting attributes for "RUM Session Ended" telemetry.
+internal final class SessionEndedMetric {
+    /// Definition of fields in "RUM Session Ended" telemetry, following the "RUM Session Ended" telemetry spec.
+    internal enum Constants {
+        /// The name of this metric, included in telemetry log.
+        /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+        static let name = "RUM Session Ended"
+        /// Metric type value.
+        static let typeValue = "rum session ended"
+        /// Namespace for bundling metric attributes ("rse" = "RUM Session Ended").
+        static let rseKey = "rse"
+        /// Key referencing the session ID (`String`) that the metric refers to.
+        static let sessionIDKey = "sessionID"
+    }
+
+    /// An ID of the session being tracked through this metric object.
+    private let sessionID: String
+
+    /// The type of OS component where the session was tracked.
+    private let bundleType: BundleType
+
+    /// The session precondition that led to the creation of this session.
+    private let precondition: RUMSessionPrecondition?
+
+    private struct TrackedViewInfo {
+        let viewURL: String
+        let startMs: Int64
+        var durationNs: Int64
+
+        // TODO: RUM-4591 Track diagnostic attributes:
+        // - `instrumentationType`: manual | uikit | swiftui
+    }
+
+    /// Stores information about tracked views, referencing them by their view ID.
+    @ReadWriteLock
+    private var trackedViews: [String: TrackedViewInfo] = [:]
+
+    /// Info about the first tracked view.
+    @ReadWriteLock
+    private var firstTrackedView: TrackedViewInfo?
+
+    /// Info about the last tracked view.
+    @ReadWriteLock
+    private var lastTrackedView: TrackedViewInfo?
+
+    /// Tracks the number of SDK errors by their kind.
+    @ReadWriteLock
+    private var trackedSDKErrors: [String: Int] = [:]
+
+    /// Indicates if the session was stopped through `stopSession()` API.
+    @ReadWriteLock
+    private var wasStopped: Bool = false
+
+    // TODO: RUM-4591 Track diagnostic attributes:
+    // - no_view_events_count
+    // - has_background_events_tracking_enabled
+    // - has_replay
+    // - ntp_offset
+
+    // MARK: - Tracking Metric State
+
+    /// Initializer.
+    /// - Parameters:
+    ///   - sessionID: An ID of the session that is being tracked with this metric.
+    ///   - precondition: The precondition that led to starting this session.
+    ///   - context: The SDK context at the moment of starting this session.
+    init(
+        sessionID: String,
+        precondition: RUMSessionPrecondition?,
+        context: DatadogContext
+    ) {
+        self.sessionID = sessionID
+        self.bundleType = context.applicationBundleType
+        self.precondition = precondition
+    }
+
+    /// Tracks the view event that occurred during the session.
+    func track(view: RUMViewEvent) {
+        guard view.session.id == sessionID else {
+            return // sanity check, unexpected
+        }
+
+        var info = trackedViews[view.view.id] ?? TrackedViewInfo(
+            viewURL: view.view.url,
+            startMs: view.date,
+            durationNs: view.view.timeSpent
+        )
+
+        info.durationNs = view.view.timeSpent
+        trackedViews[view.view.id] = info
+
+        if firstTrackedView == nil {
+            firstTrackedView = info
+        }
+        lastTrackedView = info
+    }
+
+    /// Tracks the kind of SDK error that occurred during the session.
+    func track(sdkErrorKind: String) {
+        if let count = trackedSDKErrors[sdkErrorKind] {
+            trackedSDKErrors[sdkErrorKind] = count + 1
+        } else {
+            trackedSDKErrors[sdkErrorKind] = 1
+        }
+    }
+
+    /// Signals that the session was stopped with `stopSession()` API.
+    func trackWasStopped() {
+        wasStopped = true
+    }
+
+    // MARK: - Exporting Attributes
+
+    /// Set of quality and diagnostic attributes for the Session Ended metric.
+    internal struct Attributes: Encodable {
+        /// The type of OS component where the session was tracked.
+        let processType: String
+        /// The precondition that led to the creation of this session.
+        ///
+        /// Note: We don't expect it to ever become `nil`, but optionality is enforced in upstream code.
+        let precondition: String?
+        /// The session's duration, calculated from view events.
+        ///
+        /// This calculation only includes view events that are written to disk, with no consideration if the I/O operation
+        /// has succeeded or not. Views dropped through the mapper API are not included in this duration.
+        ///
+        /// Note: It becomes `nil` if no views were tracked in this session.
+        let duration: Int64?
+        /// Indicates if the session was stopped through `stopSession()` API.
+        let wasStopped: Bool
+
+        struct ViewsCount: Encodable {
+            /// The number of distinct views (view UUIDs) sent during this session.
+            let total: Int
+            /// The number of standard "Background" views tracked during this session.
+            let background: Int
+            /// The number of standard "ApplicationLaunch" views tracked during this session (sanity check: we expect `0` or `1`).
+            let applicationLaunch: Int
+
+            enum CodingKeys: String, CodingKey {
+                case total
+                case background
+                case applicationLaunch = "app_launch"
+            }
+        }
+
+        let viewsCount: ViewsCount
+
+        struct SDKErrorsCount: Encodable {
+            /// The total number of SDK errors that occurred during the session, excluding any effects from telemetry limits
+            /// such as duplicate filtering or maximum caps.
+            let total: Int
+            /// The map of TOP 5 SDK error kinds to the number of their occurrences during the session.
+            /// Error kinds may include characters illegal for being a JSON key, so they are escaped.
+            let byKind: [String: Int]
+
+            enum CodingKeys: String, CodingKey {
+                case total
+                case byKind = "by_kind"
+            }
+        }
+
+        let sdkErrorsCount: SDKErrorsCount
+
+        enum CodingKeys: String, CodingKey {
+            case processType = "process_type"
+            case precondition
+            case duration
+            case wasStopped = "was_stopped"
+            case viewsCount = "views_count"
+            case sdkErrorsCount = "sdk_errors_count"
+        }
+    }
+
+    /// Exports metric attributes for `Telemetry.metric(name:attributes:)`.
+    func asMetricAttributes() -> [String: Encodable] {
+        // Compute duration
+        var durationNs: Int64?
+        if let firstView = firstTrackedView, let lastView = lastTrackedView {
+            let endOfLastViewNs = lastView.startMs.msToNs.addingReportingOverflow(lastView.durationNs).partialValue
+            durationNs = endOfLastViewNs.subtractingReportingOverflow(firstView.startMs.msToNs).partialValue
+        }
+
+        // Compute views count
+        let totalViewsCount = trackedViews.count
+        let backgroundViewsCount = trackedViews.values.filter({ $0.viewURL == RUMOffViewEventsHandlingRule.Constants.backgroundViewURL }).count
+        let appLaunchViewsCount = trackedViews.values.filter({ $0.viewURL == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL }).count
+
+        // Compute SDK errors count
+        let totalSDKErrors = trackedSDKErrors.count
+        let top5SDKErrorsByKind = top5SDKErrorsByKind(from: trackedSDKErrors)
+
+        return [
+            SDKMetricFields.typeKey: Constants.typeValue,
+            Constants.sessionIDKey: sessionID,
+            Constants.rseKey: Attributes(
+                processType: {
+                    switch bundleType {
+                    case .iOSApp: return "app"
+                    case .iOSAppExtension: return "extension"
+                    }
+                }(),
+                precondition: precondition?.rawValue,
+                duration: durationNs,
+                wasStopped: wasStopped,
+                viewsCount: .init(
+                    total: totalViewsCount,
+                    background: backgroundViewsCount,
+                    applicationLaunch: appLaunchViewsCount
+                ),
+                sdkErrorsCount: .init(
+                    total: totalSDKErrors,
+                    byKind: top5SDKErrorsByKind
+                )
+            )
+        ]
+    }
+
+    /// Returns the top 5 SDK errors with escaping their error kind.
+    /// - Parameter sdkErrors: All SDK errors.
+    /// - Returns: Top 5 errors with their count.
+    private func top5SDKErrorsByKind(from sdkErrors: [String: Int]) -> [String: Int] {
+        /// Replaces all non-alpanumeric characters with `_` (underscore).
+        func escapeNonAlphanumericCharacters(_ string: String) -> String {
+            let escaped = string.unicodeScalars.map { CharacterSet.alphanumerics.contains($0) ? Character($0) : "_" }
+            return String(escaped)
+        }
+
+        let sortedEntries = sdkErrors.sorted { $0.value > $1.value }
+        let top5Entries = sortedEntries.prefix(5)
+        var top5: [String: Int] = [:]
+        for (key, value) in top5Entries {
+            top5[escapeNonAlphanumericCharacters(key)] = value
+        }
+        return top5
+    }
+}
+
+// MARK: - Helpers
+
+private extension Int64 {
+    /// Converts timestamp represented in milliseconds to nanoseconds with preventing Int64 overflow.
+    var msToNs: Int64 { multipliedReportingOverflow(by: 1_000_000).partialValue }
+}

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -56,7 +56,7 @@ internal final class SessionEndedMetric {
 
     /// Indicates if the session was stopped through `stopSession()` API.
     @ReadWriteLock
-    private var wasStopped: Bool = false
+    private var wasStopped = false
 
     // TODO: RUM-4591 Track diagnostic attributes:
     // - no_view_events_count

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -18,12 +18,10 @@ internal final class SessionEndedMetric {
         static let typeValue = "rum session ended"
         /// Namespace for bundling metric attributes ("rse" = "RUM Session Ended").
         static let rseKey = "rse"
-        /// Key referencing the session ID (`String`) that the metric refers to.
-        static let sessionIDKey = "sessionID"
     }
 
     /// An ID of the session being tracked through this metric object.
-    private let sessionID: String
+    let sessionID: String
 
     /// The type of OS component where the session was tracked.
     private let bundleType: BundleType
@@ -128,7 +126,7 @@ internal final class SessionEndedMetric {
         ///
         /// Note: We don't expect it to ever become `nil`, but optionality is enforced in upstream code.
         let precondition: String?
-        /// The session's duration, calculated from view events.
+        /// The session's duration (in nanoseconds), calculated from view events.
         ///
         /// This calculation only includes view events that are written to disk, with no consideration if the I/O operation
         /// has succeeded or not. Views dropped through the mapper API are not included in this duration.
@@ -196,12 +194,12 @@ internal final class SessionEndedMetric {
         let appLaunchViewsCount = trackedViews.values.filter({ $0.viewURL == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL }).count
 
         // Compute SDK errors count
-        let totalSDKErrors = trackedSDKErrors.count
+        let totalSDKErrors = trackedSDKErrors.values.reduce(0, +)
         let top5SDKErrorsByKind = top5SDKErrorsByKind(from: trackedSDKErrors)
 
         return [
             SDKMetricFields.typeKey: Constants.typeValue,
-            Constants.sessionIDKey: sessionID,
+            SDKMetricFields.sessionIDOverrideKey: sessionID,
             Constants.rseKey: Attributes(
                 processType: {
                     switch bundleType {

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// A controller responsible for managing "RUM Session Ended" metrics.
+internal final class SessionEndedMetricController {
+    /// Dictionary to keep track of pending metrics, keyed by session ID.
+    @ReadWriteLock
+    private var pendingMetrics: [String: SessionEndedMetric] = [:]
+
+    /// Telemetry endpoint for sending metrics.
+    private let telemetry: Telemetry
+
+    /// Initializes a new instance of the metric controller.
+    /// - Parameter telemetry: The telemetry endpoint used for sending metrics.
+    init(telemetry: Telemetry) {
+        self.telemetry = telemetry
+    }
+
+    /// Starts a new metric for a given session.
+    /// - Parameters:
+    ///   - sessionID: The ID of the session to track.
+    ///   - precondition: The precondition that led to starting this session.
+    ///   - context: The SDK context at the moment of starting this session.
+    /// - Returns: The newly created `SessionEndedMetric` instance.
+    func startMetric(sessionID: String, precondition: RUMSessionPrecondition?, context: DatadogContext) -> SessionEndedMetric {
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: precondition, context: context)
+        pendingMetrics[sessionID] = metric
+        return metric
+    }
+
+    /// Retrieves the metric for a given session ID.
+    /// - Parameter sessionID: The ID of the session to retrieve the metric for.
+    /// - Returns: The `SessionEndedMetric` instance if found, otherwise `nil`.
+    func metric(for sessionID: String) -> SessionEndedMetric? {
+        return pendingMetrics[sessionID]
+    }
+
+    /// Ends the metric for a given session, sending it to telemetry and removing it from pending metrics.
+    /// - Parameter sessionID: The ID of the session to end the metric for.
+    func endMetric(sessionID: String) {
+        guard let metric = pendingMetrics[sessionID] else {
+            return
+        }
+        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes())
+        pendingMetrics[sessionID] = nil
+    }
+}

--- a/DatadogRUM/Sources/UUIDs/RUMUUID.swift
+++ b/DatadogRUM/Sources/UUIDs/RUMUUID.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct RUMUUID: Equatable {
+internal struct RUMUUID: Equatable, Hashable {
     let rawValue: UUID
 
     /// UUID with all zeros, used to represent no-op values.

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -12,7 +12,7 @@ import DatadogInternal
 class TelemetryInterceptorTests: XCTestCase {
     func testWhenInterceptingErrorTelemetry_itItUpdatesSessionEndedMetric() throws {
         let sessionID = RUMUUID.mockRandom().toRUMDataFormat
-        
+
         // Given
         let metricController = SessionEndedMetricController(telemetry: NOPTelemetry())
         let interceptor = TelemetryInterecptor(sessionEndedMetric: metricController)

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -17,7 +17,7 @@ class TelemetryInterceptorTests: XCTestCase {
 
         // Given
         let metricController = SessionEndedMetricController(telemetry: telemetry)
-        let interceptor = TelemetryInterecptor(sessionEndedMetric: metricController)
+        let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
 
         // When
         metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny())

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class TelemetryInterceptorTests: XCTestCase {
+    func testWhenInterceptingErrorTelemetry_itItUpdatesSessionEndedMetric() throws {
+        let sessionID = RUMUUID.mockRandom().toRUMDataFormat
+        
+        // Given
+        let metricController = SessionEndedMetricController(telemetry: NOPTelemetry())
+        let interceptor = TelemetryInterecptor(sessionEndedMetric: metricController)
+
+        // When
+        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny())
+        let errorTelemetry: TelemetryMessage = .error(id: .mockAny(), message: .mockAny(), kind: .mockAny(), stack: .mockAny())
+        let result = interceptor.receive(message: .telemetry(errorTelemetry), from: NOPDatadogCore())
+
+        // Then
+        XCTAssertFalse(result)
+        let metricAttributes = try XCTUnwrap(metricController.metric(for: sessionID)?.asMetricAttributes())
+        let rse = try XCTUnwrap(metricAttributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
+        XCTAssertEqual(rse.sdkErrorsCount.total, 1)
+    }
+}

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -424,6 +424,27 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.action?.id, rumContext.userActionID)
     }
 
+    func testSendTelemetryMetricWithRUMContextAndSessionIDOverride() {
+        // Given
+        let rumContext: RUMCoreContext = .mockRandom()
+        featureScope.contextMock.baggages = [RUMFeature.name: FeatureBaggage(rumContext)]
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
+        let sessionIDOverride = "session-id-override"
+
+        // When
+        var attributes = mockRandomAttributes()
+        attributes[SDKMetricFields.sessionIDOverrideKey] = sessionIDOverride
+        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: attributes)
+
+        // Then
+        let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
+        XCTAssertEqual(event?.application?.id, rumContext.applicationID)
+        XCTAssertEqual(event?.session?.id, sessionIDOverride)
+        XCTAssertEqual(event?.view?.id, rumContext.viewID)
+        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertNil(event?.telemetry.telemetryInfo[SDKMetricFields.sessionIDOverrideKey], "It should delete `sessionIDOverrideKey` from metric attributes")
+    }
+
     func testMethodCallTelemetryPropagetsAllData() throws {
         // Given
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -131,7 +131,7 @@ extension RUMViewEvent: RandomMockable {
 
     /// Produces random `RUMViewEvent` with setting given fields to certain values.
     static func mockRandomWith(
-        sessionID: String = .mockRandom(),
+        sessionID: RUMUUID = .mockRandom(),
         viewID: String = .mockRandom(),
         date: Int64 = .mockRandom(),
         viewIsActive: Bool? = .random(),
@@ -166,7 +166,7 @@ extension RUMViewEvent: RandomMockable {
             service: .mockRandom(),
             session: .init(
                 hasReplay: nil,
-                id: sessionID,
+                id: sessionID.toRUMDataFormat,
                 isActive: true,
                 sampledForReplay: nil,
                 type: .user

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -131,8 +131,12 @@ extension RUMViewEvent: RandomMockable {
 
     /// Produces random `RUMViewEvent` with setting given fields to certain values.
     static func mockRandomWith(
+        sessionID: String = .mockRandom(),
+        viewID: String = .mockRandom(),
+        date: Int64 = .mockRandom(),
         viewIsActive: Bool? = .random(),
         viewTimeSpent: Int64 = .mockRandom(),
+        viewURL: String = .mockRandom(),
         crashCount: Int64? = nil
     ) -> RUMViewEvent {
         return RUMViewEvent(
@@ -154,7 +158,7 @@ extension RUMViewEvent: RandomMockable {
             connectivity: .mockRandom(),
             container: nil,
             context: .mockRandom(),
-            date: .mockRandom(),
+            date: date,
             device: .mockRandom(),
             display: nil,
             os: .mockRandom(),
@@ -162,7 +166,7 @@ extension RUMViewEvent: RandomMockable {
             service: .mockRandom(),
             session: .init(
                 hasReplay: nil,
-                id: .mockRandom(),
+                id: sessionID,
                 isActive: true,
                 sampledForReplay: nil,
                 type: .user
@@ -192,7 +196,7 @@ extension RUMViewEvent: RandomMockable {
                 flutterRasterTime: nil,
                 frozenFrame: .init(count: .mockRandom()),
                 frustration: nil,
-                id: .mockRandom(),
+                id: viewID,
                 inForegroundPeriods: [
                     .init(
                         duration: .mockRandom(),
@@ -218,7 +222,7 @@ extension RUMViewEvent: RandomMockable {
                 refreshRateMin: .mockRandom(),
                 resource: .init(count: .mockRandom()),
                 timeSpent: viewTimeSpent,
-                url: .mockRandom()
+                url: viewURL
             )
         )
     }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -771,7 +771,8 @@ extension RUMScopeDependencies {
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
         viewCache: ViewCache = ViewCache(),
-        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock()
+        fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry())
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -788,7 +789,8 @@ extension RUMScopeDependencies {
             vitalsReaders: vitalsReaders,
             onSessionStart: onSessionStart,
             viewCache: viewCache,
-            fatalErrorContext: fatalErrorContext
+            fatalErrorContext: fatalErrorContext,
+            sessionEndedMetric: sessionEndedMetric
         )
     }
 
@@ -807,7 +809,8 @@ extension RUMScopeDependencies {
         vitalsReaders: VitalsReaders? = nil,
         onSessionStart: RUM.SessionListener? = nil,
         viewCache: ViewCache? = nil,
-        fatalErrorContext: FatalErrorContextNotifying? = nil
+        fatalErrorContext: FatalErrorContextNotifying? = nil,
+        sessionEndedMetric: SessionEndedMetricController? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -824,7 +827,8 @@ extension RUMScopeDependencies {
             vitalsReaders: vitalsReaders ?? self.vitalsReaders,
             onSessionStart: onSessionStart ?? self.onSessionStart,
             viewCache: viewCache ?? self.viewCache,
-            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext
+            fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
+            sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric
         )
     }
 }
@@ -846,16 +850,16 @@ extension RUMSessionScope {
         parent: RUMContextProvider = RUMContextProviderMock(),
         startTime: Date = .mockAny(),
         startPrecondition: RUMSessionPrecondition? = .userAppLaunch,
-        dependencies: RUMScopeDependencies = .mockAny(),
-        hasReplay: Bool? = .mockAny()
+        context: DatadogContext = .mockAny(),
+        dependencies: RUMScopeDependencies = .mockAny()
     ) -> RUMSessionScope {
         return RUMSessionScope(
             isInitialSession: isInitialSession,
             parent: parent,
             startTime: startTime,
             startPrecondition: startPrecondition,
-            dependencies: dependencies,
-            hasReplay: hasReplay
+            context: context,
+            dependencies: dependencies
         )
     }
 }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -689,7 +689,7 @@ extension RUMInternalErrorSource: RandomMockable {
 
 // MARK: - RUMContext Mocks
 
-extension RUMUUID {
+extension RUMUUID: RandomMockable {
     public static func mockRandom() -> RUMUUID {
         return RUMUUID(rawValue: UUID())
     }

--- a/DatadogRUM/Tests/RUMMonitor/RUMScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMScopeTests.swift
@@ -12,6 +12,7 @@ import DatadogInternal
 class RUMScopeTests: XCTestCase {
     /// A mock `RUMScope` that completes or not based on the configuration.
     private class CompletableScope: RUMScope {
+        let dependencies: RUMScopeDependencies = .mockAny()
         let isCompleted: Bool
 
         init(isCompleted: Bool) {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -348,12 +348,16 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: randomIsInitialSession,
             parent: parent,
+            context: .mockWith(
+                baggages: [
+                    SessionReplayDependency.hasReplay: FeatureBaggage(randomIsReplayBeingRecorded),
+                ]
+            ),
             dependencies: .mockWith(
                 featureScope: featureScope,
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter if sampled or not,
                 fatalErrorContext: fatalErrorContext
-            ),
-            hasReplay: randomIsReplayBeingRecorded
+            )
         )
 
         // Then
@@ -379,11 +383,15 @@ class RUMSessionScopeTests: XCTestCase {
             isInitialSession: randomIsInitialSession,
             parent: parent,
             startTime: sessionStartTime,
+            context: .mockWith(
+                baggages: [
+                    SessionReplayDependency.hasReplay: FeatureBaggage(randomIsReplayBeingRecorded),
+                ]
+            ),
             dependencies: .mockWith(
                 featureScope: featureScope,
                 fatalErrorContext: fatalErrorContext
-            ),
-            hasReplay: randomIsReplayBeingRecorded
+            )
         )
 
         // When

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -1,0 +1,119 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class SessionEndedMetricControllerTests: XCTestCase {
+    private let telemetry = TelemetryMock()
+
+    func testWhenMetricIsStarted_itCanBeRetrievedByID() throws {
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+
+        // When
+        let sessionID1: String = .mockRandom()
+        let sessionID2: String = .mockRandom()
+        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
+        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
+
+        // Then
+        let metric1 = try XCTUnwrap(controller.metric(for: sessionID1))
+        let metric2 = try XCTUnwrap(controller.metric(for: sessionID2))
+        XCTAssertEqual(metric1.sessionID, sessionID1)
+        XCTAssertEqual(metric2.sessionID, sessionID2)
+    }
+
+    func testWhenMetricIsStarted_itCanBeRetrievedAsLatest() throws {
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+
+        // When
+        let sessionID1: String = .mockRandom()
+        let sessionID2: String = .mockRandom()
+        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
+        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
+
+        // Then
+        XCTAssertEqual(controller.latestMetric?.sessionID, sessionID2)
+        controller.endMetric(sessionID: sessionID2)
+        XCTAssertEqual(controller.latestMetric?.sessionID, sessionID1)
+        controller.endMetric(sessionID: sessionID1)
+        XCTAssertNil(controller.latestMetric)
+    }
+
+    func testWhenMetricIsEnded_itIsSentToTelemetry() throws {
+        let sessionID: String = .mockRandom()
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+        controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        controller.endMetric(sessionID: sessionID)
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: SessionEndedMetric.Constants.name))
+        XCTAssertEqual(metric.attributes[SDKMetricFields.typeKey] as? String, SessionEndedMetric.Constants.typeValue)
+        XCTAssertEqual(metric.attributes[SDKMetricFields.sessionIDOverrideKey] as? String, sessionID)
+    }
+
+    func testAfterMetricIsEnded_itCanNoLongerBeRetrieved() throws {
+        let sessionID: String = .mockRandom()
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+        controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        XCTAssertNotNil(controller.metric(for: sessionID))
+        controller.endMetric(sessionID: sessionID)
+
+        // Then
+        XCTAssertNil(controller.metric(for: sessionID))
+        XCTAssertNil(controller.latestMetric)
+    }
+
+    func testWhenSessionIsSampled_itDoesNotTrackMetric() throws {
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+
+        // When
+        let rejectedSessionID = RUMUUID.nullUUID.toRUMDataFormat
+        controller.startMetric(sessionID: rejectedSessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // Then
+        XCTAssertNil(controller.metric(for: rejectedSessionID))
+        XCTAssertNil(controller.latestMetric)
+
+        controller.endMetric(sessionID: rejectedSessionID)
+        XCTAssertTrue(telemetry.messages.isEmpty)
+    }
+
+    // MARK: - Thread Safety
+
+    func testTrackingSessionEndedMetricIsThreadSafe() {
+        let sessionIDs: [String] = .mockRandom(count: 10)
+        let controller = SessionEndedMetricController(telemetry: telemetry)
+
+        // swiftlint:disable opening_brace
+        callConcurrently(
+            closures: [
+                { controller.startMetric(
+                    sessionID: sessionIDs.randomElement()!, precondition: .mockRandom(), context: .mockRandom()
+                ) },
+                { _ = controller.metric(for: sessionIDs.randomElement()!) },
+                {
+                    _ = controller.metric(for: sessionIDs.randomElement()!)?.track(view: .mockRandom())
+                },
+                {
+                    _ = controller.metric(for: sessionIDs.randomElement()!)?.track(sdkErrorKind: .mockRandom())
+                },
+                {
+                    _ = controller.metric(for: sessionIDs.randomElement()!)?.trackWasStopped()
+                },
+                { controller.endMetric(sessionID: sessionIDs.randomElement()!) },
+            ],
+            iterations: 100
+        )
+        // swiftlint:enable opening_brace
+    }
+}

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -103,6 +103,9 @@ class SessionEndedMetricControllerTests: XCTestCase {
                 { controller.track(view: .mockRandom(), in: sessionIDs.randomElement()!) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: sessionIDs.randomElement()!) },
                 { controller.trackWasStopped(sessionID: sessionIDs.randomElement()!) },
+                { controller.track(view: .mockRandom(), in: nil) },
+                { controller.track(sdkErrorKind: .mockRandom(), in: nil) },
+                { controller.trackWasStopped(sessionID: nil) },
                 { controller.endMetric(sessionID: sessionIDs.randomElement()!) },
             ],
             iterations: 100

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -1,0 +1,356 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class SessionEndedMetricTests: XCTestCase {
+    private typealias Constants = SessionEndedMetric.Constants
+    private typealias SessionEndedAttributes = SessionEndedMetric.Attributes
+    private let sessionID: String = .mockRandom()
+
+    func testReportingEmptyMetric() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertNil(rse.duration)
+        XCTAssertEqual(rse.viewsCount.total, 0)
+        XCTAssertEqual(rse.viewsCount.background, 0)
+        XCTAssertEqual(rse.viewsCount.applicationLaunch, 0)
+        XCTAssertEqual(rse.sdkErrorsCount.total, 0)
+        XCTAssertEqual(rse.sdkErrorsCount.byKind, [:])
+    }
+
+    // MARK: - Metric Type
+
+    func testReportingMetricType() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        XCTAssertEqual(attributes[SDKMetricFields.typeKey] as? String, Constants.typeValue)
+    }
+
+    // MARK: - Session ID
+
+    func testReportingSessionID() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        XCTAssertEqual(attributes[Constants.sessionIDKey] as? String, sessionID)
+    }
+
+    // MARK: - Process Type
+
+    func testReportingAppProcessType() throws {
+        // Given
+        let metric = SessionEndedMetric(
+            sessionID: sessionID, precondition: .mockRandom(), context: .mockWith(applicationBundleType: .iOSApp)
+        )
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.processType, "app")
+    }
+
+    func testReportingExtensionProcessType() throws {
+        // Given
+        let metric = SessionEndedMetric(
+            sessionID: sessionID, precondition: .mockRandom(), context: .mockWith(applicationBundleType: .iOSAppExtension)
+        )
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.processType, "extension")
+    }
+
+    // MARK: - Precondition
+
+    func testReportingSessionPrecondition() throws {
+        // Given
+        let expectedPrecondition: RUMSessionPrecondition = .mockRandom()
+        let metric = SessionEndedMetric(
+            sessionID: sessionID, precondition: expectedPrecondition, context: .mockRandom()
+        )
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.precondition, expectedPrecondition.rawValue)
+    }
+
+    // MARK: - Duration
+
+    func testComputingDurationFromSingleView() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID)
+
+        // When
+        metric.track(view: view)
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.duration, view.view.timeSpent)
+    }
+
+    func testComputingDurationFromMultipleViews() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
+        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
+        let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
+
+        // When
+        metric.track(view: view1)
+        metric.track(view: view2)
+        metric.track(view: view3)
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.duration, 10.s2ns + 20.s2ns + 50.s2ns)
+    }
+
+    func testComputingDurationFromOverlappingViews() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
+        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
+
+        // When
+        metric.track(view: view1)
+        metric.track(view: view2)
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.duration, 25.s2ns)
+    }
+
+    func testDurationIsAlwaysComputedFromTheFirstAndLastView() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        let firstView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms, viewTimeSpent: 10.s2ns)
+        let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
+
+        // When
+        metric.track(view: firstView)
+        (0..<10).forEach { _ in metric.track(view: .mockRandom()) } // middle views should not alter the duration
+        metric.track(view: lastView)
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.duration, 10.s2ns + 20.s2ns)
+    }
+
+    func testWhenComputingDuration_itIgnoresViewsFromDifferentSession() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        metric.track(view: .mockRandom())
+        metric.track(view: .mockRandom())
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertNil(rse.duration)
+    }
+
+    // MARK: - Was Stopped
+
+    func testReportingSessionThatWasStopped() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        metric.trackWasStopped()
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertTrue(rse.wasStopped)
+    }
+
+    func testReportingSessionThatWasNotStopped() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertFalse(rse.wasStopped)
+    }
+
+    // MARK: - Views Count
+
+    func testReportingTotalViewsCount() throws {
+        let viewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        viewIDs.forEach { metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0)) }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.viewsCount.total, viewIDs.count)
+    }
+
+    func testReportingBackgorundViewsCount() throws {
+        let backgroundViewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
+        let otherViewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
+        let viewIDs = backgroundViewIDs.union(otherViewIDs)
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        viewIDs.forEach { viewID in
+            let viewURL = backgroundViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.backgroundViewURL : .mockRandom()
+            metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
+        }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.viewsCount.background, backgroundViewIDs.count)
+    }
+
+    func testReportingApplicationLaunchViewsCount() throws {
+        let appLaunchViewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
+        let otherViewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
+        let viewIDs = appLaunchViewIDs.union(otherViewIDs)
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        viewIDs.forEach { viewID in
+            let viewURL = appLaunchViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL : .mockRandom()
+            metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
+        }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.viewsCount.applicationLaunch, appLaunchViewIDs.count)
+    }
+
+    func testReportingViewsCount_itIgnoresViewsFromDifferentSession() throws {
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        metric.track(view: .mockRandom())
+        metric.track(view: .mockRandom())
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.viewsCount.total, 0)
+    }
+
+    // MARK: - SDK Errors Count
+
+    func testReportingTotalSDKErrorsCount() throws {
+        let errorKinds: [String] = .mockRandom(count: .mockRandom(min: 0, max: 50))
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        errorKinds.forEach { metric.track(sdkErrorKind: $0) }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.sdkErrorsCount.total, errorKinds.count)
+    }
+
+    func testReportingTopSDKErrorsCount() throws {
+        let errorKinds: [String: Int] = [
+            "top1": 9, "top2": 8, "top3": 7, "top4": 6,
+            "top5": 5, "top6": 4, "top7": 3, "top8": 2,
+        ]
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        errorKinds.forEach { kind, count in
+            (0..<count).forEach { _ in metric.track(sdkErrorKind: kind) }
+        }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(
+            rse.sdkErrorsCount.byKind,
+            ["top1": 9, "top2": 8, "top3": 7, "top4": 6, "top5": 5]
+        )
+    }
+
+    func testWhenReportingTopSDKErrorsCount_itEscapesTheKind() throws {
+        let errorKinds: [String: Int] = [
+            "top 1 error": 9, "top: 2 error": 8, "top_3_error": 7, "top4/error": 6,
+        ]
+
+        // Given
+        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+
+        // When
+        errorKinds.forEach { kind, count in
+            (0..<count).forEach { _ in metric.track(sdkErrorKind: kind) }
+        }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(
+            rse.sdkErrorsCount.byKind,
+            ["top_1_error": 9, "top__2_error": 8, "top_3_error": 7, "top4_error": 6]
+        )
+    }
+}
+
+private extension Int {
+    /// Converts seconds to milliseconds.
+    var s2ms: Int64 { Int64(self) * 1_000 }
+    /// Converts seconds to nanoseconds.
+    var s2ns: Int64 { Int64(self) * 1_000_000_000 }
+    /// Converts nanoseconds to milliseconds.
+    var ns2ms: Int64 { Int64(self) / 1_000_000 }
+}

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -54,7 +54,7 @@ class SessionEndedMetricTests: XCTestCase {
         let attributes = metric.asMetricAttributes()
 
         // Then
-        XCTAssertEqual(attributes[Constants.sessionIDKey] as? String, sessionID)
+        XCTAssertEqual(attributes[SDKMetricFields.sessionIDOverrideKey] as? String, sessionID)
     }
 
     // MARK: - Process Type
@@ -286,18 +286,21 @@ class SessionEndedMetricTests: XCTestCase {
     // MARK: - SDK Errors Count
 
     func testReportingTotalSDKErrorsCount() throws {
-        let errorKinds: [String] = .mockRandom(count: .mockRandom(min: 0, max: 50))
+        let errorKinds: [String] = .mockRandom(count: .mockRandom(min: 0, max: 10))
+        let repetitions = 5
 
         // Given
         let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        errorKinds.forEach { metric.track(sdkErrorKind: $0) }
+        (0..<repetitions).forEach { _ in
+            errorKinds.forEach { metric.track(sdkErrorKind: $0) }
+        }
         let attributes = metric.asMetricAttributes()
 
         // Then
         let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
-        XCTAssertEqual(rse.sdkErrorsCount.total, errorKinds.count)
+        XCTAssertEqual(rse.sdkErrorsCount.total, errorKinds.count * repetitions)
     }
 
     func testReportingTopSDKErrorsCount() throws {

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -347,6 +347,30 @@ class SessionEndedMetricTests: XCTestCase {
             ["top_1_error": 9, "top__2_error": 8, "top_3_error": 7, "top4_error": 6]
         )
     }
+
+    // MARK: - Metric Spec
+
+    func testEncodedMetricAttributesFollowTheSpec() throws {
+        // Given
+        let metric = SessionEndedMetric(
+            sessionID: sessionID, precondition: .mockRandom(), context: .mockWith(applicationBundleType: .iOSApp)
+        )
+        metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10))
+
+        // When
+        let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))
+
+        // Then
+        XCTAssertNotNil(try matcher.value("rse.process_type") as String)
+        XCTAssertNotNil(try matcher.value("rse.precondition") as String)
+        XCTAssertNotNil(try matcher.value("rse.duration") as Int)
+        XCTAssertNotNil(try matcher.value("rse.was_stopped") as Bool)
+        XCTAssertNotNil(try matcher.value("rse.views_count.total") as Int)
+        XCTAssertNotNil(try matcher.value("rse.views_count.background") as Int)
+        XCTAssertNotNil(try matcher.value("rse.views_count.app_launch") as Int)
+        XCTAssertNotNil(try matcher.value("rse.sdk_errors_count.total") as Int)
+        XCTAssertNotNil(try matcher.value("rse.sdk_errors_count.by_kind") as [String: Int])
+    }
 }
 
 private extension Int {

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -112,7 +112,7 @@ class SessionEndedMetricTests: XCTestCase {
         let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID)
 
         // When
-        metric.track(view: view)
+        try metric.track(view: view)
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -128,9 +128,9 @@ class SessionEndedMetricTests: XCTestCase {
         let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
 
         // When
-        metric.track(view: view1)
-        metric.track(view: view2)
-        metric.track(view: view3)
+        try metric.track(view: view1)
+        try metric.track(view: view2)
+        try metric.track(view: view3)
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -145,8 +145,8 @@ class SessionEndedMetricTests: XCTestCase {
         let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
 
         // When
-        metric.track(view: view1)
-        metric.track(view: view2)
+        try metric.track(view: view1)
+        try metric.track(view: view2)
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -161,9 +161,9 @@ class SessionEndedMetricTests: XCTestCase {
         let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
 
         // When
-        metric.track(view: firstView)
-        (0..<10).forEach { _ in metric.track(view: .mockRandom()) } // middle views should not alter the duration
-        metric.track(view: lastView)
+        try metric.track(view: firstView)
+        try (0..<10).forEach { _ in try metric.track(view: .mockRandomWith(sessionID: sessionID)) } // middle views should not alter the duration
+        try metric.track(view: lastView)
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -176,8 +176,8 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        metric.track(view: .mockRandom())
-        metric.track(view: .mockRandom())
+        XCTAssertThrowsError(try metric.track(view: .mockRandom()))
+        XCTAssertThrowsError(try metric.track(view: .mockRandom()))
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -221,7 +221,7 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        viewIDs.forEach { metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0)) }
+        try viewIDs.forEach { try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0)) }
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -238,9 +238,9 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        viewIDs.forEach { viewID in
+        try viewIDs.forEach { viewID in
             let viewURL = backgroundViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.backgroundViewURL : .mockRandom()
-            metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
+            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
         }
         let attributes = metric.asMetricAttributes()
 
@@ -258,9 +258,9 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        viewIDs.forEach { viewID in
+        try viewIDs.forEach { viewID in
             let viewURL = appLaunchViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL : .mockRandom()
-            metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
+            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL))
         }
         let attributes = metric.asMetricAttributes()
 
@@ -274,8 +274,8 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        metric.track(view: .mockRandom())
-        metric.track(view: .mockRandom())
+        XCTAssertThrowsError(try metric.track(view: .mockRandom()))
+        XCTAssertThrowsError(try metric.track(view: .mockRandom()))
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -355,7 +355,7 @@ class SessionEndedMetricTests: XCTestCase {
         var metric = SessionEndedMetric(
             sessionID: sessionID, precondition: .mockRandom(), context: .mockWith(applicationBundleType: .iOSApp)
         )
-        metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10))
+        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10))
 
         // When
         let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -12,7 +12,7 @@ import DatadogInternal
 class SessionEndedMetricTests: XCTestCase {
     private typealias Constants = SessionEndedMetric.Constants
     private typealias SessionEndedAttributes = SessionEndedMetric.Attributes
-    private let sessionID: String = .mockRandom()
+    private let sessionID: RUMUUID = .mockRandom()
 
     func testReportingEmptyMetric() throws {
         // Given
@@ -54,7 +54,7 @@ class SessionEndedMetricTests: XCTestCase {
         let attributes = metric.asMetricAttributes()
 
         // Then
-        XCTAssertEqual(attributes[SDKMetricFields.sessionIDOverrideKey] as? String, sessionID)
+        XCTAssertEqual(attributes[SDKMetricFields.sessionIDOverrideKey] as? String, sessionID.toRUMDataFormat)
     }
 
     // MARK: - Process Type
@@ -108,7 +108,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromSingleView() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
         let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID)
 
         // When
@@ -122,7 +122,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromMultipleViews() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
         let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
         let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
         let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
@@ -140,7 +140,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromOverlappingViews() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
         let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
         let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
 
@@ -156,7 +156,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testDurationIsAlwaysComputedFromTheFirstAndLastView() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
         let firstView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms, viewTimeSpent: 10.s2ns)
         let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
 
@@ -173,7 +173,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testWhenComputingDuration_itIgnoresViewsFromDifferentSession() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         metric.track(view: .mockRandom())
@@ -189,7 +189,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testReportingSessionThatWasStopped() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         metric.trackWasStopped()
@@ -218,7 +218,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         viewIDs.forEach { metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0)) }
@@ -235,7 +235,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs = backgroundViewIDs.union(otherViewIDs)
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         viewIDs.forEach { viewID in
@@ -255,7 +255,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs = appLaunchViewIDs.union(otherViewIDs)
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         viewIDs.forEach { viewID in
@@ -271,7 +271,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testReportingViewsCount_itIgnoresViewsFromDifferentSession() throws {
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         metric.track(view: .mockRandom())
@@ -290,7 +290,7 @@ class SessionEndedMetricTests: XCTestCase {
         let repetitions = 5
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         (0..<repetitions).forEach { _ in
@@ -310,7 +310,7 @@ class SessionEndedMetricTests: XCTestCase {
         ]
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         errorKinds.forEach { kind, count in
@@ -332,7 +332,7 @@ class SessionEndedMetricTests: XCTestCase {
         ]
 
         // Given
-        let metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        var metric = SessionEndedMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
         errorKinds.forEach { kind, count in
@@ -352,7 +352,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testEncodedMetricAttributesFollowTheSpec() throws {
         // Given
-        let metric = SessionEndedMetric(
+        var metric = SessionEndedMetric(
             sessionID: sessionID, precondition: .mockRandom(), context: .mockWith(applicationBundleType: .iOSApp)
         )
         metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10))

--- a/TestUtilities/Matchers/JSONObjectMatcher.swift
+++ b/TestUtilities/Matchers/JSONObjectMatcher.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 public enum JSONMatcherException: Error {
     case objectException(String)
@@ -119,4 +120,22 @@ public class JSONArrrayMatcher {
 
     /// The number of elements in the array.
     public var count: Int { array.count }
+}
+
+// MARK: - Convenience
+
+public extension JSONObjectMatcher {
+    /// Instantiates `JSONObjectMatcher` with an encodable value.
+    ///
+    /// Note: Provided value is first encoded to JSON data and then gets decoded to `[String: Any]`
+    /// - Parameters:
+    ///   - anyValue: the value to initialize matcher
+    ///   - encoder: an instance of encoder to perform JSON serialization (defaults to SDK default encoder)
+    convenience init(_ anyValue: AnyEncodable, encoder: JSONEncoder = .dd.default()) throws {
+        let encoded = try encoder.encode(anyValue)
+        guard let jsonObject = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+            throw JSONMatcherException.objectException("Encoded value can't be decoded [String: Any]")
+        }
+        self.init(object: jsonObject)
+    }
 }

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -25,6 +25,7 @@ extension DatadogContext: AnyMockable {
         serverTimeOffset: TimeInterval = .zero,
         applicationName: String = .mockAny(),
         applicationBundleIdentifier: String = .mockAny(),
+        applicationBundleType: BundleType = .mockAny(),
         sdkInitDate: Date = Date(),
         nativeSourceOverride: String? = nil,
         device: DeviceInfo = .mockAny(),
@@ -53,6 +54,7 @@ extension DatadogContext: AnyMockable {
             serverTimeOffset: serverTimeOffset,
             applicationName: applicationName,
             applicationBundleIdentifier: applicationBundleIdentifier,
+            applicationBundleType: applicationBundleType,
             sdkInitDate: sdkInitDate,
             device: device,
             nativeSourceOverride: nativeSourceOverride,
@@ -84,6 +86,7 @@ extension DatadogContext: AnyMockable {
             serverTimeOffset: .mockRandomInThePast(),
             applicationName: .mockRandom(),
             applicationBundleIdentifier: .mockRandom(),
+            applicationBundleType: .mockRandom(),
             sdkInitDate: .mockRandomInThePast(),
             device: .mockRandom(),
             userInfo: .mockRandom(),
@@ -106,6 +109,16 @@ extension DatadogSite: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> Self {
         return [.us1, .us3, .us5, .eu1, .ap1, .us1_fed].randomElement()!
+    }
+}
+
+extension BundleType: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        return .iOSApp
+    }
+
+    public static func mockRandom() -> Self {
+        return [.iOSApp, .iOSAppExtension].randomElement()!
     }
 }
 

--- a/TestUtilities/Mocks/TelemetryMocks.swift
+++ b/TestUtilities/Mocks/TelemetryMocks.swift
@@ -89,6 +89,11 @@ public extension Array where Element == TelemetryMessage {
         return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).first
     }
 
+    /// Returns properties of the first metric message of given name.
+    func lastMetric(named metricName: String) -> (name: String, attributes: [String: Encodable])? {
+        return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).last
+    }
+
     /// Returns attributes of the first debug telemetry in this array.
     func firstDebug() -> (id: String, message: String, attributes: [String: Encodable]?)? {
         return compactMap { $0.asDebug }.first


### PR DESCRIPTION
### What and why?

📦 🔭 Following [the spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3663167927/RUM+Session+Ended+Telemetry+-+Spec) (internal), this PR adds "RUM Session Ended" telemetry.

The "RUM Session Ended" telemetry marks the conclusion of a RUM session and provides meta parameters that describe the session's quality and diagnostic details.

### How?

The goal of this implementation is to better understand the possible states of a RUM session by making minimal assumptions about how sessions are tracked in RUM scopes. For instance, it can track multiple sessions simultaneously, which, though unlikely, is observed in some telemetry data. The design aims to be loosely coupled with the RUM architecture, allowing flexible and convenient access to the metric object rather than restricting its lifecycle to RUM scopes.

The high-level design of this telemetry consists of two main components:
- `SessionEndedMetricController`: Manages the lifecycle of metric objects.
- `SessionEndedMetric`: Tracks the state of a RUM session and exports metric attributes.

Both are thoroughly covered in unit tests. Integration tests ensure the proper integration of the metric with RUM.

The interface of `SessionEndedMetricController`:
```swift
internal final class SessionEndedMetricController {
    // Starts a new metric for a given session.
    func startMetric(sessionID: RUMUUID, precondition: RUMSessionPrecondition?, context: DatadogContext)

    // 3 APIs tracking session state for given session ID (or `nil` for latest session):
    func track(view: RUMViewEvent, in sessionID: RUMUUID?)
    func track(sdkErrorKind: String, in sessionID: RUMUUID?)
    func trackWasStopped(sessionID: RUMUUID?)

    // Ends the metric for a given session, sending it to telemetry and removing it from pending metrics.
    func endMetric(sessionID: String)
}
```
The interface of `SessionEndedMetric`:
```swift
internal final struct SessionEndedMetric {
    mutating func track(view: RUMViewEvent)
    mutating func track(sdkErrorKind: String)
    mutating func trackWasStopped()
    func asMetricAttributes() -> [String: Encodable]
}
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
