### PR TITLE
Reduce telemetry sampling for method called

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -99,7 +99,7 @@ public class Recorder: Recording {
         snapshotProcessor: SnapshotProcessing,
         resourceProcessor: ResourceProcessing,
         telemetry: Telemetry,
-        methodCallTelemetrySamplingRate: Float = 5
+        methodCallTelemetrySamplingRate: Float = 0.1
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.viewTreeSnapshotProducer = viewTreeSnapshotProducer
@@ -123,7 +123,7 @@ public class Recorder: Recording {
         let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
-            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 5% = 0.15% of calls
+            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 0.1% = 0.003% of calls
         )
         var isSuccessful = true
         do {


### PR DESCRIPTION
### What and why?

Reduced Capture Record Method Called sampling rate from 3% to 0.1%.
Right now we gather way more data than we need. It should ease the load on the performance of dashboard maintaining statistical distribution.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
