### PR TITLE
chore: Fix dogfooding automation

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -537,6 +537,17 @@ workflows:
             cd tools/distribution && make
             venv/bin/python3 -m pytest tests
     - script:
+        title: Smoke test dogfooding (with dry-run)
+        run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+
+            export DD_DRY_RUN=yes
+            cd tools/distribution && make
+            venv/bin/python3 dogfood.py
+    - script:
         title: Run tests for nightly-unit-tests tool
         run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
         inputs:

--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -111,6 +111,8 @@ if __name__ == "__main__":
 
     try:
         dry_run = os.environ.get('DD_DRY_RUN') == 'yes'
+        if dry_run:
+            print(f'ℹ️ Running in dry-run mode')
         skip_datadog_ios = os.environ.get('DD_SKIP_DATADOG_IOS') == 'yes'
         skip_shopist_ios = os.environ.get('DD_SKIP_SHOPIST_IOS') == 'yes'
 

--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -73,7 +73,7 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
                     else:
                         package.add_dependency(
                             package_id=dependency_id,
-                            repository_url=dependency['repositoryURL'],
+                            repository_url=dependency['location'],
                             branch=dependency['state'].get('branch'),
                             revision=dependency['state']['revision'],
                             version=dependency['state'].get('version'),

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -361,7 +361,7 @@ class PackageResolvedContentV2(PackageResolvedContent):
 
 class PackageResolvedContentV3(PackageResolvedContentV2):
     """
-    Example of `package.resolved` in version `2` looks this::
+    Example of `package.resolved` in version `3` looks this::
 
         {
             "originHash" : "b47de6af98c4a9811a8d2af11d70b960dfc66b7c8e4944b35bb74c8f8bb9c487",


### PR DESCRIPTION
### What and why?

🧰 💊 Fixes the recent problem with dogfooding script:
```
❌ Failed to dogfood: 'repositoryURL'
------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/vagrant/git/tools/distribution/dogfood.py", line 119, in <module>
    dogfood(
  File "/Users/vagrant/git/tools/distribution/dogfood.py", line 76, in dogfood
    repository_url=dependency['repositoryURL'],
                   ~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'repositoryURL'
```

### How?

The `dependency['repositoryURL']` is not valid syntax for version 2 and version 3 `Package.resolved`. Updating the key name to `location` fixes the problem.

🎁 As a bonus, I added a basic smoke test for dogfooding automation. By running it with dry-run mode we ensure that it works fine after any change to `dogfooding.py`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
