### PR TITLE
Add app hang tracking to Objective-C API

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
@@ -106,6 +106,13 @@ class DDRUMConfigurationTests: XCTestCase {
         XCTAssertEqual(swift.longTaskThreshold, random)
     }
 
+    func testAppHangThreshold() {
+        let random: TimeInterval = .mockRandom()
+        objc.appHangThreshold = random
+        XCTAssertEqual(objc.appHangThreshold, random)
+        XCTAssertEqual(swift.appHangThreshold, random)
+    }
+
     func testVitalsUpdateFrequency() {
         objc.vitalsUpdateFrequency = .frequent
         XCTAssertEqual(swift.vitalsUpdateFrequency, .frequent)

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUM+apiTests.m
@@ -99,6 +99,10 @@
     config.longTaskThreshold = 1;
     XCTAssertEqual(config.longTaskThreshold, 1);
 
+    XCTAssertEqual(config.appHangThreshold, 0);
+    config.appHangThreshold = 1;
+    XCTAssertEqual(config.appHangThreshold, 1);
+
     XCTAssertEqual(config.vitalsUpdateFrequency, DDRUMVitalsFrequencyAverage);
     config.vitalsUpdateFrequency = DDRUMVitalsFrequencyFrequent;
     XCTAssertEqual(config.vitalsUpdateFrequency, DDRUMVitalsFrequencyFrequent);

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -371,6 +371,11 @@ public class DDRUMConfiguration: NSObject {
         get { swiftConfig.longTaskThreshold ?? 0 }
     }
 
+    @objc public var appHangThreshold: TimeInterval {
+        set { swiftConfig.appHangThreshold = newValue }
+        get { swiftConfig.appHangThreshold ?? 0 }
+    }
+
     @objc public var vitalsUpdateFrequency: DDRUMVitalsFrequency {
         set { swiftConfig.vitalsUpdateFrequency = newValue.swiftType }
         get { DDRUMVitalsFrequency(swiftType: swiftConfig.vitalsUpdateFrequency) }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -231,6 +231,7 @@ public class DDRUMConfiguration: NSObject
     @objc public var trackFrustrations: Bool
     @objc public var trackBackgroundEvents: Bool
     @objc public var longTaskThreshold: TimeInterval
+    @objc public var appHangThreshold: TimeInterval
     @objc public var vitalsUpdateFrequency: DDRUMVitalsFrequency
     public func setViewEventMapper(_ mapper: @escaping (DDRUMViewEvent) -> DDRUMViewEvent)
     public func setResourceEventMapper(_ mapper: @escaping (DDRUMResourceEvent) -> DDRUMResourceEvent?)
@@ -243,6 +244,8 @@ public class DDRUM: NSObject
     public static func enable(with configuration: DDRUMConfiguration)
 public class DDRUMMonitor: NSObject
     public static func shared() -> DDRUMMonitor
+    public func currentSessionID(completion: @escaping (String?) -> Void)
+    public func stopSession()
     public func startView(viewController: UIViewController,name: String?,attributes: [String: Any])
     public func stopView(viewController: UIViewController,attributes: [String: Any])
     public func startView(key: String,name: String?,attributes: [String: Any])
@@ -263,6 +266,8 @@ public class DDRUMMonitor: NSObject
     public func addAction(type: DDRUMActionType,name: String,attributes: [String: Any])
     public func addAttribute(forKey key: String,value: Any)
     public func removeAttribute(forKey key: String)
+    public func addFeatureFlagEvaluation(name: String, value: Any)
+    @objc public var debug: Bool
 public class DDRUMActionEvent: NSObject
     @objc public var dd: DDRUMActionEventDD
     @objc public var action: DDRUMActionEventAction
@@ -585,6 +590,7 @@ public class DDRUMErrorEventError: NSObject
     @objc public var binaryImages: [DDRUMErrorEventErrorBinaryImages]?
     @objc public var category: DDRUMErrorEventErrorCategory
     @objc public var causes: [DDRUMErrorEventErrorCauses]?
+    @objc public var csp: DDRUMErrorEventErrorCSP?
     @objc public var fingerprint: String?
     @objc public var handling: DDRUMErrorEventErrorHandling
     @objc public var handlingStack: String?
@@ -597,6 +603,7 @@ public class DDRUMErrorEventError: NSObject
     @objc public var sourceType: DDRUMErrorEventErrorSourceType
     @objc public var stack: String?
     @objc public var threads: [DDRUMErrorEventErrorThreads]?
+    @objc public var timeSinceAppStart: NSNumber?
     @objc public var type: String?
     @objc public var wasTruncated: NSNumber?
 public class DDRUMErrorEventErrorBinaryImages: NSObject
@@ -624,6 +631,12 @@ public enum DDRUMErrorEventErrorCausesSource: Int
     case agent
     case webview
     case custom
+    case report
+public class DDRUMErrorEventErrorCSP: NSObject
+    @objc public var disposition: DDRUMErrorEventErrorCSPDisposition
+public enum DDRUMErrorEventErrorCSPDisposition: Int
+    case none
+    case enforce
     case report
 public enum DDRUMErrorEventErrorHandling: Int
     case none
@@ -1028,18 +1041,22 @@ public class DDRUMResourceEventRUMOperatingSystem: NSObject
     @objc public var versionMajor: String
 public class DDRUMResourceEventResource: NSObject
     @objc public var connect: DDRUMResourceEventResourceConnect?
+    @objc public var decodedBodySize: NSNumber?
     @objc public var dns: DDRUMResourceEventResourceDNS?
     @objc public var download: DDRUMResourceEventResourceDownload?
     @objc public var duration: NSNumber?
+    @objc public var encodedBodySize: NSNumber?
     @objc public var firstByte: DDRUMResourceEventResourceFirstByte?
     @objc public var graphql: DDRUMResourceEventResourceGraphql?
     @objc public var id: String?
     @objc public var method: DDRUMResourceEventResourceRUMMethod
     @objc public var provider: DDRUMResourceEventResourceProvider?
     @objc public var redirect: DDRUMResourceEventResourceRedirect?
+    @objc public var renderBlockingStatus: DDRUMResourceEventResourceRenderBlockingStatus
     @objc public var size: NSNumber?
     @objc public var ssl: DDRUMResourceEventResourceSSL?
     @objc public var statusCode: NSNumber?
+    @objc public var transferSize: NSNumber?
     @objc public var type: DDRUMResourceEventResourceResourceType
     @objc public var url: String
 public class DDRUMResourceEventResourceConnect: NSObject
@@ -1097,6 +1114,10 @@ public enum DDRUMResourceEventResourceProviderProviderType: Int
 public class DDRUMResourceEventResourceRedirect: NSObject
     @objc public var duration: NSNumber
     @objc public var start: NSNumber
+public enum DDRUMResourceEventResourceRenderBlockingStatus: Int
+    case none
+    case blocking
+    case nonBlocking
 public class DDRUMResourceEventResourceSSL: NSObject
     @objc public var duration: NSNumber
     @objc public var start: NSNumber
@@ -1675,6 +1696,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var batchProcessingLevel: NSNumber?
     @objc public var batchSize: NSNumber?
     @objc public var batchUploadFrequency: NSNumber?
+    @objc public var compressIntakeRequests: NSNumber?
     @objc public var dartVersion: String?
     @objc public var defaultPrivacyLevel: String?
     @objc public var forwardConsoleLogs: DDTelemetryConfigurationEventTelemetryConfigurationForwardConsoleLogs?
@@ -1694,7 +1716,11 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var storeContextsAcrossPages: NSNumber?
     @objc public var telemetryConfigurationSampleRate: NSNumber?
     @objc public var telemetrySampleRate: NSNumber?
+    @objc public var telemetryUsageSampleRate: NSNumber?
+    @objc public var traceContextInjection: DDTelemetryConfigurationEventTelemetryConfigurationTraceContextInjection
     @objc public var traceSampleRate: NSNumber?
+    @objc public var tracerApi: String?
+    @objc public var tracerApiVersion: String?
     @objc public var trackBackgroundEvents: NSNumber?
     @objc public var trackCrossPlatformLongTasks: NSNumber?
     @objc public var trackErrors: NSNumber?
@@ -1710,6 +1736,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var trackSessionAcrossSubdomains: NSNumber?
     @objc public var trackUserInteractions: NSNumber?
     @objc public var trackViewsManually: NSNumber?
+    @objc public var trackingConsent: String?
     @objc public var unityVersion: String?
     @objc public var useAllowedTracingOrigins: NSNumber?
     @objc public var useAllowedTracingUrls: NSNumber?
@@ -1719,6 +1746,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var useFirstPartyHosts: NSNumber?
     @objc public var useLocalEncryption: NSNumber?
     @objc public var usePartitionedCrossSiteSessionCookie: NSNumber?
+    @objc public var usePciIntake: NSNumber?
     @objc public var useProxy: NSNumber?
     @objc public var useSecureSessionCookie: NSNumber?
     @objc public var useTracing: NSNumber?
@@ -1736,6 +1764,10 @@ public enum DDTelemetryConfigurationEventTelemetryConfigurationSelectedTracingPr
     case b3
     case b3multi
     case tracecontext
+public enum DDTelemetryConfigurationEventTelemetryConfigurationTraceContextInjection: Int
+    case none
+    case all
+    case sampled
 public enum DDTelemetryConfigurationEventTelemetryConfigurationViewTrackingStrategy: Int
     case none
     case activityViewTrackingStrategy
@@ -1763,12 +1795,15 @@ public class DDB3HTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float,injectEncoding: DDInjectEncoding = .single)
     public init(sampleRate: Float = 20,injectEncoding: DDInjectEncoding = .single)
-    public init(samplingStrategy: DDTraceSamplingStrategy,injectEncoding: DDInjectEncoding = .single)
+    public init(samplingStrategy: DDTraceSamplingStrategy,injectEncoding: DDInjectEncoding = .single,traceContextInjection: DDTraceContextInjection = .all)
 public class DDHTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float)
     public init(sampleRate: Float = 20)
-    public init(samplingStrategy: DDTraceSamplingStrategy)
+    public init(samplingStrategy: DDTraceSamplingStrategy,traceContextInjection: DDTraceContextInjection)
+public enum DDTraceContextInjection: Int
+    case all
+    case sampled
 public class DDTraceSamplingStrategy: NSObject
     public static func headBased() -> DDTraceSamplingStrategy
     public static func custom(sampleRate: Float) -> DDTraceSamplingStrategy
@@ -1776,7 +1811,7 @@ public class DDW3CHTTPHeadersWriter: NSObject
     @objc public var traceHeaderFields: [String: String]
     public convenience init(samplingRate: Float)
     public init(sampleRate: Float = 20)
-    public init(samplingStrategy: DDTraceSamplingStrategy)
+    public init(samplingStrategy: DDTraceSamplingStrategy,traceContextInjection: DDTraceContextInjection)
 public class DDTraceConfiguration: NSObject
     override public init()
     @objc public var sampleRate: Float

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -75,11 +75,19 @@ public struct LogEvent: Encodable
         public let email: String?
         public var extraInfo: [String: Encodable]
     public struct Error
+        public struct BinaryImage: Codable
+            public let arch: String?
+            public let isSystem: Bool
+            public let loadAddress: String?
+            public let maxAddress: String?
+            public let name: String
+            public let uuid: String
         public var kind: String?
         public var message: String?
         public var stack: String?
         public var sourceType: String = "ios"
         public var fingerprint: String?
+        public var binaryImages: [BinaryImage]?
     public struct DeviceInfo: Codable
         public let brand: String
         public let name: String
@@ -190,6 +198,11 @@ public protocol LogEventMapper
         case warn
         case error
         case critical
+[?] extension OpenTelemetryApi.TraceState
+    public func w3c() -> String
+public class OTelTracerProvider: OpenTelemetryApi.TracerProvider
+    public init(in core: DatadogCoreProtocol = CoreRegistry.default)
+    public func get(instrumentationName: String, instrumentationVersion: String?) -> OpenTelemetryApi.Tracer
 public struct OTTags
     public static let component = "component"
     public static let dbInstance = "db.instance"
@@ -295,12 +308,14 @@ public enum Trace
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing
             public enum FirstPartyHostsTracing
-                case trace(hosts: Set<String>, sampleRate: Float = 20)
-                case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>], sampleRate: Float = 20)
+                case trace(hosts: Set<String>,sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
+                case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
             public init(firstPartyHostsTracing: FirstPartyHostsTracing)
         public init(sampleRate: Float = 100,service: String? = nil,tags: [String: Encodable]? = nil,urlSessionTracking: URLSessionTracking? = nil,bundleWithRumEnabled: Bool = true,networkInfoEnabled: Bool = false,eventMapper: EventMapper? = nil,customEndpoint: URL? = nil)
 public enum SpanTags
     public static let resource = "resource.name"
+    public static let operation = "operation.name"
+    public static let service = "service.name"
 public class Tracer
     public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> OTTracer
 
@@ -495,6 +510,7 @@ public struct RUMErrorEvent: RUMDataModel
         public let binaryImages: [BinaryImages]?
         public let category: Category?
         public var causes: [Causes]?
+        public let csp: CSP?
         public var fingerprint: String?
         public let handling: Handling?
         public let handlingStack: String?
@@ -507,6 +523,7 @@ public struct RUMErrorEvent: RUMDataModel
         public let sourceType: SourceType?
         public var stack: String?
         public let threads: [Threads]?
+        public let timeSinceAppStart: Int64?
         public let type: String?
         public let wasTruncated: Bool?
         public struct BinaryImages: Codable
@@ -533,6 +550,11 @@ public struct RUMErrorEvent: RUMDataModel
                 case agent = "agent"
                 case webview = "webview"
                 case custom = "custom"
+                case report = "report"
+        public struct CSP: Codable
+            public let disposition: Disposition?
+            public enum Disposition: String, Codable
+                case enforce = "enforce"
                 case report = "report"
         public enum Handling: String, Codable
             case handled = "handled"
@@ -764,18 +786,22 @@ public struct RUMResourceEvent: RUMDataModel
             public let width: Double
     public struct Resource: Codable
         public let connect: Connect?
+        public let decodedBodySize: Int64?
         public let dns: DNS?
         public let download: Download?
         public let duration: Int64?
+        public let encodedBodySize: Int64?
         public let firstByte: FirstByte?
         public var graphql: Graphql?
         public let id: String?
         public let method: RUMMethod?
         public let provider: Provider?
         public let redirect: Redirect?
+        public let renderBlockingStatus: RenderBlockingStatus?
         public let size: Int64?
         public let ssl: SSL?
         public let statusCode: Int64?
+        public let transferSize: Int64?
         public let type: ResourceType
         public var url: String
         public struct Connect: Codable
@@ -821,6 +847,9 @@ public struct RUMResourceEvent: RUMDataModel
         public struct Redirect: Codable
             public let duration: Int64
             public let start: Int64
+        public enum RenderBlockingStatus: String, Codable
+            case blocking = "blocking"
+            case nonBlocking = "non-blocking"
         public struct SSL: Codable
             public let duration: Int64
             public let start: Int64
@@ -1238,6 +1267,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let batchProcessingLevel: Int64?
             public let batchSize: Int64?
             public let batchUploadFrequency: Int64?
+            public let compressIntakeRequests: Bool?
             public var dartVersion: String?
             public var defaultPrivacyLevel: String?
             public let forwardConsoleLogs: ForwardConsoleLogs?
@@ -1257,7 +1287,11 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let storeContextsAcrossPages: Bool?
             public let telemetryConfigurationSampleRate: Int64?
             public let telemetrySampleRate: Int64?
+            public let telemetryUsageSampleRate: Int64?
+            public var traceContextInjection: TraceContextInjection?
             public let traceSampleRate: Int64?
+            public var tracerApi: String?
+            public var tracerApiVersion: String?
             public var trackBackgroundEvents: Bool?
             public var trackCrossPlatformLongTasks: Bool?
             public var trackErrors: Bool?
@@ -1273,6 +1307,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let trackSessionAcrossSubdomains: Bool?
             public var trackUserInteractions: Bool?
             public var trackViewsManually: Bool?
+            public let trackingConsent: String?
             public var unityVersion: String?
             public let useAllowedTracingOrigins: Bool?
             public let useAllowedTracingUrls: Bool?
@@ -1282,6 +1317,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public var useFirstPartyHosts: Bool?
             public let useLocalEncryption: Bool?
             public let usePartitionedCrossSiteSessionCookie: Bool?
+            public var usePciIntake: Bool?
             public var useProxy: Bool?
             public let useSecureSessionCookie: Bool?
             public let useTracing: Bool?
@@ -1302,6 +1338,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel
                 case b3 = "b3"
                 case b3multi = "b3multi"
                 case tracecontext = "tracecontext"
+            public enum TraceContextInjection: String, Codable
+                case all = "all"
+                case sampled = "sampled"
             public enum ViewTrackingStrategy: String, Codable
                 case activityViewTrackingStrategy = "ActivityViewTrackingStrategy"
                 case fragmentViewTrackingStrategy = "FragmentViewTrackingStrategy"
@@ -1476,8 +1515,8 @@ public enum RUM
             case rare
 [?] extension RUM.Configuration.URLSessionTracking
     public enum FirstPartyHostsTracing
-        case trace(hosts: Set<String>, sampleRate: Float = 20)
-        case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>], sampleRate: Float = 20)
+        case trace(hosts: Set<String>,sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
+        case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
 [?] extension RUM.Configuration
     public init(applicationID: String,sessionSampleRate: Float = 100,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,vitalsUpdateFrequency: VitalsFrequency? = .average,viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,telemetrySampleRate: Float = 20)
@@ -1566,6 +1605,17 @@ public static func enable()
 # API surface for DatadogWebViewTracking:
 # ----------------------------------
 
+public final class objc_WebViewTracking: NSObject
+    public final class SessionReplayConfiguration: NSObject
+        public enum PrivacyLevel: Int
+            case allow
+            case mask
+            case maskUserInput
+        @objc public var privacyLevel: PrivacyLevel
+        override public init()
+        public init(privacyLevel: PrivacyLevel)
+    public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: Float = 100,with configuration: SessionReplayConfiguration? = nil)
+    public static func disable(webView: WKWebView)
 public enum WebViewTracking
     public struct SessionReplayConfiguration
         public enum PrivacyLevel: String


### PR DESCRIPTION
### What and why?

This PR adds app hang tracking to Objective-C API. It exists for Swift, but was missing in Objective-C.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
