### PR TITLE
RUM-4632 Use global session-replay configuration in webview tracking

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1367,6 +1367,9 @@
 		D2C5D5302B84F71200B63F36 /* WebRecordIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52F2B84F71200B63F36 /* WebRecordIntegrationTests.swift */; };
 		D2C7E3AB28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */; };
 		D2C7E3AE28FEBDA10023B2CC /* LaunchTimePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C7E3AD28FEBDA10023B2CC /* LaunchTimePublisher.swift */; };
+		D2C9A26A2C0F3F5A007526F5 /* SessionReplayConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */; };
+		D2C9A2872C0F467C007526F5 /* SessionReplayConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C9A2852C0F4660007526F5 /* SessionReplayConfigurationMocks.swift */; };
+		D2C9A2882C0F467C007526F5 /* SessionReplayConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C9A2852C0F4660007526F5 /* SessionReplayConfigurationMocks.swift */; };
 		D2CB6E0C27C50EAE00A62B57 /* DatadogCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* DatadogCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0D27C50EAE00A62B57 /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0E27C50EAE00A62B57 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1576,6 +1579,7 @@
 		D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
 		D2DE63532A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
 		D2DE63542A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
+		D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */; };
 		D2EBEE1F29BA160F00B15732 /* HTTPHeadersReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */; };
 		D2EBEE2029BA160F00B15732 /* TracePropagationHeadersWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */; };
 		D2EBEE2129BA160F00B15732 /* W3CHTTPHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = A728AD9C2934CE4400397996 /* W3CHTTPHeaders.swift */; };
@@ -2908,6 +2912,7 @@
 		D2C5D52F2B84F71200B63F36 /* WebRecordIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRecordIntegrationTests.swift; sourceTree = "<group>"; };
 		D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisherTests.swift; sourceTree = "<group>"; };
 		D2C7E3AD28FEBDA10023B2CC /* LaunchTimePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTimePublisher.swift; sourceTree = "<group>"; };
+		D2C9A2852C0F4660007526F5 /* SessionReplayConfigurationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayConfigurationMocks.swift; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* DatadogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6F8F27C520D400A62B57 /* DatadogCoreTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogCoreTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2935,6 +2940,7 @@
 		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRegistry.swift; sourceTree = "<group>"; };
 		D2E8D59728C7AB90007E5DE1 /* ContextMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMessageReceiverTests.swift; sourceTree = "<group>"; };
+		D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayConfiguration.swift; sourceTree = "<group>"; };
 		D2EBEDCC29B893D800B15732 /* TraceID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceID.swift; sourceTree = "<group>"; };
 		D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracePropagationHeadersWriter.swift; sourceTree = "<group>"; };
 		D2EBEDD229B8A58E00B15732 /* TracePropagationHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracePropagationHeadersReader.swift; sourceTree = "<group>"; };
@@ -4669,6 +4675,7 @@
 		6167E6DF2B81203A00C3CA2D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				D2EA0F442C0E1A8700CB20F8 /* SessionReplay */,
 				619F5CEB2BF5089B004BFE70 /* RUM */,
 				D25C834D2B88A261008E73B1 /* WebViewTracking */,
 				6167E6E02B81204B00C3CA2D /* CrashReporting */,
@@ -4700,6 +4707,7 @@
 			isa = PBXGroup;
 			children = (
 				6167E7172B837F6300C3CA2D /* CrashReporting */,
+				D2C9A2852C0F4660007526F5 /* SessionReplayConfigurationMocks.swift */,
 			);
 			path = FeatureModels;
 			sourceTree = "<group>";
@@ -6232,6 +6240,14 @@
 				D2DA239E298D58F300C6C7E6 /* DeviceInfoTests.swift */,
 			);
 			path = Context;
+			sourceTree = "<group>";
+		};
+		D2EA0F442C0E1A8700CB20F8 /* SessionReplay */ = {
+			isa = PBXGroup;
+			children = (
+				D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */,
+			);
+			path = SessionReplay;
 			sourceTree = "<group>";
 		};
 		D2EBEE1D29BA15BC00B15732 /* NetworkInstrumentation */ = {
@@ -8520,6 +8536,7 @@
 				D23039E5298D5236001A1FA3 /* DateProvider.swift in Sources */,
 				D23039E0298D5235001A1FA3 /* DatadogCoreProtocol.swift in Sources */,
 				D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */,
+				D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */,
 				6167E6F92B81E95900C3CA2D /* BinaryImage.swift in Sources */,
 				6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
 				D23039F0298D5236001A1FA3 /* AnyEncoder.swift in Sources */,
@@ -8709,6 +8726,7 @@
 				D2F44FBC299AA36D0074B0D9 /* Decompression.swift in Sources */,
 				D24C9C5229A7BD12002057CF /* SamplerMock.swift in Sources */,
 				D2579557298ABB04008A1BE5 /* AttributesMocks.swift in Sources */,
+				D2C9A2872C0F467C007526F5 /* SessionReplayConfigurationMocks.swift in Sources */,
 				6167E7292B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C7298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
 				613F9C1B2BB03188007C7606 /* FeatureScopeMock.swift in Sources */,
@@ -8755,6 +8773,7 @@
 				D2F44FBD299AA36D0074B0D9 /* Decompression.swift in Sources */,
 				D24C9C5329A7BD12002057CF /* SamplerMock.swift in Sources */,
 				D257957F298ABB83008A1BE5 /* AttributesMocks.swift in Sources */,
+				D2C9A2882C0F467C007526F5 /* SessionReplayConfigurationMocks.swift in Sources */,
 				6167E72A2B84C11900C3CA2D /* DDCrashReportMocks.swift in Sources */,
 				D2DA23C8298D5AC000C6C7E6 /* TelemetryMocks.swift in Sources */,
 				613F9C1C2BB03188007C7606 /* FeatureScopeMock.swift in Sources */,
@@ -9452,6 +9471,7 @@
 				D2DA237B298D57AA00C6C7E6 /* DateProvider.swift in Sources */,
 				D2DA237C298D57AA00C6C7E6 /* DatadogCoreProtocol.swift in Sources */,
 				D2DA237D298D57AA00C6C7E6 /* DataCompression.swift in Sources */,
+				D2C9A26A2C0F3F5A007526F5 /* SessionReplayConfiguration.swift in Sources */,
 				6167E6FA2B81E95900C3CA2D /* BinaryImage.swift in Sources */,
 				6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
 				D2DA237E298D57AA00C6C7E6 /* AnyEncoder.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
@@ -36,7 +36,6 @@ class WebLogIntegrationTests: XCTestCase {
             hosts: [],
             hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
-            sessionReplayConfiguration: nil,
             in: core
         )
     }

--- a/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
@@ -35,7 +35,6 @@ class WebEventIntegrationTests: XCTestCase {
             hosts: [],
             hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
-            sessionReplayConfiguration: nil,
             in: core
         )
     }

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -292,8 +292,8 @@ extension DatadogCore: DatadogCoreProtocol {
     ///   - name: The Feature's name.
     ///   - type: The Feature instance type.
     /// - Returns: The Feature if any.
-    func get<T>(feature type: T.Type = T.self) -> T? where T: DatadogFeature {
-        features[T.name] as? T
+    func feature<T>(named name: String, type: T.Type) -> T? {
+        features[name] as? T
     }
 
     func scope<Feature>(for featureType: Feature.Type) -> FeatureScope where Feature: DatadogFeature {

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -70,8 +70,8 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
         try core.register(feature: feature)
     }
 
-    func get<T>(feature type: T.Type) -> T? where T: DatadogFeature {
-        return core.get(feature: type)
+    func feature<T>(named name: String, type: T.Type) -> T? {
+        return core.feature(named: name, type: type)
     }
 
     func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature {

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDWebViewTracking+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDWebViewTracking+apiTests.m
@@ -32,17 +32,8 @@
     [DDWebViewTracking enableWithWebView:webView
                                    hosts:[NSSet<NSString*> setWithArray:@[@"host1.com", @"host2.com"]]
                           logsSampleRate:100.0
-                                    with:nil];
+    ];
     [DDWebViewTracking disableWithWebView:webView];
-}
-
-- (void)testDDWebViewTrackingSessionReplayConfigurationAPI {
-    DDWebViewTrackingSessionReplayConfiguration *config = [[DDWebViewTrackingSessionReplayConfiguration alloc] init];
-    XCTAssertEqual(config.privacyLevel, DDPrivacyLevelMask);
-    config.privacyLevel = DDPrivacyLevelAllow;
-    XCTAssertEqual(config.privacyLevel, DDPrivacyLevelAllow);
-    config.privacyLevel = DDPrivacyLevelMaskUserInput;
-    XCTAssertEqual(config.privacyLevel, DDPrivacyLevelMaskUserInput);
 }
 
 #pragma clang diagnostic pop

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -38,7 +38,7 @@ public protocol DatadogCoreProtocol: AnyObject, MessageSending, BaggageSharing {
     ///   - name: The Feature's name.
     ///   - type: The Feature instance type.
     /// - Returns: The Feature if any.
-    func get<T>(feature type: T.Type) -> T? where T: DatadogFeature
+    func feature<T>(named name: String, type: T.Type) -> T?
 
     /// Retrieves a Feature Scope for given feature type.
     ///
@@ -98,6 +98,17 @@ public protocol BaggageSharing {
     ///   - baggage: The Feature's baggage to set.
     ///   - key: The baggage's key.
     func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String)
+}
+
+extension DatadogCoreProtocol {
+    /// Returns a `DatadogFeature` conforming type from the
+    /// Feature registry.
+    ///
+    /// - Parameter type: The Feature instance type.
+    /// - Returns: The Feature if any.
+    public func get<T>(feature type: T.Type = T.self) -> T? where T: DatadogFeature {
+        feature(named: T.name, type: type)
+    }
 }
 
 extension MessageSending {
@@ -290,7 +301,7 @@ public class NOPDatadogCore: DatadogCoreProtocol {
     /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
-    public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
+    public func feature<T>(named name: String, type: T.Type) -> T? { nil }
     /// no-op
     public func scope<T>(for featureType: T.Type) -> FeatureScope { NOPFeatureScope() }
     /// no-op

--- a/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 
+public let SessionReplayFeaturneName = "session-replay"
+
 /// Available privacy levels for content masking in Session Replay.
 public enum SessionReplayPrivacyLevel: String {
     /// Record all content.
@@ -32,4 +34,8 @@ public enum SessionReplayPrivacyLevel: String {
 public protocol SessionReplayConfiguration {
     /// The privacy level to use for the web view replay recording.
     var privacyLevel: SessionReplayPrivacyLevel { get }
+}
+
+extension DatadogFeature where Self: SessionReplayConfiguration {
+    public static var name: String { SessionReplayFeaturneName }
 }

--- a/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Available privacy levels for content masking in Session Replay.
+public enum SessionReplayPrivacyLevel: String {
+    /// Record all content.
+    case allow
+
+    /// Mask all content.
+    case mask
+
+    /// Mask input elements, but record all other content.
+    case maskUserInput = "mask_user_input"
+}
+
+/// The Session Replay shared configuration.
+///
+/// The Feature object  named `session-replay` will be registered to the core
+/// when enabling Session Replay. If available, the configuration can be retreived
+/// with:
+///
+///     let sessionReplay = core.feature(
+///         named: "session-replay",
+///         type: SessionReplayConfiguration.self
+///     )
+///
+public protocol SessionReplayConfiguration {
+    /// The privacy level to use for the web view replay recording.
+    var privacyLevel: SessionReplayPrivacyLevel { get }
+}

--- a/DatadogObjc/Sources/SessionReplay/SessionReplay+objc.swift
+++ b/DatadogObjc/Sources/SessionReplay/SessionReplay+objc.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 #if os(iOS)
+
+import DatadogInternal
 import DatadogSessionReplay
 
 /// An entry point to Datadog Session Replay feature.
@@ -89,7 +91,7 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
     /// Mask input elements, but record all other content.
     case maskUserInput
 
-    internal var _swift: SessionReplay.Configuration.PrivacyLevel {
+    internal var _swift: SessionReplayPrivacyLevel {
         switch self {
         case .allow: return .allow
         case .mask: return .mask
@@ -98,7 +100,7 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
         }
     }
 
-    internal init(_ swift: SessionReplay.Configuration.PrivacyLevel) {
+    internal init(_ swift: SessionReplayPrivacyLevel) {
         switch swift {
         case .allow: self = .allow
         case .mask: self = .mask

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -7,11 +7,12 @@
 import XCTest
 import SRFixtures
 import TestUtilities
+import DatadogInternal
 @_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import SRHost
 
-private var defaultPrivacyLevel: SessionReplay.Configuration.PrivacyLevel {
+private var defaultPrivacyLevel: SessionReplayPrivacyLevel {
     return SessionReplay.Configuration(replaySampleRate: 100).defaultPrivacyLevel
 }
 
@@ -36,7 +37,7 @@ internal class SnapshotTestCase: XCTestCase {
     }
 
     /// Captures side-by-side snapshot of the app UI and recorded wireframes.
-    func takeSnapshot(with privacyLevel: SessionReplay.Configuration.PrivacyLevel = defaultPrivacyLevel) throws -> UIImage {
+    func takeSnapshot(with privacyLevel: SessionReplayPrivacyLevel = defaultPrivacyLevel) throws -> UIImage {
         let expectWireframes = self.expectation(description: "Wait for wireframes")
         let expectResources = self.expectation(description: "Wait for resources")
 
@@ -115,8 +116,8 @@ internal class SnapshotTestCase: XCTestCase {
     }
 
     func forPrivacyModes(
-        _ modes: [SessionReplay.Configuration.PrivacyLevel] = [.mask, .allow, .maskUserInput],
-        do work: (SessionReplay.Configuration.PrivacyLevel) throws -> Void) rethrows {
+        _ modes: [SessionReplayPrivacyLevel] = [.mask, .allow, .maskUserInput],
+        do work: (SessionReplayPrivacyLevel) throws -> Void) rethrows {
         try modes.forEach { try work($0) }
     }
 }

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -9,8 +9,6 @@ import Foundation
 import DatadogInternal
 
 internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFeature {
-    static let name: String = "session-replay"
-
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -8,12 +8,13 @@
 import Foundation
 import DatadogInternal
 
-internal class SessionReplayFeature: DatadogRemoteFeature {
+internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFeature {
     static let name: String = "session-replay"
 
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?
+    let privacyLevel: SessionReplayPrivacyLevel
 
     // MARK: - Main Components
 
@@ -46,6 +47,7 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         let scheduler = MainThreadScheduler(interval: 0.1)
         let contextReceiver = RUMContextReceiver()
 
+        self.privacyLevel = configuration.defaultPrivacyLevel
         self.messageReceiver = CombinedFeatureMessageReceiver([
             contextReceiver,
             WebViewRecordReceiver(

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -5,14 +5,13 @@
  */
 
 #if os(iOS)
-@_spi(Internal)
-public typealias SessionReplayPrivacyLevel = SessionReplay.Configuration.PrivacyLevel
+import DatadogInternal
 
 internal typealias PrivacyLevel = SessionReplayPrivacyLevel
 
 /// Text obfuscation strategies for different text types.
 @_spi(Internal)
-public extension SessionReplay.Configuration.PrivacyLevel {
+public extension PrivacyLevel {
     /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Sensitive Text" is:
@@ -59,7 +58,7 @@ public extension SessionReplay.Configuration.PrivacyLevel {
 }
 
 /// Other convenience helpers.
-internal extension SessionReplay.Configuration.PrivacyLevel {
+internal extension SessionReplayPrivacyLevel {
     /// If input elements should be masked in this privacy mode.
     var shouldMaskInputElements: Bool {
         switch self {

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -5,6 +5,8 @@
  */
 
 import Foundation
+import DatadogInternal
+
 #if os(iOS)
 
 /// An entry point to Datadog Session Replay feature.
@@ -87,7 +89,7 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
     /// Mask input elements, but record all other content.
     case maskUserInput
 
-    internal var _swift: SessionReplay.Configuration.PrivacyLevel {
+    internal var _swift: SessionReplayPrivacyLevel {
         switch self {
         case .allow: return .allow
         case .mask: return .mask
@@ -96,7 +98,7 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
         }
     }
 
-    internal init(_ swift: SessionReplay.Configuration.PrivacyLevel) {
+    internal init(_ swift: SessionReplayPrivacyLevel) {
         switch swift {
         case .allow: self = .allow
         case .mask: self = .mask

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -24,19 +24,7 @@ extension SessionReplay {
         /// Defines the way sensitive content (e.g. text) should be masked.
         ///
         /// Default: `.mask`.
-        public var defaultPrivacyLevel: PrivacyLevel
-
-        /// Available privacy levels for content masking.
-        public enum PrivacyLevel: String {
-            /// Record all content.
-            case allow
-
-            /// Mask all content.
-            case mask
-
-            /// Mask input elements, but record all other content.
-            case maskUserInput = "mask_user_input"
-        }
+        public var defaultPrivacyLevel: SessionReplayPrivacyLevel
 
         /// Custom server url for sending replay data.
         ///
@@ -56,7 +44,7 @@ extension SessionReplay {
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         public init(
             replaySampleRate: Float,
-            defaultPrivacyLevel: PrivacyLevel = .mask,
+            defaultPrivacyLevel: SessionReplayPrivacyLevel = .mask,
             customEndpoint: URL? = nil
         ) {
             self.replaySampleRate = replaySampleRate

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -14,16 +14,6 @@ import WebKit
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
-extension PrivacyLevel: AnyMockable, RandomMockable {
-    public static func mockAny() -> PrivacyLevel {
-        return .allow
-    }
-
-    public static func mockRandom() -> PrivacyLevel {
-        return [.allow, .mask, .maskUserInput].randomElement()!
-    }
-}
-
 // MARK: - ViewTreeSnapshot Mocks
 
 extension ViewTreeSnapshot: AnyMockable, RandomMockable {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -14,7 +14,13 @@ class UINavigationBarRecorderTests: XCTestCase {
 
     func testWhenViewIsOfExpectedType() throws {
         // Given
-        let navigationBar = UINavigationBar.mock(withFixture: .allCases.randomElement()!)
+        let fixtures: [ViewAttributes.Fixture] = [
+            .visible(.noAppearance),
+            .visible(.someAppearance),
+            .opaque
+        ]
+
+        let navigationBar = UINavigationBar.mock(withFixture: fixtures.randomElement()!)
         let viewAttributes = ViewAttributes(frameInRootView: navigationBar.frame, view: navigationBar)
 
         // When

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -18,64 +18,6 @@ import WebKit
 public final class objc_WebViewTracking: NSObject {
     override private init() { }
 
-    /// The Session Replay configuration to capture records coming from the web view.
-    ///
-    /// Setting the Session Replay configuration in `WebViewTracking` will enable transmitting replay data from
-    /// the Datadog Browser SDK installed in the web page. Datadog will then be able to combine the native
-    /// and web recordings in a single replay.
-    @objc(DDWebViewTrackingSessionReplayConfiguration)
-    @_spi(objc)
-    public final class SessionReplayConfiguration: NSObject {
-        /// Available privacy levels for content masking.
-        @objc(DDPrivacyLevel)
-        @_spi(objc)
-        public enum PrivacyLevel: Int {
-            /// Record all content.
-            case allow
-            /// Mask all content.
-            case mask
-            /// Mask input elements, but record all other content.
-            case maskUserInput
-
-            internal var toSwift: SessionReplayPrivacyLevel {
-                switch self {
-                case .allow: return .allow
-                case .mask: return .mask
-                case .maskUserInput: return .maskUserInput
-                }
-            }
-        }
-
-        /// The privacy level to use for the web view replay recording.
-        @objc public var privacyLevel: PrivacyLevel
-
-        /// Creates Webview Session Replay configuration.
-        ///
-        /// - Parameters:
-        ///   - privacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
-        @objc
-        override public init() {
-            self.privacyLevel = .mask
-        }
-
-        /// Creates Webview Session Replay configuration.
-        ///
-        /// - Parameters:
-        ///   - privacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
-        @objc
-        public init(
-            privacyLevel: PrivacyLevel
-        ) {
-            self.privacyLevel = privacyLevel
-        }
-
-        internal var toSwift: WebViewTracking.SessionReplayConfiguration {
-            return .init(
-                privacyLevel: privacyLevel.toSwift
-            )
-        }
-    }
-
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session.
     ///
     /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified
@@ -86,20 +28,17 @@ public final class objc_WebViewTracking: NSObject {
     ///   - hosts: A set of hosts instrumented with Browser SDK to capture Datadog events from.
     ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
     ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
-    ///   - sessionReplayConfiguration: Session Replay configuration to enable linking Web and Native replays.
     ///   - core: Datadog SDK core to use for tracking.
     @objc
     public static func enable(
         webView: WKWebView,
         hosts: Set<String> = [],
-        logsSampleRate: Float = 100,
-        with configuration: SessionReplayConfiguration? = nil
+        logsSampleRate: Float = 100
     ) {
         WebViewTracking.enable(
             webView: webView,
             hosts: hosts,
-            logsSampleRate: logsSampleRate,
-            sessionReplayConfiguration: configuration?.toSwift
+            logsSampleRate: logsSampleRate
         )
     }
 

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -5,6 +5,8 @@
  */
 
 import Foundation
+import DatadogInternal
+
 #if os(tvOS)
 #warning("Datadog WebView Tracking does not support tvOS")
 #else
@@ -35,7 +37,7 @@ public final class objc_WebViewTracking: NSObject {
             /// Mask input elements, but record all other content.
             case maskUserInput
 
-            internal var toSwift: WebViewTracking.SessionReplayConfiguration.PrivacyLevel {
+            internal var toSwift: SessionReplayPrivacyLevel {
                 switch self {
                 case .allow: return .allow
                 case .mask: return .mask

--- a/DatadogWebViewTracking/Tests/Mocks.swift
+++ b/DatadogWebViewTracking/Tests/Mocks.swift
@@ -43,14 +43,4 @@ final class MockScriptMessage: WKScriptMessage {
     override weak var webView: WKWebView? { _webView }
 }
 
-extension WebViewTracking.SessionReplayConfiguration.PrivacyLevel: AnyMockable, RandomMockable {
-    public static func mockAny() -> Self {
-        .allow
-    }
-
-    public static func mockRandom() -> Self {
-        [.allow, .mask, .maskUserInput].randomElement()!
-    }
-}
-
 #endif

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -24,7 +24,6 @@ class WebViewTrackingTests: XCTestCase {
             hosts: [host],
             hostsSanitizer: mockSanitizer,
             logsSampleRate: 30,
-            sessionReplayConfiguration: nil,
             in: PassthroughCoreMock()
         )
 
@@ -49,11 +48,17 @@ class WebViewTrackingTests: XCTestCase {
     }
 
     func testItAddsUserScriptWithSessionReplay() throws {
+        struct SessionReplayFeature: DatadogFeature, SessionReplayConfiguration {
+            static let name = "session-replay"
+            let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+            let privacyLevel: SessionReplayPrivacyLevel
+        }
+
         let mockSanitizer = HostsSanitizerMock()
         let controller = DDUserContentController()
 
         let host: String = .mockRandom()
-        let sessionReplayConfiguration = WebViewTracking.SessionReplayConfiguration(
+        let sr = SessionReplayFeature(
             privacyLevel: .mockRandom()
         )
 
@@ -62,8 +67,7 @@ class WebViewTrackingTests: XCTestCase {
             hosts: [host],
             hostsSanitizer: mockSanitizer,
             logsSampleRate: 30,
-            sessionReplayConfiguration: sessionReplayConfiguration,
-            in: PassthroughCoreMock()
+            in: SingleFeatureCoreMock(feature: sr)
         )
 
         let script = try XCTUnwrap(controller.userScripts.last)
@@ -80,7 +84,7 @@ class WebViewTrackingTests: XCTestCase {
                 return '["records"]'
             },
             getPrivacyLevel() {
-                return '\(sessionReplayConfiguration.privacyLevel.rawValue)'
+                return '\(sr.privacyLevel.rawValue)'
             }
         }
         """)
@@ -97,7 +101,6 @@ class WebViewTrackingTests: XCTestCase {
             hosts: ["datadoghq.com"],
             hostsSanitizer: mockSanitizer,
             logsSampleRate: 30,
-            sessionReplayConfiguration: nil,
             in: PassthroughCoreMock()
         )
 
@@ -129,7 +132,6 @@ class WebViewTrackingTests: XCTestCase {
                 hosts: ["datadoghq.com"],
                 hostsSanitizer: mockSanitizer,
                 logsSampleRate: 100,
-                sessionReplayConfiguration: nil,
                 in: PassthroughCoreMock()
             )
         }
@@ -208,7 +210,6 @@ class WebViewTrackingTests: XCTestCase {
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),
             logsSampleRate: 100,
-            sessionReplayConfiguration: nil,
             in: core
         )
 
@@ -261,7 +262,6 @@ class WebViewTrackingTests: XCTestCase {
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),
             logsSampleRate: 100,
-            sessionReplayConfiguration: nil,
             in: core
         )
 
@@ -354,7 +354,6 @@ class WebViewTrackingTests: XCTestCase {
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),
             logsSampleRate: 100,
-            sessionReplayConfiguration: nil,
             in: core
         )
 

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -826,6 +826,7 @@
 				61441C0024616DE9003D8BB8 /* Resources */,
 				D240687A27CF982B00C04F44 /* Embed Frameworks */,
 				5DAD8F2510CB09A5BA7723B9 /* [CP] Copy Pods Resources */,
+				5FC520EDF6AC52CE770441C8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -848,6 +849,7 @@
 				61441C2724616F1D003D8BB8 /* Frameworks */,
 				61441C2824616F1D003D8BB8 /* Resources */,
 				7F6DA13A8C70117DE98BAFD7 /* [CP] Copy Pods Resources */,
+				FF0828D858AD2E214162EA0C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -978,6 +980,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		5FC520EDF6AC52CE770441C8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		7F6DA13A8C70117DE98BAFD7 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1015,6 +1034,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FF0828D858AD2E214162EA0C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/TestUtilities/Mocks/CoreMocks/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/FeatureRegistrationCoreMock.swift
@@ -40,7 +40,7 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         registeredFeatures.append(feature)
     }
 
-    public func get<T>(feature type: T.Type) -> T? where T : DatadogFeature {
+    public func feature<T>(named name: String, type: T.Type) -> T? {
         return registeredFeatures.firstElement(of: type)
     }
 

--- a/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/PassthroughCoreMock.swift
@@ -85,7 +85,7 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
     /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
-    public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
+    public func feature<T>(named name: String, type: T.Type) -> T? { nil }
 
     /// Always returns a feature-scope.
     public func scope<T>(for featureType: T.Type) -> FeatureScope where T : DatadogFeature {

--- a/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
+++ b/TestUtilities/Mocks/CoreMocks/SingleFeatureCoreMock.swift
@@ -89,7 +89,7 @@ public final class SingleFeatureCoreMock<Feature>: PassthroughCoreMock where Fea
         self.feature = feature as? Feature
     }
 
-    public override func get<T>(feature type: T.Type) -> T? where T: DatadogFeature {
+    public override func feature<T>(named name: String, type: T.Type) -> T? {
         feature as? T
     }
 

--- a/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension SessionReplayPrivacyLevel: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        .allow
+    }
+
+    public static func mockRandom() -> Self {
+        [.allow, .mask, .maskUserInput].randomElement()!
+    }
+}


### PR DESCRIPTION
### What and why?

Use the Session Replay masking when enabling WebView Tracking.

### How?

Allow retrieving any type from the core's feature registry and share the `SessionReplayConfiguration` protocol definition so it can be read from WebView tracking.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [x] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
