### PR TITLE
fix: SR Test Flakiness

### DIFF
--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -14,7 +14,13 @@ class UINavigationBarRecorderTests: XCTestCase {
 
     func testWhenViewIsOfExpectedType() throws {
         // Given
-        let navigationBar = UINavigationBar.mock(withFixture: .allCases.randomElement()!)
+        let fixtures: [ViewAttributes.Fixture] = [
+            .visible(.noAppearance),
+            .visible(.someAppearance),
+            .opaque
+        ]
+
+        let navigationBar = UINavigationBar.mock(withFixture: fixtures.randomElement()!)
         let viewAttributes = ViewAttributes(frameInRootView: navigationBar.frame, view: navigationBar)
 
         // When


### PR DESCRIPTION
### What and why?

The `testWhenViewIsOfExpectedType` uses a fuzzy fixture, following #1864 we now ignore invisible navigation bar so we need to remove  the `.invisible` attribute from fixture as well.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
