### PR TITLE
Add `connect`, `trace`, `options` values to DDRumMethod type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Add `.connect`, `.trace`, `.options` values to `DDRUMMethod` type. See [#1886][]
+
 # 2.12.0 / 03-06-2024
 
 - [IMPROVEMENT] Crash errors now include up-to-date global RUM attributes. See [#1834][]
@@ -675,6 +677,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1854]: https://github.com/DataDog/dd-sdk-ios/pull/1854
 [#1828]: https://github.com/DataDog/dd-sdk-ios/pull/1828
 [#1835]: https://github.com/DataDog/dd-sdk-ios/pull/1835
+[#1886]: https://github.com/DataDog/dd-sdk-ios/pull/1886
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
@@ -129,6 +129,9 @@ class DDRUMMethodTests: XCTestCase {
         XCTAssertEqual(DDRUMMethod.put.swiftType, .put)
         XCTAssertEqual(DDRUMMethod.delete.swiftType, .delete)
         XCTAssertEqual(DDRUMMethod.patch.swiftType, .patch)
+        XCTAssertEqual(DDRUMMethod.connect.swiftType, .connect)
+        XCTAssertEqual(DDRUMMethod.trace.swiftType, .trace)
+        XCTAssertEqual(DDRUMMethod.options.swiftType, .options)
     }
 }
 

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -45,7 +45,8 @@
 }
 
 - (void)testDDRUMMethodAPI {
-    DDRUMMethodPost; DDRUMMethodGet; DDRUMMethodHead; DDRUMMethodPut; DDRUMMethodDelete; DDRUMMethodPatch;
+    DDRUMMethodPost; DDRUMMethodGet; DDRUMMethodHead; DDRUMMethodPut; DDRUMMethodDelete; DDRUMMethodPatch; DDRUMMethodConnect;
+    DDRUMMethodTrace; DDRUMMethodOptions;
 }
 
 - (void)testDDRUMMonitorAPI {

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -228,6 +228,9 @@ public enum DDRUMMethod: Int {
     case put
     case delete
     case patch
+    case connect
+    case trace
+    case options
 
     internal var swiftType: RUMMethod {
         switch self {
@@ -237,6 +240,9 @@ public enum DDRUMMethod: Int {
         case .put: return .put
         case .delete: return .delete
         case .patch: return .patch
+        case .connect: return .connect
+        case .trace: return .trace
+        case .options: return .options
         default: return .get
         }
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -206,6 +206,9 @@ public enum DDRUMMethod: Int
     case put
     case delete
     case patch
+    case connect
+    case trace
+    case options
 public enum DDRUMVitalsFrequency: Int
     case frequent
     case average


### PR DESCRIPTION
### What and why?

These values exist on the RUM data model side, but were not exposed in ObjC API.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
