### PR TITLE
RUM-3463 feat(watchdog-termination): track app state and detect watchdog terminations

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		1434A4642B7F73170072E3BB /* OpenTelemetryApi.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1434A4662B7F8D880072E3BB /* DebugOTelTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */; };
 		1434A4672B7F8D880072E3BB /* DebugOTelTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */; };
+		3C0CB3452C19A1ED003B0E9B /* WatchdogTerminationReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */; };
+		3C0CB3462C19A1ED003B0E9B /* WatchdogTerminationReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */; };
 		3C0D5DD72A543B3B00446CF9 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0D5DD62A543B3B00446CF9 /* Event.swift */; };
 		3C0D5DD82A543B3B00446CF9 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0D5DD62A543B3B00446CF9 /* Event.swift */; };
 		3C0D5DE22A543DC400446CF9 /* EventGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0D5DDF2A543DAE00446CF9 /* EventGeneratorTests.swift */; };
@@ -38,7 +40,11 @@
 		3C3235A02B55387A000B4258 /* OTelSpanLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C32359F2B55387A000B4258 /* OTelSpanLinkTests.swift */; };
 		3C3235A12B55387A000B4258 /* OTelSpanLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C32359F2B55387A000B4258 /* OTelSpanLinkTests.swift */; };
 		3C33E4072BEE35A8003B2988 /* RUMContextMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C33E4062BEE35A7003B2988 /* RUMContextMocks.swift */; };
+		3C3EF2B02C1AEBAB009E9E57 /* LaunchReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */; };
+		3C3EF2B12C1AEBAB009E9E57 /* LaunchReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */; };
 		3C41693C29FBF4D50042B9D2 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
+		3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */; };
+		3C43A3892C188975000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */; };
 		3C5D63692B55512B00FEB4BA /* OTelTraceState+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */; };
 		3C5D636A2B55512B00FEB4BA /* OTelTraceState+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */; };
 		3C5D636C2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5D636B2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift */; };
@@ -95,8 +101,24 @@
 		3CDA3F802BCD8687005D2C13 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3CDA3F7F2BCD8687005D2C13 /* DatadogSDKTesting */; };
 		3CE11A1129F7BE0900202522 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3CE11A1229F7BE0900202522 /* DatadogWebViewTracking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CEC57732C16FD0B0042B5F2 /* WatchdogTerminationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEC57702C16FD000042B5F2 /* WatchdogTerminationMocks.swift */; };
+		3CEC57742C16FD0C0042B5F2 /* WatchdogTerminationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEC57702C16FD000042B5F2 /* WatchdogTerminationMocks.swift */; };
+		3CEC57772C16FDD70042B5F2 /* WatchdogTerminationAppStateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEC57752C16FDD30042B5F2 /* WatchdogTerminationAppStateManagerTests.swift */; };
+		3CEC57782C16FDD80042B5F2 /* WatchdogTerminationAppStateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEC57752C16FDD30042B5F2 /* WatchdogTerminationAppStateManagerTests.swift */; };
 		3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
 		3CF673372B4807490016CE17 /* OTelSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF673352B4807490016CE17 /* OTelSpanTests.swift */; };
+		3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F8A2C09E61A006F191D /* WatchdogTerminationAppState.swift */; };
+		3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F8A2C09E61A006F191D /* WatchdogTerminationAppState.swift */; };
+		3CFF4F912C09E630006F191D /* WatchdogTerminationAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F902C09E630006F191D /* WatchdogTerminationAppStateManager.swift */; };
+		3CFF4F922C09E630006F191D /* WatchdogTerminationAppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F902C09E630006F191D /* WatchdogTerminationAppStateManager.swift */; };
+		3CFF4F942C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F932C09E63C006F191D /* WatchdogTerminationChecker.swift */; };
+		3CFF4F952C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F932C09E63C006F191D /* WatchdogTerminationChecker.swift */; };
+		3CFF4F972C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F962C09E64C006F191D /* WatchdogTerminationMonitor.swift */; };
+		3CFF4F982C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F962C09E64C006F191D /* WatchdogTerminationMonitor.swift */; };
+		3CFF4F9A2C0DBE4C006F191D /* LaunchReportReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F992C0DBE4C006F191D /* LaunchReportReceiver.swift */; };
+		3CFF4F9B2C0DBE4C006F191D /* LaunchReportReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4F992C0DBE4C006F191D /* LaunchReportReceiver.swift */; };
+		3CFF4FA42C0E0FE8006F191D /* WatchdogTerminationCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */; };
+		3CFF4FA52C0E0FE9006F191D /* WatchdogTerminationCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */; };
 		3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */; };
 		3CFF5D4A2B555F4F00FC483A /* OTelTracerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
@@ -2063,6 +2085,7 @@
 
 /* Begin PBXFileReference section */
 		1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOTelTracingViewController.swift; sourceTree = "<group>"; };
+		3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporter.swift; sourceTree = "<group>"; };
 		3C0D5DD62A543B3B00446CF9 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		3C0D5DDC2A543D5D00446CF9 /* EventGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventGenerator.swift; sourceTree = "<group>"; };
 		3C0D5DDF2A543DAE00446CF9 /* EventGeneratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventGeneratorTests.swift; sourceTree = "<group>"; };
@@ -2075,6 +2098,8 @@
 		3C32359C2B55386C000B4258 /* OTelSpanLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLink.swift; sourceTree = "<group>"; };
 		3C32359F2B55387A000B4258 /* OTelSpanLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLinkTests.swift; sourceTree = "<group>"; };
 		3C33E4062BEE35A7003B2988 /* RUMContextMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMContextMocks.swift; sourceTree = "<group>"; };
+		3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReport.swift; sourceTree = "<group>"; };
+		3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMonitorTests.swift; sourceTree = "<group>"; };
 		3C5D63682B55512B00FEB4BA /* OTelTraceState+Datadog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTelTraceState+Datadog.swift"; sourceTree = "<group>"; };
 		3C5D636B2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTelTraceState+DatadogTests.swift"; sourceTree = "<group>"; };
 		3C6C7FE02B459AAA006F5CBC /* OTelSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpan.swift; sourceTree = "<group>"; };
@@ -2101,7 +2126,15 @@
 		3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanIDTests.swift; sourceTree = "<group>"; };
 		3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogWebViewTracking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogWebViewTrackingTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CEC57702C16FD000042B5F2 /* WatchdogTerminationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMocks.swift; sourceTree = "<group>"; };
+		3CEC57752C16FDD30042B5F2 /* WatchdogTerminationAppStateManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationAppStateManagerTests.swift; sourceTree = "<group>"; };
 		3CF673352B4807490016CE17 /* OTelSpanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanTests.swift; sourceTree = "<group>"; };
+		3CFF4F8A2C09E61A006F191D /* WatchdogTerminationAppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationAppState.swift; sourceTree = "<group>"; };
+		3CFF4F902C09E630006F191D /* WatchdogTerminationAppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationAppStateManager.swift; sourceTree = "<group>"; };
+		3CFF4F932C09E63C006F191D /* WatchdogTerminationChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationChecker.swift; sourceTree = "<group>"; };
+		3CFF4F962C09E64C006F191D /* WatchdogTerminationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMonitor.swift; sourceTree = "<group>"; };
+		3CFF4F992C0DBE4C006F191D /* LaunchReportReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReportReceiver.swift; sourceTree = "<group>"; };
+		3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationCheckerTests.swift; sourceTree = "<group>"; };
 		3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelTracerProvider.swift; sourceTree = "<group>"; };
 		49274903288048AA00ECD49B /* InternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalProxyTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
@@ -3360,6 +3393,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C68FCD12C05EE8E00723696 /* WatchdogTerminations */ = {
+			isa = PBXGroup;
+			children = (
+				3CFF4F8A2C09E61A006F191D /* WatchdogTerminationAppState.swift */,
+				3CFF4F902C09E630006F191D /* WatchdogTerminationAppStateManager.swift */,
+				3CFF4F932C09E63C006F191D /* WatchdogTerminationChecker.swift */,
+				3CFF4F962C09E64C006F191D /* WatchdogTerminationMonitor.swift */,
+				3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */,
+			);
+			path = WatchdogTerminations;
+			sourceTree = "<group>";
+		};
 		3C6C7FDE2B459AAA006F5CBC /* OpenTelemetry */ = {
 			isa = PBXGroup;
 			children = (
@@ -3411,6 +3456,17 @@
 			);
 			name = DatadogWebViewTrackingTests;
 			path = ../DatadogWebViewTracking/Tests;
+			sourceTree = "<group>";
+		};
+		3CFF4F9C2C0DBEEA006F191D /* WatchdogTerminations */ = {
+			isa = PBXGroup;
+			children = (
+				3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */,
+				3CEC57702C16FD000042B5F2 /* WatchdogTerminationMocks.swift */,
+				3CEC57752C16FDD30042B5F2 /* WatchdogTerminationAppStateManagerTests.swift */,
+				3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */,
+			);
+			path = WatchdogTerminations;
 			sourceTree = "<group>";
 		};
 		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
@@ -4644,6 +4700,7 @@
 				D236BE2729520FED00676E67 /* CrashReportReceiver.swift */,
 				D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */,
 				D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */,
+				3CFF4F992C0DBE4C006F191D /* LaunchReportReceiver.swift */,
 				61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */,
 			);
 			path = Integrations;
@@ -4714,6 +4771,7 @@
 				6167E6E72B8122E900C3CA2D /* BacktraceReport.swift */,
 				6167E6F52B81E94C00C3CA2D /* DDThread.swift */,
 				6167E6F82B81E95900C3CA2D /* BinaryImage.swift */,
+				3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -4757,6 +4815,7 @@
 				6157FA5C252767B3009A8A3B /* Resources */,
 				9E06058F26EF904200F5F935 /* LongTasks */,
 				6167E6D12B7F8B1300C3CA2D /* AppHangs */,
+				3C68FCD12C05EE8E00723696 /* WatchdogTerminations */,
 			);
 			path = Instrumentation;
 			sourceTree = "<group>";
@@ -5419,6 +5478,7 @@
 				6141014C251A577D00E3C2D9 /* Actions */,
 				613F23EF252B1287006CD2D7 /* Resources */,
 				6167E6D82B80047900C3CA2D /* AppHangs */,
+				3CFF4F9C2C0DBEEA006F191D /* WatchdogTerminations */,
 				61C713BB2A3C95AD00FA735A /* RUMInstrumentationTests.swift */,
 			);
 			path = Instrumentation;
@@ -8577,6 +8637,7 @@
 				D2F8235329915E12003C7E99 /* DatadogSite.swift in Sources */,
 				D2D3199A29E98D970004F169 /* DefaultJSONEncoder.swift in Sources */,
 				6128F56A2BA2237300D35B08 /* DataStore.swift in Sources */,
+				3C3EF2B02C1AEBAB009E9E57 /* LaunchReport.swift in Sources */,
 				6167E7002B81EF7500C3CA2D /* BacktraceReportingFeature.swift in Sources */,
 				D2EBEE2729BA160F00B15732 /* B3HTTPHeadersWriter.swift in Sources */,
 				D23039E2298D5236001A1FA3 /* UserInfo.swift in Sources */,
@@ -8621,6 +8682,7 @@
 				D253EE972B988CA90010B589 /* ViewCache.swift in Sources */,
 				D23F8E5A29DDCD28001CFAE8 /* RUMResourceScope.swift in Sources */,
 				D23F8E5C29DDCD28001CFAE8 /* RUMApplicationScope.swift in Sources */,
+				3CFF4F982C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */,
 				D23F8E5D29DDCD28001CFAE8 /* SwiftUIViewModifier.swift in Sources */,
 				D23F8E5E29DDCD28001CFAE8 /* VitalInfo.swift in Sources */,
 				D23F8E5F29DDCD28001CFAE8 /* UIApplicationSwizzler.swift in Sources */,
@@ -8630,6 +8692,7 @@
 				D23F8E6329DDCD28001CFAE8 /* RUMDataModels.swift in Sources */,
 				61C713AB2A3B790B00FA735A /* Monitor.swift in Sources */,
 				D23F8E6429DDCD28001CFAE8 /* SwiftUIViewHandler.swift in Sources */,
+				3CFF4F922C09E630006F191D /* WatchdogTerminationAppStateManager.swift in Sources */,
 				D23F8E6529DDCD28001CFAE8 /* RUMFeature.swift in Sources */,
 				D23F8E6629DDCD28001CFAE8 /* RUMDebugging.swift in Sources */,
 				D23F8E6729DDCD28001CFAE8 /* RUMUUID.swift in Sources */,
@@ -8643,6 +8706,7 @@
 				49D8C0B82AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D23F8E6E29DDCD28001CFAE8 /* RUMViewsHandler.swift in Sources */,
 				61C713BA2A3C935C00FA735A /* RUM.swift in Sources */,
+				3C0CB3462C19A1ED003B0E9B /* WatchdogTerminationReporter.swift in Sources */,
 				D23F8E6F29DDCD28001CFAE8 /* RequestBuilder.swift in Sources */,
 				D224430529E9588500274EC7 /* TelemetryReceiver.swift in Sources */,
 				D23F8E7029DDCD28001CFAE8 /* URLSessionRUMResourcesHandler.swift in Sources */,
@@ -8675,6 +8739,7 @@
 				D23F8E8329DDCD28001CFAE8 /* RUMUser.swift in Sources */,
 				D23F8E8429DDCD28001CFAE8 /* UIKitRUMUserActionsPredicate.swift in Sources */,
 				D23F8E8529DDCD28001CFAE8 /* SwiftUIExtensions.swift in Sources */,
+				3CFF4F952C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */,
 				D23F8E8629DDCD28001CFAE8 /* RUMDataModelsMapping.swift in Sources */,
 				D23F8E8729DDCD28001CFAE8 /* RUMInstrumentation.swift in Sources */,
 				D23F8E8829DDCD28001CFAE8 /* VitalCPUReader.swift in Sources */,
@@ -8684,8 +8749,10 @@
 				D23F8E8C29DDCD28001CFAE8 /* RUMBaggageKeys.swift in Sources */,
 				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
+				3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
+				3CFF4F9B2C0DBE4C006F191D /* LaunchReportReceiver.swift in Sources */,
 				61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8706,16 +8773,19 @@
 				D23F8EA629DDCD38001CFAE8 /* RUMDeviceInfoTests.swift in Sources */,
 				D23F8EA829DDCD38001CFAE8 /* RUMResourceScopeTests.swift in Sources */,
 				D23F8EA929DDCD38001CFAE8 /* RUMOperatingSystemInfoTests.swift in Sources */,
+				3CFF4FA52C0E0FE9006F191D /* WatchdogTerminationCheckerTests.swift in Sources */,
 				D23F8EAB29DDCD38001CFAE8 /* RUMDataModelMocks.swift in Sources */,
 				D23F8EAC29DDCD38001CFAE8 /* RUMDataModelsMappingTests.swift in Sources */,
 				D23F8EAD29DDCD38001CFAE8 /* RUMEventBuilderTests.swift in Sources */,
 				61CE2E602BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */,
+				3CEC57782C16FDD80042B5F2 /* WatchdogTerminationAppStateManagerTests.swift in Sources */,
 				D23F8EAE29DDCD38001CFAE8 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D23F8EAF29DDCD38001CFAE8 /* RUMScopeTests.swift in Sources */,
 				D23F8EB029DDCD38001CFAE8 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B72A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,
 				D23F8EB129DDCD38001CFAE8 /* RUMViewScopeTests.swift in Sources */,
 				D224431029E977A100274EC7 /* TelemetryReceiverTests.swift in Sources */,
+				3C43A3892C188975000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */,
 				D23F8EB229DDCD38001CFAE8 /* ValuePublisherTests.swift in Sources */,
 				6174D61B2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
@@ -8732,6 +8802,7 @@
 				D23F8EBE29DDCD38001CFAE8 /* WebViewEventReceiverTests.swift in Sources */,
 				D23F8EBF29DDCD38001CFAE8 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				D23F8EC029DDCD38001CFAE8 /* RUMEventSanitizerTests.swift in Sources */,
+				3CEC57742C16FD0C0042B5F2 /* WatchdogTerminationMocks.swift in Sources */,
 				D253EE9C2B98B37C0010B589 /* ViewCacheTests.swift in Sources */,
 				6176C1732ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D23F8EC129DDCD38001CFAE8 /* RUMEventsMapperTests.swift in Sources */,
@@ -8941,6 +9012,7 @@
 				D253EE962B988CA90010B589 /* ViewCache.swift in Sources */,
 				D29A9F8429DD85BB005C54A4 /* RUMResourceScope.swift in Sources */,
 				D29A9F7329DD85BB005C54A4 /* RUMApplicationScope.swift in Sources */,
+				3CFF4F972C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */,
 				D29A9F6A29DD85BB005C54A4 /* SwiftUIViewModifier.swift in Sources */,
 				D29A9F6429DD85BB005C54A4 /* VitalInfo.swift in Sources */,
 				D29A9F6D29DD85BB005C54A4 /* UIApplicationSwizzler.swift in Sources */,
@@ -8950,6 +9022,7 @@
 				D29A9F7B29DD85BB005C54A4 /* RUMDataModels.swift in Sources */,
 				61C713AA2A3B790B00FA735A /* Monitor.swift in Sources */,
 				D29A9F8529DD85BB005C54A4 /* SwiftUIViewHandler.swift in Sources */,
+				3CFF4F912C09E630006F191D /* WatchdogTerminationAppStateManager.swift in Sources */,
 				D29A9F7429DD85BB005C54A4 /* RUMFeature.swift in Sources */,
 				D29A9F7729DD85BB005C54A4 /* RUMDebugging.swift in Sources */,
 				D29A9F6E29DD85BB005C54A4 /* RUMUUID.swift in Sources */,
@@ -8963,6 +9036,7 @@
 				49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D29A9F7629DD85BB005C54A4 /* RUMViewsHandler.swift in Sources */,
 				61C713B92A3C935C00FA735A /* RUM.swift in Sources */,
+				3C0CB3452C19A1ED003B0E9B /* WatchdogTerminationReporter.swift in Sources */,
 				D29A9F7929DD85BB005C54A4 /* RequestBuilder.swift in Sources */,
 				D224430429E9588100274EC7 /* TelemetryReceiver.swift in Sources */,
 				D29A9F5729DD85BB005C54A4 /* URLSessionRUMResourcesHandler.swift in Sources */,
@@ -8995,6 +9069,7 @@
 				D29A9F6629DD85BB005C54A4 /* RUMUser.swift in Sources */,
 				D29A9F8229DD85BB005C54A4 /* UIKitRUMUserActionsPredicate.swift in Sources */,
 				D29A9F8E29DD8665005C54A4 /* SwiftUIExtensions.swift in Sources */,
+				3CFF4F942C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */,
 				D29A9F7829DD85BB005C54A4 /* RUMDataModelsMapping.swift in Sources */,
 				D29A9F6F29DD85BB005C54A4 /* RUMInstrumentation.swift in Sources */,
 				D29A9F7A29DD85BB005C54A4 /* VitalCPUReader.swift in Sources */,
@@ -9004,8 +9079,10 @@
 				D29A9F8329DD85BB005C54A4 /* RUMBaggageKeys.swift in Sources */,
 				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
+				3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
+				3CFF4F9A2C0DBE4C006F191D /* LaunchReportReceiver.swift in Sources */,
 				61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9026,16 +9103,19 @@
 				D29A9FA329DDB483005C54A4 /* RUMDeviceInfoTests.swift in Sources */,
 				D29A9FBC29DDB483005C54A4 /* RUMResourceScopeTests.swift in Sources */,
 				D29A9FB029DDB483005C54A4 /* RUMOperatingSystemInfoTests.swift in Sources */,
+				3CFF4FA42C0E0FE8006F191D /* WatchdogTerminationCheckerTests.swift in Sources */,
 				D29A9FC629DDBA8A005C54A4 /* RUMDataModelMocks.swift in Sources */,
 				D29A9FD529DDC624005C54A4 /* RUMDataModelsMappingTests.swift in Sources */,
 				D29A9FBE29DDB483005C54A4 /* RUMEventBuilderTests.swift in Sources */,
 				61CE2E5F2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */,
+				3CEC57772C16FDD70042B5F2 /* WatchdogTerminationAppStateManagerTests.swift in Sources */,
 				D29A9FCC29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B62A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,
 				D29A9FB829DDB483005C54A4 /* RUMViewScopeTests.swift in Sources */,
 				D224430F29E9779F00274EC7 /* TelemetryReceiverTests.swift in Sources */,
+				3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */,
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
 				6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
@@ -9052,6 +9132,7 @@
 				D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */,
 				D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				D29A9FA229DDB483005C54A4 /* RUMEventSanitizerTests.swift in Sources */,
+				3CEC57732C16FD0B0042B5F2 /* WatchdogTerminationMocks.swift in Sources */,
 				D253EE9B2B98B37B0010B589 /* ViewCacheTests.swift in Sources */,
 				6176C1722ABDBA2E00131A70 /* MonitorTests.swift in Sources */,
 				D29A9FB929DDB483005C54A4 /* RUMEventsMapperTests.swift in Sources */,
@@ -9525,6 +9606,7 @@
 				D2F8235429915E12003C7E99 /* DatadogSite.swift in Sources */,
 				D2D3199B29E98D970004F169 /* DefaultJSONEncoder.swift in Sources */,
 				6128F56B2BA2237300D35B08 /* DataStore.swift in Sources */,
+				3C3EF2B12C1AEBAB009E9E57 /* LaunchReport.swift in Sources */,
 				6167E7012B81EF7500C3CA2D /* BacktraceReportingFeature.swift in Sources */,
 				D2EBEE3529BA161100B15732 /* B3HTTPHeadersWriter.swift in Sources */,
 				D2DA2376298D57AA00C6C7E6 /* UserInfo.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -93,6 +93,8 @@ class CrashReportSenderMock: CrashReportSender {
     }
 
     var didSendCrashReport: (() -> Void)?
+
+    func send(launch: DatadogInternal.LaunchReport) {}
 }
 
 class RUMCrashReceiverMock: FeatureMessageReceiver {

--- a/DatadogCrashReporting/Sources/CrashReportingFeature.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingFeature.swift
@@ -59,6 +59,8 @@ internal final class CrashReportingFeature: DatadogFeature {
             self.plugin.readPendingCrashReport { [weak self] crashReport in
                 guard let self = self, let availableCrashReport = crashReport else {
                     DD.logger.debug("No pending Crash found")
+                    // TODO: RUM-4911 enable after `WatchdogTerminationReporter` is implemented.
+                    // self?.sender.send(launch: .init(didCrash: false))
                     return false
                 }
 
@@ -71,6 +73,8 @@ internal final class CrashReportingFeature: DatadogFeature {
                 }
 
                 self.sender.send(report: availableCrashReport, with: crashContext)
+                // TODO: RUM-4911 enable after `WatchdogTerminationReporter` is implemented.
+                // self.sender.send(launch: .init(didCrash: true))
                 return true
             }
         }

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -14,6 +14,12 @@ internal protocol CrashReportSender {
     ///   - report: The crash report.
     ///   - context: The crash context
     func send(report: DDCrashReport, with context: CrashContext)
+
+    /// Send the launch report and context to integrations.
+    ///
+    /// - Parameters:
+    ///   - launch: The launch report.
+    func send(launch: LaunchReport)
 }
 
 /// An object for sending crash reports on the Core message-bus.
@@ -55,6 +61,34 @@ internal struct MessageBusSender: CrashReportSender {
             message: .baggage(
                 key: MessageKeys.crash,
                 value: Crash(report: report, context: context)
+            ),
+            else: {
+                DD.logger.warn(
+                    """
+                    In order to use Crash Reporting, RUM or Logging feature must be enabled.
+                    Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
+                    """
+                )
+            }
+        )
+    }
+
+    /// Send the launch report and context to integrations.
+    ///
+    /// - Parameters:
+    ///   - launch: The launch report.
+    func send(launch: DatadogInternal.LaunchReport) {
+        guard let core = core else {
+            return
+        }
+
+        // We use baggage message to pass the launch report instead updating the global context
+        // because under the hood, some integrations start certain features based on the launch report (e.g. `WatchdogTerminationMonitor`).
+        // If we update the global context, the integrations will keep starting the features on every update which is not desired.
+        core.send(
+            message: .baggage(
+                key: LaunchReport.messageKey,
+                value: launch
             ),
             else: {
                 DD.logger.warn(

--- a/DatadogInternal/Sources/Context/AppState.swift
+++ b/DatadogInternal/Sources/Context/AppState.swift
@@ -15,13 +15,15 @@ public enum AppState: Codable, PassthroughAnyCodable {
     case inactive
     /// The app is running in the background.
     case background
+    /// The app is terminated.
+    case terminated
 
     /// If the app is running in the foreground - no matter if receiving events or not (i.e. being interrupted because of transitioning from background).
     public var isRunningInForeground: Bool {
         switch self {
         case .active, .inactive:
             return true
-        case .background:
+        case .background, .terminated:
             return false
         }
     }

--- a/DatadogInternal/Sources/Context/DeviceInfo.swift
+++ b/DatadogInternal/Sources/Context/DeviceInfo.swift
@@ -31,13 +31,29 @@ public struct DeviceInfo: Codable, Equatable, PassthroughAnyCodable {
     /// The architecture of the device
     public let architecture: String
 
+    /// The device is a simulator
+    public let isSimulator: Bool
+
+    /// The vendor identifier of the device.
+    public let vendorId: String?
+
+    /// Returns `true` if the debugger is attached.
+    public let isDebugging: Bool
+
+    /// Returns system boot time since epoch.
+    public let systemBootTime: TimeInterval
+
     public init(
         name: String,
         model: String,
         osName: String,
         osVersion: String,
         osBuildNumber: String?,
-        architecture: String
+        architecture: String,
+        isSimulator: Bool,
+        vendorId: String?,
+        isDebugging: Bool,
+        systemBootTime: TimeInterval
     ) {
         self.brand = "Apple"
         self.name = name
@@ -46,6 +62,10 @@ public struct DeviceInfo: Codable, Equatable, PassthroughAnyCodable {
         self.osVersion = osVersion
         self.osBuildNumber = osBuildNumber
         self.architecture = architecture
+        self.isSimulator = isSimulator
+        self.vendorId = vendorId
+        self.isDebugging = isDebugging
+        self.systemBootTime = systemBootTime
     }
 }
 
@@ -62,17 +82,20 @@ extension DeviceInfo {
     ///   - device: The `UIDevice` description.
     public init(
         processInfo: ProcessInfo = .processInfo,
-        device: UIDevice = .current
+        device: UIDevice = .current,
+        sysctl: SysctlProviding = Sysctl()
     ) {
         var architecture = "unknown"
         if let archInfo = NXGetLocalArchInfo()?.pointee {
             architecture = String(utf8String: archInfo.name) ?? "unknown"
         }
 
-        let build = try? Sysctl.osVersion()
+        let build = try? sysctl.osBuild()
+        let isDebugging = try? sysctl.isDebugging()
+        let systemBootTime = try? sysctl.systemBootTime()
 
         #if !targetEnvironment(simulator)
-        let model = try? Sysctl.model()
+        let model = try? sysctl.model()
         // Real iOS device
         self.init(
             name: device.model,
@@ -80,7 +103,11 @@ extension DeviceInfo {
             osName: device.systemName,
             osVersion: device.systemVersion,
             osBuildNumber: build,
-            architecture: architecture
+            architecture: architecture,
+            isSimulator: false,
+            vendorId: device.identifierForVendor?.uuidString,
+            isDebugging: isDebugging ?? false,
+            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate
         )
         #else
         let model = processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] ?? device.model
@@ -91,7 +118,11 @@ extension DeviceInfo {
             osName: device.systemName,
             osVersion: device.systemVersion,
             osBuildNumber: build,
-            architecture: architecture
+            architecture: architecture,
+            isSimulator: true,
+            vendorId: device.identifierForVendor?.uuidString,
+            isDebugging: isDebugging ?? false,
+            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate
         )
         #endif
     }

--- a/DatadogInternal/Sources/Context/Sysctl.swift
+++ b/DatadogInternal/Sources/Context/Sysctl.swift
@@ -118,7 +118,7 @@ public struct Sysctl: SysctlProviding {
         var info = kinfo_proc()
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
         var size = MemoryLayout<kinfo_proc>.stride
-        let junk = sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0)
+        _ = sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0)
         return (info.kp_proc.p_flag & P_TRACED) != 0
     }
 }

--- a/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
@@ -41,6 +41,8 @@ public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
     }
 }
 
+/// A receiver that combines multiple receivers. It will loop though receivers and stop on the first that is able to
+/// consume the given message.
 public struct CombinedFeatureMessageReceiver: FeatureMessageReceiver {
     let receivers: [FeatureMessageReceiver]
 

--- a/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Launch report format supported by Datadog SDK.
+public struct LaunchReport: Codable, PassthroughAnyCodable {
+    /// The key used to encode/decode the `LaunchReport` while sending across features.
+    public static let messageKey = "launch-report"
+
+    /// Returns `true` if the previous session crashed.
+    public let didCrash: Bool
+
+    ///  Creates a new `LaunchReport`.
+    /// - Parameter didCrash: `true` if the previous session crashed.
+    public init(didCrash: Bool) {
+        self.didCrash = didCrash
+    }
+}
+
+extension LaunchReport: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return """
+        LaunchReport
+        - didCrash: \(didCrash)
+        """
+    }
+}

--- a/DatadogRUM/Sources/Feature/RUMDataStore.swift
+++ b/DatadogRUM/Sources/Feature/RUMDataStore.swift
@@ -30,6 +30,7 @@ internal struct RUMDataStore {
         /// References pending App Hang information.
         /// If found during app start it is considered a fatal hang in previous process.
         case fatalAppHangKey = "fatal-app-hang"
+        case watchdogAppStateKey = "watchdog-app-state"
     }
 
     /// Encodes values in RUM data store.
@@ -45,7 +46,7 @@ internal struct RUMDataStore {
             let data = try RUMDataStore.encoder.encode(value)
             featureScope.dataStore.setValue(data, forKey: key.rawValue, version: version)
         } catch let error {
-            DD.logger.error("Failed to encode \(type(of: value)) in RUM Data Store")
+            DD.logger.error("Failed to encode \(type(of: value)) in RUM Data Store", error: error)
             featureScope.telemetry.error("Failed to encode \(type(of: value)) in RUM Data Store", error: error)
         }
     }
@@ -64,7 +65,7 @@ internal struct RUMDataStore {
                 let value = try RUMDataStore.decoder.decode(V.self, from: data)
                 callback(value)
             } catch let error {
-                DD.logger.error("Failed to decode \(V.self) from RUM Data Store")
+                DD.logger.error("Failed to decode \(V.self) from RUM Data Store", error: error)
                 featureScope.telemetry.error("Failed to decode \(V.self) from RUM Data Store", error: error)
                 callback(nil)
             }

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import DatadogInternal
+import UIKit
 
 /// Bundles RUM instrumentation components.
 internal final class RUMInstrumentation: RUMCommandPublisher {
@@ -36,6 +37,9 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     /// Instruments App Hangs. It is `nil` if hangs monitoring is not enabled.
     let appHangs: AppHangsMonitor?
 
+    /// Instruments Watchdog Terminations.
+    let watchdogTermination: WatchdogTerminationMonitor?
+
     // MARK: - Initialization
 
     init(
@@ -48,7 +52,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         dateProvider: DateProvider,
         backtraceReporter: BacktraceReporting,
         fatalErrorContext: FatalErrorContextNotifying,
-        processID: UUID
+        processID: UUID,
+        watchdogTermination: WatchdogTerminationMonitor
     ) {
         // Always create views handler (we can't know if it will be used by SwiftUI instrumentation)
         // and only swizzle `UIViewController` if UIKit instrumentation is configured:
@@ -119,6 +124,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.longTasks = longTasks
         self.appHangs = appHangs
+        self.watchdogTermination = watchdogTermination
 
         // Enable configured instrumentations:
         self.viewControllerSwizzler?.swizzle()
@@ -133,6 +139,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         uiApplicationSwizzler?.unswizzle()
         longTasks?.stop()
         appHangs?.stop()
+        watchdogTermination?.stop()
     }
 
     func publish(to subscriber: RUMCommandSubscriber) {

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppState.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppState.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Represents the app state observed during application lifecycle events such as application start, resume and termination.
+/// This state is used to detect Watchdog Terminations.
+internal struct WatchdogTerminationAppState: Codable {
+    /// The Application version provided by the `Bundle`.
+    let appVersion: String
+
+    /// The Operating System version.
+    let osVersion: String
+
+    /// Last time the system was booted.
+    let systemBootTime: TimeInterval
+
+    /// Returns true, if the app is running with a debug configuration.
+    let isDebugging: Bool
+
+    /// Returns true, if the app was terminated normally.
+    var wasTerminated: Bool
+
+    /// Returns true, if the app was in the foreground.
+    var isActive: Bool
+
+    /// The vendor identifier of the device.
+    /// This value can change when installing test builds using Xcode or when installing an app on a device using ad-hoc distribution.
+    let vendorId: String?
+
+    /// The process identifier of the app. This value stays the same during SDK start and stop but the app stays in memory.
+    let processId: UUID
+}
+
+extension WatchdogTerminationAppState: CustomDebugStringConvertible {
+    var debugDescription: String {
+        return """
+        WatchdogTerminationAppState
+        - appVersion: \(appVersion)
+        - osVersion: \(osVersion)
+        - systemBootTime: \(systemBootTime)
+        - isDebugging: \(isDebugging)
+        - wasTerminated: \(wasTerminated)
+        - isActive: \(isActive)
+        - vendorId: \(vendorId ?? "nil")
+        - processId: \(processId)
+        """
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManager.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManager.swift
@@ -1,0 +1,140 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Manages the app state changes observed during application lifecycle events such as application start, resume and termination.
+internal final class WatchdogTerminationAppStateManager {
+    let featureScope: FeatureScope
+
+    /// The last app state observed during application lifecycle events.
+    @ReadWriteLock
+    var lastAppState: AppState?
+
+    /// The status of the app state manager indicating if it is active or not.
+    /// When it is active, it listens to the app state changes and updates the app state in the data store.
+    @ReadWriteLock
+    var isActive: Bool
+
+    /// The process identifier of the app whose state is being monitored.
+    let processId: UUID
+
+    init(featureScope: FeatureScope, processId: UUID) {
+        self.featureScope = featureScope
+        self.isActive = false
+        self.processId = processId
+    }
+
+    /// Starts the app state monitoring. Depending on the app state changes, it updates the app state in the data store.
+    /// For example, when the app goes to the background, the app state is updated with `isActive = false`.`
+    func start() throws {
+        DD.logger.debug("Start app state monitoring")
+        isActive = true
+        try storeCurrentAppState()
+    }
+
+    /// Stops the app state monitoring.
+    func stop() throws {
+        DD.logger.debug("Stop app state monitoring")
+        isActive = false
+    }
+
+    /// Deletes the app state from the data store.
+    func deleteAppState() {
+        DD.logger.debug("Deleting app state from data store")
+        featureScope.rumDataStore.removeValue(forKey: .watchdogAppStateKey)
+    }
+
+    /// Updates the app state in the data store with the given block.
+    /// - Parameter block: The block to update the app state.
+    private func updateAppState(block: @escaping (inout WatchdogTerminationAppState?) -> Void) {
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (appState: WatchdogTerminationAppState?) in
+            var appState = appState
+            block(&appState)
+            DD.logger.debug("Updating app state in data store")
+            self.featureScope.rumDataStore.setValue(appState, forKey: .watchdogAppStateKey)
+        }
+    }
+
+    /// Builds the current app state and stores it in the data store.
+    private func storeCurrentAppState() throws {
+        try currentAppState { [self] appState in
+            featureScope.rumDataStore.setValue(appState, forKey: .watchdogAppStateKey)
+        }
+    }
+
+    /// Reads the app state from the data store asynchronously.
+    /// - Parameter completion: The completion block called with the app state.
+    func readAppState(completion: @escaping (WatchdogTerminationAppState?) -> Void) {
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (state: WatchdogTerminationAppState?) in
+            DD.logger.debug("Reading app state from data store.")
+            completion(state)
+        }
+    }
+
+    /// Builds the current app state asynchronously.
+    /// - Parameter completion: The completion block called with the app state.
+    func currentAppState(completion: @escaping (WatchdogTerminationAppState) -> Void) throws {
+        featureScope.context { context in
+            let state: WatchdogTerminationAppState = .init(
+                appVersion: context.version,
+                osVersion: context.device.osVersion,
+                systemBootTime: context.device.systemBootTime,
+                isDebugging: context.device.isDebugging,
+                wasTerminated: false,
+                isActive: true,
+                vendorId: context.device.vendorId,
+                processId: self.processId
+            )
+            completion(state)
+        }
+    }
+}
+
+extension WatchdogTerminationAppStateManager: FeatureMessageReceiver {
+    /// Receives the feature message and updates the app state based on the context message.
+    /// It relies on `ApplicationStatePublisher` context message to update the app state.
+    /// Other messages are ignored.
+    /// - Parameters:
+    ///   - message: The feature message.
+    ///   - core: The core instance.
+    /// - Returns: Always `false`, because it doesn't block the message propagation.
+    func receive(message: DatadogInternal.FeatureMessage, from core: any DatadogInternal.DatadogCoreProtocol) -> Bool {
+        guard isActive else {
+            return false
+        }
+
+        switch message {
+        case .baggage, .webview, .telemetry:
+            break
+        case .context(let context):
+            let state = context.applicationStateHistory.currentSnapshot.state
+
+            // the message received on multiple times whenever there is change in context
+            // but it may not be the application state, hence we guard against the same state
+            guard state != lastAppState else {
+                return false
+            }
+            switch state {
+            case .active:
+                updateAppState { state in
+                    state?.isActive = true
+                }
+            case .inactive, .background:
+                updateAppState { state in
+                    state?.isActive = false
+                }
+            case .terminated:
+                updateAppState { state in
+                    state?.wasTerminated = true
+                }
+            }
+            lastAppState = state
+        }
+        return false
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
@@ -1,0 +1,123 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Checks if the app was terminated by Watchdog using heuristics.
+/// It uses the app state information from the last app session and the current app session
+/// to determine if the app was terminated by Watchdog.
+internal final class WatchdogTerminationChecker {
+    let appStateManager: WatchdogTerminationAppStateManager
+    let deviceInfo: DeviceInfo
+
+    init(
+        appStateManager: WatchdogTerminationAppStateManager,
+        deviceInfo: DeviceInfo
+    ) {
+        self.appStateManager = appStateManager
+        self.deviceInfo = deviceInfo
+    }
+
+    /// Checks if the app was terminated by Watchdog.
+    /// - Parameters:
+    ///   - launch: The launch report containing information about the app launch.
+    ///   - completion: The completion block called with the result.
+    func isWatchdogTermination(launch: LaunchReport, completion: @escaping (Bool) -> Void) throws {
+        do {
+            try appStateManager.currentAppState { current in
+                self.appStateManager.readAppState { [weak self] previous in
+                    guard let self = self else {
+                        completion(false)
+                        return
+                    }
+                    completion(self.isWatchdogTermination(launch: launch, from: previous, to: current))
+                }
+            }
+        } catch let error {
+            DD.logger.error("Failed to check if Watchdog Termination occurred", error: error)
+            completion(false)
+            throw error
+        }
+    }
+
+    /// Checks if the app was terminated by Watchdog.
+    /// - Parameters:
+    ///  - launch: The launch report containing information about the app launch.
+    ///  - previous: The previous app state stored in the data store from the last app session.
+    ///  - current: The current app state of the app.
+    func isWatchdogTermination(
+        launch: LaunchReport,
+        from previous: WatchdogTerminationAppState?,
+        to current: WatchdogTerminationAppState
+    ) -> Bool {
+        DD.logger.debug(launch.debugDescription)
+        DD.logger.debug(previous.debugDescription)
+        DD.logger.debug(current.debugDescription)
+
+        guard let previous = previous else {
+            return false
+        }
+
+        // Watchdog Termination detection doesn't work on simulators.
+        guard deviceInfo.isSimulator == false else {
+            return false
+        }
+
+        // When the app is running in debug mode, we can't reliably tell if it was a Watchdog Termination or not.
+        guard previous.isDebugging == false else {
+           return false
+        }
+
+        // Is the app version different than the last time the app was opened?
+        guard previous.appVersion == current.appVersion else {
+            return false
+        }
+
+        // Is there a crash from the last time the app was opened?
+        guard launch.didCrash == false else {
+            return false
+        }
+
+        // Did we receive a termination call the last time the app was opened?
+        guard previous.wasTerminated == false else {
+            return false
+        }
+
+        // Is the OS version different than the last time the app was opened?
+        guard previous.osVersion == current.osVersion else {
+            return false
+        }
+
+        // Was the system rebooted since the last time the app was opened?
+        guard previous.systemBootTime == current.systemBootTime else {
+            return false
+        }
+
+        // This value can change when installing test builds using Xcode or when installing an app
+        // on a device using ad-hoc distribution.
+        guard previous.vendorId == current.vendorId else {
+            return false
+        }
+
+        // This is likely same process but another check due to stop & start of the SDK
+        guard previous.processId != current.processId else {
+            return false
+        }
+
+        // Was the app in foreground/active ?
+        // If the app was in background we can't reliably tell if it was a Watchdog Termination or not.
+        guard previous.isActive else {
+            return false
+        }
+
+        return true
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Monitors the Watchdog Termination events and reports them to Datadog.
+internal final class WatchdogTerminationMonitor {
+    enum ErrorMessages {
+        static let failedToCheckWatchdogTermination = "Failed to check if Watchdog Termination occurred"
+        static let failedToStartAppState = "Failed to start Watchdog Termination App State Manager"
+        static let failedToStopAppState = "Failed to stop Watchdog Termination App State Manager"
+        static let detectedWatchdogTermination = "Based on heuristics, previous app session was terminated by Watchdog"
+        static let detectedNonWatchdogTermination = "Previous app session was not terminated by Watchdog"
+    }
+
+    let checker: WatchdogTerminationChecker
+    let appStateManager: WatchdogTerminationAppStateManager
+    let telemetry: Telemetry
+    let reporter: WatchdogTerminationReporting
+
+    init(
+        appStateManager: WatchdogTerminationAppStateManager,
+        checker: WatchdogTerminationChecker,
+        reporter: WatchdogTerminationReporting,
+        telemetry: Telemetry
+    ) {
+        self.checker = checker
+        self.appStateManager = appStateManager
+        self.telemetry = telemetry
+        self.reporter = reporter
+    }
+
+    /// Starts the Watchdog Termination Monitor.
+    /// - Parameter launchReport: The launch report containing information about the app launch (if available).
+    func start(launchReport: LaunchReport?) {
+        if let launchReport = launchReport {
+            sendWatchTerminationIfFound(launch: launchReport)
+        }
+
+        do {
+            try appStateManager.start()
+        } catch let error {
+            DD.logger.error(ErrorMessages.failedToStartAppState, error: error)
+            telemetry.error(ErrorMessages.failedToStartAppState, error: error)
+        }
+    }
+
+    /// Checks if the app was terminated by Watchdog and sends the Watchdog Termination event to Datadog.
+    /// - Parameter launch: The launch report containing information about the app launch.
+    private func sendWatchTerminationIfFound(launch: LaunchReport) {
+        do {
+            try checker.isWatchdogTermination(launch: launch) { isWatchdogTermination in
+                if isWatchdogTermination {
+                    DD.logger.debug(ErrorMessages.detectedWatchdogTermination)
+                    self.reporter.send()
+                } else {
+                    DD.logger.debug(ErrorMessages.detectedNonWatchdogTermination)
+                }
+            }
+        } catch let error {
+            DD.logger.error(ErrorMessages.failedToCheckWatchdogTermination, error: error)
+            telemetry.error(ErrorMessages.failedToCheckWatchdogTermination, error: error)
+        }
+    }
+
+    /// Stops the Watchdog Termination Monitor.
+    func stop() {
+        do {
+            try appStateManager.stop()
+        } catch {
+            DD.logger.error(ErrorMessages.failedToStopAppState, error: error)
+            telemetry.error(ErrorMessages.failedToStopAppState, error: error)
+        }
+    }
+}
+
+extension WatchdogTerminationMonitor: Flushable {
+    /// Flushes the Watchdog Termination Monitor. It stops the monitor and deletes the app state.
+    /// - Note: This method must be called manually only or in the tests.
+    /// This will reset the app state and the monitor will not able to detect Watchdog Termination due to absence of the previous app state.
+    func flush() {
+        stop()
+        appStateManager.deleteAppState()
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Reports Watchdog Termination events to Datadog.
+internal protocol WatchdogTerminationReporting {
+    /// Sends the Watchdog Termination event to Datadog.
+    func send()
+}
+
+/// Default implementation of `WatchdogTerminationReporting`.
+internal final class WatchdogTerminationReporter: WatchdogTerminationReporting {
+    /// Sends the Watchdog Termination event to Datadog.
+    func send() {
+        DD.logger.error("TODO: WatchdogTerminationReporter.report()")
+    }
+}

--- a/DatadogRUM/Sources/Integrations/LaunchReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/LaunchReportReceiver.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Receives `LaunchReport` from CrashReporter and starts the Watchdog Termination Monitor.
+internal struct LaunchReportReceiver: FeatureMessageReceiver {
+    let featureScope: FeatureScope
+    let watchdogTermination: WatchdogTerminationMonitor?
+
+    init(
+        featureScope: FeatureScope,
+        watchdogTermination: WatchdogTerminationMonitor?
+    ) {
+        self.featureScope = featureScope
+        self.watchdogTermination = watchdogTermination
+    }
+
+    /// Receives `LaunchReport` from CrashReporter and starts the Watchdog Termination Monitor.
+    /// - Parameters:
+    ///   - message: The message containing `LaunchReport`.
+    ///   - core: The `DatadogCore` instance.
+    /// - Returns: `true` if the message was successfully received, `false` otherwise.
+    func receive(message: DatadogInternal.FeatureMessage, from core: any DatadogInternal.DatadogCoreProtocol) -> Bool {
+        do {
+            guard let launch: LaunchReport? = try message.baggage(forKey: LaunchReport.messageKey) else {
+                return false
+            }
+            watchdogTermination?.start(launchReport: launch)
+            return false
+        } catch {
+            featureScope.telemetry.error("Fails to decode LaunchReport in RUM", error: error)
+        }
+        return false
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -24,7 +24,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -49,7 +50,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -71,7 +73,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -96,7 +99,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -117,7 +121,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -138,7 +143,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
 
         // Then
@@ -159,7 +165,8 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider(),
             backtraceReporter: BacktraceReporterMock(),
             fatalErrorContext: FatalErrorContextNotifierMock(),
-            processID: .mockAny()
+            processID: .mockAny(),
+            watchdogTermination: .mockRandom()
         )
         let subscriber = RUMCommandSubscriberMock()
 

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManagerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManagerTests.swift
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+final class WatchdogTerminationAppStateManagerTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    var sut: WatchdogTerminationAppStateManager!
+    var featureScope: FeatureScopeMock!
+    var context: DatadogContext = .mockWith(applicationStateHistory: .mockAppInBackground())
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        featureScope = FeatureScopeMock()
+        sut = WatchdogTerminationAppStateManager(
+            featureScope: featureScope,
+            processId: .init()
+        )
+    }
+
+    func testAppStart_SetsIsActive() throws {
+        try sut.start()
+
+        let isActiveExpectation = expectation(description: "isActive is set to true")
+
+        // app state changes
+        context.applicationStateHistory.append(.init(state: .active, date: .init()))
+        _ = sut.receive(message: .context(context), from: NOPDatadogCore())
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (appState: WatchdogTerminationAppState?) in
+            XCTAssertTrue(appState?.isActive == true)
+            isActiveExpectation.fulfill()
+        }
+        wait(for: [isActiveExpectation], timeout: 1)
+
+        let isBackgroundedExpectation = expectation(description: "isActive is set to false")
+
+        // app state changes again
+        context.applicationStateHistory.append(.init(state: .background, date: .init()))
+        _ = sut.receive(message: .context(context), from: NOPDatadogCore())
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (appState: WatchdogTerminationAppState?) in
+            XCTAssertTrue(appState?.isActive == false)
+            isBackgroundedExpectation.fulfill()
+        }
+
+        wait(for: [isBackgroundedExpectation], timeout: 1)
+    }
+
+    func testDeleteAppState() throws {
+        try sut.start()
+
+        let isActiveExpectation = expectation(description: "isActive is set")
+        context.applicationStateHistory.append(.init(state: .active, date: .init()))
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (appState: WatchdogTerminationAppState?) in
+            XCTAssertNotNil(appState)
+            isActiveExpectation.fulfill()
+        }
+        wait(for: [isActiveExpectation], timeout: 1)
+
+        let deleteExpectation = expectation(description: "isActive is set to false")
+        sut.deleteAppState()
+        featureScope.rumDataStore.value(forKey: .watchdogAppStateKey) { (appState: WatchdogTerminationAppState?) in
+            XCTAssertNil(appState)
+            deleteExpectation.fulfill()
+        }
+
+        wait(for: [deleteExpectation], timeout: 1)
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationCheckerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationCheckerTests.swift
@@ -1,0 +1,320 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+final class WatchdogTerminationCheckerTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    var sut: WatchdogTerminationChecker!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    func testNoPreviousState_NoWatchdogTermination() throws {
+        given(isSimulator: .mockRandom())
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), from: nil, to: .mockRandom()))
+    }
+
+    func testIsSimulatorBuild_NoWatchdogTermination() throws {
+        given(isSimulator: true)
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), from: .mockRandom(), to: .mockRandom()))
+    }
+
+    func testIsDebugging_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: .mockAny(),
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: true,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), from: previous, to: .mockRandom()))
+    }
+
+    func testDifferentAppVersions_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.1",
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), from: previous, to: current))
+    }
+
+    func testApplicationDidCrash_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: .mockAny(),
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: .mockAny(),
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: true), from: previous, to: current))
+    }
+
+    func testApplicationWasTerminated_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: true,
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testDifferentOSVersions_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.1",
+            systemBootTime: .mockAny(),
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testDifferentBootTimes_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 2.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testDifferentVendorId_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: "foo",
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: "bar",
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testSDKWasStoppedAndStarted_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let pid = UUID()
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: "foo",
+            processId: pid
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: "foo",
+            processId: pid
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testApplicationWasInBackground_NoWatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: false,
+            vendorId: "foo",
+            processId: .mockAny()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: "foo",
+            processId: .mockAny()
+        )
+
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    func testApplicationWasInForeground_WatchdogTermination() throws {
+        given(isSimulator: false)
+
+        let previous = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: true,
+            vendorId: "foo",
+            processId: UUID()
+        )
+
+        let current = WatchdogTerminationAppState(
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            isDebugging: false,
+            wasTerminated: .mockAny(),
+            isActive: true,
+            vendorId: "foo",
+            processId: UUID()
+        )
+
+        XCTAssertTrue(sut.isWatchdogTermination(launch: .init(didCrash: false), from: previous, to: current))
+    }
+
+    // MARK: Helpers
+
+    func given(isSimulator: Bool) {
+        let deviceInfo: DeviceInfo = .init(
+            name: .mockAny(),
+            model: .mockAny(),
+            osName: .mockAny(),
+            osVersion: .mockAny(),
+            osBuildNumber: .mockAny(),
+            architecture: .mockAny(),
+            isSimulator: isSimulator,
+            vendorId: .mockAny(),
+            isDebugging: .mockAny(),
+            systemBootTime: .mockAny()
+        )
+
+        sut = WatchdogTerminationChecker(
+            appStateManager: .mockRandom(),
+            deviceInfo: deviceInfo
+        )
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+extension WatchdogTerminationAppState: RandomMockable, AnyMockable {
+    public static func mockAny() -> DatadogRUM.WatchdogTerminationAppState {
+        return .init(
+            appVersion: .mockAny(),
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: .mockAny(),
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny()
+        )
+    }
+
+    public static func mockRandom() -> WatchdogTerminationAppState {
+        return .init(
+            appVersion: .mockRandom(),
+            osVersion: .mockRandom(),
+            systemBootTime: .mockRandom(),
+            isDebugging: .mockRandom(),
+            wasTerminated: .mockRandom(),
+            isActive: .mockRandom(),
+            vendorId: .mockRandom(),
+            processId: .mockAny()
+        )
+    }
+}
+
+class WatchdogTerminationReporterMock: WatchdogTerminationReporting {
+    var didSend: XCTestExpectation
+
+    init(didSend: XCTestExpectation) {
+        self.didSend = didSend
+    }
+
+    func send() {
+        didSend.fulfill()
+    }
+}
+
+extension WatchdogTerminationReporter: RandomMockable {
+    public static func mockRandom() -> Self {
+        return .init()
+    }
+}
+
+extension WatchdogTerminationChecker: RandomMockable {
+    public static func mockRandom() -> WatchdogTerminationChecker {
+        return .init(
+            appStateManager: .mockRandom(),
+            deviceInfo: .mockRandom()
+        )
+    }
+}
+
+extension WatchdogTerminationAppStateManager: RandomMockable {
+    public static func mockRandom() -> WatchdogTerminationAppStateManager {
+        return .init(
+            featureScope: FeatureScopeMock(),
+            processId: .mockRandom()
+        )
+    }
+}
+
+extension Sysctl: RandomMockable {
+    public static func mockRandom() -> DatadogInternal.Sysctl {
+        return .init()
+    }
+}
+
+extension RUMDataStore: RandomMockable {
+    public static func mockRandom() -> DatadogRUM.RUMDataStore {
+        return .init(featureScope: FeatureScopeMock())
+    }
+}
+
+extension WatchdogTerminationMonitor: RandomMockable {
+    public static func mockRandom() -> WatchdogTerminationMonitor {
+        return .init(
+            appStateManager: .mockRandom(),
+            checker: .mockRandom(),
+            reporter: WatchdogTerminationReporter.mockRandom(),
+            telemetry: NOPTelemetry()
+        )
+    }
+}
+
+extension LaunchReport: RandomMockable {
+    public static func mockRandom() -> DatadogInternal.LaunchReport {
+        return .init(didCrash: .mockRandom())
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+final class WatchdogTerminationMonitorTests: XCTestCase {
+    let featureScope = FeatureScopeMock()
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var sut: WatchdogTerminationMonitor!
+    private var core: PassthroughCoreMock!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    func testApplicationWasInForeground_WatchdogTermination() throws {
+        let didSend = self.expectation(description: "Watchdog termination was reported")
+
+        // app starts
+        given(
+            isSimulator: false,
+            isDebugging: false,
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            vendorId: "foo",
+            processId: UUID(),
+            didSend: didSend
+        )
+        core.context.applicationStateHistory.append(.init(state: .active, date: .init()))
+
+        // saves the current state
+        sut.start(launchReport: nil)
+
+        // watchdog termination happens here which causes app launch
+        given(
+            isSimulator: false,
+            isDebugging: false,
+            appVersion: "1.0.0",
+            osVersion: "1.0.0",
+            systemBootTime: 1.0,
+            vendorId: "foo",
+            processId: UUID(),
+            didSend: didSend
+        )
+        core.context.applicationStateHistory.append(.init(state: .active, date: .init()))
+        sut.start(launchReport: .init(didCrash: false))
+
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: Helpers
+
+    func given(
+        isSimulator: Bool,
+        isDebugging: Bool,
+        appVersion: String,
+        osVersion: String,
+        systemBootTime: TimeInterval,
+        vendorId: String?,
+        processId: UUID,
+        didSend: XCTestExpectation
+    ) {
+        let deviceInfo: DeviceInfo = .init(
+            name: .mockAny(),
+            model: .mockAny(),
+            osName: .mockAny(),
+            osVersion: .mockAny(),
+            osBuildNumber: .mockAny(),
+            architecture: .mockAny(),
+            isSimulator: isSimulator,
+            vendorId: vendorId,
+            isDebugging: false,
+            systemBootTime: systemBootTime
+        )
+
+        featureScope.contextMock.version = appVersion
+
+        let appStateManager = WatchdogTerminationAppStateManager(
+            featureScope: featureScope,
+            processId: processId
+        )
+
+        let checker = WatchdogTerminationChecker(appStateManager: appStateManager, deviceInfo: deviceInfo)
+
+        let reporter = WatchdogTerminationReporterMock(didSend: didSend)
+
+        sut = WatchdogTerminationMonitor(
+            appStateManager: appStateManager,
+            checker: checker,
+            reporter: reporter,
+            telemetry: featureScope.telemetryMock
+        )
+
+        core = PassthroughCoreMock(
+            context: .mockWith(applicationStateHistory: .mockAppInBackground()),
+            messageReceiver: appStateManager
+        )
+    }
+}

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -133,7 +133,11 @@ extension DeviceInfo {
         osName: String = "iOS",
         osVersion: String = "15.4.1",
         osBuildNumber: String = "13D20",
-        architecture: String = "arm64e"
+        architecture: String = "arm64e",
+        isSimulator: Bool = true,
+        vendorId: String? = "xyz",
+        isDebugging: Bool = false,
+        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate
     ) -> DeviceInfo {
         return .init(
             name: name,
@@ -141,7 +145,11 @@ extension DeviceInfo {
             osName: osName,
             osVersion: osVersion,
             osBuildNumber: osBuildNumber,
-            architecture: architecture
+            architecture: architecture, 
+            isSimulator: isSimulator, 
+            vendorId: vendorId,
+            isDebugging: isDebugging,
+            systemBootTime: systemBootTime
         )
     }
 
@@ -152,7 +160,11 @@ extension DeviceInfo {
             osName: .mockRandom(),
             osVersion: .mockRandom(),
             osBuildNumber: .mockRandom(),
-            architecture: .mockRandom()
+            architecture: .mockRandom(),
+            isSimulator: .mockRandom(),
+            vendorId: .mockRandom(),
+            isDebugging: .mockRandom(),
+            systemBootTime: .mockRandom()
         )
     }
 }


### PR DESCRIPTION
### What and why?

We want to detect the watchdog terminations in the SDK and report them as a crash to the backend.

### How?

This PR setups the building block of detecting a watchdog termination using the heuristic based approach. The heuristic works on checking all the possible ways an app can be terminated and if the termination is from an unknown method, it is considered as a watchdog termination.

Read more about the approach in the [internal RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3750756810).

The reporting part is not yet implemented in this PR.


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
