### PR TITLE
RUM-2442 [S8S] Emit `_dd.session.id` and `_dd.application.id` on view change

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -43,11 +43,6 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             activeViewName: nil,
             activeUserActionID: nil
         )
-
-        // Notify Synthetics if needed
-        if dependencies.syntheticsTest != nil {
-            NSLog("_dd.application.id=" + dependencies.rumApplicationID)
-        }
     }
 
     // MARK: - RUMContextProvider

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -119,11 +119,6 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Update fatal error context with recent RUM session state:
         dependencies.fatalErrorContext.sessionState = state
-
-        // Notify Synthetics if needed
-        if dependencies.syntheticsTest != nil && sessionUUID != .nullUUID {
-            NSLog("_dd.session.id=" + sessionUUID.toRUMDataFormat)
-        }
     }
 
     /// Creates a new Session upon expiration of the previous one.

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -127,6 +127,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {
+            NSLog("_dd.session.id=" + self.context.sessionID.toRUMDataFormat)
+            NSLog("_dd.application.id=" + self.context.rumApplicationID)
             NSLog("_dd.view.id=" + self.viewUUID.toRUMDataFormat)
         }
     }


### PR DESCRIPTION
### What and why?

Same as https://github.com/DataDog/dd-sdk-android/pull/1813

Emit the Application and Session ID with the view so S8S can retrieve them in the device logs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
