### PR TITLE
Added MainActor annotation for matches UIApplication.beginBackgroundTask(expirationHandler:)

### DIFF
--- a/DatadogCore/Sources/Core/Upload/BackgroundTaskCoordinator.swift
+++ b/DatadogCore/Sources/Core/Upload/BackgroundTaskCoordinator.swift
@@ -22,7 +22,7 @@ import DatadogInternal
 
 /// Bridge protocol that matches `UIApplication` interface for background tasks. Allows easier testablity.
 internal protocol UIKitAppBackgroundTaskCoordinator {
-    func beginBackgroundTask(expirationHandler handler: (() -> Void)?) -> UIBackgroundTaskIdentifier
+    func beginBackgroundTask(expirationHandler handler: (@MainActor () -> Void)?) -> UIBackgroundTaskIdentifier
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
 }
 


### PR DESCRIPTION
### What and why?

This fix addresses a build error in Xcode 16. The error occurs when building my app and the message is:

`Type 'UIApplication' does not conform to protocol 'UIKitAppBackgroundTaskCoordinator'`

The error logs provide more details:

```
UIKit.UIApplication:70:27: note: candidate has non-matching type '((@MainActor () -> Void)?) -> UIBackgroundTaskIdentifier'

nonisolated open func beginBackgroundTask(expirationHandler handler: (@MainActor () -> Void)? = nil) -> UIBackgroundTaskIdentifier
```

It seems that type checking has become more strict in Xcode 16 and Swift 6.0.

fix issue  #1892

### How?

just added annotation MainActor into expirationHander in UIKitAppBackgroundTaskCoordinator.beginBackgroundTask(expirationHandler:)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
