### PR TITLE
RUM-4824 Make color SR identifier lazy

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -37,6 +37,16 @@ extension DatadogExtension where ExtendedType: UIImage {
 
 extension UIColor {
     var srIdentifier: String {
+        if let hash = objc_getAssociatedObject(self, &srIdentifierKey) as? String {
+            return hash
+        } else {
+            let hash = computeIdentifier()
+            objc_setAssociatedObject(self, &srIdentifierKey, hash, .OBJC_ASSOCIATION_RETAIN)
+            return hash
+        }
+    }
+
+    private func computeIdentifier() -> String {
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0


### PR DESCRIPTION
### What and why?

Color identifier calculation seems to be quite slow for the customer testing. We can improve by making it lazy the same way we did for UIViews.

### How?

Leverages associated object to calculate identifier once and retain it for given instance of color.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [x] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
