### PR TITLE
Fix complication issues on Xcode 16

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/Upload/AppBackgroundTaskCoordinatorTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/AppBackgroundTaskCoordinatorTests.swift
@@ -57,13 +57,13 @@ class AppSpy: UIKitAppBackgroundTaskCoordinator {
 
     var handler: (() -> Void)? = nil
 
-    func beginBackgroundTask(expirationHandler handler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+    func beginBgTask(_ handler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
         self.handler = handler
         beginBackgroundTaskCalled = true
         return UIBackgroundTaskIdentifier(rawValue: 1)
     }
 
-    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+    func endBgTask(_ identifier: UIBackgroundTaskIdentifier) {
         endBackgroundTaskCalled = true
     }
 }


### PR DESCRIPTION
### What and why?

Resolve compilation issue reported in https://github.com/DataDog/dd-sdk-ios/issues/1892

Issue is that in new version of Xcode copies signature function:
`open func beginBackgroundTask(expirationHandler handler: (() -> Void)? = nil) -> UIBackgroundTaskIdentifier` is enriched with `@MainActor` resulting in a conflict.

This PR renames those functions signatures and adds extension that calls corresponding `UIApplication` functions.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
