### PR TITLE
RUM-1660 chore: Enhance RUM session debugging in Example app

### DIFF
--- a/Datadog/Example/Debugging/Helpers/SwiftUI.swift
+++ b/Datadog/Example/Debugging/Helpers/SwiftUI.swift
@@ -34,10 +34,10 @@ extension Color {
 internal struct DatadogButtonStyle: ButtonStyle {
     func makeBody(configuration: DatadogButtonStyle.Configuration) -> some View {
         return configuration.label
-            .font(.system(size: 14, weight: .medium))
-            .padding(10)
+            .font(.system(size: 12, weight: .medium))
+            .padding(6)
             .background(Color.datadogPurple)
             .foregroundColor(.white)
-            .cornerRadius(8)
+            .cornerRadius(6)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds convenience to the RUM Session Debugging page in Example app.

It comes handy in debugging RUM sessions, notably for the "Session Ended" telemetry added in #1866.

Re-opening https://github.com/DataDog/dd-sdk-ios/pull/1894 which was closed by GH 🤔💭.

### How?

3 changes:
- added a button to manually end the session through `stopSession()` API,
- added extra label displaying the current session ID,
- overal revamp to make more space for rendering session state at the bottom.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/f9f9f145-ea64-4525-b3fb-075a2e47a5f3" alt="before" width="50%"/>
    </td>
    <td>
      <img src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/b0368ef3-551a-4c93-ada2-2e256a094871" alt="after" width="50%"/>
    </td>
  </tr>
</table>

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
