### PR TITLE
chore: Fix E2E tests build

### DIFF
--- a/E2ETests/Runner/Scenarios/SessionReplayWebView/SessionReplayWebViewController.swift
+++ b/E2ETests/Runner/Scenarios/SessionReplayWebView/SessionReplayWebViewController.swift
@@ -22,10 +22,7 @@ class SessionReplayWebViewController: UIViewController, WKUIDelegate {
         super.viewDidLoad()
         WebViewTracking.enable(
             webView: webView,
-            hosts: ["datadoghq.dev"],
-            sessionReplayConfiguration: WebViewTracking.SessionReplayConfiguration(
-                privacyLevel: .allow
-            )
+            hosts: ["datadoghq.dev"]
         )
     }
 


### PR DESCRIPTION
### What and why?

🧰 Fixes E2E test build error:
```
❌ /Users/vagrant/git/E2ETests/Runner/Scenarios/SessionReplayWebView/SessionReplayWebViewController.swift:26:57: extra argument 'sessionReplayConfiguration' in call
            sessionReplayConfiguration: WebViewTracking.SessionReplayConfiguration(

```

It comes from public API change to `DatadogWebViewTracking` introduced in https://github.com/DataDog/dd-sdk-ios/pull/1879

### How?

Aligned public API use to changes from https://github.com/DataDog/dd-sdk-ios/pull/1879.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
