### PR TITLE
RUM-4591 chore: Add diagnostic attributes to "RUM Session Ended" telemetry

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -180,6 +180,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         XCTAssertEqual(metricAttributes.viewsCount.total, 10)
         XCTAssertEqual(metricAttributes.viewsCount.applicationLaunch, 1)
         XCTAssertEqual(metricAttributes.viewsCount.background, 3)
+        XCTAssertEqual(metricAttributes.viewsCount.byInstrumentation, ["manual": 6])
     }
 
     func testTrackingSDKErrors() throws {

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -182,6 +182,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         XCTAssertEqual(metricAttributes.viewsCount.applicationLaunch, 1)
         XCTAssertEqual(metricAttributes.viewsCount.background, 3)
         XCTAssertEqual(metricAttributes.viewsCount.byInstrumentation, ["manual": 6])
+        XCTAssertEqual(metricAttributes.viewsCount.withHasReplay, 0)
     }
 
     func testTrackingSDKErrors() throws {

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -212,6 +212,27 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
             "It should report TOP 5 error kinds"
         )
     }
+
+    func testTrackingNTPOffset() throws {
+        let offsetAtStart: TimeInterval = .mockRandom(min: -10, max: 10)
+        let offsetAtEnd: TimeInterval = .mockRandom(min: -10, max: 10)
+
+        core.context.serverTimeOffset = offsetAtStart
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key", name: "View")
+
+        // When
+        core.context.serverTimeOffset = offsetAtEnd
+        monitor.stopSession()
+
+        // Then
+        let metric = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent())
+        XCTAssertEqual(metric.attributes?.ntpOffset.atStart, offsetAtStart.toInt64Milliseconds)
+        XCTAssertEqual(metric.attributes?.ntpOffset.atEnd, offsetAtEnd.toInt64Milliseconds)
+    }
 }
 
 // MARK: - Helpers

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -101,7 +101,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
 
     // MARK: - Reporting Session Attributes
 
-    func testReportingSessionID() throws {
+    func testReportingSessionInformation() throws {
         var currentSessionID: String?
         RUM.enable(with: rumConfig, in: core)
 
@@ -118,6 +118,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         let metric = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent())
         let expectedSessionID = try XCTUnwrap(currentSessionID)
         XCTAssertEqual(metric.session?.id, expectedSessionID.lowercased())
+        XCTAssertEqual(metric.attributes?.hasBackgroundEventsTrackingEnabled, rumConfig.trackBackgroundEvents)
     }
 
     func testTrackingSessionDuration() throws {

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -200,14 +200,16 @@ extension RUMStartViewCommand: AnyMockable, RandomMockable {
         attributes: [AttributeKey: AttributeValue] = [:],
         identity: ViewIdentifier = .mockViewIdentifier(),
         name: String = .mockAny(),
-        path: String = .mockAny()
+        path: String = .mockAny(),
+        instrumentationType: SessionEndedMetric.ViewInstrumentationType = .manual
     ) -> RUMStartViewCommand {
         return RUMStartViewCommand(
             time: time,
             identity: identity,
             name: name,
             path: path,
-            attributes: attributes
+            attributes: attributes,
+            instrumentationType: instrumentationType
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -152,6 +152,7 @@ struct RUMCommandMock: RUMCommand {
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
     var isUserInteraction = false
+    var missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 /// Creates random `RUMCommand` from available ones.

--- a/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
@@ -25,6 +25,9 @@ internal final class RUMViewsHandler {
 
         /// Custom attributes to attach to the View.
         let attributes: [AttributeKey: AttributeValue]
+
+        /// The type of instrumentation that started this view.
+        let instrumentationType: SessionEndedMetric.ViewInstrumentationType
     }
 
     /// The current date provider.
@@ -157,7 +160,8 @@ internal final class RUMViewsHandler {
                 identity: view.identity,
                 name: view.name,
                 path: view.path,
-                attributes: view.attributes
+                attributes: view.attributes,
+                instrumentationType: view.instrumentationType
             )
         )
     }
@@ -205,7 +209,8 @@ extension RUMViewsHandler: UIViewControllerHandler {
                     name: rumView.name,
                     path: rumView.path ?? viewController.canonicalClassName,
                     isUntrackedModal: rumView.isUntrackedModal,
-                    attributes: rumView.attributes
+                    attributes: rumView.attributes,
+                    instrumentationType: .uikit
                 )
             )
         } else if #available(iOS 13, tvOS 13, *), viewController.isModalInPresentation {
@@ -215,7 +220,8 @@ extension RUMViewsHandler: UIViewControllerHandler {
                     name: "RUMUntrackedModal",
                     path: viewController.canonicalClassName,
                     isUntrackedModal: true,
-                    attributes: [:]
+                    attributes: [:],
+                    instrumentationType: .uikit
                 )
             )
         }
@@ -240,7 +246,8 @@ extension RUMViewsHandler: SwiftUIViewHandler {
                 name: name,
                 path: path,
                 isUntrackedModal: false,
-                attributes: attributes
+                attributes: attributes,
+                instrumentationType: .swiftui
             )
         )
     }

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -250,7 +250,8 @@ extension Monitor: RUMMonitorProtocol {
                 identity: ViewIdentifier(viewController),
                 name: name ?? viewController.canonicalClassName,
                 path: viewController.canonicalClassName,
-                attributes: attributes
+                attributes: attributes,
+                instrumentationType: .manual
             )
         )
     }
@@ -272,7 +273,8 @@ extension Monitor: RUMMonitorProtocol {
                 identity: ViewIdentifier(key),
                 name: name ?? key,
                 path: key,
-                attributes: attributes
+                attributes: attributes,
+                instrumentationType: .manual
             )
         )
     }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -18,6 +18,8 @@ internal protocol RUMCommand {
     var canStartBackgroundView: Bool { get }
     /// Whether or not this command is considered a user intaraction
     var isUserInteraction: Bool { get }
+    /// A type of event missed upon receiving this command in case of absence of an active view; `nil` if none or N/A.
+    var missedEventType: SessionEndedMetric.MissedEventType? { get }
 }
 
 internal struct RUMSDKInitCommand: RUMCommand {
@@ -25,6 +27,7 @@ internal struct RUMSDKInitCommand: RUMCommand {
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
     var isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 internal struct RUMApplicationStartCommand: RUMCommand {
@@ -32,6 +35,7 @@ internal struct RUMApplicationStartCommand: RUMCommand {
     var attributes: [AttributeKey: AttributeValue]
     var canStartBackgroundView = false
     var isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 internal struct RUMStopSessionCommand: RUMCommand {
@@ -39,6 +43,7 @@ internal struct RUMStopSessionCommand: RUMCommand {
     var attributes: [AttributeKey: AttributeValue] = [:]
     let canStartBackgroundView = false // no, stopping a session should not start a backgorund session
     let isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 
     init(time: Date) {
         self.time = time
@@ -64,6 +69,7 @@ internal struct RUMStartViewCommand: RUMCommand, RUMViewScopePropagatableAttribu
 
     /// The type of instrumentation that started this view.
     let instrumentationType: SessionEndedMetric.ViewInstrumentationType
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 
     init(
         time: Date,
@@ -90,6 +96,7 @@ internal struct RUMStopViewCommand: RUMCommand, RUMViewScopePropagatableAttribut
 
     /// The value holding stable identity of the RUM View.
     let identity: ViewIdentifier
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 /// Any error command, like exception or App Hang.
@@ -135,6 +142,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
     let threads: [DDThread]?
     let binaryImages: [BinaryImage]?
     let isStackTraceTruncated: Bool?
+    let missedEventType: SessionEndedMetric.MissedEventType? = .error
 
     /// Constructor dedicated to errors defined by message, type and stack.
     init(
@@ -234,6 +242,7 @@ internal struct RUMAddCurrentViewAppHangCommand: RUMErrorCommand {
 
     /// The duration of hang.
     let hangDuration: TimeInterval
+    let missedEventType: SessionEndedMetric.MissedEventType? = .error
 }
 
 internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAttributes {
@@ -245,6 +254,7 @@ internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAtt
     /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
     /// measured since the start of the View.
     let timingName: String
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 // MARK: - RUM Resource related commands
@@ -280,6 +290,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     let kind: RUMResourceType?
     /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
     let spanContext: RUMSpanContext?
+    let missedEventType: SessionEndedMetric.MissedEventType? = .resource
 }
 
 internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
@@ -291,6 +302,7 @@ internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
 
     /// Resource metrics.
     let metrics: ResourceMetrics
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 internal struct RUMStopResourceCommand: RUMResourceCommand {
@@ -306,6 +318,7 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
     let httpStatusCode: Int?
     /// The size of loaded Resource
     let size: Int64?
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
@@ -327,6 +340,7 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     let stack: String?
     /// HTTP status code of the Ressource error.
     let httpStatusCode: Int?
+    let missedEventType: SessionEndedMetric.MissedEventType? = .error
 
     init(
         resourceKey: String,
@@ -390,6 +404,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
 
     let actionType: RUMActionType
     let name: String
+    let missedEventType: SessionEndedMetric.MissedEventType? = .action
 }
 
 /// Stops continuous User Action.
@@ -401,6 +416,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
 
     let actionType: RUMActionType
     let name: String?
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 /// Adds discrete (discontinuous) User Action.
@@ -412,6 +428,7 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
 
     let actionType: RUMActionType
     let name: String
+    let missedEventType: SessionEndedMetric.MissedEventType? = .action
 }
 
 /// Adds that a feature flag has been evaluated to the view
@@ -422,6 +439,7 @@ internal struct RUMAddFeatureFlagEvaluationCommand: RUMCommand {
     let isUserInteraction = false
     let name: String
     let value: Encodable
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 
     init(time: Date, name: String, value: Encodable) {
         self.time = time
@@ -440,6 +458,7 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
     let isUserInteraction = false // a long task is not an interactive event
 
     let duration: TimeInterval
+    let missedEventType: SessionEndedMetric.MissedEventType? = .longTask
 }
 
 // MARK: - RUM Web Events related commands
@@ -450,6 +469,7 @@ internal struct RUMKeepSessionAliveCommand: RUMCommand {
     let isUserInteraction = false
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 // MARK: - Cross-platform perf metrics
@@ -461,4 +481,5 @@ internal struct RUMUpdatePerformanceMetric: RUMCommand {
     let value: Double
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -62,18 +62,23 @@ internal struct RUMStartViewCommand: RUMCommand, RUMViewScopePropagatableAttribu
     /// The path of this View, rendered in RUM Explorer as `VIEW URL`.
     let path: String
 
+    /// The type of instrumentation that started this view.
+    let instrumentationType: SessionEndedMetric.ViewInstrumentationType
+
     init(
         time: Date,
         identity: ViewIdentifier,
         name: String,
         path: String,
-        attributes: [AttributeKey: AttributeValue]
+        attributes: [AttributeKey: AttributeValue],
+        instrumentationType: SessionEndedMetric.ViewInstrumentationType
     ) {
         self.time = time
         self.attributes = attributes
         self.identity = identity
         self.name = name
         self.path = path
+        self.instrumentationType = instrumentationType
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -102,7 +102,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
             // proccss(command:context:writer) returned false, so the scope will be deallocated at the end of
             // this execution context. End the "RUM Session Ended" metric:
-            defer { dependencies.sessionEndedMetric.endMetric(sessionID: scope.sessionUUID) }
+            defer { dependencies.sessionEndedMetric.endMetric(sessionID: scope.sessionUUID, with: context) }
 
             // proccss(command:context:writer) returned false, but if the scope is still active
             // it means the session reached one of the end reasons

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -325,12 +325,14 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 // As no view scope will handle this command, warn the user on dropping it.
                 DD.logger.warn(
                 """
-                \(String(describing: command)) was detected, but no view is active. To track views automatically, try calling the
-                DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
-                the RumMonitor.startView() and RumMonitor.stopView() methods.
+                \(String(describing: command)) was detected, but no view is active. To track views automatically, configure
+                `RUM.Configuration.uiKitViewsPredicate` or use `.trackRUMView()` modifier in SwiftUI. You can also track views manually
+                with `RUMMonitor.shared().startView()` and `RUMMonitor.shared().stopView()`.
                 """
                 )
             }
+
+            _ = dependencies.sessionEndedMetric // TODO: RUM-1660 pass the command to SE metric for tracking off-view events
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -110,7 +110,6 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             precondition: startPrecondition,
             context: context,
             tracksBackgroundEvents: trackBackgroundEvents
-            // TODO: RUM-4591 pass NTP offset at session start to SE metric
         )
 
         if let viewScope = resumingViewScope {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -109,6 +109,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             sessionID: sessionUUID,
             precondition: startPrecondition,
             context: context
+            // TODO: RUM-4591 pass `trackBackgroundEvents` to SE metric
+            // TODO: RUM-4591 pass NTP offset at session start to SE metric
         )
 
         if let viewScope = resumingViewScope {
@@ -330,9 +332,9 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 with `RUMMonitor.shared().startView()` and `RUMMonitor.shared().stopView()`.
                 """
                 )
-            }
 
-            _ = dependencies.sessionEndedMetric // TODO: RUM-1660 pass the command to SE metric for tracking off-view events
+                _ = dependencies.sessionEndedMetric // TODO: RUM-4591 pass the command to SE metric for tracking off-view events
+            }
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -108,8 +108,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         dependencies.sessionEndedMetric.startMetric(
             sessionID: sessionUUID,
             precondition: startPrecondition,
-            context: context
-            // TODO: RUM-4591 pass `trackBackgroundEvents` to SE metric
+            context: context,
+            tracksBackgroundEvents: trackBackgroundEvents
             // TODO: RUM-4591 pass NTP offset at session start to SE metric
         )
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -556,6 +556,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = event
 
             // Track this view in Session Ended metric:
+            _ = (command as? RUMStartViewCommand)?.instrumentationType // TODO: RUM-1660 pass instrumentation type to SE metric
             dependencies.sessionEndedMetric.track(view: event, in: self.context.sessionID)
         } else { // if event was dropped by mapper
             version -= 1

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -556,7 +556,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = event
 
             // Track this view in Session Ended metric:
-            _ = (command as? RUMStartViewCommand)?.instrumentationType // TODO: RUM-1660 pass instrumentation type to SE metric
+            _ = (command as? RUMStartViewCommand)?.instrumentationType // TODO: RUM-4591 pass instrumentation type to SE metric
             dependencies.sessionEndedMetric.track(view: event, in: self.context.sessionID)
         } else { // if event was dropped by mapper
             version -= 1

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -556,8 +556,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = event
 
             // Track this view in Session Ended metric:
-            _ = (command as? RUMStartViewCommand)?.instrumentationType // TODO: RUM-4591 pass instrumentation type to SE metric
-            dependencies.sessionEndedMetric.track(view: event, in: self.context.sessionID)
+            dependencies.sessionEndedMetric.track(
+                view: event,
+                instrumentationType: (command as? RUMStartViewCommand)?.instrumentationType,
+                in: self.context.sessionID
+            )
         } else { // if event was dropped by mapper
             version -= 1
         }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -81,9 +81,11 @@ internal struct SessionEndedMetric {
     /// Indicates if the session was stopped through `stopSession()` API.
     private var wasStopped = false
 
+    /// If `RUM.Configuration.trackBackgroundEvents` was enabled for this session.
+    private let tracksBackgroundEvents: Bool
+
     // TODO: RUM-4591 Track diagnostic attributes:
     // - no_view_events_count
-    // - has_background_events_tracking_enabled
     // - has_replay
     // - ntp_offset
 
@@ -94,14 +96,17 @@ internal struct SessionEndedMetric {
     ///   - sessionID: An ID of the session that is being tracked with this metric.
     ///   - precondition: The precondition that led to starting this session.
     ///   - context: The SDK context at the moment of starting this session.
+    ///   - tracksBackgroundEvents: If background events tracking is enabled for this session.
     init(
         sessionID: RUMUUID,
         precondition: RUMSessionPrecondition?,
-        context: DatadogContext
+        context: DatadogContext,
+        tracksBackgroundEvents: Bool
     ) {
         self.sessionID = sessionID
         self.bundleType = context.applicationBundleType
         self.precondition = precondition
+        self.tracksBackgroundEvents = tracksBackgroundEvents
     }
 
     /// Tracks the view event that occurred during the session.
@@ -165,6 +170,8 @@ internal struct SessionEndedMetric {
         let duration: Int64?
         /// Indicates if the session was stopped through `stopSession()` API.
         let wasStopped: Bool
+        /// If background events tracking is enabled for this session.
+        let hasBackgroundEventsTrackingEnabled: Bool
 
         struct ViewsCount: Encodable {
             /// The number of distinct views (view UUIDs) sent during this session.
@@ -207,6 +214,7 @@ internal struct SessionEndedMetric {
             case precondition
             case duration
             case wasStopped = "was_stopped"
+            case hasBackgroundEventsTrackingEnabled = "has_background_events_tracking_enabled"
             case viewsCount = "views_count"
             case sdkErrorsCount = "sdk_errors_count"
         }
@@ -249,6 +257,7 @@ internal struct SessionEndedMetric {
                 precondition: precondition?.rawValue,
                 duration: durationNs,
                 wasStopped: wasStopped,
+                hasBackgroundEventsTrackingEnabled: tracksBackgroundEvents,
                 viewsCount: .init(
                     total: totalViewsCount,
                     background: backgroundViewsCount,

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -35,6 +35,12 @@ internal struct SessionEndedMetric {
         static let rseKey = "rse"
     }
 
+    internal enum ViewInstrumentationType: String {
+        case manual
+        case uikit
+        case swiftui
+    }
+
     /// An ID of the session being tracked through this metric object.
     let sessionID: RUMUUID
 

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -116,6 +116,8 @@ internal struct SessionEndedMetric {
             firstTrackedView = info
         }
         lastTrackedView = info
+
+        _ = view.session.hasReplay // TODO: RUM-4591 track replay information
     }
 
     /// Tracks the kind of SDK error that occurred during the session.

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -80,11 +80,11 @@ internal final class SessionEndedMetricController {
     /// Ends the metric for a given session, sending it to telemetry and removing it from pending metrics.
     /// - Parameter sessionID: The ID of the session to end the metric for.
     func endMetric(sessionID: RUMUUID, with context: DatadogContext) {
-        guard let metric = metricsBySessionID[sessionID] else {
-            return
-        }
-        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes(with: context))
         _metricsBySessionID.mutate { metrics in
+            guard let metric = metrics[sessionID] else {
+                return
+            }
+            telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes(with: context))
             metrics[sessionID] = nil
             pendingSessionIDs.removeAll(where: { $0 == sessionID }) // O(n), but "ending the metric" is very rare event
         }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -62,7 +62,7 @@ internal final class SessionEndedMetricController {
     func track(sdkErrorKind: String, in sessionID: RUMUUID?) {
         updateMetric(for: sessionID) { $0?.track(sdkErrorKind: sdkErrorKind) }
     }
-    
+
     /// Tracks an event missed due to absence of an active view.
     /// - Parameters:
     ///   - missedEventType: the type of an event that was missed

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -29,13 +29,14 @@ internal final class SessionEndedMetricController {
     ///   - sessionID: The ID of the session to track.
     ///   - precondition: The precondition that led to starting this session.
     ///   - context: The SDK context at the moment of starting this session.
+    ///   - tracksBackgroundEvents: If background events tracking is enabled for this session.
     /// - Returns: The newly created `SessionEndedMetric` instance.
-    func startMetric(sessionID: RUMUUID, precondition: RUMSessionPrecondition?, context: DatadogContext) {
+    func startMetric(sessionID: RUMUUID, precondition: RUMSessionPrecondition?, context: DatadogContext, tracksBackgroundEvents: Bool) {
         guard sessionID != RUMUUID.nullUUID else {
             return // do not track metric when session is not sampled
         }
         _metricsBySessionID.mutate { metrics in
-            metrics[sessionID] = SessionEndedMetric(sessionID: sessionID, precondition: precondition, context: context)
+            metrics[sessionID] = SessionEndedMetric(sessionID: sessionID, precondition: precondition, context: context, tracksBackgroundEvents: tracksBackgroundEvents)
             pendingSessionIDs.append(sessionID)
         }
     }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -43,9 +43,15 @@ internal final class SessionEndedMetricController {
     /// Tracks the view event that occurred during the session.
     /// - Parameters:
     ///   - view: the view event to track
+    ///   - instrumentationType: the type of instrumentation used to start this view (only the first value for each `view.id` is tracked; succeeding values
+    ///   will be ignored so it is okay to pass value on first call and then follow with `nil` for next updates of given `view.id`)
     ///   - sessionID: session ID to track this view in (pass `nil` to track it for the last started session)
-    func track(view: RUMViewEvent, in sessionID: RUMUUID?) {
-        updateMetric(for: sessionID) { try $0?.track(view: view) }
+    func track(
+        view: RUMViewEvent,
+        instrumentationType: SessionEndedMetric.ViewInstrumentationType?,
+        in sessionID: RUMUUID?
+    ) {
+        updateMetric(for: sessionID) { try $0?.track(view: view, instrumentationType: instrumentationType) }
     }
 
     /// Tracks the kind of SDK error that occurred during the session.

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -62,6 +62,14 @@ internal final class SessionEndedMetricController {
     func track(sdkErrorKind: String, in sessionID: RUMUUID?) {
         updateMetric(for: sessionID) { $0?.track(sdkErrorKind: sdkErrorKind) }
     }
+    
+    /// Tracks an event missed due to absence of an active view.
+    /// - Parameters:
+    ///   - missedEventType: the type of an event that was missed
+    ///   - sessionID: session ID to track this error in (pass `nil` to track it for the last started session)
+    func track(missedEventType: SessionEndedMetric.MissedEventType, in sessionID: RUMUUID?) {
+        updateMetric(for: sessionID) { $0?.track(missedEventType: missedEventType) }
+    }
 
     /// Signals that the session was stopped with `stopSession()` API.
     /// - Parameter sessionID: session ID to mark as stopped (pass `nil` to track it for the last started session)

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -71,11 +71,11 @@ internal final class SessionEndedMetricController {
 
     /// Ends the metric for a given session, sending it to telemetry and removing it from pending metrics.
     /// - Parameter sessionID: The ID of the session to end the metric for.
-    func endMetric(sessionID: RUMUUID) {
+    func endMetric(sessionID: RUMUUID, with context: DatadogContext) {
         guard let metric = metricsBySessionID[sessionID] else {
             return
         }
-        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes()) // TODO: RUM-4591 track NTP offset at session end
+        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes(with: context))
         _metricsBySessionID.mutate { metrics in
             metrics[sessionID] = nil
             pendingSessionIDs.removeAll(where: { $0 == sessionID }) // O(n), but "ending the metric" is very rare event

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -68,7 +68,7 @@ internal final class SessionEndedMetricController {
         guard let metric = metricsBySessionID[sessionID] else {
             return
         }
-        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes())
+        telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes()) // TODO: RUM-4591 track NTP offset at session end
         _metricsBySessionID.mutate { metrics in
             metrics[sessionID] = nil
             pendingSessionIDs.removeAll(where: { $0 == sessionID }) // O(n), but "ending the metric" is very rare event

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -20,7 +20,7 @@ class TelemetryInterceptorTests: XCTestCase {
         let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
 
         // When
-        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny())
+        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny(), tracksBackgroundEvents: .mockRandom())
         let errorTelemetry: TelemetryMessage = .error(id: .mockAny(), message: .mockAny(), kind: .mockAny(), stack: .mockAny())
         let result = interceptor.receive(message: .telemetry(errorTelemetry), from: NOPDatadogCore())
         XCTAssertFalse(result)

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -26,7 +26,7 @@ class TelemetryInterceptorTests: XCTestCase {
         XCTAssertFalse(result)
 
         // Then
-        metricController.endMetric(sessionID: sessionID)
+        metricController.endMetric(sessionID: sessionID, with: .mockRandom())
         let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
         let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
         XCTAssertEqual(rse.sdkErrorsCount.total, 1)

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -137,7 +137,8 @@ extension RUMViewEvent: RandomMockable {
         viewIsActive: Bool? = .random(),
         viewTimeSpent: Int64 = .mockRandom(),
         viewURL: String = .mockRandom(),
-        crashCount: Int64? = nil
+        crashCount: Int64? = nil,
+        hasReplay: Bool? = nil
     ) -> RUMViewEvent {
         return RUMViewEvent(
             dd: .init(
@@ -165,7 +166,7 @@ extension RUMViewEvent: RandomMockable {
             privacy: nil,
             service: .mockRandom(),
             session: .init(
-                hasReplay: nil,
+                hasReplay: hasReplay,
                 id: sessionID.toRUMDataFormat,
                 isActive: true,
                 sampledForReplay: nil,

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -218,14 +218,16 @@ extension RUMStartViewCommand: AnyMockable, RandomMockable {
         attributes: [AttributeKey: AttributeValue] = [:],
         identity: ViewIdentifier = .mockViewIdentifier(),
         name: String = .mockAny(),
-        path: String = .mockAny()
+        path: String = .mockAny(),
+        instrumentationType: SessionEndedMetric.ViewInstrumentationType = .manual
     ) -> RUMStartViewCommand {
         return RUMStartViewCommand(
             time: time,
             identity: identity,
             name: name,
             path: path,
-            attributes: attributes
+            attributes: attributes,
+            instrumentationType: instrumentationType
         )
     }
 }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -147,6 +147,7 @@ struct RUMCommandMock: RUMCommand {
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
     var isUserInteraction = false
+    var missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
 
 /// Creates random `RUMCommand` from available ones.

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -623,9 +623,9 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertEqual(
             randomCommandLog,
             """
-            \(String(describing: randomCommand)) was detected, but no view is active. To track views automatically, try calling the
-            DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
-            the RumMonitor.startView() and RumMonitor.stopView() methods.
+            \(String(describing: randomCommand)) was detected, but no view is active. To track views automatically, configure
+            `RUM.Configuration.uiKitViewsPredicate` or use `.trackRUMView()` modifier in SwiftUI. You can also track views manually
+            with `RUMMonitor.shared().startView()` and `RUMMonitor.shared().stopView()`.
             """
         )
 

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -22,7 +22,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
 
         // When
-        viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), in: sessionID) }
+        viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil, in: sessionID) }
         errorKinds.forEach { controller.track(sdkErrorKind: $0, in: sessionID) }
         controller.trackWasStopped(sessionID: sessionID)
         controller.endMetric(sessionID: sessionID)
@@ -43,7 +43,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
         // Session 1:
-        controller.track(view: .mockRandomWith(sessionID: sessionID1), in: sessionID1)
+        controller.track(view: .mockRandomWith(sessionID: sessionID1), instrumentationType: nil, in: sessionID1)
         controller.track(sdkErrorKind: "error.kind1", in: sessionID1)
         controller.trackWasStopped(sessionID: sessionID1)
         // Session 2:
@@ -75,7 +75,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
         // Track latest session (`sessionID: nil`)
-        controller.track(view: .mockRandomWith(sessionID: sessionID2), in: nil)
+        controller.track(view: .mockRandomWith(sessionID: sessionID2), instrumentationType: nil, in: nil)
         controller.track(sdkErrorKind: "error.kind1", in: nil)
         controller.trackWasStopped(sessionID: nil)
         // Send 2nd:
@@ -100,10 +100,10 @@ class SessionEndedMetricControllerTests: XCTestCase {
                 { controller.startMetric(
                     sessionID: sessionIDs.randomElement()!, precondition: .mockRandom(), context: .mockRandom()
                 ) },
-                { controller.track(view: .mockRandom(), in: sessionIDs.randomElement()!) },
+                { controller.track(view: .mockRandom(), instrumentationType: nil, in: sessionIDs.randomElement()!) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: sessionIDs.randomElement()!) },
                 { controller.trackWasStopped(sessionID: sessionIDs.randomElement()!) },
-                { controller.track(view: .mockRandom(), in: nil) },
+                { controller.track(view: .mockRandom(), instrumentationType: nil, in: nil) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: nil) },
                 { controller.trackWasStopped(sessionID: nil) },
                 { controller.endMetric(sessionID: sessionIDs.randomElement()!) },

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -24,6 +24,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         // When
         viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil, in: sessionID) }
         errorKinds.forEach { controller.track(sdkErrorKind: $0, in: sessionID) }
+        controller.track(missedEventType: .action, in: sessionID)
         controller.trackWasStopped(sessionID: sessionID)
         controller.endMetric(sessionID: sessionID, with: .mockRandom())
 
@@ -31,6 +32,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let metric = try XCTUnwrap(telemetry.messages.lastSessionEndedMetric)
         XCTAssertEqual(metric.viewsCount.total, viewIDs.count)
         XCTAssertEqual(metric.sdkErrorsCount.total, errorKinds.count)
+        XCTAssertEqual(metric.noViewEventsCount.actions, 1)
         XCTAssertEqual(metric.wasStopped, true)
     }
 
@@ -77,6 +79,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         // Track latest session (`sessionID: nil`)
         controller.track(view: .mockRandomWith(sessionID: sessionID2), instrumentationType: nil, in: nil)
         controller.track(sdkErrorKind: "error.kind1", in: nil)
+        controller.track(missedEventType: .resource, in: nil)
         controller.trackWasStopped(sessionID: nil)
         // Send 2nd:
         controller.endMetric(sessionID: sessionID2, with: .mockRandom())
@@ -85,6 +88,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         // Then
         XCTAssertEqual(metric.viewsCount.total, 1)
         XCTAssertEqual(metric.sdkErrorsCount.total, 1)
+        XCTAssertEqual(metric.noViewEventsCount.resources, 1)
         XCTAssertEqual(metric.wasStopped, true)
     }
 
@@ -105,6 +109,8 @@ class SessionEndedMetricControllerTests: XCTestCase {
                 { controller.trackWasStopped(sessionID: sessionIDs.randomElement()!) },
                 { controller.track(view: .mockRandom(), instrumentationType: nil, in: nil) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: nil) },
+                { controller.track(missedEventType: .action, in: sessionIDs.randomElement()!) },
+                { controller.track(missedEventType: .resource, in: nil) },
                 { controller.trackWasStopped(sessionID: nil) },
                 { controller.endMetric(sessionID: sessionIDs.randomElement()!, with: .mockRandom()) },
             ],

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -19,7 +19,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
 
         // Given
         let controller = SessionEndedMetricController(telemetry: telemetry)
-        controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom())
+        controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
 
         // When
         viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil, in: sessionID) }
@@ -40,8 +40,8 @@ class SessionEndedMetricControllerTests: XCTestCase {
 
         // When
         let controller = SessionEndedMetricController(telemetry: telemetry)
-        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
-        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
+        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
+        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Session 1:
         controller.track(view: .mockRandomWith(sessionID: sessionID1), instrumentationType: nil, in: sessionID1)
         controller.track(sdkErrorKind: "error.kind1", in: sessionID1)
@@ -72,8 +72,8 @@ class SessionEndedMetricControllerTests: XCTestCase {
 
         // When
         let controller = SessionEndedMetricController(telemetry: telemetry)
-        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom())
-        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom())
+        controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
+        controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Track latest session (`sessionID: nil`)
         controller.track(view: .mockRandomWith(sessionID: sessionID2), instrumentationType: nil, in: nil)
         controller.track(sdkErrorKind: "error.kind1", in: nil)
@@ -98,7 +98,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         callConcurrently(
             closures: [
                 { controller.startMetric(
-                    sessionID: sessionIDs.randomElement()!, precondition: .mockRandom(), context: .mockRandom()
+                    sessionID: sessionIDs.randomElement()!, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom()
                 ) },
                 { controller.track(view: .mockRandom(), instrumentationType: nil, in: sessionIDs.randomElement()!) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: sessionIDs.randomElement()!) },

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -25,7 +25,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil, in: sessionID) }
         errorKinds.forEach { controller.track(sdkErrorKind: $0, in: sessionID) }
         controller.trackWasStopped(sessionID: sessionID)
-        controller.endMetric(sessionID: sessionID)
+        controller.endMetric(sessionID: sessionID, with: .mockRandom())
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.lastSessionEndedMetric)
@@ -49,9 +49,9 @@ class SessionEndedMetricControllerTests: XCTestCase {
         // Session 2:
         controller.track(sdkErrorKind: "error.kind2", in: sessionID2)
         // Send 1st and 2nd:
-        controller.endMetric(sessionID: sessionID1)
+        controller.endMetric(sessionID: sessionID1, with: .mockRandom())
         let metric1 = try XCTUnwrap(telemetry.messages.lastSessionEndedMetric)
-        controller.endMetric(sessionID: sessionID2)
+        controller.endMetric(sessionID: sessionID2, with: .mockRandom())
         let metric2 = try XCTUnwrap(telemetry.messages.lastSessionEndedMetric)
 
         // Then
@@ -79,7 +79,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.track(sdkErrorKind: "error.kind1", in: nil)
         controller.trackWasStopped(sessionID: nil)
         // Send 2nd:
-        controller.endMetric(sessionID: sessionID2)
+        controller.endMetric(sessionID: sessionID2, with: .mockRandom())
         let metric = try XCTUnwrap(telemetry.messages.lastSessionEndedMetric)
 
         // Then
@@ -106,7 +106,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
                 { controller.track(view: .mockRandom(), instrumentationType: nil, in: nil) },
                 { controller.track(sdkErrorKind: .mockRandom(), in: nil) },
                 { controller.trackWasStopped(sessionID: nil) },
-                { controller.endMetric(sessionID: sessionIDs.randomElement()!) },
+                { controller.endMetric(sessionID: sessionIDs.randomElement()!, with: .mockRandom()) },
             ],
             iterations: 100
         )

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -117,7 +117,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromSingleView() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
         let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID)
 
         // When
@@ -131,7 +131,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromMultipleViews() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
         let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
         let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
         let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
@@ -149,7 +149,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testComputingDurationFromOverlappingViews() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
         let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
         let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
 
@@ -165,7 +165,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testDurationIsAlwaysComputedFromTheFirstAndLastView() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
         let firstView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms, viewTimeSpent: 10.s2ns)
         let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
 
@@ -182,7 +182,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testWhenComputingDuration_itIgnoresViewsFromDifferentSession() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         XCTAssertThrowsError(try metric.track(view: .mockRandom(), instrumentationType: nil))
@@ -198,7 +198,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testReportingSessionThatWasStopped() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         metric.trackWasStopped()
@@ -245,7 +245,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs: Set<String> = .mockRandom(count: .mockRandom(min: 1, max: 10))
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try viewIDs.forEach { try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil) }
@@ -261,7 +261,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewID2: String = .mockRandom(otherThan: [viewID1])
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try (0..<5).forEach { _ in // repeat few times
@@ -281,7 +281,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs = backgroundViewIDs.union(otherViewIDs)
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try viewIDs.forEach { viewID in
@@ -301,7 +301,7 @@ class SessionEndedMetricTests: XCTestCase {
         let viewIDs = appLaunchViewIDs.union(otherViewIDs)
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try viewIDs.forEach { viewID in
@@ -322,7 +322,7 @@ class SessionEndedMetricTests: XCTestCase {
         let unknownViewsCount: Int = .mockRandom(min: 1, max: 10)
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try (0..<manualViewsCount).forEach { idx in
@@ -354,7 +354,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testWhenReportingViewsCountByInstrumentationType_itIgnoresSuccedingInstrumentationTypesForGivenViewID() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "view-id"), instrumentationType: .manual)
 
         // When
@@ -370,7 +370,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testReportingHasReplayViewsCount() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "1", hasReplay: nil), instrumentationType: nil)
@@ -389,7 +389,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testWhenReportingViewsCount_itIgnoresViewsFromDifferentSession() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         XCTAssertThrowsError(try metric.track(view: .mockRandom(), instrumentationType: nil))
@@ -408,7 +408,7 @@ class SessionEndedMetricTests: XCTestCase {
         let repetitions = 5
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         (0..<repetitions).forEach { _ in
@@ -428,7 +428,7 @@ class SessionEndedMetricTests: XCTestCase {
         ]
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         errorKinds.forEach { kind, count in
@@ -450,7 +450,7 @@ class SessionEndedMetricTests: XCTestCase {
         ]
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         errorKinds.forEach { kind, count in
@@ -475,7 +475,7 @@ class SessionEndedMetricTests: XCTestCase {
         let missedLongTasksCount: Int = .mockRandom(min: 1, max: 10)
 
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID)
+        let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
         (0..<missedActionsCount).forEach { _ in metric.track(missedEventType: .action) }
@@ -496,7 +496,7 @@ class SessionEndedMetricTests: XCTestCase {
 
     func testEncodedMetricAttributesFollowTheSpec() throws {
         // Given
-        var metric = SessionEndedMetric.with(sessionID: sessionID, context: .mockWith(applicationBundleType: .iOSApp))
+        let metric = SessionEndedMetric.with(sessionID: sessionID, context: .mockWith(applicationBundleType: .iOSApp))
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .manual)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .swiftui)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .uikit)

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -466,6 +466,32 @@ class SessionEndedMetricTests: XCTestCase {
         )
     }
 
+    // MARK: - No View Events Count
+
+    func testReportingMissedEventsCount() throws {
+        let missedActionsCount: Int = .mockRandom(min: 1, max: 10)
+        let missedResourcesCount: Int = .mockRandom(min: 1, max: 10)
+        let missedErrorsCount: Int = .mockRandom(min: 1, max: 10)
+        let missedLongTasksCount: Int = .mockRandom(min: 1, max: 10)
+
+        // Given
+        var metric = SessionEndedMetric.with(sessionID: sessionID)
+
+        // When
+        (0..<missedActionsCount).forEach { _ in metric.track(missedEventType: .action) }
+        (0..<missedResourcesCount).forEach { _ in metric.track(missedEventType: .resource) }
+        (0..<missedErrorsCount).forEach { _ in metric.track(missedEventType: .error) }
+        (0..<missedLongTasksCount).forEach { _ in metric.track(missedEventType: .longTask) }
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
+        XCTAssertEqual(rse.noViewEventsCount.actions, missedActionsCount)
+        XCTAssertEqual(rse.noViewEventsCount.resources, missedResourcesCount)
+        XCTAssertEqual(rse.noViewEventsCount.errors, missedErrorsCount)
+        XCTAssertEqual(rse.noViewEventsCount.longTasks, missedLongTasksCount)
+    }
+
     // MARK: - Metric Spec
 
     func testEncodedMetricAttributesFollowTheSpec() throws {
@@ -495,6 +521,10 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertNotNil(try matcher.value("rse.sdk_errors_count.by_kind") as [String: Int])
         XCTAssertNotNil(try matcher.value("rse.ntp_offset.at_start") as Int)
         XCTAssertNotNil(try matcher.value("rse.ntp_offset.at_end") as Int)
+        XCTAssertNotNil(try matcher.value("rse.no_view_events_count.actions") as Int)
+        XCTAssertNotNil(try matcher.value("rse.no_view_events_count.resources") as Int)
+        XCTAssertNotNil(try matcher.value("rse.no_view_events_count.errors") as Int)
+        XCTAssertNotNil(try matcher.value("rse.no_view_events_count.long_tasks") as Int)
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 🔭 According to [the spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3663167927/RUM+Session+Ended+Telemetry+-+Spec) (internal), this PR adds "diagnostic attributes" to "RUM Session Ended" telemetry.

This is a follow-up on https://github.com/DataDog/dd-sdk-ios/pull/1866 where we implemented a handset of "quality attributes".

### How?

The list of added attributes:
#### `rse.has_background_events_tracking_enabled`
Indicates whether [tracking of background events](https://github.com/DataDog/dd-sdk-ios/blob/888d39fc5407e01b72deab78451be689232b3342/DatadogRUM/Sources/RUMConfiguration.swift#L105-L112) was enabled in the RUM configuration.


#### `rse.views_count.by_instrumentation`
Holds the map of instrumentation type to the number of distinct views (view UUIDs) tracked through it (`manual` | `swiftui` | `uikit`).

#### `rse.views_count.with_has_replay`
The number of views with `has_replay == true`.

#### `rse.ntp_offset`
The NTP offset at the beginning and end of the session.

#### `rse.no_view_events_count`
The number of events (`actions` | `resources` | `errors` | `long_tasks`) dropped because there was no active view at the time they occurred.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
