### PR TITLE
Allow disabling app hang monitoring in ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Allow disabling app hang monitoring in ObjC API. See [#1908][]
+
 # 2.13.0 / 13-06-2024
 
 - [IMPROVEMENT] Bump `IPHONEOS_DEPLOYMENT_TARGET` and `TVOS_DEPLOYMENT_TARGET` from 11 to 12. See [#1891][]
@@ -684,6 +686,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1835]: https://github.com/DataDog/dd-sdk-ios/pull/1835
 [#1886]: https://github.com/DataDog/dd-sdk-ios/pull/1886
 [#1898]: https://github.com/DataDog/dd-sdk-ios/pull/1898
+[#1908]: https://github.com/DataDog/dd-sdk-ios/pull/1908
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
@@ -107,10 +107,16 @@ class DDRUMConfigurationTests: XCTestCase {
     }
 
     func testAppHangThreshold() {
-        let random: TimeInterval = .mockRandom()
+        let random: TimeInterval = .mockRandom(min: 0.01, max: .greatestFiniteMagnitude)
         objc.appHangThreshold = random
         XCTAssertEqual(objc.appHangThreshold, random)
         XCTAssertEqual(swift.appHangThreshold, random)
+    }
+
+    func testAppHangThresholdDisable() {
+        objc.appHangThreshold = 0
+        XCTAssertEqual(objc.appHangThreshold, 0)
+        XCTAssertEqual(swift.appHangThreshold, nil)
     }
 
     func testVitalsUpdateFrequency() {

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -378,7 +378,7 @@ public class DDRUMConfiguration: NSObject {
     }
 
     @objc public var appHangThreshold: TimeInterval {
-        set { swiftConfig.appHangThreshold = newValue }
+        set { swiftConfig.appHangThreshold = newValue == 0 ? nil : newValue }
         get { swiftConfig.appHangThreshold ?? 0 }
     }
 


### PR DESCRIPTION
### What and why?

Unlike long tasks tracking, app hang monitoring can be disabled. This PR treats 0 passed as an argument in ObjC API as a special value to disable app hang monitoring (to avoid changing property type to the optional).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
