### PR TITLE
RUM-4911 feat(watchdog-termination): setup trackWatchdogTermination configuration

### DIFF
--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -80,7 +80,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
                     }
                 ),
                 trackBackgroundEvents: true,
-                trackWatchdogTermination: true,
+                trackWatchdogTerminations: true,
                 customEndpoint: Environment.readCustomRUMURL(),
                 telemetrySampleRate: 100
             )

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -77,8 +77,10 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
                     resourceAttributesProvider: { req, resp, data, err in
                         print("⭐️ [Attributes Provider] data: \(String(describing: data))")
                         return [:]
-            }),
+                    }
+                ),
                 trackBackgroundEvents: true,
+                trackWatchdogTermination: true,
                 customEndpoint: Environment.readCustomRUMURL(),
                 telemetrySampleRate: 100
             )

--- a/DatadogCrashReporting/Sources/CrashReportingFeature.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingFeature.swift
@@ -59,8 +59,7 @@ internal final class CrashReportingFeature: DatadogFeature {
             self.plugin.readPendingCrashReport { [weak self] crashReport in
                 guard let self = self, let availableCrashReport = crashReport else {
                     DD.logger.debug("No pending Crash found")
-                    // TODO: RUM-4911 enable after `WatchdogTerminationReporter` is implemented.
-                    // self?.sender.send(launch: .init(didCrash: false))
+                     self?.sender.send(launch: .init(didCrash: false))
                     return false
                 }
 
@@ -69,12 +68,12 @@ internal final class CrashReportingFeature: DatadogFeature {
                 guard let crashContext = availableCrashReport.context.flatMap({ self.decode(crashContextData: $0) }) else {
                     // `CrashContext` is malformed and and cannot be read. Return `true` to let the crash reporter
                     // purge this crash report as we are not able to process it respectively.
+                    self.sender.send(launch: .init(didCrash: true))
                     return true
                 }
 
                 self.sender.send(report: availableCrashReport, with: crashContext)
-                // TODO: RUM-4911 enable after `WatchdogTerminationReporter` is implemented.
-                // self.sender.send(launch: .init(didCrash: true))
+                self.sender.send(launch: .init(didCrash: true))
                 return true
             }
         }

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -372,6 +372,11 @@ public class DDRUMConfiguration: NSObject {
         get { swiftConfig.trackBackgroundEvents }
     }
 
+    @objc public var trackWatchdogTerminations: Bool {
+        set { swiftConfig.trackWatchdogTerminations = newValue }
+        get { swiftConfig.trackWatchdogTerminations }
+    }
+
     @objc public var longTaskThreshold: TimeInterval {
         set { swiftConfig.longTaskThreshold = newValue }
         get { swiftConfig.longTaskThreshold ?? 0 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -40,7 +40,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
         var watchdogTermination: WatchdogTerminationMonitor?
         var watchdogTerminationAppStateManager: WatchdogTerminationAppStateManager?
-        if configuration.trackWatchdogTermination {
+        if configuration.trackWatchdogTerminations {
             let appStateManager = WatchdogTerminationAppStateManager(
                 featureScope: featureScope,
                 processId: configuration.processID

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -53,7 +53,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         backtraceReporter: BacktraceReporting,
         fatalErrorContext: FatalErrorContextNotifying,
         processID: UUID,
-        watchdogTermination: WatchdogTerminationMonitor
+        watchdogTermination: WatchdogTerminationMonitor?
     ) {
         // Always create views handler (we can't know if it will be used by SwiftUI instrumentation)
         // and only swizzle `UIViewController` if UIKit instrumentation is configured:

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -19,18 +19,18 @@ internal final class WatchdogTerminationMonitor {
 
     let checker: WatchdogTerminationChecker
     let appStateManager: WatchdogTerminationAppStateManager
-    let telemetry: Telemetry
+    let feature: FeatureScope
     let reporter: WatchdogTerminationReporting
 
     init(
         appStateManager: WatchdogTerminationAppStateManager,
         checker: WatchdogTerminationChecker,
-        reporter: WatchdogTerminationReporting,
-        telemetry: Telemetry
+        feature: FeatureScope,
+        reporter: WatchdogTerminationReporting
     ) {
         self.checker = checker
         self.appStateManager = appStateManager
-        self.telemetry = telemetry
+        self.feature = feature
         self.reporter = reporter
     }
 
@@ -45,7 +45,7 @@ internal final class WatchdogTerminationMonitor {
             try appStateManager.start()
         } catch let error {
             DD.logger.error(ErrorMessages.failedToStartAppState, error: error)
-            telemetry.error(ErrorMessages.failedToStartAppState, error: error)
+            feature.telemetry.error(ErrorMessages.failedToStartAppState, error: error)
         }
     }
 
@@ -63,7 +63,7 @@ internal final class WatchdogTerminationMonitor {
             }
         } catch let error {
             DD.logger.error(ErrorMessages.failedToCheckWatchdogTermination, error: error)
-            telemetry.error(ErrorMessages.failedToCheckWatchdogTermination, error: error)
+            feature.telemetry.error(ErrorMessages.failedToCheckWatchdogTermination, error: error)
         }
     }
 
@@ -73,7 +73,7 @@ internal final class WatchdogTerminationMonitor {
             try appStateManager.stop()
         } catch {
             DD.logger.error(ErrorMessages.failedToStopAppState, error: error)
-            telemetry.error(ErrorMessages.failedToStopAppState, error: error)
+            feature.telemetry.error(ErrorMessages.failedToStopAppState, error: error)
         }
     }
 }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -111,6 +111,13 @@ extension RUM {
         /// Default: `false`.
         public var trackBackgroundEvents: Bool
 
+        /// Determines whether the SDK should track application termination by the watchdog.
+        ///
+        /// Read more about watchdog terminations at https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations
+        ///
+        /// Default: `false`.
+        public var trackWatchdogTermination: Bool
+
         /// Enables RUM long tasks tracking with the given threshold (in seconds).
         ///
         /// Any operation on the main thread that exceeds this threshold will be reported as a RUM long task.
@@ -339,6 +346,7 @@ extension RUM.Configuration {
     ///   - trackBackgroundEvents: Determines whether RUM events should be tracked when no view is active. Default: `false`.
     ///   - longTaskThreshold: The threshold for RUM long tasks tracking (in seconds). Default: `0.1`.
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
+    ///   - trackWatchdogTermination: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
@@ -358,6 +366,7 @@ extension RUM.Configuration {
         trackBackgroundEvents: Bool = false,
         longTaskThreshold: TimeInterval? = 0.1,
         appHangThreshold: TimeInterval? = nil,
+        trackWatchdogTermination: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
@@ -386,6 +395,7 @@ extension RUM.Configuration {
         self.onSessionStart = onSessionStart
         self.customEndpoint = customEndpoint
         self.telemetrySampleRate = telemetrySampleRate
+        self.trackWatchdogTermination = trackWatchdogTermination
     }
 }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -116,7 +116,7 @@ extension RUM {
         /// Read more about watchdog terminations at https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations
         ///
         /// Default: `false`.
-        public var trackWatchdogTermination: Bool
+        public var trackWatchdogTerminations: Bool
 
         /// Enables RUM long tasks tracking with the given threshold (in seconds).
         ///
@@ -346,7 +346,7 @@ extension RUM.Configuration {
     ///   - trackBackgroundEvents: Determines whether RUM events should be tracked when no view is active. Default: `false`.
     ///   - longTaskThreshold: The threshold for RUM long tasks tracking (in seconds). Default: `0.1`.
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
-    ///   - trackWatchdogTermination: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
+    ///   - trackWatchdogTerminations: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
@@ -366,7 +366,7 @@ extension RUM.Configuration {
         trackBackgroundEvents: Bool = false,
         longTaskThreshold: TimeInterval? = 0.1,
         appHangThreshold: TimeInterval? = nil,
-        trackWatchdogTermination: Bool = false,
+        trackWatchdogTerminations: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
@@ -395,7 +395,7 @@ extension RUM.Configuration {
         self.onSessionStart = onSessionStart
         self.customEndpoint = customEndpoint
         self.telemetrySampleRate = telemetrySampleRate
-        self.trackWatchdogTermination = trackWatchdogTermination
+        self.trackWatchdogTerminations = trackWatchdogTerminations
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
@@ -90,8 +90,8 @@ extension WatchdogTerminationMonitor: RandomMockable {
         return .init(
             appStateManager: .mockRandom(),
             checker: .mockRandom(),
-            reporter: WatchdogTerminationReporter.mockRandom(),
-            telemetry: NOPTelemetry()
+            feature: FeatureScopeMock(),
+            reporter: WatchdogTerminationReporter.mockRandom()
         )
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -91,8 +91,8 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut = WatchdogTerminationMonitor(
             appStateManager: appStateManager,
             checker: checker,
-            reporter: reporter,
-            telemetry: featureScope.telemetryMock
+            feature: FeatureScopeMock(),
+            reporter: reporter
         )
 
         core = PassthroughCoreMock(


### PR DESCRIPTION
### What and why?

Ability to enable disable WT. Default is false.

### How?

We don't want to enable WT by default as they will have huge disk IO implications.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
