### PR TITLE
RUM-4911 feat(watchdog-termination): ability to find most recently updated file in a dir

### DIFF
--- a/DatadogCore/Sources/Core/Storage/Files/File.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/File.swift
@@ -7,6 +7,17 @@
 import Foundation
 import DatadogInternal
 
+/// Provides interfaces for accessing common properties and operations for a file.
+internal protocol FileProtocol {
+    /// URL of the file on the disk.
+    var url: URL { get }
+
+    /// Returns the date when the file was last modified. Returns `nil` if the file does not exist.
+    /// If the file is created and never modified, the creation date is returned.
+    /// - Returns: The date when the file was last modified.
+    func modifiedAt() throws -> Date?
+}
+
 /// Provides convenient interface for reading metadata and appending data to the file.
 internal protocol WritableFile {
     /// Name of this file.
@@ -37,13 +48,17 @@ private enum FileError: Error {
 
 /// An immutable `struct` designed to provide optimized and thread safe interface for file manipulation.
 /// It doesn't own the file, which means the file presence is not guaranteed - the file can be deleted by OS at any time (e.g. due to memory pressure).
-internal struct File: WritableFile, ReadableFile {
+internal struct File: WritableFile, ReadableFile, FileProtocol {
     let url: URL
     let name: String
 
     init(url: URL) {
         self.url = url
         self.name = url.lastPathComponent
+    }
+
+    func modifiedAt() throws -> Date? {
+        try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
     }
 
     /// Appends given data at the end of this file.

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Files/FileTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Files/FileTests.swift
@@ -88,4 +88,26 @@ class FileTests: XCTestCase {
             XCTAssertEqual((error as NSError).localizedDescription, "The file “file” doesn’t exist.")
         }
     }
+
+    func testModifiedAt() throws {
+        // when file is created
+        let before = Date.timeIntervalSinceReferenceDate
+        let file = try directory.createFile(named: "file")
+        let creationDate = try file.modifiedAt()
+        let after = Date.timeIntervalSinceReferenceDate
+
+        XCTAssertNotNil(creationDate)
+        XCTAssertGreaterThanOrEqual(creationDate!.timeIntervalSinceReferenceDate, before)
+        XCTAssertLessThanOrEqual(creationDate!.timeIntervalSinceReferenceDate, after)
+
+        // when file is modified
+        let beforeModification = Date.timeIntervalSinceReferenceDate
+        try file.append(data: .mock(ofSize: 5))
+        let modificationDate = try file.modifiedAt()
+        let afterModification = Date.timeIntervalSinceReferenceDate
+
+        XCTAssertNotNil(modificationDate)
+        XCTAssertGreaterThanOrEqual(modificationDate!.timeIntervalSinceReferenceDate, beforeModification)
+        XCTAssertLessThanOrEqual(modificationDate!.timeIntervalSinceReferenceDate, afterModification)
+    }
 }


### PR DESCRIPTION
### What and why?

We need to know the timestamp of file update to get the approximate timing for the watchdog termination. This will be used to build the rum error event.

### How?

The implementation is quite straight forward, with the new API `Directory.mostRecentModifiedFile(before:)`, we can find the most recently updated file. It recursively checks all the subdirectories, files and itself and returns the file which is most recently updated.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Core, RUM, Trace, Logs, CR and WVT
- [ ] Run unit tests for Session Replay
- [ ] Run integration tests
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
