### PR TITLE
RUM-5004 Record resources while processing snapshots

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -42,19 +42,21 @@ internal class SnapshotTestCase: XCTestCase {
         let expectResources = self.expectation(description: "Wait for resources")
 
         // Set up SR recorder:
-        let snapshotProcessor = SnapshotProcessor(
-            queue: NoQueue(),
-            recordWriter: RecordWriter(core: PassthroughCoreMock()),
-            srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
-            telemetry: TelemetryMock()
-        )
         let resourceProcessor = ResourceProcessor(
             queue: NoQueue(),
             resourcesWriter: ResourcesWriter(scope: FeatureScopeMock())
         )
+
+        let snapshotProcessor = SnapshotProcessor(
+            queue: NoQueue(),
+            recordWriter: RecordWriter(core: PassthroughCoreMock()),
+            resourceProcessor: resourceProcessor,
+            srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
+            telemetry: TelemetryMock()
+        )
+
         let recorder = try Recorder(
             snapshotProcessor: snapshotProcessor,
-            resourceProcessor: resourceProcessor,
             additionalNodeRecorders: []
         )
 

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -26,21 +26,25 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
         configuration: SessionReplay.Configuration
     ) throws {
         let processorsQueue = BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processors")
-        let snapshotProcessor = SnapshotProcessor(
-            queue: processorsQueue,
-            recordWriter: RecordWriter(core: core),
-            srContextPublisher: SRContextPublisher(core: core),
-            telemetry: core.telemetry
-        )
+
         let resourceProcessor = ResourceProcessor(
             queue: processorsQueue,
             resourcesWriter: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
         )
+
+        let snapshotProcessor = SnapshotProcessor(
+            queue: processorsQueue,
+            recordWriter: RecordWriter(core: core),
+            resourceProcessor: resourceProcessor,
+            srContextPublisher: SRContextPublisher(core: core),
+            telemetry: core.telemetry
+        )
+
         let recorder = try Recorder(
             snapshotProcessor: snapshotProcessor,
-            resourceProcessor: resourceProcessor,
             additionalNodeRecorders: configuration._additionalNodeRecorders
         )
+
         let scheduler = MainThreadScheduler(interval: 0.1)
         let contextReceiver = RUMContextReceiver()
 

--- a/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
@@ -89,35 +89,6 @@ extension SessionReplayWireframesBuilder {
     }
 
     public func createImageWireframe(
-        resourceId: String,
-        id: WireframeID,
-        frame: CGRect,
-        mimeType: String = "png",
-        clip: SRContentClip? = nil,
-        borderColor: CGColor? = nil,
-        borderWidth: CGFloat? = nil,
-        backgroundColor: CGColor? = nil,
-        cornerRadius: CGFloat? = nil,
-        opacity: CGFloat? = nil
-    ) -> SRWireframe {
-        let wireframe = SRImageWireframe(
-            base64: nil, // field deprecated - we should use resource endpoint instead
-            border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
-            clip: clip,
-            height: Int64(withNoOverflow: frame.height),
-            id: id,
-            isEmpty: false, // field deprecated - we should use placeholder wireframe instead
-            mimeType: mimeType,
-            resourceId: resourceId,
-            shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
-            width: Int64(withNoOverflow: frame.width),
-            x: Int64(withNoOverflow: frame.minX),
-            y: Int64(withNoOverflow: frame.minY)
-        )
-        return .imageWireframe(value: wireframe)
-    }
-
-    public func createImageWireframe(
         id: WireframeID,
         resource: SessionReplayResource,
         frame: CGRect,
@@ -129,6 +100,7 @@ extension SessionReplayWireframesBuilder {
         cornerRadius: CGFloat? = nil,
         opacity: CGFloat? = nil
     ) -> SRWireframe {
+        // Save resource
         resources.append(resource)
 
         let wireframe = SRImageWireframe(

--- a/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
@@ -20,6 +20,8 @@ public typealias WireframeID = NodeID
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
 @_spi(Internal)
 public class SessionReplayWireframesBuilder {
+    /// The resources that were collected while processing snapshots.
+    private(set) var resources: [Resource]
     /// The cache of webview slot IDs in memory during snapshot.
     private var webViewSlotIDs: Set<Int>
 
@@ -30,7 +32,8 @@ public class SessionReplayWireframesBuilder {
     /// that are not visible be still need to be kept by the player.
     ///
     /// - Parameter webviewSlotIDs: The webview slot IDs in memory during snapshot.
-    init(webViewSlotIDs: Set<Int> = []) {
+    init(resources: [Resource] = [], webViewSlotIDs: Set<Int> = []) {
+        self.resources = resources
         self.webViewSlotIDs = webViewSlotIDs
     }
 }
@@ -106,6 +109,37 @@ extension SessionReplayWireframesBuilder {
             isEmpty: false, // field deprecated - we should use placeholder wireframe instead
             mimeType: mimeType,
             resourceId: resourceId,
+            shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
+            width: Int64(withNoOverflow: frame.width),
+            x: Int64(withNoOverflow: frame.minX),
+            y: Int64(withNoOverflow: frame.minY)
+        )
+        return .imageWireframe(value: wireframe)
+    }
+
+    public func createImageWireframe(
+        id: WireframeID,
+        resource: SessionReplayResource,
+        frame: CGRect,
+        mimeType: String = "png",
+        clip: SRContentClip? = nil,
+        borderColor: CGColor? = nil,
+        borderWidth: CGFloat? = nil,
+        backgroundColor: CGColor? = nil,
+        cornerRadius: CGFloat? = nil,
+        opacity: CGFloat? = nil
+    ) -> SRWireframe {
+        resources.append(resource)
+
+        let wireframe = SRImageWireframe(
+            base64: nil, // field deprecated - we should use resource endpoint instead
+            border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
+            clip: clip,
+            height: Int64(withNoOverflow: frame.height),
+            id: id,
+            isEmpty: false, // field deprecated - we should use placeholder wireframe instead
+            mimeType: mimeType,
+            resourceId: resource.calculateIdentifier(),
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
             width: Int64(withNoOverflow: frame.width),
             x: Int64(withNoOverflow: frame.minX),
@@ -223,7 +257,7 @@ extension SessionReplayWireframesBuilder {
         return .webviewWireframe(value: wireframe)
     }
 
-    internal func hiddenWebViewWireframes() -> [SRWireframe] {
+    public func hiddenWebViewWireframes() -> [SRWireframe] {
         defer { webViewSlotIDs.removeAll() }
         return webViewSlotIDs.map { id in
             let wireframe = SRWebviewWireframe(

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -40,6 +40,8 @@ internal class SnapshotProcessor: SnapshotProcessing {
     private let queue: Queue
     /// Writes records to `DatadogCore`.
     private let recordWriter: RecordWriting
+    /// Processes resources on a background thread.
+    private let resourceProcessor: ResourceProcessing
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
 
@@ -59,11 +61,13 @@ internal class SnapshotProcessor: SnapshotProcessing {
     init(
         queue: Queue,
         recordWriter: RecordWriting,
+        resourceProcessor: ResourceProcessing,
         srContextPublisher: SRContextPublisher,
         telemetry: Telemetry
     ) {
         self.queue = queue
         self.recordWriter = recordWriter
+        self.resourceProcessor = resourceProcessor
         self.srContextPublisher = srContextPublisher
         self.telemetry = telemetry
         self.recordsBuilder = RecordsBuilder(telemetry: telemetry)
@@ -138,6 +142,11 @@ internal class SnapshotProcessor: SnapshotProcessing {
         // Track state:
         lastSnapshot = viewTreeSnapshot
         lastWireframes = wireframes
+
+        resourceProcessor.process(
+            resources: builder.resources,
+            context: .init(viewTreeSnapshot.context.applicationID)
+        )
     }
 
     private func trackRecord(key: String, value: Int64) {

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -60,12 +60,9 @@ public class Recorder: Recording {
     private let touchSnapshotProducer: TouchSnapshotProducer
     /// Turns view tree snapshots into data models that will be uploaded to SR BE.
     private let snapshotProcessor: SnapshotProcessing
-    /// Processes resources on a background thread.
-    private let resourceProcessor: ResourceProcessing
 
     convenience init(
         snapshotProcessor: SnapshotProcessing,
-        resourceProcessor: ResourceProcessing,
         additionalNodeRecorders: [NodeRecorder]
     ) throws {
         let windowObserver = KeyWindowObserver()
@@ -81,8 +78,7 @@ public class Recorder: Recording {
             uiApplicationSwizzler: try UIApplicationSwizzler(handler: touchSnapshotProducer),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: snapshotProcessor,
-            resourceProcessor: resourceProcessor
+            snapshotProcessor: snapshotProcessor
         )
     }
 
@@ -90,14 +86,12 @@ public class Recorder: Recording {
         uiApplicationSwizzler: UIApplicationSwizzler,
         viewTreeSnapshotProducer: ViewTreeSnapshotProducer,
         touchSnapshotProducer: TouchSnapshotProducer,
-        snapshotProcessor: SnapshotProcessing,
-        resourceProcessor: ResourceProcessing
+        snapshotProcessor: SnapshotProcessing
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.viewTreeSnapshotProducer = viewTreeSnapshotProducer
         self.touchSnapshotProducer = touchSnapshotProducer
         self.snapshotProcessor = snapshotProcessor
-        self.resourceProcessor = resourceProcessor
         uiApplicationSwizzler.swizzle()
     }
 
@@ -117,11 +111,6 @@ public class Recorder: Recording {
 
         let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
         snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
-
-        resourceProcessor.process(
-            resources: viewTreeSnapshot.resources,
-            context: .init(recorderContext.applicationID)
-        )
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -22,25 +22,25 @@ internal struct UIDatePickerRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        var recordingResult: RecordingResult?
+        var nodes: [Node]?
         if #available(iOS 13.4, *) {
             switch datePicker.datePickerStyle {
             case .wheels:
-                recordingResult = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
+                nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
             case .compact:
-                recordingResult = compactStyleRecorder.record(datePicker, with: attributes, in: context)
+                nodes = compactStyleRecorder.record(datePicker, with: attributes, in: context)
             case .inline:
-                recordingResult = inlineStyleRecorder.record(datePicker, with: attributes, in: context)
+                nodes = inlineStyleRecorder.record(datePicker, with: attributes, in: context)
             case .automatic:
                 // According to `datePicker.datePickerStyle` documentation:
                 // > "This property always returns a concrete style, never `UIDatePickerStyle.automatic`."
                 break
             @unknown default:
-                recordingResult = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
+                nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
             }
         } else {
             // Observation: older OS versions use the "wheels" style
-            recordingResult = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
+            nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
         }
 
         let isDisplayedInPopover: Bool = {
@@ -64,8 +64,7 @@ internal struct UIDatePickerRecorder: NodeRecorder {
         )
         return SpecificElement(
             subtreeStrategy: .ignore,
-            nodes: [backgroundNode] + (recordingResult?.nodes ?? []),
-            resources: recordingResult?.resources ?? []
+            nodes: [backgroundNode] + (nodes ?? [])
         )
     }
 }
@@ -81,7 +80,7 @@ private struct WheelsStyleDatePickerRecorder {
         ]
     )
 
-    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> RecordingResult {
+    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> [Node] {
         return pickerTreeRecorder.record(view, in: context)
     }
 }
@@ -108,7 +107,7 @@ private struct InlineStyleDatePickerRecorder {
         )
     }
 
-    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> RecordingResult {
+    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> [Node] {
         viewRecorder.semanticsOverride = { _, viewAttributes in
             if context.recorder.privacy.shouldMaskInputElements {
                 let isSquare = viewAttributes.frame.width == viewAttributes.frame.height
@@ -144,7 +143,7 @@ private struct CompactStyleDatePickerRecorder {
         ]
     )
 
-    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> RecordingResult {
+    func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> [Node] {
         return subtreeRecorder.record(view, in: context)
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -133,7 +133,7 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
                 opacity: attributes.alpha
             )
         ]
-        
+
         guard let contentFrame = contentFrame else {
             return wireframes
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -134,11 +134,11 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
             )
         ]
 
-        guard let contentFrame = contentFrame else {
+        guard let contentFrame else {
             return wireframes
         }
 
-        if let imageResource = imageResource {
+        if let imageResource {
             wireframes.append(
                 builder.createImageWireframe(
                     id: imageWireframeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -71,16 +71,15 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         // in the actual `UIPickerView's` tree their order is opposite (blending is used to make the label
         // pass through the shape). For that reason, we record both kinds of nodes separately and then reorder
         // them in returned semantics:
-        let backgroundRecordingResult = selectionRecorder.record(picker, in: context)
-        let titleRecordingResult = labelsRecorder.record(picker, in: context)
+        let backgroundRecordingNodes = selectionRecorder.record(picker, in: context)
+        let titleRecordingNodes = labelsRecorder.record(picker, in: context)
 
         guard attributes.hasAnyAppearance else {
             // If the root view of `UIPickerView` defines no other appearance (e.g. no custom `.background`), we can
             // safely ignore it, with only forwarding child nodes to final recording.
             return SpecificElement(
                 subtreeStrategy: .ignore,
-                nodes: backgroundRecordingResult.nodes + titleRecordingResult.nodes,
-                resources: backgroundRecordingResult.resources + titleRecordingResult.resources
+                nodes: backgroundRecordingNodes + titleRecordingNodes
             )
         }
 
@@ -93,8 +92,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(
             subtreeStrategy: .ignore,
-            nodes: [node] + backgroundRecordingResult.nodes + titleRecordingResult.nodes,
-            resources: backgroundRecordingResult.resources + titleRecordingResult.resources
+            nodes: [node] + backgroundRecordingNodes + titleRecordingNodes
         )
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -23,14 +23,12 @@ internal final class UITabBarRecorder: NodeRecorder {
         )
 
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
-        let subtreeRecordingResults = recordSubtree(of: tabBar, in: context)
-        let allNodes = [node] + subtreeRecordingResults.nodes
-        let resources = subtreeRecordingResults.resources
+        let allNodes = [node] + recordSubtree(of: tabBar, in: context)
 
-        return SpecificElement(subtreeStrategy: .ignore, nodes: allNodes, resources: resources)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: allNodes)
     }
 
-    private func recordSubtree(of tabBar: UITabBar, in context: ViewTreeRecordingContext) -> RecordingResult {
+    private func recordSubtree(of tabBar: UITabBar, in context: ViewTreeRecordingContext) -> [Node] {
         let subtreeViewRecorder = ViewTreeRecorder(
             nodeRecorders: [
                 UIImageViewRecorder(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -42,8 +42,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
 
         // For our "approximation", we render text field's text on top of other TF's appearance.
         // Here we record both kind of nodes separately and order them respectively in returned semantics:
-        let appearanceRecordingResult = recordAppearance(in: textField, textFieldAttributes: attributes, using: context)
-        let appearanceNodes = appearanceRecordingResult.nodes
+        let appearanceNodes = recordAppearance(in: textField, textFieldAttributes: attributes, using: context)
         if let textNode = recordText(in: textField, attributes: attributes, using: context) {
             return SpecificElement(subtreeStrategy: .ignore, nodes: appearanceNodes + [textNode])
         } else {
@@ -52,7 +51,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
     }
 
     /// Records `UIView` and `UIImageViewRecorder` nodes that define text field's appearance.
-    private func recordAppearance(in textField: UITextField, textFieldAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> RecordingResult {
+    private func recordAppearance(in textField: UITextField, textFieldAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> [Node] {
         backgroundViewRecorder.semanticsOverride = { _, viewAttributes in
             // We consider view to define text field's appearance if it has the same
             // size as text field:

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -50,7 +50,7 @@ internal class UIViewRecorder: NodeRecorder {
             attributes: attributes
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
-        return AmbiguousElement(nodes: [node], resources: [])
+        return AmbiguousElement(nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -7,11 +7,6 @@
 #if os(iOS)
 import UIKit
 
-internal struct RecordingResult {
-    let nodes: [Node]
-    let resources: [Resource]
-}
-
 internal struct ViewTreeRecorder {
     /// An array of enabled node recorders.
     ///
@@ -20,18 +15,16 @@ internal struct ViewTreeRecorder {
     let nodeRecorders: [NodeRecorder]
 
     /// Creates `Nodes` for given view and its subtree hierarchy.
-    func record(_ anyView: UIView, in context: ViewTreeRecordingContext) -> RecordingResult {
+    func record(_ anyView: UIView, in context: ViewTreeRecordingContext) -> [Node] {
         var nodes: [Node] = []
-        var resources: [Resource] = []
-        recordRecursively(nodes: &nodes, resources: &resources, view: anyView, context: context)
-        return RecordingResult(nodes: nodes, resources: resources)
+        recordRecursively(nodes: &nodes, view: anyView, context: context)
+        return nodes
     }
 
     // MARK: - Private
 
     private func recordRecursively(
         nodes: inout [Node],
-        resources: inout [Resource],
         view: UIView,
         context: ViewTreeRecordingContext
     ) {
@@ -48,14 +41,11 @@ internal struct ViewTreeRecorder {
         if !semantics.nodes.isEmpty {
             nodes.append(contentsOf: semantics.nodes)
         }
-        if !semantics.resources.isEmpty {
-            resources.append(contentsOf: semantics.resources)
-        }
 
         switch semantics.subtreeStrategy {
         case .record:
             for subview in view.subviews {
-                recordRecursively(nodes: &nodes, resources: &resources, view: subview, context: context)
+                recordRecursively(nodes: &nodes, view: subview, context: context)
             }
         case .ignore:
             break

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -25,8 +25,6 @@ internal struct ViewTreeSnapshot {
     let viewportSize: CGSize
     /// An array of nodes recorded for this snapshot - sequenced in DFS order.
     let nodes: [Node]
-    /// An array of resource references recorded for this snapshot - sequenced in DFS order.
-    let resources: [Resource]
     /// A set of webview slot IDs recorded for this and past snapshots.
     let webViewSlotIDs: Set<Int>
 }
@@ -175,8 +173,6 @@ public protocol SessionReplayNodeSemantics {
     var subtreeStrategy: SessionReplayNodeSubtreeStrategy { get }
     /// Nodes that share this semantics.
     var nodes: [SessionReplayNode] { get }
-    /// Resources collected while traversing the subtree of this node.
-    var resources: [SessionReplayResource] { get }
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
@@ -213,7 +209,6 @@ internal struct UnknownElement: NodeSemantics {
     static let importance: Int = .min
     let subtreeStrategy: NodeSubtreeStrategy = .record
     let nodes: [Node] = []
-    let resources: [Resource] = []
 
     /// Use `UnknownElement.constant` instead.
     private init () {}
@@ -231,7 +226,6 @@ public struct SessionReplayInvisibleElement: SessionReplayNodeSemantics {
     public static let importance: Int = 0
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode] = []
-    public let resources: [SessionReplayResource] = []
 
     /// Use `InvisibleElement.constant` instead.
     private init () {
@@ -255,7 +249,6 @@ internal struct IgnoredElement: NodeSemantics {
     static var importance: Int = .max
     let subtreeStrategy: NodeSubtreeStrategy
     let nodes: [Node] = []
-    let resources: [Resource] = []
 }
 
 /// A semantics of an UI element that is of `UIView` type. This semantics mean that the element has visual appearance in SR, but
@@ -266,7 +259,6 @@ internal struct AmbiguousElement: NodeSemantics {
     static let importance: Int = 0
     let subtreeStrategy: NodeSubtreeStrategy = .record
     let nodes: [Node]
-    let resources: [Resource]
 }
 
 /// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
@@ -277,16 +269,13 @@ public struct SessionReplaySpecificElement: SessionReplayNodeSemantics {
     public static let importance: Int = .max
     public let subtreeStrategy: SessionReplayNodeSubtreeStrategy
     public let nodes: [SessionReplayNode]
-    public let resources: [SessionReplayResource]
 
     public init(
         subtreeStrategy: SessionReplayNodeSubtreeStrategy,
-        nodes: [SessionReplayNode],
-        resources: [SessionReplayResource] = []
+        nodes: [SessionReplayNode]
     ) {
         self.subtreeStrategy = subtreeStrategy
         self.nodes = nodes
-        self.resources = resources
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -34,13 +34,12 @@ internal struct ViewTreeSnapshotBuilder {
             ids: idsGenerator,
             webViewCache: webViewCache
         )
-        let recording = viewTreeRecorder.record(rootView, in: context)
+        let nodes = viewTreeRecorder.record(rootView, in: context)
         let snapshot = ViewTreeSnapshot(
             date: recorderContext.date.addingTimeInterval(recorderContext.viewServerTimeOffset ?? 0),
             context: recorderContext,
             viewportSize: rootView.bounds.size,
-            nodes: recording.nodes,
-            resources: recording.resources,
+            nodes: nodes,
             webViewSlotIDs: Set(webViewCache.allObjects.map(\.hash))
         )
         return snapshot

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -27,7 +27,6 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
             context: .mockRandom(),
             viewportSize: .mockRandom(),
             nodes: .mockRandom(count: .random(in: (5..<50))),
-            resources: .mockRandom(count: .random(in: (5..<50))),
             webViewSlotIDs: .mockRandom()
         )
     }
@@ -37,7 +36,6 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
         context: Recorder.Context = .mockAny(),
         viewportSize: CGSize = .mockAny(),
         nodes: [Node] = .mockAny(),
-        resources: [Resource] = .mockAny(),
         webViewSlotIDs: Set<Int> = .mockAny()
     ) -> ViewTreeSnapshot {
         return ViewTreeSnapshot(
@@ -45,7 +43,6 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
             context: context,
             viewportSize: viewportSize,
             nodes: nodes,
-            resources: resources,
             webViewSlotIDs: webViewSlotIDs
         )
     }
@@ -221,8 +218,7 @@ func mockRandomNodeSemantics() -> NodeSemantics {
         UnknownElement.constant,
         InvisibleElement.constant,
         AmbiguousElement(
-            nodes: .mockRandom(count: .mockRandom(min: 1, max: 5)),
-            resources: .mockRandom(count: .mockRandom(min: 1, max: 5))
+            nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))
         ),
         SpecificElement(subtreeStrategy: .mockRandom(), nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))),
     ]

--- a/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
+++ b/DatadogSessionReplay/Tests/Mocks/ResourceProcessorSpy.swift
@@ -12,6 +12,8 @@ import Foundation
 internal class ResourceProcessorSpy: ResourceProcessing {
     var processedResources: [(resources: [Resource], context: EnrichedResource.Context)] = []
 
+    var resources: [Resource] { processedResources.reduce([]) { $0 + $1.resources } }
+
     func process(resources: [Resource], context: EnrichedResource.Context) {
         processedResources.append((resources: resources, context: context))
     }

--- a/DatadogSessionReplay/Tests/Processor/Builders/WireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Builders/WireframesBuilderTests.swift
@@ -60,5 +60,35 @@ class WireframesBuilderTests: XCTestCase {
 
         XCTAssertTrue(builder.hiddenWebViewWireframes().isEmpty)
     }
+
+    func testBuildingImageWireframe_ItCreatesAResource() throws {
+        let id: WireframeID = .mockRandom()
+        let resource: MockResource = .mockRandom()
+        let frame: CGRect = .mockRandom()
+        let clip: SRContentClip = .mockRandom()
+        let builder = WireframesBuilder()
+
+        let wireframe = builder.createImageWireframe(
+            id: id,
+            resource: resource,
+            frame: frame,
+            clip: clip
+        )
+
+        guard case let .imageWireframe(wireframe) = wireframe else {
+            return XCTFail("The wireframe must be imageWireframe case")
+        }
+
+        XCTAssertEqual(wireframe.id, id)
+        XCTAssertNil(wireframe.border)
+        XCTAssertEqual(wireframe.clip, clip)
+        XCTAssertEqual(wireframe.height, Int64(withNoOverflow: frame.height))
+        XCTAssertNil(wireframe.shapeStyle)
+        XCTAssertEqual(wireframe.width, Int64(withNoOverflow: frame.width))
+        XCTAssertEqual(wireframe.x, Int64(withNoOverflow: frame.minX))
+        XCTAssertEqual(wireframe.y, Int64(withNoOverflow: frame.minY))
+        XCTAssertEqual(builder.resources.first?.calculateIdentifier(), resource.identifier)
+        XCTAssertEqual(builder.resources.first?.calculateData(), resource.data)
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -31,10 +31,11 @@ class SnapshotProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
+        let resourceProcessor = ResourceProcessorSpy()
         let processor = SnapshotProcessor(
             queue: NoQueue(),
             recordWriter: recordWriter,
-            resourceProcessor: ResourceProcessorSpy(),
+            resourceProcessor: resourceProcessor,
             srContextPublisher: srContextPublisher,
             telemetry: TelemetryMock()
         )
@@ -46,6 +47,7 @@ class SnapshotProcessorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(recordWriter.records.count, 1)
+        XCTAssertTrue(resourceProcessor.resources.isEmpty)
 
         let enrichedRecord = try XCTUnwrap(recordWriter.records.first)
         XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
@@ -296,7 +298,7 @@ class SnapshotProcessorTests: XCTestCase {
         XCTAssertEqual(fullSnapshotRecord.data.wireframes.first?.id, Int64(webview.hash), "The hidden webview wireframe should be first")
     }
 
-    func testWhenProcessingViewTreeSnapshot_itRecordResources() throws {
+    func testWhenProcessingViewTreeSnapshot_itRecordsResources() throws {
         let resource: UIImageResource = .mockRandom()
         let builder = UIImageViewWireframesBuilder(
             wireframeID: .mockAny(),

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -236,7 +236,6 @@ class SnapshotProcessorTests: XCTestCase {
             context: .init(privacy: .allow, rumContext: rum, date: time),
             viewportSize: .mockRandom(minWidth: 1_000, minHeight: 1_000),
             nodes: [node],
-            resources: [],
             webViewSlotIDs: Set([hiddenSlot, visibleSlot])
         )
 

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -15,15 +15,13 @@ class RecorderTests: XCTestCase {
         let mockViewTreeSnapshots: [ViewTreeSnapshot] = .mockRandom(count: 1)
         let mockTouchSnapshots: [TouchSnapshot] = .mockRandom(count: 1)
         let snapshotProcessor = SnapshotProcessorSpy()
-        let resourceProcessor = ResourceProcessorSpy()
 
         // Given
         let recorder = Recorder(
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: ViewTreeSnapshotProducerMock(succeedingSnapshots: mockViewTreeSnapshots),
             touchSnapshotProducer: TouchSnapshotProducerMock(succeedingSnapshots: mockTouchSnapshots),
-            snapshotProcessor: snapshotProcessor,
-            resourceProcessor: resourceProcessor
+            snapshotProcessor: snapshotProcessor
         )
         let recorderContext = Recorder.Context.mockRandom()
 
@@ -33,8 +31,6 @@ class RecorderTests: XCTestCase {
         // Then
         DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.viewTreeSnapshot }, mockViewTreeSnapshots)
         DDAssertReflectionEqual(snapshotProcessor.processedSnapshots.map { $0.touchSnapshot }, mockTouchSnapshots)
-        DDAssertReflectionEqual(resourceProcessor.processedResources.map { $0.resources }, mockViewTreeSnapshots.map { $0.resources })
-        DDAssertReflectionEqual(resourceProcessor.processedResources.map { $0.context }, mockViewTreeSnapshots.map { _ in EnrichedResource.Context(recorderContext.applicationID) })
     }
 
     func testWhenCapturingSnapshots_itUsesDefaultRecorderContext() throws {
@@ -47,8 +43,7 @@ class RecorderTests: XCTestCase {
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: SnapshotProcessorSpy(),
-            resourceProcessor: ResourceProcessorSpy()
+            snapshotProcessor: SnapshotProcessorSpy()
         )
         // When
         try recorder.captureNextRecord(recorderContext)
@@ -73,8 +68,7 @@ class RecorderTests: XCTestCase {
             uiApplicationSwizzler: .mockAny(),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: SnapshotProcessorSpy(),
-            resourceProcessor: ResourceProcessorSpy()
+            snapshotProcessor: SnapshotProcessorSpy()
         )
         // When
         try recorder.captureNextRecord(recorderContext)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -64,8 +64,7 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertTrue(semantics is SpecificElement)
         XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
         let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
-        XCTAssertFalse(builder.shouldRecordImage)
-        XCTAssertNil(semantics.resources.first as? UIImage)
+        XCTAssertNil(builder.imageResource)
     }
 
     func testWhenShouldRecordImagePredicateReturnsTrue() throws {
@@ -79,8 +78,7 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertTrue(semantics is SpecificElement)
         XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
         let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
-        XCTAssertTrue(builder.shouldRecordImage)
-        XCTAssertNotNil(semantics.resources.first)
+        XCTAssertNotNil(builder.imageResource)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewWireframesBuilderTests.swift
@@ -26,8 +26,7 @@ class UIImageViewWireframesBuilderTests: XCTestCase {
             attributes: ViewAttributes.mock(fixture: .visible(.someAppearance)),
             contentFrame: CGRect(x: 10, y: 10, width: 200, height: 200),
             clipsToBounds: true,
-            imageResource: .mockRandom(),
-            shouldRecordImage: true
+            imageResource: .mockRandom()
         )
 
         let wireframes = builder.buildWireframes(with: wireframesBuilder)
@@ -57,8 +56,7 @@ class UIImageViewWireframesBuilderTests: XCTestCase {
             attributes: ViewAttributes.mock(fixture: .visible(.someAppearance)),
             contentFrame: CGRect(x: 10, y: 10, width: 200, height: 200),
             clipsToBounds: true,
-            imageResource: nil,
-            shouldRecordImage: false
+            imageResource: nil
         )
 
         let wireframes = builder.buildWireframes(with: wireframesBuilder)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -65,7 +65,7 @@ class ViewTreeRecorderTests: XCTestCase {
         // Given
         let view = UIView(frame: .mockRandom())
         let unknownElement = UnknownElement.constant
-        let ambiguousElement = AmbiguousElement(nodes: .mockAny(), resources: .mockAny())
+        let ambiguousElement = AmbiguousElement(nodes: .mockAny())
         let specificElement = SpecificElement(subtreeStrategy: .mockRandom(), nodes: .mockAny())
 
         // When
@@ -135,18 +135,12 @@ class ViewTreeRecorderTests: XCTestCase {
         // When
         let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
         let recorder = ViewTreeRecorder(nodeRecorders: [nodeRecorder])
-        let recordingResult = recorder.record(rootView, in: .mockRandom())
-        let nodes = recordingResult.nodes
-        let resources = recordingResult.resources
+        let nodes = recorder.record(rootView, in: .mockRandom())
 
         // Then
         let expectedNodes = ["rootView", "a", "aa", "aav1", "aav2", "aav3", "ab", "aba", "abb", "b", "c"]
         let actualNodes = nodes.compactMap { ($0.wireframesBuilder as? MockWireframesBuilder)?.nodeName }
         XCTAssertEqual(expectedNodes, actualNodes, "Nodes must be recorded in DFS order")
-
-        let expectedResources = ["rootResource", "a", "aa", "aav1", "aav2", "aav3", "ab", "aba", "abb", "b", "c"]
-        let actualResources = resources.map { $0.calculateIdentifier() }
-        XCTAssertEqual(expectedResources, actualResources, "Resources must be recorded in DFS order")
 
         let expectedQueriedViews: [UIView] = [rootView, a, b, c, aa, ab, aba, abb]
         XCTAssertEqual(nodeRecorder.queriedViews.count, expectedQueriedViews.count)
@@ -171,12 +165,9 @@ class ViewTreeRecorderTests: XCTestCase {
 
         views.forEach { view in
             // When
-            let recordingResult = recorder.record(view, in: .mockRandom())
-            let nodes = recordingResult.nodes
-            let resources = recordingResult.resources
+            let nodes = recorder.record(view, in: .mockRandom())
             // Then
             XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for \(type(of: view)) when it is not visible")
-            XCTAssertTrue(resources.isEmpty, "No resources should be recorded for \(type(of: view)) when it is not visible")
         }
     }
 
@@ -191,38 +182,23 @@ class ViewTreeRecorderTests: XCTestCase {
         let `switch` = UISwitch.mock(withFixture: .visible(.noAppearance))
 
         // When
-        var recordingResult = recorder.record(view, in: .mockRandom())
-        var nodes = recordingResult.nodes
-        var resources = recordingResult.resources
+        var nodes = recorder.record(view, in: .mockRandom())
         XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for `UIView` when it has no appearance")
-        XCTAssertTrue(resources.isEmpty, "No resources should be recorded for `UIView` when it has no appearance")
 
-        recordingResult = recorder.record(label, in: .mockRandom())
-        nodes = recordingResult.nodes
-        resources = recordingResult.resources
+        nodes = recorder.record(label, in: .mockRandom())
         XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for `UILabel` when it has no appearance")
-        XCTAssertTrue(resources.isEmpty, "No resources should be recorded for `UILabel` when it has no appearance")
 
-        recordingResult = recorder.record(imageView, in: .mockRandom())
-        nodes = recordingResult.nodes
-        resources = recordingResult.resources
+        nodes = recorder.record(imageView, in: .mockRandom())
         XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for `UIImageView` when it has no appearance")
-        XCTAssertTrue(resources.isEmpty, "No resources should be recorded for `UIImageView` when it has no appearance")
 
-        recordingResult = recorder.record(textField, in: .mockRandom())
-        nodes = recordingResult.nodes
-        resources = recordingResult.resources
+        nodes = recorder.record(textField, in: .mockRandom())
         XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for `UITextField` when it has no appearance")
-        XCTAssertTrue(resources.isEmpty, "No resources should be recorded for `UITextField` when it has no appearance")
 
-        recordingResult = recorder.record(`switch`, in: .mockRandom())
-        nodes = recordingResult.nodes
-        resources = recordingResult.resources
+        nodes = recorder.record(`switch`, in: .mockRandom())
         XCTAssertFalse(
             nodes.isEmpty,
             "`UISwitch` with no appearance should record some nodes as it has style coming from its internal subtree."
         )
-        XCTAssertTrue(resources.isEmpty, "No resources should be recorded for `UISwitch` when it has no appearance")
     }
 
     func testItRecordsViewsWithSomeAppearance() {
@@ -240,13 +216,9 @@ class ViewTreeRecorderTests: XCTestCase {
 
         views.forEach { view in
             // When
-            let recordingResults = recorder.record(view, in: .mockRandom())
-            let nodes = recordingResults.nodes
-            let resources = recordingResults.resources
-
+            let nodes = recorder.record(view, in: .mockRandom())
             // Then
             XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for \(type(of: view)) when it has some appearance")
-            XCTAssertTrue(resources.isEmpty, "No resources should be recorded for \(type(of: view)) regardless it has some appearance")
         }
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -182,7 +182,7 @@ class NodeSemanticsTests: XCTestCase {
     func testImportance() {
         let unknownElement = UnknownElement.constant
         let invisibleElement = InvisibleElement.constant
-        let ambiguousElement = AmbiguousElement(nodes: [], resources: [])
+        let ambiguousElement = AmbiguousElement(nodes: [])
         let specificElement = SpecificElement(subtreeStrategy: .mockAny(), nodes: [])
 
         XCTAssertGreaterThan(


### PR DESCRIPTION
### What and why?

Previously, resources where created while recording the views. But in SwiftUI, we will only be able to create resources at the processing phase. To accommodate this, resources will now be created when building the wireframes and written by the snapshot processor.

### How?

The `SnapshotProcessor` now holds a reference to a `ResourceProcessor`, and the `SessionReplayWireframesBuilder` will keep track of resources while building the wireframes. The `SnapshotProcessor` will pass all collected resources to its `ResourceProcessor` instance. 

**Note:**
The `ResourceProcessor` and the `ResourcesWriter` are doing the same checks to deduplicate images, but on different threads. This needs a refactoring as well, but it's outside the scope of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Session Replay
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
