### PR TITLE
RUM-1000 chore: improve telemetry messages for file I/O errors

### DIFF
--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -15,6 +15,7 @@ internal protocol FilesOrchestratorType: AnyObject {
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason)
 
     var ignoreFilesAgeWhenReading: Bool { get set }
+    var trackName: String { get }
 }
 
 /// Orchestrates files in a single directory.
@@ -51,6 +52,10 @@ internal class FilesOrchestrator: FilesOrchestratorType {
 
     /// An extra information to include in metrics or `nil` if metrics should not be reported for this orchestrator.
     let metricsData: MetricsData?
+
+    var trackName: String {
+        metricsData?.trackName ?? "Unknown"
+    }
 
     init(
         directory: Directory,

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -149,7 +149,8 @@ class FileWriterTests: XCTestCase {
                     maxObjectSize: 23 // 23 bytes is enough for TLV with {"key1":"value1"} JSON
                 ),
                 dateProvider: SystemDateProvider(),
-                telemetry: NOPTelemetry()
+                telemetry: NOPTelemetry(),
+                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
             ),
             encryption: nil,
             telemetry: NOPTelemetry()
@@ -168,7 +169,7 @@ class FileWriterTests: XCTestCase {
         reader = try BatchDataBlockReader(input: directory.files()[0].stream())
         blocks = try XCTUnwrap(reader.all())
         XCTAssertEqual(blocks.count, 1) // same content as before
-        XCTAssertEqual(dd.logger.errorLog?.message, "Failed to write data")
+        XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to encode value")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, "DataBlock length exceeds limit of 23 bytes")
     }
 
@@ -181,7 +182,8 @@ class FileWriterTests: XCTestCase {
                 directory: directory,
                 performance: PerformancePreset.mockAny(),
                 dateProvider: SystemDateProvider(),
-                telemetry: NOPTelemetry()
+                telemetry: NOPTelemetry(),
+                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
             ),
             encryption: nil,
             telemetry: NOPTelemetry()
@@ -189,7 +191,7 @@ class FileWriterTests: XCTestCase {
 
         writer.write(value: FailingEncodableMock(errorMessage: "failed to encode `FailingEncodable`."))
 
-        XCTAssertEqual(dd.logger.errorLog?.message, "Failed to write data")
+        XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to encode value")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, "failed to encode `FailingEncodable`.")
     }
 
@@ -202,7 +204,8 @@ class FileWriterTests: XCTestCase {
                 directory: directory,
                 performance: PerformancePreset.mockAny(),
                 dateProvider: SystemDateProvider(),
-                telemetry: NOPTelemetry()
+                telemetry: NOPTelemetry(),
+                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
             ),
             encryption: nil,
             telemetry: NOPTelemetry()
@@ -213,7 +216,7 @@ class FileWriterTests: XCTestCase {
         writer.write(value: ["won't be written"])
         try? directory.files()[0].makeReadWrite()
 
-        XCTAssertEqual(dd.logger.errorLog?.message, "Failed to write data")
+        XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to write 26 bytes to file")
         XCTAssertTrue(dd.logger.errorLog!.error!.message.contains("You don’t have permission"))
     }
 

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -270,6 +270,7 @@ internal class NOPFilesOrchestrator: FilesOrchestratorType {
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) { }
 
     var ignoreFilesAgeWhenReading = false
+    var trackName: String = "nop"
 }
 
 extension DataFormat {


### PR DESCRIPTION
### What and why?

Current telemetry message is not very helpful to diagnose file IO related issues

For example

```
Failed to write data to file - Cannot create file at path: /var/mobile/Containers/Data/Application/*/Library/Caches
```

### How?

Split the big `do-try-catch` block into individual ones to get more insights where the issue.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
- [ ] Run smoke tests
- [ ] Run tests for `tools/`
