### PR TITLE
chore: use otel-swift fork that only has APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2"),
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "1.6.0")
+        .package(url: "https://github.com/DataDog/opentelemetry-swift-packages.git", branch: "ganeshnj/chore/import-1.6.0-code")
     ],
     targets: [
         .target(
@@ -111,7 +111,7 @@ let package = Package(
             name: "DatadogTrace",
             dependencies: [
                 .target(name: "DatadogInternal"),
-                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift")
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-packages")
             ],
             path: "DatadogTrace/Sources"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2"),
-        .package(url: "https://github.com/DataDog/opentelemetry-swift-packages.git", branch: "ganeshnj/chore/import-1.6.0-code")
+        .package(url: "https://github.com/DataDog/opentelemetry-swift-packages.git", exact: "1.6.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

Related https://github.com/DataDog/opentelemetry-swift-packages/pull/17

We are not sure when the dependency issue will be resolved at the root level. 

### How?

Take a dependency on the forked version of otel-swift that has only APIs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
