### PR TITLE
chore: Update CHANGELOG.md with `hotfix/2.11.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - [IMPROVEMENT] Allow disabling app hang monitoring in ObjC API. See [#1908][]
 - [IMPROVEMENT] Update RUM and Telemetry models with KMP source. See [#1925][]
 
+# 2.11.1 / 01-07-2024
+
+- [FIX] Fix compilation issues on Xcode 16 beta. See [#1898][]
+
 # 2.13.0 / 13-06-2024
 
 - [IMPROVEMENT] Bump `IPHONEOS_DEPLOYMENT_TARGET` and `TVOS_DEPLOYMENT_TARGET` from 11 to 12. See [#1891][]


### PR DESCRIPTION
### What and why?

📦 As mentioned in https://github.com/DataDog/dd-sdk-ios/issues/1877#issuecomment-2191541062, we cherry-pick https://github.com/DataDog/dd-sdk-ios/issues/1892 fix to 2.11 release, making `2.11.1` hotfix.

### How?

We don't follow regular git-flow for this hotfix as the released change already exists in `2.13.0` and we only cherry-pick it.

The `2.11.1` tag will be put on the [last commit](https://github.com/DataDog/dd-sdk-ios/commits/hotfix/2.11.1/) from `hotfix/2.11.1` branch. Check [`hotfix/2.11.1` → `master` diff](https://github.com/DataDog/dd-sdk-ios/compare/master...hotfix/2.11.1?expand=1) to review what we're about to release.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
