### PR TITLE
fix: send Watchdog Termination once only

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
@@ -76,9 +76,6 @@ internal final class WatchdogTerminationReporter: WatchdogTerminationReporting {
                 DD.logger.debug("Sending Watchdog Termination as RUM error without updating RUM view")
                 writer.write(value: error)
             }
-
-            writer.write(value: error)
-            writer.write(value: view)
         }
     }
 }


### PR DESCRIPTION
### What and why?

We added the logic to send only view updated under the 4h threshold but didn't remove the original logic. Hence, WT are reported 2 times.

### How?

remove the redundant WT event writing.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
