### PR TITLE
RUM-5174 Fix attributes objc interop

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDDatadogTests.swift
@@ -139,11 +139,11 @@ class DDDatadogTests: XCTestCase {
         XCTAssertEqual(userInfo.current.id, "id")
         XCTAssertEqual(userInfo.current.name, "name")
         XCTAssertEqual(userInfo.current.email, "email")
-        let extraInfo = try XCTUnwrap(userInfo.current.extraInfo as? [String: AnyEncodable])
-        XCTAssertEqual(extraInfo["attribute-int"]?.value as? Int, 42)
-        XCTAssertEqual(extraInfo["attribute-double"]?.value as? Double, 42.5)
-        XCTAssertEqual(extraInfo["attribute-string"]?.value as? String, "string value")
-        XCTAssertEqual(extraInfo["foo"]?.value as? String, "bar")
+        let extraInfo = userInfo.current.extraInfo
+        XCTAssertEqual(extraInfo["attribute-int"] as? Int, 42)
+        XCTAssertEqual(extraInfo["attribute-double"] as? Double, 42.5)
+        XCTAssertEqual(extraInfo["attribute-string"] as? String, "string value")
+        XCTAssertEqual(extraInfo["foo"] as? String, "bar")
 
         DDDatadog.setUserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
         XCTAssertNil(userInfo.current.id)

--- a/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
@@ -34,7 +34,7 @@ class DDRUMViewTests: XCTestCase {
     func testItCreatesSwiftRUMView() {
         let objcRUMView = DDRUMView(name: "name", attributes: ["foo": "bar"])
         XCTAssertEqual(objcRUMView.swiftView.name, "name")
-        XCTAssertEqual((objcRUMView.swiftView.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
+        XCTAssertEqual(objcRUMView.swiftView.attributes["foo"] as? String, "bar")
         XCTAssertEqual(objcRUMView.name, "name")
         XCTAssertEqual(objcRUMView.attributes["foo"] as? String, "bar")
     }
@@ -80,7 +80,7 @@ class DDRUMActionTests: XCTestCase {
     func testItCreatesSwiftRUMAction() {
         let objcRUMAction = DDRUMAction(name: "name", attributes: ["foo": "bar"])
         XCTAssertEqual(objcRUMAction.swiftAction.name, "name")
-        XCTAssertEqual((objcRUMAction.swiftAction.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
+        XCTAssertEqual(objcRUMAction.swiftAction.attributes["foo"] as? String, "bar")
         XCTAssertEqual(objcRUMAction.name, "name")
         XCTAssertEqual(objcRUMAction.attributes["foo"] as? String, "bar")
     }

--- a/DatadogObjc/Sources/ObjcIntercompatibility/ObjcIntercompatibility.swift
+++ b/DatadogObjc/Sources/ObjcIntercompatibility/ObjcIntercompatibility.swift
@@ -10,19 +10,16 @@ import DatadogCore
 
 /// Casts `[String: Any]` attributes to their `Encodable` representation by wrapping each `Any` into `AnyEncodable`.
 internal func castAttributesToSwift(_ attributes: [String: Any]) -> [String: Encodable] {
-    return attributes.mapValues { AnyEncodable($0) }
+    attributes.mapValues { $0 as? Encodable ?? AnyEncodable($0) }
 }
 
 /// Casts `[String: Encodable]` attributes to their `Any` representation by unwrapping each `AnyEncodable` into `Any`.
 internal func castAttributesToObjectiveC(_ attributes: [String: Encodable]) -> [String: Any] {
-    return attributes
-        .compactMapValues { value in (value as? AnyEncodable)?.value }
+    attributes.mapValues { ($0 as? AnyEncodable).map(\.value) ?? $0 }
 }
 
 /// Helper extension to use `castAttributesToObjectiveC(_:)` in auto generated ObjC interop `RUMDataModels`.
 /// Unlike the function it wraps, it has postfix notation which makes it easier to use in generated code.
 internal extension Dictionary where Key == String, Value == Encodable {
-    func castToObjectiveC() -> [String: Any] {
-        return castAttributesToObjectiveC(self)
-    }
+    func castToObjectiveC() -> [String: Any] { castAttributesToObjectiveC(self) }
 }


### PR DESCRIPTION
### What and why?

All the attributes coming from ObjC API are wrapped into `AnyEncodable` https://github.com/DataDog/dd-sdk-ios/blob/1a61f0f8b1388b12145c4ef5695b7892b48146d6/DatadogObjc/Sources/ObjcIntercompatibility/ObjcIntercompatibility.swift#L13. It means that we cannot get raw attribute value when getting it by key, we need to unwrap it.

### How?

Wrap objc attribute in `AnyEncodable` **only** if the type is not already `Encodable`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
