### PR TITLE
chore: Pin OpenTelemetryApi version in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "microsoft/plcrashreporter" ~> 1.11.2
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" ~> 1.6.0
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.6.0

--- a/SmokeTests/carthage/Makefile
+++ b/SmokeTests/carthage/Makefile
@@ -34,6 +34,8 @@ endif
 clean:
 	@$(ECHO_SUBTITLE2) "make clean"
 	rm -rf Carthage
+	rm -f Cartfile.resolved
+	rm -f Cartfile
 
 install:
 	@$(ECHO_SUBTITLE2) "make install"


### PR DESCRIPTION
### What and why?

📦 This is to ensure that upstream projects resolve the right version of `OpenTelemetryApi`. This includes not only customer projects, but also `carthage` Smoke Tests in our repo.

### How?

Pinned the version of `OpenTelemetryApi` in `Cartfile`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
