### PR TITLE
chore: Fix linter issue for `swiftlint` 0.55.1

### DIFF
--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -8,7 +8,9 @@
 import Foundation
 import DatadogInternal
 
+// swiftlint:disable duplicate_imports
 @_exported import enum DatadogInternal.SessionReplayPrivacyLevel
+// swiftlint:enable duplicate_imports
 
 extension SessionReplay {
     /// Session Replay feature configuration.


### PR DESCRIPTION
### What and why?

📦 Fixing lint problem for `swiftlint` 0.55.1.

It passed CI because we use `swiftlint` 0.53.0 in our runners. This fix prepares `develop` branch for linter upgrade on CI.

### How?

The `@_exported import` introduced for SR configuration was missing linter opt-out. It is now added the same way as it was done for in [RUM](https://github.com/DataDog/dd-sdk-ios/blob/1a61f0f8b1388b12145c4ef5695b7892b48146d6/DatadogRUM/Sources/RUMConfiguration.swift#L11-L17) and [Trace](https://github.com/DataDog/dd-sdk-ios/blob/1a61f0f8b1388b12145c4ef5695b7892b48146d6/DatadogTrace/Sources/TraceConfiguration.swift#L11-L22) configuration.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
