### PR TITLE
fix: Watchdog Termination is not supported in Synthetics env

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -42,7 +42,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
         if configuration.trackWatchdogTerminations {
             let appStateManager = WatchdogTerminationAppStateManager(
                 featureScope: featureScope,
-                processId: configuration.processID
+                processId: configuration.processID,
+                syntheticsEnvironment: configuration.syntheticsEnvironment
             )
             let monitor = WatchdogTerminationMonitor(
                 appStateManager: appStateManager,

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppState.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppState.swift
@@ -41,6 +41,9 @@ internal struct WatchdogTerminationAppState: Codable {
 
     /// The user's tracking consent at the recoding time.
     let trackingConsent: TrackingConsent
+
+    /// Returns true, if the app is running in a synthetic environment.
+    let syntheticsEnvironment: Bool
 }
 
 extension WatchdogTerminationAppState: CustomDebugStringConvertible {
@@ -56,6 +59,7 @@ extension WatchdogTerminationAppState: CustomDebugStringConvertible {
         - vendorId: \(vendorId ?? "nil")
         - processId: \(processId)
         - trackingConsent: \(trackingConsent)
+        - syntheticsEnvironment: \(syntheticsEnvironment)
         """
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManager.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManager.swift
@@ -18,9 +18,17 @@ internal final class WatchdogTerminationAppStateManager {
     /// The process identifier of the app whose state is being monitored.
     let processId: UUID
 
-    init(featureScope: FeatureScope, processId: UUID) {
+    /// Returns true, if the app is running in a synthetic environment.
+    let syntheticsEnvironment: Bool
+
+    init(
+        featureScope: FeatureScope,
+        processId: UUID,
+        syntheticsEnvironment: Bool
+    ) {
         self.featureScope = featureScope
         self.processId = processId
+        self.syntheticsEnvironment = syntheticsEnvironment
     }
 
     /// Deletes the app state from the data store.
@@ -99,7 +107,8 @@ internal final class WatchdogTerminationAppStateManager {
                 isActive: true,
                 vendorId: context.device.vendorId,
                 processId: self.processId,
-                trackingConsent: context.trackingConsent
+                trackingConsent: context.trackingConsent,
+                syntheticsEnvironment: self.syntheticsEnvironment
             )
             completion(state)
         }

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
@@ -67,6 +67,13 @@ internal final class WatchdogTerminationChecker {
             return false
         }
 
+        // We can't reliably tell if it was a Watchdog Termination or not if the app was running in a synthetic environment.
+        // Synthetics uses terminateApp API https://github.com/appium/appium-xcuitest-driver/blob/main/lib/real-device.js#L216
+        // for restarting the app which we can't distinguish from Watchdog Termination.
+        guard previous.syntheticsEnvironment == false else {
+            return false
+        }
+
         // Watchdog Termination detection doesn't work on simulators.
         guard deviceInfo.isSimulator == false else {
             return false

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -291,6 +291,9 @@ extension RUM {
         internal var ciTestExecutionID: String? = ProcessInfo.processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"]
         internal var syntheticsTestId: String? = ProcessInfo.processInfo.environment["_dd.synthetics.test_id"]
         internal var syntheticsResultId: String? = ProcessInfo.processInfo.environment["_dd.synthetics.result_id"]
+        internal var syntheticsEnvironment: Bool {
+            syntheticsTestId != nil || syntheticsResultId != nil
+        }
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManagerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationAppStateManagerTests.swift
@@ -21,7 +21,8 @@ final class WatchdogTerminationAppStateManagerTests: XCTestCase {
         featureScope = FeatureScopeMock()
         sut = WatchdogTerminationAppStateManager(
             featureScope: featureScope,
-            processId: .init()
+            processId: .init(),
+            syntheticsEnvironment: false
         )
     }
 

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationCheckerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationCheckerTests.swift
@@ -16,6 +16,22 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
         XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), deviceInfo: .mockWith(isSimulator: false), from: nil, to: .mockRandom()))
     }
 
+    func testSyntheticsEnvironment_NoWatchdogTermination() throws {
+        let previous = WatchdogTerminationAppState(
+            appVersion: .mockAny(),
+            osVersion: .mockAny(),
+            systemBootTime: .mockAny(),
+            isDebugging: true,
+            wasTerminated: .mockAny(),
+            isActive: .mockAny(),
+            vendorId: .mockAny(),
+            processId: .mockAny(),
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: true
+        )
+        XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), deviceInfo: .mockWith(isSimulator: false), from: previous, to: .mockRandom()))
+    }
+
     func testIsSimulatorBuild_NoWatchdogTermination() throws {
         XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), deviceInfo: .mockWith(isSimulator: false), from: .mockRandom(), to: .mockRandom()))
     }
@@ -30,7 +46,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
         XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), deviceInfo: .mockWith(isSimulator: false), from: previous, to: .mockRandom()))
     }
@@ -45,7 +62,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -57,7 +75,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .mockRandom(), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -73,7 +92,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -85,7 +105,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: true), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -101,7 +122,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -113,7 +135,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -129,7 +152,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -141,7 +165,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -157,7 +182,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -169,7 +195,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -185,7 +212,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: "foo",
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -197,7 +225,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: "bar",
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -215,7 +244,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: "foo",
             processId: pid,
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -227,7 +257,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: "foo",
             processId: pid,
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -243,7 +274,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: false,
             vendorId: "foo",
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -255,7 +287,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: .mockAny(),
             vendorId: "foo",
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertFalse(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))
@@ -271,7 +304,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: true,
             vendorId: "foo",
             processId: UUID(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         let current = WatchdogTerminationAppState(
@@ -283,7 +317,8 @@ final class WatchdogTerminationCheckerTests: XCTestCase {
             isActive: true,
             vendorId: "foo",
             processId: UUID(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: false
         )
 
         XCTAssertTrue(sut.isWatchdogTermination(launch: .init(didCrash: false), deviceInfo: .mockWith(isSimulator: false), from: previous, to: current))

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
@@ -20,7 +20,8 @@ extension WatchdogTerminationAppState: RandomMockable, AnyMockable {
             isActive: .mockAny(),
             vendorId: .mockAny(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: .mockRandom()
         )
     }
 
@@ -34,7 +35,8 @@ extension WatchdogTerminationAppState: RandomMockable, AnyMockable {
             isActive: .mockRandom(),
             vendorId: .mockRandom(),
             processId: .mockAny(),
-            trackingConsent: .mockRandom()
+            trackingConsent: .mockRandom(),
+            syntheticsEnvironment: .mockRandom()
         )
     }
 }
@@ -78,7 +80,8 @@ extension WatchdogTerminationAppStateManager: RandomMockable {
     public static func mockRandom() -> WatchdogTerminationAppStateManager {
         return .init(
             featureScope: FeatureScopeMock(),
-            processId: .mockRandom()
+            processId: .mockRandom(),
+            syntheticsEnvironment: .mockRandom()
         )
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -100,7 +100,8 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
 
         let appStateManager = WatchdogTerminationAppStateManager(
             featureScope: featureScope,
-            processId: processId
+            processId: processId,
+            syntheticsEnvironment: false
         )
 
         let checker = WatchdogTerminationChecker(appStateManager: appStateManager, featureScope: featureScope)


### PR DESCRIPTION
### What and why?

After starting dogfooding WT, we saw 300+ terminations caused by WT in s8s but those are not actually WT but normal terminations caused by https://github.com/appium/appium-xcuitest-driver/blob/main/lib/real-device.js#L216 API. This API is used by s8s for Restart Application special action.

### How?

Add extra `syntheticsEnvironment` state variable which stores the state if the app was running in s8s or not. This value is determined based on the presence of `_dd.synthetics.test_id` or `_dd.synthetics.result_id` env vars.

I couldn't find any other information in the form of env var, args or launch args which we can use to make a decision so it not only covers s8s but also covers other UI automation frameworks.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
