### PR TITLE
feat: Replace use of #filePath with #fileID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVEMENT] Use `#fileID` over `#filePath` as the default argument in errors. See [#1938][]
 - [FEATURE] Add support for Watchdog Terminations tracking in RUM. See [#1917][] [#1911][] [#1912][] [#1889][]
 - [IMPROVEMENT] Allow disabling app hang monitoring in ObjC API. See [#1908][]
 - [IMPROVEMENT] Update RUM and Telemetry models with KMP source. See [#1925][]
@@ -698,6 +699,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1912]: https://github.com/DataDog/dd-sdk-ios/pull/1912
 [#1889]: https://github.com/DataDog/dd-sdk-ios/pull/1889
 [#1925]: https://github.com/DataDog/dd-sdk-ios/pull/1925
+[#1938]: https://github.com/DataDog/dd-sdk-ios/pull/1938
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -77,7 +77,7 @@ public extension RUMMonitorProtocol {
     ///   - stack: stack trace of the error. No specific format is required. If not specified, it will be inferred from `file` and `line`.
     ///   - source: the origin of the error.
     ///   - attributes: custom attributes to attach to this error.
-    ///   - file: the file in which the error occurred (the default is the `#filePath` of the caller).
+    ///   - file: the file in which the error occurred (the default is the `#fileID` of the caller).
     ///   - line: the line number on which the error occurred (the default is the `#line` of the caller).
     func addError(
         message: String,
@@ -85,7 +85,7 @@ public extension RUMMonitorProtocol {
         stack: String? = nil,
         source: RUMErrorSource = .custom,
         attributes: [AttributeKey: AttributeValue] = [:],
-        file: StaticString? = #filePath,
+        file: StaticString? = #fileID,
         line: UInt? = #line
     ) {
         addError(

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -126,7 +126,7 @@ public protocol RUMMonitorProtocol: AnyObject {
     ///   - stack: stack trace of the error. No specific format is required. If not specified, it will be inferred from `file` and `line`.
     ///   - source: the origin of the error.
     ///   - attributes: custom attributes to attach to this error.
-    ///   - file: the file in which the error occurred (the default is the `#filePath` of the caller).
+    ///   - file: the file in which the error occurred (the default is the `#fileID` of the caller).
     ///   - line: the line number on which the error occurred (the default is the `#line` of the caller).
     func addError(
         message: String,

--- a/DatadogRUM/Tests/DDTAssertValidRUMUUID.swift
+++ b/DatadogRUM/Tests/DDTAssertValidRUMUUID.swift
@@ -7,7 +7,7 @@
 import Foundation
 import TestUtilities
 
-func DDTAssertValidRUMUUID(_ uuid: @autoclosure () throws -> String?, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+func DDTAssertValidRUMUUID(_ uuid: @autoclosure () throws -> String?, _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         try _DDTAssertValidRUMUUID(uuid())
     }

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -183,7 +183,7 @@ class RUMInstrumentationTests: XCTestCase {
     }
 }
 
-internal func DDAssertActiveSwizzlings(_ expectedSwizzledSelectors: [String], file: StaticString = #filePath, line: UInt = #line) {
+internal func DDAssertActiveSwizzlings(_ expectedSwizzledSelectors: [String], file: StaticString = #fileID, line: UInt = #line) {
     _DDEvaluateAssertion(message: "Only \(expectedSwizzledSelectors) swizzlings should be active", file: file, line: line) {
         let actual = Swizzling.methods.map { "\(method_getName($0))" }.sorted()
         let expected = expectedSwizzledSelectors.sorted()

--- a/TestUtilities/Helpers/DDAssert.swift
+++ b/TestUtilities/Helpers/DDAssert.swift
@@ -148,19 +148,19 @@ private func _DDAssertJSONEqual<T, U>(_ expression1: @autoclosure () throws -> T
     }
 }
 
-public func DDAssertJSONEqual(_ expression1: @autoclosure () throws -> Any, _ expression2: @autoclosure () throws -> Any, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+public func DDAssertJSONEqual(_ expression1: @autoclosure () throws -> Any, _ expression2: @autoclosure () throws -> Any, _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         try _DDAssertJSONEqual(AnyCodable(expression1()), AnyCodable(expression2()))
     }
 }
 
-public func DDAssertJSONEqual<T, U>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> U, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) where T: Encodable, U: Encodable {
+public func DDAssertJSONEqual<T, U>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> U, _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) where T: Encodable, U: Encodable {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         try _DDAssertJSONEqual(expression1(), expression2())
     }
 }
 
-public func DDAssertJSONNotEqual<T, U>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> U, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) where T: Encodable, U: Encodable {
+public func DDAssertJSONNotEqual<T, U>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> U, _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) where T: Encodable, U: Encodable {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         do {
             try _DDAssertJSONEqual(expression1(), expression2())
@@ -198,13 +198,13 @@ private func _DDAssertDictionariesEqual(_ expression1: @autoclosure () throws ->
     }
 }
 
-public func DDAssertDictionariesEqual(_ expression1: @autoclosure () throws -> [String: Any], _ expression2: @autoclosure () throws -> [String: Any], _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+public func DDAssertDictionariesEqual(_ expression1: @autoclosure () throws -> [String: Any], _ expression2: @autoclosure () throws -> [String: Any], _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         try _DDAssertDictionariesEqual(expression1(), expression2())
     }
 }
 
-public func DDAssertDictionariesNotEqual(_ expression1: @autoclosure () throws -> [String: Any], _ expression2: @autoclosure () throws -> [String: Any], _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+public func DDAssertDictionariesNotEqual(_ expression1: @autoclosure () throws -> [String: Any], _ expression2: @autoclosure () throws -> [String: Any], _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         do {
             try _DDAssertDictionariesEqual(expression1(), expression2())
@@ -216,7 +216,7 @@ public func DDAssertDictionariesNotEqual(_ expression1: @autoclosure () throws -
     }
 }
 
-public func DDAssertThrowsError<T, E: Error>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line, _ errorHandler: (_ error: E) -> Void = { _ in }) {
+public func DDAssertThrowsError<T, E: Error>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line, _ errorHandler: (_ error: E) -> Void = { _ in }) {
     _DDEvaluateAssertion(message: message(), file: file, line: line) {
         do {
              let result = try expression()


### PR DESCRIPTION
### What and why?

#filePath exposes full paths of build files. Use of #fileID is encouraged by Apple both because it gives you better privacy and reduces the size of the compiled binary.

refs: RUM-5155

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests for Session Replay
