### PR TITLE
Inject backtrace reporter into Logs feature

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ Smoke Tests (iOS):
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15 Pro"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "$OS" # temporary, waiting for AMI
     - make clean repo-setup ENV=ci
     - make spm-build-ios
     - make smoke-test-ios-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
@@ -152,7 +152,7 @@ Smoke Tests (tvOS):
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --tvOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "$OS" # temporary, waiting for AMI
     - make clean repo-setup ENV=ci
     - make spm-build-tvos
     - make smoke-test-tvos-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Objc attributes interop for KMP. See [#1947][]
+- [FIX] Inject backtrace reporter into Logs feature. See [#1948][]
 
 # 2.14.0 / 04-07-2024
 
@@ -711,6 +712,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1934]: https://github.com/DataDog/dd-sdk-ios/pull/1934
 [#1938]: https://github.com/DataDog/dd-sdk-ios/pull/1938
 [#1947]: https://github.com/DataDog/dd-sdk-ios/pull/1947
+[#1948]: https://github.com/DataDog/dd-sdk-ios/pull/1948
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -64,7 +64,8 @@ public enum Logs {
             logEventMapper: logEventMapper,
             dateProvider: configuration.dateProvider,
             customIntakeURL: configuration.customEndpoint,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            backtraceReporter: core.backtraceReporter
         )
 
         do {

--- a/DatadogLogs/Tests/LogsTests.swift
+++ b/DatadogLogs/Tests/LogsTests.swift
@@ -39,6 +39,18 @@ class LogsTests: XCTestCase {
         XCTAssertTrue(Logs._internal.isEnabled(in: core))
     }
 
+    func testInitializedWithBacktraceReporter() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+
+        // When
+        Logs.enable(in: core)
+
+        // Then
+        let logs = try XCTUnwrap(core.get(feature: LogsFeature.self))
+        XCTAssertNotNil(logs.backtraceReporter)
+    }
+
     func testConfigurationOverrides() throws {
         // Given
         let customEndpoint: URL = .mockRandom()


### PR DESCRIPTION
### What and why?

Follow-up for https://github.com/DataDog/dd-sdk-ios/commit/00fd8f7366e80cb2fed92bcc883f41026cdaed9e - backtrace reporter was added to the Logs feature, but it was never passed in the constructor call.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests for Session Replay
