### PR TITLE
RUM-1000 chore: use throwing API to create the file

### DIFF
--- a/DatadogCore/Sources/Core/Storage/Files/Directory.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/Directory.swift
@@ -7,6 +7,10 @@
 import Foundation
 import DatadogInternal
 
+extension Data {
+    static let empty = Data()
+}
+
 /// Provides interfaces for accessing common properties and operations for a directory.
 internal protocol DirectoryProtocol: FileProtocol {
     /// Returns list of subdirectories in the directory.
@@ -106,9 +110,7 @@ internal struct Directory: DirectoryProtocol {
     /// Creates file with given name.
     func createFile(named fileName: String) throws -> File {
         let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
-        guard FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil) == true else {
-            throw InternalError(description: "Cannot create file at path: \(fileURL.path)")
-        }
+        try Data.empty.write(to: fileURL, options: .atomic)
         return File(url: fileURL)
     }
 


### PR DESCRIPTION
### What and why?

The error message we get today is non actionable and doesn't provide information why the file create failed.

```
InternalError: Failed to write data to file - Cannot create file at path: /var/mobile/Containers/Data/Application/E08E89DC-F1F2-496E-BEB0-B5D9E9359F8E/Library/Caches/com.datadoghq/v2/5168944e862876aa5a9ad4e5df4a654f6d54deca3edc50e66544bff2a690103e/rum/v2/742819228496
```

### How?

Replaced file creation with a API which throws.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
