### PR TITLE
RUM-5344 chore: Export GH token to avoid rate limiting `carthage` in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ default:
         paths:
           - "Datadog*/**/*"
           - "IntegrationTests/**/*"
+          - "SmokeTests/**/*"
           - "TestUtilities/**/*"
           - "*" # match any file in the root directory
         compare_to: 'develop' # cannot use $DEVELOP_BRANCH var due to: https://gitlab.com/gitlab-org/gitlab/-/issues/369916
@@ -236,6 +237,9 @@ Smoke Tests (macOS):
 
 Smoke Tests (watchOS):
   stage: smoke-test
+  rules: 
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
   tags:
     - macos:ventura
     - specific:true

--- a/SmokeTests/carthage/Makefile
+++ b/SmokeTests/carthage/Makefile
@@ -46,7 +46,7 @@ ifeq ($(CARTHAGE_PLATFORM),)
 	@exit 1
 endif
 	@$(ECHO_INFO) "Using CARTHAGE_PLATFORM='$(CARTHAGE_PLATFORM)'"
-	carthage update --platform $(CARTHAGE_PLATFORM) --use-xcframeworks
+	REPO_ROOT=$(REPO_ROOT) $(REPO_ROOT)/tools/carthage-shim.sh update --platform $(CARTHAGE_PLATFORM) --use-xcframeworks
 
 test:
 	@$(call require_param,OS)

--- a/tools/carthage-shim.sh
+++ b/tools/carthage-shim.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+
+# Usage:
+# - in repo root:
+# $ ./tools/carthage-shim.sh [carthage commands and parameters]
+# - in different directory:
+# $ REPO_ROOT="../../" ../../tools/carthage-shim.sh [carthage commands and parameters]
+#
+# Shims Carthage commands with avoiding rate-limiting on CI.
+
+source "${REPO_ROOT:-.}/tools/secrets/get-secret.sh"
+
+# "In shared environment where several virtual machines are using the same public ip address (like CI),
+# carthage user could hit a Github API rate limit. By providing a Github API access token, carthage can get
+# a higher rate limit."
+# Ref.: https://github.com/Carthage/Carthage/pull/605
+if [ "$CI" = "true" ]; then
+    export GITHUB_ACCESS_TOKEN=$(get_secret $DD_IOS_SECRET__CARTHAGE_GH_TOKEN)
+fi
+
+carthage "$@"

--- a/tools/release/build-xcframeworks.sh
+++ b/tools/release/build-xcframeworks.sh
@@ -25,6 +25,7 @@ parse_args "$@"
 
 
 REPO_PATH=$(realpath "$repo_path")
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo_info "Clean '$REPO_PATH' with 'git clean -fxd'"
 cd "$REPO_PATH" && git clean -fxd && cd -
@@ -107,7 +108,8 @@ echo_info "▸ PLATFORMS = '$PLATFORMS'"
 
 # Build third-party XCFrameworks
 echo_subtitle2 "Run 'carthage bootstrap --platform $PLATFORMS --use-xcframeworks'"
-carthage bootstrap --platform $PLATFORMS --use-xcframeworks
+export REPO_ROOT=$(realpath "$SCRIPT_DIR/../..") 
+$REPO_ROOT/tools/carthage-shim.sh bootstrap --platform $PLATFORMS --use-xcframeworks
 cp -r "Carthage/Build/CrashReporter.xcframework" "$XCFRAMEWORKS_OUTPUT"
 cp -r "Carthage/Build/OpenTelemetryApi.xcframework" "$XCFRAMEWORKS_OUTPUT"
 

--- a/tools/repo-setup/repo-setup.sh
+++ b/tools/repo-setup/repo-setup.sh
@@ -34,7 +34,7 @@ if [[ "$env" == "$ENV_DEV" ]]; then
 fi
 
 bundle install
-carthage bootstrap --platform iOS,tvOS --use-xcframeworks
+./tools/carthage-shim.sh bootstrap --platform iOS,tvOS --use-xcframeworks
 
 echo_succ "Using OpenTelemetryApi version: $(cat ./Carthage/Build/.OpenTelemetryApi.version | grep 'commitish' | awk -F'"' '{print $4}')"
 echo_succ "Using PLCrashReporter version: $(cat ./Carthage/Build/.plcrashreporter.version | grep 'commitish' | awk -F'"' '{print $4}')"

--- a/tools/secrets/config.sh
+++ b/tools/secrets/config.sh
@@ -13,6 +13,7 @@ DD_IOS_SECRETS_PATH_PREFIX='kv/aws/arn:aws:iam::486234852809:role/ci-dd-sdk-ios/
 # Keep this list and Confluence page up-to-date with every secret that is added to the list.
 DD_IOS_SECRET__TEST_SECRET="test.secret"
 DD_IOS_SECRET__GH_CLI_TOKEN="gh.cli.token"
+DD_IOS_SECRET__CARTHAGE_GH_TOKEN="carthage.gh.token"
 DD_IOS_SECRET__CP_TRUNK_TOKEN="cocoapods.trunk.token"
 DD_IOS_SECRET__SSH_KEY="ssh.key"
 DD_IOS_SECRET__E2E_CERTIFICATE_P12_BASE64="e2e.certificate.p12.base64"
@@ -23,16 +24,17 @@ DD_IOS_SECRET__E2E_S8S_API_KEY="e2e.s8s.api.key"
 DD_IOS_SECRET__E2E_S8S_APP_KEY="e2e.s8s.app.key"
 DD_IOS_SECRET__E2E_S8S_APPLICATION_ID="e2e.s8s.app.id"
 
-declare -A DD_IOS_SECRETS=(
-    [0]="$DD_IOS_SECRET__TEST_SECRET | test secret to see if things work, free to change but not delete"
-    [1]="$DD_IOS_SECRET__GH_CLI_TOKEN | GitHub token to authenticate 'gh' cli (https://cli.github.com/)"
-    [2]="$DD_IOS_SECRET__CP_TRUNK_TOKEN | Cocoapods token to authenticate 'pod trunk' operations (https://guides.cocoapods.org/terminal/commands.html)"
-    [3]="$DD_IOS_SECRET__SSH_KEY | SSH key to authenticate 'git clone git@github.com:...' operations"
-    [4]="$DD_IOS_SECRET__E2E_CERTIFICATE_P12_BASE64 | Base64-encoded '.p12' certificate file for signing E2E app"
-    [5]="$DD_IOS_SECRET__E2E_CERTIFICATE_P12_PASSWORD | Password to '$DD_IOS_SECRET__E2E_CERTIFICATE_P12_BASE64' certificate"
-    [6]="$DD_IOS_SECRET__E2E_PROVISIONING_PROFILE_BASE64 | Base64-encoded provisioning profile file for signing E2E app"
-    [7]="$DD_IOS_SECRET__E2E_XCCONFIG_BASE64 | Base64-encoded xcconfig file for E2E app"
-    [8]="$DD_IOS_SECRET__E2E_S8S_API_KEY | DATADOG_API_KEY for uploading E2E app to synthetics"
-    [9]="$DD_IOS_SECRET__E2E_S8S_APP_KEY | DATADOG_APP_KEY for uploading E2E app to synthetics"
-    [10]="$DD_IOS_SECRET__E2E_S8S_APPLICATION_ID | Synthetics app ID for E2E tests"
-)
+idx=0
+declare -A DD_IOS_SECRETS
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__TEST_SECRET | test secret to see if things work, free to change but not delete"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__GH_CLI_TOKEN | GitHub token to authenticate 'gh' cli (https://cli.github.com/)"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__CARTHAGE_GH_TOKEN | GitHub token to avoid rate limiting Carthage commands (https://github.com/Carthage/Carthage/pull/605)"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__CP_TRUNK_TOKEN | Cocoapods token to authenticate 'pod trunk' operations (https://guides.cocoapods.org/terminal/commands.html)"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__SSH_KEY | SSH key to authenticate 'git clone git@github.com:...' operations"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_CERTIFICATE_P12_BASE64 | Base64-encoded '.p12' certificate file for signing E2E app"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_CERTIFICATE_P12_PASSWORD | Password to '$DD_IOS_SECRET__E2E_CERTIFICATE_P12_BASE64' certificate"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_PROVISIONING_PROFILE_BASE64 | Base64-encoded provisioning profile file for signing E2E app"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_XCCONFIG_BASE64 | Base64-encoded xcconfig file for E2E app"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_S8S_API_KEY | DATADOG_API_KEY for uploading E2E app to synthetics"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_S8S_APP_KEY | DATADOG_APP_KEY for uploading E2E app to synthetics"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_S8S_APPLICATION_ID | Synthetics app ID for E2E tests"

--- a/tools/secrets/get-secret.sh
+++ b/tools/secrets/get-secret.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
-source ./tools/utils/echo-color.sh
-source ./tools/secrets/config.sh
+source "${REPO_ROOT:-.}/tools/utils/echo-color.sh"
+source "${REPO_ROOT:-.}/tools/secrets/config.sh"
 
 # Usage:
 #   get_secret <secret_name>


### PR DESCRIPTION
### What and Why?

📦 To prevent a known [Carthage issue](https://github.com/Carthage/Carthage/issues/545) where the GitHub API rate limit is exceeded:
```
GitHub API request failed: API rate limit exceeded for (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```
this PR introduces the use of `GITHUB_ACCESS_TOKEN` to authenticate Carthage operations. By using a GitHub token, Carthage will benefit from a higher rate limit, as detailed [here](https://github.com/Carthage/Carthage/pull/605). This setup was previously implemented in Bitrise, and we are now porting it to GitLab.

### How?

Unlike in Bitrise, where we could export a global `GITHUB_ACCESS_TOKEN` environment variable for a single workflow, GitLab requires a different approach. We use `carthage` in multiple automations, each running as different jobs in separate runner instances.

To streamline this, this PR introduces a `carthage-shim.sh` script. This script forwards all passed arguments to `carthage`, ensuring that `GITHUB_ACCESS_TOKEN` is set in the CI environment.

The actual `GITHUB_ACCESS_TOKEN` value is stored securely as a CI secret.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
