### PR TITLE
RUM-4709 feat: decorate network span kind as `client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FEATURE] Enable DatadogCore, DatadogLogs and DatadogTrace to compile on watchOS platform. See [#1918][] (Thanks [@jfiser-paylocity][]) [#1946][]
 - [IMPROVEMENT] Ability to clear feature data storage using `clearAllData` API. See [#1940][]
 - [IMPROVEMENT] Send memory warning as RUM error. See [#1955][]
+- [IMPROVEMENT] Decorate network span kind as `client`. See [#1963][]
 
 # 2.14.1 / 09-07-2024
 
@@ -725,6 +726,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1948]: https://github.com/DataDog/dd-sdk-ios/pull/1948
 [#1940]: https://github.com/DataDog/dd-sdk-ios/pull/1940
 [#1955]: https://github.com/DataDog/dd-sdk-ios/pull/1955
+[#1963]: https://github.com/DataDog/dd-sdk-ios/pull/1963
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -109,12 +109,13 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.tags[OTTags.httpUrl], request.url!.absoluteString)
         XCTAssertEqual(span.tags[OTTags.httpMethod], "GET")
         XCTAssertEqual(span.tags[SpanTags.errorType], "domain - 123")
+        XCTAssertEqual(span.tags[SpanTags.kind], "client")
         XCTAssertEqual(
             span.tags[SpanTags.errorStack],
             "Error Domain=domain Code=123 \"network error\" UserInfo={NSLocalizedDescription=network error}"
         )
         XCTAssertEqual(span.tags[SpanTags.errorMessage], "network error")
-        XCTAssertEqual(span.tags.count, 7)
+        XCTAssertEqual(span.tags.count, 8)
 
         let log: LogEvent = try XCTUnwrap(core.events().last, "It should send error log")
         XCTAssertEqual(log.status, .error)
@@ -178,11 +179,12 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.tags[OTTags.httpStatusCode], "404")
         XCTAssertEqual(span.tags[SpanTags.errorType], "HTTPURLResponse - 404")
         XCTAssertEqual(span.tags[SpanTags.errorMessage], "404 not found")
+        XCTAssertEqual(span.tags[SpanTags.kind], "client")
         XCTAssertEqual(
             span.tags[SpanTags.errorStack],
             "Error Domain=HTTPURLResponse Code=404 \"404 not found\" UserInfo={NSLocalizedDescription=404 not found}"
         )
-        XCTAssertEqual(span.tags.count, 8)
+        XCTAssertEqual(span.tags.count, 9)
 
         let log: LogEvent = try XCTUnwrap(core.events().last, "It should send error log")
         XCTAssertEqual(log.status, .error)

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -137,6 +137,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             return
         }
 
+        span.setTag(key: SpanTags.kind, value: "client")
+
         let url = interception.request.url?.absoluteString ?? "unknown_url"
 
         if let requestUrl = interception.request.url {

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -19,6 +19,7 @@ import DatadogInternal
 @_exported import class DatadogInternal.W3CHTTPHeadersWriter
 @_exported import enum DatadogInternal.TraceSamplingStrategy
 @_exported import enum DatadogInternal.TraceContextInjection
+@_exported import enum DatadogInternal.TracingHeaderType
 // swiftlint:enable duplicate_imports
 
 extension Trace {

--- a/DatadogTrace/Sources/Tracer.swift
+++ b/DatadogTrace/Sources/Tracer.swift
@@ -42,6 +42,9 @@ public enum SpanTags {
     internal static let rumViewID = "_dd.view.id"
     /// Internal tag used to encode the RUM action ID, linking the span to the current RUM session.
     internal static let rumActionID = "_dd.action.id"
+    /// Internal tag used to encode the span kind. This can be either "client" or "server" for RPC spans,
+    /// and "producer" or "consumer" for messaging spans.
+    internal static let kind = "span.kind"
 }
 
 /// A class for manual interaction with the Trace feature. It records spans that are sent to Datadog APM.

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -289,7 +289,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.tags[OTTags.httpUrl], request.url!.absoluteString)
         XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
         XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
-        XCTAssertEqual(span.tags.count, 5)
+        XCTAssertEqual(span.tags[OTTags.spanKind], "client")
+        XCTAssertEqual(span.tags.count, 6)
     }
 
     func testGivenFirstPartyIncompleteInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {


### PR DESCRIPTION
### What and why?

APM needs to be able to differentiate between a client span vs other span to be able to build features on top of it.

### How?

Attach `span.kind` for all network spans in Trace module.

The ask is for APM spans only, not for RUM spans as they are ingested by RUM BE.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
