### PR TITLE
Fix: Typo in WatchdogTerminationMonitor init argument

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -54,7 +54,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     appStateManager: appStateManager,
                     featureScope: featureScope
                 ),
-                stroage: core.storage,
+                storage: core.storage,
                 feature: featureScope,
                 reporter: WatchdogTerminationReporter(
                     featureScope: featureScope,

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -44,7 +44,7 @@ internal final class WatchdogTerminationMonitor {
     init(
         appStateManager: WatchdogTerminationAppStateManager,
         checker: WatchdogTerminationChecker,
-        stroage: Storage?,
+        storage: Storage?,
         feature: FeatureScope,
         reporter: WatchdogTerminationReporting
     ) {
@@ -52,7 +52,7 @@ internal final class WatchdogTerminationMonitor {
         self.appStateManager = appStateManager
         self.feature = feature
         self.reporter = reporter
-        self.storage = stroage
+        self.storage = storage
         self.currentState = .stopped
     }
 

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
@@ -103,7 +103,7 @@ extension WatchdogTerminationMonitor: RandomMockable {
         return .init(
             appStateManager: .mockRandom(),
             checker: .mockRandom(),
-            stroage: NOPDatadogCore().storage,
+            storage: NOPDatadogCore().storage,
             feature: FeatureScopeMock(),
             reporter: WatchdogTerminationReporter.mockRandom()
         )

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -111,7 +111,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut = WatchdogTerminationMonitor(
             appStateManager: appStateManager,
             checker: checker,
-            stroage: NOPDatadogCore().storage,
+            storage: NOPDatadogCore().storage,
             feature: featureScope,
             reporter: reporter
         )


### PR DESCRIPTION
### What and why?

Fix typo in WatchdogTerminationMonitor init argument name.

### How?

~~stroage~~ storage


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
