### PR TITLE
RUM-4079 chore: Do not block CI pipeline with dogfooding jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,6 +278,7 @@ Dogfood (Shopist):
   rules:
     - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH'
       when: manual
+      allow_failure: true
   script:
     - ./tools/runner-setup.sh --ssh # temporary, waiting for AMI
     - DRY_RUN=0 make dogfood-shopist
@@ -287,6 +288,7 @@ Dogfood (Datadog app):
   rules:
     - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH'
       when: manual
+      allow_failure: true
   script:
     - ./tools/runner-setup.sh --ssh # temporary, waiting for AMI
     - DRY_RUN=0 make dogfood-datadog-app


### PR DESCRIPTION
### What and why?

📦 Fixes the problem of [blocking CI pipeline](https://gitlab.ddbuild.io/DataDog/dd-sdk-ios/-/pipelines/39669904) for `develop` when manual Dogfooding jobs are added (since https://github.com/DataDog/dd-sdk-ios/pull/1961).

Expected behaviorus are:
- The `develop` pipeline is not blocked by awaiting manual jobs to be ran.
- The failures of Dogfooding jobs should not alter the state of `develop` commit integration (such should be only determined from default integration stages like tests, ui-tests and smoke-tests).

### How?

Using [`rules:allow_failure:true`](https://docs.gitlab.com/ee/ci/yaml/index.html#rulesallow_failure):

> Use [`allow_failure: true`](https://docs.gitlab.com/ee/ci/yaml/index.html#allow_failure) in rules to allow a job to fail without stopping the pipeline.
> 
> You can also use `allow_failure: true` with a manual job. The pipeline continues running **without waiting for the result of the manual job**. 

Without customizing `allow_failure`, the pipeline uses [default (`false`)](https://docs.gitlab.com/ee/ci/yaml/index.html#when:~:text=The%20default%20behavior%20of%20allow_failure%20changes%20to%20true%20with%20when%3A%20manual.%20However%2C%20if%20you%20use%20when%3A%20manual%20with%20rules%2C%20allow_failure%20defaults%20to%20false.), which was causing the whole pipeline to wait:

> `allow_failure: false` combined with `when: manual` in rules causes the pipeline to wait for the manual job to run before continuing.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
