### PR TITLE
RUM-3060 feat: Deprecate Alamofire extension pod

### DIFF
--- a/DatadogAlamofireExtension.podspec
+++ b/DatadogAlamofireExtension.podspec
@@ -2,6 +2,11 @@ Pod::Spec.new do |s|
   s.name         = "DatadogAlamofireExtension"
   s.version      = "2.14.1"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
+  s.description  = <<-DESC
+                   The DatadogAlamofireExtension pod is deprecated and will no longer be maintained.
+                   Please refer to the following documentation on how to instrument Alamofire with the Datadog iOS SDK:
+                   https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/ios
+                   DESC
 
   s.homepage     = "https://www.datadoghq.com"
   s.social_media_url   = "https://twitter.com/datadoghq"
@@ -13,6 +18,8 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com",
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
+
+  s.deprecated = true
 
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'

--- a/DatadogExtensions/Alamofire/README.md
+++ b/DatadogExtensions/Alamofire/README.md
@@ -1,3 +1,9 @@
+## **Deprecated**
+
+**Note:** The `DatadogAlamofireExtension` pod is deprecated and will no longer be maintained. Please refer to the [Integrated Libraries][6] documentation on how to instrument Alamofire with the Datadog iOS SDK.
+
+---
+
 # Datadog Integration for Alamofire
 
 `DatadogAlamofireExtension` enables `Alamofire.Session` auto instrumentation with Datadog SDK.
@@ -49,3 +55,4 @@ Pull requests are welcome. First, open an issue to discuss what you would like t
 [3]: https://swift.org/package-manager/
 [4]: https://docs.datadoghq.com/tracing/setup_overview/setup/ios/
 [5]: https://docs.datadoghq.com/real_user_monitoring/ios
+[6]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/ios

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ RUM allows you to monitor web views and eliminate blind spots in your hybrid mob
 
 ## Integrations
 
-### Alamofire
-
-If you use [Alamofire][4], review the [`Datadog Alamofire Extension` library](DatadogExtensions/Alamofire/) to learn how to automatically instrument requests with the Datadog iOS SDK.
+If you use [Alamofire][7] or [Apollo GraphQL][8], see [Integrated Libraries][4] to learn how to instrument requests automatically.
 
 ## Contributing
 
@@ -63,6 +61,8 @@ See the [Supported Versions][6] documentation for more details.
 [1]: https://docs.datadoghq.com/logs/log_collection/ios
 [2]: https://docs.datadoghq.com/tracing/setup_overview/setup/ios
 [3]: https://docs.datadoghq.com/real_user_monitoring/ios
-[4]: https://github.com/Alamofire/Alamofire
+[4]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/ios
 [5]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking?tab=ios
 [6]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios/
+[7]: https://github.com/Alamofire/Alamofire
+[8]: https://github.com/apollographql/apollo-ios


### PR DESCRIPTION
### What and why?

📦 Starting from [2.5.0](https://github.com/DataDog/dd-sdk-ios/releases/tag/2.5.0), RUM can automatically track Alamofire requests, making the DatadogAlamofireExtension pod obsolete. Maintaining this pod is cumbersome as it adds an extra code path to the network instrumentation logic, which became problematic in [issue #1638](https://github.com/DataDog/dd-sdk-ios/issues/1638).

The new network instrumentation API introduced in 2.5.0 can handle Alamofire requests without requiring a separate pod. This solution also works for SPM, Carthage, and XCFramework integration. This PR deprecates DatadogAlamofireExtension in favor of the new instructions explained in the following documentation PR:
- https://github.com/DataDog/documentation/pull/24253

### How?

- Created https://github.com/DataDog/documentation/pull/24253 to explain how to instrument Alamofire (and Apollo GraphQL) requests;
- `DatadogAlamofireExtension.podspec` is marked deprecated;

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
