### PR TITLE
Fix: Session Replay TabBar Recorder id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [IMPROVEMENT] Ability to clear feature data storage using `clearAllData` API. See [#1940][]
 - [IMPROVEMENT] Send memory warning as RUM error. See [#1955][]
 - [IMPROVEMENT] Decorate network span kind as `client`. See [#1963][]
+- [FIX] Fix CPU spike when recording UITabBar using SessionReplay. See [#1967][]
 
 # 2.14.1 / 09-07-2024
 
@@ -727,6 +728,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1940]: https://github.com/DataDog/dd-sdk-ios/pull/1940
 [#1955]: https://github.com/DataDog/dd-sdk-ios/pull/1955
 [#1963]: https://github.com/DataDog/dd-sdk-ios/pull/1963
+[#1967]: https://github.com/DataDog/dd-sdk-ios/pull/1967
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -21,7 +21,10 @@ public protocol SessionReplayNodeRecorder {
     /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
     func semantics(of view: UIView, with attributes: SessionReplayViewAttributes, in context: SessionReplayViewTreeRecordingContext) -> SessionReplayNodeSemantics?
 
-    /// Unique identifier of the node recorder.
+    /// Unique identifier for the node recorder, used to generate unique wireframe IDs.
+    ///
+    /// Note: Node recorders of the same type but with different UUIDs will generate different IDs for the same views.
+    /// To maintain consistency, propagate the parent UUID when nesting node recorders.
     var identifier: UUID { get }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIActivityIndicatorRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIActivityIndicatorRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UIActivityIndicatorRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let activityIndicator = view as? UIActivityIndicatorView else {
@@ -38,6 +42,7 @@ internal struct UIActivityIndicatorRecorder: NodeRecorder {
         let subtreeViewRecorder = ViewTreeRecorder(
             nodeRecorders: [
                 UIImageViewRecorder(
+                    identifier: identifier,
                     shouldRecordImagePredicate: { $0.image != nil }
                 )
             ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -8,10 +8,18 @@
 import UIKit
 
 internal struct UIDatePickerRecorder: NodeRecorder {
-    let identifier = UUID()
-    private let wheelsStyleRecorder = WheelsStyleDatePickerRecorder()
-    private let compactStyleRecorder = CompactStyleDatePickerRecorder()
-    private let inlineStyleRecorder = InlineStyleDatePickerRecorder()
+    internal let identifier: UUID
+
+    private let wheelsStyleRecorder: WheelsStyleDatePickerRecorder
+    private let compactStyleRecorder: CompactStyleDatePickerRecorder
+    private let inlineStyleRecorder: InlineStyleDatePickerRecorder
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+        self.wheelsStyleRecorder = WheelsStyleDatePickerRecorder(identifier: identifier)
+        self.compactStyleRecorder = CompactStyleDatePickerRecorder(identifier: identifier)
+        self.inlineStyleRecorder = InlineStyleDatePickerRecorder(identifier: identifier)
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let datePicker = view as? UIDatePicker else {
@@ -70,15 +78,20 @@ internal struct UIDatePickerRecorder: NodeRecorder {
 }
 
 private struct WheelsStyleDatePickerRecorder {
-    let pickerTreeRecorder = ViewTreeRecorder(
-        nodeRecorders: [
-            UIPickerViewRecorder(
-                textObfuscator: { context in
-                    return context.recorder.privacy.staticTextObfuscator
-                }
-            )
-        ]
-    )
+    private let pickerTreeRecorder: ViewTreeRecorder
+
+    init(identifier: UUID) {
+        self.pickerTreeRecorder = ViewTreeRecorder(
+            nodeRecorders: [
+                UIPickerViewRecorder(
+                    identifier: identifier,
+                    textObfuscator: { context in
+                        return context.recorder.privacy.staticTextObfuscator
+                    }
+                )
+            ]
+        )
+    }
 
     func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> [Node] {
         return pickerTreeRecorder.record(view, in: context)
@@ -90,9 +103,10 @@ private struct InlineStyleDatePickerRecorder {
     let labelRecorder: UILabelRecorder
     let subtreeRecorder: ViewTreeRecorder
 
-    init() {
-        self.viewRecorder = UIViewRecorder()
+    init(identifier: UUID) {
+        self.viewRecorder = UIViewRecorder(identifier: identifier)
         self.labelRecorder = UILabelRecorder(
+            identifier: identifier,
             textObfuscator: { context in
                 return context.recorder.privacy.staticTextObfuscator
             }
@@ -101,8 +115,8 @@ private struct InlineStyleDatePickerRecorder {
             nodeRecorders: [
                 viewRecorder,
                 labelRecorder,
-                UIImageViewRecorder(),
-                UISegmentRecorder(), // iOS 14.x uses `UISegmentedControl` for "AM | PM"
+                UIImageViewRecorder(identifier: identifier),
+                UISegmentRecorder(identifier: identifier), // iOS 14.x uses `UISegmentedControl` for "AM | PM"
             ]
         )
     }
@@ -132,16 +146,21 @@ private struct InlineStyleDatePickerRecorder {
 }
 
 private struct CompactStyleDatePickerRecorder {
-    let subtreeRecorder = ViewTreeRecorder(
-        nodeRecorders: [
-            UIViewRecorder(),
-            UILabelRecorder(
-                textObfuscator: { context in
-                    return context.recorder.privacy.staticTextObfuscator
-                }
-            )
-        ]
-    )
+    let subtreeRecorder: ViewTreeRecorder
+
+    init(identifier: UUID) {
+        self.subtreeRecorder = ViewTreeRecorder(
+            nodeRecorders: [
+                UIViewRecorder(identifier: identifier),
+                UILabelRecorder(
+                    identifier: identifier,
+                    textObfuscator: { context in
+                        return context.recorder.privacy.staticTextObfuscator
+                    }
+                )
+            ]
+        )
+    }
 
     func record(_ view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> [Node] {
         return subtreeRecorder.record(view, in: context)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 internal struct UIImageViewRecorder: NodeRecorder {
-    internal let identifier = UUID()
+    internal let identifier: UUID
 
     private let tintColorProvider: (UIImageView) -> UIColor?
     private let shouldRecordImagePredicate: (UIImageView) -> Bool
@@ -18,6 +18,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
     }
 
     internal init(
+        identifier: UUID,
         tintColorProvider: @escaping (UIImageView) -> UIColor? = { imageView in
             if #available(iOS 13.0, *), let image = imageView.image {
                 return image.isTinted ? imageView.tintColor : nil
@@ -33,6 +34,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
             }
         }
     ) {
+        self.identifier = identifier
         self.tintColorProvider = tintColorProvider
         self.shouldRecordImagePredicate = shouldRecordImagePredicate
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -8,18 +8,20 @@
 import UIKit
 
 internal class UILabelRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
 
     /// An option for customizing wireframes builder created by this recorder.
     var builderOverride: (UILabelWireframesBuilder) -> UILabelWireframesBuilder
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating
 
     init(
+        identifier: UUID,
         builderOverride: @escaping (UILabelWireframesBuilder) -> UILabelWireframesBuilder = { $0 },
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
             return context.recorder.privacy.staticTextObfuscator
         }
     ) {
+        self.identifier = identifier
         self.builderOverride = builderOverride
         self.textObfuscator = textObfuscator
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UINavigationBarRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let navigationBar = view as? UINavigationBar else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -17,7 +17,8 @@ import UIKit
 /// - Instead, we infer the value by traversing picker's subtree and finding texts that have no "3D wheel" effect applied.
 /// - If privacy mode is elevated, we don't replace individual characters with "x" letter - instead we change whole options to fixed-width mask value.
 internal struct UIPickerViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
     /// Records all shapes in picker's subtree.
     /// It is used to capture the background of selected option.
     private let selectionRecorder: ViewTreeRecorder
@@ -26,14 +27,17 @@ internal struct UIPickerViewRecorder: NodeRecorder {
     private let labelsRecorder: ViewTreeRecorder
 
     init(
+        identifier: UUID,
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
             return context.recorder.privacy.inputAndOptionTextObfuscator
         }
     ) {
-        self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])
+        self.identifier = identifier
+        self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder(identifier: identifier)])
         self.labelsRecorder = ViewTreeRecorder(
             nodeRecorders: [
                 UIViewRecorder(
+                    identifier: identifier,
                     semanticsOverride: { view, attributes in
                         if #available(iOS 13.0, *) {
                             if !attributes.isVisible || attributes.alpha < 1 || !CATransform3DIsIdentity(view.transform3D) {
@@ -46,6 +50,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
                     }
                 ),
                 UILabelRecorder(
+                    identifier: identifier,
                     builderOverride: { builder in
                         var builder = builder
                         builder.textAlignment = .center

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIProgressViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIProgressViewRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UIProgressViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let progressView = view as? UIProgressView else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
         return context.recorder.privacy.inputAndOptionTextObfuscator
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UISliderRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let slider = view as? UISlider else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UIStepperRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let stepper = view as? UIStepper else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UISwitchRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let `switch` = view as? UISwitch else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal final class UITabBarRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let tabBar = view as? UITabBar else {
@@ -32,6 +36,7 @@ internal final class UITabBarRecorder: NodeRecorder {
         let subtreeViewRecorder = ViewTreeRecorder(
             nodeRecorders: [
                 UIImageViewRecorder(
+                    identifier: identifier,
                     tintColorProvider: { imageView in
                         guard let imageViewImage = imageView.image else {
                             return nil
@@ -58,9 +63,9 @@ internal final class UITabBarRecorder: NodeRecorder {
                         return tabBar.tintColor ?? SystemColors.systemBlue
                     }
                 ),
-                UILabelRecorder(),
+                UILabelRecorder(identifier: identifier),
                 // This is for recording the badge view
-                UIViewRecorder()
+                UIViewRecorder(identifier: identifier)
             ]
         )
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 internal struct UITextFieldRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
     /// `UIViewRecorder` for recording appearance of the text field.
     private let backgroundViewRecorder: UIViewRecorder
     /// `UIImageViewRecorder` for recording icons that are displayed in text field.
@@ -25,9 +26,10 @@ internal struct UITextFieldRecorder: NodeRecorder {
         }
     }
 
-    init() {
-        self.backgroundViewRecorder = UIViewRecorder()
-        self.iconsRecorder = UIImageViewRecorder()
+    init(identifier: UUID) {
+        self.identifier = identifier
+        self.backgroundViewRecorder = UIViewRecorder(identifier: identifier)
+        self.iconsRecorder = UIImageViewRecorder(identifier: identifier)
         self.subtreeRecorder = ViewTreeRecorder(nodeRecorders: [backgroundViewRecorder, iconsRecorder])
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 internal struct UITextViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
         if isSensitive {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -8,14 +8,16 @@
 import UIKit
 
 internal class UIViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
 
     /// An option for overriding default semantics from parent recorder.
     var semanticsOverride: (UIView, ViewAttributes) -> NodeSemantics?
 
     init(
+        identifier: UUID,
         semanticsOverride: @escaping (UIView, ViewAttributes) -> NodeSemantics? = { _, _ in nil }
     ) {
+        self.identifier = identifier
         self.semanticsOverride = semanticsOverride
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -10,7 +10,12 @@ import WebKit
 import SwiftUI
 
 internal struct UnsupportedViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
+
     // swiftlint:disable opening_brace
     private let unsupportedViewsPredicates: [(UIView, ViewTreeRecordingContext) -> Bool] = [
         { _, context in context.viewControllerContext.isRootView(of: .safari) },

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
@@ -9,7 +9,11 @@ import UIKit
 import WebKit
 
 internal class WKWebViewRecorder: NodeRecorder {
-    let identifier = UUID()
+    internal let identifier: UUID
+
+    init(identifier: UUID) {
+        self.identifier = identifier
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let webView = view as? WKWebView else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -58,23 +58,23 @@ extension ViewTreeSnapshotBuilder {
 /// An arrays of default node recorders executed for the root view-tree hierarchy.
 internal func createDefaultNodeRecorders() -> [NodeRecorder] {
     return [
-        UnsupportedViewRecorder(),
-        UIViewRecorder(),
-        UILabelRecorder(),
-        UIImageViewRecorder(),
-        UITextFieldRecorder(),
-        UITextViewRecorder(),
-        UISwitchRecorder(),
-        UISliderRecorder(),
-        UISegmentRecorder(),
-        UIStepperRecorder(),
-        UINavigationBarRecorder(),
-        UITabBarRecorder(),
-        UIPickerViewRecorder(),
-        UIDatePickerRecorder(),
-        WKWebViewRecorder(),
-        UIProgressViewRecorder(),
-        UIActivityIndicatorRecorder()
+        UnsupportedViewRecorder(identifier: UUID()),
+        UIViewRecorder(identifier: UUID()),
+        UILabelRecorder(identifier: UUID()),
+        UIImageViewRecorder(identifier: UUID()),
+        UITextFieldRecorder(identifier: UUID()),
+        UITextViewRecorder(identifier: UUID()),
+        UISwitchRecorder(identifier: UUID()),
+        UISliderRecorder(identifier: UUID()),
+        UISegmentRecorder(identifier: UUID()),
+        UIStepperRecorder(identifier: UUID()),
+        UINavigationBarRecorder(identifier: UUID()),
+        UITabBarRecorder(identifier: UUID()),
+        UIPickerViewRecorder(identifier: UUID()),
+        UIDatePickerRecorder(identifier: UUID()),
+        WKWebViewRecorder(identifier: UUID()),
+        UIProgressViewRecorder(identifier: UUID()),
+        UIActivityIndicatorRecorder(identifier: UUID())
     ]
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIActivityIndicatorRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIActivityIndicatorRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIActivityIndicatorRecorderTests: XCTestCase {
-    private let recorder = UIActivityIndicatorRecorder()
+    private let recorder = UIActivityIndicatorRecorder(identifier: UUID())
     private let activityIndicator = UIActivityIndicatorView()
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIDatePickerRecorderTests: XCTestCase {
-    private let recorder = UIDatePickerRecorder()
+    private let recorder = UIDatePickerRecorder(identifier: UUID())
     private let datePicker = UIDatePicker()
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -12,7 +12,7 @@ import TestUtilities
 
 // swiftlint:disable opening_brace
 class UIImageViewRecorderTests: XCTestCase {
-    private let recorder = UIImageViewRecorder()
+    private let recorder = UIImageViewRecorder(identifier: UUID())
     /// The view under test.
     private let imageView = UIImageView()
     /// `ViewAttributes` simulating common attributes of image view's `UIView`.
@@ -55,7 +55,7 @@ class UIImageViewRecorderTests: XCTestCase {
 
     func testWhenShouldRecordImagePredicateReturnsFalse() throws {
         // When
-        let recorder = UIImageViewRecorder(shouldRecordImagePredicate: { _ in return false })
+        let recorder = UIImageViewRecorder(identifier: UUID(), shouldRecordImagePredicate: { _ in return false })
         imageView.image = UIImage()
         viewAttributes = .mock(fixture: .visible())
 
@@ -69,7 +69,7 @@ class UIImageViewRecorderTests: XCTestCase {
 
     func testWhenShouldRecordImagePredicateReturnsTrue() throws {
         // When
-        let recorder = UIImageViewRecorder(shouldRecordImagePredicate: { _ in return true })
+        let recorder = UIImageViewRecorder(identifier: UUID(), shouldRecordImagePredicate: { _ in return true })
         imageView.image = UIImage()
         viewAttributes = .mock(fixture: .visible())
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -12,7 +12,7 @@ import TestUtilities
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {
-    private let recorder = UILabelRecorder()
+    private let recorder = UILabelRecorder(identifier: UUID())
     /// The label under test.
     private let label = UILabel()
     /// `ViewAttributes` simulating common attributes of label's `UIView`.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UINavigationBarRecorderTests: XCTestCase {
-    private let recorder = UINavigationBarRecorder()
+    private let recorder = UINavigationBarRecorder(identifier: UUID())
 
     func testWhenViewIsOfExpectedType() throws {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIPickerViewRecorderTests: XCTestCase {
-    private let recorder = UIPickerViewRecorder()
+    private let recorder = UIPickerViewRecorder(identifier: UUID())
     private let picker = UIPickerView()
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIProgressViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIProgressViewRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIProgressViewRecorderTests: XCTestCase {
-    private let recorder = UIProgressViewRecorder()
+    private let recorder = UIProgressViewRecorder(identifier: UUID())
     private let progressView = UIProgressView()
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
-    private let recorder = UISegmentRecorder()
+    private let recorder = UISegmentRecorder(identifier: UUID())
     private let segment = UISegmentedControl(items: ["first", "second", "third"])
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
-    private let recorder = UISliderRecorder()
+    private let recorder = UISliderRecorder(identifier: UUID())
     private let slider = UISlider()
     private var viewAttributes: ViewAttributes = .mockAny()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIStepperRecorderTests: XCTestCase {
-    private let recorder = UIStepperRecorder()
+    private let recorder = UIStepperRecorder(identifier: UUID())
     private let stepper = UIStepper()
     /// `ViewAttributes` simulating common attributes of switch's `UIView`.
     private var viewAttributes: ViewAttributes = .mockAny()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
-    private let recorder = UISwitchRecorder()
+    private let recorder = UISwitchRecorder(identifier: UUID())
     /// The label under test.
     private let `switch` = UISwitch()
     /// `ViewAttributes` simulating common attributes of switch's `UIView`.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -6,11 +6,13 @@
 
 #if os(iOS)
 import XCTest
+import TestUtilities
+
 @_spi(Internal)
 @testable import DatadogSessionReplay
 
 class UITabBarRecorderTests: XCTestCase {
-    private let recorder = UITabBarRecorder()
+    private let recorder = UITabBarRecorder(identifier: UUID())
 
     func testWhenViewIsOfExpectedType() throws {
         // When
@@ -30,6 +32,24 @@ class UITabBarRecorderTests: XCTestCase {
 
         // Then
         XCTAssertNil(recorder.semantics(of: view, with: .mockAny(), in: .mockAny()))
+    }
+
+    func testWhenRecordingSubviewTwice() {
+        // Given
+        let tabBar = UITabBar.mock(withFixture: .visible(.someAppearance))
+        tabBar.items = [UITabBarItem(title: "first", image: UIImage(), tag: 0)]
+        let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar)
+
+        // When
+        let semantics1 = recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny())
+        let semantics2 = recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny())
+
+        let builder = SessionReplayWireframesBuilder()
+        let wireframes1 = semantics1?.nodes.flatMap { $0.wireframesBuilder.buildWireframes(with: builder) }
+        let wireframes2 = semantics2?.nodes.flatMap { $0.wireframesBuilder.buildWireframes(with: builder) }
+
+        // Then
+        DDAssertReflectionEqual(wireframes1, wireframes2)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -12,7 +12,7 @@ import TestUtilities
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {
-    private let recorder = UITextFieldRecorder()
+    private let recorder = UITextFieldRecorder(identifier: UUID())
     /// The label under test.
     private let textField = UITextField(frame: .mockAny())
     /// `ViewAttributes` simulating common attributes of text field's `UIView`.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 // swiftlint:disable opening_brace
 class UITextViewRecorderTests: XCTestCase {
-    private let recorder = UITextViewRecorder()
+    private let recorder = UITextViewRecorder(identifier: UUID())
     /// The label under test.
     private let textView = UITextView()
     /// `ViewAttributes` simulating common attributes of text view's `UIView`.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
-    private let recorder = UIViewRecorder()
+    private let recorder = UIViewRecorder(identifier: UUID())
     /// The view under test.
     private let view = UIView()
     /// `ViewAttributes` simulating common attributes of the view.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -14,7 +14,7 @@ import SafariServices
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {
-    private let recorder = UnsupportedViewRecorder()
+    private let recorder = UnsupportedViewRecorder(identifier: UUID())
 
     func testWhenViewIsUnsupportedViewControllersRootView() throws {
         var context = ViewTreeRecordingContext.mockRandom()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
@@ -13,7 +13,7 @@ import TestUtilities
 @testable import DatadogSessionReplay
 
 class WKWebViewRecorderTests: XCTestCase {
-    private let recorder = WKWebViewRecorder()
+    private let recorder = WKWebViewRecorder(identifier: UUID())
     /// The web-view under test.
     private let webView = WKWebView()
     /// `ViewAttributes` simulating common attributes of web-view's `UIView`.


### PR DESCRIPTION
### What and why?

Fixes an issue where TabBar recorder subviews ID generation was inconsistent.

### How?

It was caused by the fact that subtree recorders in the TabBarRecorder where created inline with different UUID each time. I refactored the entire setup and provided additional documentation about providing identifiers.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
