### PR TITLE
fix: do not send context updates on context read

### DIFF
--- a/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
+++ b/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
@@ -40,9 +40,7 @@ internal final class DatadogContextProvider {
     /// The current `context`.
     ///
     /// The value must be accessed from the `queue` only.
-    private var context: DatadogContext {
-        didSet { receivers.forEach { $0(context) } }
-    }
+    private var context: DatadogContext
 
     /// The queue used to synchronize the access to the `DatadogContext`.
     internal let queue = DispatchQueue(
@@ -110,7 +108,12 @@ internal final class DatadogContextProvider {
     ///
     /// - Parameter block: The block closure called with the current context.
     func write(block: @escaping (inout DatadogContext) -> Void) {
-        queue.async { block(&self.context) }
+        queue.async {
+            block(&self.context)
+            self.receivers.forEach { receiver in
+                receiver(self.context)
+            }
+        }
     }
 
     /// Subscribes a context's property to a publisher.

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/DatadogContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/DatadogContextProviderTests.swift
@@ -91,25 +91,6 @@ class DatadogContextProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 0.5)
     }
 
-    func testPublishContextOnContextRead() throws {
-        let expectation = self.expectation(description: "publish new context")
-        expectation.expectedFulfillmentCount = 3
-
-        // Given
-
-        let provider = DatadogContextProvider(context: context)
-        provider.publish { _ in
-            expectation.fulfill()
-        }
-
-        // When
-        (0..<expectation.expectedFulfillmentCount).forEach { _ in
-            _ = provider.read()
-        }
-
-        wait(for: [expectation], timeout: 0.5)
-    }
-
     // MARK: - Thread Safety
 
     func testThreadSafety() {

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -38,7 +38,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut.update(viewEvent: viewEvent1)
 
         // monitor reveives the launch report
-        _ = sut.receive(message: .context(.mockAny()), from: NOPDatadogCore())
+        _ = sut.receive(message: .context(featureScope.contextMock), from: NOPDatadogCore())
 
         // RUM view update after start
         let viewEvent2: RUMViewEvent = .mockRandom()
@@ -62,7 +62,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut.update(viewEvent: viewEvent3)
 
         // monitor reveives the launch report
-        _ = sut.receive(message: .context(.mockAny()), from: NOPDatadogCore())
+        _ = sut.receive(message: .context(featureScope.contextMock), from: NOPDatadogCore())
 
         waitForExpectations(timeout: 1)
         XCTAssertEqual(reporter.sendParams?.viewEvent.view.id, viewEvent2.view.id)


### PR DESCRIPTION
### What and why?

TLDR: when reading `context` from `FeatureScope` triggers a context update which again publishes context updates again to all the subscribes and we end up in a loop.

This shoots up CPU usage and an app termination likely.

### How?

- Now, when we read the context, we no longer update it.
- a small improvement in WT message receiver

There a few learnings from this bug
- The current pub-sub mechanism is very complex and requires a lot of dive deep before you can start making sense.
- The value pub-sub delivers to its consumers is very simple which we have talked before also. For example, on every context, telemetry, webview or baggage message, each receiver is notified which is wastage of CPU cycles. The receivers must be able to subscribe to individual message or part of message.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
