### PR TITLE
RUM-2903 fix: refresh rate vital for variable refresh rate displays when over performing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
+
 # 2.15.0 / 25-07-2024
 
 - [FEATURE] Enable DatadogCore, DatadogLogs and DatadogTrace to compile on watchOS platform. See [#1918][] (Thanks [@jfiser-paylocity][]) [#1946][]
@@ -733,6 +735,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1963]: https://github.com/DataDog/dd-sdk-ios/pull/1963
 [#1968]: https://github.com/DataDog/dd-sdk-ios/pull/1968
 [#1967]: https://github.com/DataDog/dd-sdk-ios/pull/1967
+[#1973]: https://github.com/DataDog/dd-sdk-ios/pull/1973
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
@@ -220,6 +220,34 @@ class VitalRefreshRateReaderTests: XCTestCase {
         let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(thirdFps, 42.85714285714286)
     }
+
+    /* Rate representation
+     *
+     * 0----------8ms---------16ms--------24ms--------32ms
+     * |   6ms   |   6ms   |   6ms   |   6ms   |
+     *
+    */
+    func testFramesPerSecond_givenAdaptiveSyncDisplayWithQuickerThanExpectedFrames() {
+        let reader = VitalRefreshRateReader(notificationCenter: mockNotificationCenter)
+        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+
+        // first frame recorded
+        frameInfoProvider.currentFrameTimestamp = 0
+        frameInfoProvider.nextFrameTimestamp = 0.008
+        let firstFps = reader.framesPerSecond(provider: frameInfoProvider)
+        XCTAssertNil(firstFps)
+
+        // second frame recorded
+        frameInfoProvider.currentFrameTimestamp = 0.006
+        frameInfoProvider.nextFrameTimestamp = 0.014
+        let secondFps = reader.framesPerSecond(provider: frameInfoProvider)
+        XCTAssertEqual(secondFps, 60)
+
+        // third frame recorded
+        frameInfoProvider.currentFrameTimestamp = 0.012
+        let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
+        XCTAssertEqual(thirdFps, 60)
+    }
 }
 
 struct FrameInfoProviderMock: FrameInfoProvider {

--- a/DatadogRUM/Sources/RUMVitals/VitalRefreshRateReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalRefreshRateReader.swift
@@ -77,7 +77,8 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
                     return nil
                 }
                 let expectedFPS = 1.0 / expectedCurrentFrameDuration
-                fps = currentFPS * (Self.backendSupportedFrameRate / expectedFPS)
+                let normalizedFPS = currentFPS * (Self.backendSupportedFrameRate / expectedFPS)
+                fps = min(normalizedFPS, Self.backendSupportedFrameRate)
             } else {
                 fps = currentFPS
             }


### PR DESCRIPTION
### What and why?

Last time when we touched this area, we normalized the FPS relative to the expected rendering rate for variable refresh rate displays.

ie when a display is rendering at 30fps and expected rate is also 30fps, we report 60fps. This is because our backend only supports 60fps and renders useful indicators.

However, in some case, it has been observed that sometimes display renders quicker than expected.

ie when a display is rendering at 45fps and expected rate is 30fps, in this case normalization doesn't work and we go on to report 90fps which is not correct.

### How?

- [x] For variable refresh rate displays, if the refresh rate goes above the 60fps, we cap the FPS to 60fps.
- [x] There is no change in the behavior for fixed refresh rate displays.
- [x] There is no change in the behavior for displays rendering slower than expected rate for variable refresh rate displays.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes