### PR TITLE
chore: Upgrade CI jobs to Xcode 15.4.0; fix: Cocoapods release in 2.15.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,10 @@ stages:
 variables:
   MAIN_BRANCH: "master"
   DEVELOP_BRANCH: "develop"
+  # Default Xcode and runtime versions for all jobs:
+  DEFAULT_XCODE: "15.4.0"
+  DEFAULT_IOS_OS: "17.5"
+  DEFAULT_TVOS_OS: "17.5"
   # Prefilled variables for running a pipeline manually:
   # Ref.: https://docs.gitlab.com/ee/ci/pipelines/index.html#prefill-variables-in-manual-pipelines
   RELEASE_GIT_TAG:
@@ -64,7 +68,7 @@ ENV check:
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   script:
-    - ./tools/runner-setup.sh --datadog-ci # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --datadog-ci
     - make env-check
 
 # ┌──────────────────────────┐
@@ -86,14 +90,12 @@ Unit Tests (iOS):
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   variables:
-    XCODE: "15.3.0"
-    OS: "17.4"
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15 Pro"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-ios-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+    - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
 
 Unit Tests (tvOS):
   stage: test
@@ -101,14 +103,12 @@ Unit Tests (tvOS):
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   variables:
-    XCODE: "15.3.0"
-    OS: "17.4"
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --tvOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-tvos-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+    - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
 
 UI Tests:
   stage: ui-test
@@ -116,8 +116,6 @@ UI Tests:
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   variables:
-    XCODE: "15.3.0"
-    OS: "17.4"
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15 Pro"
   parallel:
@@ -128,9 +126,9 @@ UI Tests:
           - CrashReporting
           - NetworkInstrumentation
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make ui-test TEST_PLAN="$TEST_PLAN" OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+    - make ui-test TEST_PLAN="$TEST_PLAN" OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
 
 SR Snapshot Tests:
   stage: ui-test
@@ -138,8 +136,6 @@ SR Snapshot Tests:
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   variables:
-    XCODE: "15.4.0"
-    OS: "17.5"
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15"
     ARTIFACTS_PATH: "artifacts"
@@ -149,9 +145,9 @@ SR Snapshot Tests:
     expire_in: 1 week
     when: on_failure
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
     - make clean repo-setup ENV=ci
-    - make sr-snapshots-pull sr-snapshot-test OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" ARTIFACTS_PATH="$ARTIFACTS_PATH"
+    - make sr-snapshots-pull sr-snapshot-test OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" ARTIFACTS_PATH="$ARTIFACTS_PATH"
 
 Tools Tests:
   stage: test
@@ -181,7 +177,7 @@ Smoke Tests (iOS):
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15 Pro"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "$OS" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" --ssh # temporary, waiting for AMI
     - make clean repo-setup ENV=ci
     - make spm-build-ios
     - make smoke-test-ios-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
@@ -200,7 +196,7 @@ Smoke Tests (tvOS):
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "$OS" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$XCODE" --tvOS --os "$OS" --ssh # temporary, waiting for AMI
     - make clean repo-setup ENV=ci
     - make spm-build-tvos
     - make smoke-test-tvos-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
@@ -260,15 +256,12 @@ E2E Test (upload to s8s):
   stage: e2e-test
   rules:
     - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH'
-  variables:
-    XCODE: "15.3.0"
-    OS: "17.4"
   artifacts:
     paths:
       - artifacts
     expire_in: 2 weeks
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" --datadog-ci # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --datadog-ci
     - make clean
     - export DRY_RUN=${DRY_RUN:-0} # default to 0 if not specified
     - make e2e-build-upload ARTIFACTS_PATH="artifacts/e2e"
@@ -284,7 +277,7 @@ Dogfood (Shopist):
       when: manual
       allow_failure: true
   script:
-    - ./tools/runner-setup.sh --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --ssh
     - DRY_RUN=0 make dogfood-shopist
 
 Dogfood (Datadog app):
@@ -294,7 +287,7 @@ Dogfood (Datadog app):
       when: manual
       allow_failure: true
   script:
-    - ./tools/runner-setup.sh --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --ssh
     - DRY_RUN=0 make dogfood-datadog-app
 
 # ┌──────────────┐
@@ -312,8 +305,6 @@ Build Artifacts:
   stage: release-build
   rules: 
     - !reference [.release-pipeline-job, rules]
-  variables:
-    XCODE: "15.3.0"
   artifacts:
     paths:
       - artifacts
@@ -321,7 +312,7 @@ Build Artifacts:
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "17.4" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
     - make env-check
     - make clean
     - make release-build release-validate
@@ -330,12 +321,10 @@ Publish GH Asset:
   stage: release-publish
   rules: 
     - !reference [.release-pipeline-job, rules]
-  variables:
-    XCODE: "15.3.0"
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "17.4" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-github
@@ -344,12 +333,10 @@ Publish CP podspecs (internal):
   stage: release-publish
   rules: 
     - !reference [.release-pipeline-job, rules]
-  variables:
-    XCODE: "15.3.0"
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "17.4" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-internal-podspecs
@@ -358,12 +345,10 @@ Publish CP podspecs (dependent):
   stage: release-publish
   rules: 
     - !reference [.release-pipeline-delayed-job, rules]
-  variables:
-    XCODE: "15.3.0"
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "17.4" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-dependent-podspecs
@@ -372,12 +357,10 @@ Publish CP podspecs (legacy):
   stage: release-publish
   rules: 
     - !reference [.release-pipeline-delayed-job, rules]
-  variables:
-    XCODE: "15.3.0"
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --os "17.4" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-legacy-podspecs


### PR DESCRIPTION
### What and why?

🧰 💊 The [Cocoapods podspec lint job](https://gitlab.ddbuild.io/DataDog/dd-sdk-ios/-/jobs/584827484) failed for the `2.15.0` release due to:
```
    - ERROR | [watchOS] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - NOTE  | [watchOS] xcodebuild:  xcodebuild: error: Found no destinations for the scheme 'App' and action clean.
```
Root cause:
- In #1918 we added `watchOS` build compatibility which required Internal, Core, Logs, and Trace podspecs to build for `watchOS`.
- The "Publish CP podspecs (*)" jobs were [using Xcode 15.3.0](https://github.com/DataDog/dd-sdk-ios/blob/0331b7ef6605b6c014f169ac96993dfbd450c010/.gitlab-ci.yml#L348) without supplying watchOS runtime via `./tools/runner-setup.sh` script.

### How?

Following the [latest upgrade to macOS Sonoma runner](https://github.com/DataDog/ci-platform-machine-images/blob/410f37f947a43d7407b2a61c92e6ee7c073c9065/packer/ami/macos/team/rum-sdk-ios-sonoma.pkr.hcl#L38-L40), Xcode 15.4.0 is now pre-installed by default (with Xcode 15.3.0 for backward compatibility). Next to Xcode 15.4.0 the runner includes also iOS, tvOS, watchOS, and visionOS runtimes, eliminating the need for `./tools/runner-setup.sh` to install missing ones.

To fix the release pipeline and upgrade major integration jobs to the latest Xcode, I reduced the use of `./tools/runner-setup.sh` in `.gitlab-ci.yml`. It is still needed for some operations, but not for supplying runtimes.

⏱️ This update should also speed up CI job execution time by skipping the installation of missing runtimes for Xcode 15.3.0.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
