### PR TITLE
chore: Update CHANGELOG.md with `hotfix/2.14.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
 
+# 2.14.2 / 26-07-2024
+
+- [FIX] Fix CPU spikes when Watchdog Terminations tracking is enabled. See #1968
+- [FIX] Fix CPU spike when recording UITabBar using SessionReplay. See #1967
+
 # 2.15.0 / 25-07-2024
 
 - [FEATURE] Enable DatadogCore, DatadogLogs and DatadogTrace to compile on watchOS platform. See [#1918][] (Thanks [@jfiser-paylocity][]) [#1946][]

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -17,6 +17,7 @@ clean_dir() {
 }
 
 clean_dir ~/Library/Developer/Xcode/DerivedData
+clean_dir ~/Library/Caches/org.carthage.CarthageKit/dependencies/
 clean_dir ./Carthage/Build
 clean_dir ./Carthage/Checkouts
 clean_dir ./IntegrationTests/Pods


### PR DESCRIPTION
### What and why?

📦 We cherry-pick #1968 and #1967 fixes to `2.14.x` release, making `2.14.2` hotfix.

### How?

We don't follow regular git-flow for this hotfix as the released change already exists in `2.15.0` and we only cherry-pick it to `2.14.x` family.

The `2.14.2` tag will be put on the [last commit](https://github.com/DataDog/dd-sdk-ios/commits/hotfix/2.14.2/) from `hotfix/2.14.2` branch. Check [`hotfix/2.14.2` → `master` diff](https://github.com/DataDog/dd-sdk-ios/compare/master...hotfix/2.14.2?expand=1) to review what we're about to release.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
