### PR TITLE
chore: Clean Carthage cache as part of `make clean`

### DIFF
--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -17,6 +17,7 @@ clean_dir() {
 }
 
 clean_dir ~/Library/Developer/Xcode/DerivedData
+clean_dir ~/Library/Caches/org.carthage.CarthageKit/dependencies/
 clean_dir ./Carthage/Build
 clean_dir ./Carthage/Checkouts
 clean_dir ./IntegrationTests/Pods


### PR DESCRIPTION
### What and why?

🧰 This PR recovers our CI after the bad effect of moving pre-release tag in **2.15.0** release. 

What has happened:

- 2.15.0 tag was originally put on master [0331b7e](https://github.com/DataDog/dd-sdk-ios/commit/0331b7ef6605b6c014f169ac96993dfbd450c010) by creating **2.15.0** pre-release
- “Publish CP podspecs (internal)” job has failed and required #1975 patch
- With patch merged, the 2.15.0 tag was moved to [df7f98e](https://github.com/DataDog/dd-sdk-ios/commit/df7f98ea7cadbe2f8e775b474573f3db7ba81938)

We assumed that moving tags for GH pre-releases is safe but it is definitely not. Some iOS dependency managers rely on cloning `dd-sdk-ios` repo and caching it. By changing tag’s reference we interrupted these systems.

The problem became evident in our CI with `carthage bootstrap` failures in Smoke Tests:
```
*** Fetching dd-sdk-ios
A shell task (/usr/bin/env git fetch --prune --quiet https://github.com/DataDog/dd-sdk-ios.git refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/* (launched in /Users/.../Library/Caches/org.carthage.CarthageKit/dependencies/dd-sdk-ios)) failed with exit code 1
```
The issue has also interrupted CI/CD systems for our users as reported in:
- https://github.com/DataDog/dd-sdk-ios/issues/1979 (impact in SPM)

### How?

`rm -rf ~/Library/Caches/org.carthage.CarthageKit/dependencies/`

(cherry picked from commit 7f24eaa99ecdab4ce17d4b3a2d3b35af8468b5ad)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
