### PR TITLE
RUM-5598 Update RUM models with startRecordingImmediately

### DIFF
--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -7299,6 +7299,11 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.silentMultipleInit as NSNumber?
     }
 
+    @objc public var startRecordingImmediately: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.startRecordingImmediately = newValue?.boolValue }
+        get { root.swiftModel.telemetry.configuration.startRecordingImmediately as NSNumber? }
+    }
+
     @objc public var startSessionReplayRecordingManually: NSNumber? {
         set { root.swiftModel.telemetry.configuration.startSessionReplayRecordingManually = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.startSessionReplayRecordingManually as NSNumber? }
@@ -7710,4 +7715,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/31c73753ff5c954cf9aef475c91ec0b413743f77
+// Generated from https://github.com/DataDog/rum-events-format/tree/41d2cb901a87fa025843c85568c16d3e199fea4c

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -3594,6 +3594,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether initialization fails silently if the SDK is already initialized
             public let silentMultipleInit: Bool?
 
+            /// Whether Session Replay should automatically start a recording when enabled
+            public var startRecordingImmediately: Bool?
+
             /// Whether the session replay start is handled manually
             public var startSessionReplayRecordingManually: Bool?
 
@@ -3742,6 +3745,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case silentMultipleInit = "silent_multiple_init"
+                case startRecordingImmediately = "start_recording_immediately"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
                 case storeContextsAcrossPages = "store_contexts_across_pages"
                 case telemetryConfigurationSampleRate = "telemetry_configuration_sample_rate"
@@ -4335,4 +4339,4 @@ public struct RUMTelemetryOperatingSystem: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/31c73753ff5c954cf9aef475c91ec0b413743f77
+// Generated from https://github.com/DataDog/rum-events-format/tree/41d2cb901a87fa025843c85568c16d3e199fea4c


### PR DESCRIPTION
### What and why?

The telemetry configuration schema has been updated in [this PR](https://github.com/DataDog/rum-events-format/pull/216) to add the new `startRecordingImmediately` parameter, which allows to automatically start a recording when enabling Session Replay on mobile SDKs ([RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3897426405/RFC+-+Session+Replay+Start+Stop+API)). This PR takes care of updating the corresponding models in the iOS SDK.

### How?

Running `make rum-models-generate` to automatically update the models locally.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
