### PR TITLE
fix: Carthage build on Xcode Cloud

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "framer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ncreated/Framer",
+      "state" : {
+        "branch" : "ncreated-patch-1",
+        "revision" : "2a5669490efef2c866692f2b3ebcf778816d3ef1"
+      }
+    },
+    {
+      "identity" : "framing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ncreated/Framing.git",
+      "state" : {
+        "revision" : "64459fe73419d56fadd6e428edba75e441ddbf71",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "framer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ncreated/Framer",
+      "state" : {
+        "branch" : "ncreated-patch-1",
+        "revision" : "2a5669490efef2c866692f2b3ebcf778816d3ef1"
+      }
+    },
+    {
+      "identity" : "framing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ncreated/Framing.git",
+      "state" : {
+        "revision" : "64459fe73419d56fadd6e428edba75e441ddbf71",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "opentelemetry-swift-packages",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DataDog/opentelemetry-swift-packages.git",
+      "state" : {
+        "revision" : "adcfc3d7fc6ad411bb576cfa4512c2d3f8b2dbc7",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "6752f71de206f6a53fa6a758c3660fd9a7fe7527",
+        "version" : "1.11.2"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
### What and why?

Carthage build fails on Xcode Cloud with the following error:
```
2024-08-01 01:44:15.903 xcodebuild[6725:26775] Writing error result bundle to /var/folders/cy/nwzds5px5v13hvt6ndwvg1d80000gn/T/ResultBundle_2024-01-08_01-44-0015.xcresult

xcodebuild: error: Could not resolve package dependencies:

a resolved file is required when automatic dependency resolution is disabled and should be placed at /Volumes/workspace/repository/Carthage/Checkouts/dd-sdk-ios/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved. Running resolver because the following dependencies were added: 'framer' (https://github.com/ncreated/Framer)
```

And [Xcode Cloud documentation](https://developer.apple.com/documentation/xcode/making-dependencies-available-to-xcode-cloud) state the following:
> Following the best practice for using Swift package dependencies in a CI/CD environment, Xcode Cloud doesn’t use automatic package resolution and instead relies on the `Package.resolved` file to resolve your dependencies. If you use Swift package dependencies in your project, make sure to include the `Package.resolved` file in your Git repository and commit any changes to it. Don’t include the file in your `.gitignore` file. Additionally, make sure the `Package.resolved` file resides at `$filename.xcodeproj/project.workspace/xcshareddata/swiftpm/Package.resolved`.

Resolve #1984

### How?

Commit the `Package.resolved` files in `DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj` and `DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
