### PR TITLE
RUM-5536 [SR] Start / Stop API

### DIFF
--- a/DatadogInternal/Sources/Concurrency/ReadWriteLock.swift
+++ b/DatadogInternal/Sources/Concurrency/ReadWriteLock.swift
@@ -9,8 +9,8 @@ import Foundation
 /// A property wrapper using a fair, POSIX conforming reader-writer lock for atomic
 /// access to the value.  It is optimised for concurrent reads and exclusive writes.
 ///
-/// The wrapper is a class to prevent copying the lock, it creates and initilaizes a `pthread_rwlock_t`.
-/// An additional method `mutate` allow to safely mutate the value in-place (to read it
+/// The wrapper is a class to prevent copying the lock, it creates and initializes a `pthread_rwlock_t`.
+/// An additional method `mutate` allows to safely mutate the value in-place (to read it
 /// and write it while obtaining the lock only once).
 @propertyWrapper
 public final class ReadWriteLock<Value>: @unchecked Sendable {

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -25,6 +25,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let sessionReplaySampleRate: Int64?
     public let sessionSampleRate: Int64?
     public let silentMultipleInit: Bool?
+    public let startRecordingImmediately: Bool?
     public let startSessionReplayRecordingManually: Bool?
     public let telemetryConfigurationSampleRate: Int64?
     public let telemetrySampleRate: Int64?
@@ -259,6 +260,7 @@ extension Telemetry {
         sessionReplaySampleRate: Int64? = nil,
         sessionSampleRate: Int64? = nil,
         silentMultipleInit: Bool? = nil,
+        startRecordingImmediately: Bool? = nil,
         startSessionReplayRecordingManually: Bool? = nil,
         telemetryConfigurationSampleRate: Int64? = nil,
         telemetrySampleRate: Int64? = nil,
@@ -309,6 +311,7 @@ extension Telemetry {
             sessionReplaySampleRate: sessionReplaySampleRate,
             sessionSampleRate: sessionSampleRate,
             silentMultipleInit: silentMultipleInit,
+            startRecordingImmediately: startRecordingImmediately,
             startSessionReplayRecordingManually: startSessionReplayRecordingManually,
             telemetryConfigurationSampleRate: telemetryConfigurationSampleRate,
             telemetrySampleRate: telemetrySampleRate,
@@ -422,6 +425,7 @@ extension ConfigurationTelemetry {
             sessionReplaySampleRate: other.sessionReplaySampleRate ?? sessionReplaySampleRate,
             sessionSampleRate: other.sessionSampleRate ?? sessionSampleRate,
             silentMultipleInit: other.silentMultipleInit ?? silentMultipleInit,
+            startRecordingImmediately: other.startRecordingImmediately ?? startRecordingImmediately,
             startSessionReplayRecordingManually: other.startSessionReplayRecordingManually ?? startSessionReplayRecordingManually,
             telemetryConfigurationSampleRate: other.telemetryConfigurationSampleRate ?? telemetryConfigurationSampleRate,
             telemetrySampleRate: other.telemetrySampleRate ?? telemetrySampleRate,

--- a/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryMocks.swift
@@ -29,6 +29,7 @@ extension ConfigurationTelemetry {
             sessionReplaySampleRate: .mockRandom(),
             sessionSampleRate: .mockRandom(),
             silentMultipleInit: .mockRandom(),
+            startRecordingImmediately: .mockRandom(),
             startSessionReplayRecordingManually: .mockRandom(),
             telemetryConfigurationSampleRate: .mockRandom(),
             telemetrySampleRate: .mockRandom(),

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -303,6 +303,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             sessionReplaySampleRate: nil,
             sessionSampleRate: configuration.sessionSampleRate,
             silentMultipleInit: nil,
+            startRecordingImmediately: configuration.startRecordingImmediately,
             storeContextsAcrossPages: nil,
             telemetryConfigurationSampleRate: nil,
             telemetrySampleRate: configuration.telemetrySampleRate,

--- a/DatadogSessionReplay/Sources/Feature/Baggages.swift
+++ b/DatadogSessionReplay/Sources/Feature/Baggages.swift
@@ -5,7 +5,6 @@
  */
 
 import Foundation
-import DatadogInternal
 
 /// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
@@ -38,11 +37,4 @@ internal struct RUMContext: Codable, Equatable {
     let viewID: String?
     /// Current view related server time offset
     let viewServerTimeOffset: TimeInterval?
-}
-
-extension DatadogContext {
-    /// The value indicating if replay is being performed by Session Replay.
-    var hasReplay: Bool? {
-        try? baggages[RUMDependency.hasReplay]?.decode()
-    }
 }

--- a/DatadogSessionReplay/Sources/Feature/Baggages.swift
+++ b/DatadogSessionReplay/Sources/Feature/Baggages.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
@@ -37,4 +38,11 @@ internal struct RUMContext: Codable, Equatable {
     let viewID: String?
     /// Current view related server time offset
     let viewServerTimeOffset: TimeInterval?
+}
+
+extension DatadogContext {
+    /// The value indicating if replay is being performed by Session Replay.
+    var hasReplay: Bool? {
+        try? baggages[RUMDependency.hasReplay]?.decode()
+    }
 }

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -23,7 +23,8 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
 
     init(
         core: DatadogCoreProtocol,
-        configuration: SessionReplay.Configuration
+        configuration: SessionReplay.Configuration,
+        startRecordingImmediately: Bool
     ) throws {
         let processorsQueue = BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processors")
 
@@ -63,7 +64,8 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
             srContextPublisher: SRContextPublisher(core: core),
             recorder: recorder,
             sampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.replaySampleRate),
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            startRecordingImmediately: startRecordingImmediately
         )
         self.requestBuilder = SegmentRequestBuilder(
             customUploadURL: configuration.customEndpoint,
@@ -79,6 +81,14 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
                 changeRate: 0.75 // vs 0.1 with `uploadFrequency: .frequent`
             )
         )
+    }
+
+    func startRecording() {
+        self.recordingCoordinator.startRecording()
+    }
+
+    func stopRecording() {
+        self.recordingCoordinator.stopRecording()
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -23,8 +23,7 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
 
     init(
         core: DatadogCoreProtocol,
-        configuration: SessionReplay.Configuration,
-        startRecordingImmediately: Bool
+        configuration: SessionReplay.Configuration
     ) throws {
         let processorsQueue = BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processors")
 
@@ -65,7 +64,7 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
             recorder: recorder,
             sampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.replaySampleRate),
             telemetry: core.telemetry,
-            startRecordingImmediately: startRecordingImmediately
+            startRecordingImmediately: configuration.startRecordingImmediately
         )
         self.requestBuilder = SegmentRequestBuilder(
             customUploadURL: configuration.customEndpoint,

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -20,6 +20,7 @@ internal class RecordingCoordinator {
     let srContextPublisher: SRContextPublisher
 
     private var currentRUMContext: RUMContext? = nil
+    @ReadWriteLock
     private var isSampled = false
 
     /// `recordingEnabled` is used to track when the user 

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -20,13 +20,11 @@ internal class RecordingCoordinator {
     let srContextPublisher: SRContextPublisher
 
     private var currentRUMContext: RUMContext? = nil
-    @ReadWriteLock
     private var isSampled = false
 
     /// `recordingEnabled` is used to track when the user 
     /// has enabled or disabled the recording for Session Replay.
-    @ReadWriteLock
-    private(set) var recordingEnabled = false
+    private var recordingEnabled = false
 
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
@@ -67,14 +65,18 @@ internal class RecordingCoordinator {
 
     /// Enables recording based on user request.
     func startRecording() {
-        recordingEnabled = true
-        evaluateRecordingConditions()
+        scheduler.queue.run { [weak self] in
+            self?.recordingEnabled = true
+            self?.evaluateRecordingConditions()
+        }
     }
 
     /// Disables recording based on user request.
     func stopRecording() {
-        recordingEnabled = false
-        evaluateRecordingConditions()
+        scheduler.queue.run { [weak self] in
+            self?.recordingEnabled = false
+            self?.evaluateRecordingConditions()
+        }
     }
 
     // MARK: Private

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -9,7 +9,9 @@ import Foundation
 import DatadogInternal
 
 /// Object is responsible for getting the RUM context, randomising the sampling rate,
-/// starting/stopping the recording scheduler as needed and propagating `has_replay` to other features.
+/// managing the recording state, starting/stopping the recording scheduler as needed,
+/// and propagating `has_replay` to other features.
+
 internal class RecordingCoordinator {
     let recorder: Recording
     let scheduler: Scheduler
@@ -20,9 +22,14 @@ internal class RecordingCoordinator {
     private var currentRUMContext: RUMContext? = nil
     private var isSampled = false
 
+    /// `recordingEnabled` is used to track when the user 
+    /// has enabled or disabled the recording for Session Replay.
+    @ReadWriteLock
+    private(set) var recordingEnabled = false
+
     /// Sends telemetry through sdk core.
     private let telemetry: Telemetry
-    /// The sampling rate for internal telemetry of method call.
+    /// The sampling rate for internal telemetry of method calls.
     private let methodCallTelemetrySamplingRate: Float
 
     init(
@@ -33,6 +40,7 @@ internal class RecordingCoordinator {
         recorder: Recording,
         sampler: Sampler,
         telemetry: Telemetry,
+        startRecordingImmediately: Bool,
         methodCallTelemetrySamplingRate: Float = 0.1
     ) {
         self.recorder = recorder
@@ -46,10 +54,39 @@ internal class RecordingCoordinator {
         srContextPublisher.setHasReplay(false)
 
         scheduler.schedule { [weak self] in self?.captureNextRecord() }
-        scheduler.start()
 
+        // Start recording immediately if specified.
+        if startRecordingImmediately {
+            startRecording()
+        }
+
+        // Observe changes in the RUM context.
         rumContextObserver.observe(on: scheduler.queue) { [weak self] in self?.onRUMContextChanged(rumContext: $0) }
     }
+
+    /// Enables recording based on user request.
+    func startRecording() {
+        recordingEnabled = true
+        evaluateRecordingConditions()
+    }
+
+    /// Disables recording based on user request.
+    func stopRecording() {
+        recordingEnabled = false
+        evaluateRecordingConditions()
+    }
+
+    // MARK: Private
+
+    /// Evaluates whether recording should start or stop based on user request and sampling.
+    private func evaluateRecordingConditions() {
+       if recordingEnabled && isSampled {
+           scheduler.start()
+       } else {
+           scheduler.stop()
+       }
+       updateHasReplay()
+   }
 
     private func onRUMContextChanged(rumContext: RUMContext?) {
         if currentRUMContext?.sessionID != rumContext?.sessionID || currentRUMContext == nil {
@@ -58,18 +95,20 @@ internal class RecordingCoordinator {
 
         currentRUMContext = rumContext
 
-        if isSampled {
-            scheduler.start()
-        } else {
-            scheduler.stop()
-        }
-
-        srContextPublisher.setHasReplay(
-            isSampled == true && currentRUMContext?.viewID != nil
-        )
+        evaluateRecordingConditions()
     }
 
+    /// Updates the `has_replay` flag to indicate if recording is active.
+    private func updateHasReplay() {
+        /// `has_replay` is set to `true` only when the session is sampled
+        /// and  the user has enabled the recording.
+        let hasReplay = isSampled == true && recordingEnabled == true
+        srContextPublisher.setHasReplay(hasReplay)
+    }
+
+    /// Captures the next recording if conditions are met.
     private func captureNextRecord() {
+        /// We don't capture any snapshots if the RUM context has no view ID.
         guard let rumContext = currentRUMContext,
               let viewID = rumContext.viewID else {
             return
@@ -99,7 +138,7 @@ internal class RecordingCoordinator {
             // the framework is not built with `-fobjc-arc-exceptions` option.
             // We recover from the exception and stop the scheduler as a measure of
             // caution. The scheduler could start again at a next RUM context change.
-            scheduler.stop()
+            stopRecording()
         } catch {
             telemetry.error("[SR] Failed to take snapshot", error: error)
         }

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -86,12 +86,6 @@ public enum SessionReplay {
     }
 
     internal static func startRecording(core: DatadogCoreProtocol) throws {
-        guard !(core is NOPDatadogCore) else {
-            throw ProgrammerError(
-                description: "Datadog SDK must be initialized before calling `SessionReplay.startRecording()`."
-            )
-        }
-
         guard let sr = core.get(feature: SessionReplayFeature.self) else {
             throw ProgrammerError(
                 description: "Session Replay must be initialized before calling `SessionReplay.startRecording()`."
@@ -102,19 +96,8 @@ public enum SessionReplay {
     }
 
     internal static func stopRecording(core: DatadogCoreProtocol) throws {
-        guard !(core is NOPDatadogCore) else {
-            throw ProgrammerError(
-                description: "Datadog SDK must be initialized before calling `SessionReplay.stopRecording()`."
-            )
-        }
-
-        guard let sr = core.get(feature: SessionReplayFeature.self) else {
-            throw ProgrammerError(
-                description: "Session Replay must be initialized before calling `SessionReplay.stopRecording()`."
-            )
-        }
-
-        sr.stopRecording()
+        let sr = core.get(feature: SessionReplayFeature.self)
+        sr?.stopRecording()
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -30,6 +30,11 @@ extension SessionReplay {
         /// Default: `.mask`.
         public var defaultPrivacyLevel: SessionReplayPrivacyLevel
 
+        /// Defines it the recording should start automatically. When `true`, the recording starts automatically; when `false` it doesn't, and the recording will need to be started manually.
+        ///
+        /// Default: `true`.
+        public var startRecordingImmediately: Bool
+
         /// Custom server url for sending replay data.
         ///
         /// Default: `nil`.
@@ -49,10 +54,12 @@ extension SessionReplay {
         public init(
             replaySampleRate: Float,
             defaultPrivacyLevel: SessionReplayPrivacyLevel = .mask,
+            startRecordingImmediately: Bool = true,
             customEndpoint: URL? = nil
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
+            self.startRecordingImmediately = startRecordingImmediately
             self.customEndpoint = customEndpoint
         }
 

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -50,6 +50,7 @@ extension SessionReplay {
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
         ///   - defaultPrivacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
+        ///   - startRecordingImmediately: If the recording should start automatically. When `true`, the recording starts automatically; when `false` it doesn't, and the recording will need to be started manually. Default: `true`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         public init(
             replaySampleRate: Float,

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -33,9 +33,9 @@ class RecordingCoordinatorTests: XCTestCase {
 
     // MARK: Configuration Tests
 
-    func test_itEnablesRecording_afterInitializing() {
+    func test_itDoesNotStartScheduler_afterInitializing() {
         prepareRecordingCoordinator(sampler: Sampler(samplingRate: .mockRandom(min: 0, max: 100)))
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
+        XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
     }
 
@@ -47,7 +47,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: .mockRandom())
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), false)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
@@ -63,7 +62,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: rumContext)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertTrue(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), true)
         XCTAssertEqual(recordingMock.captureNextRecordReceivedRecorderContext?.applicationID, rumContext.applicationID)
@@ -82,7 +80,7 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: nil)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
+        XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
     }
 
@@ -91,7 +89,6 @@ class RecordingCoordinatorTests: XCTestCase {
         prepareRecordingCoordinator(sampler: Sampler(samplingRate: .mockRandom(min: 0, max: 100)))
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), false)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
@@ -106,7 +103,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: rumContext)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertTrue(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), true)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
@@ -182,7 +178,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: rumContext)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertTrue(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), true)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 1)
@@ -197,7 +192,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: rumContext)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertTrue(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), true)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 1)
@@ -212,7 +206,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: rumContext)
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, false)
         XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), false)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
@@ -230,7 +223,6 @@ class RecordingCoordinatorTests: XCTestCase {
         recordingCoordinator?.stopRecording()
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, false)
         XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), false)
     }
@@ -246,7 +238,6 @@ class RecordingCoordinatorTests: XCTestCase {
         recordingCoordinator?.startRecording()
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, true)
         XCTAssertTrue(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), true)
     }
@@ -262,7 +253,6 @@ class RecordingCoordinatorTests: XCTestCase {
         recordingCoordinator?.stopRecording()
 
         // Then
-        XCTAssertEqual(recordingCoordinator?.recordingEnabled, false)
         XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(try core.context.baggages["sr_has_replay"]?.decode(), false)
     }

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -72,7 +72,7 @@ class RecordingCoordinatorTests: XCTestCase {
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 1)
     }
 
-    func test_whenEmptyRUMContext_itShouldRecord_itShouldNotCaptureSnapshots() {
+    func test_whenEmptyRUMContext_itShouldNotRecord() {
         // Given
         prepareRecordingCoordinator(sampler: Sampler(samplingRate: .mockRandom(min: 0, max: 100)))
 
@@ -80,7 +80,6 @@ class RecordingCoordinatorTests: XCTestCase {
         rumContextObserver.notify(rumContext: nil)
 
         // Then
-        XCTAssertFalse(scheduler.isRunning)
         XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 0)
     }
 

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -20,6 +20,7 @@ class SessionReplayConfigurationTests: XCTestCase {
         // Then
         XCTAssertEqual(config.replaySampleRate, random)
         XCTAssertEqual(config.defaultPrivacyLevel, .mask)
+        XCTAssertEqual(config.startRecordingImmediately, true)
         XCTAssertNil(config.customEndpoint)
         XCTAssertEqual(config._additionalNodeRecorders.count, 0)
     }

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -182,58 +182,8 @@ class SessionReplayTests: XCTestCase {
         // Then
         XCTAssertEqual(
             printFunction.printedMessage,
-            "🔥 Datadog SDK usage error: Datadog SDK must be initialized before calling `SessionReplay.startRecording()`."
+            "🔥 Datadog SDK usage error: Session Replay must be initialized before calling `SessionReplay.startRecording()`."
         )
-    }
-
-    func testWhenEnabledWithStartRecordingImmediatelyTrue_itStartsRecording() throws {
-        // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: true)
-
-        // When
-        SessionReplay.enable(with: config, in: core)
-
-        // Then
-        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
-        XCTAssertEqual(sr.recordingCoordinator.recordingEnabled, true)
-    }
-
-    func testWhenEnabledWithStartRecordingImmediatelyFalse_itDoesNotStartRecording() throws {
-        // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: false)
-
-        // When
-        SessionReplay.enable(with: config, in: core)
-
-        // Then
-        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
-        XCTAssertEqual(sr.recordingCoordinator.recordingEnabled, false)
-    }
-
-    func testStartRecordingManually() throws {
-        // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: false)
-        SessionReplay.enable(with: config, in: core)
-        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
-
-        // When
-        SessionReplay.startRecording(in: core)
-
-        // Then
-        XCTAssertEqual(sr.recordingCoordinator.recordingEnabled, true)
-    }
-
-    func testStopRecordingManually() throws {
-        // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: true)
-        SessionReplay.enable(with: config, in: core)
-        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
-
-        // When
-        SessionReplay.stopRecording(in: core)
-
-        // Then
-        XCTAssertEqual(sr.recordingCoordinator.recordingEnabled, false)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -81,10 +81,10 @@ class SessionReplayTests: XCTestCase {
         SessionReplay.enable(
             with: SessionReplay.Configuration(
                 replaySampleRate: Float(sampleRate),
-                defaultPrivacyLevel: privacyLevel
+                defaultPrivacyLevel: privacyLevel,
+                startRecordingImmediately: startRecordingImmediately
             ),
-            in: core,
-            startRecordingImmediately: startRecordingImmediately
+            in: core
         )
 
         // Then
@@ -188,10 +188,10 @@ class SessionReplayTests: XCTestCase {
 
     func testWhenEnabledWithStartRecordingImmediatelyTrue_itStartsRecording() throws {
         // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42)
+        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: true)
 
         // When
-        SessionReplay.enable(with: config, in: core, startRecordingImmediately: true)
+        SessionReplay.enable(with: config, in: core)
 
         // Then
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
@@ -200,10 +200,10 @@ class SessionReplayTests: XCTestCase {
 
     func testWhenEnabledWithStartRecordingImmediatelyFalse_itDoesNotStartRecording() throws {
         // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42)
+        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: false)
 
         // When
-        SessionReplay.enable(with: config, in: core, startRecordingImmediately: false)
+        SessionReplay.enable(with: config, in: core)
 
         // Then
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
@@ -212,8 +212,8 @@ class SessionReplayTests: XCTestCase {
 
     func testStartRecordingManually() throws {
         // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42)
-        SessionReplay.enable(with: config, in: core, startRecordingImmediately: false)
+        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: false)
+        SessionReplay.enable(with: config, in: core)
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
 
         // When
@@ -225,8 +225,8 @@ class SessionReplayTests: XCTestCase {
 
     func testStopRecordingManually() throws {
         // Given
-        config = SessionReplay.Configuration(replaySampleRate: 42)
-        SessionReplay.enable(with: config, in: core, startRecordingImmediately: true)
+        config = SessionReplay.Configuration(replaySampleRate: 42, startRecordingImmediately: true)
+        SessionReplay.enable(with: config, in: core)
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
 
         // When


### PR DESCRIPTION
### What and why?

This PR adds the ability for customers to:
- Start and stop a recording 
- Disable automatic recording when enabling Session Replay

See [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3897426405/RFC+-+Session+Replay+Start+Stop+API#Actions) for more details.

### How?

- Introduce a new `startRecordingImmediately` optional parameter when enabling Session Replay, defaulting to `true`
  - A new field has been added for telemetry as well
  - Models have already been updated in [#216](https://github.com/DataDog/rum-events-format/pull/216) and #1983
- Add new set of `start` and `stop` public APIs to the existing `SessionReplay` public enum, through static functions
- Introduce a `recordingEnabled` variable to `RecordingCoordinator` to track when the user wants to start or stop a recording
- Update the RUM flag `has_replay` accordingly when starting or stopping a recording 
- Modified a bit the logic in `RecordingCoordinator`:
  - The scheduler is only started if the recording has been enabled by the user and the RUM session is sampled
  - We decouple the update of the `has_replay` flag from the RUM view ID; whether it's `nil` or not has no impact on this flag anymore

**Note**: ignoring webviews' snapshots will be tackled separately

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
