### PR TITLE
chore: mark Alamofire extension types deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
+- [FIX] Alamofire extension types are deprecated now. See [#1988][]
 
 # 2.14.2 / 26-07-2024
 
@@ -741,6 +742,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1968]: https://github.com/DataDog/dd-sdk-ios/pull/1968
 [#1967]: https://github.com/DataDog/dd-sdk-ios/pull/1967
 [#1973]: https://github.com/DataDog/dd-sdk-ios/pull/1973
+[#1988]: https://github.com/DataDog/dd-sdk-ios/pull/1988
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
+++ b/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
@@ -8,6 +8,7 @@ import DatadogInternal
 import Alamofire
 
 /// An `Alamofire.EventMonitor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.
+@available(*, deprecated, message: "Use `URLSessionInstrumentation.enable(with:)` instead.")
 public class DDEventMonitor: EventMonitor {
     /// The instance of the SDK core notified by this monitor.
     private weak var core: DatadogCoreProtocol?
@@ -39,6 +40,7 @@ public class DDEventMonitor: EventMonitor {
 }
 
 /// An `Alamofire.RequestInterceptor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.
+@available(*, deprecated, message: "Use `URLSessionInstrumentation.enable(with:)` instead.")
 public class DDRequestInterceptor: RequestInterceptor {
 /// The instance of the SDK core notified by this monitor.
     private weak var core: DatadogCoreProtocol?


### PR DESCRIPTION
### What and why?

Customers are not fully aware that extension is no longer support from APIs.

### How?

Marked all the Alamofire types as deprecated with suggesting to use `URLSessionInstrumentation`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
