### PR TITLE
RUM-3889 feat: send retry information with network requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
+- [IMPROVEMENT] Send retry information with network requests (eg. retry_count, last_failure_status and idempotency key). See [#1991][]
+
 # 2.16.0 / 20-08-2024
 
 - [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
 - [FIX] Alamofire extension types are deprecated now. See [#1988][]
-- [IMPROVEMENT] Send retry information with network requests (eg. retry_count, last_failure_status and idempotency key). See [#1991][]
 
 # 2.14.2 / 26-07-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
 - [FIX] Alamofire extension types are deprecated now. See [#1988][]
+- [IMPROVEMENT] Send retry information with network requests (eg. retry_count, last_failure_status and idempotency key). See [#1991][]
 
 # 2.14.2 / 26-07-2024
 
@@ -745,6 +746,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1967]: https://github.com/DataDog/dd-sdk-ios/pull/1967
 [#1973]: https://github.com/DataDog/dd-sdk-ios/pull/1973
 [#1988]: https://github.com/DataDog/dd-sdk-ios/pull/1988
+[#1991]: https://github.com/DataDog/dd-sdk-ios/pull/1991
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -112,6 +112,10 @@
 		3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDAE2BC688120013C125 /* SpanIDGeneratorTests.swift */; };
 		3CCECDB22BC68A0A0013C125 /* SpanIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */; };
 		3CCECDB32BC68A0A0013C125 /* SpanIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */; };
+		3CD3A13A2C6C99ED00436A69 /* Data+Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C9E2B2C64F3CA003AF22F /* Data+Crypto.swift */; };
+		3CD3A13B2C6C99ED00436A69 /* Data+Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C9E2B2C64F3CA003AF22F /* Data+Crypto.swift */; };
+		3CD3A13C2C6C99FE00436A69 /* Data+CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */; };
+		3CD3A13D2C6C99FE00436A69 /* Data+CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */; };
 		3CDA3F7E2BCD866D005D2C13 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3CDA3F7D2BCD866D005D2C13 /* DatadogSDKTesting */; };
 		3CDA3F802BCD8687005D2C13 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3CDA3F7F2BCD8687005D2C13 /* DatadogSDKTesting */; };
 		3CE11A1129F7BE0900202522 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
@@ -2112,6 +2116,8 @@
 		3C32359C2B55386C000B4258 /* OTelSpanLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLink.swift; sourceTree = "<group>"; };
 		3C32359F2B55387A000B4258 /* OTelSpanLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTelSpanLinkTests.swift; sourceTree = "<group>"; };
 		3C33E4062BEE35A7003B2988 /* RUMContextMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMContextMocks.swift; sourceTree = "<group>"; };
+		3C3C9E2B2C64F3CA003AF22F /* Data+Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Crypto.swift"; sourceTree = "<group>"; };
+		3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+CryptoTests.swift"; sourceTree = "<group>"; };
 		3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReport.swift; sourceTree = "<group>"; };
 		3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMonitorTests.swift; sourceTree = "<group>"; };
 		3C4CF9972C47CC8C006DE1C0 /* MemoryWarningMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMonitorTests.swift; sourceTree = "<group>"; };
@@ -5922,6 +5928,7 @@
 		D23039D6298D5235001A1FA3 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3C3C9E2B2C64F3CA003AF22F /* Data+Crypto.swift */,
 				D23039D8298D5235001A1FA3 /* DatadogExtended.swift */,
 				D23354FB2A42E32000AFCAE2 /* InternalExtended.swift */,
 				D23039D7298D5235001A1FA3 /* Foundation+Datadog.swift */,
@@ -6134,6 +6141,7 @@
 		D263BCB129DB014900FA0E21 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */,
 				D263BCB229DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift */,
 				D263BCB329DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift */,
 			);
@@ -8677,6 +8685,7 @@
 				D23039E8298D5236001A1FA3 /* DatadogContext.swift in Sources */,
 				D23039FF298D5236001A1FA3 /* Foundation+Datadog.swift in Sources */,
 				D2F8235329915E12003C7E99 /* DatadogSite.swift in Sources */,
+				3CD3A13A2C6C99ED00436A69 /* Data+Crypto.swift in Sources */,
 				D2D3199A29E98D970004F169 /* DefaultJSONEncoder.swift in Sources */,
 				6128F56A2BA2237300D35B08 /* DataStore.swift in Sources */,
 				3C3EF2B02C1AEBAB009E9E57 /* LaunchReport.swift in Sources */,
@@ -9653,6 +9662,7 @@
 				D2DA2374298D57AA00C6C7E6 /* DatadogContext.swift in Sources */,
 				D2DA2375298D57AA00C6C7E6 /* Foundation+Datadog.swift in Sources */,
 				D2F8235429915E12003C7E99 /* DatadogSite.swift in Sources */,
+				3CD3A13B2C6C99ED00436A69 /* Data+Crypto.swift in Sources */,
 				D2D3199B29E98D970004F169 /* DefaultJSONEncoder.swift in Sources */,
 				6128F56B2BA2237300D35B08 /* DataStore.swift in Sources */,
 				3C3EF2B12C1AEBAB009E9E57 /* LaunchReport.swift in Sources */,
@@ -9731,6 +9741,7 @@
 				D2160CD429C0DF6700FAA9A5 /* NetworkInstrumentationFeatureTests.swift in Sources */,
 				D263BCB629DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift in Sources */,
 				D2DA23AA298D58F400C6C7E6 /* FeatureMessageReceiverTests.swift in Sources */,
+				3CD3A13D2C6C99FE00436A69 /* Data+CryptoTests.swift in Sources */,
 				D2DA23A8298D58F400C6C7E6 /* DeviceInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9781,6 +9792,7 @@
 				D2160CD529C0DF6700FAA9A5 /* NetworkInstrumentationFeatureTests.swift in Sources */,
 				D263BCB729DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift in Sources */,
 				D2DA23B8298D59DC00C6C7E6 /* FeatureMessageReceiverTests.swift in Sources */,
+				3CD3A13C2C6C99FE00436A69 /* Data+CryptoTests.swift in Sources */,
 				D2DA23BA298D59DC00C6C7E6 /* DeviceInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DatadogCore/Sources/Core/Upload/DataUploadStatus.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadStatus.swift
@@ -72,28 +72,32 @@ internal struct DataUploadStatus {
     let userDebugDescription: String
 
     let error: DataUploadError?
+
+    let attempt: UInt
 }
 
 extension DataUploadStatus {
     // MARK: - Initialization
 
-    init(httpResponse: HTTPURLResponse, ddRequestID: String?) {
+    init(httpResponse: HTTPURLResponse, ddRequestID: String?, attempt: UInt) {
         let statusCode = HTTPResponseStatusCode(rawValue: httpResponse.statusCode) ?? .unexpected
 
         self.init(
             needsRetry: statusCode.needsRetry,
             responseCode: httpResponse.statusCode,
-            userDebugDescription: "[response code: \(httpResponse.statusCode) (\(statusCode)), request ID: \(ddRequestID ?? "(???)")]",
-            error: DataUploadError(status: httpResponse.statusCode)
+            userDebugDescription: "[response code: \(httpResponse.statusCode) (\(statusCode)), request ID: \(ddRequestID ?? "(???)")",
+            error: DataUploadError(status: httpResponse.statusCode),
+            attempt: attempt
         )
     }
 
-    init(networkError: Error) {
+    init(networkError: Error, attempt: UInt) {
         self.init(
             needsRetry: true, // retry this upload as it failed due to network transport isse
             responseCode: nil,
             userDebugDescription: "[error: \(DDError(error: networkError).message)]", // e.g. "[error: A data connection is not currently allowed]"
-            error: DataUploadError(networkError: networkError)
+            error: DataUploadError(networkError: networkError),
+            attempt: attempt
         )
     }
 }

--- a/DatadogCore/Sources/Core/Upload/DataUploader.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploader.swift
@@ -6,10 +6,11 @@
 
 import Foundation
 import DatadogInternal
+import CommonCrypto
 
 /// A type that performs data uploads.
 internal protocol DataUploaderType {
-    func upload(events: [Event], context: DatadogContext) throws -> DataUploadStatus
+    func upload(events: [Event], context: DatadogContext, previous: DataUploadStatus?) throws -> DataUploadStatus
 }
 
 /// Synchronously uploads data to server using `HTTPClient`.
@@ -19,7 +20,8 @@ internal final class DataUploader: DataUploaderType {
         needsRetry: false,
         responseCode: nil,
         userDebugDescription: "",
-        error: nil
+        error: nil,
+        attempt: 0
     )
 
     private let httpClient: HTTPClient
@@ -32,8 +34,17 @@ internal final class DataUploader: DataUploaderType {
 
     /// Uploads data synchronously (will block current thread) and returns the upload status.
     /// Uses timeout configured for `HTTPClient`.
-    func upload(events: [Event], context: DatadogContext) throws -> DataUploadStatus {
-        let request = try requestBuilder.request(for: events, with: context)
+    func upload(events: [Event], context: DatadogContext, previous: DataUploadStatus?) throws -> DataUploadStatus {
+        let attempt: UInt
+        if let previous = previous {
+            attempt = previous.attempt + 1
+        } else {
+            attempt = 0
+        }
+
+        let execution: ExecutionContext = .init(previousResponseCode: previous?.responseCode, attempt: attempt)
+        let request = try requestBuilder.request(for: events, with: context, execution: execution)
+
         let requestID = request.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddRequestIDHeaderField)
 
         var uploadStatus: DataUploadStatus?
@@ -43,9 +54,16 @@ internal final class DataUploader: DataUploaderType {
         httpClient.send(request: request) { result in
             switch result {
             case .success(let httpResponse):
-                uploadStatus = DataUploadStatus(httpResponse: httpResponse, ddRequestID: requestID)
+                uploadStatus = DataUploadStatus(
+                    httpResponse: httpResponse,
+                    ddRequestID: requestID,
+                    attempt: attempt
+                )
             case .failure(let error):
-                uploadStatus = DataUploadStatus(networkError: error)
+                uploadStatus = DataUploadStatus(
+                    networkError: error,
+                    attempt: attempt
+                )
             }
 
             semaphore.signal()

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadStatusTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadStatusTests.swift
@@ -11,85 +11,75 @@ import TestUtilities
 class DataUploadStatusTests: XCTestCase {
     // MARK: - Test `.needsRetry`
 
-    private let statusCodesExpectingNoRetry = [
-        202, // ACCEPTED
-        400, // BAD REQUEST
-        401, // UNAUTHORIZED
-        403, // FORBIDDEN
-        413, // PAYLOAD TOO LARGE
+    private let statusCodesExpectingNoRetry: [Int: String] = [
+        202: "accepted",
+        400: "badRequest",
+        401: "unauthorized",
+        403: "forbidden",
+        413: "payloadTooLarge",
     ]
 
-    private let statusCodesExpectingRetry = [
-        408, // REQUEST TIMEOUT
-        429, // TOO MANY REQUESTS
-        500, // INTERNAL SERVER ERROR
-        502, // BAD GATEWAY
-        503, // SERVICE UNAVAILABLE
-        504, // GATEWAY TIMEOUT
-        507, // INSUFFICIENT STORAGE
+    private let statusCodesExpectingRetry: [Int: String] = [
+        408: "requestTimeout",
+        429: "tooManyRequests",
+        500: "internalServerError",
+        502: "badGateway",
+        503: "serviceUnavailable",
+        504: "gatewayTimeout",
+        507: "insufficientStorage",
     ]
 
     private lazy var expectedStatusCodes = statusCodesExpectingNoRetry + statusCodesExpectingRetry
 
     func testWhenUploadFinishesWithResponse_andStatusCodeNeedsNoRetry_itSetsNeedsRetryFlagToFalse() {
-        statusCodesExpectingNoRetry.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny())
+        statusCodesExpectingNoRetry.forEach { statusCode, _ in
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny(), attempt: 0)
             XCTAssertFalse(status.needsRetry, "Upload should not be retried for status code \(statusCode)")
         }
     }
 
     func testWhenUploadFinishesWithResponse_andStatusCodeNeedsRetry_itSetsNeedsRetryFlagToTrue() {
-        statusCodesExpectingRetry.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny())
+        statusCodesExpectingRetry.forEach { statusCode, _ in
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny(), attempt: 0)
             XCTAssertTrue(status.needsRetry, "Upload should be retried for status code \(statusCode)")
         }
     }
 
     func testWhenUploadFinishesWithResponse_andStatusCodeIsUnexpected_itSetsNeedsRetryFlagToFalse() {
         let allStatusCodes = Set((100...599))
-        let unexpectedStatusCodes = allStatusCodes.subtracting(Set(expectedStatusCodes))
+        let unexpectedStatusCodes = allStatusCodes.subtracting(Set(expectedStatusCodes.keys))
 
         unexpectedStatusCodes.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny())
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockAny(), attempt: 0)
             XCTAssertFalse(status.needsRetry, "Upload should not be retried for status code \(statusCode)")
         }
     }
 
     func testWhenUploadFinishesWithError_itSetsNeedsRetryFlagToTrue() {
-        let status = DataUploadStatus(networkError: ErrorMock())
+        let status = DataUploadStatus(networkError: ErrorMock(), attempt: 0)
         XCTAssertTrue(status.needsRetry, "Upload should be retried if it finished with error")
     }
 
     // MARK: - Test `.userDebugDescription`
 
     func testWhenUploadFinishesWithResponse_andRequestIDIsAvailable_itCreatesUserDebugDescription() {
-        expectedStatusCodes.forEach { statusCode in
+        expectedStatusCodes.forEach { statusCode, message in
             let requestID: String = .mockRandom(among: .alphanumerics)
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: requestID)
-            XCTAssertTrue(
-                status.userDebugDescription.matches(
-                    regex: "\\[response code: [0-9]{3} \\([a-zA-Z]+\\), request ID: \(requestID)\\]"
-                ),
-                "'\(status.userDebugDescription)' is not an expected description for status code '\(statusCode)' and request id '\(requestID)'"
-            )
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: requestID, attempt: 0)
+            XCTAssertEqual(status.userDebugDescription, "[response code: \(statusCode) (\(message)), request ID: \(requestID)")
         }
     }
 
     func testWhenUploadFinishesWithResponse_andRequestIDIsNotAvailable_itCreatesUserDebugDescription() {
-        expectedStatusCodes.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil)
-            XCTAssertTrue(
-                status.userDebugDescription.matches(
-                    regex: "\\[response code: [0-9]{3} \\([a-zA-Z]+\\), request ID: \\(\\?\\?\\?\\)\\]"
-                ),
-                "'\(status.userDebugDescription)' is not an expected description for status code '\(statusCode)' and no request id"
-            )
+        expectedStatusCodes.forEach { statusCode, message in
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil, attempt: 0)
+            XCTAssertEqual(status.userDebugDescription, "[response code: \(statusCode) (\(message)), request ID: (???)")
         }
     }
 
     func testWhenUploadFinishesWithError_itCreatesUserDebugDescription() {
         let randomErrorDescription: String = .mockRandom()
-        let status = DataUploadStatus(networkError: ErrorMock(randomErrorDescription))
+        let status = DataUploadStatus(networkError: ErrorMock(randomErrorDescription), attempt: 0)
         XCTAssertEqual(status.userDebugDescription, "[error: \(randomErrorDescription)]")
     }
 
@@ -105,20 +95,20 @@ class DataUploadStatusTests: XCTestCase {
     ]
 
     func testWhenUploadFinishesWithResponse_andStatusCodeIs401_itCreatesError() {
-        let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: 401), ddRequestID: nil)
+        let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: 401), ddRequestID: nil, attempt: 0)
         XCTAssertEqual(status.error, .unauthorized)
     }
 
     func testWhenUploadFinishesWithResponse_andStatusCodeIsDifferentThan401_itDoesNotCreateAnyError() {
         Set((100...599)).subtracting(alertingStatusCodes).forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil)
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil, attempt: 0)
             XCTAssertNil(status.error)
         }
     }
 
     func testWhenUploadFinishesWithResponse_andStatusCodeMeansSDKIssue_itCreatesHTTPError() {
         alertingStatusCodes.subtracting([401, 403]).forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockRandom())
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: .mockRandom(), attempt: 01)
 
             guard case let .httpError(statusCode: receivedStatusCode) = status.error else {
                 return XCTFail("Upload status error should be created for status code: \(statusCode)")
@@ -129,24 +119,24 @@ class DataUploadStatusTests: XCTestCase {
     }
 
     func testWhenUploadFinishesWithResponse_andStatusCodeMeansClientIssue_itDoesNotCreateHTTPError() {
-        let clientIssueStatusCodes = Set(expectedStatusCodes).subtracting(Set(alertingStatusCodes))
+        let clientIssueStatusCodes = Set(expectedStatusCodes.keys).subtracting(Set(alertingStatusCodes))
         clientIssueStatusCodes.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil)
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil, attempt: 0)
             XCTAssertNil(status.error, "Upload status error should not be created for status code \(statusCode)")
         }
     }
 
     func testWhenUploadFinishesWithResponse_andUnexpectedStatusCodeMeansClientIssue_itDoesNotCreateHTTPError() {
-        let unexpectedStatusCodes = Set((100...599)).subtracting(Set(expectedStatusCodes))
+        let unexpectedStatusCodes = Set((100...599)).subtracting(Set(expectedStatusCodes.keys))
         unexpectedStatusCodes.forEach { statusCode in
-            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil)
+            let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: statusCode), ddRequestID: nil, attempt: 0)
             XCTAssertNil(status.error)
         }
     }
 
     func testWhenUploadFinishesWithError_andErrorCodeMeansSDKIssue_itCreatesNetworkError() throws {
         let alertingNSURLErrorCode = NSURLErrorBadURL
-        let status = DataUploadStatus(networkError: NSError(domain: NSURLErrorDomain, code: alertingNSURLErrorCode, userInfo: nil))
+        let status = DataUploadStatus(networkError: NSError(domain: NSURLErrorDomain, code: alertingNSURLErrorCode, userInfo: nil), attempt: 0)
 
         guard case let .networkError(error: nserror) = status.error else {
             return XCTFail("Upload status error should be created for NSURLError code: \(alertingNSURLErrorCode)")
@@ -157,7 +147,7 @@ class DataUploadStatusTests: XCTestCase {
 
     func testWhenUploadFinishesWithError_andErrorCodeMeansExternalFactors_itDoesNotCreateNetworkError() {
         let notAlertingNSURLErrorCode = NSURLErrorNetworkConnectionLost
-        let status = DataUploadStatus(networkError: NSError(domain: NSURLErrorDomain, code: notAlertingNSURLErrorCode, userInfo: nil))
+        let status = DataUploadStatus(networkError: NSError(domain: NSURLErrorDomain, code: notAlertingNSURLErrorCode, userInfo: nil), attempt: 0)
         XCTAssertNil(status.error, "Upload status error should not be created for NSURLError code: \(notAlertingNSURLErrorCode)")
     }
 
@@ -165,7 +155,7 @@ class DataUploadStatusTests: XCTestCase {
 
     func testWhenUploadFinishesWithResponse_itSetsResponseCode() {
         let randomCode: Int = .mockRandom(min: 1, max: 999)
-        let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: randomCode), ddRequestID: nil)
+        let status = DataUploadStatus(httpResponse: .mockResponseWith(statusCode: randomCode), ddRequestID: nil, attempt: 0)
         XCTAssertEqual(status.responseCode, randomCode)
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -27,13 +27,15 @@ class DataUploaderTests: XCTestCase {
         // When
         let uploadStatus = try uploader.upload(
             events: .mockAny(),
-            context: .mockAny()
+            context: .mockAny(),
+            previous: nil
         )
 
         // Then
         let expectedUploadStatus = DataUploadStatus(
             httpResponse: randomResponse,
-            ddRequestID: randomRequest.value(forHTTPHeaderField: "DD-REQUEST-ID")
+            ddRequestID: randomRequest.value(forHTTPHeaderField: "DD-REQUEST-ID"),
+            attempt: 0
         )
 
         DDAssertReflectionEqual(uploadStatus, expectedUploadStatus)
@@ -54,11 +56,12 @@ class DataUploaderTests: XCTestCase {
         // When
         let uploadStatus = try uploader.upload(
             events: .mockAny(),
-            context: .mockAny()
+            context: .mockAny(),
+            previous: nil
         )
 
         // Then
-        let expectedUploadStatus = DataUploadStatus(networkError: randomError)
+        let expectedUploadStatus = DataUploadStatus(networkError: randomError, attempt: 0)
 
         DDAssertReflectionEqual(uploadStatus, expectedUploadStatus)
     }
@@ -73,7 +76,7 @@ class DataUploaderTests: XCTestCase {
         )
 
         // When & Then
-        XCTAssertThrowsError(try uploader.upload(events: .mockAny(), context: .mockAny())) { error in
+        XCTAssertThrowsError(try uploader.upload(events: .mockAny(), context: .mockAny(), previous: nil)) { error in
             XCTAssertTrue(error is ErrorMock)
         }
     }

--- a/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
@@ -84,7 +84,7 @@ class DatadogLogsFeatureTests: XCTestCase {
         let requestURL = try XCTUnwrap(request.url)
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(requestURL.absoluteString.starts(with: randomUploadURL.absoluteString + "?"))
-        XCTAssertEqual(requestURL.query, "ddsource=\(randomSource)")
+        XCTAssertEqual(requestURL.query, "ddsource=\(randomSource)&ddtags=retry_count:1")
         XCTAssertEqual(
             request.allHTTPHeaderFields?["User-Agent"],
             """

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -297,23 +297,36 @@ class NOPDataUploadWorker: DataUploadWorkerType {
 }
 
 internal class DataUploaderMock: DataUploaderType {
-    let uploadStatus: DataUploadStatus
+    let uploadStatuses: [DataUploadStatus]
 
     /// Notifies on each started upload.
-    var onUpload: (() throws -> Void)?
+    var onUpload: ((DataUploadStatus?) throws -> Void)?
 
     /// Tracks uploaded events.
     private(set) var uploadedEvents: [Event] = []
 
-    init(uploadStatus: DataUploadStatus, onUpload: (() -> Void)? = nil) {
-        self.uploadStatus = uploadStatus
+    convenience init(uploadStatus: DataUploadStatus, onUpload: ((DataUploadStatus?) -> Void)? = nil) {
+        self.init(uploadStatuses: [uploadStatus], onUpload: onUpload)
+    }
+
+    init(uploadStatuses: [DataUploadStatus], onUpload: ((DataUploadStatus?) -> Void)? = nil) {
+        self.uploadStatuses = uploadStatuses
         self.onUpload = onUpload
     }
 
-    func upload(events: [Event], context: DatadogContext) throws -> DataUploadStatus {
-        uploadedEvents += events
-        try onUpload?()
-        return uploadStatus
+    func upload(
+        events: [DatadogInternal.Event],
+        context: DatadogInternal.DatadogContext,
+        previous: DataUploadStatus?) throws -> DataUploadStatus {
+            uploadedEvents += events
+            try onUpload?(previous)
+            let attempt: UInt
+            if let previous = previous {
+                attempt = previous.attempt + 1
+            } else {
+                attempt = 0
+            }
+            return uploadStatuses[Int(attempt)]
     }
 }
 
@@ -323,7 +336,8 @@ extension DataUploadStatus: RandomMockable {
             needsRetry: .random(),
             responseCode: .mockRandom(),
             userDebugDescription: .mockRandom(),
-            error: nil
+            error: nil,
+            attempt: .mockRandom()
         )
     }
 
@@ -331,13 +345,15 @@ extension DataUploadStatus: RandomMockable {
         needsRetry: Bool = .mockAny(),
         responseCode: Int = .mockAny(),
         userDebugDescription: String = .mockAny(),
-        error: DataUploadError? = nil
+        error: DataUploadError? = nil,
+        attempt: UInt = 0
     ) -> DataUploadStatus {
         return DataUploadStatus(
             needsRetry: needsRetry,
             responseCode: responseCode,
             userDebugDescription: userDebugDescription,
-            error: error
+            error: error,
+            attempt: attempt
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/UploadMock.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/UploadMock.swift
@@ -19,7 +19,11 @@ internal class FeatureRequestBuilderMock: FeatureRequestBuilder {
         self.init(factory: { _, _ in request })
     }
 
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
         return try factory(events, context)
     }
 }
@@ -28,7 +32,11 @@ internal class FeatureRequestBuilderSpy: FeatureRequestBuilder {
     /// Records parameters passed to `requet(for:with:)`
     private(set) var requestParameters: [(events: [Event], context: DatadogContext)] = []
 
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
         requestParameters.append((events: events, context: context))
         return .mockAny()
     }
@@ -37,7 +45,11 @@ internal class FeatureRequestBuilderSpy: FeatureRequestBuilder {
 internal struct FailingRequestBuilderMock: FeatureRequestBuilder {
     let error: Error
 
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
         throw error
     }
 }

--- a/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
@@ -91,7 +91,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(
             requestURL.query,
             """
-            ddsource=\(randomSource)&ddtags=service:\(randomServiceName),version:\(randomApplicationVersion),sdk_version:\(randomSDKVersion),env:\(randomEnvironmentName)
+            ddsource=\(randomSource)&ddtags=service:\(randomServiceName),version:\(randomApplicationVersion),sdk_version:\(randomSDKVersion),env:\(randomEnvironmentName),retry_count:1
             """
         )
         XCTAssertEqual(

--- a/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
@@ -84,8 +84,9 @@ class DatadogTraceFeatureTests: XCTestCase {
         let request = server.waitAndReturnRequests(count: 1)[0]
         let requestURL = try XCTUnwrap(request.url)
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(requestURL.absoluteString, randomUploadURL.absoluteString)
-        XCTAssertNil(requestURL.query)
+        XCTAssertEqual(requestURL.host, randomUploadURL.host)
+        XCTAssertEqual(requestURL.path, randomUploadURL.path)
+        XCTAssertEqual(requestURL.query, "ddtags=retry_count:1")
         XCTAssertEqual(
             request.allHTTPHeaderFields?["User-Agent"],
             """

--- a/DatadogInternal/Sources/Extensions/Data+Crypto.swift
+++ b/DatadogInternal/Sources/Extensions/Data+Crypto.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import CommonCrypto
+
+extension Data {
+    public func sha1() -> String {
+        let hash = withUnsafeBytes { bytes -> [UInt8] in
+            var hash: [UInt8] = Array(repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+            CC_SHA1(bytes.baseAddress, CC_LONG(count), &hash)
+            return hash
+        }
+
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/DatadogInternal/Sources/Upload/FeatureRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/FeatureRequestBuilder.swift
@@ -25,5 +25,30 @@ public protocol FeatureRequestBuilder {
     ///   - context: The current core context.
     ///   - events: The events data to be uploaded.
     /// - Returns: The URL request.
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest
+}
+
+/// Represents the context in which the request is being executed.
+public struct ExecutionContext {
+    /// HTTP status code of the previous response.
+    public let previousResponseCode: Int?
+
+    /// The current attempt number.
+    public let attempt: UInt
+
+    /// Initializes the execution context.
+    /// - Parameters:
+    ///   - previousResponseCode: Previous HTTP status code, if available.
+    ///   - attempt: The current attempt number.
+    public init(
+        previousResponseCode: Int?,
+        attempt: UInt
+    ) {
+        self.previousResponseCode = previousResponseCode
+        self.attempt = attempt
+    }
 }

--- a/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
@@ -23,6 +23,7 @@ public struct URLRequestBuilder {
         public static let ddEVPOriginHeaderField = "DD-EVP-ORIGIN"
         public static let ddEVPOriginVersionHeaderField = "DD-EVP-ORIGIN-VERSION"
         public static let ddRequestIDHeaderField = "DD-REQUEST-ID"
+        public static let ddIdempotencyKeyHeaderField = "DD-IDEMPOTENCY-KEY"
 
         public enum ContentType {
             case applicationJSON
@@ -90,6 +91,13 @@ public struct URLRequestBuilder {
         /// An optional Datadog header for debugging Intake requests by their ID.
         public static func ddRequestIDHeader() -> HTTPHeader {
             return HTTPHeader(field: ddRequestIDHeaderField, value: { UUID().uuidString })
+        }
+
+        /// An optional Datadog header for ensuring idempotent requests.
+        /// - Parameter key: The idempotency key.
+        /// - Returns: Header with the idempotency key.
+        public static func ddIdempotencyKeyHeader(key: String) -> HTTPHeader {
+            return HTTPHeader(field: ddIdempotencyKeyHeaderField, value: { key })
         }
     }
     /// Upload `URL`.

--- a/DatadogInternal/Tests/Extensions/Data+CryptoTests.swift
+++ b/DatadogInternal/Tests/Extensions/Data+CryptoTests.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+
+final class DataCryptoTests: XCTestCase {
+    func testSha1() throws {
+        let str1 = "The quick brown fox jumps over the lazy dog"
+        let data1 = str1.data(using: .utf8)!
+        let sha1 = data1.sha1()
+        XCTAssertEqual(sha1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+
+        let str2 = "The quick brown fox jumps over the lazy cog"
+        let data2 = str2.data(using: .utf8)!
+        let sha2 = data2.sha1()
+        XCTAssertEqual(sha2, "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3")
+    }
+
+    func testSha1_emptyString() throws {
+        let str = ""
+        let data = str.data(using: .utf8)!
+        let sha = data.sha1()
+        XCTAssertEqual(sha, "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    }
+}

--- a/DatadogLogs/Sources/Feature/RequestBuilder.swift
+++ b/DatadogLogs/Sources/Feature/RequestBuilder.swift
@@ -27,11 +27,24 @@ internal struct RequestBuilder: FeatureRequestBuilder {
         self.telemetry = telemetry
     }
 
-    func request(for events: [Event], with context: DatadogContext) -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) -> URLRequest {
+        var tags = [
+            "retry_count:\(execution.attempt + 1)"
+        ]
+
+        if let previousResponseCode = execution.previousResponseCode {
+            tags.append("last_failure_status:\(previousResponseCode)")
+        }
+
         let builder = URLRequestBuilder(
             url: url(with: context),
             queryItems: [
-                .ddsource(source: context.source)
+                .ddsource(source: context.source),
+                .ddtags(tags: tags)
             ],
             headers: [
                 .contentTypeHeader(contentType: .applicationJSON),

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -107,12 +107,8 @@ class RequestBuilderTests: XCTestCase {
         let request = builder.request(for: mockEvents, with: context, execution: execution)
 
         // Then
-        XCTAssertEqual(
-            request.url?.query,
-            """
-            ddsource=\(randomSource)&ddtags=service:\(randomService),version:\(randomVersion),sdk_version:\(randomSDKVersion),env:\(randomEnv),retry_count:\(randomAttempt),last_failure_status:\(randomStatus)
-            """
-        )
+        let expextedQuery = "ddsource=\(randomSource)&ddtags=service:\(randomService),version:\(randomVersion),sdk_version:\(randomSDKVersion),env:\(randomEnv),retry_count:\(randomAttempt + 1),last_failure_status:\(randomStatus)"
+        XCTAssertEqual(request.url?.query, expextedQuery)
     }
 
     func testItSetsVariantAsExtraQueryParameter() {

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -25,7 +25,7 @@ class RequestBuilderTests: XCTestCase {
         )
 
         // When
-        let request = builder.request(for: mockEvents, with: .mockAny())
+        let request = builder.request(for: mockEvents, with: .mockAny(), execution: .mockAny())
 
         // Then
         XCTAssertEqual(request.httpMethod, "POST")
@@ -41,7 +41,7 @@ class RequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) -> String {
-            let request = builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -65,7 +65,7 @@ class RequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) -> String {
-            let request = builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -85,6 +85,8 @@ class RequestBuilderTests: XCTestCase {
         let randomService: String = .mockRandom(among: .alphanumerics)
         let randomEnv: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
+        let randomAttempt: UInt = .mockRandom()
+        let randomStatus: Int = .mockRandom()
 
         // Given
         let builder = RequestBuilder(
@@ -99,15 +101,16 @@ class RequestBuilderTests: XCTestCase {
             source: randomSource,
             sdkVersion: randomSDKVersion
         )
+        let execution: ExecutionContext = .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt)
 
         // When
-        let request = builder.request(for: mockEvents, with: context)
+        let request = builder.request(for: mockEvents, with: context, execution: execution)
 
         // Then
         XCTAssertEqual(
             request.url?.query,
             """
-            ddsource=\(randomSource)&ddtags=service:\(randomService),version:\(randomVersion),sdk_version:\(randomSDKVersion),env:\(randomEnv)
+            ddsource=\(randomSource)&ddtags=service:\(randomService),version:\(randomVersion),sdk_version:\(randomSDKVersion),env:\(randomEnv),retry_count:\(randomAttempt),last_failure_status:\(randomStatus)
             """
         )
     }
@@ -124,11 +127,11 @@ class RequestBuilderTests: XCTestCase {
         let context: DatadogContext = .mockWith(variant: randomVariant)
 
         // When
-        let request = builder.request(for: mockEvents, with: context)
+        let request = builder.request(for: mockEvents, with: context, execution: .mockAny())
 
         // Then
         let query = request.url?.query ?? ""
-        XCTAssertTrue(query.hasSuffix(",variant:\(randomVariant)"))
+        XCTAssertTrue(query.contains(",variant:\(randomVariant)"))
     }
 
     func testItSetsRUMHTTPHeaders() {
@@ -167,7 +170,7 @@ class RequestBuilderTests: XCTestCase {
         )
 
         // When
-        let request = builder.request(for: mockEvents, with: context)
+        let request = builder.request(for: mockEvents, with: context, execution: .mockAny())
 
         // Then
         XCTAssertEqual(
@@ -193,7 +196,7 @@ class RequestBuilderTests: XCTestCase {
         )
 
         // When
-        let request = builder.request(for: mockEvents, with: .mockAny())
+        let request = builder.request(for: mockEvents, with: .mockAny(), execution: .mockAny())
 
         // Then
         let decompressed = zlib.decode(request.httpBody!)!

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -31,19 +31,29 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) throws -> URLRequest {
-    let decoder = JSONDecoder()
+        var tags = [
+            "retry_count:\(execution.attempt + 1)"
+        ]
+
+        if let previousResponseCode = execution.previousResponseCode {
+            tags.append("last_failure_status:\(previousResponseCode)")
+        }
+
+        let decoder = JSONDecoder()
         let resources = try events.map { event in
             try decoder.decode(EnrichedResource.self, from: event.data)
         }
-        return try createRequest(resources: resources, context: context)
+        return try createRequest(resources: resources, context: context, tags: tags)
     }
 
-    private func createRequest(resources: [EnrichedResource], context: DatadogContext) throws -> URLRequest {
+    private func createRequest(resources: [EnrichedResource], context: DatadogContext, tags: [String]) throws -> URLRequest {
         var multipart = multipartBuilder
 
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [],
+            queryItems: [
+                .ddtags(tags: tags)
+            ],
             headers: [
                 .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
                 .userAgentHeader(appName: context.applicationName, appVersion: context.version, device: context.device),

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -26,8 +26,12 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
         self.multipartBuilder = multipartBuilder
     }
 
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest {
-        let decoder = JSONDecoder()
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
+    let decoder = JSONDecoder()
         let resources = try events.map { event in
             try decoder.decode(EnrichedResource.self, from: event.data)
         }

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
@@ -28,7 +28,11 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
         self.multipartBuilder = multipartBuilder
     }
 
-    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
         guard !events.isEmpty else {
             throw InternalError(description: "[SR] batch events must not be empty.")
         }

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -71,15 +71,15 @@ class ResourceRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .us1_fed), expectedURL)
     }
 
-    func testItSetsNoQueryParameters() throws {
+    func testItSetsQueryParameters() throws {
         // Given
         let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When
-        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .mockAny())
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .init(previousResponseCode: nil, attempt: 0))
 
         // Then
-        XCTAssertEqual(request.url!.query, nil)
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
     }
 
     func testItSetsHTTPHeaders() throws {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -25,7 +25,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When
-        let request = try builder.request(for: mockEvents, with: .mockRandom())
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .mockAny())
 
         // Then
         XCTAssertEqual(request.httpMethod, "POST")
@@ -37,7 +37,7 @@ class ResourceRequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) throws -> String {
-            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -57,7 +57,7 @@ class ResourceRequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) throws -> String {
-            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -76,7 +76,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When
-        let request = try builder.request(for: mockEvents, with: .mockRandom())
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .mockAny())
 
         // Then
         XCTAssertEqual(request.url!.query, nil)
@@ -108,7 +108,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         )
 
         // When
-        let request = try builder.request(for: mockEvents, with: context)
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
@@ -132,7 +132,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock(), multipartBuilder: multipartSpy)
 
         // When
-        let request = try builder.request(for: mockEvents, with: .mockRandom())
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .mockAny())
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
@@ -154,7 +154,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When, Then
-        XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockRandom()))
+        XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockRandom(), execution: .mockAny()))
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -28,7 +28,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When
-        let request = try builder.request(for: mockEvents, with: .mockAny())
+        let request = try builder.request(for: mockEvents, with: .mockAny(), execution: .mockAny())
 
         // Then
         XCTAssertEqual(request.httpMethod, "POST")
@@ -40,7 +40,7 @@ class SegmentRequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) throws -> String {
-            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -60,7 +60,7 @@ class SegmentRequestBuilderTests: XCTestCase {
 
         // When
         func url(for site: DatadogSite) throws -> String {
-            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
             return request.url!.absoluteStringWithoutQuery!
         }
 
@@ -80,7 +80,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let context: DatadogContext = .mockRandom()
 
         // When
-        let request = try builder.request(for: mockEvents, with: context)
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
 
         // Then
         XCTAssertEqual(request.url!.query, nil)
@@ -112,7 +112,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         )
 
         // When
-        let request = try builder.request(for: mockEvents, with: context)
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
@@ -152,7 +152,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         }
 
         // When
-        let request = try builder.request(for: events, with: .mockWith(source: "ios"))
+        let request = try builder.request(for: events, with: .mockWith(source: "ios"), execution: .mockAny())
 
         // Then
         let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
@@ -235,7 +235,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
 
         // When, Then
-        XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockAny()))
+        XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockAny(), execution: .mockAny()))
     }
 
     func testWhenSourceIsInvalid_itSendsErrorTelemetry() throws {
@@ -244,7 +244,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: telemetry)
 
         // When
-        _ = try builder.request(for: mockEvents, with: .mockWith(source: "invalid source"))
+        _ = try builder.request(for: mockEvents, with: .mockWith(source: "invalid source"), execution: .mockAny())
 
         // Then
         XCTAssertTrue(

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -74,16 +74,16 @@ class SegmentRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .us1_fed), expectedURL)
     }
 
-    func testItSetsNoQueryParameters() throws {
+    func testItSetsQueryParameters() throws {
         // Given
         let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
         let context: DatadogContext = .mockRandom()
 
         // When
-        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockWith(previousResponseCode: nil, attempt: 0))
 
         // Then
-        XCTAssertEqual(request.url!.query, nil)
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
     }
 
     func testItSetsHTTPHeaders() throws {

--- a/DatadogSessionReplay/Tests/Mocks/MockFeature.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockFeature.swift
@@ -19,7 +19,6 @@ internal class MockFeature: DatadogRemoteFeature {
 internal class MockRequestBuilder: FeatureRequestBuilder {
     func request(for events: [DatadogInternal.Event], with context: DatadogInternal.DatadogContext, execution: DatadogInternal.ExecutionContext) throws -> URLRequest {
         URLRequest.mockAny()
-
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Mocks/MockFeature.swift
+++ b/DatadogSessionReplay/Tests/Mocks/MockFeature.swift
@@ -17,8 +17,9 @@ internal class MockFeature: DatadogRemoteFeature {
 }
 
 internal class MockRequestBuilder: FeatureRequestBuilder {
-    func request(for events: [DatadogInternal.Event], with context: DatadogInternal.DatadogContext) throws -> URLRequest {
+    func request(for events: [DatadogInternal.Event], with context: DatadogInternal.DatadogContext, execution: DatadogInternal.ExecutionContext) throws -> URLRequest {
         URLRequest.mockAny()
+
     }
 }
 #endif

--- a/DatadogTrace/Sources/Feature/RequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/RequestBuilder.swift
@@ -19,10 +19,24 @@ internal struct TracingRequestBuilder: FeatureRequestBuilder {
     /// Telemetry interface.
     let telemetry: Telemetry
 
-    func request(for events: [Event], with context: DatadogContext) -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) -> URLRequest {
+        var tags = [
+            "retry_count:\(execution.attempt + 1)"
+        ]
+
+        if let previousResponseCode = execution.previousResponseCode {
+            tags.append("last_failure_status:\(previousResponseCode)")
+        }
+
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [],
+            queryItems: [
+                .ddtags(tags: tags)
+            ],
             headers: [
                 .contentTypeHeader(contentType: .textPlainUTF8),
                 .userAgentHeader(

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
@@ -21,18 +21,16 @@ extension LoggingCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios`
-            let pathRegex = #"^(.*)(\?ddsource=ios)$"#
-            XCTAssertTrue(
-                request.path.matches(regex: pathRegex),
-                """
-                Request path doesn't match the expected regex.
-                ✉️ path: \(request.path)
-                🧪 expected regex: \(pathRegex)
-                """,
-                file: file,
-                line: line
-            )
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios&ddtags=retry_count:1`
+            XCTAssertNotNil(request.path, file: file, line: line)
+            XCTAssertNotNil(request.queryItems)
+            XCTAssertEqual(request.queryItems!.count, 2)
+            XCTAssertEqual(request.queryItems?.value(name: "ddsource"), "ios", file: file, line: line)
+
+            let ddtags = request.queryItems?.ddtags()
+            XCTAssertNotNil(ddtags, file: file, line: line)
+            XCTAssertEqual(ddtags?.count, 1, file: file, line: line)
+            XCTAssertEqual(ddtags?["retry_count"], "1", file: file, line: line)
 
             XCTAssertEqual(request.httpHeaders["Content-Type"], "application/json", file: file, line: line)
             XCTAssertEqual(request.httpHeaders["User-Agent"]?.matches(regex: userAgentRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRCommonAsserts.swift
@@ -21,16 +21,15 @@ extension SRCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309`
-            XCTAssertFalse(
-                request.path.contains("?"),
-                """
-                Request path must contain no query parameters.
-                ✉️ path: \(request.path)
-                """,
-                file: file,
-                line: line
-            )
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddtags=retry_count:1`
+            XCTAssertNotNil(request.path, file: file, line: line)
+            XCTAssertNotNil(request.queryItems)
+            XCTAssertEqual(request.queryItems!.count, 1)
+
+            let ddtags = request.queryItems?.ddtags()
+            XCTAssertNotNil(ddtags, file: file, line: line)
+            XCTAssertEqual(ddtags?.count, 1, file: file, line: line)
+            XCTAssertEqual(ddtags?["retry_count"], "1", file: file, line: line)
 
             let contentTypeRegex = #"^multipart/form-data; boundary=.*$"#
             XCTAssertEqual(request.httpHeaders["Content-Type"]?.matches(regex: contentTypeRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
@@ -33,16 +33,15 @@ extension TracingCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309`
-            XCTAssertFalse(
-                request.path.contains("?"),
-                """
-                Request path must contain no query parameters.
-                ✉️ path: \(request.path)
-                """,
-                file: file,
-                line: line
-            )
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddtags=retry_count:1`
+            XCTAssertFalse(request.path.isEmpty)
+            XCTAssertNotNil(request.queryItems)
+            XCTAssertEqual(request.queryItems!.count, 1)
+
+            let ddtags = request.queryItems?.ddtags()
+            XCTAssertNotNil(ddtags)
+            XCTAssertEqual(ddtags?.count, 1)
+            XCTAssertEqual(ddtags!["retry_count"], "1")
 
             XCTAssertEqual(request.httpHeaders["Content-Type"], "text/plain;charset=UTF-8", file: file, line: line)
             XCTAssertEqual(request.httpHeaders["User-Agent"]?.matches(regex: userAgentRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/UITestsHelpers.swift
+++ b/IntegrationTests/IntegrationScenarios/UITestsHelpers.swift
@@ -14,6 +14,8 @@ let semverRegex = "^\(semverPattern)$"
 let userAgentRegex = #"^.*/\d+[.\d]* CFNetwork \([a-zA-Z ]+; iOS/[0-9.]+\)$"#
 /// Regex for matching the value of `DD-REQUEST-ID` header, e.g. "DD-REQUEST-ID: 524A2616-D2AA-4FE5-BBD9-898D173BE658"
 let ddRequestIDRegex = #"^[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}$"#
+let numberPattern = "[0-9]+$"
+let sha1Regex = "^[0-9a-f]{40}$"
 
 /// Convenient interface to navigate through Example app's main screen.
 class ExampleApplication: XCUIApplication {

--- a/TestUtilities/Helpers/SwiftExtensions.swift
+++ b/TestUtilities/Helpers/SwiftExtensions.swift
@@ -92,6 +92,11 @@ public extension URL {
         components?.query = nil // drop query params
         return components?.url?.absoluteString
     }
+
+    func queryItem(_ name: String) -> URLQueryItem? {
+        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        return components?.queryItems?.first { $0.name == name }
+    }
 }
 
 extension URLRequest {
@@ -173,5 +178,11 @@ public extension Array {
             )
         }
         return all.first
+    }
+}
+
+extension Dictionary where Key == Int, Value == String {
+    public static func + (lhs: Self, rhs: Self) -> Self {
+        lhs.merging(rhs) { _, new in new }
     }
 }

--- a/TestUtilities/Mocks/UploadMocks.swift
+++ b/TestUtilities/Mocks/UploadMocks.swift
@@ -43,3 +43,17 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         uploadDelayChangeRate: 60 / 0.05
     )
 }
+
+extension ExecutionContext: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        return .init(previousResponseCode: .mockAny(), attempt: .mockAny())
+    }
+
+    public static func mockRandom() -> Self {
+        return .init(previousResponseCode: .mockRandom(), attempt: .mockRandom())
+    }
+    
+    public static func mockWith(previousResponseCode: Int?, attempt: UInt) -> Self {
+        return .init(previousResponseCode: previousResponseCode, attempt: attempt)
+    }
+}

--- a/tools/http-server-mock/Sources/HTTPServerMock/Request.swift
+++ b/tools/http-server-mock/Sources/HTTPServerMock/Request.swift
@@ -10,10 +10,58 @@ import Foundation
 public struct Request {
     /// Original path of this request.
     public let path: String
+    /// Query params of this request.
+    public let queryItems: [URLQueryItem]?
     /// HTTP method of this request.
     public let httpMethod: String
     /// HTTP headers associated with this request.
     public let httpHeaders: [String: String]
     /// HTTP body of this request.
     public let httpBody: Data
+}
+
+extension Array where Element == URLQueryItem {
+    /// Returns the `ddtags` query item as a dictionary.
+    /// The `ddtags` query item is expected to be in the format `key:value,key:value`.
+    /// - Returns: The `ddtags` query item as a dictionary.
+    public func ddtags() -> [String: String]? {
+        guard let ddtags = first(where: { $0.name == "ddtags" })?.value else {
+            return nil
+        }
+        return ddtags.split(seperator: ",", keyValueSeperator: ":")
+    }
+
+    /// Returns the value of the first query item with the given name.
+    /// - Parameter name: The name of the query item to return.
+    /// - Returns: The value of the first query item with the given name, or `nil` if no such query item exists.
+    public func value(name: String) -> String? {
+        first(where: { $0.name == name })?.value
+    }
+
+    /// Returns the values of all query items with the given name.
+    /// - Parameter name: The name of the query items to return.
+    /// - Returns: The values of all query items with the given name. If no such query item exists, an empty array is returned.
+    public func values(name: String) -> [String?] {
+        filter { $0.name == name }.map { $0.value }
+    }
+}
+
+extension String {
+    /// Splits the string into a dictionary.
+    /// - Parameters:
+    ///   - seperator: Seperator to split the string.
+    ///   - keyValueSeperator: Seperator to split the key and value.
+    /// - Returns: The string as a dictionary. If the string is not in the expected format, an empty dictionary is returned.
+    public func split(seperator: String, keyValueSeperator: String) -> [String: String] {
+        let components = self.components(separatedBy: seperator)
+        var result: [String: String] = [:]
+        components.forEach { header in
+            let components = header.components(separatedBy: keyValueSeperator)
+            if let field = components.first {
+                let value = components.dropFirst().joined(separator: keyValueSeperator)
+                result[field] = value
+            }
+        }
+        return result
+    }
 }

--- a/tools/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
+++ b/tools/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
@@ -42,10 +42,28 @@ fileprivate extension Request {
             }
         }
 
-        self.path = intermediateRequest.path
+        self.path = Self.path(pathWithQuery: intermediateRequest.path)
+        self.queryItems = Self.queryItems(pathWithQuery: intermediateRequest.path)
         self.httpMethod = intermediateRequest.method
         self.httpHeaders = headers
         self.httpBody = bodyData
+    }
+
+    static func path(pathWithQuery: String) -> String {
+        guard let url = URL(string: pathWithQuery) else {
+            return pathWithQuery
+        }
+
+        return url.path
+    }
+
+    static func queryItems(pathWithQuery: String) -> [URLQueryItem]? {
+        guard let url = URL(string: pathWithQuery) else {
+            return []
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        return components?.queryItems
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR is implementation of https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3422683761/RFC+Retry+information+headers+and+query+string+params

### How?

The gist of PR is, when we make a network request to upload data

- Inject `retry_count` and `last_failure_status` under `ddtags` query param
- Inject `DD-IDEMPOTENCY-KEY` header

Both `retry_count` and `last_failure_status` are available after the first request failure which is persisted in the uploader, and during the next request used to populate the query param.



### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
