### PR TITLE
RUM-5762 [SR] Create touchPrivacyLevel masking option

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDSessionReplayTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDSessionReplayTests.swift
@@ -23,6 +23,21 @@ class DDSessionReplayTests: XCTestCase {
         // Then
         XCTAssertEqual(config._swift.replaySampleRate, sampleRate)
         XCTAssertEqual(config._swift.defaultPrivacyLevel, .mask)
+        XCTAssertEqual(config._swift.touchPrivacyLevel, .hide)
+        XCTAssertNil(config._swift.customEndpoint)
+    }
+
+    func testDefaultConfigurationWithNewApi() {
+        // Given
+        let sampleRate: Float = .mockRandom(min: 0, max: 100)
+
+        // When
+        let config = DDSessionReplayConfiguration(sampleRate: sampleRate)
+
+        // Then
+        XCTAssertEqual(config._swift.replaySampleRate, sampleRate)
+        XCTAssertEqual(config._swift.defaultPrivacyLevel, .mask)
+        XCTAssertEqual(config._swift.touchPrivacyLevel, .hide)
         XCTAssertNil(config._swift.customEndpoint)
     }
 
@@ -30,17 +45,41 @@ class DDSessionReplayTests: XCTestCase {
         // Given
         let sampleRate: Float = .mockRandom(min: 0, max: 100)
         let privacy: DDSessionReplayConfigurationPrivacyLevel = [.allow, .mask, .maskUserInput].randomElement()!
+        let touchPrivacy: DDSessionReplayConfigurationTouchPrivacyLevel = [.show, .hide].randomElement()!
         let url: URL = .mockRandom()
 
         // When
         let config = DDSessionReplayConfiguration(replaySampleRate: 100)
         config.replaySampleRate = sampleRate
         config.defaultPrivacyLevel = privacy
+        config.touchPrivacyLevel = touchPrivacy
         config.customEndpoint = url
 
         // Then
         XCTAssertEqual(config._swift.replaySampleRate, sampleRate)
         XCTAssertEqual(config._swift.defaultPrivacyLevel, privacy._swift)
+        XCTAssertEqual(config._swift.touchPrivacyLevel, touchPrivacy._swift)
+        XCTAssertEqual(config._swift.customEndpoint, url)
+    }
+
+    func testConfigurationOverridesWithNewApi() {
+        // Given
+        let sampleRate: Float = .mockRandom(min: 0, max: 100)
+        let privacy: DDSessionReplayConfigurationPrivacyLevel = [.allow, .mask, .maskUserInput].randomElement()!
+        let touchPrivacy: DDSessionReplayConfigurationTouchPrivacyLevel = [.show, .hide].randomElement()!
+        let url: URL = .mockRandom()
+
+        // When
+        let config = DDSessionReplayConfiguration(sampleRate: 100)
+        config.replaySampleRate = sampleRate
+        config.defaultPrivacyLevel = privacy
+        config.touchPrivacyLevel = touchPrivacy
+        config.customEndpoint = url
+
+        // Then
+        XCTAssertEqual(config._swift.replaySampleRate, sampleRate)
+        XCTAssertEqual(config._swift.defaultPrivacyLevel, privacy._swift)
+        XCTAssertEqual(config._swift.touchPrivacyLevel, touchPrivacy._swift)
         XCTAssertEqual(config._swift.customEndpoint, url)
     }
 
@@ -52,6 +91,14 @@ class DDSessionReplayTests: XCTestCase {
         XCTAssertEqual(DDSessionReplayConfigurationPrivacyLevel(.allow), .allow)
         XCTAssertEqual(DDSessionReplayConfigurationPrivacyLevel(.mask), .mask)
         XCTAssertEqual(DDSessionReplayConfigurationPrivacyLevel(.maskUserInput), .maskUserInput)
+    }
+
+    func testTouchPrivacyLevelsInterop() {
+        XCTAssertEqual(DDSessionReplayConfigurationTouchPrivacyLevel.show._swift, .show)
+        XCTAssertEqual(DDSessionReplayConfigurationTouchPrivacyLevel.hide._swift, .hide)
+
+        XCTAssertEqual(DDSessionReplayConfigurationTouchPrivacyLevel(.show), .show)
+        XCTAssertEqual(DDSessionReplayConfigurationTouchPrivacyLevel(.hide), .hide)
     }
 
     func testWhenEnabled() throws {
@@ -70,6 +117,27 @@ class DDSessionReplayTests: XCTestCase {
         let requestBuilder = try XCTUnwrap(sr.requestBuilder as? DatadogSessionReplay.SegmentRequestBuilder)
         XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, 42)
         XCTAssertEqual(sr.recordingCoordinator.privacy, .mask)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, .hide)
+        XCTAssertNil(requestBuilder.customUploadURL)
+    }
+
+    func testWhenEnabledWithNewApi() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        CoreRegistry.register(default: core)
+        defer { CoreRegistry.unregisterDefault() }
+
+        let config = DDSessionReplayConfiguration(sampleRate: 42)
+
+        // When
+        DDSessionReplay.enable(with: config)
+
+        // Then
+        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
+        let requestBuilder = try XCTUnwrap(sr.requestBuilder as? DatadogSessionReplay.SegmentRequestBuilder)
+        XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, 42)
+        XCTAssertEqual(sr.recordingCoordinator.privacy, .mask)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, .hide)
         XCTAssertNil(requestBuilder.customUploadURL)
     }
 }

--- a/DatadogCore/Tests/DatadogObjc/DDSessionReplayTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDSessionReplayTests.swift
@@ -27,17 +27,18 @@ class DDSessionReplayTests: XCTestCase {
         XCTAssertNil(config._swift.customEndpoint)
     }
 
-    func testDefaultConfigurationWithNewApi() {
+    func testConfigurationWithNewApi() {
         // Given
+        let touchPrivacy: DDSessionReplayConfigurationTouchPrivacyLevel = [.show, .hide].randomElement()!
         let sampleRate: Float = .mockRandom(min: 0, max: 100)
 
         // When
-        let config = DDSessionReplayConfiguration(sampleRate: sampleRate)
+        let config = DDSessionReplayConfiguration(replaySampleRate: sampleRate, touchPrivacyLevel: touchPrivacy)
 
         // Then
         XCTAssertEqual(config._swift.replaySampleRate, sampleRate)
         XCTAssertEqual(config._swift.defaultPrivacyLevel, .mask)
-        XCTAssertEqual(config._swift.touchPrivacyLevel, .hide)
+        XCTAssertEqual(config._swift.touchPrivacyLevel, touchPrivacy._swift)
         XCTAssertNil(config._swift.customEndpoint)
     }
 
@@ -70,7 +71,7 @@ class DDSessionReplayTests: XCTestCase {
         let url: URL = .mockRandom()
 
         // When
-        let config = DDSessionReplayConfiguration(sampleRate: 100)
+        let config = DDSessionReplayConfiguration(replaySampleRate: 100, touchPrivacyLevel: .hide)
         config.replaySampleRate = sampleRate
         config.defaultPrivacyLevel = privacy
         config.touchPrivacyLevel = touchPrivacy
@@ -125,9 +126,10 @@ class DDSessionReplayTests: XCTestCase {
         // Given
         let core = FeatureRegistrationCoreMock()
         CoreRegistry.register(default: core)
+        let touchPrivacy: DDSessionReplayConfigurationTouchPrivacyLevel = [.show, .hide].randomElement()!
         defer { CoreRegistry.unregisterDefault() }
 
-        let config = DDSessionReplayConfiguration(sampleRate: 42)
+        let config = DDSessionReplayConfiguration(replaySampleRate: 42, touchPrivacyLevel: touchPrivacy)
 
         // When
         DDSessionReplay.enable(with: config)
@@ -137,7 +139,7 @@ class DDSessionReplayTests: XCTestCase {
         let requestBuilder = try XCTUnwrap(sr.requestBuilder as? DatadogSessionReplay.SegmentRequestBuilder)
         XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, 42)
         XCTAssertEqual(sr.recordingCoordinator.privacy, .mask)
-        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, .hide)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, touchPrivacy._swift)
         XCTAssertNil(requestBuilder.customUploadURL)
     }
 }

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -23,7 +23,7 @@
 }
 
 - (void)testConfigurationWithNewApi {
-    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithSampleRate:100];
+    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100 touchPrivacyLevel:DDSessionReplayConfigurationTouchPrivacyLevelShow];
     configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
     configuration.touchPrivacyLevel = DDSessionReplayConfigurationTouchPrivacyLevelShow;
     configuration.customEndpoint = [NSURL new];

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -16,6 +16,16 @@
 - (void)testConfiguration {
     DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100];
     configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
+    configuration.touchPrivacyLevel = DDSessionReplayConfigurationTouchPrivacyLevelShow;
+    configuration.customEndpoint = [NSURL new];
+
+    [DDSessionReplay enableWith:configuration];
+}
+
+- (void)testConfigurationWithNewApi {
+    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithSampleRate:100];
+    configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
+    configuration.touchPrivacyLevel = DDSessionReplayConfigurationTouchPrivacyLevelShow;
     configuration.customEndpoint = [NSURL new];
 
     [DDSessionReplay enableWith:configuration];

--- a/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
@@ -20,6 +20,15 @@ public enum SessionReplayPrivacyLevel: String {
     case maskUserInput = "mask_user_input"
 }
 
+/// Available privacy levels for touch masking in Session Replay.
+public enum SessionReplayTouchPrivacyLevel: String {
+    /// Show all user touches.
+    case show
+
+    /// Hide all user touches.
+    case hide
+}
+
 /// The Session Replay shared configuration.
 ///
 /// The Feature object  named `session-replay` will be registered to the core
@@ -34,6 +43,8 @@ public enum SessionReplayPrivacyLevel: String {
 public protocol SessionReplayConfiguration {
     /// The privacy level to use for the web view replay recording.
     var privacyLevel: SessionReplayPrivacyLevel { get }
+    /// The touch privacy level to use for the web view replay recording.
+    var touchPrivacyLevel: SessionReplayTouchPrivacyLevel { get }
 }
 
 extension DatadogFeature where Self: SessionReplayConfiguration {

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -154,7 +154,7 @@ internal class SnapshotTestCase: XCTestCase {
 
         // Capture next record with mock RUM Context
         try recorder.captureNextRecord(
-            .init(privacy: privacyLevel, applicationID: "", sessionID: "", viewID: "", viewServerTimeOffset: 0)
+            .init(privacy: privacyLevel, touchPrivacy: .show, applicationID: "", sessionID: "", viewID: "", viewServerTimeOffset: 0)
         )
 
         waitForExpectations(timeout: 30) // very pessimistic timeout to mitigate CI lags

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -13,6 +13,7 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?
     let privacyLevel: SessionReplayPrivacyLevel
+    let touchPrivacyLevel: SessionReplayTouchPrivacyLevel
 
     // MARK: - Main Components
 
@@ -48,7 +49,6 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
         let scheduler = MainThreadScheduler(interval: 0.1)
         let contextReceiver = RUMContextReceiver()
 
-        self.privacyLevel = configuration.defaultPrivacyLevel
         self.messageReceiver = CombinedFeatureMessageReceiver([
             contextReceiver,
             WebViewRecordReceiver(
@@ -56,9 +56,13 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
             )
         ])
 
+        self.privacyLevel = configuration.defaultPrivacyLevel
+        self.touchPrivacyLevel = configuration.touchPrivacyLevel
+
         self.recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
             privacy: configuration.defaultPrivacyLevel,
+            touchPrivacy: configuration.touchPrivacyLevel,
             rumContextObserver: contextReceiver,
             srContextPublisher: SRContextPublisher(core: core),
             recorder: recorder,

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -8,6 +8,7 @@
 import DatadogInternal
 
 internal typealias PrivacyLevel = SessionReplayPrivacyLevel
+internal typealias TouchPrivacyLevel = SessionReplayTouchPrivacyLevel
 
 /// Text obfuscation strategies for different text types.
 @_spi(Internal)

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -24,6 +24,8 @@ public class Recorder: Recording {
     public struct Context: Equatable {
         /// The content recording policy from the moment of requesting snapshot.
         public let privacy: SessionReplayPrivacyLevel
+        /// The content recording policy from the moment of requesting snapshot.
+        public let touchPrivacy: SessionReplayTouchPrivacyLevel
         /// Current RUM application ID - standard UUID string, lowecased.
         let applicationID: String
         /// Current RUM session ID - standard UUID string, lowecased.
@@ -37,6 +39,7 @@ public class Recorder: Recording {
 
         internal init(
             privacy: PrivacyLevel,
+            touchPrivacy: TouchPrivacyLevel,
             applicationID: String,
             sessionID: String,
             viewID: String,
@@ -44,6 +47,7 @@ public class Recorder: Recording {
             date: Date = Date()
         ) {
             self.privacy = privacy
+            self.touchPrivacy = touchPrivacy
             self.applicationID = applicationID
             self.sessionID = sessionID
             self.viewID = viewID

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -15,6 +15,7 @@ internal class RecordingCoordinator {
     let scheduler: Scheduler
     let sampler: Sampler
     let privacy: PrivacyLevel
+    let touchPrivacy: TouchPrivacyLevel
     let srContextPublisher: SRContextPublisher
 
     private var currentRUMContext: RUMContext? = nil
@@ -28,6 +29,7 @@ internal class RecordingCoordinator {
     init(
         scheduler: Scheduler,
         privacy: PrivacyLevel,
+        touchPrivacy: TouchPrivacyLevel,
         rumContextObserver: RUMContextObserver,
         srContextPublisher: SRContextPublisher,
         recorder: Recording,
@@ -39,6 +41,7 @@ internal class RecordingCoordinator {
         self.scheduler = scheduler
         self.sampler = sampler
         self.privacy = privacy
+        self.touchPrivacy = touchPrivacy
         self.srContextPublisher = srContextPublisher
         self.telemetry = telemetry
         self.methodCallTelemetrySamplingRate = methodCallTelemetrySamplingRate
@@ -77,6 +80,7 @@ internal class RecordingCoordinator {
 
         let recorderContext = Recorder.Context(
             privacy: privacy,
+            touchPrivacy: touchPrivacy,
             applicationID: rumContext.applicationID,
             sessionID: rumContext.sessionID,
             viewID: viewID,

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -54,6 +54,14 @@ public final class DDSessionReplayConfiguration: NSObject {
         get { .init(_swift.defaultPrivacyLevel) }
     }
 
+    /// Defines the way user touches (e.g. tap) should be masked.
+    ///
+    /// Default: `.mask`.
+    @objc public var touchPrivacyLevel: DDSessionReplayConfigurationTouchPrivacyLevel {
+        set { _swift.touchPrivacyLevel = newValue._swift }
+        get { .init(_swift.touchPrivacyLevel) }
+    }
+
     /// Custom server url for sending replay data.
     ///
     /// Default: `nil`.
@@ -62,6 +70,22 @@ public final class DDSessionReplayConfiguration: NSObject {
         get { _swift.customEndpoint }
     }
 
+    /// Creates Session Replay configuration.
+    ///
+    /// - Parameters:
+    ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+    ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
+    @objc
+    public required init(
+        sampleRate: Float
+    ) {
+        _swift = SessionReplay.Configuration(
+            sampleRate: sampleRate
+        )
+        super.init()
+    }
+
+    // TODO: RUM-5764 Deprecate former API
     /// Creates Session Replay configuration.
     ///
     /// - Parameters:
@@ -103,6 +127,31 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
         case .allow: self = .allow
         case .mask: self = .mask
         case .maskUserInput: self = .maskUserInput
+        }
+    }
+}
+
+/// Available privacy levels for content masking.
+@objc
+public enum DDSessionReplayConfigurationTouchPrivacyLevel: Int {
+    /// Show all touches.
+    case show
+
+    /// Hide all touches.
+    case hide
+
+    internal var _swift: SessionReplayTouchPrivacyLevel {
+        switch self {
+        case .show: return .show
+        case .hide: return .hide
+        default: return .hide
+        }
+    }
+
+    internal init(_ swift: SessionReplayTouchPrivacyLevel) {
+        switch swift {
+        case .show: self = .show
+        case .hide: self = .hide
         }
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -77,10 +77,12 @@ public final class DDSessionReplayConfiguration: NSObject {
     ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
     @objc
     public required init(
-        sampleRate: Float
+        replaySampleRate: Float,
+        touchPrivacyLevel: DDSessionReplayConfigurationTouchPrivacyLevel
     ) {
         _swift = SessionReplay.Configuration(
-            sampleRate: sampleRate
+            replaySampleRate: replaySampleRate,
+            touchPrivacyLevel: touchPrivacyLevel._swift
         )
         super.init()
     }

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -48,6 +48,7 @@ public enum SessionReplay {
         let sessionReplay = try SessionReplayFeature(core: core, configuration: configuration)
         try core.register(feature: sessionReplay)
 
+        // TODO: RUM-5782 Add new privacy levels to config telemetry
         core.telemetry.configuration(
             defaultPrivacyLevel: configuration.defaultPrivacyLevel.rawValue,
             sessionReplaySampleRate: Int64(withNoOverflow: configuration.replaySampleRate)

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -10,6 +10,7 @@ import DatadogInternal
 
 // swiftlint:disable duplicate_imports
 @_exported import enum DatadogInternal.SessionReplayPrivacyLevel
+@_exported import enum DatadogInternal.SessionReplayTouchPrivacyLevel
 // swiftlint:enable duplicate_imports
 
 extension SessionReplay {
@@ -30,6 +31,11 @@ extension SessionReplay {
         /// Default: `.mask`.
         public var defaultPrivacyLevel: SessionReplayPrivacyLevel
 
+        /// Defines the way user touches (e.g. tap) should be masked.
+        ///
+        /// Default: `.hide`.
+        public var touchPrivacyLevel: SessionReplayTouchPrivacyLevel
+
         /// Custom server url for sending replay data.
         ///
         /// Default: `nil`.
@@ -43,6 +49,23 @@ extension SessionReplay {
 
         /// Creates Session Replay configuration
         /// - Parameters:
+        ///   - sampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+        ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
+        ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
+        public init(
+            sampleRate: Float,
+            touchPrivacyLevel: SessionReplayTouchPrivacyLevel = .hide,
+            customEndpoint: URL? = nil
+        ) {
+            self.replaySampleRate = sampleRate
+            self.defaultPrivacyLevel = .mask
+            self.touchPrivacyLevel = touchPrivacyLevel
+            self.customEndpoint = customEndpoint
+        }
+
+        // TODO: RUM-5764 Deprecate former API
+        /// Creates Session Replay configuration.
+        /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
         ///   - defaultPrivacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
@@ -53,6 +76,7 @@ extension SessionReplay {
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
+            self.touchPrivacyLevel = .hide
             self.customEndpoint = customEndpoint
         }
 

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -49,15 +49,15 @@ extension SessionReplay {
 
         /// Creates Session Replay configuration
         /// - Parameters:
-        ///   - sampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+        ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
         ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         public init(
-            sampleRate: Float,
-            touchPrivacyLevel: SessionReplayTouchPrivacyLevel = .hide,
+            replaySampleRate: Float,
+            touchPrivacyLevel: SessionReplayTouchPrivacyLevel,
             customEndpoint: URL? = nil
         ) {
-            self.replaySampleRate = sampleRate
+            self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = .mask
             self.touchPrivacyLevel = touchPrivacyLevel
             self.customEndpoint = customEndpoint

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
@@ -145,6 +145,7 @@ class SegmentJSONTests: XCTestCase {
     private func generateEnrichedRecordJSONs(for segment: SRSegment) throws -> [SegmentJSON] {
         let context = Recorder.Context(
             privacy: .mockRandom(),
+            touchPrivacy: .mockRandom(),
             rumContext: RUMContext(
                 applicationID: segment.application.id,
                 sessionID: segment.session.id,

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -458,6 +458,7 @@ extension Recorder.Context: AnyMockable, RandomMockable {
     public static func mockRandom() -> Recorder.Context {
         return Recorder.Context(
             privacy: .mockRandom(),
+            touchPrivacy: .mockRandom(),
             rumContext: .mockRandom(),
             date: .mockRandom()
         )
@@ -466,10 +467,12 @@ extension Recorder.Context: AnyMockable, RandomMockable {
     static func mockWith(
         date: Date = .mockAny(),
         privacy: PrivacyLevel = .mockAny(),
+        touchPrivacy: TouchPrivacyLevel = .mockAny(),
         rumContext: RUMContext = .mockAny()
     ) -> Recorder.Context {
         return Recorder.Context(
             privacy: privacy,
+            touchPrivacy: touchPrivacy,
             rumContext: rumContext,
             date: date
         )
@@ -477,11 +480,13 @@ extension Recorder.Context: AnyMockable, RandomMockable {
 
     init(
         privacy: PrivacyLevel,
+        touchPrivacy: TouchPrivacyLevel,
         rumContext: RUMContext,
         date: Date = Date()
     ) {
         self.init(
             privacy: privacy,
+            touchPrivacy: touchPrivacy,
             applicationID: rumContext.applicationID,
             sessionID: rumContext.sessionID,
             viewID: rumContext.viewID ?? "",

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -235,7 +235,7 @@ class SnapshotProcessorTests: XCTestCase {
         // When
         let snapshot = ViewTreeSnapshot(
             date: time,
-            context: .init(privacy: .allow, rumContext: rum, date: time),
+            context: .init(privacy: .allow, touchPrivacy: .show, rumContext: rum, date: time),
             viewportSize: .mockRandom(minWidth: 1_000, minHeight: 1_000),
             nodes: [node],
             webViewSlotIDs: Set([hiddenSlot, visibleSlot])
@@ -436,7 +436,7 @@ class SnapshotProcessorTests: XCTestCase {
     private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [])
 
     private func generateViewTreeSnapshot(for viewTree: UIView, date: Date, rumContext: RUMContext) -> ViewTreeSnapshot {
-        snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, rumContext: rumContext, date: date))
+        snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, touchPrivacy: .show, rumContext: rumContext, date: date))
     }
 
     private func generateSimpleViewTree() -> UIView {

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -166,12 +166,14 @@ class RecordingCoordinatorTests: XCTestCase {
     private func prepareRecordingCoordinator(
         sampler: Sampler = .mockKeepAll(),
         privacy: PrivacyLevel = .allow,
+        touchPrivacy: TouchPrivacyLevel = .show,
         telemetry: Telemetry = NOPTelemetry(),
         methodCallTelemetrySamplingRate: Float = 0
     ) {
         recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
             privacy: privacy,
+            touchPrivacy: touchPrivacy,
             rumContextObserver: rumContextObserver,
             srContextPublisher: contextPublisher,
             recorder: recordingMock,

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -69,7 +69,8 @@ class SessionReplayTests: XCTestCase {
     }
 
     func testWhenEnabledWithDefaultConfigurationWithNewAPI() throws {
-        config = SessionReplay.Configuration(sampleRate: 42)
+        let touchprivacy: SessionReplayTouchPrivacyLevel = .mockRandom()
+        config = SessionReplay.Configuration(replaySampleRate: 42, touchPrivacyLevel: touchprivacy)
 
         // When
         SessionReplay.enable(with: config, in: core)
@@ -78,7 +79,7 @@ class SessionReplayTests: XCTestCase {
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
         XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, 42)
         XCTAssertEqual(sr.recordingCoordinator.privacy, .mask)
-        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, .hide)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, touchprivacy)
         XCTAssertNil((sr.requestBuilder as? SegmentRequestBuilder)?.customUploadURL)
         let r = try XCTUnwrap(core.get(feature: ResourcesFeature.self))
         XCTAssertNil((r.requestBuilder as? ResourceRequestBuilder)?.customUploadURL)
@@ -136,7 +137,7 @@ class SessionReplayTests: XCTestCase {
     }
 
     func testWhenEnabledWithRandomPrivacyLevelWithNewAPI() throws {
-        config = SessionReplay.Configuration(sampleRate: 42)
+        config = SessionReplay.Configuration(replaySampleRate: 42, touchPrivacyLevel: .hide)
 
         let randomPrivacy: PrivacyLevel = .mockRandom()
         config.defaultPrivacyLevel = randomPrivacy

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -52,6 +52,7 @@ class WebViewTrackingTests: XCTestCase {
             static let name = "session-replay"
             let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
             let privacyLevel: SessionReplayPrivacyLevel
+            let touchPrivacyLevel: SessionReplayTouchPrivacyLevel
         }
 
         let mockSanitizer = HostsSanitizerMock()
@@ -59,7 +60,8 @@ class WebViewTrackingTests: XCTestCase {
 
         let host: String = .mockRandom()
         let sr = SessionReplayFeature(
-            privacyLevel: .mockRandom()
+            privacyLevel: .mockRandom(),
+            touchPrivacyLevel: .mockRandom()
         )
 
         WebViewTracking.enable(

--- a/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
@@ -16,3 +16,13 @@ extension SessionReplayPrivacyLevel: AnyMockable, RandomMockable {
         [.allow, .mask, .maskUserInput].randomElement()!
     }
 }
+
+extension SessionReplayTouchPrivacyLevel: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        .show
+    }
+
+    public static func mockRandom() -> Self {
+        [.show, .hide].randomElement()!
+    }
+}


### PR DESCRIPTION
### What and why?

This PR is the first step towards providing more granular control over global masking in Session Replay. It introduces a new privacy level for user touches (e.g., tap, swipe), allowing customers to choose whether to show or hide these touches in replays. Currently, touches are always visible.

For full context, refer to the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3884548349/RFC+-+Session+Replay+Global+Masking+Configuration).

### How?

This PR establishes the new privacy level within the Session Replay Configuration but does not yet implement the logic for touch visibility in snapshots.

Future PRs will introduce additional privacy levels for images, text, and user inputs. The current Privacy Level will be deprecated once the global masking feature is fully implemented and released.

This PR:
- Creates an enum for `SessionReplayTouchPrivacyLevel`
- Adds a new initializer for `SessionReplayConfiguration` that accepts the new `touchPrivacyLevel`
  - The new API for initializing `SessionReplayConfiguration` uses a mandatory `sampleRate` parameter and an optional `touchPrivacyLevel` parameter, whereas the former initializer uses a mandatory `replaySampleRate` parameter and an optional `defaultPrivacyLevel`. This change in parameter naming was necessary to avoid ambiguity in method calls.
- Updates various tests accordingly

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
