### PR TITLE
fix: Ensure needed attributes are sent from logs on the message bus

### DIFF
--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -189,6 +189,15 @@ internal final class RemoteLogger: LoggerProtocol {
                     return
                 }
 
+                // Add back in fingerprint and error source type
+                var busCombinedAttributes = combinedAttributes
+                if let errorSourcetype = error?.sourceType {
+                    busCombinedAttributes[CrossPlatformAttributes.errorSourceType] = errorSourcetype
+                }
+                if let errorFingerprint = errorFingerprint {
+                    busCombinedAttributes[Logs.Attributes.errorFingerprint] = errorFingerprint
+                }
+
                 self.core?.send(
                     message: .baggage(
                         key: ErrorMessage.key,
@@ -197,7 +206,7 @@ internal final class RemoteLogger: LoggerProtocol {
                             message: log.error?.message ?? log.message,
                             type: log.error?.kind,
                             stack: log.error?.stack,
-                            attributes: .init(combinedAttributes),
+                            attributes: .init(busCombinedAttributes),
                             binaryImages: binaryImages
                         )
                     )


### PR DESCRIPTION
### What and why?

Certain attributes (fingerprint and error source type) are removed as part of log processing because they are moved onto official properties of errors in logs.  However, when these errors are transmitted to RUM, the properties are not replaced, which they should be, so that RUM has all of the information about the error.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
