### PR TITLE
RUM-5716 fix: propagate global Tracer tags to otel span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Propagate global Tracer tags to OpenTelemetry span attributes. See [#2000][]
+
 # 2.16.0 / 20-08-2024
 
 - [FIX] Refresh rate vital for variable refresh rate displays when over performing. See [#1973][]
@@ -745,6 +747,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1967]: https://github.com/DataDog/dd-sdk-ios/pull/1967
 [#1973]: https://github.com/DataDog/dd-sdk-ios/pull/1973
 [#1988]: https://github.com/DataDog/dd-sdk-ios/pull/1988
+[#2000]: https://github.com/DataDog/dd-sdk-ios/pull/2000
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -64,6 +64,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         // Enable Trace
         Trace.enable(
             with: Trace.Configuration(
+                tags: ["testing-tag": "my-value"], 
                 networkInfoEnabled: true,
                 customEndpoint: Environment.readCustomTraceURL()
             )

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -167,7 +167,13 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         isRecording = false
         tags = attributes.tags
 
-        // There is no need to lock here, because `DDSpan` is thread-safe
+        // set global tags
+        for (key, value) in tracer.tags {
+            ddSpan.setTag(key: key, value: value)
+        }
+
+        // set local tags
+        // local takes precedence over global
         for (key, value) in tags {
             ddSpan.setTag(key: key, value: value)
         }

--- a/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
@@ -277,6 +277,42 @@ final class OTelSpanTests: XCTestCase {
         DDAssertDictionariesEqual(recordedSpan.tags, expectedTags)
     }
 
+    func testSetGlobalAttribute() throws {
+        // Given
+        let tracer: DatadogTracer = .mockWith(
+            featureScope: featureScope,
+            tags: [
+                "global": "keep_me",
+                "key3": "replace_me"
+            ]
+        )
+
+        let span = tracer.spanBuilder(spanName: "Span").startSpan()
+
+        // When
+        span.setAttribute(key: "key", value: .bool(true))
+        span.setAttribute(key: "key2", value: .string("value2"))
+        span.setAttribute(key: "key3", value: .int(3))
+        span.setAttribute(key: "key4", value: .double(4.0))
+
+        span.end()
+
+        // Then
+        let recordedSpans = try featureScope.spanEventsWritten()
+        XCTAssertEqual(recordedSpans.count, 1)
+        let recordedSpan = recordedSpans.first!
+        let expectedTags =
+        [
+            "global": "keep_me",
+            "key": "true",
+            "key2": "value2",
+            "key3": "3",
+            "key4": "4.0",
+            "span.kind": "internal",
+        ]
+        DDAssertDictionariesEqual(recordedSpan.tags, expectedTags)
+    }
+
     func testStatus_whenStatusIsNotSet() throws {
         // Given
         let tracer: DatadogTracer = .mockWith(featureScope: featureScope)


### PR DESCRIPTION
### What and why?

Currently global tags are not included in the otel spans

### How?

- add global tags to the span first
- add local tags to the span, and if there is same key, then replace it

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
