### PR TITLE
Always assume device is online on Apple Watch

### DIFF
--- a/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
@@ -28,12 +28,17 @@ internal struct DataUploadConditions {
     }
 
     func blockersForUpload(with context: DatadogContext) -> [Blocker] {
+        var blockers: [Blocker] = []
+        #if !os(watchOS)
         guard let reachability = context.networkConnectionInfo?.reachability else {
             // when `NetworkConnectionInfo` is not yet available
             return [.networkReachability(description: "unknown")]
         }
         let networkIsReachable = reachability == .yes || reachability == .maybe
-        var blockers: [Blocker] = networkIsReachable ? [] : [.networkReachability(description: reachability.rawValue)]
+        if !networkIsReachable {
+            blockers = [.networkReachability(description: reachability.rawValue)]
+        }
+        #endif
 
         guard let battery = context.batteryStatus, battery.state != .unknown else {
             // Note: in RUMS-132 we got the report on `.unknown` battery state reporing `-1` battery level on iPad device


### PR DESCRIPTION
### What and why?

Workaround for the issue https://github.com/DataDog/dd-sdk-ios/issues/2004.

On a real Apple Watch device, `NWPathMonitor` component always returns value of `.unsatisfied` that results in no logs being ever uploaded to API. As there is no straight-forward replacement for watchOS platform, this PR assumes that Apple Watch device is always online (another solution could be to implement periodic URL check in time interval).

From _https://developer.apple.com/documentation/Technotes/tn3135-low-level-networking-on-watchOS_:
![Capture-2024-08-20-142242](https://github.com/user-attachments/assets/0614241b-7247-42cb-86b8-57b708d4ca88)

Datadog dashboard logs using the fix:
| Simulator | Real device |
| - | - |
| ![Capture-2024-08-20-141120](https://github.com/user-attachments/assets/a9d9248d-d56d-4507-b53d-cda41f0ebe15) | ![Capture-2024-08-20-140535](https://github.com/user-attachments/assets/c7f5efc3-e8c0-4808-88c3-077104f1cedb) |

### How?

This PR specifically fixes logs upload by bypassing reachability check in `DataUploadConditions`. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes