### PR TITLE
RUM-5760 [Session Replay] Add textAndInputPrivacyLevel

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -16,6 +16,7 @@
 - (void)testConfiguration {
     DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100];
     configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
+    configuration.textAndInputPrivacyLevel = DDSessionReplayConfigurationTextAndInputPrivacyLevelMaskSensitiveInputs;
     configuration.touchPrivacyLevel = DDSessionReplayConfigurationTouchPrivacyLevelShow;
     configuration.customEndpoint = [NSURL new];
 
@@ -23,8 +24,9 @@
 }
 
 - (void)testConfigurationWithNewApi {
-    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100 touchPrivacyLevel:DDSessionReplayConfigurationTouchPrivacyLevelShow];
+    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100 textAndInputPrivacyLevel:DDSessionReplayConfigurationTextAndInputPrivacyLevelMaskSensitiveInputs touchPrivacyLevel:DDSessionReplayConfigurationTouchPrivacyLevelHide];
     configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
+    configuration.textAndInputPrivacyLevel = DDSessionReplayConfigurationTextAndInputPrivacyLevelMaskAllInputs;
     configuration.touchPrivacyLevel = DDSessionReplayConfigurationTouchPrivacyLevelShow;
     configuration.customEndpoint = [NSURL new];
 

--- a/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
@@ -20,6 +20,18 @@ public enum SessionReplayPrivacyLevel: String {
     case maskUserInput = "mask_user_input"
 }
 
+/// Available privacy levels for text and input masking in Session Replay.
+public enum SessionReplayTextAndInputPrivacyLevel: String {
+    /// Show all texts except sensitive inputs, eg. password fields.
+    case maskSensitiveInputs = "mask_sensitive_inputs"
+
+    /// Mask all inputs fields, eg. textfields, switches, checkboxes.
+    case maskAllInputs = "mask_all_inputs"
+
+    /// Mask all texts and inputs, eg. labels.
+    case maskAll = "mask_all"
+}
+
 /// Available privacy levels for touch masking in Session Replay.
 public enum SessionReplayTouchPrivacyLevel: String {
     /// Show all user touches.
@@ -45,6 +57,8 @@ public protocol SessionReplayConfiguration {
     var privacyLevel: SessionReplayPrivacyLevel { get }
     /// The touch privacy level to use for the web view replay recording.
     var touchPrivacyLevel: SessionReplayTouchPrivacyLevel { get }
+    /// The text and input privacy level to use for the web view replay recording.
+    var textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel { get }
 }
 
 extension DatadogFeature where Self: SessionReplayConfiguration {

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -154,7 +154,7 @@ internal class SnapshotTestCase: XCTestCase {
 
         // Capture next record with mock RUM Context
         try recorder.captureNextRecord(
-            .init(privacy: privacyLevel, touchPrivacy: .show, applicationID: "", sessionID: "", viewID: "", viewServerTimeOffset: 0)
+            .init(privacy: privacyLevel, textAndInputPrivacy: .maskSensitiveInputs, touchPrivacy: .show, applicationID: "", sessionID: "", viewID: "", viewServerTimeOffset: 0)
         )
 
         waitForExpectations(timeout: 30) // very pessimistic timeout to mitigate CI lags

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -13,6 +13,7 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?
     let privacyLevel: SessionReplayPrivacyLevel
+    let textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel
     let touchPrivacyLevel: SessionReplayTouchPrivacyLevel
 
     // MARK: - Main Components
@@ -57,11 +58,13 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
         ])
 
         self.privacyLevel = configuration.defaultPrivacyLevel
+        self.textAndInputPrivacyLevel = configuration.textAndInputPrivacyLevel
         self.touchPrivacyLevel = configuration.touchPrivacyLevel
 
         self.recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
             privacy: configuration.defaultPrivacyLevel,
+            textAndInputPrivacy: configuration.textAndInputPrivacyLevel,
             touchPrivacy: configuration.touchPrivacyLevel,
             rumContextObserver: contextReceiver,
             srContextPublisher: SRContextPublisher(core: core),

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -9,6 +9,7 @@ import DatadogInternal
 
 internal typealias PrivacyLevel = SessionReplayPrivacyLevel
 internal typealias TouchPrivacyLevel = SessionReplayTouchPrivacyLevel
+internal typealias TextAndInputPrivacyLevel = SessionReplayTextAndInputPrivacyLevel
 
 /// Text obfuscation strategies for different text types.
 @_spi(Internal)

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -22,9 +22,11 @@ internal protocol Recording {
 public class Recorder: Recording {
     /// The context of recording next snapshot.
     public struct Context: Equatable {
-        /// The content recording policy from the moment of requesting snapshot.
+        /// The content recording policy at the moment of requesting snapshot.
         public let privacy: SessionReplayPrivacyLevel
-        /// The content recording policy from the moment of requesting snapshot.
+        /// The content recording policy for texts and inputs at the moment of requesting snapshot.
+        public let textAndInputPrivacy: SessionReplayTextAndInputPrivacyLevel
+        /// The content recording policy for touches at the moment of requesting snapshot.
         public let touchPrivacy: SessionReplayTouchPrivacyLevel
         /// Current RUM application ID - standard UUID string, lowecased.
         let applicationID: String
@@ -39,6 +41,7 @@ public class Recorder: Recording {
 
         internal init(
             privacy: PrivacyLevel,
+            textAndInputPrivacy: TextAndInputPrivacyLevel,
             touchPrivacy: TouchPrivacyLevel,
             applicationID: String,
             sessionID: String,
@@ -47,6 +50,7 @@ public class Recorder: Recording {
             date: Date = Date()
         ) {
             self.privacy = privacy
+            self.textAndInputPrivacy = textAndInputPrivacy
             self.touchPrivacy = touchPrivacy
             self.applicationID = applicationID
             self.sessionID = sessionID

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -17,6 +17,7 @@ internal class RecordingCoordinator {
     let scheduler: Scheduler
     let sampler: Sampler
     let privacy: PrivacyLevel
+    let textAndInputPrivacy: TextAndInputPrivacyLevel
     let touchPrivacy: TouchPrivacyLevel
     let srContextPublisher: SRContextPublisher
 
@@ -35,6 +36,7 @@ internal class RecordingCoordinator {
     init(
         scheduler: Scheduler,
         privacy: PrivacyLevel,
+        textAndInputPrivacy: TextAndInputPrivacyLevel,
         touchPrivacy: TouchPrivacyLevel,
         rumContextObserver: RUMContextObserver,
         srContextPublisher: SRContextPublisher,
@@ -48,6 +50,7 @@ internal class RecordingCoordinator {
         self.scheduler = scheduler
         self.sampler = sampler
         self.privacy = privacy
+        self.textAndInputPrivacy = textAndInputPrivacy
         self.touchPrivacy = touchPrivacy
         self.srContextPublisher = srContextPublisher
         self.telemetry = telemetry
@@ -122,6 +125,7 @@ internal class RecordingCoordinator {
 
         let recorderContext = Recorder.Context(
             privacy: privacy,
+            textAndInputPrivacy: textAndInputPrivacy,
             touchPrivacy: touchPrivacy,
             applicationID: rumContext.applicationID,
             sessionID: rumContext.sessionID,

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -54,6 +54,14 @@ public final class DDSessionReplayConfiguration: NSObject {
         get { .init(_swift.defaultPrivacyLevel) }
     }
 
+    /// Defines the way texts and inputs (e.g. labels, textfields, checkboxes) should be masked.
+    ///
+    /// Default: `.maskAll`.
+    @objc public var textAndInputPrivacyLevel: DDSessionReplayConfigurationTextAndInputPrivacyLevel {
+        set { _swift.textAndInputPrivacyLevel = newValue._swift }
+        get { .init(_swift.textAndInputPrivacyLevel) }
+    }
+
     /// Defines the way user touches (e.g. tap) should be masked.
     ///
     /// Default: `.mask`.
@@ -74,14 +82,17 @@ public final class DDSessionReplayConfiguration: NSObject {
     ///
     /// - Parameters:
     ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+    ///   - textAndInputPrivacyLevel: The way texts and inputs (e.g. label, textfield, checkbox) should be masked. Default: `.maskAll`.
     ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
     @objc
     public required init(
         replaySampleRate: Float,
+        textAndInputPrivacyLevel: DDSessionReplayConfigurationTextAndInputPrivacyLevel,
         touchPrivacyLevel: DDSessionReplayConfigurationTouchPrivacyLevel
     ) {
         _swift = SessionReplay.Configuration(
             replaySampleRate: replaySampleRate,
+            textAndInputPrivacyLevel: textAndInputPrivacyLevel._swift,
             touchPrivacyLevel: touchPrivacyLevel._swift
         )
         super.init()
@@ -129,6 +140,36 @@ public enum DDSessionReplayConfigurationPrivacyLevel: Int {
         case .allow: self = .allow
         case .mask: self = .mask
         case .maskUserInput: self = .maskUserInput
+        }
+    }
+}
+
+/// Available privacy levels for text and input masking.
+@objc
+public enum DDSessionReplayConfigurationTextAndInputPrivacyLevel: Int {
+    /// Show all text except sensitive input (eg. password fields).
+    case maskSensitiveInputs
+
+    /// Mask all text and input, eg. textfields, switches, checkboxes.
+    case maskAllInputs
+
+    /// Mask all text and input.
+    case maskAll
+
+    internal var _swift: SessionReplayTextAndInputPrivacyLevel {
+        switch self {
+        case .maskSensitiveInputs: return .maskSensitiveInputs
+        case .maskAllInputs: return .maskAllInputs
+        case .maskAll: return .maskAll
+        default: return .maskAll
+        }
+    }
+
+    internal init(_ swift: SessionReplayTextAndInputPrivacyLevel) {
+        switch swift {
+        case .maskSensitiveInputs: self = .maskSensitiveInputs
+        case .maskAllInputs: self = .maskAllInputs
+        case .maskAll: self = .maskAll
         }
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -11,6 +11,7 @@ import DatadogInternal
 // swiftlint:disable duplicate_imports
 @_exported import enum DatadogInternal.SessionReplayPrivacyLevel
 @_exported import enum DatadogInternal.SessionReplayTouchPrivacyLevel
+@_exported import enum DatadogInternal.SessionReplayTextAndInputPrivacyLevel
 // swiftlint:enable duplicate_imports
 
 extension SessionReplay {
@@ -30,6 +31,11 @@ extension SessionReplay {
         ///
         /// Default: `.mask`.
         public var defaultPrivacyLevel: SessionReplayPrivacyLevel
+
+        /// Defines the way text and input (e.g. textfields, checkboxes) should be masked.
+        ///
+        /// Default: `.maskAll`.
+        public var textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel
 
         /// Defines the way user touches (e.g. tap) should be masked.
         ///
@@ -55,15 +61,18 @@ extension SessionReplay {
         /// Creates Session Replay configuration
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+        ///   - textAndInputPrivacyLevel: The way texts and inputs (e.g. label, textfield, checkbox) should be masked. Default: `.maskAll`.
         ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         public init(
             replaySampleRate: Float,
+            textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel,
             touchPrivacyLevel: SessionReplayTouchPrivacyLevel,
             customEndpoint: URL? = nil
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = .mask
+            self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
             self.touchPrivacyLevel = touchPrivacyLevel
             self.customEndpoint = customEndpoint
         }
@@ -83,6 +92,7 @@ extension SessionReplay {
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
+            self.textAndInputPrivacyLevel = .maskAll
             self.touchPrivacyLevel = .hide
             self.startRecordingImmediately = startRecordingImmediately
             self.customEndpoint = customEndpoint

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -68,12 +68,14 @@ extension SessionReplay {
             replaySampleRate: Float,
             textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel,
             touchPrivacyLevel: SessionReplayTouchPrivacyLevel,
+            startRecordingImmediately: Bool = true,
             customEndpoint: URL? = nil
         ) {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = .mask
             self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
             self.touchPrivacyLevel = touchPrivacyLevel
+            self.startRecordingImmediately = startRecordingImmediately
             self.customEndpoint = customEndpoint
         }
 

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/JSON/SegmentJSONTests.swift
@@ -145,6 +145,7 @@ class SegmentJSONTests: XCTestCase {
     private func generateEnrichedRecordJSONs(for segment: SRSegment) throws -> [SegmentJSON] {
         let context = Recorder.Context(
             privacy: .mockRandom(),
+            textAndInputPrivacy: .mockRandom(),
             touchPrivacy: .mockRandom(),
             rumContext: RUMContext(
                 applicationID: segment.application.id,

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -458,6 +458,7 @@ extension Recorder.Context: AnyMockable, RandomMockable {
     public static func mockRandom() -> Recorder.Context {
         return Recorder.Context(
             privacy: .mockRandom(),
+            textAndInputPrivacy: .mockRandom(),
             touchPrivacy: .mockRandom(),
             rumContext: .mockRandom(),
             date: .mockRandom()
@@ -467,11 +468,13 @@ extension Recorder.Context: AnyMockable, RandomMockable {
     static func mockWith(
         date: Date = .mockAny(),
         privacy: PrivacyLevel = .mockAny(),
+        textAndInputPrivacy: TextAndInputPrivacyLevel = .mockAny(),
         touchPrivacy: TouchPrivacyLevel = .mockAny(),
         rumContext: RUMContext = .mockAny()
     ) -> Recorder.Context {
         return Recorder.Context(
             privacy: privacy,
+            textAndInputPrivacy: textAndInputPrivacy,
             touchPrivacy: touchPrivacy,
             rumContext: rumContext,
             date: date
@@ -480,12 +483,14 @@ extension Recorder.Context: AnyMockable, RandomMockable {
 
     init(
         privacy: PrivacyLevel,
+        textAndInputPrivacy: TextAndInputPrivacyLevel,
         touchPrivacy: TouchPrivacyLevel,
         rumContext: RUMContext,
         date: Date = Date()
     ) {
         self.init(
             privacy: privacy,
+            textAndInputPrivacy: textAndInputPrivacy,
             touchPrivacy: touchPrivacy,
             applicationID: rumContext.applicationID,
             sessionID: rumContext.sessionID,

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -235,7 +235,7 @@ class SnapshotProcessorTests: XCTestCase {
         // When
         let snapshot = ViewTreeSnapshot(
             date: time,
-            context: .init(privacy: .allow, touchPrivacy: .show, rumContext: rum, date: time),
+            context: .init(privacy: .allow, textAndInputPrivacy: .maskSensitiveInputs, touchPrivacy: .show, rumContext: rum, date: time),
             viewportSize: .mockRandom(minWidth: 1_000, minHeight: 1_000),
             nodes: [node],
             webViewSlotIDs: Set([hiddenSlot, visibleSlot])
@@ -436,7 +436,7 @@ class SnapshotProcessorTests: XCTestCase {
     private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [])
 
     private func generateViewTreeSnapshot(for viewTree: UIView, date: Date, rumContext: RUMContext) -> ViewTreeSnapshot {
-        snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, touchPrivacy: .show, rumContext: rumContext, date: date))
+        snapshotBuilder.createSnapshot(of: viewTree, with: .init(privacy: .allow, textAndInputPrivacy: .maskSensitiveInputs, touchPrivacy: .show, rumContext: rumContext, date: date))
     }
 
     private func generateSimpleViewTree() -> UIView {

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -259,6 +259,7 @@ class RecordingCoordinatorTests: XCTestCase {
     private func prepareRecordingCoordinator(
         sampler: Sampler = .mockKeepAll(),
         privacy: PrivacyLevel = .allow,
+        textAndInputPrivacy: TextAndInputPrivacyLevel = .maskSensitiveInputs,
         touchPrivacy: TouchPrivacyLevel = .show,
         telemetry: Telemetry = NOPTelemetry(),
         methodCallTelemetrySamplingRate: Float = 0,
@@ -267,6 +268,7 @@ class RecordingCoordinatorTests: XCTestCase {
         recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
             privacy: privacy,
+            textAndInputPrivacy: textAndInputPrivacy,
             touchPrivacy: touchPrivacy,
             rumContextObserver: rumContextObserver,
             srContextPublisher: contextPublisher,

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -71,8 +71,9 @@ class SessionReplayTests: XCTestCase {
     }
 
     func testWhenEnabledWithDefaultConfigurationWithNewAPI() throws {
-        let touchprivacy: SessionReplayTouchPrivacyLevel = .mockRandom()
-        config = SessionReplay.Configuration(replaySampleRate: 42, touchPrivacyLevel: touchprivacy)
+        let textAndInputPrivacy: SessionReplayTextAndInputPrivacyLevel = .mockRandom()
+        let touchPrivacy: SessionReplayTouchPrivacyLevel = .mockRandom()
+        config = SessionReplay.Configuration(replaySampleRate: 42, textAndInputPrivacyLevel: textAndInputPrivacy, touchPrivacyLevel: touchPrivacy)
 
         // When
         SessionReplay.enable(with: config, in: core)
@@ -81,7 +82,8 @@ class SessionReplayTests: XCTestCase {
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
         XCTAssertEqual(sr.recordingCoordinator.sampler.samplingRate, 42)
         XCTAssertEqual(sr.recordingCoordinator.privacy, .mask)
-        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, touchprivacy)
+        XCTAssertEqual(sr.recordingCoordinator.textAndInputPrivacy, textAndInputPrivacy)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, touchPrivacy)
         XCTAssertNil((sr.requestBuilder as? SegmentRequestBuilder)?.customUploadURL)
         let r = try XCTUnwrap(core.get(feature: ResourcesFeature.self))
         XCTAssertNil((r.requestBuilder as? ResourceRequestBuilder)?.customUploadURL)
@@ -129,6 +131,8 @@ class SessionReplayTests: XCTestCase {
     func testWhenEnabledWithRandomPrivacyLevel() throws {
         let randomPrivacy: PrivacyLevel = .mockRandom()
         config.defaultPrivacyLevel = randomPrivacy
+        let textAndInputPrivacy: SessionReplayTextAndInputPrivacyLevel = .mockRandom()
+        config.textAndInputPrivacyLevel = textAndInputPrivacy
         let randomTouchPrivacy: SessionReplayTouchPrivacyLevel = .mockRandom()
         config.touchPrivacyLevel = randomTouchPrivacy
 
@@ -138,14 +142,17 @@ class SessionReplayTests: XCTestCase {
         // Then
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
         XCTAssertEqual(sr.recordingCoordinator.privacy, randomPrivacy)
+        XCTAssertEqual(sr.recordingCoordinator.textAndInputPrivacy, textAndInputPrivacy)
         XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, randomTouchPrivacy)
     }
 
     func testWhenEnabledWithRandomPrivacyLevelWithNewAPI() throws {
-        config = SessionReplay.Configuration(replaySampleRate: 42, touchPrivacyLevel: .hide)
+        config = SessionReplay.Configuration(replaySampleRate: 42, textAndInputPrivacyLevel: .maskAll, touchPrivacyLevel: .hide)
 
         let randomPrivacy: PrivacyLevel = .mockRandom()
         config.defaultPrivacyLevel = randomPrivacy
+        let randomTextAndInputPrivacy: SessionReplayTextAndInputPrivacyLevel = .mockRandom()
+        config.textAndInputPrivacyLevel = randomTextAndInputPrivacy
         let randomTouchPrivacy: SessionReplayTouchPrivacyLevel = .mockRandom()
         config.touchPrivacyLevel = randomTouchPrivacy
 
@@ -155,6 +162,7 @@ class SessionReplayTests: XCTestCase {
         // Then
         let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
         XCTAssertEqual(sr.recordingCoordinator.privacy, randomPrivacy)
+        XCTAssertEqual(sr.recordingCoordinator.textAndInputPrivacy, randomTextAndInputPrivacy)
         XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, randomTouchPrivacy)
     }
 

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -52,6 +52,7 @@ class WebViewTrackingTests: XCTestCase {
             static let name = "session-replay"
             let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
             let privacyLevel: SessionReplayPrivacyLevel
+            let textAndInputPrivacyLevel: SessionReplayTextAndInputPrivacyLevel
             let touchPrivacyLevel: SessionReplayTouchPrivacyLevel
         }
 
@@ -61,6 +62,7 @@ class WebViewTrackingTests: XCTestCase {
         let host: String = .mockRandom()
         let sr = SessionReplayFeature(
             privacyLevel: .mockRandom(),
+            textAndInputPrivacyLevel: .mockRandom(),
             touchPrivacyLevel: .mockRandom()
         )
 

--- a/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
+++ b/TestUtilities/Mocks/FeatureModels/SessionReplayConfigurationMocks.swift
@@ -17,6 +17,16 @@ extension SessionReplayPrivacyLevel: AnyMockable, RandomMockable {
     }
 }
 
+extension SessionReplayTextAndInputPrivacyLevel: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        .maskSensitiveInputs
+    }
+
+    public static func mockRandom() -> Self {
+        [.maskAll, .maskAllInputs, .maskSensitiveInputs].randomElement()!
+    }
+}
+
 extension SessionReplayTouchPrivacyLevel: AnyMockable, RandomMockable {
     public static func mockAny() -> Self {
         .show


### PR DESCRIPTION
### What and why?

Following #1992, this PR introduces a new privacy level for text and inputs (e.g., label, textfield, checkbox, switch), allowing customers to decide what they want to mask. Currently, text and inputs are handled through the `defaultPrivacyLevel`, which will be later deprecated.

There are 3 levels:
- `maskSensitiveInputs`: shows all texts except sensitive inputs, eg. password fields.
- `maskAllInputs`: masks all inputs fields, eg. textfields, switches, checkboxes.
- `maskAll`: masks all texts and inputs, even labels.

For full context, refer to the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3884548349/RFC+-+Session+Replay+Global+Masking+Configuration).

### How?

This PR establishes the new privacy level within the Session Replay Configuration but does not yet implement the new logic to mask texts and inputs.

The current Privacy Level will be deprecated once the global masking feature is fully implemented and released.

This PR:

- Creates an enum for `SessionReplayTextAndInputPrivacyLevel`
- Adds a parameter to the new `SessionReplayConfiguration` initializer
- Updates various tests accordingly

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
