### PR TITLE
RUM-5762 [SR] Ignore touch snapshots when touchPrivacyLevel is set to .hide

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -117,7 +117,7 @@ public class Recorder: Recording {
             return
         }
 
-        let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
+        let touchSnapshot = recorderContext.touchPrivacy == .show ? touchSnapshotProducer.takeSnapshot(context: recorderContext) : nil
         snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
     }
 }

--- a/IntegrationTests/Runner/Scenarios/SessionReplay/SRScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/SessionReplay/SRScenarios.swift
@@ -24,6 +24,7 @@ final class SRMultipleViewsRecordingScenario: TestScenario {
 
         var srConfig = SessionReplay.Configuration(replaySampleRate: 100)
         srConfig.defaultPrivacyLevel = .mask
+        srConfig.touchPrivacyLevel = .show
         srConfig.customEndpoint = Environment.serverMockConfiguration()?.srEndpoint
         SessionReplay.enable(with: srConfig)
     }


### PR DESCRIPTION
### What and why?

In #1992, we introduced a new privacy level: `SessionReplayTouchPrivacyLevel`, with offers 2 options: `.show` and `.hide`. This PR ensures that the privacy configuration is respected by preventing the capture of touch snapshots when the level is set to `.hide`.

### How?

This update skips touch snapshots when `touchPrivacyLevel` is set to `.hide` 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
