### PR TITLE
Fix lazy image SR identifier

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -14,11 +14,11 @@ private var srIdentifierKey: UInt8 = 11
 extension UIImage: DatadogExtended {}
 extension DatadogExtension where ExtendedType: UIImage {
     var srIdentifier: String {
-        if let hash = objc_getAssociatedObject(self, &srIdentifierKey) as? String {
+        if let hash = objc_getAssociatedObject(type, &srIdentifierKey) as? String {
             return hash
         } else {
             let hash = computeHash()
-            objc_setAssociatedObject(self, &srIdentifierKey, hash, .OBJC_ASSOCIATION_RETAIN)
+            objc_setAssociatedObject(type, &srIdentifierKey, hash, .OBJC_ASSOCIATION_RETAIN)
             return hash
         }
     }


### PR DESCRIPTION
### What and why?

While working on the configuration we have discovered that lazy identifier for UIImages in Session Replay doesn't work.

Mitigation is simple. When introducing `DatadogExtension` instead of direct extension we forget to change the object that maintains associated objects.

This is hard to test. We could potentially measure the time. Second time should be way faster than the first one, but it has a risk of being flaky.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
