### PR TITLE
RUM-5755 Add Benchmark Profiler Interface

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		D231DCF92C7342D500F3F66C /* ModuleBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DCF82C7342D500F3F66C /* ModuleBundle.swift */; };
 		D23DD32D2C58D80C00B90C4C /* DatadogBenchmarks in Frameworks */ = {isa = PBXBuildFile; productRef = D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */; };
 		D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */; };
+		D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */; };
 		D27606A12C514F37002D2A14 /* SessionReplayScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27606982C514F37002D2A14 /* SessionReplayScenario.swift */; };
 		D27606A32C514F37002D2A14 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D276069B2C514F37002D2A14 /* Scenario.swift */; };
 		D27606A42C514F37002D2A14 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D276069D2C514F37002D2A14 /* AppConfiguration.swift */; };
@@ -186,6 +187,7 @@
 		D231DCF82C7342D500F3F66C /* ModuleBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleBundle.swift; sourceTree = "<group>"; };
 		D231DCFA2C735FC200F3F66C /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticScenario.swift; sourceTree = "<group>"; };
+		D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
 		D27606982C514F37002D2A14 /* SessionReplayScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayScenario.swift; sourceTree = "<group>"; };
 		D276069B2C514F37002D2A14 /* Scenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
 		D276069D2C514F37002D2A14 /* AppConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 			children = (
 				D29F754F2C4AA07E00288638 /* AppDelegate.swift */,
 				D276069D2C514F37002D2A14 /* AppConfiguration.swift */,
+				D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */,
 				D276069C2C514F37002D2A14 /* Scenarios */,
 				D29F755D2C4AA08000288638 /* Info.plist */,
 			);
@@ -575,6 +578,7 @@
 				D27606A42C514F37002D2A14 /* AppConfiguration.swift in Sources */,
 				D29F75502C4AA07E00288638 /* AppDelegate.swift in Sources */,
 				D27606A12C514F37002D2A14 /* SessionReplayScenario.swift in Sources */,
+				D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */,
 				D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */,
 				D27606A32C514F37002D2A14 /* Scenario.swift in Sources */,
 			);

--- a/BenchmarkTests/Benchmarks/Package.swift
+++ b/BenchmarkTests/Benchmarks/Package.swift
@@ -31,9 +31,10 @@ func addOpenTelemetryDependency(_ version: Version) {
                 name: "DatadogBenchmarks",
                 dependencies: [
                     .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
-                    .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift")
+                    .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
+                    .product(name: "DatadogExporter", package: "opentelemetry-swift")
                 ],
-                swiftSettings: [.unsafeFlags(["-DOTEL_SWIFT"])]
+                swiftSettings: [.define("OTEL_SWIFT")]
             )
         ]
 
@@ -48,7 +49,7 @@ func addOpenTelemetryDependency(_ version: Version) {
                 dependencies: [
                     .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-packages")
                 ],
-                swiftSettings: [.unsafeFlags(["-DOTEL_API"])]
+                swiftSettings: [.define("OTEL_API")]
             )
         ]
     }

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -11,6 +11,7 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import DatadogExporter
 
 let instrumentationName = "benchmarks"
 let instrumentationVersion = "1.0.0"
@@ -151,5 +152,30 @@ public enum Benchmarks {
         }
 
         OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
+    }
+
+    /// Configure and register a OpenTelemetry Tracer.
+    ///
+    /// - Parameter configuration: The Benchmark configuration.
+    public static func tracer(with configuration: Configuration) {
+        let exporterConfiguration = ExporterConfiguration(
+            serviceName: configuration.context.applicationIdentifier,
+            resource: "Benchmark Tracer",
+            applicationName: configuration.context.applicationName,
+            applicationVersion: configuration.context.applicationVersion,
+            environment: "benchmarks",
+            apiKey: configuration.apiKey,
+            endpoint: .us1,
+            uploadCondition: { true }
+        )
+        
+        let exporter = try! DatadogExporter(config: exporterConfiguration)
+        let processor = SimpleSpanProcessor(spanExporter: exporter)
+
+        let provider = TracerProviderBuilder()
+            .add(spanProcessor: processor)
+            .build()
+
+        OpenTelemetry.registerTracerProvider(tracerProvider: provider)
     }
 }

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -78,7 +78,7 @@ public enum Benchmarks {
     /// Configure OpenTelemetry metrics meter and start measuring Memory.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func metrics(with configuration: Configuration) {
+    public static func enableMetrics(with configuration: Configuration) {
         let loggerProvider = LoggerProviderBuilder()
             .build()
 
@@ -157,7 +157,7 @@ public enum Benchmarks {
     /// Configure and register a OpenTelemetry Tracer.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func tracer(with configuration: Configuration) {
+    public static func enableTracer(with configuration: Configuration) {
         let exporterConfiguration = ExporterConfiguration(
             serviceName: configuration.context.applicationIdentifier,
             resource: "Benchmark Tracer",

--- a/BenchmarkTests/Makefile
+++ b/BenchmarkTests/Makefile
@@ -58,4 +58,4 @@ upload:
 
 open:
 	@$(ECHO_SUBTITLE2) "make open"
-	@open --env BENCHMARK --env OTEL_SWIFT --new BenchmarkTests.xcodeproj
+	@open --env DD_BENCHMARK --env OTEL_SWIFT --new BenchmarkTests.xcodeproj

--- a/BenchmarkTests/Makefile
+++ b/BenchmarkTests/Makefile
@@ -19,7 +19,7 @@ archive:
 	@$(ECHO_SUBTITLE2) "make archive VERSION='$(VERSION)'"
 	@xcrun agvtool new-version "$(VERSION)"
 	set -eo pipefail; \
-	OTEL_SWIFT=1 xcodebuild \
+	BENCHMARK=1 OTEL_SWIFT=1 xcodebuild \
 		-project BenchmarkTests.xcodeproj \
 		-scheme Runner \
 		-sdk iphoneos \
@@ -58,4 +58,4 @@ upload:
 
 open:
 	@$(ECHO_SUBTITLE2) "make open"
-	@open --new --env OTEL_SWIFT BenchmarkTests.xcodeproj
+	@open --env BENCHMARK --env OTEL_SWIFT --new BenchmarkTests.xcodeproj

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         switch run {
         case .baseline, .instrumented:
             // measure metrics during baseline and metrics runs
-            Benchmarks.metrics(
+            Benchmarks.enableMetrics(
                 with: Benchmarks.Configuration(
                     info: applicationInfo,
                     scenario: scenario,
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             )
         case .profiling:
             // Collect traces during profiling run
-            Benchmarks.tracer(
+            Benchmarks.enableTracer(
                 with: Benchmarks.Configuration(
                     info: applicationInfo,
                     scenario: scenario,

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -33,7 +33,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 )
             )
         case .profiling:
-            // collect profiles
+            // Collect traces during profiling run
+            Benchmarks.tracer(
+                with: Benchmarks.Configuration(
+                    info: applicationInfo,
+                    scenario: scenario,
+                    run: run
+                )
+            )
+            
+            DatadogInternal.profiler = Profiler()
             break
         }
 

--- a/BenchmarkTests/Runner/BenchmarkProfiler.swift
+++ b/BenchmarkTests/Runner/BenchmarkProfiler.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+import DatadogInternal
+import DatadogBenchmarks
+
+internal final class Profiler: DatadogInternal.BenchmarkProfiler {
+    func tracer(operation: @autoclosure () -> String) -> any DatadogInternal.BenchmarkTracer {
+        DummyTracer()
+    }
+}
+
+internal final class DummyTracer: DatadogInternal.BenchmarkTracer {
+    func startSpan(named: @autoclosure () -> String) -> any DatadogInternal.BenchmarkSpan {
+        DummySpan()
+    }
+}
+
+internal final class DummySpan: DatadogInternal.BenchmarkSpan {
+    func stop() { }
+}

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -859,6 +859,8 @@
 		D22743EA29DEC9A9001A7EF9 /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */; };
 		D22743EB29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61411B0F24EC15AC0012EAB2 /* Casting+RUM.swift */; };
 		D22743EC29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61411B0F24EC15AC0012EAB2 /* Casting+RUM.swift */; };
+		D227A0A42C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */; };
+		D227A0A52C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */; };
 		D22C5BC82A98A0B20024CC1F /* Baggages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C5BC52A989D130024CC1F /* Baggages.swift */; };
 		D22C5BC92A98A0B30024CC1F /* Baggages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C5BC52A989D130024CC1F /* Baggages.swift */; };
 		D22C5BCB2A98A5400024CC1F /* Baggages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C5BCA2A98A5400024CC1F /* Baggages.swift */; };
@@ -2826,6 +2828,7 @@
 		D2216EC22A96632F00ADAEC8 /* FeatureBaggageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureBaggageTests.swift; sourceTree = "<group>"; };
 		D224430C29E95D6600274EC7 /* CrashReportReceiverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportReceiverTests.swift; sourceTree = "<group>"; };
 		D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
+		D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D22C5BC52A989D130024CC1F /* Baggages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Baggages.swift; sourceTree = "<group>"; };
 		D22C5BCA2A98A5400024CC1F /* Baggages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Baggages.swift; sourceTree = "<group>"; };
@@ -5805,6 +5808,14 @@
 			path = Integrations;
 			sourceTree = "<group>";
 		};
+		D227A0A22C76229400C83324 /* Benchmarks */ = {
+			isa = PBXGroup;
+			children = (
+				D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */,
+			);
+			path = Benchmarks;
+			sourceTree = "<group>";
+		};
 		D22C1F5A2714849700922024 /* Scrubbing */ = {
 			isa = PBXGroup;
 			children = (
@@ -5816,6 +5827,7 @@
 		D23039A6298D513D001A1FA3 /* DatadogInternal */ = {
 			isa = PBXGroup;
 			children = (
+				D227A0A22C76229400C83324 /* Benchmarks */,
 				6167E6DF2B81203A00C3CA2D /* Models */,
 				D23039CA298D5235001A1FA3 /* Attributes */,
 				D23039C3298D5235001A1FA3 /* Codable */,
@@ -8655,6 +8667,7 @@
 				D21A94F22B8397CA00AC4256 /* WebViewMessage.swift in Sources */,
 				D23039EC298D5236001A1FA3 /* LaunchTime.swift in Sources */,
 				6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */,
+				D227A0A42C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */,
 				D23039EE298D5236001A1FA3 /* FeatureMessageReceiver.swift in Sources */,
 				D23039DE298D5235001A1FA3 /* Writer.swift in Sources */,
 				D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */,
@@ -9633,6 +9646,7 @@
 				D21A94F32B8397CA00AC4256 /* WebViewMessage.swift in Sources */,
 				D2DA2364298D57AA00C6C7E6 /* LaunchTime.swift in Sources */,
 				6175C3522BCE66DB006FAAB0 /* TraceContext.swift in Sources */,
+				D227A0A52C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */,
 				D2DA2365298D57AA00C6C7E6 /* FeatureMessageReceiver.swift in Sources */,
 				D2DA2366298D57AA00C6C7E6 /* Writer.swift in Sources */,
 				D2DA2367298D57AA00C6C7E6 /* Telemetry.swift in Sources */,

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -53,26 +53,11 @@ public protocol BenchmarkSpan {
     func stop()
 }
 
-private final class NOPBenchmarkProfiler: BenchmarkProfiler {
-    /// Returns no-op tracer shared instance.
-    func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer {
-        NOPBenchmarkTracer.shared
-    }
-}
-
-private final class NOPBenchmarkTracer: BenchmarkTracer {
-    /// The no-op tracer shared instance.
-    static let shared: BenchmarkTracer = NOPBenchmarkTracer()
-
-    /// Returns no-op span shared instance.
-    func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan {
-        NOPBenchmarkSpan.shared
-    }
-}
-
-private final class NOPBenchmarkSpan: BenchmarkSpan {
-    /// The no-op span shared instance.
-    static let shared: BenchmarkSpan = NOPBenchmarkSpan()
+private final class NOPBenchmarkProfiler: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan {
+    /// no-op
+    func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer { self }
+    /// no-op
+    func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan { self }
     /// no-op
     func stop() {}
 }

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if BENCHMARK
+/// The profiler endpoint to collect data for benchmarking.
+public var profiler: BenchmarkProfiler = NOPBenchmarkProfiler()
+#else
+/// The profiler endpoint to collect data for benchmarking. This static variable can only
+/// be mutated in the benchmark environment.
+public let profiler: BenchmarkProfiler = NOPBenchmarkProfiler()
+#endif
+
+/// The Benchmark Profiler provides interfaces to collect data in a benchmark
+/// environment.
+///
+/// During benchmarking, a concrete implementation of the profiler will be
+/// injected to collect data during execution of the SDK.
+///
+/// In production, the profiler is no-op and immutable.
+public protocol BenchmarkProfiler {
+    /// Returns a `BenchmarkTracer` instance for the given operation.
+    ///
+    /// The profiler must return the same instance of a tracer for the same operation.
+    /// - Parameter operation: The tracer operation name. The parameter is an auto-closure
+    /// to not intialise the value if the profiler is no-op.
+    /// - Returns: The tracer instance.
+    func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer
+}
+
+/// The Benchmark Tracer will create and start spans in a benchmark environment.
+/// This tracer can be used to measure CPU Time of inner operation of the SDK.
+/// In production, the Benchmark Tracer is no-op.
+public protocol BenchmarkTracer {
+    /// Create and starts a span at the current time..
+    ///
+    /// The span will be activated automatically and linked to its parent in this tracer context.
+    ///
+    /// - Parameter named: The span name. The parameter is an auto-closure
+    /// to not intialise the value if the profiler is no-op.
+    /// - Returns: The started span.
+    func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan
+}
+
+/// A timespan of an operation in a benchmark environment.
+public protocol BenchmarkSpan {
+    /// Stops the span at the current time.
+    func stop()
+}
+
+private final class NOPBenchmarkProfiler: BenchmarkProfiler {
+    /// Returns no-op tracer shared instance.
+    func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer {
+        NOPBenchmarkTracer.shared
+    }
+}
+
+private final class NOPBenchmarkTracer: BenchmarkTracer {
+    /// The no-op tracer shared instance.
+    static let shared: BenchmarkTracer = NOPBenchmarkTracer()
+
+    /// Returns no-op span shared instance.
+    func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan {
+        NOPBenchmarkSpan.shared
+    }
+}
+
+private final class NOPBenchmarkSpan: BenchmarkSpan {
+    /// The no-op span shared instance.
+    static let shared: BenchmarkSpan = NOPBenchmarkSpan()
+    /// no-op
+    func stop() {}
+}

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-#if BENCHMARK
+#if DD_BENCHMARK
 /// The profiler endpoint to collect data for benchmarking.
 public var profiler: BenchmarkProfiler = NOPBenchmarkProfiler()
 #else
@@ -26,6 +26,7 @@ public protocol BenchmarkProfiler {
     /// Returns a `BenchmarkTracer` instance for the given operation.
     ///
     /// The profiler must return the same instance of a tracer for the same operation.
+    /// 
     /// - Parameter operation: The tracer operation name. The parameter is an auto-closure
     /// to not intialise the value if the profiler is no-op.
     /// - Returns: The tracer instance.
@@ -36,7 +37,7 @@ public protocol BenchmarkProfiler {
 /// This tracer can be used to measure CPU Time of inner operation of the SDK.
 /// In production, the Benchmark Tracer is no-op.
 public protocol BenchmarkTracer {
-    /// Create and starts a span at the current time..
+    /// Creates and starts a span at the current time.
     ///
     /// The span will be activated automatically and linked to its parent in this tracer context.
     ///

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ let opentelemetry = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil ?
     (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git") :
     (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git")
 
+let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["BENCHMARK"] != nil ?
+    [.define("BENCHMARK")] : []
+
 let package = Package(
     name: "Datadog",
     platforms: [
@@ -85,7 +88,8 @@ let package = Package(
 
         .target(
             name: "DatadogInternal",
-            path: "DatadogInternal/Sources"
+            path: "DatadogInternal/Sources",
+            swiftSettings: internalSwiftSettings
         ),
         .testTarget(
             name: "DatadogInternalTests",

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let opentelemetry = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil ?
     (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git") :
     (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git")
 
-let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["BENCHMARK"] != nil ?
-    [.define("BENCHMARK")] : []
+let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["DD_BENCHMARK"] != nil ?
+    [.define("DD_BENCHMARK")] : []
 
 let package = Package(
     name: "Datadog",


### PR DESCRIPTION
### What and why?

Expose profiler interface for benchmarking.

During benchmarking, a concrete implementation of the profiler will be injected to collect data during execution of the SDK. In production, the profiler is no-op and immutable.

Current profiler interface can create a tracer instance for a given operation.

### How?

The `BenchmarkProfiler` is added to the `DatadogInternal` module with a single static variable allowing injecting a profiler instance from the Benchmark project.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
