### PR TITLE
RUM-5083 refactor: Allow different sampling rates for each metric

### DIFF
--- a/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
@@ -34,9 +34,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         #sourceLocation(file: "File.swift", line: 42)
         core.telemetry.error("Error Telemetry")
         #sourceLocation()
-        core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42])
+        core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
         )
 
         // Then
@@ -79,9 +79,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Then
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
-        core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -125,9 +125,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Then
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
-        core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -172,9 +172,9 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Then
         core.telemetry.debug("Debug Telemetry")
         core.telemetry.error("Error Telemetry")
-        core.telemetry.metric(name: "Metric Name", attributes: [:])
+        core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom())
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)

--- a/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
@@ -26,7 +26,6 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Given
         var config = RUM.Configuration(applicationID: .mockAny())
         config.telemetrySampleRate = 100
-        config.metricsTelemetrySampleRate = 100
         RUM.enable(with: config, in: core)
 
         // When
@@ -36,7 +35,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         #sourceLocation()
         core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
+            sampleRate: 100
         )
 
         // Then
@@ -69,7 +69,6 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Given
         var config = RUM.Configuration(applicationID: "rum-app-id")
         config.telemetrySampleRate = 100
-        config.metricsTelemetrySampleRate = 100
         RUM.enable(with: config, in: core)
 
         // When
@@ -81,7 +80,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
+            sampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -116,7 +116,6 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Given
         var config = RUM.Configuration(applicationID: "rum-app-id")
         config.telemetrySampleRate = 100
-        config.metricsTelemetrySampleRate = 100
         RUM.enable(with: config, in: core)
 
         // When
@@ -127,7 +126,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
+            sampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -162,7 +162,6 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         // Given
         var config = RUM.Configuration(applicationID: "rum-app-id")
         config.telemetrySampleRate = 100
-        config.metricsTelemetrySampleRate = 100
         RUM.enable(with: config, in: core)
 
         // When
@@ -174,7 +173,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100)
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
+            sampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)

--- a/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/CoreTelemetryIntegrationTests.swift
@@ -35,8 +35,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         #sourceLocation()
         core.telemetry.metric(name: "Metric Name", attributes: ["metric.attribute": 42], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
-            sampleRate: 100
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), headSampleRate: 100),
+            tailSampleRate: 100
         )
 
         // Then
@@ -80,8 +80,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
-            sampleRate: 100
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), headSampleRate: 100),
+            tailSampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -126,8 +126,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
-            sampleRate: 100
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), headSampleRate: 100),
+            tailSampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
@@ -173,8 +173,8 @@ class CoreTelemetryIntegrationTests: XCTestCase {
         core.telemetry.error("Error Telemetry")
         core.telemetry.metric(name: "Metric Name", attributes: [:], sampleRate: 100)
         core.telemetry.stopMethodCalled(
-            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), sampleRate: 100),
-            sampleRate: 100
+            core.telemetry.startMethodCalled(operationName: .mockRandom(), callerClass: .mockRandom(), headSampleRate: 100),
+            tailSampleRate: 100
         )
 
         let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -21,7 +21,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         )
         rumConfig = RUM.Configuration(applicationID: .mockAny())
         rumConfig.telemetrySampleRate = 100
-        rumConfig.metricsTelemetrySampleRate = 100
+        rumConfig.sessionEndedMetricSampleRate = 100
         rumConfig.dateProvider = dateProvider
     }
 

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -250,7 +250,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
                 BatchDeletedMetric.inBackgroundKey: false
-            ]
+            ],
+            sampleRate: MetricTelemetry.defaultSampleRate
         )
     }
 
@@ -276,7 +277,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchClosedMetric.batchSizeKey: lastWritableFileApproximatedSize,
                 BatchClosedMetric.batchEventsCountKey: lastWritableFileObjectsCount,
                 BatchClosedMetric.batchDurationKey: batchDuration.toMilliseconds
-            ]
+            ],
+            sampleRate: MetricTelemetry.defaultSampleRate
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -729,7 +729,7 @@ extension RUMScopeDependencies {
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
         viewCache: ViewCache = ViewCache(),
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
-        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry()),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -58,11 +58,18 @@ public struct ConfigurationTelemetry: Equatable {
     public let useWorkerUrl: Bool?
 }
 
+public struct MetricTelemetry {
+    /// The name of the metric.
+    public let name: String
+    /// The attributes associated with this metric.
+    public let attributes: [String: Encodable]
+}
+
 public enum TelemetryMessage {
     case debug(id: String, message: String, attributes: [String: Encodable]?)
     case error(id: String, message: String, kind: String, stack: String)
     case configuration(ConfigurationTelemetry)
-    case metric(name: String, attributes: [String: Encodable])
+    case metric(MetricTelemetry)
 }
 
 /// The `Telemetry` protocol defines methods to collect debug information
@@ -106,7 +113,7 @@ public extension Telemetry {
     ///   - isSuccessful: A flag indicating if the method call was successful.
     func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool = true) {
         if let metric = metric {
-            send(telemetry: metric.asTelemetryMetric(isSuccessful: isSuccessful))
+            send(telemetry: .metric(metric.asTelemetryMetric(isSuccessful: isSuccessful)))
         }
     }
 }
@@ -117,12 +124,12 @@ public struct MethodCalledTrace {
     let callerClass: String
     let startTime = Date()
 
-    var exectutionTime: Int64 {
+    private var exectutionTime: Int64 {
         return -startTime.timeIntervalSinceNow.toInt64Nanoseconds
     }
 
-    func asTelemetryMetric(isSuccessful: Bool) -> TelemetryMessage {
-        return .metric(
+    func asTelemetryMetric(isSuccessful: Bool) -> MetricTelemetry {
+        return MetricTelemetry(
             name: MethodCalledMetric.name,
             attributes: [
                 MethodCalledMetric.executionTime: exectutionTime,
@@ -354,7 +361,7 @@ extension Telemetry {
     ///   - name: The name of this metric.
     ///   - attributes: Parameters associated with this metric.
     public func metric(name: String, attributes: [String: Encodable]) {
-        send(telemetry: .metric(name: name, attributes: attributes))
+        send(telemetry: .metric(MetricTelemetry(name: name, attributes: attributes)))
     }
 }
 

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -59,10 +59,24 @@ public struct ConfigurationTelemetry: Equatable {
 }
 
 public struct MetricTelemetry {
+    /// The default sample rate for metric events, applied in addition to the telemetry sample rate (20% by default).
+    public static let defaultSampleRate: Float = 15
+
     /// The name of the metric.
     public let name: String
+
     /// The attributes associated with this metric.
     public let attributes: [String: Encodable]
+
+    /// The sample rate for this metric, applied in addition to the telemetry sample rate.
+    ///
+    /// Must be a value between `0` (reject all) and `100` (keep all).
+    ///
+    /// Note: This sample rate is compounded with the telemetry sample rate. For example, if the telemetry sample rate is 20% (default)
+    /// and this metric's sample rate is 15%, the effective sample rate for this metric will be 3%.
+    ///
+    /// This sample rate is applied in the telemetry receiver, after the metric has been processed by the SDK core (tail-based sampling).
+    public let sampleRate: Float
 }
 
 public enum TelemetryMessage {
@@ -82,20 +96,28 @@ public protocol Telemetry {
 }
 
 public extension Telemetry {
-    /// Starts a method call.
+    /// Starts timing a method call using the "Method Called" metric.
     ///
     /// - Parameters:
-    ///   - operationName: Platform agnostic name of the operation.
-    ///   - callerClass: The name of the class that calls the method.
-    ///   - samplingRate: The sampling rate of the method call. Value between `0.0` and `100.0`, where `0.0` means NO event will be processed and `100.0` means ALL events will be processed. Note that this value is multiplicated by telemetry sampling (by default 20%) and metric events sampling (hardcoded to 15%). Making it effectively 3% sampling rate for sending events, when this value is set to `100`.
+    ///   - operationName: A platform-agnostic name for the operation.
+    ///   - callerClass: The name of the class that invokes the method.
+    ///   - sampleRate: The sample rate for **head-based** sampling of the method call metric. Must be a value between `0` (reject all) and `100` (keep all).
     ///
-    /// - Returns: A `MethodCalledTrace` instance to be used to stop the method call and measure it's execution time. It can be `nil` if the method call is not sampled.
+    /// Note: The head sample rate is compounded with the tail sample rate, which is configured in `stopMethodCalled()`. Both are applied
+    /// in addition to the telemetry sample rate. For example, if the telemetry sample rate is 20% (default), the head sample rate is 1%, and the tail sample
+    /// rate is 15% (default), the effective sample rate will be 20% x 1% x 15% = 0.03%.
+    ///
+    /// Unlike the telemetry sample rate and tail-based sampling in `stopMethodCalled()`, this sample rate is applied at the start of the method call timing.
+    /// This head-based sampling reduces the impact of processing high-frequency metrics in the SDK core, as most samples can be dropped
+    /// before being passed to the message bus.
+    ///
+    /// - Returns: A `MethodCalledTrace` instance for stopping the method call and measuring its execution time, or `nil` if the method call is not sampled.
     func startMethodCalled(
         operationName: String,
         callerClass: String,
-        samplingRate: Float = 100.0
+        sampleRate: Float
     ) -> MethodCalledTrace? {
-        if Sampler(samplingRate: samplingRate).sample() {
+        if Sampler(samplingRate: sampleRate).sample() {
             return MethodCalledTrace(
                 operationName: operationName,
                 callerClass: callerClass
@@ -105,15 +127,38 @@ public extension Telemetry {
         }
     }
 
-    /// Stops a method call, transforms method call metric to telemetry message,
-    /// and transmits on the message-bus of the core.
+    /// Stops timing a method call and posts a value for the "Method Called" metric.
     ///
-    /// - Parameters
+    /// This method applies tail-based sampling in addition to the head-based sampling applied in `startMethodCalled()`.
+    /// The tail sample rate is compounded with the head sample rate and the telemetry sample rate to determine the effective sample rate.
+    ///
+    /// - Parameters:
     ///   - metric: The `MethodCalledTrace` instance.
-    ///   - isSuccessful: A flag indicating if the method call was successful.
-    func stopMethodCalled(_ metric: MethodCalledTrace?, isSuccessful: Bool = true) {
+    ///   - isSuccessful: A flag indicating whether the method call was successful.
+    ///   - sampleRate: The sample rate for **tail-based** sampling of the metric, applied after the metric is processed by the SDK core.
+    ///     Defaults to `MetricTelemetry.defaultSampleRate` (15%).
+    func stopMethodCalled(
+        _ metric: MethodCalledTrace?,
+        isSuccessful: Bool = true,
+        sampleRate: Float = MetricTelemetry.defaultSampleRate
+    ) {
         if let metric = metric {
-            send(telemetry: .metric(metric.asTelemetryMetric(isSuccessful: isSuccessful)))
+            let exectutionTime = -metric.startTime.timeIntervalSinceNow.toInt64Nanoseconds
+            send(
+                telemetry: .metric(
+                    MetricTelemetry(
+                        name: MethodCalledMetric.name,
+                        attributes: [
+                            MethodCalledMetric.executionTime: exectutionTime,
+                            MethodCalledMetric.operationName: metric.operationName,
+                            MethodCalledMetric.callerClass: metric.callerClass,
+                            MethodCalledMetric.isSuccessful: isSuccessful,
+                            SDKMetricFields.typeKey: MethodCalledMetric.typeValue
+                        ],
+                        sampleRate: sampleRate
+                    )
+                )
+            )
         }
     }
 }
@@ -123,23 +168,6 @@ public struct MethodCalledTrace {
     let operationName: String
     let callerClass: String
     let startTime = Date()
-
-    private var exectutionTime: Int64 {
-        return -startTime.timeIntervalSinceNow.toInt64Nanoseconds
-    }
-
-    func asTelemetryMetric(isSuccessful: Bool) -> MetricTelemetry {
-        return MetricTelemetry(
-            name: MethodCalledMetric.name,
-            attributes: [
-                MethodCalledMetric.executionTime: exectutionTime,
-                MethodCalledMetric.operationName: operationName,
-                MethodCalledMetric.callerClass: callerClass,
-                MethodCalledMetric.isSuccessful: isSuccessful,
-                SDKMetricFields.typeKey: MethodCalledMetric.typeValue
-            ]
-        )
-    }
 }
 
 extension Telemetry {
@@ -352,16 +380,23 @@ extension Telemetry {
         ))
     }
 
-    /// Collect metric value.
+    /// Collects a metric value.
     ///
-    /// Metrics are reported as debug telemetry. Unlike regular events, they are not subject to duplicates filtering and
-    /// are get sampled with a different rate. Metric attributes are used to create facets for later querying and graphing.
+    /// Metrics are reported as debug telemetry. Unlike regular events, they are not subject to duplicate filtering and
+    /// are sampled at a different rate. Metric attributes are used to create facets for later querying and graphing.
     ///
     /// - Parameters:
-    ///   - name: The name of this metric.
-    ///   - attributes: Parameters associated with this metric.
-    public func metric(name: String, attributes: [String: Encodable]) {
-        send(telemetry: .metric(MetricTelemetry(name: name, attributes: attributes)))
+    ///   - name: The name of the metric.
+    ///   - attributes: The attributes associated with this metric.
+    ///   - sampleRate: The sample rate for this metric, applied in addition to the telemetry sample rate (15% by default).
+    ///     Must be a value between `0` (reject all) and `100` (keep all).
+    ///
+    ///     Note: This sample rate is compounded with the telemetry sample rate. For example, if the telemetry sample rate is 20% (default)
+    ///     and this metric's sample rate is 15%, the effective sample rate for this metric will be 3%.
+    ///
+    ///     This sample rate is applied in the telemetry receiver, after the metric has been processed by the SDK core (tail-based sampling).
+    public func metric(name: String, attributes: [String: Encodable], sampleRate: Float = MetricTelemetry.defaultSampleRate) {
+        send(telemetry: .metric(MetricTelemetry(name: name, attributes: attributes, sampleRate: sampleRate)))
     }
 }
 

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -59,7 +59,7 @@ public struct ConfigurationTelemetry: Equatable {
 }
 
 public struct MetricTelemetry {
-    /// The default sample rate for metric events, applied in addition to the telemetry sample rate (20% by default).
+    /// The default sample rate for metric events (15%), applied in addition to the telemetry sample rate (20% by default).
     public static let defaultSampleRate: Float = 15
 
     /// The name of the metric.

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -130,15 +130,14 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(metric.sampleRate, 4.21)
     }
 
-    // TODO: RUM-5083 Enable this test
-//    func testMetricTelemetryDefaultSampleRate() throws {
-//        // When
-//        telemetry.metric(name: "metric name", attributes: [:])
-//
-//        // Then
-//        let metric = try XCTUnwrap(telemetry.messages.compactMap({ $0.asMetric }).first)
-//        XCTAssertEqual(metric.sampleRate, MetricTelemetry.defaultSampleRate)
-//    }
+    func testMetricTelemetryDefaultSampleRate() throws {
+        // When
+        telemetry.metric(name: "metric name", attributes: [:])
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.compactMap({ $0.asMetric }).first)
+        XCTAssertEqual(metric.sampleRate, MetricTelemetry.defaultSampleRate)
+    }
 
     func testStartingMethodCalledMetricTrace_whenSampled() throws {
         XCTAssertNotNil(telemetry.startMethodCalled(operationName: .mockAny(), callerClass: .mockAny(), sampleRate: 100))

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -36,7 +36,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
 
         let featureScope = core.scope(for: RUMFeature.self)
-        let sessionEndedMetric = SessionEndedMetricController(telemetry: core.telemetry)
+        let sessionEndedMetric = SessionEndedMetricController(
+            telemetry: core.telemetry,
+            sampleRate: configuration.sessionEndedMetricSampleRate
+        )
 
         var watchdogTermination: WatchdogTerminationMonitor?
         if configuration.trackWatchdogTerminations {
@@ -139,8 +142,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 featureScope: featureScope,
                 dateProvider: configuration.dateProvider,
                 sampler: Sampler(samplingRate: configuration.telemetrySampleRate),
-                configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate),
-                metricsExtraSampler: Sampler(samplingRate: configuration.metricsTelemetrySampleRate)
+                configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate)
             ),
             ErrorMessageReceiver(
                 featureScope: featureScope,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -15,10 +15,10 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     let featureScope: FeatureScope
     let dateProvider: DateProvider
 
+    /// Sampler for all telemetry events.
     let sampler: Sampler
-
+    /// Additional sampler for configuration telemetry events, applied in addition to the `sampler`.
     let configurationExtraSampler: Sampler
-    let metricsExtraSampler: Sampler
 
     /// Keeps track of current session
     @ReadWriteLock
@@ -39,19 +39,16 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///   - dateProvider: Current device time provider.
     ///   - sampler: Telemetry events sampler.
     ///   - configurationExtraSampler: Extra sampler for configuration events (applied on top of `sampler`).
-    ///   - metricsExtraSampler: Extra sampler for metric events (applied on top of `sampler`).
     init(
         featureScope: FeatureScope,
         dateProvider: DateProvider,
         sampler: Sampler,
-        configurationExtraSampler: Sampler,
-        metricsExtraSampler: Sampler
+        configurationExtraSampler: Sampler
     ) {
         self.featureScope = featureScope
         self.dateProvider = dateProvider
         self.sampler = sampler
         self.configurationExtraSampler = configurationExtraSampler
-        self.metricsExtraSampler = metricsExtraSampler
     }
 
     /// Receives a message from the bus.
@@ -209,7 +206,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     }
 
     private func send(metric: MetricTelemetry) {
-        guard metricsExtraSampler.sample() else {
+        guard Sampler(samplingRate: metric.sampleRate).sample() else {
             return
         }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -264,16 +264,10 @@ extension RUM {
 
         // MARK: - Internal
 
-        /// An extra sampling rate for configuration telemetry events.
-        ///
-        /// It is applied on top of the value configured in public `telemetrySampleRate`.
-        /// It can be overwritten by `InternalConfiguration`.
+        /// An extra sampling rate for configuration telemetry events. It is applied on top of the value configured in public `telemetrySampleRate`.
         internal var configurationTelemetrySampleRate: Float = 20.0
-
-        /// An extra sampling rate for metric events.
-        ///
-        /// It is applied on top of the value configured in public `telemetrySampleRate`.
-        internal var metricsTelemetrySampleRate: Float = 15
+        /// The sample rate for "RUM Session Ended" telemetry. It is applied on top of the value configured in public `telemetrySampleRate`.
+        internal var sessionEndedMetricSampleRate: Float = MetricTelemetry.defaultSampleRate
 
         internal var uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
 

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -17,11 +17,16 @@ internal final class SessionEndedMetricController {
 
     /// Telemetry endpoint for sending metrics.
     private let telemetry: Telemetry
+    /// The sample rate for "RUM Session Ended" metric.
+    internal let sampleRate: Float
 
     /// Initializes a new instance of the metric controller.
-    /// - Parameter telemetry: The telemetry endpoint used for sending metrics.
-    init(telemetry: Telemetry) {
+    /// - Parameters:
+    ///    - telemetry: The telemetry endpoint used for sending metrics.
+    ///    - sampleRate: The sample rate for "RUM Session Ended" metric.
+    init(telemetry: Telemetry, sampleRate: Float) {
         self.telemetry = telemetry
+        self.sampleRate = sampleRate
     }
 
     /// Starts a new metric for a given session.
@@ -87,7 +92,7 @@ internal final class SessionEndedMetricController {
             telemetry.metric(
                 name: SessionEndedMetric.Constants.name,
                 attributes: metric.asMetricAttributes(with: context),
-                sampleRate: MetricTelemetry.defaultSampleRate
+                sampleRate: sampleRate
             )
             metrics[sessionID] = nil
             pendingSessionIDs.removeAll(where: { $0 == sessionID }) // O(n), but "ending the metric" is very rare event

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -84,7 +84,11 @@ internal final class SessionEndedMetricController {
             guard let metric = metrics[sessionID] else {
                 return
             }
-            telemetry.metric(name: SessionEndedMetric.Constants.name, attributes: metric.asMetricAttributes(with: context))
+            telemetry.metric(
+                name: SessionEndedMetric.Constants.name,
+                attributes: metric.asMetricAttributes(with: context),
+                sampleRate: MetricTelemetry.defaultSampleRate
+            )
             metrics[sessionID] = nil
             pendingSessionIDs.removeAll(where: { $0 == sessionID }) // O(n), but "ending the metric" is very rare event
         }

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -16,7 +16,7 @@ class TelemetryInterceptorTests: XCTestCase {
         let sessionID: RUMUUID = .mockRandom()
 
         // Given
-        let metricController = SessionEndedMetricController(telemetry: telemetry)
+        let metricController = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
         let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
 
         // When

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -477,9 +477,9 @@ class TelemetryReceiverTests: XCTestCase {
         let operationName = String.mockRandom()
         let callerClass = String.mockRandom()
         let isSuccessful = Bool.random()
-        let trace = telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, sampleRate: 100)
+        let trace = telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, headSampleRate: 100)
         Thread.sleep(forTimeInterval: 0.001)
-        telemetry.stopMethodCalled(trace, isSuccessful: isSuccessful, sampleRate: 100)
+        telemetry.stopMethodCalled(trace, isSuccessful: isSuccessful, tailSampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -511,7 +511,7 @@ class TelemetryReceiverTests: XCTestCase {
         let trace = telemetry.startMethodCalled(
             operationName: .mockAny(),
             callerClass: .mockAny(),
-            sampleRate: 0
+            headSampleRate: 0
         )
         telemetry.stopMethodCalled(trace, isSuccessful: true)
 

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -215,7 +215,7 @@ class TelemetryReceiverTests: XCTestCase {
         for index in 0..<10 {
             telemetry.debug(id: "debug-\(index)", message: .mockAny())
             telemetry.error(id: "error-\(index)", message: .mockAny(), kind: .mockAny(), stack: .mockAny())
-            telemetry.metric(name: .mockAny(), attributes: [:])
+            telemetry.metric(name: .mockAny(), attributes: [:], sampleRate: 100)
             telemetry.configuration(batchSize: .mockAny())
         }
 
@@ -229,8 +229,7 @@ class TelemetryReceiverTests: XCTestCase {
         // Given
         let receiver = TelemetryReceiver.mockWith(
             featureScope: featureScope,
-            sampler: .mockKeepAll(),
-            metricsExtraSampler: .mockRejectAll()
+            sampler: .mockKeepAll()
         )
         let telemetry = TelemetryMock(with: receiver)
 
@@ -238,7 +237,7 @@ class TelemetryReceiverTests: XCTestCase {
         for index in 0..<10 {
             telemetry.debug(id: "debug-\(index)", message: .mockAny())
             telemetry.error(id: "error-\(index)", message: .mockAny(), kind: .mockAny(), stack: .mockAny())
-            telemetry.metric(name: .mockAny(), attributes: [:])
+            telemetry.metric(name: .mockAny(), attributes: [:], sampleRate: 0)
             telemetry.configuration(batchSize: .mockAny())
         }
 
@@ -397,7 +396,7 @@ class TelemetryReceiverTests: XCTestCase {
         // When
         let randomName: String = .mockRandom()
         let randomAttributes = mockRandomAttributes()
-        TelemetryMock(with: receiver).metric(name: randomName, attributes: randomAttributes)
+        TelemetryMock(with: receiver).metric(name: randomName, attributes: randomAttributes, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -428,7 +427,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
 
         // When
-        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes())
+        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes(), sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -456,7 +455,7 @@ class TelemetryReceiverTests: XCTestCase {
         // When
         var attributes = mockRandomAttributes()
         attributes[SDKMetricFields.sessionIDOverrideKey] = sessionIDOverride
-        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: attributes)
+        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: attributes, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -478,12 +477,9 @@ class TelemetryReceiverTests: XCTestCase {
         let operationName = String.mockRandom()
         let callerClass = String.mockRandom()
         let isSuccessful = Bool.random()
-        let trace = telemetry.startMethodCalled(
-            operationName: operationName,
-            callerClass: callerClass,
-            samplingRate: 100
-        )
-        telemetry.stopMethodCalled(trace, isSuccessful: isSuccessful)
+        let trace = telemetry.startMethodCalled(operationName: operationName, callerClass: callerClass, sampleRate: 100)
+        Thread.sleep(forTimeInterval: 0.001)
+        telemetry.stopMethodCalled(trace, isSuccessful: isSuccessful, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -515,7 +511,7 @@ class TelemetryReceiverTests: XCTestCase {
         let trace = telemetry.startMethodCalled(
             operationName: .mockAny(),
             callerClass: .mockAny(),
-            samplingRate: 0
+            sampleRate: 0
         )
         telemetry.stopMethodCalled(trace, isSuccessful: true)
 

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -64,15 +64,13 @@ extension TelemetryReceiver: AnyMockable {
         featureScope: FeatureScope = NOPFeatureScope(),
         dateProvider: DateProvider = SystemDateProvider(),
         sampler: Sampler = .mockKeepAll(),
-        configurationExtraSampler: Sampler = .mockKeepAll(),
-        metricsExtraSampler: Sampler = .mockKeepAll()
+        configurationExtraSampler: Sampler = .mockKeepAll()
     ) -> Self {
         .init(
             featureScope: featureScope,
             dateProvider: dateProvider,
             sampler: sampler,
-            configurationExtraSampler: configurationExtraSampler,
-            metricsExtraSampler: metricsExtraSampler
+            configurationExtraSampler: configurationExtraSampler
         )
     }
 }
@@ -775,7 +773,7 @@ extension RUMScopeDependencies {
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
         viewCache: ViewCache = ViewCache(),
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
-        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry()),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -91,8 +91,8 @@ class RUMTests: XCTestCase {
         let crashReportReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
         XCTAssertEqual(monitor.scopes.dependencies.rumApplicationID, applicationID)
         XCTAssertEqual(monitor.scopes.dependencies.sessionSampler.samplingRate, 100)
+        XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.sampleRate, 15)
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 20)
-        XCTAssertEqual(telemetryReceiver?.metricsExtraSampler.samplingRate, 15)
         XCTAssertEqual(crashReportReceiver?.sessionSampler.samplingRate, 100)
     }
 

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -18,7 +18,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let errorKinds: [String] = .mockRandom(count: 5)
 
         // Given
-        let controller = SessionEndedMetricController(telemetry: telemetry)
+        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 4.2)
         controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
 
         // When
@@ -34,6 +34,8 @@ class SessionEndedMetricControllerTests: XCTestCase {
         XCTAssertEqual(metric.sdkErrorsCount.total, errorKinds.count)
         XCTAssertEqual(metric.noViewEventsCount.actions, 1)
         XCTAssertEqual(metric.wasStopped, true)
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 4.2)
     }
 
     func testTrackingMultipleSessionsWithExplicitSessionID() throws {
@@ -41,7 +43,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let sessionID2: RUMUUID = .mockRandom()
 
         // When
-        let controller = SessionEndedMetricController(telemetry: telemetry)
+        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Session 1:
@@ -73,7 +75,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let sessionID2: RUMUUID = .mockRandom()
 
         // When
-        let controller = SessionEndedMetricController(telemetry: telemetry)
+        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Track latest session (`sessionID: nil`)
@@ -96,7 +98,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
 
     func testTrackingSessionEndedMetricIsThreadSafe() {
         let sessionIDs: [RUMUUID] = .mockRandom(count: 10)
-        let controller = SessionEndedMetricController(telemetry: telemetry)
+        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
 
         // swiftlint:disable opening_brace
         callConcurrently(

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -128,7 +128,7 @@ internal class RecordingCoordinator {
         let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
-            sampleRate: methodCallTelemetrySamplingRate // Effectively 3% * 0.1% = 0.003% of calls
+            headSampleRate: methodCallTelemetrySamplingRate // Effectively 3% * 0.1% = 0.003% of calls
         )
 
         var isSuccessful = false

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -128,7 +128,7 @@ internal class RecordingCoordinator {
         let methodCalledTrace = telemetry.startMethodCalled(
             operationName: MethodCallConstants.captureRecordOperationName,
             callerClass: MethodCallConstants.className,
-            samplingRate: methodCallTelemetrySamplingRate // Effectively 3% * 0.1% = 0.003% of calls
+            sampleRate: methodCallTelemetrySamplingRate // Effectively 3% * 0.1% = 0.003% of calls
         )
 
         var isSuccessful = false

--- a/TestUtilities/Mocks/TelemetryMocks.swift
+++ b/TestUtilities/Mocks/TelemetryMocks.swift
@@ -76,21 +76,21 @@ public class TelemetryMock: Telemetry, CustomStringConvertible {
             description.append("\n - [error] \(message), kind: \(kind), stack: \(stack)")
         case .configuration(let configuration):
             description.append("\n- [configuration] \(configuration)")
-        case let .metric(name, attributes):
-            let attributesString = attributes.map({ "\($0.key): \($0.value)" }).joined(separator: ", ")
-            description.append("\n- [metric] '\(name)' (" + attributesString + ")")
+        case let .metric(metric):
+            let attributesString = metric.attributes.map({ "\($0.key): \($0.value)" }).joined(separator: ", ")
+            description.append("\n- [metric] '\(metric.name)' (" + attributesString + ")")
         }
     }
 }
 
 public extension Array where Element == TelemetryMessage {
     /// Returns properties of the first metric message of given name.
-    func firstMetric(named metricName: String) -> (name: String, attributes: [String: Encodable])? {
+    func firstMetric(named metricName: String) -> MetricTelemetry? {
         return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).first
     }
 
     /// Returns properties of the first metric message of given name.
-    func lastMetric(named metricName: String) -> (name: String, attributes: [String: Encodable])? {
+    func lastMetric(named metricName: String) -> MetricTelemetry? {
         return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).last
     }
 
@@ -136,11 +136,11 @@ public extension TelemetryMessage {
     }
 
     /// Extracts metric attributes if this is metric message.
-    var asMetric: (name: String, attributes: [String: Encodable])? {
-        guard case let .metric(name, attributes) = self else {
+    var asMetric: MetricTelemetry? {
+        guard case let .metric(metric) = self else {
             return nil
         }
-        return (name: name, attributes: attributes)
+        return metric
     }
 }
 


### PR DESCRIPTION
### What and Why?

📦 This PR introduces the ability to sample each SDK metric using distinct sample rates.

Previously, [all metrics](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3534554673/Telemetry+Metric+Specs) shared the same [`metricTelemetrySampleRate`](https://github.com/DataDog/dd-sdk-ios/blob/691fc07fbc32267ec313cd3c3590f1155a9573ac/DatadogRUM/Sources/RUMConfiguration.swift#L273-L276) (15%). To sample batch metrics at different rates in `RUM-5083`, this refactoring is necessary.

### How?

A new property, `sampleRate`, has been added to the telemetry message that carries metric data:

```swift
public struct MetricTelemetry {
    public let name: String
    public let attributes: [String: Encodable]

    /// The sample rate for this metric, applied in addition to the telemetry sample rate.
    /// ...
    /// This sample rate is applied in the telemetry receiver, after the metric has been processed by the SDK core (tail-based sampling).
    public let sampleRate: Float
}

public enum TelemetryMessage {
    // ...
    case metric(MetricTelemetry)
}
```
The [`metricTelemetrySampleRate`](https://github.com/DataDog/dd-sdk-ios/blob/691fc07fbc32267ec313cd3c3590f1155a9573ac/DatadogRUM/Sources/RUMConfiguration.swift#L273-L276) has been removed, and now each metric is sampled individually using the metric-specific `sampleRate` (15% by default).

As before, this sample rate is applied in addition to the user-controlled [`telemetrySampleRate`](https://github.com/DataDog/dd-sdk-ios/blob/691fc07fbc32267ec313cd3c3590f1155a9573ac/DatadogRUM/Sources/RUMConfiguration.swift#L213-L218) (20% by default) in the RUM `TelemetryReceiver`. Both rates are applied after telemetry is passed over the `MessageBus` to RUM (tail-based sampling):

<img width="1016" alt="Screenshot 2024-08-23 at 09 46 44" src="https://github.com/user-attachments/assets/687937ff-fd7f-47ab-a946-223ff7b9e833">

#### Alternative Considered: Head-Based Telemetry Sampling

I also explored the potential benefits of switching to head-based sampling for the entire telemetry (not just metrics). By dropping telemetry samples earlier, we could reduce the cost of processing them over the `MessageBus`.

To evaluate this, I benchmarked Shopist iOS app, running one of its scenarios for 50s on an iPhone 13 Pro Max in "Release" configuration. Each time, I measured the number and timings of messages passed over the `MessageBus`:

<img width="1043" alt="Screenshot 2024-08-23 at 09 54 48" src="https://github.com/user-attachments/assets/d40038c4-07a2-42ac-9e1c-cfa424309786">

**Conclusion:** Head-based telemetry sampling doesn't offer significant gains. In this benchmark, telemetry accounted for the fewest type of messages sent over the message bus (~7%) and contributed only a negligible processing duration (~17ms) to the overall 50s run.

Instead, we should focus on the number of `context` and `baggage` messages exchanged over the bus which are more numerous and way heavier. The full results of this benchmark and further conclusions will be published in a separate document.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
