### PR TITLE
RUM-5083 chore: Lower Batch Metrics sample rate to 10% of its original value

### DIFF
--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -251,7 +251,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
                 BatchDeletedMetric.inBackgroundKey: false
             ],
-            sampleRate: MetricTelemetry.defaultSampleRate
+            sampleRate: BatchDeletedMetric.sampleRate
         )
     }
 
@@ -278,7 +278,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchClosedMetric.batchEventsCountKey: lastWritableFileObjectsCount,
                 BatchClosedMetric.batchDurationKey: batchDuration.toMilliseconds
             ],
-            sampleRate: MetricTelemetry.defaultSampleRate
+            sampleRate: BatchClosedMetric.sampleRate
         )
     }
 }

--- a/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
+++ b/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
@@ -38,6 +38,9 @@ internal enum BatchDeletedMetric {
     static let name = "Batch Deleted"
     /// Metric type value.
     static let typeValue = "batch deleted"
+    /// The sample rate for this metric.
+    /// It is applied in addition to the telemetry sample rate (20% by default).
+    static let sampleRate: Float = 1.5 // 1.5%
     /// The key for uploader's delay options.
     static let uploaderDelayKey = "uploader_delay"
     /// The min delay of uploads for this track (in ms).
@@ -107,6 +110,9 @@ internal enum BatchClosedMetric {
     static let name = "Batch Closed"
     /// Metric type value.
     static let typeValue = "batch closed"
+    /// The sample rate for this metric.
+    /// It is applied in addition to the telemetry sample rate (20% by default).
+    static let sampleRate: Float = 1.5 // 1.5%
     /// The default duration since last write (in ms) after which the uploader considers the file to be "ready for upload".
     static let uploaderWindowKey = "uploader_window"
 

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -71,6 +71,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             "batch_age": expectedBatchAge.toMilliseconds,
             "batch_removal_reason": "intake-code-202",
         ])
+        XCTAssertEqual(metric.sampleRate, BatchDeletedMetric.sampleRate)
     }
 
     func testWhenObsoleteFileIsDeleted_itSendsBatchDeletedMetric() throws {
@@ -100,6 +101,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             "batch_age": (storage.maxFileAgeForRead + 1).toMilliseconds,
             "batch_removal_reason": "obsolete",
         ])
+        XCTAssertEqual(metric.sampleRate, BatchDeletedMetric.sampleRate)
     }
 
     func testWhenDirectoryIsPurged_itSendsBatchDeletedMetrics() throws {
@@ -132,6 +134,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             "batch_age": expectedBatchAge.toMilliseconds,
             "batch_removal_reason": "purged",
         ])
+        XCTAssertEqual(metric.sampleRate, BatchDeletedMetric.sampleRate)
     }
 
     // MARK: - "Batch Closed" Metric
@@ -170,5 +173,6 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             "batch_events_count": expectedWrites.count,
             "batch_duration": expectedWriteDelays.reduce(0, +).toMilliseconds
         ])
+        XCTAssertEqual(metric.sampleRate, BatchClosedMetric.sampleRate)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR lowers the sample rate for "Batch Deleted" and "Batch Closed" metrics from 15% to 1.5%.

Counterpart of https://github.com/DataDog/dd-sdk-android/pull/2146

### How?

Leveraging metric-specific sample rate configuration added in https://github.com/DataDog/dd-sdk-ios/pull/2015, this PR changes `sampleRate` in batch metrics from default 15% to custom 1.5%.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
