### PR TITLE
fix: Exclude `BenchmarkTests/UIKitCatalog` from license check

### DIFF
--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -27,6 +27,7 @@ function files {
 		-not -name "OTReference.swift" \
 		-not -name "OTSpanContext.swift" \
 		-not -name "Versioning.swift" \
+		-not -path "*/BenchmarkTests/UIKitCatalog/*" \
 		-not -name "__init__.py"
 }
 


### PR DESCRIPTION
### What and why?

Exclude `BenchmarkTests/UIKitCatalog` from license check.
Not sure why the job was not executed for the PR 🤔 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
