### PR TITLE
fix: Increment the `CURRENT_PROJECT_VERSION` only

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -874,7 +874,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.UIKitCatalog;
@@ -885,7 +884,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -905,7 +903,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.UIKitCatalog;
@@ -916,7 +913,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -936,7 +932,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.UIKitCatalog;
@@ -947,7 +942,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Synthetics;
 		};
@@ -1014,6 +1008,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Datadog Benchmark Runner";
@@ -1026,6 +1021,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.Runner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1160,6 +1156,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Datadog Benchmark Runner";
@@ -1172,6 +1169,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.Runner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1187,6 +1185,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Datadog Benchmark Runner";
@@ -1199,6 +1198,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.benchmarks.Runner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -53,7 +53,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "BENCHMARK_RUN"
-            value = "metrics"
+            value = "instrumented"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/BenchmarkTests/Makefile
+++ b/BenchmarkTests/Makefile
@@ -29,7 +29,7 @@ build:
 archive:
 	@:$(eval VERSION ?= $(CURRENT_GIT_COMMIT_SHORT))
 	@$(ECHO_SUBTITLE2) "make archive VERSION='$(VERSION)'"
-	@xcrun agvtool new-marketing-version "$(VERSION)"
+	@xcrun agvtool new-version "$(VERSION)"
 	set -eo pipefail; \
 	OTEL_SWIFT=1 xcodebuild \
 		-project BenchmarkTests.xcodeproj \

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -66,7 +66,7 @@ extension Benchmarks.Configuration {
             context: Benchmarks.Configuration.Context(
                 applicationIdentifier: bundle.bundleIdentifier!,
                 applicationName: bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as! String,
-                applicationVersion: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String,
+                applicationVersion: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as! String,
                 sdkVersion: "",
                 deviceModel: try! sysctl.model(),
                 osName: device.systemName,

--- a/BenchmarkTests/Runner/Info.plist
+++ b/BenchmarkTests/Runner/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
 	<key>DatadogConfiguration</key>
 	<dict>
 		<key>ApiKey</key>


### PR DESCRIPTION
### What and why?

Updates in `Info.plist` were not used in the `.app` build

### How?

Use `agvtool new-version` to update the `CURRENT_PROJECT_VERSION` from the Runner target only.
The `CURRENT_PROJECT_VERSION` will translate to `CFBundleVersion` in app bundle which will be used as metric tag.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
