### PR TITLE
RUM-5841 feat: setup addViewLoadingTime usage telemetry

### DIFF
--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -7866,4 +7866,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/5158bc1d54b6e88f2d47c9d6ac9f53c417ef8870
+// Generated from https://github.com/DataDog/rum-events-format/tree/86e7c73b800f5297bac06b68689c1944342dc4a0

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -4467,13 +4467,13 @@ public struct TelemetryUsageEvent: RUMDataModel {
                     public let feature: String = "addViewLoadingTime"
 
                     /// Whether the available view is not active
-                    public let noActiveView: Bool?
+                    public let noActiveView: Bool
 
                     /// Whether the view is not available
-                    public let noView: Bool?
+                    public let noView: Bool
 
                     /// Whether the loading time was overwritten
-                    public let overwritten: Bool?
+                    public let overwritten: Bool
 
                     enum CodingKeys: String, CodingKey {
                         case feature = "feature"
@@ -4879,4 +4879,4 @@ public struct RUMTelemetryOperatingSystem: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/5158bc1d54b6e88f2d47c9d6ac9f53c417ef8870
+// Generated from https://github.com/DataDog/rum-events-format/tree/86e7c73b800f5297bac06b68689c1944342dc4a0


### PR DESCRIPTION
### What and why?

We want to use usage telemetry to trace the `addViewLoadingTime` usage.

### How?

There are different cases we want to track per https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3951001790/RFC+View+loading+time+manual+API

- when API is used
- when there is no view to report
- when there is a view but not active
- when there is view, active and already has the timing

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
