### PR TITLE
RUM-3889 fix: remove retry information from Logs and Trace requests

### DIFF
--- a/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/DatadogLogsFeatureTests.swift
@@ -84,7 +84,7 @@ class DatadogLogsFeatureTests: XCTestCase {
         let requestURL = try XCTUnwrap(request.url)
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(requestURL.absoluteString.starts(with: randomUploadURL.absoluteString + "?"))
-        XCTAssertEqual(requestURL.query, "ddsource=\(randomSource)&ddtags=retry_count:1")
+        XCTAssertEqual(requestURL.query, "ddsource=\(randomSource)")
         XCTAssertEqual(
             request.allHTTPHeaderFields?["User-Agent"],
             """

--- a/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/DatadogTraceFeatureTests.swift
@@ -86,7 +86,7 @@ class DatadogTraceFeatureTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(requestURL.host, randomUploadURL.host)
         XCTAssertEqual(requestURL.path, randomUploadURL.path)
-        XCTAssertEqual(requestURL.query, "ddtags=retry_count:1")
+        XCTAssertNil(requestURL.query)
         XCTAssertEqual(
             request.allHTTPHeaderFields?["User-Agent"],
             """

--- a/DatadogLogs/Sources/Feature/RequestBuilder.swift
+++ b/DatadogLogs/Sources/Feature/RequestBuilder.swift
@@ -32,19 +32,10 @@ internal struct RequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) -> URLRequest {
-        var tags = [
-            "retry_count:\(execution.attempt + 1)"
-        ]
-
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
-        }
-
         let builder = URLRequestBuilder(
             url: url(with: context),
             queryItems: [
                 .ddsource(source: context.source),
-                .ddtags(tags: tags)
             ],
             headers: [
                 .contentTypeHeader(contentType: .applicationJSON),

--- a/DatadogTrace/Sources/Feature/RequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/RequestBuilder.swift
@@ -24,19 +24,9 @@ internal struct TracingRequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) -> URLRequest {
-        var tags = [
-            "retry_count:\(execution.attempt + 1)"
-        ]
-
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
-        }
-
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [
-                .ddtags(tags: tags)
-            ],
+            queryItems: [],
             headers: [
                 .contentTypeHeader(contentType: .textPlainUTF8),
                 .userAgentHeader(

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
@@ -24,7 +24,7 @@ extension LoggingCommonAsserts {
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios&ddtags=retry_count:1`
             XCTAssertNotNil(request.path, file: file, line: line)
             XCTAssertNotNil(request.queryItems)
-            XCTAssertEqual(request.queryItems!.count, 2)
+            XCTAssertEqual(request.queryItems!.count, 1)
             XCTAssertEqual(request.queryItems?.value(name: "ddsource"), "ios", file: file, line: line)
 
             let ddtags = request.queryItems?.ddtags()

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
@@ -28,9 +28,7 @@ extension LoggingCommonAsserts {
             XCTAssertEqual(request.queryItems?.value(name: "ddsource"), "ios", file: file, line: line)
 
             let ddtags = request.queryItems?.ddtags()
-            XCTAssertNotNil(ddtags, file: file, line: line)
-            XCTAssertEqual(ddtags?.count, 1, file: file, line: line)
-            XCTAssertEqual(ddtags?["retry_count"], "1", file: file, line: line)
+            XCTAssertNil(ddtags, file: file, line: line)
 
             XCTAssertEqual(request.httpHeaders["Content-Type"], "application/json", file: file, line: line)
             XCTAssertEqual(request.httpHeaders["User-Agent"]?.matches(regex: userAgentRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
@@ -35,8 +35,7 @@ extension TracingCommonAsserts {
 
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddtags=retry_count:1`
             XCTAssertFalse(request.path.isEmpty)
-            XCTAssertNotNil(request.queryItems)
-            XCTAssertEqual(request.queryItems!.count, 1)
+            XCTAssertNil(request.queryItems)
 
             let ddtags = request.queryItems?.ddtags()
             XCTAssertNil(ddtags)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
@@ -39,9 +39,7 @@ extension TracingCommonAsserts {
             XCTAssertEqual(request.queryItems!.count, 1)
 
             let ddtags = request.queryItems?.ddtags()
-            XCTAssertNotNil(ddtags)
-            XCTAssertEqual(ddtags?.count, 1)
-            XCTAssertEqual(ddtags!["retry_count"], "1")
+            XCTAssertNil(ddtags)
 
             XCTAssertEqual(request.httpHeaders["Content-Type"], "text/plain;charset=UTF-8", file: file, line: line)
             XCTAssertEqual(request.httpHeaders["User-Agent"]?.matches(regex: userAgentRegex), true, file: file, line: line)


### PR DESCRIPTION
### What and why?

query param ddtags getting injected to log tags

https://docs.datadoghq.com/api/latest/logs/

### How?

This PR removes retry info from non RUM endpoints where we are not sure about the behavior of ddtags query param.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
