### PR TITLE
Bundle dependencies update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,19 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.3.4)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -62,7 +63,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     drb (2.2.1)
     escape (0.0.4)
@@ -77,29 +78,30 @@ GEM
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
-    minitest (5.23.1)
+    logger (1.6.0)
+    minitest (5.25.1)
     molinillo (0.8.0)
-    mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.9)
+    rexml (3.3.6)
       strscan
     ruby-macho (2.5.1)
+    securerandom (0.3.1)
     strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.2, < 4.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -111,4 +113,4 @@ DEPENDENCIES
   cocoapods (= 1.15.2)
 
 BUNDLED WITH
-   2.3.25
+   2.5.18


### PR DESCRIPTION
### What and why?

Updates dependencies using `Bundler` to address [dependabot](https://github.com/DataDog/dd-sdk-ios/security/dependabot) warnings.

### How?

By running:
`bundle update`
