### PR TITLE
RUM-5841 feat(view-loading-api): implement addViewLoadingTime API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FEATURE] Add support for view loading API (addViewLoadingTime). See [#2026][]
 - [IMPROVEMENT] Drop support for deprecated cocoapod specs. See [#1998][]
 - [FIX] Propagate global Tracer tags to OpenTelemetry span attributes. See [#2000][]
 - [FEATURE] Add Logs event mapper to ObjC API. See [#2008][]
@@ -758,6 +759,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2005]: https://github.com/DataDog/dd-sdk-ios/pull/2005
 [#1998]: https://github.com/DataDog/dd-sdk-ios/pull/1998
 [#1998]: https://github.com/DataDog/dd-sdk-ios/pull/1966
+[#2026]: https://github.com/DataDog/dd-sdk-ios/pull/2026
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -275,6 +275,15 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
+    func addViewLoadingTime() {
+        process(
+            command: RUMAddViewLoadingTime(
+                time: dateProvider.now,
+                attributes: [:]
+            )
+        )
+    }
+
     // MARK: - custom timings
 
     func addTiming(name: String) {

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -271,9 +271,7 @@ internal struct RUMAddViewLoadingTime: RUMCommand, RUMViewScopePropagatableAttri
     let canStartBackgroundView = false // no, it doesn't make sense to start "Background" view on receiving custom timing, as it will be `0ns` timing
     let isUserInteraction = false // a custom view timing is not an interactive event
 
-    /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
-    /// measured since the start of the View.
-    let missedEventType: SessionEndedMetric.MissedEventType? = nil
+    let missedEventType: SessionEndedMetric.MissedEventType? = .viewLoadingTime
 }
 
 internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAttributes {

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -265,6 +265,17 @@ internal struct RUMAddCurrentViewMemoryWarningCommand: RUMErrorCommand {
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
 }
 
+internal struct RUMAddViewLoadingTime: RUMCommand, RUMViewScopePropagatableAttributes {
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, it doesn't make sense to start "Background" view on receiving custom timing, as it will be `0ns` timing
+    let isUserInteraction = false // a custom view timing is not an interactive event
+
+    /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
+    /// measured since the start of the View.
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
+}
+
 internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAttributes {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -51,7 +51,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// The start time of this View.
     let viewStartTime: Date
     /// The load time of this View.
-    var viewLoadingTime: TimeInterval?
+    private(set) var viewLoadingTime: TimeInterval?
 
     /// Server time offset for date correction.
     ///

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -50,6 +50,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     let viewName: String
     /// The start time of this View.
     let viewStartTime: Date
+    /// The load time of this View.
+    var viewLoadingTime: TimeInterval?
 
     /// Server time offset for date correction.
     ///
@@ -197,6 +199,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             needsViewUpdate = true
         case let command as RUMStopViewCommand where identity == command.identity:
             isActiveView = false
+            needsViewUpdate = true
+        case let command as RUMAddViewLoadingTime where isActiveView:
+            viewLoadingTime = command.time.timeIntervalSince(viewStartTime)
             needsViewUpdate = true
         case let command as RUMAddViewTimingCommand where isActiveView:
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
@@ -534,7 +539,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 largestContentfulPaint: nil,
                 largestContentfulPaintTargetSelector: nil,
                 loadEvent: nil,
-                loadingTime: nil,
+                loadingTime: viewLoadingTime?.toInt64Nanoseconds,
                 loadingType: nil,
                 longTask: .init(count: longTasksCount),
                 memoryAverage: memoryInfo?.meanValue,

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -325,6 +325,13 @@ public protocol RUMMonitorProtocol: AnyObject {
     var debug: Bool { set get }
 }
 
+extension RUMMonitorProtocol {
+    /// Itcannot be declared '@_spi' without a default implementation in a protocol extension
+    func addViewLoadingTime() {
+        // no-op
+    }
+}
+
 // MARK: - NOP moniotor
 
 internal class NOPMonitor: RUMMonitorProtocol {

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -326,7 +326,7 @@ public protocol RUMMonitorProtocol: AnyObject {
 }
 
 extension RUMMonitorProtocol {
-    /// Itcannot be declared '@_spi' without a default implementation in a protocol extension
+    /// It cannot be declared '@_spi' without a default implementation in a protocol extension
     func addViewLoadingTime() {
         // no-op
     }

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -109,6 +109,13 @@ public protocol RUMMonitorProtocol: AnyObject {
         attributes: [AttributeKey: AttributeValue]
     )
 
+    /// Adds view loading time to current RUM view based on the time elapsed since the view was started.
+    /// This method should be called only once per view.
+    /// If the view is not started, this method does nothing.
+    /// If the view is not active, this method does nothing.
+    @_spi(Experimental)
+    func addViewLoadingTime()
+
     // MARK: - custom timings
 
     /// Records a specific timing within the current RUM view.
@@ -187,7 +194,7 @@ public protocol RUMMonitorProtocol: AnyObject {
     )
 
     /// Adds temporal metrics to given RUM resource.
-    /// 
+    ///
     /// It must be called before the resource is stopped.
     /// - Parameters:
     ///   - resourceKey: the key representing the resource. It must match the one used to start the resource.
@@ -282,7 +289,7 @@ public protocol RUMMonitorProtocol: AnyObject {
     )
 
     /// Stops RUM action.
-    /// 
+    ///
     /// The action must be first started with `startAction(type:)`.
     /// - Parameters:
     ///   - type: the type of the action. It should match type passed when starting this action.
@@ -338,6 +345,7 @@ internal class NOPMonitor: RUMMonitorProtocol {
     func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) { warn() }
     func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func stopView(key: String, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func addViewLoadingTime() { warn() }
     func addTiming(name: String) { warn() }
     func addError(message: String, type: String?, stack: String?, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?) { warn() }
     func addError(error: Error, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]) { warn() }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -114,6 +114,7 @@ internal class SessionEndedMetric {
         case resource
         case error
         case longTask
+        case viewLoadingTime
     }
 
     /// Tracks the number of RUM events missed due to absence of an active RUM view.

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import TestUtilities
 import DatadogInternal
+@_spi(Experimental)
 @testable import DatadogRUM
 
 class Monitor_GlobalAttributesTests: XCTestCase {
@@ -482,6 +483,68 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(viewAfterFirstTiming.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(viewAfterSecondTiming.attribute(forKey: "attribute2"), "value2")
+    }
+
+    // MARK: - View Loading Time
+
+    func testAddViewLoadingTimeToActiveView_thenLoadingTimeUpdated() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+
+        // When
+        monitor.addViewLoadingTime()
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
+        let lastView = try XCTUnwrap(viewEvents.last)
+
+        XCTAssertNotNil(lastView.view.loadingTime)
+        XCTAssertTrue(lastView.view.loadingTime! > 0)
+    }
+
+    func testAddViewLoadingTimeNoActiveView_thenNoEvent() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "InactiveView")
+        monitor.stopView(key: "InactiveView")
+
+        // When
+        monitor.addViewLoadingTime()
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "InactiveView" }
+        XCTAssertNil(viewEvents.last?.view.loadingTime)
+    }
+
+    func testAddViewLoadingTimeMultipleTimes_thenLoadingTimeOverwritten() throws {
+        // Given
+        monitor.notifySDKInit()
+        monitor.startView(key: "ActiveView")
+
+        // When
+        monitor.addViewLoadingTime()
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
+        let lastView = try XCTUnwrap(viewEvents.last)
+
+        XCTAssertNotNil(lastView.view.loadingTime)
+        XCTAssertTrue(lastView.view.loadingTime! > 0)
+
+        let old = lastView.view.loadingTime!
+
+        // When
+        monitor.addViewLoadingTime()
+
+        // Then
+        let viewEvents2 = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
+        let lastView2 = try XCTUnwrap(viewEvents2.last)
+
+        XCTAssertNotNil(lastView2.view.loadingTime)
+        XCTAssertTrue(lastView2.view.loadingTime! > 0)
+
+        XCTAssertTrue(lastView2.view.loadingTime! > old)
     }
 
     // MARK: - Updating Fatal Error Context With Global Attributes


### PR DESCRIPTION
### What and why?

https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3951001790/RFC+View+loading+time+manual+API

### How?

This PR follows the RFC and introduces `addViewLoadingTime` API. The implementation follows the existing command pattern and updates the `RUMViewEvent.view.loading` when called which also triggers the view update.

This PR doesn't introduce any telemetry which will be added in upcoming PRs. We will require https://github.com/DataDog/dd-sdk-ios/pull/2019 to merged as prerequisite. 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
