### PR TITLE
RUM-1053 Make `DatadogLogs` public API concurrency-safe

### DIFF
--- a/DatadogLogs/Sources/LoggerProtocol.swift
+++ b/DatadogLogs/Sources/LoggerProtocol.swift
@@ -39,7 +39,7 @@ extension CoreLoggerLevel {
 ///
 ///     // logger reference
 ///     var logger = Logger.create()
-public protocol LoggerProtocol {
+public protocol LoggerProtocol: Sendable {
     /// General purpose logging method.
     /// Sends a log with certain `level`, `message`, `error` and `attributes`.
     ///


### PR DESCRIPTION
### What and why?

📦 This PR prepares DatadogLogs for compatibility with apps that [enable "complete" concurrency checking](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/completechecking/) in Swift 6.

### How?

I identified one scenario where the `DatadogLogs` API could raise a data-race safety issue in Swift 6. Specifically, this occurs when a `LoggerProtocol` instance is passed across isolation boundaries, such as when it’s used from a different thread:

```swift
import DatadogLogs


let logger = Logger.create(with: .init())

DispatchQueue.global(qos: .userInitiated).async {
    logger.debug("foo") 
    // ^ ❌ Error: Capture of 'logger' with non-sendable type 'any LoggerProtocol' in a `@Sendable` closure
}
```

This issue is resolved by [declaring Sendable conformance](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/dataracesafety#Sendable-Types) for LoggerProtocol:

> A conformance to `Sendable` means the given type is thread safe, and values of the type can be shared across arbitrary isolation domains without introducing a risk of data races.

Since our logger implementation has been thread-safe from the beginning, this conformance ensures that it meets the upcoming requirements of the Swift 6 language model.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
