### PR TITLE
chore: Enable test visibility in unit test jobs (iOS + tvOS)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,20 +96,6 @@ Unit Tests (iOS):
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
-
-Unit Tests (iOS, Test Visibility shadow):
-  stage: test
-  rules: 
-    - !reference [.test-pipeline-job, rules]
-    - !reference [.release-pipeline-job, rules]
-  variables:
-    PLATFORM: "iOS Simulator"
-    DEVICE: "iPhone 15 Pro"
-  allow_failure: true
-  script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
-    - make clean repo-setup ENV=ci
     - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
 
 Unit Tests (tvOS):
@@ -123,7 +109,7 @@ Unit Tests (tvOS):
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
+    - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
 
 UI Tests:
   stage: ui-test


### PR DESCRIPTION
### What and why?

📦 This PR enables CI Test Visibility in Unit Test jobs (iOS and tvOS).

Test Visibility was earlier integrated in https://github.com/DataDog/dd-sdk-ios/pull/1999 through separate "shadow" job. It was to pre-check the impact on our CI in sandbox environment. Because everything looks stable and performant, we now integrate it to regular jobs.

### How?

- Removed "shadow" job.
- Changed regular jobs to `USE_TEST_VISIBILITY=1`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
