### PR TITLE
Add background upload configuration info to batch deleted telemetry

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -255,6 +255,7 @@ extension DatadogCore: DatadogCoreProtocol {
                 dateProvider: dateProvider,
                 performance: performancePreset,
                 encryption: encryption,
+                backgroundTasksEnabled: backgroundTasksEnabled,
                 telemetry: telemetry
             )
 

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -116,6 +116,7 @@ extension FeatureStorage {
         dateProvider: DateProvider,
         performance: PerformancePreset,
         encryption: DataEncryption?,
+        backgroundTasksEnabled: Bool,
         telemetry: Telemetry
     ) {
         let trackName = BatchMetric.trackValue(for: featureName)
@@ -133,7 +134,8 @@ extension FeatureStorage {
                 return FilesOrchestrator.MetricsData(
                     trackName: trackName,
                     consentLabel: BatchMetric.consentGrantedValue,
-                    uploaderPerformance: performance
+                    uploaderPerformance: performance, 
+                    backgroundTasksEnabled: backgroundTasksEnabled
                 )
             }
         )
@@ -146,7 +148,8 @@ extension FeatureStorage {
                 return FilesOrchestrator.MetricsData(
                     trackName: trackName,
                     consentLabel: BatchMetric.consentPendingValue,
-                    uploaderPerformance: performance
+                    uploaderPerformance: performance, 
+                    backgroundTasksEnabled: backgroundTasksEnabled
                 )
             }
         )

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -134,7 +134,7 @@ extension FeatureStorage {
                 return FilesOrchestrator.MetricsData(
                     trackName: trackName,
                     consentLabel: BatchMetric.consentGrantedValue,
-                    uploaderPerformance: performance, 
+                    uploaderPerformance: performance,
                     backgroundTasksEnabled: backgroundTasksEnabled
                 )
             }
@@ -148,7 +148,7 @@ extension FeatureStorage {
                 return FilesOrchestrator.MetricsData(
                     trackName: trackName,
                     consentLabel: BatchMetric.consentPendingValue,
-                    uploaderPerformance: performance, 
+                    uploaderPerformance: performance,
                     backgroundTasksEnabled: backgroundTasksEnabled
                 )
             }

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -48,6 +48,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         let consentLabel: String
         /// The preset for uploader performance in this feature to include in metric.
         let uploaderPerformance: UploadPerformancePreset
+        /// The present configuration of background upload in this feature to include in metric.
+        let backgroundTasksEnabled: Bool
     }
 
     /// An extra information to include in metrics or `nil` if metrics should not be reported for this orchestrator.
@@ -249,7 +251,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchDeletedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
                 BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
-                BatchDeletedMetric.inBackgroundKey: false
+                BatchDeletedMetric.inBackgroundKey: metricsData.backgroundTasksEnabled
             ],
             sampleRate: BatchDeletedMetric.sampleRate
         )

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -251,7 +251,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchDeletedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
                 BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
-                BatchDeletedMetric.inBackgroundKey: metricsData.backgroundTasksEnabled
+                BatchDeletedMetric.inBackgroundKey: false,
+                BatchDeletedMetric.backgroundTasksEnabled: metricsData.backgroundTasksEnabled
             ],
             sampleRate: BatchDeletedMetric.sampleRate
         )

--- a/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
+++ b/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
@@ -54,7 +54,7 @@ internal enum BatchDeletedMetric {
     static let batchAgeKey = "batch_age"
     /// The reason of batch deletion.
     static let batchRemovalReasonKey = "batch_removal_reason"
-    /// If the batch was deleted in the background.
+    /// If the background upload was enabled.
     static let inBackgroundKey = "in_background"
 
     /// Allowed values for `batchRemovalReasonKey`.

--- a/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
+++ b/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
@@ -54,8 +54,10 @@ internal enum BatchDeletedMetric {
     static let batchAgeKey = "batch_age"
     /// The reason of batch deletion.
     static let batchRemovalReasonKey = "batch_removal_reason"
-    /// If the background upload was enabled.
+    /// If the batch was deleted in the background.
     static let inBackgroundKey = "in_background"
+    /// If the background tasks were enabled.
+    static let backgroundTasksEnabled = "background_tasks_enabled"
 
     /// Allowed values for `batchRemovalReasonKey`.
     enum RemovalReason {

--- a/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/FeatureTests.swift
@@ -23,6 +23,7 @@ class FeatureStorageTests: XCTestCase {
             dateProvider: RelativeDateProvider(advancingBySeconds: 0.01),
             performance: .mockRandom(),
             encryption: nil,
+            backgroundTasksEnabled: .mockRandom(),
             telemetry: NOPTelemetry()
         )
         temporaryFeatureDirectories.create()

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -69,6 +69,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             ],
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "in_background": false,
+            "background_tasks_enabled": false,
             "batch_age": expectedBatchAge.toMilliseconds,
             "batch_removal_reason": "intake-code-202",
         ])
@@ -99,6 +100,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             ],
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "in_background": false,
+            "background_tasks_enabled": false,
             "batch_age": (storage.maxFileAgeForRead + 1).toMilliseconds,
             "batch_removal_reason": "obsolete",
         ])
@@ -132,6 +134,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             ],
             "uploader_window": storage.uploaderWindow.toMilliseconds,
             "in_background": false,
+            "background_tasks_enabled": false,
             "batch_age": expectedBatchAge.toMilliseconds,
             "batch_removal_reason": "purged",
         ])

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -38,7 +38,8 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
             metricsData: FilesOrchestrator.MetricsData(
                 trackName: "track name",
                 consentLabel: "consent value",
-                uploaderPerformance: upload
+                uploaderPerformance: upload,
+                backgroundTasksEnabled: .mockAny()
             )
         )
     }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -150,7 +150,12 @@ class FileWriterTests: XCTestCase {
                 ),
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry(),
-                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
+                metricsData: .init(
+                    trackName: "rum",
+                    consentLabel: .mockAny(),
+                    uploaderPerformance: UploadPerformanceMock.noOp,
+                    backgroundTasksEnabled: .mockAny()
+                )
             ),
             encryption: nil,
             telemetry: NOPTelemetry()
@@ -183,7 +188,12 @@ class FileWriterTests: XCTestCase {
                 performance: PerformancePreset.mockAny(),
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry(),
-                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
+                metricsData: .init(
+                    trackName: "rum",
+                    consentLabel: .mockAny(),
+                    uploaderPerformance: UploadPerformanceMock.noOp,
+                    backgroundTasksEnabled: .mockAny()
+                )
             ),
             encryption: nil,
             telemetry: NOPTelemetry()
@@ -205,7 +215,12 @@ class FileWriterTests: XCTestCase {
                 performance: PerformancePreset.mockAny(),
                 dateProvider: SystemDateProvider(),
                 telemetry: NOPTelemetry(),
-                metricsData: .init(trackName: "rum", consentLabel: .mockAny(), uploaderPerformance: UploadPerformanceMock.noOp)
+                metricsData: .init(
+                    trackName: "rum",
+                    consentLabel: .mockAny(),
+                    uploaderPerformance: UploadPerformanceMock.noOp,
+                    backgroundTasksEnabled: .mockAny()
+                )
             ),
             encryption: nil,
             telemetry: NOPTelemetry()

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -109,12 +109,13 @@ class TelemetryTests: XCTestCase {
 
     func testSendingConfigurationTelemetry() throws {
         // When
-        telemetry.configuration(batchSize: 123, batchUploadFrequency: 456) // only some values
+        telemetry.configuration(backgroundTasksEnabled: true, batchSize: 123, batchUploadFrequency: 456) // only some values
 
         // Then
         let configuration = try XCTUnwrap(telemetry.messages.firstConfiguration())
         XCTAssertEqual(configuration.batchSize, 123)
         XCTAssertEqual(configuration.batchUploadFrequency, 456)
+        XCTAssertEqual(configuration.backgroundTasksEnabled, true)
     }
 
     // MARK: - Metric Telemetry


### PR DESCRIPTION
### What and why?

Enriches `Batch Deleted` telemetry metric with `backgroundTaskEnabled` configuration info.
This is needed for measuring batch delivery success rate based on existence of the configuration.

### How?

I have added new field `background_tasks_enabled`.

`in_background` is still hardcoded to false, because knowing if the deletion happen in the background is not trivial.
Although I think we're mostly interested in measuring the difference is success rate for two different configurations, rather than knowing if batch file was deleted in background/foreground.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
