### PR TITLE
RUM-5841 feat(view-loading-api): introduce telemetry for the API and overwrite flag

### DIFF
--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -132,14 +132,14 @@ public struct UsageTelemetry: SampledTelemetry {
     /// The usage telemetry event.
     public let event: Event
 
-    /// The sample rate for this metric, applied in addition to the telemetry sample rate.
+    /// The sample rate for usage event, applied in addition to the telemetry sample rate.
     ///
     /// Must be a value between `0` (reject all) and `100` (keep all).
     ///
     /// Note: This sample rate is compounded with the telemetry sample rate. For example, if the telemetry sample rate is 20% (default)
-    /// and this metric's sample rate is 15%, the effective sample rate for this metric will be 3%.
+    /// and this event's sample rate is 15%, the effective sample rate for this event will be 3%.
     ///
-    /// This sample rate is applied in the telemetry receiver, after the metric has been processed by the SDK core (tail-based sampling).
+    /// This sample rate is applied in the telemetry receiver, after the event has been processed by the SDK core (tail-based sampling).
     public let sampleRate: Float
 
     public init(event: Event, sampleRate: Float = Self.defaultSampleRate) {

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -126,7 +126,7 @@ public struct UsageTelemetry: SampledTelemetry {
         }
     }
 
-    /// The default sample rate for metric events (15%), applied in addition to the telemetry sample rate (20% by default).
+    /// The default sample rate for usage telemetry events (15%), applied in addition to the telemetry sample rate (20% by default).
     public static let defaultSampleRate: Float = 15
 
     /// The usage telemetry event.

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -59,7 +59,13 @@ public struct ConfigurationTelemetry: Equatable {
     public let useWorkerUrl: Bool?
 }
 
-public struct MetricTelemetry {
+/// A telemetry event that can be sampled in addition to the global telemetry sample rate.
+public protocol SampledTelemetry {
+    /// The sample rate for this metric, applied in addition to the telemetry sample rate.
+    var sampleRate: Float { get }
+}
+
+public struct MetricTelemetry: SampledTelemetry {
     /// The default sample rate for metric events (15%), applied in addition to the telemetry sample rate (20% by default).
     public static let defaultSampleRate: Float = 15
 
@@ -81,34 +87,64 @@ public struct MetricTelemetry {
 }
 
 /// Describes the type of the usage telemetry events supported by the SDK.
-public enum UsageTelemetry {
-    /// setTrackingConsent API
-    case setTrackingConsent(TrackingConsent)
-    /// stopSession API
-    case stopSession
-    /// startView API
-    case startView
-    /// addAction API
-    case addAction
-    /// addError API
-    case addError
-    /// setGlobalContext, setGlobalContextProperty, addAttribute APIs
-    case setGlobalContext
-    /// setUser, setUserProperty, setUserInfo APIs
-    case setUser
-    /// addFeatureFlagEvaluation API
-    case addFeatureFlagEvaluation
-    /// addFeatureFlagEvaluation API
-    case addViewLoadingTime(ViewLoadingTime)
+public struct UsageTelemetry: SampledTelemetry {
+    /// Supported usage telemetry events.
+    public enum Event {
+        /// setTrackingConsent API
+        case setTrackingConsent(TrackingConsent)
+        /// stopSession API
+        case stopSession
+        /// startView API
+        case startView
+        /// addAction API
+        case addAction
+        /// addError API
+        case addError
+        /// setGlobalContext, setGlobalContextProperty, addAttribute APIs
+        case setGlobalContext
+        /// setUser, setUserProperty, setUserInfo APIs
+        case setUser
+        /// addFeatureFlagEvaluation API
+        case addFeatureFlagEvaluation
+        /// addFeatureFlagEvaluation API
+        case addViewLoadingTime(ViewLoadingTime)
 
-    /// Describes the properties of `addViewLoadingTime` usage telemetry.
-    public struct ViewLoadingTime {
-        /// Whether the available view is not active
-        public let noActiveView: Bool
-        /// Whether the view is not available
-        public let noView: Bool
-        /// Whether the loading time was overwritten
-        public let overwritten: Bool
+        /// Describes the properties of `addViewLoadingTime` usage telemetry.
+        public struct ViewLoadingTime {
+            /// Whether the available view is not active
+            public let noActiveView: Bool
+            /// Whether the view is not available
+            public let noView: Bool
+            /// Whether the loading time was overwritten
+            public let overwritten: Bool
+
+            public init(noActiveView: Bool, noView: Bool, overwritten: Bool) {
+                self.noActiveView = noActiveView
+                self.noView = noView
+                self.overwritten = overwritten
+            }
+        }
+    }
+
+    /// The default sample rate for metric events (15%), applied in addition to the telemetry sample rate (20% by default).
+    public static let defaultSampleRate: Float = 15
+
+    /// The usage telemetry event.
+    public let event: Event
+
+    /// The sample rate for this metric, applied in addition to the telemetry sample rate.
+    ///
+    /// Must be a value between `0` (reject all) and `100` (keep all).
+    ///
+    /// Note: This sample rate is compounded with the telemetry sample rate. For example, if the telemetry sample rate is 20% (default)
+    /// and this metric's sample rate is 15%, the effective sample rate for this metric will be 3%.
+    ///
+    /// This sample rate is applied in the telemetry receiver, after the metric has been processed by the SDK core (tail-based sampling).
+    public let sampleRate: Float
+
+    public init(event: Event, sampleRate: Float = Self.defaultSampleRate) {
+        self.event = event
+        self.sampleRate = sampleRate
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -275,11 +275,12 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
-    func addViewLoadingTime() {
+    func addViewLoadingTime(overwrite: Bool) {
         process(
             command: RUMAddViewLoadingTime(
                 time: dateProvider.now,
-                attributes: [:]
+                attributes: [:],
+                overwrite: overwrite
             )
         )
     }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -272,6 +272,7 @@ internal struct RUMAddViewLoadingTime: RUMCommand, RUMViewScopePropagatableAttri
     let isUserInteraction = false // a custom view timing is not an interactive event
 
     let missedEventType: SessionEndedMetric.MissedEventType? = .viewLoadingTime
+    let overwrite: Bool
 }
 
 internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAttributes {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -228,9 +228,14 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = nil
         }
 
-        if let command = command as? RUMAddViewLoadingTime, viewScopes.isEmpty {
-            DD.logger.warn("No active view found to add the loading time")
-            dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: true, overwritten: command.overwrite)))))
+        if let command = command as? RUMAddViewLoadingTime {
+            if viewScopes.isEmpty {
+                DD.logger.warn("No view found to add the loading time.")
+                dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: true, overwritten: command.overwrite)))))
+            } else if !hasActiveView {
+                DD.logger.warn("No active view found to add the loading time.")
+                dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: true, noView: false, overwritten: command.overwrite)))))
+            }
         }
 
         return isActive || !viewScopes.isEmpty

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -228,6 +228,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = nil
         }
 
+        if let command = command as? RUMAddViewLoadingTime, viewScopes.isEmpty {
+            DD.logger.warn("No active view found to add the loading time")
+            dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: true, overwritten: command.overwrite)))))
+        }
+
         return isActive || !viewScopes.isEmpty
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -200,9 +200,25 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMStopViewCommand where identity == command.identity:
             isActiveView = false
             needsViewUpdate = true
-        case let command as RUMAddViewLoadingTime where isActiveView:
-            viewLoadingTime = command.time.timeIntervalSince(viewStartTime)
-            needsViewUpdate = true
+        case let command as RUMAddViewLoadingTime:
+            if isActiveView {
+                if viewLoadingTime == nil {
+                    let time = command.time.timeIntervalSince(viewStartTime)
+                    viewLoadingTime = time
+                    needsViewUpdate = true
+                    DD.logger.debug("View loading time \(time)ns added to the view \(viewName)")
+                    dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: false)))))
+                } else if command.overwrite {
+                    let time = command.time.timeIntervalSince(viewStartTime)
+                    viewLoadingTime = time
+                    needsViewUpdate = true
+                    DD.logger.warn("View loading time already exists for the view \(viewName). Replacing the existing \(String(describing: viewLoadingTime))ns with the new \(time)ns loading time.")
+                    dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: true)))))
+                }
+            } else {
+                DD.logger.warn("View \(viewName) is not active. Skipping adding the loading time.")
+                dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: true, noView: false, overwritten: command.overwrite)))))
+            }
         case let command as RUMAddViewTimingCommand where isActiveView:
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -113,8 +113,9 @@ public protocol RUMMonitorProtocol: AnyObject {
     /// This method should be called only once per view.
     /// If the view is not started, this method does nothing.
     /// If the view is not active, this method does nothing.
+    /// - Parameter overwrite: if true, overwrites the previosuly calculated view loading time.
     @_spi(Experimental)
-    func addViewLoadingTime()
+    func addViewLoadingTime(overwrite: Bool)
 
     // MARK: - custom timings
 
@@ -327,7 +328,7 @@ public protocol RUMMonitorProtocol: AnyObject {
 
 extension RUMMonitorProtocol {
     /// It cannot be declared '@_spi' without a default implementation in a protocol extension
-    func addViewLoadingTime() {
+    func addViewLoadingTime(overwrite: Bool) {
         // no-op
     }
 }
@@ -352,7 +353,7 @@ internal class NOPMonitor: RUMMonitorProtocol {
     func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) { warn() }
     func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func stopView(key: String, attributes: [AttributeKey: AttributeValue]) { warn() }
-    func addViewLoadingTime() { warn() }
+    func addViewLoadingTime(overwrite: Bool) { warn() }
     func addTiming(name: String) { warn() }
     func addError(message: String, type: String?, stack: String?, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?) { warn() }
     func addError(error: Error, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]) { warn() }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -493,7 +493,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.startView(key: "ActiveView")
 
         // When
-        monitor.addViewLoadingTime()
+        monitor.addViewLoadingTime(overwrite: false)
 
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
@@ -510,7 +510,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.stopView(key: "InactiveView")
 
         // When
-        monitor.addViewLoadingTime()
+        monitor.addViewLoadingTime(overwrite: false)
 
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "InactiveView" }
@@ -523,7 +523,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.startView(key: "ActiveView")
 
         // When
-        monitor.addViewLoadingTime()
+        monitor.addViewLoadingTime(overwrite: false)
 
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
@@ -535,7 +535,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         let old = lastView.view.loadingTime!
 
         // When
-        monitor.addViewLoadingTime()
+        monitor.addViewLoadingTime(overwrite: false)
 
         // Then
         let viewEvents2 = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
@@ -544,7 +544,19 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertNotNil(lastView2.view.loadingTime)
         XCTAssertTrue(lastView2.view.loadingTime! > 0)
 
-        XCTAssertTrue(lastView2.view.loadingTime! > old)
+        XCTAssertEqual(lastView2.view.loadingTime!, old)
+
+        // When
+        monitor.addViewLoadingTime(overwrite: true)
+
+        // Then
+        let viewEvents3 = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
+        let lastView3 = try XCTUnwrap(viewEvents3.last)
+
+        XCTAssertNotNil(lastView3.view.loadingTime)
+        XCTAssertTrue(lastView3.view.loadingTime! > 0)
+
+        XCTAssertTrue(lastView3.view.loadingTime! > old)
     }
 
     // MARK: - Updating Fatal Error Context With Global Attributes


### PR DESCRIPTION
### What and why?

https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3951001790/RFC+View+loading+time+manual+API

### How?


- Integration of the telemetry events
  - happy path
  - when there is overwrite
  - when there the current view is not active
  - when there is no view scope
- `overwrite` argument to the API

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
