### PR TITLE
RUM-5757 benchmark: Collect Session Replay Record Spans

### DIFF
--- a/BenchmarkTests/Runner/BenchmarkProfiler.swift
+++ b/BenchmarkTests/Runner/BenchmarkProfiler.swift
@@ -5,22 +5,50 @@
  */
 
 import Foundation
-
 import DatadogInternal
 import DatadogBenchmarks
+import OpenTelemetryApi
+import OpenTelemetrySdk
 
 internal final class Profiler: DatadogInternal.BenchmarkProfiler {
+    let opentelemetry: OpenTelemetry
+
+    init(opentelemetry: OpenTelemetry = .instance) {
+        self.opentelemetry = opentelemetry
+    }
+
     func tracer(operation: @autoclosure () -> String) -> any DatadogInternal.BenchmarkTracer {
-        DummyTracer()
+        TracerWrapper(
+            tracer: opentelemetry.tracerProvider.get(instrumentationName: operation(), instrumentationVersion: nil)
+        )
     }
 }
 
-internal final class DummyTracer: DatadogInternal.BenchmarkTracer {
+private final class TracerWrapper: DatadogInternal.BenchmarkTracer {
+    let tracer: OpenTelemetryApi.Tracer
+
+    init(tracer: OpenTelemetryApi.Tracer) {
+        self.tracer = tracer
+    }
+
     func startSpan(named: @autoclosure () -> String) -> any DatadogInternal.BenchmarkSpan {
-        DummySpan()
+        SpanWrapper(
+            span: tracer
+                .spanBuilder(spanName: named())
+                .setActive(true)
+                .startSpan()
+        )
     }
 }
 
-internal final class DummySpan: DatadogInternal.BenchmarkSpan {
-    func stop() { }
+private final class SpanWrapper: DatadogInternal.BenchmarkSpan {
+    let span: OpenTelemetryApi.Span
+
+    init(span: OpenTelemetryApi.Span) {
+        self.span = span
+    }
+
+    func stop() {
+        span.end()
+    }
 }

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -61,3 +61,11 @@ private final class NOPBenchmarkProfiler: BenchmarkProfiler, BenchmarkTracer, Be
     /// no-op
     func stop() {}
 }
+
+public final class NOPBenchmarkTracer: BenchmarkTracer, BenchmarkSpan {
+    public init() {}
+    /// no-op
+    public func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan { self }
+    /// no-op
+    public func stop() {}
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -28,6 +28,9 @@ internal struct ViewTreeRecorder {
         view: UIView,
         context: ViewTreeRecordingContext
     ) {
+        let span = context.benchmarkTracer.startSpan(named: "<UIView>")
+        defer { span.stop() }
+
         var context = context
         if let viewController = view.next as? UIViewController {
             context.viewControllerContext.parentType = .init(viewController)
@@ -61,6 +64,9 @@ internal struct ViewTreeRecorder {
         var semantics: NodeSemantics = UnknownElement.constant
 
         for nodeRecorder in nodeRecorders {
+            let span = context.benchmarkTracer.startSpan(named: String(describing: type(of: nodeRecorder)))
+            defer { span.stop() }
+
             guard let nextSemantics = nodeRecorder.semantics(of: view, with: attributes, in: context) else {
                 continue
             }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -9,6 +9,7 @@ import Foundation
 import SafariServices
 import SwiftUI
 import WebKit
+import DatadogInternal
 
 /// The context of recording subtree hierarchy.
 ///
@@ -25,6 +26,8 @@ public struct SessionReplayViewTreeRecordingContext {
     var viewControllerContext: ViewControllerContext = .init()
     /// Webviews caching.
     let webViewCache: NSHashTable<WKWebView>
+
+    let benchmarkTracer: BenchmarkTracer
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -10,6 +10,7 @@ import XCTest
 import UIKit
 import WebKit
 
+import DatadogInternal
 @_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
@@ -337,7 +338,8 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
             recorder: .mockRandom(),
             coordinateSpace: UIView.mockRandom(),
             ids: NodeIDGenerator(),
-            webViewCache: .weakObjects()
+            webViewCache: .weakObjects(),
+            benchmarkTracer: NOPBenchmarkTracer()
         )
     }
 
@@ -351,7 +353,8 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
             recorder: recorder,
             coordinateSpace: coordinateSpace,
             ids: ids,
-            webViewCache: webViewCache
+            webViewCache: webViewCache,
+            benchmarkTracer: NOPBenchmarkTracer()
         )
     }
 }


### PR DESCRIPTION
### What and why?

Do not merge: Tracer perfs skew the measures

Collection traces of the recording phase of Session Replay.

### How?

- Create an OpenTelemetry tracer
- Inject the tracer in the SDK
- Start/Stop spans of recorders.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
