### PR TITLE
chore: Increase delay in publish "legacy" podspecs job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,11 +57,17 @@ default:
   rules: 
     - if: '$CI_COMMIT_TAG || $RELEASE_GIT_TAG'
 
-.release-pipeline-delayed-job:
+.release-pipeline-20m-delayed-job:
   rules: 
     - if: '$CI_COMMIT_TAG || $RELEASE_GIT_TAG'
       when: delayed
       start_in: 20 minutes
+
+.release-pipeline-40m-delayed-job:
+  rules: 
+    - if: '$CI_COMMIT_TAG || $RELEASE_GIT_TAG'
+      when: delayed
+      start_in: 40 minutes
 
 ENV check:
   stage: pre
@@ -375,7 +381,7 @@ Publish CP podspecs (internal):
 Publish CP podspecs (dependent):
   stage: release-publish
   rules: 
-    - !reference [.release-pipeline-delayed-job, rules]
+    - !reference [.release-pipeline-20m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
   script:
@@ -387,7 +393,7 @@ Publish CP podspecs (dependent):
 Publish CP podspecs (legacy):
   stage: release-publish
   rules: 
-    - !reference [.release-pipeline-delayed-job, rules]
+    - !reference [.release-pipeline-40m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
   script:


### PR DESCRIPTION
### What does this PR do?

🧰 This PR adds an additional 20-minute delay to the "Publish CP podspecs (legacy)" release job. The extra time ensures that "internal" and "dependent" podspecs, published earlier, are  available, reducing the need for manual job restart.

This delay should have been included in [PR #1945](https://github.com/DataDog/dd-sdk-ios/pull/1945) but was missed due to an oversight.

### How?

The job configuration was updated to include the extended delay.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
