### PR TITLE
RUM-5650 chore: Refine Smoke Tests and add Swift 5.9 coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,71 +187,42 @@ Smoke Tests (iOS):
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:ventura
-    - specific:true
   variables:
-    XCODE: "15.2.0"
-    OS: "17.2"
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 15 Pro"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --os "$OS" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
     - make clean repo-setup ENV=ci
-    - make spm-build-ios
-    - make smoke-test-ios-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+    - make smoke-test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
 
 Smoke Tests (tvOS):
   stage: smoke-test
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:ventura
-    - specific:true
   variables:
-    XCODE: "15.2.0"
-    OS: "17.2"
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --tvOS --os "$OS" --ssh # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
     - make clean repo-setup ENV=ci
+    - make smoke-test-tvos-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+
+SPM Build (Swift 5.10):
+  stage: smoke-test
+  rules: 
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
+  script:
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --iOS --tvOS --visionOS --watchOS
+    - make clean repo-setup ENV=ci
+    - make spm-build-ios
     - make spm-build-tvos
-    - make smoke-test-tvos-all OS="$OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
-    
-Smoke Tests (visionOS):
-  stage: smoke-test
-  rules: 
-    - !reference [.test-pipeline-job, rules]
-    - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:ventura
-    - specific:true
-  variables:
-    XCODE: "15.2.0"
-    OS: "1.0"
-  script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --visionOS --os "$OS" # temporary, waiting for AMI
-    - make clean repo-setup ENV=ci
     - make spm-build-visionos
-
-Smoke Tests (macOS):
-  stage: smoke-test
-  rules: 
-    - !reference [.test-pipeline-job, rules]
-    - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:ventura
-    - specific:true
-  variables:
-    XCODE: "15.2.0"
-  script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" # temporary, waiting for AMI
-    - make clean repo-setup ENV=ci
     - make spm-build-macos
+    - make spm-build-watchos
 
-Smoke Tests (watchOS):
+SPM Build (Swift 5.9):
   stage: smoke-test
   rules: 
     - !reference [.test-pipeline-job, rules]
@@ -261,10 +232,13 @@ Smoke Tests (watchOS):
     - specific:true
   variables:
     XCODE: "15.2.0"
-    OS: "10.2"
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --watchOS --os "$OS" # temporary, waiting for AMI
+    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --visionOS --watchOS
     - make clean repo-setup ENV=ci
+    - make spm-build-ios
+    - make spm-build-tvos
+    - make spm-build-visionos
+    - make spm-build-macos
     - make spm-build-watchos
 
 # ┌──────────────────────┐

--- a/tools/runner-setup.sh
+++ b/tools/runner-setup.sh
@@ -2,32 +2,30 @@
 
 # Usage:
 # $ ./tools/runner-setup.sh -h
-# This script is for TEMPORARY. It supplements missing components on the runner. It will be removed once all configurations are integrated into the AMI.
+# This script supplements missing components on the runner before they are included through the AMI.
 
 # Options:
-#   --xcode: Sets the Xcode version on the runner.
-#   --iOS: Flag that prepares the runner instance for iOS testing. Disabled by default.
-#   --tvOS: Flag that prepares the runner instance for tvOS testing. Disabled by default.
-#   --visionOS: Flag that prepares the runner instance for visionOS testing. Disabled by default.
-#   --watchOS: Flag that prepares the runner instance for watchOS testing. Disabled by default.
-#   --os: Sets the expected OS version for installed simulators when --iOS, --tvOS, --visionOS or --watchOS flag is set. Default: '17.4'.
-#   --ssh: Flag that adds ssh configuration for interacting with GitHub repositories. Disabled by default.
-#   --datadog-ci: Flag that installs 'datadog-ci' on the runner. Disabled by default.
+#   --xcode: Specify the Xcode version to activate.
+#   --iOS: Install the iOS platform with the latest simulator if not already installed. Default: disabled.
+#   --tvOS: Install the tvOS platform with the latest simulator if not already installed. Default: disabled.
+#   --visionOS: Install the visionOS platform with the latest simulator if not already installed. Default: disabled.
+#   --watchOS: Install the watchOS platform with the latest simulator if not already installed. Default: disabled.
+#   --ssh: Configure SSH for GitHub repository access. Default: disabled.
+#   --datadog-ci: Install 'datadog-ci' on the runner. Default: disabled.
 
 set -eo pipefail
 source ./tools/utils/echo-color.sh
 source ./tools/utils/argparse.sh
 source ./tools/secrets/get-secret.sh
 
-set_description "This script is for TEMPORARY. It supplements missing components on the runner. It will be removed once all configurations are integrated into the AMI."
-define_arg "xcode" "" "Sets the Xcode version on the runner." "string" "false"
-define_arg "iOS" "false" "Flag that prepares the runner instance for iOS testing. Disabled by default." "store_true"
-define_arg "tvOS" "false" "Flag that prepares the runner instance for tvOS testing. Disabled by default." "store_true"
-define_arg "visionOS" "false" "Flag that prepares the runner instance for visionOS testing. Disabled by default." "store_true"
-define_arg "watchOS" "false" "Flag that prepares the runner instance for watchOS testing. Disabled by default." "store_true"
-define_arg "os" "17.4" "Sets the expected OS version for installed simulators when --iOS, --tvOS, --visionOS or --watchOS flag is set. Default: '17.4'." "string" "false"
-define_arg "ssh" "false" "Flag that adds ssh configuration for interacting with GitHub repositories. Disabled by default." "store_true"
-define_arg "datadog-ci" "false" "Flag that installs 'datadog-ci' on the runner. Disabled by default." "store_true"
+set_description "This script supplements missing components on the runner before they are included through the AMI."
+define_arg "xcode" "" "Specify the Xcode version to activate." "string" "false"
+define_arg "iOS" "false" "Install the iOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
+define_arg "tvOS" "false" "Install the tvOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
+define_arg "visionOS" "false" "Install the visionOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
+define_arg "watchOS" "false" "Install the watchOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
+define_arg "ssh" "false" "Configure SSH for GitHub repository access. Default: disabled." "store_true"
+define_arg "datadog-ci" "false" "Install 'datadog-ci' on the runner. Default: disabled." "store_true"
 
 check_for_help "$@"
 parse_args "$@"
@@ -79,47 +77,27 @@ echo_succ "Using 'xcodebuild -version':"
 xcodebuild -version
 
 if [ "$iOS" = "true" ]; then
-    echo_subtitle "Supply iPhone Simulator runtime ($os)"
-    echo "Check current runner for any iPhone Simulator runtime supporting OS '$os':"
-    if ! xctrace list devices | grep "iPhone.*Simulator ($os)"; then
-        echo_warn "Found no iOS Simulator runtime supporting OS '$os'. Installing..."
-        xcodebuild -downloadPlatform iOS -quiet | xcbeautify
-    else
-        echo_succ "Found some iOS Simulator runtime supporting OS '$os'. Skipping..."
-    fi
+    echo_subtitle "Install iOS platform"
+    echo "▸ xcodebuild -downloadPlatform iOS -quiet"
+    xcodebuild -downloadPlatform iOS -quiet
 fi
 
 if [ "$tvOS" = "true" ]; then
-    echo_subtitle "Supply tvOS Simulator runtime ($os)"
-    echo "Check current runner for any tvOS Simulator runtime supporting OS '$os':"
-    if ! xctrace list devices | grep "Apple TV.*Simulator ($os)"; then
-        echo_warn "Found no tvOS Simulator runtime supporting OS '$os'. Installing..."
-        xcodebuild -downloadPlatform tvOS -quiet | xcbeautify
-    else
-        echo_succ "Found some tvOS Simulator runtime supporting OS '$os'. Skipping..."
-    fi
+    echo_subtitle "Install tvOS platform"
+    echo "▸ xcodebuild -downloadPlatform tvOS -quiet"
+    xcodebuild -downloadPlatform tvOS -quiet
 fi
 
 if [ "$visionOS" = "true" ]; then
-    echo_subtitle "Supply visionOS Simulator runtime ($os)"
-    echo "Check current runner for any visionOS Simulator runtime supporting OS '$os':"
-    if ! xctrace list devices | grep "Apple Vision.*($os)"; then
-        echo_warn "Found no visionOS Simulator runtime supporting OS '$os'. Installing..."
-        xcodebuild -downloadPlatform visionOS -quiet | xcbeautify
-    else
-        echo_succ "Found some visionOS Simulator runtime supporting OS '$os'. Skipping..."
-    fi
+    echo_subtitle "Install visionOS platform"
+    echo "▸ xcodebuild -downloadPlatform visionOS -quiet"
+    xcodebuild -downloadPlatform visionOS -quiet
 fi
 
 if [ "$watchOS" = "true" ]; then
-    echo_subtitle "Supply watchOS Simulator runtime ($os)"
-    echo "Check current runner for any watchOS Simulator runtime supporting OS '$os':"
-    if ! xctrace list devices | grep "Apple Watch.*Simulator ($os)"; then
-        echo_warn "Found no watchOS Simulator runtime supporting OS '$os'. Installing..."
-        xcodebuild -downloadPlatform watchOS -quiet | xcbeautify
-    else
-        echo_succ "Found some watchOS Simulator runtime supporting OS '$os'. Skipping..."
-    fi
+    echo_subtitle "Install watchOS platform"
+    echo "▸ xcodebuild -downloadPlatform watchOS -quiet"
+    xcodebuild -downloadPlatform watchOS -quiet
 fi
 
 if [ "$ssh" = "true" ]; then


### PR DESCRIPTION
### What and why?

📦 This PR reorganizes and improves the coverage of smoke tests for our iOS SDK. It now includes coverage for all supported Swift versions while maintaining compatibility with various dependency managers.

### How?

The `smoke-test` stage has been streamlined to 4 key jobs:

<img width="318" alt="Screenshot 2024-09-13 at 11 50 12" src="https://github.com/user-attachments/assets/4a3a6fdd-9374-42e9-b241-313fbd66c5a8">

- **Smoke Test (iOS)** and **Smoke Test (tvOS)**: These jobs test SDK integration through CocoaPods, Carthage, Xcode's SPM, and XCFrameworks. They run on a `macos:sonoma` runner with Xcode 15.4.
  
- **SPM Build (Swift 5.9)**: This job builds `Package.swift` for each supported platform using the `macos:ventura` runner with Xcode 15.2.
  
- **SPM Build (Swift 5.10)**: Similar to the above, but for Swift 5.10 using the `macos:sonoma` runner with Xcode 15.4.

The two "SPM Build" jobs now fully mirror [SDK builds in Swift Package Index](https://swiftpackageindex.com/DataDog/dd-sdk-ios/builds).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
