### PR TITLE
chore: Add "Sync GH Checks" utility job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
   - dogfood
   - release-build
   - release-publish
+  - post
 
 variables:
   MAIN_BRANCH: "master"
@@ -401,3 +402,14 @@ Publish CP podspecs (legacy):
     - make env-check
     - make clean
     - make release-publish-legacy-podspecs
+
+# ┌────────────────┐
+# │ Notifications: │
+# └────────────────┘
+
+# This job runs at the end of every successful pipeline.
+# It syncs the GitLab pipeline status with GitHub status checks.
+Sync GH Checks:
+  stage: post
+  script:
+    - echo "All good"


### PR DESCRIPTION
### What and why?

📦 This PR adds utility job a the end of every CI pipeline. It will be listed in "status checks" required for PR to be merged.

### How?

After this is merged, this job should be listed as the only job in:

<img width="50%" alt="Screenshot 2024-09-13 at 16 29 02" src="https://github.com/user-attachments/assets/6f50c0fb-6380-4cc8-87bb-92db49969c1b">

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
