### PR TITLE
RUM-3175 fix: Fix race condition during consent change (pending → granted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FIX] Fix race condition during consent change, preventing loss of events recorded on the current thread. See [#2063][]
 - [IMPROVEMENT] Support mutation of events' attributes. See [#2099][]
 
 # 2.19.0 / 28-10-2024
@@ -786,6 +787,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2088]: https://github.com/DataDog/dd-sdk-ios/pull/2088
 [#2083]: https://github.com/DataDog/dd-sdk-ios/pull/2083
 [#2099]: https://github.com/DataDog/dd-sdk-ios/pull/2099
+[#2063]: https://github.com/DataDog/dd-sdk-ios/pull/2063
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/UploadMock.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DatadogInternal/UploadMock.swift
@@ -29,8 +29,13 @@ internal class FeatureRequestBuilderMock: FeatureRequestBuilder {
 }
 
 internal class FeatureRequestBuilderSpy: FeatureRequestBuilder {
-    /// Records parameters passed to `requet(for:with:)`
+    /// Stores the parameters passed to the `request(for:with:)` method.
+    @ReadWriteLock
     private(set) var requestParameters: [(events: [Event], context: DatadogContext)] = []
+
+    /// A closure that is called when a request is about to be created in the `request(for:with:)` method.
+    @ReadWriteLock
+    var onRequest: ((_ events: [Event], _ context: DatadogContext) -> Void)?
 
     func request(
         for events: [Event],
@@ -38,6 +43,7 @@ internal class FeatureRequestBuilderSpy: FeatureRequestBuilder {
         execution: ExecutionContext
     ) throws -> URLRequest {
         requestParameters.append((events: events, context: context))
+        onRequest?(events, context)
         return .mockAny()
     }
 }


### PR DESCRIPTION
### What and why?

📦🐞 This PR fixes a race condition that occurs during the change of tracking consent from `.pending` to `.granted`. This issue could result in the loss of events recorded on the current thread right before the consent change. 

### How?

The fix involves synchronizing data migration on the context queue to prevent conflicts with ongoing "event write" operations. This change guarantees that all latest events are accurately migrated based on the updated consent state.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
