### PR TITLE
RUM-6223 Implement Hidden Override logic

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -13,6 +13,7 @@
 
 @implementation DDSessionReplay_apiTests
 
+// MARK: Configuration
 - (void)testConfiguration {
     DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100];
     configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
@@ -31,4 +32,48 @@
     [DDSessionReplay enableWith:configuration];
 }
 
+// MARK: Overrides
+- (void)testSettingAndGettingOverrides {
+    // Given
+    UIView *view = [[UIView alloc] init];
+    DDSessionReplayOverride *override = [[DDSessionReplayOverride alloc] init];
+
+    // When
+    view.ddSessionReplayOverride = override;
+    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
+    view.ddSessionReplayOverride.hide = @YES;
+
+    // Then
+    XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideMaskAll);
+    XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, DDImagePrivacyLevelOverrideMaskAll);
+    XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, DDTouchPrivacyLevelOverrideHide);
+    XCTAssertTrue(view.ddSessionReplayOverride.hide.boolValue);
+}
+
+- (void)testClearingOverride {
+    // Given
+    UIView *view = [[UIView alloc] init];
+    DDSessionReplayOverride *override = [[DDSessionReplayOverride alloc] init];
+
+    // Set initial values
+    view.ddSessionReplayOverride = override;
+    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
+    view.ddSessionReplayOverride.hide = @YES;
+
+    // When
+    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideNone;
+    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideNone;
+    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideNone;
+    view.ddSessionReplayOverride.hide = nil;
+
+    // Then
+    XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideNone);
+    XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, DDImagePrivacyLevelOverrideNone);
+    XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, DDTouchPrivacyLevelOverrideNone);
+    XCTAssertNil(view.ddSessionReplayOverride.hide);
+}
 @end

--- a/DatadogSessionReplay/Sources/PrivacyLevel+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/PrivacyLevel+SessionReplay.swift
@@ -67,7 +67,7 @@ public final class SessionReplayOverrideExtension {
     }
 
     /// Hidden privacy override (e.g., mark a view as hidden, rendering it as an opaque wireframe in replays).
-    public var hidden: Bool? {
+    public var hide: Bool? {
         get {
             return objc_getAssociatedObject(view, &associatedHiddenPrivacyKey) as? Bool
         }
@@ -83,7 +83,7 @@ extension SessionReplayOverrideExtension: Equatable {
         && lhs.textAndInputPrivacy == rhs.textAndInputPrivacy
         && lhs.imagePrivacy == rhs.imagePrivacy
         && lhs.touchPrivacy == rhs.touchPrivacy
-        && lhs.hidden == rhs.hidden
+        && lhs.hide == rhs.hide
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/PrivacyLevel+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/PrivacyLevel+SessionReplay.swift
@@ -39,41 +39,51 @@ public final class SessionReplayOverrideExtension {
     /// Text and input privacy override (e.g., mask or unmask specific text fields, labels, etc.).
     public var textAndInputPrivacy: TextAndInputPrivacyLevel? {
         get {
-            return objc_getAssociatedObject(view as AnyObject, &associatedTextAndInputPrivacyKey) as? TextAndInputPrivacyLevel
+            return objc_getAssociatedObject(view, &associatedTextAndInputPrivacyKey) as? TextAndInputPrivacyLevel
         }
         set {
-            objc_setAssociatedObject(view as AnyObject, &associatedTextAndInputPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+            objc_setAssociatedObject(view, &associatedTextAndInputPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         }
     }
 
     /// Image privacy override (e.g., mask or unmask specific images).
     public var imagePrivacy: ImagePrivacyLevel? {
         get {
-            return objc_getAssociatedObject(view as AnyObject, &associatedImagePrivacyKey) as? ImagePrivacyLevel
+            return objc_getAssociatedObject(view, &associatedImagePrivacyKey) as? ImagePrivacyLevel
         }
         set {
-            objc_setAssociatedObject(view as AnyObject, &associatedImagePrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+            objc_setAssociatedObject(view, &associatedImagePrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         }
     }
 
     /// Touch privacy override (e.g., hide or show touch interactions on specific views).
     public var touchPrivacy: TouchPrivacyLevel? {
         get {
-            return objc_getAssociatedObject(view as AnyObject, &associatedTouchPrivacyKey) as? TouchPrivacyLevel
+            return objc_getAssociatedObject(view, &associatedTouchPrivacyKey) as? TouchPrivacyLevel
         }
         set {
-            objc_setAssociatedObject(view as AnyObject, &associatedTouchPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+            objc_setAssociatedObject(view, &associatedTouchPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         }
     }
 
     /// Hidden privacy override (e.g., mark a view as hidden, rendering it as an opaque wireframe in replays).
-    public var hiddenPrivacy: Bool? {
+    public var hidden: Bool? {
         get {
-            return objc_getAssociatedObject(view as AnyObject, &associatedHiddenPrivacyKey) as? Bool
+            return objc_getAssociatedObject(view, &associatedHiddenPrivacyKey) as? Bool
         }
         set {
-            objc_setAssociatedObject(view as AnyObject, &associatedHiddenPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+            objc_setAssociatedObject(view, &associatedHiddenPrivacyKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         }
+    }
+}
+
+extension SessionReplayOverrideExtension: Equatable {
+    public static func == (lhs: SessionReplayOverrideExtension, rhs: SessionReplayOverrideExtension) -> Bool {
+        return lhs.view === rhs.view
+        && lhs.textAndInputPrivacy == rhs.textAndInputPrivacy
+        && lhs.imagePrivacy == rhs.imagePrivacy
+        && lhs.touchPrivacy == rhs.touchPrivacy
+        && lhs.hidden == rhs.hidden
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -41,6 +41,15 @@ internal class UIViewRecorder: NodeRecorder {
             return semantics
         }
 
+        if attributes.sessionReplayOverride?.hidden == true {
+            let builder = UIViewWireframesBuilder(
+                wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
+                attributes: attributes
+            )
+            let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+            return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
+        }
+
         guard attributes.hasAnyAppearance else {
             // The view has no appearance, but it may contain subviews that bring visual elements, so
             // we use `InvisibleElement` semantics (to drop it) with `.record` strategy for its subview.
@@ -66,6 +75,11 @@ internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
     }
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        if attributes.sessionReplayOverride?.hidden == true {
+            return [
+                builder.createPlaceholderWireframe(id: wireframeID, frame: wireframeRect, label: "Hidden")
+            ]
+        }
         return [
             builder.createShapeWireframe(id: wireframeID, frame: wireframeRect, attributes: attributes)
         ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -41,7 +41,7 @@ internal class UIViewRecorder: NodeRecorder {
             return semantics
         }
 
-        if attributes.sessionReplayOverride?.hidden == true {
+        if attributes.sessionReplayOverride?.hide == true {
             let builder = UIViewWireframesBuilder(
                 wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
                 attributes: attributes
@@ -75,7 +75,7 @@ internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
     }
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
-        if attributes.sessionReplayOverride?.hidden == true {
+        if attributes.sessionReplayOverride?.hide == true {
             return [
                 builder.createPlaceholderWireframe(id: wireframeID, frame: wireframeRect, label: "Hidden")
             ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -123,6 +123,9 @@ public struct SessionReplayViewAttributes: Equatable {
     /// Example 1: A view with blue background of alpha `0.5` is considered "translucent".
     /// Example 2: A view with blue semi-transparent background, but alpha `1` is also conisdered "translucent".
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
+
+    /// If the view has privacy overrides, which take precedence over global masking privacy levels.
+    var sessionReplayOverride: SessionReplayOverrideExtension?
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
@@ -138,6 +141,7 @@ extension ViewAttributes {
         self.alpha = view.alpha
         self.isHidden = view.isHidden
         self.intrinsicContentSize = view.intrinsicContentSize
+        self.sessionReplayOverride = view.dd.sessionReplayOverride
     }
 }
 

--- a/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
@@ -9,6 +9,27 @@ import Foundation
 import DatadogInternal
 import UIKit
 
+private var associatedSROverrideKey: UInt8 = 0
+
+/// Objective-C accessible extension for UIView
+@objc
+public extension UIView {
+    @objc var ddSessionReplayOverride: DDSessionReplayOverride {
+        get {
+            if let override = objc_getAssociatedObject(self, &associatedSROverrideKey) as? DDSessionReplayOverride {
+                return override
+            } else {
+                let override = DDSessionReplayOverride()
+                objc_setAssociatedObject(self, &associatedSROverrideKey, override, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                return override
+            }
+        }
+        set {
+            objc_setAssociatedObject(self, &associatedSROverrideKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+}
+
 /// A wrapper class for Objective-C compatibility, providing overrides for Session Replay privacy settings.
 @objc
 public final class DDSessionReplayOverride: NSObject {
@@ -40,18 +61,18 @@ public final class DDSessionReplayOverride: NSObject {
     }
 
     /// Hidden privacy override (e.g., mark a view as hidden, rendering it as an opaque wireframe in replays).
-    @objc public var hidden: NSNumber? {
+    @objc public var hide: NSNumber? {
         get {
-            guard let hidden = _swift.hidden else {
+            guard let hide = _swift.hide else {
                 return nil
             }
-            return NSNumber(value: hidden)
+            return NSNumber(value: hide)
         }
         set {
             if let newValue = newValue {
-                _swift.hidden = newValue.boolValue
+                _swift.hide = newValue.boolValue
             } else {
-                _swift.hidden = nil
+                _swift.hide = nil
             }
         }
     }

--- a/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
@@ -40,18 +40,18 @@ public final class DDSessionReplayOverride: NSObject {
     }
 
     /// Hidden privacy override (e.g., mark a view as hidden, rendering it as an opaque wireframe in replays).
-    @objc public var hiddenPrivacy: NSNumber? {
+    @objc public var hidden: NSNumber? {
         get {
-            guard let hiddenPrivacy = _swift.hiddenPrivacy else {
+            guard let hidden = _swift.hidden else {
                 return nil
             }
-            return NSNumber(value: hiddenPrivacy)
+            return NSNumber(value: hidden)
         }
         set {
             if let newValue = newValue {
-                _swift.hiddenPrivacy = newValue.boolValue
+                _swift.hidden = newValue.boolValue
             } else {
-                _swift.hiddenPrivacy = nil
+                _swift.hidden = nil
             }
         }
     }

--- a/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
+++ b/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
@@ -13,6 +13,7 @@ import DatadogInternal
 @testable import DatadogSessionReplay
 
 class DDSessionReplayOverrideTests: XCTestCase {
+    // MARK: Overrides Interoperability
     func testTextAndInputPrivacyLevelsOverrideInterop() {
         XCTAssertEqual(DDTextAndInputPrivacyLevelOverride.maskAll._swift, .maskAll)
         XCTAssertEqual(DDTextAndInputPrivacyLevelOverride.maskAllInputs._swift, .maskAllInputs)
@@ -51,57 +52,102 @@ class DDSessionReplayOverrideTests: XCTestCase {
         let override = DDSessionReplayOverride()
 
         // When setting hiddenPrivacy via Swift
-        override._swift.hidden = true
-        XCTAssertEqual(override.hidden, NSNumber(value: true))
+        override._swift.hide = true
+        XCTAssertEqual(override.hide, NSNumber(value: true))
 
-        override._swift.hidden = false
-        XCTAssertEqual(override.hidden, NSNumber(value: false))
+        override._swift.hide = false
+        XCTAssertEqual(override.hide, NSNumber(value: false))
 
-        override._swift.hidden = nil
-        XCTAssertNil(override.hidden)
+        override._swift.hide = nil
+        XCTAssertNil(override.hide)
 
         // When setting hiddenPrivacy via Objective-C
-        override.hidden = NSNumber(value: true)
-        XCTAssertEqual(override._swift.hidden, true)
+        override.hide = NSNumber(value: true)
+        XCTAssertEqual(override._swift.hide, true)
 
-        override.hidden = NSNumber(value: false)
-        XCTAssertEqual(override._swift.hidden, false)
+        override.hide = NSNumber(value: false)
+        XCTAssertEqual(override._swift.hide, false)
 
-        override.hidden = nil
-        XCTAssertNil(override._swift.hidden)
+        override.hide = nil
+        XCTAssertNil(override._swift.hide)
     }
 
+    // MARK: Setting Overrides
     func testSettingAndRemovingPrivacyOverridesObjc() {
         // Given
         let override = DDSessionReplayOverride()
         let textAndInputPrivacy: DDTextAndInputPrivacyLevelOverride = [.maskAll, .maskAllInputs, .maskSensitiveInputs].randomElement()!
         let imagePrivacy: DDImagePrivacyLevelOverride = [.maskAll, .maskNonBundledOnly, .maskNone].randomElement()!
         let touchPrivacy: DDTouchPrivacyLevelOverride = [.show, .hide].randomElement()!
-        let hidden: NSNumber? = [true, false].randomElement().map { NSNumber(value: $0) } ?? nil
+        let hide: NSNumber? = [true, false].randomElement().map { NSNumber(value: $0) } ?? nil
 
         // When
         override.textAndInputPrivacy = textAndInputPrivacy
         override.imagePrivacy = imagePrivacy
         override.touchPrivacy = touchPrivacy
-        override.hidden = hidden
+        override.hide = hide
 
         // Then
         XCTAssertEqual(override.textAndInputPrivacy, textAndInputPrivacy)
         XCTAssertEqual(override.imagePrivacy, imagePrivacy)
         XCTAssertEqual(override.touchPrivacy, touchPrivacy)
-        XCTAssertEqual(override.hidden, hidden)
+        XCTAssertEqual(override.hide, hide)
 
         // When
         override.textAndInputPrivacy = .none
         override.imagePrivacy = .none
         override.touchPrivacy = .none
-        override.hidden = false
+        override.hide = false
 
         // Then
         XCTAssertEqual(override.textAndInputPrivacy, .none)
         XCTAssertEqual(override.imagePrivacy, .none)
         XCTAssertEqual(override.touchPrivacy, .none)
-        XCTAssertEqual(override.hidden, false)
+        XCTAssertEqual(override.hide, false)
     }
+
+    func testSettingAndGettingOverridesFromObjC() {
+            // Given
+            let view = UIView()
+            let override = DDSessionReplayOverride()
+
+            // When
+            view.ddSessionReplayOverride = override
+            override.textAndInputPrivacy = .maskAll
+            override.imagePrivacy = .maskAll
+            override.touchPrivacy = .hide
+            override.hide = NSNumber(value: true)
+
+            // Then
+            XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, .maskAll)
+            XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, .maskAll)
+            XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, .hide)
+            XCTAssertEqual(view.ddSessionReplayOverride.hide?.boolValue, true)
+        }
+
+        func testClearingOverridesFromObjC() {
+            // Given
+            let view = UIView()
+            let override = DDSessionReplayOverride()
+
+            // Set initial values
+            view.ddSessionReplayOverride = override
+            override.textAndInputPrivacy = .maskAll
+            override.imagePrivacy = .maskAll
+            override.touchPrivacy = .hide
+            override.hide = NSNumber(value: true)
+
+            // When
+            view.ddSessionReplayOverride.textAndInputPrivacy = .none
+            view.ddSessionReplayOverride.imagePrivacy = .none
+            view.ddSessionReplayOverride.touchPrivacy = .none
+            view.ddSessionReplayOverride.hide = nil
+
+            // Then
+            XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, .none)
+            XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, .none)
+            XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, .none)
+            XCTAssertNil(view.ddSessionReplayOverride.hide)
+        }
 }
 #endif

--- a/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
+++ b/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
@@ -51,24 +51,24 @@ class DDSessionReplayOverrideTests: XCTestCase {
         let override = DDSessionReplayOverride()
 
         // When setting hiddenPrivacy via Swift
-        override._swift.hiddenPrivacy = true
-        XCTAssertEqual(override.hiddenPrivacy, NSNumber(value: true))
+        override._swift.hidden = true
+        XCTAssertEqual(override.hidden, NSNumber(value: true))
 
-        override._swift.hiddenPrivacy = false
-        XCTAssertEqual(override.hiddenPrivacy, NSNumber(value: false))
+        override._swift.hidden = false
+        XCTAssertEqual(override.hidden, NSNumber(value: false))
 
-        override._swift.hiddenPrivacy = nil
-        XCTAssertNil(override.hiddenPrivacy)
+        override._swift.hidden = nil
+        XCTAssertNil(override.hidden)
 
         // When setting hiddenPrivacy via Objective-C
-        override.hiddenPrivacy = NSNumber(value: true)
-        XCTAssertEqual(override._swift.hiddenPrivacy, true)
+        override.hidden = NSNumber(value: true)
+        XCTAssertEqual(override._swift.hidden, true)
 
-        override.hiddenPrivacy = NSNumber(value: false)
-        XCTAssertEqual(override._swift.hiddenPrivacy, false)
+        override.hidden = NSNumber(value: false)
+        XCTAssertEqual(override._swift.hidden, false)
 
-        override.hiddenPrivacy = nil
-        XCTAssertNil(override._swift.hiddenPrivacy)
+        override.hidden = nil
+        XCTAssertNil(override._swift.hidden)
     }
 
     func testSettingAndRemovingPrivacyOverridesObjc() {
@@ -77,31 +77,31 @@ class DDSessionReplayOverrideTests: XCTestCase {
         let textAndInputPrivacy: DDTextAndInputPrivacyLevelOverride = [.maskAll, .maskAllInputs, .maskSensitiveInputs].randomElement()!
         let imagePrivacy: DDImagePrivacyLevelOverride = [.maskAll, .maskNonBundledOnly, .maskNone].randomElement()!
         let touchPrivacy: DDTouchPrivacyLevelOverride = [.show, .hide].randomElement()!
-        let hiddenPrivacy: NSNumber? = [true, false].randomElement().map { NSNumber(value: $0) } ?? nil
+        let hidden: NSNumber? = [true, false].randomElement().map { NSNumber(value: $0) } ?? nil
 
         // When
         override.textAndInputPrivacy = textAndInputPrivacy
         override.imagePrivacy = imagePrivacy
         override.touchPrivacy = touchPrivacy
-        override.hiddenPrivacy = hiddenPrivacy
+        override.hidden = hidden
 
         // Then
         XCTAssertEqual(override.textAndInputPrivacy, textAndInputPrivacy)
         XCTAssertEqual(override.imagePrivacy, imagePrivacy)
         XCTAssertEqual(override.touchPrivacy, touchPrivacy)
-        XCTAssertEqual(override.hiddenPrivacy, hiddenPrivacy)
+        XCTAssertEqual(override.hidden, hidden)
 
         // When
         override.textAndInputPrivacy = .none
         override.imagePrivacy = .none
         override.touchPrivacy = .none
-        override.hiddenPrivacy = false
+        override.hidden = false
 
         // Then
         XCTAssertEqual(override.textAndInputPrivacy, .none)
         XCTAssertEqual(override.imagePrivacy, .none)
         XCTAssertEqual(override.touchPrivacy, .none)
-        XCTAssertEqual(override.hiddenPrivacy, false)
+        XCTAssertEqual(override.hidden, false)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -77,7 +77,8 @@ extension ViewAttributes: AnyMockable, RandomMockable {
         layerCornerRadius: CGFloat = .mockAny(),
         alpha: CGFloat = .mockAny(),
         isHidden: Bool = .mockAny(),
-        intrinsicContentSize: CGSize = .mockAny()
+        intrinsicContentSize: CGSize = .mockAny(),
+        sessionReplayOverride: SessionReplayOverrideExtension? = .mockAny()
     ) -> ViewAttributes {
         return .init(
             frame: frame,
@@ -87,7 +88,8 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: layerCornerRadius,
             alpha: alpha,
             isHidden: isHidden,
-            intrinsicContentSize: intrinsicContentSize
+            intrinsicContentSize: intrinsicContentSize,
+            sessionReplayOverride: sessionReplayOverride
         )
     }
 
@@ -575,6 +577,35 @@ internal extension Optional where Wrapped == NodeSemantics {
         let builders: [T] = try expectWireframeBuilders(file: file, line: line)
         XCTAssertEqual(builders.count, 1, "Expected single \(T.self), found none", file: file, line: line)
         return try XCTUnwrap(builders.first, file: file, line: line)
+    }
+}
+
+extension SessionReplayOverrideExtension: AnyMockable, RandomMockable {
+    public static func mockAny() -> SessionReplayOverrideExtension {
+        return mockWith()
+    }
+
+    public static func mockRandom() -> SessionReplayOverrideExtension {
+        return mockWith(
+            textAndInputPrivacy: .mockRandom(),
+            imagePrivacy: .mockRandom(),
+            touchPrivacy: .mockRandom(),
+            hidden: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        textAndInputPrivacy: TextAndInputPrivacyLevel? = nil,
+        imagePrivacy: ImagePrivacyLevel? = nil,
+        touchPrivacy: TouchPrivacyLevel? = nil,
+        hidden: Bool? = nil
+    ) -> SessionReplayOverrideExtension {
+        let override = SessionReplayOverrideExtension(UIView.mockRandom())
+        override.textAndInputPrivacy = textAndInputPrivacy
+        override.imagePrivacy = imagePrivacy
+        override.touchPrivacy = touchPrivacy
+        override.hidden = hidden
+        return override
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -590,7 +590,7 @@ extension SessionReplayOverrideExtension: AnyMockable, RandomMockable {
             textAndInputPrivacy: .mockRandom(),
             imagePrivacy: .mockRandom(),
             touchPrivacy: .mockRandom(),
-            hidden: .mockRandom()
+            hide: .mockRandom()
         )
     }
 
@@ -598,13 +598,13 @@ extension SessionReplayOverrideExtension: AnyMockable, RandomMockable {
         textAndInputPrivacy: TextAndInputPrivacyLevel? = nil,
         imagePrivacy: ImagePrivacyLevel? = nil,
         touchPrivacy: TouchPrivacyLevel? = nil,
-        hidden: Bool? = nil
+        hide: Bool? = nil
     ) -> SessionReplayOverrideExtension {
         let override = SessionReplayOverrideExtension(UIView.mockRandom())
         override.textAndInputPrivacy = textAndInputPrivacy
         override.imagePrivacy = imagePrivacy
         override.touchPrivacy = touchPrivacy
-        override.hidden = hidden
+        override.hide = hide
         return override
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -57,5 +57,19 @@ class UIViewRecorderTests: XCTestCase {
         XCTAssertTrue(semantics is AmbiguousElement)
         XCTAssertEqual(semantics.subtreeStrategy, .record)
     }
+
+    func testWhenViewHasHiddenOverride() throws {
+        // Given
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
+        viewAttributes.sessionReplayOverride = .mockWith(hidden: true)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+
+        // Then
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIViewWireframesBuilder)
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -61,7 +61,7 @@ class UIViewRecorderTests: XCTestCase {
     func testWhenViewHasHiddenOverride() throws {
         // Given
         viewAttributes = .mock(fixture: .visible(.someAppearance))
-        viewAttributes.sessionReplayOverride = .mockWith(hidden: true)
+        viewAttributes.sessionReplayOverride = .mockWith(hide: true)
 
         // When
         let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -175,6 +175,40 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.isHidden, boolean)
         XCTAssertEqual(attributes.intrinsicContentSize, rect.size)
     }
+
+    // MARK: Overrides
+    func testItDefaultsToNilWhenNoOverrideIsSet() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+
+        // Then
+        XCTAssertNil(attributes.sessionReplayOverride?.textAndInputPrivacy)
+        XCTAssertNil(attributes.sessionReplayOverride?.imagePrivacy)
+        XCTAssertNil(attributes.sessionReplayOverride?.touchPrivacy)
+        XCTAssertNil(attributes.sessionReplayOverride?.hidden)
+    }
+
+    func testItCapturesViewAttributesWithOverrides() {
+        // Given
+        let view: UIView = .mockRandom()
+        let overrides = SessionReplayOverrideExtension.mockRandom()
+        view.dd.sessionReplayOverride.textAndInputPrivacy = overrides.textAndInputPrivacy
+        view.dd.sessionReplayOverride.imagePrivacy = overrides.imagePrivacy
+        view.dd.sessionReplayOverride.touchPrivacy = overrides.touchPrivacy
+        view.dd.sessionReplayOverride.hidden = overrides.hidden
+
+        // When
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+
+        // Then
+        XCTAssertEqual(attributes.sessionReplayOverride?.textAndInputPrivacy, overrides.textAndInputPrivacy)
+        XCTAssertEqual(attributes.sessionReplayOverride?.imagePrivacy, overrides.imagePrivacy)
+        XCTAssertEqual(attributes.sessionReplayOverride?.touchPrivacy, overrides.touchPrivacy)
+        XCTAssertEqual(attributes.sessionReplayOverride?.hidden, overrides.hidden)
+    }
 }
 // swiftlint:enable opening_brace
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -188,7 +188,7 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertNil(attributes.sessionReplayOverride?.textAndInputPrivacy)
         XCTAssertNil(attributes.sessionReplayOverride?.imagePrivacy)
         XCTAssertNil(attributes.sessionReplayOverride?.touchPrivacy)
-        XCTAssertNil(attributes.sessionReplayOverride?.hidden)
+        XCTAssertNil(attributes.sessionReplayOverride?.hide)
     }
 
     func testItCapturesViewAttributesWithOverrides() {
@@ -198,7 +198,7 @@ class ViewAttributesTests: XCTestCase {
         view.dd.sessionReplayOverride.textAndInputPrivacy = overrides.textAndInputPrivacy
         view.dd.sessionReplayOverride.imagePrivacy = overrides.imagePrivacy
         view.dd.sessionReplayOverride.touchPrivacy = overrides.touchPrivacy
-        view.dd.sessionReplayOverride.hidden = overrides.hidden
+        view.dd.sessionReplayOverride.hide = overrides.hide
 
         // When
         let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
@@ -207,7 +207,7 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.sessionReplayOverride?.textAndInputPrivacy, overrides.textAndInputPrivacy)
         XCTAssertEqual(attributes.sessionReplayOverride?.imagePrivacy, overrides.imagePrivacy)
         XCTAssertEqual(attributes.sessionReplayOverride?.touchPrivacy, overrides.touchPrivacy)
-        XCTAssertEqual(attributes.sessionReplayOverride?.hidden, overrides.hidden)
+        XCTAssertEqual(attributes.sessionReplayOverride?.hide, overrides.hide)
     }
 }
 // swiftlint:enable opening_brace

--- a/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
@@ -18,7 +18,7 @@ class SessionReplayOverrideTests: XCTestCase {
         XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hiddenPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverride.hidden)
     }
 
     func testWithOverrides() {
@@ -29,13 +29,13 @@ class SessionReplayOverrideTests: XCTestCase {
         view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
         view.dd.sessionReplayOverride.imagePrivacy = .maskAll
         view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hiddenPrivacy = true
+        view.dd.sessionReplayOverride.hidden = true
 
         // Then
         XCTAssertEqual(view.dd.sessionReplayOverride.textAndInputPrivacy, .maskAllInputs)
         XCTAssertEqual(view.dd.sessionReplayOverride.imagePrivacy, .maskAll)
         XCTAssertEqual(view.dd.sessionReplayOverride.touchPrivacy, .hide)
-        XCTAssertEqual(view.dd.sessionReplayOverride.hiddenPrivacy, true)
+        XCTAssertEqual(view.dd.sessionReplayOverride.hidden, true)
     }
 
     func testRemovingOverrides() {
@@ -44,19 +44,19 @@ class SessionReplayOverrideTests: XCTestCase {
         view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
         view.dd.sessionReplayOverride.imagePrivacy = .maskAll
         view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hiddenPrivacy = true
+        view.dd.sessionReplayOverride.hidden = true
 
         // When
         view.dd.sessionReplayOverride.textAndInputPrivacy = nil
         view.dd.sessionReplayOverride.imagePrivacy = nil
         view.dd.sessionReplayOverride.touchPrivacy = nil
-        view.dd.sessionReplayOverride.hiddenPrivacy = nil
+        view.dd.sessionReplayOverride.hidden = nil
 
         // Then
         XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hiddenPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverride.hidden)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
@@ -18,7 +18,7 @@ class SessionReplayOverrideTests: XCTestCase {
         XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hidden)
+        XCTAssertNil(view.dd.sessionReplayOverride.hide)
     }
 
     func testWithOverrides() {
@@ -29,13 +29,13 @@ class SessionReplayOverrideTests: XCTestCase {
         view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
         view.dd.sessionReplayOverride.imagePrivacy = .maskAll
         view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hidden = true
+        view.dd.sessionReplayOverride.hide = true
 
         // Then
         XCTAssertEqual(view.dd.sessionReplayOverride.textAndInputPrivacy, .maskAllInputs)
         XCTAssertEqual(view.dd.sessionReplayOverride.imagePrivacy, .maskAll)
         XCTAssertEqual(view.dd.sessionReplayOverride.touchPrivacy, .hide)
-        XCTAssertEqual(view.dd.sessionReplayOverride.hidden, true)
+        XCTAssertEqual(view.dd.sessionReplayOverride.hide, true)
     }
 
     func testRemovingOverrides() {
@@ -44,19 +44,19 @@ class SessionReplayOverrideTests: XCTestCase {
         view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
         view.dd.sessionReplayOverride.imagePrivacy = .maskAll
         view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hidden = true
+        view.dd.sessionReplayOverride.hide = true
 
         // When
         view.dd.sessionReplayOverride.textAndInputPrivacy = nil
         view.dd.sessionReplayOverride.imagePrivacy = nil
         view.dd.sessionReplayOverride.touchPrivacy = nil
-        view.dd.sessionReplayOverride.hidden = nil
+        view.dd.sessionReplayOverride.hide = nil
 
         // Then
         XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
         XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hidden)
+        XCTAssertNil(view.dd.sessionReplayOverride.hide)
     }
 }
 #endif


### PR DESCRIPTION
### What and why?

This PR implements the logic for the hidden property in Session Replay, as a continuation of #2058, which introduces Fine-Grained Masking (FGM) overrides.

### How?

- Added a new `SessionReplayOverrideExtension` property to `ViewAttributes`.
- In the view recorder, it now checks for the `hiddenPrivacy` property.
- When this property is set, it returns a placeholder frame for the hidden view and ignores its child views.
- Renamed `hiddenPrivacy` to `hide`, as it is now a `Bool`, making the name more intuitive after converting from an `enum`.
- Addressed [this comment](https://github.com/DataDog/dd-sdk-ios/pull/2058#discussion_r1775231721) from the previous PR to clean up the `SessionReplayOverrideExtension` implementation.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
