### PR TITLE
Expose Start/Stop API to Objc

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -31,4 +31,8 @@
     [DDSessionReplay enableWith:configuration];
 }
 
+- (void)testStartAndStopRecording {
+    [DDSessionReplay startRecording];
+    [DDSessionReplay stopRecording];
+}
 @end

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -26,6 +26,18 @@ public final class DDSessionReplay: NSObject {
     public static func enable(with configuration: DDSessionReplayConfiguration) {
         SessionReplay.enable(with: configuration._swift)
     }
+
+    /// Starts the recording manually.
+    @objc
+    public static func startRecording() {
+        SessionReplay.startRecording(in: CoreRegistry.default)
+    }
+
+    /// Stops the recording manually.
+    @objc
+    public static func stopRecording() {
+        SessionReplay.stopRecording(in: CoreRegistry.default)
+    }
 }
 
 /// Session Replay feature configuration.


### PR DESCRIPTION
### What and why?

The `startRecording` and `stopRecording` public APIs were introduced in #1986 to allow manual control over session recording. However, these APIs were not exposed to Objective-C, limiting access for ObjC users. This PR addresses that gap.

### How?

This PR adds `startRecording` and `stopRecording` methods to the `DDSessionReplay` class, making them accessible from Objective-C.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
