### PR TITLE
RUM-6284 Implement Overrides Logic

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -680,7 +680,7 @@
 		61FDBA15269722B4001D9D43 /* CrashReportMinifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDBA14269722B4001D9D43 /* CrashReportMinifierTests.swift */; };
 		61FDBA1726974CA9001D9D43 /* DDCrashReportBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDBA1626974CA9001D9D43 /* DDCrashReportBuilderTests.swift */; };
 		61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
-		962C41A72CA431370050B747 /* PrivacyLevel+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966253B52C98807400B90B63 /* PrivacyLevel+SessionReplay.swift */; };
+		962C41A72CA431370050B747 /* SessionReplayPrivacyOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */; };
 		962C41A82CA431AA0050B747 /* DDSessionReplayOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E863752C9C7E800023BF78 /* DDSessionReplayOverridesTests.swift */; };
 		969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */; };
 		969B3B232C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */; };
@@ -2727,7 +2727,7 @@
 		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
 		61FF416125EE5FF400CE35EC /* CrashLogReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogReceiverTests.swift; sourceTree = "<group>"; };
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
-		966253B52C98807400B90B63 /* PrivacyLevel+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrivacyLevel+SessionReplay.swift"; sourceTree = "<group>"; };
+		966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyOverrides.swift; sourceTree = "<group>"; };
 		969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorder.swift; sourceTree = "<group>"; };
 		969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorderTests.swift; sourceTree = "<group>"; };
 		96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorder.swift; sourceTree = "<group>"; };
@@ -3556,7 +3556,7 @@
 			children = (
 				61054E0C2A6EE10A00AAA894 /* SessionReplay.swift */,
 				61054E0B2A6EE10A00AAA894 /* SessionReplayConfiguration.swift */,
-				966253B52C98807400B90B63 /* PrivacyLevel+SessionReplay.swift */,
+				966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */,
 				A795069B2B974C8100AC4814 /* SessionReplay+objc.swift */,
 				96E863732C9C64180023BF78 /* SessionReplayOverrides+objc.swift */,
 				61054E3B2A6EE10A00AAA894 /* Feature */,
@@ -3625,11 +3625,9 @@
 		61054E132A6EE10A00AAA894 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				61054E152A6EE10A00AAA894 /* UIView+SessionReplay.swift */,
 				61054E142A6EE10A00AAA894 /* UIImage+SessionReplay.swift */,
 				D22442C42CA301DA002E71E4 /* UIColor+SessionReplay.swift */,
-				966253B52C98807400B90B63 /* PrivacyLevel+SessionReplay.swift */,
-				61054E152A6EE10A00AAA894 /* UIKitExtensions.swift */,
+				61054E152A6EE10A00AAA894 /* UIView+SessionReplay.swift */,
 				61054E162A6EE10A00AAA894 /* CFType+Safety.swift */,
 				61054E172A6EE10A00AAA894 /* SystemColors.swift */,
 				61054E182A6EE10A00AAA894 /* CGRect+ContentFrame.swift */,
@@ -8370,7 +8368,7 @@
 				61054EA12A6EE10B00AAA894 /* MainThreadScheduler.swift in Sources */,
 				61054E7C2A6EE10A00AAA894 /* UINavigationBarRecorder.swift in Sources */,
 				96E414142C2AF56F005A6119 /* UIProgressViewRecorder.swift in Sources */,
-				962C41A72CA431370050B747 /* PrivacyLevel+SessionReplay.swift in Sources */,
+				962C41A72CA431370050B747 /* SessionReplayPrivacyOverrides.swift in Sources */,
 				61054E772A6EE10A00AAA894 /* ViewTreeRecorder.swift in Sources */,
 				61054E9E2A6EE10B00AAA894 /* Queue.swift in Sources */,
 				61054E872A6EE10A00AAA894 /* ViewAttributes+Copy.swift in Sources */,

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -41,7 +41,7 @@
 - (void)testSettingAndGettingOverrides {
     // Given
     UIView *view = [[UIView alloc] init];
-    DDSessionReplayOverrides *override = [[DDSessionReplayOverrides alloc] init];
+    DDSessionReplayPrivacyOverrides *override = [[DDSessionReplayPrivacyOverrides alloc] init];
 
     // When
     view.ddSessionReplayOverrides = override;
@@ -60,7 +60,7 @@
 - (void)testClearingOverride {
     // Given
     UIView *view = [[UIView alloc] init];
-    DDSessionReplayOverrides *overrides = [[DDSessionReplayOverrides alloc] init];
+    DDSessionReplayPrivacyOverrides *overrides = [[DDSessionReplayPrivacyOverrides alloc] init];
 
     // Set initial values
     view.ddSessionReplayOverrides = overrides;

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -37,48 +37,48 @@
     [DDSessionReplay stopRecording];
 }
 
-// MARK: Overrides
+// MARK: Privacy Overrides
 - (void)testSettingAndGettingOverrides {
     // Given
     UIView *view = [[UIView alloc] init];
-    DDSessionReplayOverride *override = [[DDSessionReplayOverride alloc] init];
+    DDSessionReplayOverrides *override = [[DDSessionReplayOverrides alloc] init];
 
     // When
-    view.ddSessionReplayOverride = override;
-    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
-    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
-    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
-    view.ddSessionReplayOverride.hide = @YES;
+    view.ddSessionReplayOverrides = override;
+    view.ddSessionReplayOverrides.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverrides.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverrides.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
+    view.ddSessionReplayOverrides.hide = @YES;
 
     // Then
-    XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideMaskAll);
-    XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, DDImagePrivacyLevelOverrideMaskAll);
-    XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, DDTouchPrivacyLevelOverrideHide);
-    XCTAssertTrue(view.ddSessionReplayOverride.hide.boolValue);
+    XCTAssertEqual(view.ddSessionReplayOverrides.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideMaskAll);
+    XCTAssertEqual(view.ddSessionReplayOverrides.imagePrivacy, DDImagePrivacyLevelOverrideMaskAll);
+    XCTAssertEqual(view.ddSessionReplayOverrides.touchPrivacy, DDTouchPrivacyLevelOverrideHide);
+    XCTAssertTrue(view.ddSessionReplayOverrides.hide.boolValue);
 }
 
 - (void)testClearingOverride {
     // Given
     UIView *view = [[UIView alloc] init];
-    DDSessionReplayOverride *override = [[DDSessionReplayOverride alloc] init];
+    DDSessionReplayOverrides *overrides = [[DDSessionReplayOverrides alloc] init];
 
     // Set initial values
-    view.ddSessionReplayOverride = override;
-    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
-    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
-    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
-    view.ddSessionReplayOverride.hide = @YES;
+    view.ddSessionReplayOverrides = overrides;
+    view.ddSessionReplayOverrides.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverrides.imagePrivacy = DDImagePrivacyLevelOverrideMaskAll;
+    view.ddSessionReplayOverrides.touchPrivacy = DDTouchPrivacyLevelOverrideHide;
+    view.ddSessionReplayOverrides.hide = @YES;
 
     // When
-    view.ddSessionReplayOverride.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideNone;
-    view.ddSessionReplayOverride.imagePrivacy = DDImagePrivacyLevelOverrideNone;
-    view.ddSessionReplayOverride.touchPrivacy = DDTouchPrivacyLevelOverrideNone;
-    view.ddSessionReplayOverride.hide = nil;
+    view.ddSessionReplayOverrides.textAndInputPrivacy = DDTextAndInputPrivacyLevelOverrideNone;
+    view.ddSessionReplayOverrides.imagePrivacy = DDImagePrivacyLevelOverrideNone;
+    view.ddSessionReplayOverrides.touchPrivacy = DDTouchPrivacyLevelOverrideNone;
+    view.ddSessionReplayOverrides.hide = nil;
 
     // Then
-    XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideNone);
-    XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, DDImagePrivacyLevelOverrideNone);
-    XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, DDTouchPrivacyLevelOverrideNone);
-    XCTAssertNil(view.ddSessionReplayOverride.hide);
+    XCTAssertEqual(view.ddSessionReplayOverrides.textAndInputPrivacy, DDTextAndInputPrivacyLevelOverrideNone);
+    XCTAssertEqual(view.ddSessionReplayOverrides.imagePrivacy, DDImagePrivacyLevelOverrideNone);
+    XCTAssertEqual(view.ddSessionReplayOverrides.touchPrivacy, DDTouchPrivacyLevelOverrideNone);
+    XCTAssertNil(view.ddSessionReplayOverrides.hide);
 }
 @end

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -85,8 +85,8 @@ private struct WheelsStyleDatePickerRecorder {
             nodeRecorders: [
                 UIPickerViewRecorder(
                     identifier: identifier,
-                    textObfuscator: { context in
-                        return context.recorder.textAndInputPrivacy.staticTextObfuscator
+                    textObfuscator: { context, viewAttributes in
+                        return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
                     }
                 )
             ]
@@ -107,8 +107,8 @@ private struct InlineStyleDatePickerRecorder {
         self.viewRecorder = UIViewRecorder(identifier: identifier)
         self.labelRecorder = UILabelRecorder(
             identifier: identifier,
-            textObfuscator: { context in
-                return context.recorder.textAndInputPrivacy.staticTextObfuscator
+            textObfuscator: { context, viewAttributes in
+                return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
             }
         )
         self.subtreeRecorder = ViewTreeRecorder(
@@ -154,8 +154,8 @@ private struct CompactStyleDatePickerRecorder {
                 UIViewRecorder(identifier: identifier),
                 UILabelRecorder(
                     identifier: identifier,
-                    textObfuscator: { context in
-                        return context.recorder.textAndInputPrivacy.staticTextObfuscator
+                    textObfuscator: { context, viewAttributes in
+                        return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
                     }
                 )
             ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -44,6 +44,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
         if let semantics = semanticsOverride(imageView, attributes) {
             return semantics
         }
+
         guard attributes.hasAnyAppearance || imageView.image != nil else {
             return InvisibleElement.constant
         }
@@ -59,7 +60,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
         let shouldRecordImage = if let shouldRecordImagePredicateOverride {
             shouldRecordImagePredicateOverride(imageView)
         } else {
-            context.recorder.imagePrivacy.shouldRecordImagePredicate(imageView)
+            attributes.resolveImagePrivacyLevel(in: context).shouldRecordImagePredicate(imageView)
         }
         let imageResource = shouldRecordImage ? imageView.image.map { image in
             UIImageResource(image: image, tintColor: tintColorProvider(imageView))

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -12,13 +12,13 @@ internal class UILabelRecorder: NodeRecorder {
 
     /// An option for customizing wireframes builder created by this recorder.
     var builderOverride: (UILabelWireframesBuilder) -> UILabelWireframesBuilder
-    var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating
+    var textObfuscator: (ViewTreeRecordingContext, ViewAttributes) -> TextObfuscating
 
     init(
         identifier: UUID,
         builderOverride: @escaping (UILabelWireframesBuilder) -> UILabelWireframesBuilder = { $0 },
-        textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            return context.recorder.textAndInputPrivacy.staticTextObfuscator
+        textObfuscator: @escaping (ViewTreeRecordingContext, ViewAttributes) -> TextObfuscating = { context, viewAttributes in
+            return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
         }
     ) {
         self.identifier = identifier
@@ -45,7 +45,7 @@ internal class UILabelRecorder: NodeRecorder {
             textAlignment: label.textAlignment,
             font: label.font,
             fontScalingEnabled: label.adjustsFontSizeToFitWidth,
-            textObfuscator: textObfuscator(context)
+            textObfuscator: textObfuscator(context, attributes)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builderOverride(builder))
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -11,7 +11,7 @@ import UIKit
 ///
 /// The look of picker view in SR is approximated by capturing the text from "selected row" and ignoring all other values on the wheel:
 /// - If the picker defines multiple components, there will be multiple selected values.
-/// - We can't request `picker.dataSource` to receive the value - doing so will result in calling applicaiton code, which could be
+/// - We can't request `picker.dataSource` to receive the value - doing so will result in calling application code, which could be
 /// dangerous (if the code is faulty) and may significantly slow down the performance (e.g. if the underlying source requires database fetch).
 /// - Similarly, we don't call `picker.delegate` to avoid running application code outside `UIKit's` lifecycle.
 /// - Instead, we infer the value by traversing picker's subtree and finding texts that have no "3D wheel" effect applied.
@@ -28,8 +28,8 @@ internal struct UIPickerViewRecorder: NodeRecorder {
 
     init(
         identifier: UUID,
-        textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            return context.recorder.textAndInputPrivacy.inputAndOptionTextObfuscator
+        textObfuscator: @escaping (ViewTreeRecordingContext, ViewAttributes) -> TextObfuscating = { context, viewAttributes in
+            return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).inputAndOptionTextObfuscator
         }
     ) {
         self.identifier = identifier

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -13,8 +13,8 @@ internal struct UISegmentRecorder: NodeRecorder {
     init(identifier: UUID) {
         self.identifier = identifier
     }
-    var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
-        return context.recorder.textAndInputPrivacy.inputAndOptionTextObfuscator
+    var textObfuscator: (ViewTreeRecordingContext, ViewAttributes) -> TextObfuscating = { context, viewAttributes in
+        return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).inputAndOptionTextObfuscator
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
@@ -31,7 +31,7 @@ internal struct UISegmentRecorder: NodeRecorder {
         let builder = UISegmentWireframesBuilder(
             wireframeRect: attributes.frame,
             attributes: attributes,
-            textObfuscator: textObfuscator(context),
+            textObfuscator: textObfuscator(context, attributes),
             backgroundWireframeID: ids[0],
             segmentWireframeIDs: Array(ids[1..<ids.count]),
             segmentTitles: (0..<segment.numberOfSegments).map { segment.titleForSegment(at: $0) },

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -16,13 +16,15 @@ internal struct UITextFieldRecorder: NodeRecorder {
     private let iconsRecorder: UIImageViewRecorder
     private let subtreeRecorder: ViewTreeRecorder
 
-    var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isPlaceholder: Bool) -> TextObfuscating = { context, isSensitive, isPlaceholder in
+    var textObfuscator: (ViewTreeRecordingContext, _ viewAttributes: ViewAttributes, _ isSensitive: Bool, _ isPlaceholder: Bool) -> TextObfuscating = { context, viewAttributes, isSensitive, isPlaceholder in
+        let resolvedPrivacyLevel = viewAttributes.resolveTextAndInputPrivacyLevel(in: context)
+
         if isPlaceholder {
-            return context.recorder.textAndInputPrivacy.hintTextObfuscator
+            return resolvedPrivacyLevel.hintTextObfuscator
         } else if isSensitive {
-            return context.recorder.textAndInputPrivacy.sensitiveTextObfuscator
+            return resolvedPrivacyLevel.sensitiveTextObfuscator
         } else {
-            return context.recorder.textAndInputPrivacy.inputAndOptionTextObfuscator
+            return resolvedPrivacyLevel.inputAndOptionTextObfuscator
         }
     }
 
@@ -95,7 +97,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             isPlaceholderText: isPlaceholder,
             font: textField.font,
             fontScalingEnabled: textField.adjustsFontSizeToFitWidth,
-            textObfuscator: textObfuscator(context, textField.dd.isSensitiveText, isPlaceholder)
+            textObfuscator: textObfuscator(context, attributes, textField.dd.isSensitiveText, isPlaceholder)
         )
         return Node(viewAttributes: attributes, wireframesBuilder: builder)
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -14,15 +14,17 @@ internal struct UITextViewRecorder: NodeRecorder {
         self.identifier = identifier
     }
 
-    var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
+    var textObfuscator: (ViewTreeRecordingContext, _ viewAttributes: ViewAttributes, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, viewAttributes, isSensitive, isEditable in
+        let resolvedPrivacyLevel = viewAttributes.resolveTextAndInputPrivacyLevel(in: context)
+
         if isSensitive {
-            return context.recorder.textAndInputPrivacy.sensitiveTextObfuscator
+            return resolvedPrivacyLevel.sensitiveTextObfuscator
         }
 
         if isEditable {
-            return context.recorder.textAndInputPrivacy.inputAndOptionTextObfuscator
+            return resolvedPrivacyLevel.inputAndOptionTextObfuscator
         } else {
-            return context.recorder.textAndInputPrivacy.staticTextObfuscator
+            return resolvedPrivacyLevel.staticTextObfuscator
         }
     }
 
@@ -41,7 +43,7 @@ internal struct UITextViewRecorder: NodeRecorder {
             textAlignment: textView.textAlignment,
             textColor: textView.textColor?.cgColor ?? UIColor.black.cgColor,
             font: textView.font,
-            textObfuscator: textObfuscator(context, textView.dd.isSensitiveText, textView.isEditable),
+            textObfuscator: textObfuscator(context, attributes, textView.dd.isSensitiveText, textView.isEditable),
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -41,7 +41,7 @@ internal class UIViewRecorder: NodeRecorder {
             return semantics
         }
 
-        if attributes.sessionReplayOverride?.hide == true {
+        if attributes.overrides.hide == true {
             let builder = UIViewWireframesBuilder(
                 wireframeID: context.ids.nodeID(view: view, nodeRecorder: self),
                 attributes: attributes
@@ -75,7 +75,7 @@ internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
     }
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
-        if attributes.sessionReplayOverride?.hide == true {
+        if attributes.overrides.hide == true {
             return [
                 builder.createPlaceholderWireframe(id: wireframeID, frame: wireframeRect, label: "Hidden")
             ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
@@ -25,6 +25,7 @@ extension ViewAttributes {
         var alpha: CGFloat
         var isHidden: Bool
         var intrinsicContentSize: CGSize
+        var overrides: Overrides
 
         fileprivate init(original: ViewAttributes) {
             self.frame = original.frame
@@ -35,6 +36,7 @@ extension ViewAttributes {
             self.alpha = original.alpha
             self.isHidden = original.isHidden
             self.intrinsicContentSize = original.intrinsicContentSize
+            self.overrides = original.overrides
         }
 
         fileprivate func toViewAttributes() -> ViewAttributes {
@@ -46,7 +48,8 @@ extension ViewAttributes {
                 layerCornerRadius: layerCornerRadius,
                 alpha: alpha,
                 isHidden: isHidden,
-                intrinsicContentSize: intrinsicContentSize
+                intrinsicContentSize: intrinsicContentSize,
+                overrides: overrides
             )
         }
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
@@ -25,7 +25,7 @@ extension ViewAttributes {
         var alpha: CGFloat
         var isHidden: Bool
         var intrinsicContentSize: CGSize
-        var overrides: Overrides
+        var overrides: PrivacyOverrides
 
         fileprivate init(original: ViewAttributes) {
             self.frame = original.frame

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -27,7 +27,7 @@ internal struct ViewTreeRecorder {
         nodes: inout [Node],
         view: UIView,
         context: ViewTreeRecordingContext,
-        overrides: Overrides
+        overrides: PrivacyOverrides
     ) {
         var context = context
         if let viewController = view.next as? UIViewController {
@@ -46,7 +46,7 @@ internal struct ViewTreeRecorder {
         switch semantics.subtreeStrategy {
         case .record:
             for subview in view.subviews {
-                let subviewOverrides = SessionReplayOverrides.merge(subview.dd.sessionReplayOverrides, with: overrides)
+                let subviewOverrides = SessionReplayPrivacyOverrides.merge(subview.dd.sessionReplayOverrides, with: overrides)
                 recordRecursively(nodes: &nodes, view: subview, context: context, overrides: subviewOverrides)
             }
         case .ignore:
@@ -54,7 +54,7 @@ internal struct ViewTreeRecorder {
         }
     }
 
-    private func nodeSemantics(for view: UIView, in context: ViewTreeRecordingContext, overrides: Overrides) -> NodeSemantics {
+    private func nodeSemantics(for view: UIView, in context: ViewTreeRecordingContext, overrides: PrivacyOverrides) -> NodeSemantics {
         let attributes = ViewAttributes(
             frameInRootView: view.convert(view.bounds, to: context.coordinateSpace),
             view: view,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -17,7 +17,7 @@ internal struct ViewTreeRecorder {
     /// Creates `Nodes` for given view and its subtree hierarchy.
     func record(_ anyView: UIView, in context: ViewTreeRecordingContext) -> [Node] {
         var nodes: [Node] = []
-        recordRecursively(nodes: &nodes, view: anyView, context: context)
+        recordRecursively(nodes: &nodes, view: anyView, context: context, overrides: anyView.dd.sessionReplayOverrides)
         return nodes
     }
 
@@ -26,7 +26,8 @@ internal struct ViewTreeRecorder {
     private func recordRecursively(
         nodes: inout [Node],
         view: UIView,
-        context: ViewTreeRecordingContext
+        context: ViewTreeRecordingContext,
+        overrides: Overrides
     ) {
         var context = context
         if let viewController = view.next as? UIViewController {
@@ -36,7 +37,7 @@ internal struct ViewTreeRecorder {
             context.viewControllerContext.isRootView = false
         }
 
-        let semantics = nodeSemantics(for: view, in: context)
+        let semantics = nodeSemantics(for: view, in: context, overrides: overrides)
 
         if !semantics.nodes.isEmpty {
             nodes.append(contentsOf: semantics.nodes)
@@ -45,17 +46,19 @@ internal struct ViewTreeRecorder {
         switch semantics.subtreeStrategy {
         case .record:
             for subview in view.subviews {
-                recordRecursively(nodes: &nodes, view: subview, context: context)
+                let subviewOverrides = SessionReplayOverrides.merge(subview.dd.sessionReplayOverrides, with: overrides)
+                recordRecursively(nodes: &nodes, view: subview, context: context, overrides: subviewOverrides)
             }
         case .ignore:
             break
         }
     }
 
-    private func nodeSemantics(for view: UIView, in context: ViewTreeRecordingContext) -> NodeSemantics {
+    private func nodeSemantics(for view: UIView, in context: ViewTreeRecordingContext, overrides: Overrides) -> NodeSemantics {
         let attributes = ViewAttributes(
             frameInRootView: view.convert(view.bounds, to: context.coordinateSpace),
-            view: view
+            view: view,
+            overrides: overrides
         )
 
         var semantics: NodeSemantics = UnknownElement.constant

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -125,14 +125,14 @@ public struct SessionReplayViewAttributes: Equatable {
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 
     /// If the view has privacy overrides, which take precedence over global masking privacy levels.
-    var overrides: Overrides
+    var overrides: PrivacyOverrides
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias ViewAttributes = SessionReplayViewAttributes
 
 extension ViewAttributes {
-    init(frameInRootView: CGRect, view: UIView, overrides: SessionReplayOverrides) {
+    init(frameInRootView: CGRect, view: UIView, overrides: SessionReplayPrivacyOverrides) {
         self.frame = frameInRootView
         self.backgroundColor = view.backgroundColor?.cgColor.safeCast
         self.layerBorderColor = view.layer.borderColor?.safeCast

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -125,14 +125,14 @@ public struct SessionReplayViewAttributes: Equatable {
     var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 
     /// If the view has privacy overrides, which take precedence over global masking privacy levels.
-    var sessionReplayOverride: SessionReplayOverrideExtension?
+    var overrides: Overrides
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
 internal typealias ViewAttributes = SessionReplayViewAttributes
 
 extension ViewAttributes {
-    init(frameInRootView: CGRect, view: UIView) {
+    init(frameInRootView: CGRect, view: UIView, overrides: SessionReplayOverrides) {
         self.frame = frameInRootView
         self.backgroundColor = view.backgroundColor?.cgColor.safeCast
         self.layerBorderColor = view.layer.borderColor?.safeCast
@@ -141,7 +141,21 @@ extension ViewAttributes {
         self.alpha = view.alpha
         self.isHidden = view.isHidden
         self.intrinsicContentSize = view.intrinsicContentSize
-        self.sessionReplayOverride = view.dd.sessionReplayOverride
+        self.overrides = overrides
+    }
+}
+
+extension ViewAttributes {
+    /// Resolves the effective privacy level for text and input elements by considering the view's local override.
+    /// Falls back to the global privacy setting in the absence of local overrides.
+    func resolveTextAndInputPrivacyLevel(in context: ViewTreeRecordingContext) -> TextAndInputPrivacyLevel {
+        return self.overrides.textAndInputPrivacy ?? context.recorder.textAndInputPrivacy
+    }
+
+    /// Resolves the effective privacy level for image elements by considering the view's local override.
+    /// Falls back to the global privacy setting in the absence of local overrides.
+    func resolveImagePrivacyLevel(in context: ViewTreeRecordingContext) -> ImagePrivacyLevel {
+        return self.overrides.imagePrivacy ?? context.recorder.imagePrivacy
     }
 }
 

--- a/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
@@ -14,12 +14,12 @@ private var associatedSROverrideKey: UInt8 = 0
 /// Objective-C accessible extension for UIView
 @objc
 public extension UIView {
-    @objc var ddSessionReplayOverrides: DDSessionReplayOverrides {
+    @objc var ddSessionReplayOverrides: DDSessionReplayPrivacyOverrides {
         get {
-            if let override = objc_getAssociatedObject(self, &associatedSROverrideKey) as? DDSessionReplayOverrides {
+            if let override = objc_getAssociatedObject(self, &associatedSROverrideKey) as? DDSessionReplayPrivacyOverrides {
                 return override
             } else {
-                let override = DDSessionReplayOverrides()
+                let override = DDSessionReplayPrivacyOverrides()
                 objc_setAssociatedObject(self, &associatedSROverrideKey, override, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
                 return override
             }
@@ -32,13 +32,13 @@ public extension UIView {
 
 /// A wrapper class for Objective-C compatibility, providing overrides for Session Replay privacy settings.
 @objc
-public final class DDSessionReplayOverrides: NSObject {
+public final class DDSessionReplayPrivacyOverrides: NSObject {
     /// Internal Swift equivalent of the Session Replay Override, tied to the view.
-    internal var _swift: SessionReplayOverrides
+    internal var _swift: SessionReplayPrivacyOverrides
 
     @objc
     override public init() {
-        _swift = SessionReplayOverrides(UIView())
+        _swift = SessionReplayPrivacyOverrides(UIView())
         super.init()
     }
 

--- a/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayOverrides+objc.swift
@@ -14,12 +14,12 @@ private var associatedSROverrideKey: UInt8 = 0
 /// Objective-C accessible extension for UIView
 @objc
 public extension UIView {
-    @objc var ddSessionReplayOverride: DDSessionReplayOverride {
+    @objc var ddSessionReplayOverrides: DDSessionReplayOverrides {
         get {
-            if let override = objc_getAssociatedObject(self, &associatedSROverrideKey) as? DDSessionReplayOverride {
+            if let override = objc_getAssociatedObject(self, &associatedSROverrideKey) as? DDSessionReplayOverrides {
                 return override
             } else {
-                let override = DDSessionReplayOverride()
+                let override = DDSessionReplayOverrides()
                 objc_setAssociatedObject(self, &associatedSROverrideKey, override, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
                 return override
             }
@@ -32,13 +32,13 @@ public extension UIView {
 
 /// A wrapper class for Objective-C compatibility, providing overrides for Session Replay privacy settings.
 @objc
-public final class DDSessionReplayOverride: NSObject {
+public final class DDSessionReplayOverrides: NSObject {
     /// Internal Swift equivalent of the Session Replay Override, tied to the view.
-    internal var _swift: SessionReplayOverrideExtension
+    internal var _swift: SessionReplayOverrides
 
     @objc
     override public init() {
-        _swift = SessionReplayOverrideExtension(UIView())
+        _swift = SessionReplayOverrides(UIView())
         super.init()
     }
 

--- a/DatadogSessionReplay/Sources/SessionReplayPrivacyOverrides.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayPrivacyOverrides.swift
@@ -14,8 +14,8 @@ import DatadogInternal
 extension DatadogExtension where ExtendedType: UIView {
     /// Provides access to Session Replay override settings for the view.
     /// Usage: `myView.dd.sessionReplayOverrides.textAndInputPrivacy = .maskNone`.
-    public var sessionReplayOverrides: SessionReplayOverrides {
-        return SessionReplayOverrides(self.type)
+    public var sessionReplayOverrides: SessionReplayPrivacyOverrides {
+        return SessionReplayPrivacyOverrides(self.type)
     }
 }
 
@@ -29,7 +29,7 @@ private var associatedHiddenPrivacyKey: UInt8 = 6
 // MARK: - SessionReplayOverrides
 
 /// `UIView` extension  to manage the Session Replay privacy override settings.
-public final class SessionReplayOverrides {
+public final class SessionReplayPrivacyOverrides {
     private let view: UIView
 
     public init(_ view: UIView) {
@@ -77,8 +77,8 @@ public final class SessionReplayOverrides {
     }
 }
 
-extension Overrides: Equatable {
-    public static func == (lhs: SessionReplayOverrides, rhs: SessionReplayOverrides) -> Bool {
+extension PrivacyOverrides: Equatable {
+    public static func == (lhs: SessionReplayPrivacyOverrides, rhs: SessionReplayPrivacyOverrides) -> Bool {
         return lhs.view === rhs.view
         && lhs.textAndInputPrivacy == rhs.textAndInputPrivacy
         && lhs.imagePrivacy == rhs.imagePrivacy
@@ -87,10 +87,10 @@ extension Overrides: Equatable {
     }
 }
 
-extension Overrides {
+extension PrivacyOverrides {
     /// Merges child and parent overrides, giving precedence to the child’s overrides, if set.
     /// If the child has no overrides set, it inherits its parent’s overrides.
-    internal static func merge(_ child: Overrides, with parent: Overrides) -> Overrides {
+    internal static func merge(_ child: PrivacyOverrides, with parent: PrivacyOverrides) -> PrivacyOverrides {
         let merged = child
 
         // Apply child overrides if present
@@ -109,5 +109,5 @@ extension Overrides {
 }
 
 // This alias enables us to have a more unique name exposed through public-internal access level
-internal typealias Overrides = SessionReplayOverrides
+internal typealias PrivacyOverrides = SessionReplayPrivacyOverrides
 #endif

--- a/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
+++ b/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
@@ -13,7 +13,7 @@ import DatadogInternal
 @testable import DatadogSessionReplay
 
 class DDSessionReplayOverrideTests: XCTestCase {
-    // MARK: Overrides Interoperability
+    // MARK: Privacy Overrides Interoperability
     func testTextAndInputPrivacyLevelsOverrideInterop() {
         XCTAssertEqual(DDTextAndInputPrivacyLevelOverride.maskAll._swift, .maskAll)
         XCTAssertEqual(DDTextAndInputPrivacyLevelOverride.maskAllInputs._swift, .maskAllInputs)
@@ -49,7 +49,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
     }
 
     func testHiddenPrivacyLevelsOverrideInterop() {
-        let override = DDSessionReplayOverride()
+        let override = DDSessionReplayOverrides()
 
         // When setting hiddenPrivacy via Swift
         override._swift.hide = true
@@ -75,7 +75,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
     // MARK: Setting Overrides
     func testSettingAndRemovingPrivacyOverridesObjc() {
         // Given
-        let override = DDSessionReplayOverride()
+        let override = DDSessionReplayOverrides()
         let textAndInputPrivacy: DDTextAndInputPrivacyLevelOverride = [.maskAll, .maskAllInputs, .maskSensitiveInputs].randomElement()!
         let imagePrivacy: DDImagePrivacyLevelOverride = [.maskAll, .maskNonBundledOnly, .maskNone].randomElement()!
         let touchPrivacy: DDTouchPrivacyLevelOverride = [.show, .hide].randomElement()!
@@ -109,45 +109,45 @@ class DDSessionReplayOverrideTests: XCTestCase {
     func testSettingAndGettingOverridesFromObjC() {
             // Given
             let view = UIView()
-            let override = DDSessionReplayOverride()
+            let override = DDSessionReplayOverrides()
 
             // When
-            view.ddSessionReplayOverride = override
+            view.ddSessionReplayOverrides = override
             override.textAndInputPrivacy = .maskAll
             override.imagePrivacy = .maskAll
             override.touchPrivacy = .hide
             override.hide = NSNumber(value: true)
 
             // Then
-            XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, .maskAll)
-            XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, .maskAll)
-            XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, .hide)
-            XCTAssertEqual(view.ddSessionReplayOverride.hide?.boolValue, true)
+            XCTAssertEqual(view.ddSessionReplayOverrides.textAndInputPrivacy, .maskAll)
+            XCTAssertEqual(view.ddSessionReplayOverrides.imagePrivacy, .maskAll)
+            XCTAssertEqual(view.ddSessionReplayOverrides.touchPrivacy, .hide)
+            XCTAssertEqual(view.ddSessionReplayOverrides.hide?.boolValue, true)
         }
 
         func testClearingOverridesFromObjC() {
             // Given
             let view = UIView()
-            let override = DDSessionReplayOverride()
+            let override = DDSessionReplayOverrides()
 
             // Set initial values
-            view.ddSessionReplayOverride = override
+            view.ddSessionReplayOverrides = override
             override.textAndInputPrivacy = .maskAll
             override.imagePrivacy = .maskAll
             override.touchPrivacy = .hide
             override.hide = NSNumber(value: true)
 
             // When
-            view.ddSessionReplayOverride.textAndInputPrivacy = .none
-            view.ddSessionReplayOverride.imagePrivacy = .none
-            view.ddSessionReplayOverride.touchPrivacy = .none
-            view.ddSessionReplayOverride.hide = nil
+            view.ddSessionReplayOverrides.textAndInputPrivacy = .none
+            view.ddSessionReplayOverrides.imagePrivacy = .none
+            view.ddSessionReplayOverrides.touchPrivacy = .none
+            view.ddSessionReplayOverrides.hide = nil
 
             // Then
-            XCTAssertEqual(view.ddSessionReplayOverride.textAndInputPrivacy, .none)
-            XCTAssertEqual(view.ddSessionReplayOverride.imagePrivacy, .none)
-            XCTAssertEqual(view.ddSessionReplayOverride.touchPrivacy, .none)
-            XCTAssertNil(view.ddSessionReplayOverride.hide)
+            XCTAssertEqual(view.ddSessionReplayOverrides.textAndInputPrivacy, .none)
+            XCTAssertEqual(view.ddSessionReplayOverrides.imagePrivacy, .none)
+            XCTAssertEqual(view.ddSessionReplayOverrides.touchPrivacy, .none)
+            XCTAssertNil(view.ddSessionReplayOverrides.hide)
         }
 }
 #endif

--- a/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
+++ b/DatadogSessionReplay/Tests/DDSessionReplayOverridesTests.swift
@@ -49,7 +49,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
     }
 
     func testHiddenPrivacyLevelsOverrideInterop() {
-        let override = DDSessionReplayOverrides()
+        let override = DDSessionReplayPrivacyOverrides()
 
         // When setting hiddenPrivacy via Swift
         override._swift.hide = true
@@ -75,7 +75,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
     // MARK: Setting Overrides
     func testSettingAndRemovingPrivacyOverridesObjc() {
         // Given
-        let override = DDSessionReplayOverrides()
+        let override = DDSessionReplayPrivacyOverrides()
         let textAndInputPrivacy: DDTextAndInputPrivacyLevelOverride = [.maskAll, .maskAllInputs, .maskSensitiveInputs].randomElement()!
         let imagePrivacy: DDImagePrivacyLevelOverride = [.maskAll, .maskNonBundledOnly, .maskNone].randomElement()!
         let touchPrivacy: DDTouchPrivacyLevelOverride = [.show, .hide].randomElement()!
@@ -109,7 +109,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
     func testSettingAndGettingOverridesFromObjC() {
             // Given
             let view = UIView()
-            let override = DDSessionReplayOverrides()
+            let override = DDSessionReplayPrivacyOverrides()
 
             // When
             view.ddSessionReplayOverrides = override
@@ -128,7 +128,7 @@ class DDSessionReplayOverrideTests: XCTestCase {
         func testClearingOverridesFromObjC() {
             // Given
             let view = UIView()
-            let override = DDSessionReplayOverrides()
+            let override = DDSessionReplayPrivacyOverrides()
 
             // Set initial values
             view.ddSessionReplayOverrides = override

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -79,7 +79,7 @@ extension ViewAttributes: AnyMockable, RandomMockable {
         alpha: CGFloat = .mockAny(),
         isHidden: Bool = .mockAny(),
         intrinsicContentSize: CGSize = .mockAny(),
-        overrides: Overrides = .mockAny()
+        overrides: PrivacyOverrides = .mockAny()
     ) -> ViewAttributes {
         return .init(
             frame: frame,
@@ -582,12 +582,12 @@ internal extension Optional where Wrapped == NodeSemantics {
     }
 }
 
-extension Overrides: AnyMockable, RandomMockable {
-    public static func mockAny() -> Overrides {
+extension PrivacyOverrides: AnyMockable, RandomMockable {
+    public static func mockAny() -> PrivacyOverrides {
         return mockWith()
     }
 
-    public static func mockRandom() -> Overrides {
+    public static func mockRandom() -> PrivacyOverrides {
         return mockWith(
             textAndInputPrivacy: .mockRandom(),
             imagePrivacy: .mockRandom(),
@@ -601,8 +601,8 @@ extension Overrides: AnyMockable, RandomMockable {
         imagePrivacy: ImagePrivacyLevel? = nil,
         touchPrivacy: TouchPrivacyLevel? = nil,
         hide: Bool? = nil
-    ) -> Overrides {
-        let override = Overrides(UIView.mockRandom())
+    ) -> PrivacyOverrides {
+        let override = PrivacyOverrides(UIView.mockRandom())
         override.textAndInputPrivacy = textAndInputPrivacy
         override.imagePrivacy = imagePrivacy
         override.touchPrivacy = touchPrivacy

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -64,7 +64,8 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: .mockRandom(min: 0, max: 5),
             alpha: .mockRandom(min: 0, max: 1),
             isHidden: .mockRandom(),
-            intrinsicContentSize: .mockRandom()
+            intrinsicContentSize: .mockRandom(),
+            overrides: .mockAny()
         )
     }
 
@@ -78,7 +79,7 @@ extension ViewAttributes: AnyMockable, RandomMockable {
         alpha: CGFloat = .mockAny(),
         isHidden: Bool = .mockAny(),
         intrinsicContentSize: CGSize = .mockAny(),
-        sessionReplayOverride: SessionReplayOverrideExtension? = .mockAny()
+        overrides: Overrides = .mockAny()
     ) -> ViewAttributes {
         return .init(
             frame: frame,
@@ -89,7 +90,7 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             alpha: alpha,
             isHidden: isHidden,
             intrinsicContentSize: intrinsicContentSize,
-            sessionReplayOverride: sessionReplayOverride
+            overrides: overrides
         )
     }
 
@@ -173,7 +174,8 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: .mockRandom(min: 0, max: 4),
             alpha: alpha ?? .mockRandom(min: 0.01, max: 1),
             isHidden: isHidden ?? .mockRandom(),
-            intrinsicContentSize: (frame ?? .mockRandom(minWidth: 10, minHeight: 10)).size
+            intrinsicContentSize: (frame ?? .mockRandom(minWidth: 10, minHeight: 10)).size,
+            overrides: .mockAny()
         )
 
         // consistency check:
@@ -529,7 +531,7 @@ internal func mockUIView<View: UIView>(with attributes: ViewAttributes) -> View 
     // Consistency check - to make sure computed properties in `ViewAttributes` captured
     // for mocked view are equal the these from requested `attributes`.
     let expectedAttributes = attributes
-    let actualAttributes = ViewAttributes(frameInRootView: view.frame, view: view)
+    let actualAttributes = ViewAttributes(frameInRootView: view.frame, view: view, overrides: .mockAny())
 
     assert(
         actualAttributes.isVisible == expectedAttributes.isVisible,
@@ -580,12 +582,12 @@ internal extension Optional where Wrapped == NodeSemantics {
     }
 }
 
-extension SessionReplayOverrideExtension: AnyMockable, RandomMockable {
-    public static func mockAny() -> SessionReplayOverrideExtension {
+extension Overrides: AnyMockable, RandomMockable {
+    public static func mockAny() -> Overrides {
         return mockWith()
     }
 
-    public static func mockRandom() -> SessionReplayOverrideExtension {
+    public static func mockRandom() -> Overrides {
         return mockWith(
             textAndInputPrivacy: .mockRandom(),
             imagePrivacy: .mockRandom(),
@@ -599,8 +601,8 @@ extension SessionReplayOverrideExtension: AnyMockable, RandomMockable {
         imagePrivacy: ImagePrivacyLevel? = nil,
         touchPrivacy: TouchPrivacyLevel? = nil,
         hide: Bool? = nil
-    ) -> SessionReplayOverrideExtension {
-        let override = SessionReplayOverrideExtension(UIView.mockRandom())
+    ) -> Overrides {
+        let override = Overrides(UIView.mockRandom())
         override.textAndInputPrivacy = textAndInputPrivacy
         override.imagePrivacy = imagePrivacy
         override.touchPrivacy = touchPrivacy

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -18,6 +18,7 @@ class UIImageViewRecorderTests: XCTestCase {
     /// `ViewAttributes` simulating common attributes of image view's `UIView`.
     private var viewAttributes: ViewAttributes = .mockAny()
 
+    // MARK: Appearance
     func testWhenImageViewHasNoImageAndNoAppearance() throws {
         // When
         imageView.image = nil
@@ -53,6 +54,15 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIImageViewWireframesBuilder)
     }
 
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+
+    // MARK: Predicate Override
     func testWhenShouldRecordImagePredicateOverrideReturnsFalse() throws {
         // When
         let recorder = UIImageViewRecorder(identifier: UUID(), shouldRecordImagePredicateOverride: { _ in return false })
@@ -81,6 +91,7 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertNotNil(builder.imageResource)
     }
 
+    // MARK: Image Privacy
     func testWhenMaskAllImagePrivacy_itDoesNotRecordImage() throws {
         // Given
         let imagePrivacy = ImagePrivacyLevel.maskAll
@@ -137,12 +148,23 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertNotNil(builder.imageResource)
     }
 
-    func testWhenViewIsNotOfExpectedType() {
+    // MARK: Privacy Overrides
+    func testWhenImageViewHasImagePrivacyOverride() throws {
+        // Given
+        let globalImagePrivacy = ImagePrivacyLevel.maskNone
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(imagePrivacy: globalImagePrivacy))
+
+        imageView.image = UIImage()
+        let overrideImagePrivacy: ImagePrivacyLevel = .maskAll
+        let overrides: Overrides = .mockWith(imagePrivacy: overrideImagePrivacy)
+        viewAttributes = .mockWith(overrides: overrides)
+
         // When
-        let view = UITextField()
+        let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: context))
 
         // Then
-        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIImageViewWireframesBuilder)
+        XCTAssertNil(builder.imageResource)
     }
 }
 // swiftlint:enable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -156,7 +156,7 @@ class UIImageViewRecorderTests: XCTestCase {
 
         imageView.image = UIImage()
         let overrideImagePrivacy: ImagePrivacyLevel = .maskAll
-        let overrides: Overrides = .mockWith(imagePrivacy: overrideImagePrivacy)
+        let overrides: PrivacyOverrides = .mockWith(imagePrivacy: overrideImagePrivacy)
         viewAttributes = .mockWith(overrides: overrides)
 
         // When

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -85,6 +85,20 @@ class UILabelRecorderTests: XCTestCase {
         XCTAssertTrue(try textObfuscator(in: .maskAllInputs) is NOPTextObfuscator)
         XCTAssertTrue(try textObfuscator(in: .maskAll) is SpacePreservingMaskObfuscator)
     }
+
+    func testWhenLabelHasTextPrivacyOverride() throws {
+        // Given
+        label.text = .mockRandom()
+        viewAttributes = .mock(fixture: .visible())
+        viewAttributes.overrides = .mockWith(textAndInputPrivacy: .maskAll)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UILabelWireframesBuilder)
+        XCTAssertTrue(builder.textObfuscator is SpacePreservingMaskObfuscator)
+    }
 }
 // swiftlint:enable opening_brace
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -21,7 +21,7 @@ class UINavigationBarRecorderTests: XCTestCase {
         ]
 
         let navigationBar = UINavigationBar.mock(withFixture: fixtures.randomElement()!)
-        let viewAttributes = ViewAttributes(frameInRootView: navigationBar.frame, view: navigationBar)
+        let viewAttributes = ViewAttributes(frameInRootView: navigationBar.frame, view: navigationBar, overrides: .mockAny())
 
         // When
         let semantics = try XCTUnwrap(recorder.semantics(of: navigationBar, with: viewAttributes, in: .mockAny()) as? SpecificElement)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -54,5 +54,18 @@ class UISegmentRecorderTests: XCTestCase {
         // Then
         XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
     }
+
+    func testWhenSegmentHasTextPrivacyOverride() throws {
+        // Given
+        viewAttributes = .mock(fixture: .visible())
+        viewAttributes.overrides = .mockWith(textAndInputPrivacy: .maskAll)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UISegmentWireframesBuilder)
+        XCTAssertTrue(builder.textObfuscator is FixLengthMaskObfuscator)
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -17,7 +17,7 @@ class UITabBarRecorderTests: XCTestCase {
     func testWhenViewIsOfExpectedType() throws {
         // When
         let tabBar = UITabBar.mock(withFixture: .allCases.randomElement()!)
-        let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar)
+        let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar, overrides: .mockAny())
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny()))
@@ -38,7 +38,7 @@ class UITabBarRecorderTests: XCTestCase {
         // Given
         let tabBar = UITabBar.mock(withFixture: .visible(.someAppearance))
         tabBar.items = [UITabBarItem(title: "first", image: UIImage(), tag: 0)]
-        let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar)
+        let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar, overrides: .mockAny())
 
         // When
         let semantics1 = recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny())

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -107,6 +107,20 @@ class UITextFieldRecorderTests: XCTestCase {
         // Then - it keeps obfuscating
         XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLengthMaskObfuscator)
     }
+
+    func testWhenTextFieldHasTextPrivacyOverride() throws {
+        // Given
+        textField.text = .mockRandom()
+        viewAttributes = .mock(fixture: .visible())
+        viewAttributes.overrides = .mockWith(textAndInputPrivacy: .maskAll)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
+        XCTAssertTrue(builder.textObfuscator is FixLengthMaskObfuscator)
+    }
 }
 // swiftlint:enable opening_brace
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -98,6 +98,21 @@ class UITextViewRecorderTests: XCTestCase {
         // Then - it keeps obfuscating
         XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLengthMaskObfuscator)
     }
+
+    func testWhenTextViewHasTextPrivacyOverride() throws {
+        // Given
+        textView.text = .mockRandom()
+        textView.isEditable = false
+        viewAttributes = .mock(fixture: .visible())
+        viewAttributes.overrides = .mockWith(textAndInputPrivacy: .maskAll)
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UITextViewWireframesBuilder)
+        XCTAssertTrue(builder.textObfuscator is SpacePreservingMaskObfuscator)
+    }
 }
 // swiftlint:enable opening_brace
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -61,7 +61,7 @@ class UIViewRecorderTests: XCTestCase {
     func testWhenViewHasHiddenOverride() throws {
         // Given
         viewAttributes = .mock(fixture: .visible(.someAppearance))
-        viewAttributes.sessionReplayOverride = .mockWith(hide: true)
+        viewAttributes.overrides = .mockWith(hide: true)
 
         // When
         let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -294,5 +294,125 @@ class ViewTreeRecorderTests: XCTestCase {
         XCTAssertEqual(context?.viewControllerContext.isRootView, false)
         XCTAssertEqual(context?.viewControllerContext.parentType, .activity)
     }
+
+    // MARK: Privacy Overrides
+
+    func testChildViewInheritsParentHideOverride() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+        parentView.dd.sessionReplayOverrides.hide = true
+
+        // When
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 1)
+    }
+
+    func testChildViewHideOverrideIsTrueAndParentHideOverrideIsFalse() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        childView.dd.sessionReplayOverrides.hide = true
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+        parentView.dd.sessionReplayOverrides.hide = false
+
+        // When
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 2)
+    }
+
+    func testChildViewHideOverrideIsTrueAndParentHideOverrideIsNil() {
+        // Given
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        childView.dd.sessionReplayOverrides.hide = true
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+
+        // When
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 2)
+    }
+
+    func testImageViewOverrideTakesPrecedenceOverGlobalSetting() {
+        // Given
+        let globalImagePrivacy: ImagePrivacyLevel = .mockRandom()
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(imagePrivacy: globalImagePrivacy))
+
+        let viewImagePrivacy: ImagePrivacyLevel = .maskNone
+        let imageView = UIImageView.mock(withFixture: .visible(.someAppearance))
+        imageView.image = .mockRandom()
+        imageView.dd.sessionReplayOverrides.imagePrivacy = viewImagePrivacy
+
+        // When
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodes = recorder.record(imageView, in: context)
+
+        // Then
+        XCTAssertEqual(nodes.count, 1)
+        let node = nodes.first
+        XCTAssertNotNil(node)
+        XCTAssertEqual(node!.viewAttributes.overrides.imagePrivacy, viewImagePrivacy)
+        let builder = node!.wireframesBuilder as? UIImageViewWireframesBuilder
+        XCTAssertNotNil(builder)
+        XCTAssertNotNil(builder!.imageResource)
+    }
+
+    func testChildViewMaskNoneImageOverrideWithParentImageOverride() {
+        // Given
+        let childImagePrivacy: ImagePrivacyLevel = .maskNone
+        let childView = UIImageView.mock(withFixture: .visible(.someAppearance))
+        childView.image = .mockRandom()
+        childView.dd.sessionReplayOverrides.imagePrivacy = childImagePrivacy
+        let parentImagePrivacy: ImagePrivacyLevel = .mockRandom()
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.dd.sessionReplayOverrides.imagePrivacy = parentImagePrivacy
+        parentView.addSubview(childView)
+
+        // When
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 2)
+        XCTAssertEqual(nodes[0].viewAttributes.overrides.imagePrivacy, parentImagePrivacy)
+        XCTAssertEqual(nodes[1].viewAttributes.overrides.imagePrivacy, childImagePrivacy)
+        let builder = nodes[1].wireframesBuilder as? UIImageViewWireframesBuilder
+        XCTAssertNotNil(builder)
+        XCTAssertNotNil(builder!.imageResource)
+    }
+
+    func testChildViewMaskAllImageOverrideWithParentImageOverride() {
+        // Given
+        let childImagePrivacy: ImagePrivacyLevel = .maskAll
+        let childView = UIImageView.mock(withFixture: .visible(.someAppearance))
+        childView.image = .mockRandom()
+        childView.dd.sessionReplayOverrides.imagePrivacy = childImagePrivacy
+        let parentImagePrivacy: ImagePrivacyLevel = .mockRandom()
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.dd.sessionReplayOverrides.imagePrivacy = parentImagePrivacy
+        parentView.addSubview(childView)
+
+        // When
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 2)
+        XCTAssertEqual(nodes[0].viewAttributes.overrides.imagePrivacy, parentImagePrivacy)
+        XCTAssertEqual(nodes[1].viewAttributes.overrides.imagePrivacy, childImagePrivacy)
+        let builder = nodes[1].wireframesBuilder as? UIImageViewWireframesBuilder
+        XCTAssertNotNil(builder)
+        XCTAssertNil(builder!.imageResource)
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -12,12 +12,13 @@ import XCTest
 
 // swiftlint:disable opening_brace
 class ViewAttributesTests: XCTestCase {
+    // MARK: Appearance
     func testItCapturesViewAttributes() {
         // Given
-        let view: UIView = .mockRandom()
+        let view = UIView.mockRandom()
 
         // When
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
 
         // Then
         XCTAssertEqual(attributes.frame, view.frame)
@@ -28,6 +29,10 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.alpha, view.alpha)
         XCTAssertEqual(attributes.isHidden, view.isHidden)
         XCTAssertEqual(attributes.intrinsicContentSize, view.intrinsicContentSize)
+        XCTAssertNil(attributes.overrides.textAndInputPrivacy)
+        XCTAssertNil(attributes.overrides.imagePrivacy)
+        XCTAssertNil(attributes.overrides.touchPrivacy)
+        XCTAssertNil(attributes.overrides.hide)
     }
 
     func testWhenViewIsVisible() {
@@ -40,7 +45,7 @@ class ViewAttributesTests: XCTestCase {
         view.frame = .mockRandom(minWidth: 0.01, minHeight: 0.01)
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertTrue(attributes.isVisible)
     }
 
@@ -56,7 +61,7 @@ class ViewAttributesTests: XCTestCase {
         ])
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertFalse(attributes.isVisible)
     }
 
@@ -79,7 +84,7 @@ class ViewAttributesTests: XCTestCase {
         ])
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertTrue(attributes.hasAnyAppearance)
     }
 
@@ -102,7 +107,7 @@ class ViewAttributesTests: XCTestCase {
         ])
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertFalse(attributes.hasAnyAppearance)
     }
 
@@ -119,7 +124,7 @@ class ViewAttributesTests: XCTestCase {
         ])
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertTrue(attributes.isTranslucent)
     }
 
@@ -134,7 +139,7 @@ class ViewAttributesTests: XCTestCase {
         view.backgroundColor = .mockRandomWith(alpha: 1)
 
         // Then
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
         XCTAssertFalse(attributes.isTranslucent)
     }
 
@@ -144,7 +149,7 @@ class ViewAttributesTests: XCTestCase {
         view.setValue("invalid color", forKeyPath: "layer.borderColor")
 
         // When
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
 
         // Then
         XCTAssertNil(attributes.layerBorderColor)
@@ -156,7 +161,8 @@ class ViewAttributesTests: XCTestCase {
         let color: CGColor = .mockRandom()
         let float: CGFloat = .mockRandom()
         let boolean: Bool = .mockRandom()
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view).copy {
+        let overrides: Overrides = .mockRandom()
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view, overrides: overrides).copy {
             $0.frame = rect
             $0.backgroundColor = color
             $0.layerBorderColor = color
@@ -165,6 +171,7 @@ class ViewAttributesTests: XCTestCase {
             $0.alpha = float
             $0.isHidden = boolean
             $0.intrinsicContentSize = rect.size
+            $0.overrides = overrides
         }
         XCTAssertEqual(attributes.frame, rect)
         XCTAssertEqual(attributes.backgroundColor, color)
@@ -174,40 +181,75 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.alpha, float)
         XCTAssertEqual(attributes.isHidden, boolean)
         XCTAssertEqual(attributes.intrinsicContentSize, rect.size)
+        XCTAssertEqual(attributes.overrides, overrides)
     }
 
-    // MARK: Overrides
+    // MARK: Privacy Overrides
+
     func testItDefaultsToNilWhenNoOverrideIsSet() {
         // Given
-        let view: UIView = .mockRandom()
+        let view: UIView = .mockAny()
 
         // When
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let attributes = createViewAttributes(with: view)
 
         // Then
-        XCTAssertNil(attributes.sessionReplayOverride?.textAndInputPrivacy)
-        XCTAssertNil(attributes.sessionReplayOverride?.imagePrivacy)
-        XCTAssertNil(attributes.sessionReplayOverride?.touchPrivacy)
-        XCTAssertNil(attributes.sessionReplayOverride?.hide)
+        XCTAssertNil(attributes.overrides.textAndInputPrivacy)
+        XCTAssertNil(attributes.overrides.imagePrivacy)
+        XCTAssertNil(attributes.overrides.touchPrivacy)
+        XCTAssertNil(attributes.overrides.hide)
     }
 
-    func testItCapturesViewAttributesWithOverrides() {
+    func testChildViewInheritsParentHideOverride() {
         // Given
-        let view: UIView = .mockRandom()
-        let overrides = SessionReplayOverrideExtension.mockRandom()
-        view.dd.sessionReplayOverride.textAndInputPrivacy = overrides.textAndInputPrivacy
-        view.dd.sessionReplayOverride.imagePrivacy = overrides.imagePrivacy
-        view.dd.sessionReplayOverride.touchPrivacy = overrides.touchPrivacy
-        view.dd.sessionReplayOverride.hide = overrides.hide
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+        parentView.dd.sessionReplayOverrides.hide = true
+
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
 
         // When
-        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        let nodes = recorder.record(parentView, in: .mockRandom())
 
         // Then
-        XCTAssertEqual(attributes.sessionReplayOverride?.textAndInputPrivacy, overrides.textAndInputPrivacy)
-        XCTAssertEqual(attributes.sessionReplayOverride?.imagePrivacy, overrides.imagePrivacy)
-        XCTAssertEqual(attributes.sessionReplayOverride?.touchPrivacy, overrides.touchPrivacy)
-        XCTAssertEqual(attributes.sessionReplayOverride?.hide, overrides.hide)
+        XCTAssertEqual(nodes.count, 1)
+    }
+
+    func testChildViewHideOverrideSetToFalseDoesNotOverrideParentHideOverride() {
+        // Given
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+
+        parentView.dd.sessionReplayOverrides.hide = true
+        childView.dd.sessionReplayOverrides.hide = false
+
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+
+        // When
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 1, "Child view overrides parent's hidden state, so it should be recorded.")
+    }
+
+    func testChildViewInheritsParentOverrides() {
+        // Given
+        let parentView = UIView.mock(withFixture: .visible(.someAppearance))
+        let childView = UIView.mock(withFixture: .visible(.someAppearance))
+        parentView.addSubview(childView)
+
+        let parentOverrides: Overrides = .mockRandom()
+        parentView.dd.sessionReplayOverrides.textAndInputPrivacy = parentOverrides.textAndInputPrivacy
+        parentView.dd.sessionReplayOverrides.imagePrivacy = parentOverrides.imagePrivacy
+        parentView.dd.sessionReplayOverrides.touchPrivacy = parentOverrides.touchPrivacy
+
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodes = recorder.record(parentView, in: .mockRandom())
+
+        // Then
+        XCTAssertEqual(nodes.count, 2)
     }
 }
 // swiftlint:enable opening_brace
@@ -250,6 +292,12 @@ class NodeSemanticsTests: XCTestCase {
             .ignore,
             "Subtree should not be recorded for 'invisible' elements as nothing in it will be visible anyway"
         )
+    }
+}
+
+extension ViewAttributesTests {
+    func createViewAttributes(with view: UIView) -> ViewAttributes {
+        return ViewAttributes(frameInRootView: view.frame, view: view, overrides: .mockAny())
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -161,7 +161,7 @@ class ViewAttributesTests: XCTestCase {
         let color: CGColor = .mockRandom()
         let float: CGFloat = .mockRandom()
         let boolean: Bool = .mockRandom()
-        let overrides: Overrides = .mockRandom()
+        let overrides: PrivacyOverrides = .mockRandom()
         let attributes = ViewAttributes(frameInRootView: view.frame, view: view, overrides: overrides).copy {
             $0.frame = rect
             $0.backgroundColor = color
@@ -240,7 +240,7 @@ class ViewAttributesTests: XCTestCase {
         let childView = UIView.mock(withFixture: .visible(.someAppearance))
         parentView.addSubview(childView)
 
-        let parentOverrides: Overrides = .mockRandom()
+        let parentOverrides: PrivacyOverrides = .mockRandom()
         parentView.dd.sessionReplayOverrides.textAndInputPrivacy = parentOverrides.textAndInputPrivacy
         parentView.dd.sessionReplayOverrides.imagePrivacy = parentOverrides.imagePrivacy
         parentView.dd.sessionReplayOverrides.touchPrivacy = parentOverrides.touchPrivacy

--- a/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
@@ -7,18 +7,20 @@
 #if os(iOS)
 import XCTest
 import UIKit
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
-class SessionReplayOverrideTests: XCTestCase {
+class SessionReplayOverridesTests: XCTestCase {
+    // MARK: Setting overrides
     func testWhenNoOverrideIsSet_itDefaultsToNil() {
         // Given
         let view = UIView()
 
         // Then
-        XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hide)
+        XCTAssertNil(view.dd.sessionReplayOverrides.textAndInputPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.imagePrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.touchPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.hide)
     }
 
     func testWithOverrides() {
@@ -26,37 +28,164 @@ class SessionReplayOverrideTests: XCTestCase {
         let view = UIView()
 
         // When
-        view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
-        view.dd.sessionReplayOverride.imagePrivacy = .maskAll
-        view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hide = true
+        view.dd.sessionReplayOverrides.textAndInputPrivacy = .maskAllInputs
+        view.dd.sessionReplayOverrides.imagePrivacy = .maskAll
+        view.dd.sessionReplayOverrides.touchPrivacy = .hide
+        view.dd.sessionReplayOverrides.hide = true
 
         // Then
-        XCTAssertEqual(view.dd.sessionReplayOverride.textAndInputPrivacy, .maskAllInputs)
-        XCTAssertEqual(view.dd.sessionReplayOverride.imagePrivacy, .maskAll)
-        XCTAssertEqual(view.dd.sessionReplayOverride.touchPrivacy, .hide)
-        XCTAssertEqual(view.dd.sessionReplayOverride.hide, true)
+        XCTAssertEqual(view.dd.sessionReplayOverrides.textAndInputPrivacy, .maskAllInputs)
+        XCTAssertEqual(view.dd.sessionReplayOverrides.imagePrivacy, .maskAll)
+        XCTAssertEqual(view.dd.sessionReplayOverrides.touchPrivacy, .hide)
+        XCTAssertEqual(view.dd.sessionReplayOverrides.hide, true)
     }
 
     func testRemovingOverrides() {
         // Given
         let view = UIView()
-        view.dd.sessionReplayOverride.textAndInputPrivacy = .maskAllInputs
-        view.dd.sessionReplayOverride.imagePrivacy = .maskAll
-        view.dd.sessionReplayOverride.touchPrivacy = .hide
-        view.dd.sessionReplayOverride.hide = true
+        view.dd.sessionReplayOverrides.textAndInputPrivacy = .maskAllInputs
+        view.dd.sessionReplayOverrides.imagePrivacy = .maskAll
+        view.dd.sessionReplayOverrides.touchPrivacy = .hide
+        view.dd.sessionReplayOverrides.hide = true
 
         // When
-        view.dd.sessionReplayOverride.textAndInputPrivacy = nil
-        view.dd.sessionReplayOverride.imagePrivacy = nil
-        view.dd.sessionReplayOverride.touchPrivacy = nil
-        view.dd.sessionReplayOverride.hide = nil
+        view.dd.sessionReplayOverrides.textAndInputPrivacy = nil
+        view.dd.sessionReplayOverrides.imagePrivacy = nil
+        view.dd.sessionReplayOverrides.touchPrivacy = nil
+        view.dd.sessionReplayOverrides.hide = nil
 
         // Then
-        XCTAssertNil(view.dd.sessionReplayOverride.textAndInputPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.imagePrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.touchPrivacy)
-        XCTAssertNil(view.dd.sessionReplayOverride.hide)
+        XCTAssertNil(view.dd.sessionReplayOverrides.textAndInputPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.imagePrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.touchPrivacy)
+        XCTAssertNil(view.dd.sessionReplayOverrides.hide)
+    }
+
+    // MARK: Privacy overrides taking precedence over global settings
+    func testTextOverrideTakesPrecedenceOverGlobalTextPrivacy() {
+        // Given
+        let textAndInputOverride: TextAndInputPrivacyLevel = .mockRandom()
+        let viewAttributes: ViewAttributes = .mockWith(overrides: .mockWith(textAndInputPrivacy: textAndInputOverride))
+        let globalTextAndInputPrivacy: TextAndInputPrivacyLevel = .mockRandom()
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(textAndInputPrivacy: globalTextAndInputPrivacy))
+
+        // When
+        let resolvedTextPrivacy = viewAttributes.resolveTextAndInputPrivacyLevel(in: context)
+
+        // Then
+        XCTAssertEqual(resolvedTextPrivacy, textAndInputOverride)
+    }
+
+    func testTextGlobalPrivacyIsUsedWhenNoTextOverrideIsSet() {
+        // Given
+        let viewAttributes: ViewAttributes = .mockAny()
+        let globalTextAndInputPrivacy: TextAndInputPrivacyLevel = .mockRandom()
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(textAndInputPrivacy: globalTextAndInputPrivacy))
+
+        // When
+        let resolvedPrivacy = viewAttributes.resolveTextAndInputPrivacyLevel(in: context)
+
+        // Then
+        XCTAssertEqual(resolvedPrivacy, globalTextAndInputPrivacy)
+    }
+
+    func testImageOverrideTakesPrecedenceOverGlobalImagePrivacy() {
+        // Given
+        let imageOverride: ImagePrivacyLevel = .mockRandom()
+        let viewAttributes: ViewAttributes = .mockWith(overrides: .mockWith(imagePrivacy: imageOverride))
+        let globalImagePrivacy: ImagePrivacyLevel = .mockRandom()
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(imagePrivacy: globalImagePrivacy))
+
+        // When
+        let resolvedImagePrivacy = viewAttributes.resolveImagePrivacyLevel(in: context)
+
+        // Then
+        XCTAssertEqual(resolvedImagePrivacy, imageOverride)
+    }
+
+    func testImageGlobalPrivacyIsUsedWhenNoImageOverrideIsSet() {
+        // Given
+        let viewAttributes: ViewAttributes = .mockAny()
+        let globalImagePrivacy: ImagePrivacyLevel = .mockRandom()
+        let context = ViewTreeRecordingContext.mockWith(recorder: .mockWith(imagePrivacy: globalImagePrivacy))
+
+        // When
+        let resolvedImagePrivacy = viewAttributes.resolveImagePrivacyLevel(in: context)
+
+        // Then
+        XCTAssertEqual(resolvedImagePrivacy, globalImagePrivacy)
+    }
+
+    func testMergeParentAndChildOverrides() {
+        // Given
+        let overrides: Overrides = .mockRandom()
+
+        let childOverrides: Overrides = .mockAny()
+        childOverrides.textAndInputPrivacy = overrides.textAndInputPrivacy
+        // We set the `hide` override on the child because in the merge process,
+        // the child's override takes precedence. If the parent's `hide` is `false`,
+        // the final merged value will end up as `nil`, which makes the test fail.
+        childOverrides.hide = overrides.hide
+
+        let parentOverrides: Overrides = .mockAny()
+        parentOverrides.imagePrivacy = overrides.imagePrivacy
+        parentOverrides.touchPrivacy = overrides.touchPrivacy
+
+        // When
+        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+
+        // Then
+        XCTAssertEqual(merged.textAndInputPrivacy, overrides.textAndInputPrivacy)
+        XCTAssertEqual(merged.imagePrivacy, overrides.imagePrivacy)
+        XCTAssertEqual(merged.touchPrivacy, overrides.touchPrivacy)
+        XCTAssertEqual(merged.touchPrivacy, overrides.touchPrivacy)
+    }
+
+    func testMergeWithNilParentOverrides() {
+        // Given
+        let childOverrides: Overrides = .mockRandom()
+        let parentOverrides: Overrides = .mockAny()
+
+        // When
+        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+
+        // Then
+        XCTAssertEqual(merged.textAndInputPrivacy, childOverrides.textAndInputPrivacy)
+        XCTAssertEqual(merged.imagePrivacy, childOverrides.imagePrivacy)
+        XCTAssertEqual(merged.touchPrivacy, childOverrides.touchPrivacy)
+        XCTAssertEqual(merged.hide, childOverrides.hide)
+    }
+
+    func testMergeWithNilChildOverrides() {
+        // Given
+        let childOverrides: Overrides = .mockAny()
+        let parentOverrides: Overrides = .mockRandom()
+
+        // When
+        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+
+        // Then
+        XCTAssertEqual(merged.textAndInputPrivacy, parentOverrides.textAndInputPrivacy)
+        XCTAssertEqual(merged.imagePrivacy, parentOverrides.imagePrivacy)
+        XCTAssertEqual(merged.touchPrivacy, parentOverrides.touchPrivacy)
+        XCTAssertEqual(merged.hide, parentOverrides.hide)
+    }
+
+    func testMergeWhenChildHideOverrideIsNotNilAndParentHideOverrideIsTrue() {
+        // Given
+        let childOverrides: Overrides = .mockRandom()
+        childOverrides.hide = false
+        let parentOverrides: Overrides = .mockRandom()
+        parentOverrides.hide = true
+
+        // When
+        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+
+        // Then
+        XCTAssertEqual(merged.textAndInputPrivacy, childOverrides.textAndInputPrivacy)
+        XCTAssertEqual(merged.imagePrivacy, childOverrides.imagePrivacy)
+        XCTAssertEqual(merged.touchPrivacy, childOverrides.touchPrivacy)
+        XCTAssertEqual(merged.hide, true)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayOverrideTests.swift
@@ -118,21 +118,21 @@ class SessionReplayOverridesTests: XCTestCase {
 
     func testMergeParentAndChildOverrides() {
         // Given
-        let overrides: Overrides = .mockRandom()
+        let overrides: PrivacyOverrides = .mockRandom()
 
-        let childOverrides: Overrides = .mockAny()
+        let childOverrides: PrivacyOverrides = .mockAny()
         childOverrides.textAndInputPrivacy = overrides.textAndInputPrivacy
         // We set the `hide` override on the child because in the merge process,
         // the child's override takes precedence. If the parent's `hide` is `false`,
         // the final merged value will end up as `nil`, which makes the test fail.
         childOverrides.hide = overrides.hide
 
-        let parentOverrides: Overrides = .mockAny()
+        let parentOverrides: PrivacyOverrides = .mockAny()
         parentOverrides.imagePrivacy = overrides.imagePrivacy
         parentOverrides.touchPrivacy = overrides.touchPrivacy
 
         // When
-        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+        let merged = SessionReplayPrivacyOverrides.merge(childOverrides, with: parentOverrides)
 
         // Then
         XCTAssertEqual(merged.textAndInputPrivacy, overrides.textAndInputPrivacy)
@@ -143,11 +143,11 @@ class SessionReplayOverridesTests: XCTestCase {
 
     func testMergeWithNilParentOverrides() {
         // Given
-        let childOverrides: Overrides = .mockRandom()
-        let parentOverrides: Overrides = .mockAny()
+        let childOverrides: PrivacyOverrides = .mockRandom()
+        let parentOverrides: PrivacyOverrides = .mockAny()
 
         // When
-        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+        let merged = SessionReplayPrivacyOverrides.merge(childOverrides, with: parentOverrides)
 
         // Then
         XCTAssertEqual(merged.textAndInputPrivacy, childOverrides.textAndInputPrivacy)
@@ -158,11 +158,11 @@ class SessionReplayOverridesTests: XCTestCase {
 
     func testMergeWithNilChildOverrides() {
         // Given
-        let childOverrides: Overrides = .mockAny()
-        let parentOverrides: Overrides = .mockRandom()
+        let childOverrides: PrivacyOverrides = .mockAny()
+        let parentOverrides: PrivacyOverrides = .mockRandom()
 
         // When
-        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+        let merged = SessionReplayPrivacyOverrides.merge(childOverrides, with: parentOverrides)
 
         // Then
         XCTAssertEqual(merged.textAndInputPrivacy, parentOverrides.textAndInputPrivacy)
@@ -173,13 +173,13 @@ class SessionReplayOverridesTests: XCTestCase {
 
     func testMergeWhenChildHideOverrideIsNotNilAndParentHideOverrideIsTrue() {
         // Given
-        let childOverrides: Overrides = .mockRandom()
+        let childOverrides: PrivacyOverrides = .mockRandom()
         childOverrides.hide = false
-        let parentOverrides: Overrides = .mockRandom()
+        let parentOverrides: PrivacyOverrides = .mockRandom()
         parentOverrides.hide = true
 
         // When
-        let merged = SessionReplayOverrides.merge(childOverrides, with: parentOverrides)
+        let merged = SessionReplayPrivacyOverrides.merge(childOverrides, with: parentOverrides)
 
         // Then
         XCTAssertEqual(merged.textAndInputPrivacy, childOverrides.textAndInputPrivacy)


### PR DESCRIPTION
### What and why?

This PR builds on the work from #2058, which introduced Fine-Grained Masking (FGM) overrides (see the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3901129961/RFC+-+Session+Replay+Fine+Grained+Masking+Overrides) [internal] for more details). It implements the logic for applying the text and input privacy override, as well as image privacy override, at the view level. The goal is to allow views to have a specific privacy setting that overrides the global configuration.

Additionally, it ensures that privacy overrides propagate to child views, allowing parents to enforce privacy settings for their entire subtree, unless explicitly overridden by child views.

### How?

- Updated recorders that handle text and user inputs, as well as images (e.g., `UILabelRecorder`, `UIPickerViewRecorder`, `UIImageViewRecorder`) to incorporate privacy overrides logic.
- Modified these recorders to take into account the view's attributes in addition the context to determine the appropriate behavior.
- Implemented logic to resolve the effective privacy level at each view, ensuring that:
  - view-level overrides take precedence over global settings
  - child views inherit privacy settings from their parent, unless explicitly set their own overrides
- Renamed `SessionReplayOverrideExtension` to `SessionReplayOverrides` to improve clarity

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
