### PR TITLE
Add KMP to the `Segment.Source` random value mock

### DIFF
--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -1124,7 +1124,8 @@ extension SRSegment.Source: AnyMockable, RandomMockable {
             .android,
             .ios,
             .flutter,
-            .reactNative
+            .reactNative,
+            .kotlinMultiplatform
         ].randomElement()!
     }
 }


### PR DESCRIPTION
### What and why?

Tiny follow-up for https://github.com/DataDog/dd-sdk-ios/pull/2070 which I missed. It adds a value to the random value mock as well.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
