### PR TITLE
RUM-6386 Add default value for replaySampleRate

### DIFF
--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -81,8 +81,8 @@ extension SessionReplay {
         ///   - defaultImageRecordingLevel: Image recording privacy level. Default: `.maskAll`.
 
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
-        public init(
-            replaySampleRate: Float,
+        public init(    // swiftlint:disable:this function_default_parameter_at_end
+            replaySampleRate: Float = 100,
             textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
             imagePrivacyLevel: ImagePrivacyLevel,
             touchPrivacyLevel: TouchPrivacyLevel,
@@ -105,7 +105,7 @@ extension SessionReplay {
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(replaySampleRate:textAndInputPrivacyLevel:imagePrivacyLevel:touchPrivacyLevel:)` instead.")
         public init(
-            replaySampleRate: Float,
+            replaySampleRate: Float = 100,
             defaultPrivacyLevel: SessionReplayPrivacyLevel = .mask,
             startRecordingImmediately: Bool = true,
             customEndpoint: URL? = nil

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -12,15 +12,34 @@ import XCTest
 
 class SessionReplayConfigurationTests: XCTestCase {
     func testDefaultConfiguration() {
-        let random: Float = .mockRandom(min: 0, max: 100)
-
         // When
-        let config = SessionReplay.Configuration(replaySampleRate: random)
+        let config = SessionReplay.Configuration()
 
         // Then
-        XCTAssertEqual(config.replaySampleRate, random)
+        XCTAssertEqual(config.replaySampleRate, 100)
         XCTAssertEqual(config.defaultPrivacyLevel, .mask)
+        XCTAssertEqual(config.textAndInputPrivacyLevel, .maskAll)
         XCTAssertEqual(config.imagePrivacyLevel, .maskAll)
+        XCTAssertEqual(config.touchPrivacyLevel, .hide)
+        XCTAssertEqual(config.startRecordingImmediately, true)
+        XCTAssertNil(config.customEndpoint)
+        XCTAssertEqual(config._additionalNodeRecorders.count, 0)
+    }
+
+    func testDefaultConfigurationWithNewApi() {
+        // When
+        let config = SessionReplay.Configuration(
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll,
+            touchPrivacyLevel: .hide
+        )
+
+        // Then
+        XCTAssertEqual(config.replaySampleRate, 100)
+        XCTAssertEqual(config.defaultPrivacyLevel, .mask)
+        XCTAssertEqual(config.textAndInputPrivacyLevel, .maskAll)
+        XCTAssertEqual(config.imagePrivacyLevel, .maskAll)
+        XCTAssertEqual(config.touchPrivacyLevel, .hide)
         XCTAssertEqual(config.startRecordingImmediately, true)
         XCTAssertNil(config.customEndpoint)
         XCTAssertEqual(config._additionalNodeRecorders.count, 0)
@@ -32,6 +51,22 @@ class SessionReplayConfigurationTests: XCTestCase {
 
         // When
         var config = SessionReplay.Configuration(replaySampleRate: random)
+        config.setAdditionalNodeRecorders([mockNodeRecorder])
+
+        // Then
+        XCTAssertEqual(config._additionalNodeRecorders.count, 1)
+        XCTAssertEqual(config._additionalNodeRecorders[0].identifier, mockNodeRecorder.identifier)
+    }
+
+    func testConfigurationWithAdditionalNodeRecordersWithNewApi() {
+        let mockNodeRecorder = SessionReplayNodeRecorderMock()
+
+        // When
+        var config = SessionReplay.Configuration(
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll,
+            touchPrivacyLevel: .hide
+        )
         config.setAdditionalNodeRecorders([mockNodeRecorder])
 
         // Then


### PR DESCRIPTION
### What and why?

We decided to add a default value for session replay sample rate. This aligns with other public APIs which all provide a default value for sampling rates.

### How?

- Added a default value of `100` to `replaySampleRate` for both Session Replay Configuration public APIs
- Updates tests accordingly

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
