### PR TITLE
Add ObjC checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,4 @@ A brief description of implementation details of this PR.
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
 - [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
 - [ ] Add CHANGELOG entry for user facing changes
+- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)) and run `make api-surface`


### PR DESCRIPTION
### What and why?

It happened several times that when adding a new public API, we forget to add the corresponding Objective-C interface. Adding a dedicated checkbox to the PR template will serve as a reminder and help prevent this oversight in the future.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
