### PR TITLE
RUM-6354 fix: Prioritize SwiftUI RUM actions over UIKit actions

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -309,6 +309,8 @@
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
 		61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */; };
 		61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */; };
+		61193AAE2CB54C7300C3CDF5 /* RUMActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61193AAD2CB54C7300C3CDF5 /* RUMActionsHandler.swift */; };
+		61193AAF2CB54C7300C3CDF5 /* RUMActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61193AAD2CB54C7300C3CDF5 /* RUMActionsHandler.swift */; };
 		6121627C247D220500AC5D67 /* TracingWithLoggingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* TracingWithLoggingIntegrationTests.swift */; };
 		61216B762666DDA10089DCD1 /* LoggerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B752666DDA10089DCD1 /* LoggerConfigurationTests.swift */; };
 		61216B7B2667A9AE0089DCD1 /* LogsConfigurationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7A2667A9AE0089DCD1 /* LogsConfigurationE2ETests.swift */; };
@@ -987,7 +989,7 @@
 		D23F8E8B29DDCD28001CFAE8 /* RUMContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63824BF19B4008053F2 /* RUMContext.swift */; };
 		D23F8E8C29DDCD28001CFAE8 /* RUMBaggageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25FF2F329CC88060063802D /* RUMBaggageKeys.swift */; };
 		D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA3CA6826775A3500B16871 /* VitalRefreshRateReader.swift */; };
-		D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */; };
+		D23F8E8E29DDCD28001CFAE8 /* UIEventCommandFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIEventCommandFactory.swift */; };
 		D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFD824C7269500589570 /* RUMUUIDGenerator.swift */; };
 		D23F8EA029DDCD38001CFAE8 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */; };
 		D23F8EA229DDCD38001CFAE8 /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
@@ -1007,7 +1009,7 @@
 		D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */; };
 		D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
 		D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
-		D23F8EB829DDCD38001CFAE8 /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
+		D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* RUMActionsHandlerTests.swift */; };
 		D23F8EB929DDCD38001CFAE8 /* RUMFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */; };
 		D23F8EBA29DDCD38001CFAE8 /* ViewIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C1510C25AC8C1B00362D4B /* ViewIdentifierTests.swift */; };
 		D23F8EBE29DDCD38001CFAE8 /* WebViewEventReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E53889B2773C4B300A7DC42 /* WebViewEventReceiverTests.swift */; };
@@ -1204,7 +1206,7 @@
 		D29A9F6629DD85BB005C54A4 /* RUMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4A24EBC43D00A2A780 /* RUMUser.swift */; };
 		D29A9F6729DD85BB005C54A4 /* RUMOperatingSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */; };
 		D29A9F6829DD85BB005C54A4 /* RUMContextAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CBC26D294395A300134409 /* RUMContextAttributes.swift */; };
-		D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */; };
+		D29A9F6929DD85BB005C54A4 /* UIEventCommandFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIEventCommandFactory.swift */; };
 		D29A9F6A29DD85BB005C54A4 /* SwiftUIViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D249859F2728042200B4F72D /* SwiftUIViewModifier.swift */; };
 		D29A9F6B29DD85BB005C54A4 /* VitalInfoSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9973F0268DF69500D8059B /* VitalInfoSampler.swift */; };
 		D29A9F6D29DD85BB005C54A4 /* UIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */; };
@@ -1252,7 +1254,7 @@
 		D29A9FA729DDB483005C54A4 /* RUMCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */; };
 		D29A9FAA29DDB483005C54A4 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
 		D29A9FAB29DDB483005C54A4 /* RUMUserActionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */; };
-		D29A9FAC29DDB483005C54A4 /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
+		D29A9FAC29DDB483005C54A4 /* RUMActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* RUMActionsHandlerTests.swift */; };
 		D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */; };
 		D29A9FB029DDB483005C54A4 /* RUMOperatingSystemInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C0AA028573F6300C13264 /* RUMOperatingSystemInfoTests.swift */; };
 		D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFDE24C75FD300589570 /* RUMScopeTests.swift */; };
@@ -2366,6 +2368,7 @@
 		611529AD25E3E429004F740E /* ValuePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValuePublisherTests.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
 		61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorContextNotifierTests.swift; sourceTree = "<group>"; };
+		61193AAD2CB54C7300C3CDF5 /* RUMActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMActionsHandler.swift; sourceTree = "<group>"; };
 		611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* TracingWithLoggingIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithLoggingIntegration.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* TracingWithLoggingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithLoggingIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2414,7 +2417,7 @@
 		613F9C172BAC3527007C7606 /* DatadogCore+FeatureDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogCore+FeatureDataStoreTests.swift"; sourceTree = "<group>"; };
 		613F9C1A2BB03188007C7606 /* FeatureScopeMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureScopeMock.swift; sourceTree = "<group>"; };
 		6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzler.swift; sourceTree = "<group>"; };
-		6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandler.swift; sourceTree = "<group>"; };
+		6141015A251A601D00E3C2D9 /* UIEventCommandFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEventCommandFactory.swift; sourceTree = "<group>"; };
 		61410166251A661D00E3C2D9 /* UIApplicationSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzlerTests.swift; sourceTree = "<group>"; };
 		61411B0F24EC15AC0012EAB2 /* Casting+RUM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Casting+RUM.swift"; sourceTree = "<group>"; };
 		614396712A67D74F00197326 /* BatchMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchMetrics.swift; sourceTree = "<group>"; };
@@ -2458,7 +2461,7 @@
 		615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpanContext+objc.swift"; sourceTree = "<group>"; };
 		615B0F8A2BB33C2800E9ED6C /* AppHangsMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsMonitorTests.swift; sourceTree = "<group>"; };
 		615B0F8D2BB33E0400E9ED6C /* DataStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreMock.swift; sourceTree = "<group>"; };
-		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
+		615C3195251DD5080018781C /* RUMActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMActionsHandlerTests.swift; sourceTree = "<group>"; };
 		615CC40B2694A56D0005F08C /* SwiftExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		615CC40F2694A64D0005F08C /* SwiftExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionTests.swift; sourceTree = "<group>"; };
 		615CC4122695957C0005F08C /* CrashReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportTests.swift; sourceTree = "<group>"; };
@@ -4639,7 +4642,7 @@
 		6141014C251A577D00E3C2D9 /* Actions */ = {
 			isa = PBXGroup;
 			children = (
-				615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */,
+				615C3195251DD5080018781C /* RUMActionsHandlerTests.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -4647,6 +4650,7 @@
 		6141014D251A578D00E3C2D9 /* Actions */ = {
 			isa = PBXGroup;
 			children = (
+				61193AAD2CB54C7300C3CDF5 /* RUMActionsHandler.swift */,
 				D29D5A4A273BF81500A687C1 /* UIKit */,
 				D29D5A4B273BF82200A687C1 /* SwiftUI */,
 			);
@@ -6303,7 +6307,7 @@
 		D29D5A4A273BF81500A687C1 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */,
+				6141015A251A601D00E3C2D9 /* UIEventCommandFactory.swift */,
 				6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */,
 				F637AED12697404200516F32 /* UIKitRUMUserActionsPredicate.swift */,
 			);
@@ -8790,6 +8794,7 @@
 				D23F8E5A29DDCD28001CFAE8 /* RUMResourceScope.swift in Sources */,
 				D23F8E5C29DDCD28001CFAE8 /* RUMApplicationScope.swift in Sources */,
 				3CFF4F982C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */,
+				61193AAF2CB54C7300C3CDF5 /* RUMActionsHandler.swift in Sources */,
 				D23F8E5D29DDCD28001CFAE8 /* SwiftUIViewModifier.swift in Sources */,
 				D23F8E5E29DDCD28001CFAE8 /* VitalInfo.swift in Sources */,
 				D23F8E5F29DDCD28001CFAE8 /* UIApplicationSwizzler.swift in Sources */,
@@ -8860,7 +8865,7 @@
 				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
 				3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
-				D23F8E8E29DDCD28001CFAE8 /* UIKitRUMUserActionsHandler.swift in Sources */,
+				D23F8E8E29DDCD28001CFAE8 /* UIEventCommandFactory.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
 				61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
@@ -8906,7 +8911,7 @@
 				D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */,
 				D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CB2A3DC22700FA735A /* RUMTests.swift in Sources */,
-				D23F8EB829DDCD38001CFAE8 /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
+				D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */,
 				D23F8EB929DDCD38001CFAE8 /* RUMFeatureMocks.swift in Sources */,
 				61C713AE2A3B793E00FA735A /* RUMMonitorProtocolTests.swift in Sources */,
 				D23F8EBA29DDCD38001CFAE8 /* ViewIdentifierTests.swift in Sources */,
@@ -9124,6 +9129,7 @@
 				D29A9F8429DD85BB005C54A4 /* RUMResourceScope.swift in Sources */,
 				D29A9F7329DD85BB005C54A4 /* RUMApplicationScope.swift in Sources */,
 				3CFF4F972C09E64C006F191D /* WatchdogTerminationMonitor.swift in Sources */,
+				61193AAE2CB54C7300C3CDF5 /* RUMActionsHandler.swift in Sources */,
 				D29A9F6A29DD85BB005C54A4 /* SwiftUIViewModifier.swift in Sources */,
 				D29A9F6429DD85BB005C54A4 /* VitalInfo.swift in Sources */,
 				D29A9F6D29DD85BB005C54A4 /* UIApplicationSwizzler.swift in Sources */,
@@ -9194,7 +9200,7 @@
 				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
 				3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
-				D29A9F6929DD85BB005C54A4 /* UIKitRUMUserActionsHandler.swift in Sources */,
+				D29A9F6929DD85BB005C54A4 /* UIEventCommandFactory.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
 				61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 			);
@@ -9240,7 +9246,7 @@
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,
 				D29A9FAA29DDB483005C54A4 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CA2A3DC22700FA735A /* RUMTests.swift in Sources */,
-				D29A9FAC29DDB483005C54A4 /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
+				D29A9FAC29DDB483005C54A4 /* RUMActionsHandlerTests.swift in Sources */,
 				D29A9FC029DDB540005C54A4 /* RUMFeatureMocks.swift in Sources */,
 				61C713AD2A3B793E00FA735A /* RUMMonitorProtocolTests.swift in Sources */,
 				D29A9FB729DDB483005C54A4 /* ViewIdentifierTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -507,11 +507,12 @@ extension RUMStartUserActionCommand: AnyMockable, RandomMockable {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
+        instrumentation: InstrumentationType = .manual,
         actionType: RUMActionType = .swipe,
         name: String = .mockAny()
     ) -> RUMStartUserActionCommand {
         return RUMStartUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType, name: name
+            time: time, attributes: attributes, instrumentation: instrumentation, actionType: actionType, name: name
         )
     }
 }
@@ -555,11 +556,12 @@ extension RUMAddUserActionCommand: AnyMockable, RandomMockable {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
+        instrumentation: InstrumentationType = .manual,
         actionType: RUMActionType = .tap,
         name: String = .mockAny()
     ) -> RUMAddUserActionCommand {
         return RUMAddUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType, name: name
+            time: time, attributes: attributes, instrumentation: instrumentation, actionType: actionType, name: name
         )
     }
 }
@@ -936,6 +938,7 @@ extension RUMUserActionScope {
         startTime: Date = .mockAny(),
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
+        instrumentation: InstrumentationType = .manual,
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(
@@ -947,6 +950,7 @@ extension RUMUserActionScope {
                 startTime: startTime,
                 serverTimeOffset: serverTimeOffset,
                 isContinuous: isContinuous,
+                instrumentation: instrumentation,
                 onActionEventSent: onActionEventSent
         )
     }
@@ -1037,9 +1041,10 @@ class UIPressRUMActionsPredicateMock: UIPressRUMActionsPredicate {
     }
 }
 
-class UIKitRUMUserActionsHandlerMock: UIEventHandler {
+class RUMActionsHandlerMock: RUMActionsHandling {
     var onSubscribe: ((RUMCommandSubscriber) -> Void)?
     var onSendEvent: ((UIApplication, UIEvent) -> Void)?
+    var onViewModifierTapped: ((String, [String: any Encodable]) -> Void)?
 
     func publish(to subscriber: RUMCommandSubscriber) {
         onSubscribe?(subscriber)
@@ -1047,6 +1052,10 @@ class UIKitRUMUserActionsHandlerMock: UIEventHandler {
 
     func notify_sendEvent(application: UIApplication, event: UIEvent) {
         onSendEvent?(application, event)
+    }
+
+    func notify_viewModifierTapped(actionName: String, actionAttributes: [String: any Encodable]) {
+        onViewModifierTapped?(actionName, actionAttributes)
     }
 }
 

--- a/DatadogCore/Tests/Datadog/RUM/UIApplicationSwizzlerTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/UIApplicationSwizzlerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 #if !os(tvOS)
 
 class UIApplicationSwizzlerTests: XCTestCase {
-    private let handler = UIKitRUMUserActionsHandlerMock()
+    private let handler = RUMActionsHandlerMock()
     private lazy var swizzler = try! UIApplicationSwizzler(handler: handler)
 
     override func setUp() {

--- a/DatadogRUM/Sources/Instrumentation/Actions/RUMActionsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/RUMActionsHandler.swift
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+import DatadogInternal
+
+internal protocol RUMActionsHandling: RUMCommandPublisher {
+    /// Tracks RUM actions in UIKit by responding to `UIApplication.sendEvent(applicatoin:event:)` being called.
+    func notify_sendEvent(application: UIApplication, event: UIEvent)
+    /// Tracks RUM actions in SwiftUI by being notified from `RUMTapActionModifier`.
+    func notify_viewModifierTapped(actionName: String, actionAttributes: [String: Encodable])
+}
+
+internal final class RUMActionsHandler: RUMActionsHandling {
+    /// Factory interface creating "add action" commands from UIEvent intercepted in UIKit.
+    /// It is `nil` when `UIKit` instrumentation is not enabled.
+    private let uiKitCommandsFactory: UIEventCommandFactory?
+    private let dateProvider: DateProvider
+
+    weak var subscriber: RUMCommandSubscriber?
+
+    convenience init(dateProvider: DateProvider, predicate: UITouchRUMActionsPredicate?) {
+        self.init(
+            dateProvider: dateProvider,
+            uiKitCommandsFactory: predicate.map { UITouchCommandFactory(dateProvider: dateProvider, predicate: $0) }
+        )
+    }
+
+    convenience init(dateProvider: DateProvider, predicate: UIPressRUMActionsPredicate?) {
+        self.init(
+            dateProvider: dateProvider,
+            uiKitCommandsFactory: predicate.map { UIPressCommandFactory(dateProvider: dateProvider, predicate: $0) }
+        )
+    }
+
+    init(dateProvider: DateProvider, uiKitCommandsFactory: UIEventCommandFactory?) {
+        self.uiKitCommandsFactory = uiKitCommandsFactory
+        self.dateProvider = dateProvider
+    }
+
+    func publish(to subscriber: RUMCommandSubscriber) {
+        self.subscriber = subscriber
+    }
+
+    /// Tracks UIKit RUM actions in response to `UIApplication.sendEvent(application:event:)` event.
+    func notify_sendEvent(application: UIApplication, event: UIEvent) {
+        guard let command = uiKitCommandsFactory?.command(from: event) else {
+            return // Not a "tap" event or doesn't have the view.
+        }
+
+        guard let subscriber = subscriber else {
+            DD.logger.warn(
+                """
+                A RUM action was detected in UIKit, but RUM tracking appears to be disabled.
+                Ensure `RUM.enable()` is called before any actions are triggered.
+                """
+            )
+            return
+        }
+
+        subscriber.process(command: command)
+    }
+
+    /// Tracks SwiftUI RUM actions in response to `SwiftUI.TapGesture.onEnded` event.
+    func notify_viewModifierTapped(actionName: String, actionAttributes: [String: Encodable]) {
+        let command = RUMAddUserActionCommand(
+            time: dateProvider.now,
+            attributes: actionAttributes,
+            instrumentation: .swiftui,
+            actionType: .tap,
+            name: actionName
+        )
+
+        guard let subscriber = subscriber else {
+            DD.logger.warn(
+                """
+                A RUM action was detected in SwiftUI, but RUM tracking appears to be disabled.
+                Ensure `RUM.enable()` is called before any actions are triggered.
+                """
+            )
+            return
+        }
+
+        subscriber.process(command: command)
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -10,8 +10,8 @@ import DatadogInternal
 
 #if !os(tvOS)
 
-/// `SwiftUI.ViewModifier` for RUM which invoke `addUserAction` from the
-/// global RUM Monitor when the modified view receives a tap.
+/// `SwiftUI.ViewModifier` which notifes RUM instrumentation when modified view is tapped.
+/// It makes an entry point to RUM actions instrumentation in SwiftUI.
 @available(iOS 13, *)
 internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     /// The SDK core instance.
@@ -32,8 +32,11 @@ internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
                 guard let core = core else {
                     return // core was deallocated
                 }
-                RUMMonitor.shared(in: core)
-                    .addAction(type: .tap, name: name, attributes: attributes)
+                guard let feature = core.get(feature: RUMFeature.self) else {
+                    return // RUM not enabled
+                }
+                feature.instrumentation.actionsHandler
+                    .notify_viewModifierTapped(actionName: name, actionAttributes: attributes)
             }
         )
     }

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIApplicationSwizzler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIApplicationSwizzler.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 internal class UIApplicationSwizzler {
     let sendEvent: SendEvent
 
-    init(handler: UIEventHandler) throws {
+    init(handler: RUMActionsHandling) throws {
         sendEvent = try SendEvent(handler: handler)
     }
 
@@ -31,9 +31,9 @@ internal class UIApplicationSwizzler {
     > {
         private static let selector = #selector(UIApplication.sendEvent(_:))
         private let method: Method
-        private let handler: UIEventHandler
+        private let handler: RUMActionsHandling
 
-        init(handler: UIEventHandler) throws {
+        init(handler: RUMActionsHandling) throws {
             self.method = try dd_class_getInstanceMethod(UIApplication.self, Self.selector)
             self.handler = handler
         }

--- a/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
@@ -27,3 +27,17 @@ internal protocol RUMCommandPublisher: AnyObject {
     /// - Parameter subscriber: The RUM command subscriber.
     func publish(to subscriber: RUMCommandSubscriber)
 }
+
+/// Represents the type of instrumentation used to create different RUM commands.
+internal enum InstrumentationType: Int {
+    /// Command issued through UIKit-based instrumentation.
+    case uikit
+    /// Command issued through SwiftUI-based instrumentation.
+    case swiftui
+    /// Command issued through manual instrumentation, originating from the `RUMMonitor` API.
+    case manual
+
+    /// The priority of this instrumentation. Higher values take precedence, allowing actions from one type to overwrite those
+    /// from a lower-priority type (e.g., a SwiftUI button tap takes precedence over the touch on its containing UIKit table view cell).
+    var priority: Int { rawValue }
+}

--- a/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
@@ -142,12 +142,13 @@ internal final class RUMViewsHandler {
 
     private func start(view: View) {
         guard let subscriber = subscriber else {
-            return DD.logger.warn(
+            DD.logger.warn(
                 """
-                RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM instrumentation will not work.
-                Make sure `Global.rum = RUMMonitor.initialize()` is called before any view appears.
+                A RUM view was started with \(view.instrumentationType) instrumentation, but RUM tracking appears to be disabled.
+                Ensure `RUM.enable()` is called before starting any views.
                 """
             )
+            return
         }
 
         guard !view.isUntrackedModal else {

--- a/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 import DatadogInternal
 
-/// `SwiftUI.ViewModifier` for RUM which invoke `startView` and `stopView` from the
-/// global RUM Monitor when the modified view appears and disappears.
+/// `SwiftUI.ViewModifier` which notifes RUM instrumentation when modified view appears and disappears.
+/// It makes an entry point to RUM views instrumentation in SwiftUI.
 @available(iOS 13, tvOS 13, *)
 internal struct RUMViewModifier: SwiftUI.ViewModifier {
     /// Datadog RUM instrumentation instance

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -456,6 +456,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMAddUserActionCommand(
                 time: dateProvider.now,
                 attributes: attributes,
+                instrumentation: .manual,
                 actionType: type,
                 name: name
             )
@@ -467,6 +468,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStartUserActionCommand(
                 time: dateProvider.now,
                 attributes: attributes,
+                instrumentation: .manual,
                 actionType: type,
                 name: name
             )

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -431,6 +431,8 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
     let isUserInteraction = true // a user action definitely is a User Interacgion
+    /// The type of instrumentation used to create this command.
+    let instrumentation: InstrumentationType
 
     let actionType: RUMActionType
     let name: String
@@ -455,6 +457,8 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
     let isUserInteraction = true // a user action definitely is a User Interacgion
+    /// The type of instrumentation used to create this command.
+    let instrumentation: InstrumentationType
 
     let actionType: RUMActionType
     let name: String

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -32,6 +32,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
     /// This User Action's UUID.
     let actionUUID: RUMUUID
+    /// The type of instrumentation that issued an action that created this scope.
+    let instrumentation: InstrumentationType
     /// The start time of this User Action.
     private let actionStartTime: Date
 
@@ -70,6 +72,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         startTime: Date,
         serverTimeOffset: TimeInterval,
         isContinuous: Bool,
+        instrumentation: InstrumentationType,
         onActionEventSent: @escaping (RUMActionEvent) -> Void
     ) {
         self.parent = parent
@@ -82,6 +85,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         self.serverTimeOffset = serverTimeOffset
         self.isContinuous = isContinuous
         self.lastActivityTime = startTime
+        self.instrumentation = instrumentation
         self.onActionEventSent = onActionEventSent
     }
 

--- a/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
@@ -9,18 +9,18 @@ import TestUtilities
 import DatadogInternal
 @testable import DatadogRUM
 
-class UIKitRUMUserActionsHandlerTests: XCTestCase {
+class RUMActionsHandlerTests: XCTestCase {
     private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
     private let commandSubscriber = RUMCommandSubscriberMock()
 
-    private func touchHandler(with predicate: UITouchRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()) -> UIKitRUMUserActionsHandler {
-        let handler = UIKitRUMUserActionsHandler(dateProvider: dateProvider, predicate: predicate)
+    private func touchHandler(with predicate: UITouchRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()) -> RUMActionsHandler {
+        let handler = RUMActionsHandler(dateProvider: dateProvider, predicate: predicate)
         handler.publish(to: commandSubscriber)
         return handler
     }
 
-    private func pressHandler(with predicate: UIPressRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()) -> UIKitRUMUserActionsHandler {
-        let handler = UIKitRUMUserActionsHandler(dateProvider: dateProvider, predicate: predicate)
+    private func pressHandler(with predicate: UIPressRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()) -> RUMActionsHandler {
+        let handler = RUMActionsHandler(dateProvider: dateProvider, predicate: predicate)
         handler.publish(to: commandSubscriber)
         return handler
     }
@@ -39,7 +39,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
 
     // MARK: - Scenarios For Accepting Tap Events
 
-    func testGivenViewWithAccessibilityIdentifier_whenSingleTouchEnds_itSendsRUMAction() {
+    func testGivenUIKitViewWithAccessibilityIdentifier_whenSingleTouchEnds_itSendsRUMAction() {
         // Given
         let handler = touchHandler()
         let fixtures: [(view: UIView, expectedRUMActionName: String)] = [
@@ -78,12 +78,13 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
             XCTAssertEqual(command?.name, expectedRUMActionName)
             XCTAssertEqual(command?.actionType, .tap)
+            XCTAssertEqual(command?.instrumentation, .uikit)
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
             XCTAssertEqual(command?.attributes.count, 0)
         }
     }
 
-    func testGivenViewWithNoAccessibilityIdentifier_whenSingleTouchEnds_itSendsRUMAction() {
+    func testGivenUIKitViewWithNoAccessibilityIdentifier_whenSingleTouchEnds_itSendsRUMAction() {
         // Given
         let handler = touchHandler()
         let fixtures: [(view: UIView, expectedRUMActionName: String)] = [
@@ -115,6 +116,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
             XCTAssertEqual(command?.name, expectedRUMActionName)
             XCTAssertEqual(command?.actionType, .tap)
+            XCTAssertEqual(command?.instrumentation, .uikit)
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
             XCTAssertEqual(command?.attributes.count, 0)
         }
@@ -122,7 +124,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
 
     // MARK: - Scenarios For Ignoring Tap Events
 
-    func testGivenAnyViewWithUnrecognizedHierarchy_whenTouchEnds_itGetsIgnored() {
+    func testGivenAnyUIKitViewWithUnrecognizedHierarchy_whenTouchEnds_itGetsIgnored() {
         // Given
         let handler = touchHandler()
         let superview = UIView().attached(to: mockAppWindow)
@@ -138,7 +140,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testGivenAnyViewPresentedInKeyboardWindow_whenTouchEnds_itGetsIgnoredForPrivacyReason() {
+    func testGivenAnyUIKitViewPresentedInKeyboardWindow_whenTouchEnds_itGetsIgnoredForPrivacyReason() {
         let mockKeyboardWindow = MockUIRemoteKeyboardWindow(frame: .zero)
 
         // Given
@@ -170,7 +172,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testItIgnoresSingleTouchEventWithPhaseOtherThanEnded() {
+    func testItIgnoresSingleUIKitTouchEventWithPhaseOtherThanEnded() {
         // Given
         let handler = touchHandler()
         let view = UIControl().attached(to: mockAppWindow)
@@ -194,7 +196,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         }
     }
 
-    func testItIgnoresMultitouchEvents() {
+    func testItIgnoresUIKitMultitouchEvents() {
         // Given
         let handler = touchHandler()
         let view = UIControl().attached(to: mockAppWindow)
@@ -214,7 +216,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testItIgnoresEventsWithNoTouch() {
+    func testItIgnoresUIKitEventsWithNoTouch() {
         // Given
         let handler = touchHandler()
 
@@ -228,7 +230,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testGivenTouchEvent_itAppliesUserAttributesAndCustomName() {
+    func testGivenUIKitTouchEvent_itAppliesUserAttributesAndCustomName() {
         // Given
         let mockAttributes: [AttributeKey: AttributeValue] = mockRandomAttributes()
         let handler = touchHandler(
@@ -253,7 +255,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         DDAssertDictionariesEqual(command!.attributes, mockAttributes)
     }
 
-    func testGivenUserActionPredicateReturnsNil_itDoesntSendTapAction() {
+    func testGivenUIKitActionPredicateReturnsNil_itDoesntSendTapAction() {
         // Given
         let handler = touchHandler(
             with: MockUIKitRUMActionsPredicate(actionOverride: nil)
@@ -275,7 +277,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
 
     // MARK: - Scenarios For Accepting Click Events
 
-    func testGivenUIPress_whenSinglePressEnds_itSendsRUMAction() {
+    func testGivenUIKitPressEvent_whenSinglePressEnds_itSendsRUMAction() {
         // Given
         let handler = pressHandler()
         let fixtures: [(event: UIEvent, expect: String)] = [
@@ -308,6 +310,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
             XCTAssertEqual(command?.name, expect)
             XCTAssertEqual(command?.actionType, .click)
+            XCTAssertEqual(command?.instrumentation, .uikit)
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
             XCTAssertEqual(command?.attributes.count, 0)
         }
@@ -315,7 +318,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
 
     // MARK: - Scenarios For Ignoring Tap Events
 
-    func testGivenAnyViewPresentedInKeyboardWindow_whenPressEnds_itGetsIgnoredForPrivacyReason() {
+    func testGivenAnyUIKitViewPresentedInKeyboardWindow_whenPressEnds_itGetsIgnoredForPrivacyReason() {
         let mockKeyboardWindow = MockUIRemoteKeyboardWindow(frame: .zero)
 
         // Given
@@ -347,7 +350,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testItIgnoresSinglePressEventWithPhaseOtherThanEnded() {
+    func testItIgnoresSingleUIKitPressEventWithPhaseOtherThanEnded() {
         // Given
         let handler = pressHandler()
         let view = UIControl().attached(to: mockAppWindow)
@@ -366,7 +369,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         }
     }
 
-    func testItIgnoresMultiPressEvents() {
+    func testItIgnoresUIKitMultiPressEvents() {
         // Given
         let handler = pressHandler()
         let view = UIControl().attached(to: mockAppWindow)
@@ -386,7 +389,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
-    func testGivenPressEvent_ItAppliesUserAttributesAndCustomName() {
+    func testGivenUIKitPressEvent_ItAppliesUserAttributesAndCustomName() {
         // Given
         let mockAttributes: [AttributeKey: AttributeValue] = mockRandomAttributes()
         let handler = pressHandler(
@@ -411,7 +414,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         DDAssertDictionariesEqual(command!.attributes, mockAttributes)
     }
 
-    func testGivenUserActionPredicateReturnsNil_itDoesntSendClickAction() {
+    func testGivenUIKitActionPredicateReturnsNil_itDoesntSendClickAction() {
         // Given
         let handler = pressHandler(
             with: MockUIKitRUMActionsPredicate(actionOverride: nil)
@@ -429,6 +432,29 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
 
         // Then
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
+    }
+
+    // MARK: - SwiftUI Actions
+
+    func testWhenSwiftUIViewModifierIsTapped_itSendsRUMAction() throws {
+        // Given
+        let handler = oneOf([
+            { self.touchHandler() },
+            { self.pressHandler() }
+        ])
+
+        // When
+        let actionName: String = .mockRandom()
+        let actionAttributes = mockRandomAttributes()
+        handler.notify_viewModifierTapped(actionName: actionName, actionAttributes: actionAttributes)
+
+        // Then
+        let command = try XCTUnwrap(commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand)
+        XCTAssertEqual(command.name, actionName)
+        XCTAssertEqual(command.actionType, .tap)
+        XCTAssertEqual(command.instrumentation, .swiftui)
+        XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
+        DDAssertReflectionEqual(command.attributes, actionAttributes)
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -183,7 +183,7 @@ class RUMInstrumentationTests: XCTestCase {
         // Then
         withExtendedLifetime(instrumentation) {
             XCTAssertIdentical(instrumentation.viewsHandler.subscriber, subscriber)
-            XCTAssertIdentical((instrumentation.actionsHandler as? UIKitRUMUserActionsHandler)?.subscriber, subscriber)
+            XCTAssertIdentical((instrumentation.actionsHandler as? RUMActionsHandler)?.subscriber, subscriber)
             XCTAssertIdentical(instrumentation.longTasks?.subscriber, subscriber)
             XCTAssertIdentical(instrumentation.appHangs?.nonFatalHangsHandler.subscriber, subscriber)
         }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -567,11 +567,12 @@ extension RUMStartUserActionCommand: AnyMockable, RandomMockable {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
+        instrumentation: InstrumentationType = .manual,
         actionType: RUMActionType = .swipe,
         name: String = .mockAny()
     ) -> RUMStartUserActionCommand {
         return RUMStartUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType, name: name
+            time: time, attributes: attributes, instrumentation: instrumentation, actionType: actionType, name: name
         )
     }
 }
@@ -615,11 +616,12 @@ extension RUMAddUserActionCommand: AnyMockable, RandomMockable {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
+        instrumentation: InstrumentationType = .manual,
         actionType: RUMActionType = .tap,
         name: String = .mockAny()
     ) -> RUMAddUserActionCommand {
         return RUMAddUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType, name: name
+            time: time, attributes: attributes, instrumentation: instrumentation, actionType: actionType, name: name
         )
     }
 }
@@ -1007,6 +1009,7 @@ extension RUMUserActionScope {
         startTime: Date = .mockAny(),
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
+        instrumentation: InstrumentationType = .manual,
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(
@@ -1018,6 +1021,7 @@ extension RUMUserActionScope {
                 startTime: startTime,
                 serverTimeOffset: serverTimeOffset,
                 isContinuous: isContinuous,
+                instrumentation: instrumentation,
                 onActionEventSent: onActionEventSent
         )
     }

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -110,7 +110,7 @@ class RUMTests: XCTestCase {
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
         XCTAssertIdentical(monitor, rum.instrumentation.viewsHandler.subscriber)
-        XCTAssertIdentical(monitor, (rum.instrumentation.actionsHandler as? UIKitRUMUserActionsHandler)?.subscriber)
+        XCTAssertIdentical(monitor, (rum.instrumentation.actionsHandler as? RUMActionsHandler)?.subscriber)
         XCTAssertIdentical(monitor, rum.instrumentation.longTasks?.subscriber)
         XCTAssertIdentical(monitor, rum.instrumentation.appHangs?.nonFatalHangsHandler.subscriber)
     }
@@ -131,9 +131,13 @@ class RUMTests: XCTestCase {
         XCTAssertIdentical(
             monitor,
             rum.instrumentation.viewsHandler.subscriber,
-            "It must always subscribe RUM monitor to `RUMViewsHandler` as it is required for manual SwiftUI instrumentation"
+            "It must always subscribe RUM monitor to `RUMViewsHandler` as it is required for SwiftUI instrumentation"
         )
-        XCTAssertNil(rum.instrumentation.actionsHandler)
+        XCTAssertIdentical(
+            monitor,
+            (rum.instrumentation.actionsHandler as? RUMActionsHandler)?.subscriber,
+            "It must always subscribe RUM monitor to `RUMActionsHandler` as it is required for SwiftUI instrumentation"
+        )
         XCTAssertNil(rum.instrumentation.longTasks)
         XCTAssertNil(rum.instrumentation.appHangs)
     }


### PR DESCRIPTION
### What and why?

📦 This PR resolves a conflict in RUM actions instrumentation that occurs when a user taps a SwiftUI button embedded inside a UIKit table view cell. This issue arises in apps that mix both UI frameworks, leading to inaccurate tracking of the tap action.

```
+--------UITableView----------+
|   +----UITableViewCell----+  |
|   |                       |  |
|   |  [  SwiftUI Button ]  |  |
|   |                       |  |
|   +-----------------------+  |       
+-------------------------------+
```

In this case, UIKit’s instrumentation [handled by `UIKitRUMActionsHandler`](https://github.com/DataDog/dd-sdk-ios/blob/d4e2247a6f55b95292e4b1b2953a25bdd8c67306/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsHandler.swift#L137) treats the `UITableViewCell` as the best target for the action, assigning its name to `action.target.name`. However, if the [`trackRUMAction()`](https://github.com/DataDog/dd-sdk-ios/blob/d4e2247a6f55b95292e4b1b2953a25bdd8c67306/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift#L36) modifier is used on the SwiftUI button, it already provides a more specific target name, which should take precedence.

### How?

This conflict is resolved by introducing `InstrumentationType` to the `RUMAddUserActionCommand`:
```swift
internal enum InstrumentationType: Int {
    case uikit
    case swiftui
    case manual

    var priority: Int { rawValue }
}
```
The priority field allows the `RUMViewScope` to determine whether to replace the existing `RUMUserActionScope` with one from a higher-priority instrumentation type. This replacement occurs if the new command is received within 100ms of the original, a window determined by the [existing action timeout](https://github.com/DataDog/dd-sdk-ios/blob/5b5105dd6d50af7e66ad14092d4fc101fc83be90/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift#L12-L14).

Because UIKit instrumentation is triggered first, followed by SwiftUI gestures, this change ensures that the correct `action.target.name` is set. Similarly, if manual tracking (via `RUMMonitor` APIs) is mixed with UIKit or SwiftUI instrumentation, manual actions will always take precedence due to their explicit nature.

**Before:**
<img width="797" alt="Screenshot 2024-10-11 at 15 38 55" src="https://github.com/user-attachments/assets/344a490a-119f-4c46-bced-367fabc81d0f">

**After:**
<img width="797" alt="Screenshot 2024-10-11 at 15 39 00" src="https://github.com/user-attachments/assets/5f88b8d7-32d0-4a01-9500-64e942fd360f">

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)) and run `make api-surface`
