### PR TITLE
RUM-917 Fix type mistmatch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Fix race condition during consent change, preventing loss of events recorded on the current thread. See [#2063][]
 - [IMPROVEMENT] Support mutation of events' attributes. See [#2099][]
+- [FIX] Fix bug in SR that was enforcing full snapshot more often than needed. See [#2092][]
 
 # 2.19.0 / 28-10-2024
 
@@ -788,6 +789,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2083]: https://github.com/DataDog/dd-sdk-ios/pull/2083
 [#2099]: https://github.com/DataDog/dd-sdk-ios/pull/2099
 [#2063]: https://github.com/DataDog/dd-sdk-ios/pull/2063
+[#2092]: https://github.com/DataDog/dd-sdk-ios/pull/2092
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -16,9 +16,9 @@ internal struct UIDatePickerRecorder: NodeRecorder {
 
     init(identifier: UUID) {
         self.identifier = identifier
-        self.wheelsStyleRecorder = WheelsStyleDatePickerRecorder(identifier: identifier)
-        self.compactStyleRecorder = CompactStyleDatePickerRecorder(identifier: identifier)
-        self.inlineStyleRecorder = InlineStyleDatePickerRecorder(identifier: identifier)
+        self.wheelsStyleRecorder = WheelsStyleDatePickerRecorder(identifier: UUID())
+        self.compactStyleRecorder = CompactStyleDatePickerRecorder(identifier: UUID())
+        self.inlineStyleRecorder = InlineStyleDatePickerRecorder(identifier: UUID())
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
@@ -104,9 +104,9 @@ private struct InlineStyleDatePickerRecorder {
     let subtreeRecorder: ViewTreeRecorder
 
     init(identifier: UUID) {
-        self.viewRecorder = UIViewRecorder(identifier: identifier)
+        self.viewRecorder = UIViewRecorder(identifier: UUID())
         self.labelRecorder = UILabelRecorder(
-            identifier: identifier,
+            identifier: UUID(),
             textObfuscator: { context, viewAttributes in
                 return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
             }
@@ -115,8 +115,8 @@ private struct InlineStyleDatePickerRecorder {
             nodeRecorders: [
                 viewRecorder,
                 labelRecorder,
-                UIImageViewRecorder(identifier: identifier),
-                UISegmentRecorder(identifier: identifier), // iOS 14.x uses `UISegmentedControl` for "AM | PM"
+                UIImageViewRecorder(identifier: UUID()),
+                UISegmentRecorder(identifier: UUID()), // iOS 14.x uses `UISegmentedControl` for "AM | PM"
             ]
         )
     }
@@ -151,9 +151,9 @@ private struct CompactStyleDatePickerRecorder {
     init(identifier: UUID) {
         self.subtreeRecorder = ViewTreeRecorder(
             nodeRecorders: [
-                UIViewRecorder(identifier: identifier),
+                UIViewRecorder(identifier: UUID()),
                 UILabelRecorder(
-                    identifier: identifier,
+                    identifier: UUID(),
                     textObfuscator: { context, viewAttributes in
                         return viewAttributes.resolveTextAndInputPrivacyLevel(in: context).staticTextObfuscator
                     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -33,7 +33,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         }
     ) {
         self.identifier = identifier
-        self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder(identifier: identifier)])
+        self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder(identifier: UUID())])
         self.labelsRecorder = ViewTreeRecorder(
             nodeRecorders: [
                 UIViewRecorder(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -9,9 +9,13 @@ import UIKit
 
 internal final class UITabBarRecorder: NodeRecorder {
     internal let identifier: UUID
+    internal let labelRecorder: UILabelRecorder
+    internal let viewRecorder: UIViewRecorder
 
     init(identifier: UUID) {
         self.identifier = identifier
+        self.labelRecorder = UILabelRecorder(identifier: UUID())
+        self.viewRecorder = UIViewRecorder(identifier: UUID())
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
@@ -63,9 +67,8 @@ internal final class UITabBarRecorder: NodeRecorder {
                         return tabBar.tintColor ?? SystemColors.systemBlue
                     }
                 ),
-                UILabelRecorder(identifier: identifier),
-                // This is for recording the badge view
-                UIViewRecorder(identifier: identifier)
+                labelRecorder,
+                viewRecorder
             ]
         )
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -30,8 +30,8 @@ internal struct UITextFieldRecorder: NodeRecorder {
 
     init(identifier: UUID) {
         self.identifier = identifier
-        self.backgroundViewRecorder = UIViewRecorder(identifier: identifier)
-        self.iconsRecorder = UIImageViewRecorder(identifier: identifier)
+        self.backgroundViewRecorder = UIViewRecorder(identifier: UUID())
+        self.iconsRecorder = UIImageViewRecorder(identifier: UUID())
         self.subtreeRecorder = ViewTreeRecorder(nodeRecorders: [backgroundViewRecorder, iconsRecorder])
     }
 


### PR DESCRIPTION
### What and why?

Fixes the issues of type mismatch error which was causing full snapshot enforcement in some cases.

### How?

We've been wrongly passing identifier of the parent recorder to it's children which was causing in some cases issue where two views would be recorded with different type but the same id. It's because `NodeIDGenerator` depends on the identifier of the recorder.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)) and run `make api-surface`
