### PR TITLE
chore: Cleanup local simulators on CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,15 +70,15 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.17.0)
-    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux)
     ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux)
     ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux)
     ffi (1.17.0-x86-linux-musl)
     ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux)
     ffi (1.17.0-x86_64-linux-musl)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -111,16 +111,16 @@ GEM
       rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
-  aarch64-linux-gnu
+  aarch64-linux
   aarch64-linux-musl
-  arm-linux-gnu
+  arm-linux
   arm-linux-musl
   arm64-darwin
   ruby
-  x86-linux-gnu
+  x86-linux
   x86-linux-musl
   x86_64-darwin
-  x86_64-linux-gnu
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -6,6 +6,9 @@
 set -e
 source ./tools/utils/echo-color.sh
 
+# https://gist.github.com/jaytaylor/6527607
+function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+
 clean_dir() {
     local dir="$1"
     if [ -d "$dir" ] && [ "$(ls -A "$dir")" ]; then
@@ -25,3 +28,13 @@ clean_dir ./IntegrationTests/Pods
 echo_warn "Cleaning local xcconfigs"
 rm -vf ./xcconfigs/Base.ci.local.xcconfig
 rm -vf ./xcconfigs/Base.dev.local.xcconfig
+
+ENV_DEV="dev"
+ENV_CI="ci"
+
+if [[ "$ENV" == "ci" ]]; then
+    echo_warn "Cleaning local simulators"
+    xcrun simctl shutdown all
+    # Prevent hangs
+    timeout 30 xcrun simctl erase all
+fi

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -29,10 +29,8 @@ echo_warn "Cleaning local xcconfigs"
 rm -vf ./xcconfigs/Base.ci.local.xcconfig
 rm -vf ./xcconfigs/Base.dev.local.xcconfig
 
-ENV_DEV="dev"
-ENV_CI="ci"
 
-if [[ "$ENV" == "ci" ]]; then
+if [ "$CI" = "true" ]; then
     echo_warn "Cleaning local simulators"
     xcrun simctl shutdown all
     # Prevent hangs


### PR DESCRIPTION
### What and why?

CI builds started to fail with the following error on random tests:
```
🔥 Failed to delete `TestsDirectory`: Error Domain=NSCocoaErrorDomain Code=512 ""com.datadoghq.ios-sdk-tests-434C4A49-7195-4957-AE16-9A943737BDBF" couldn't be removed."
```
From [this thread](https://developer.apple.com/forums/thread/128927?answerId=631839022#631839022), the error code `512` could mean that we have reached the maximum number of items in cache.

### How?

Add a step to clean up simulators before running the pipeline. After running this, builds are passing again.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)) and run `make api-surface`
