### PR TITLE
RUM-5992 Support additional properties mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Support mutation of events' attributes. See [#2099][]
+
 # 2.19.0 / 28-10-2024
 
 - [FEATURE] Add Privacy Overrides in Session Replay. See [#2088][]
@@ -783,6 +785,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2073]: https://github.com/DataDog/dd-sdk-ios/pull/2073
 [#2088]: https://github.com/DataDog/dd-sdk-ios/pull/2088
 [#2083]: https://github.com/DataDog/dd-sdk-ios/pull/2083
+[#2099]: https://github.com/DataDog/dd-sdk-ios/pull/2099
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -256,6 +256,7 @@ extension RUMResourceEvent: RandomMockable {
                 firstByte: .init(duration: .mockRandom(), start: .mockRandom()),
                 id: .mockRandom(),
                 method: .mockRandom(),
+                protocol: nil,
                 provider: .init(
                     domain: .mockRandom(),
                     name: .mockRandom(),
@@ -478,6 +479,7 @@ extension RUMLongTaskEvent: RandomMockable {
                 isFrozenFrame: .mockRandom(),
                 renderStart: nil,
                 scripts: nil,
+                startTime: nil,
                 styleAndLayoutStart: nil
             ),
             os: .mockRandom(),

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -713,7 +713,8 @@ public class DDRUMActionEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -963,7 +964,8 @@ public class DDRUMActionEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -1502,7 +1504,8 @@ public class DDRUMErrorEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -2181,7 +2184,8 @@ public class DDRUMErrorEventFeatureFlags: NSObject {
     }
 
     @objc public var featureFlagsInfo: [String: Any] {
-        root.swiftModel.featureFlags!.featureFlagsInfo.dd.objCAttributes
+        set { root.swiftModel.featureFlags!.featureFlagsInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.featureFlags!.featureFlagsInfo.dd.objCAttributes }
     }
 }
 
@@ -2350,7 +2354,8 @@ public class DDRUMErrorEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -2885,7 +2890,8 @@ public class DDRUMLongTaskEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -3296,7 +3302,8 @@ public class DDRUMLongTaskEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -3839,7 +3846,8 @@ public class DDRUMResourceEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -4525,7 +4533,8 @@ public class DDRUMResourceEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -5100,7 +5109,8 @@ public class DDRUMViewEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -5236,7 +5246,8 @@ public class DDRUMViewEventFeatureFlags: NSObject {
     }
 
     @objc public var featureFlagsInfo: [String: Any] {
-        root.swiftModel.featureFlags!.featureFlagsInfo.dd.objCAttributes
+        set { root.swiftModel.featureFlags!.featureFlagsInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.featureFlags!.featureFlagsInfo.dd.objCAttributes }
     }
 }
 
@@ -5436,7 +5447,8 @@ public class DDRUMViewEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -6325,7 +6337,8 @@ public class DDRUMVitalEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.dd.objCAttributes
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
     }
 }
 
@@ -6575,7 +6588,8 @@ public class DDRUMVitalEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.dd.objCAttributes
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
     }
 }
 
@@ -6835,7 +6849,8 @@ public class DDTelemetryErrorEventTelemetry: NSObject {
     }
 
     @objc public var telemetryInfo: [String: Any] {
-        root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes
+        set { root.swiftModel.telemetry.telemetryInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes }
     }
 }
 
@@ -7085,7 +7100,8 @@ public class DDTelemetryDebugEventTelemetry: NSObject {
     }
 
     @objc public var telemetryInfo: [String: Any] {
-        root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes
+        set { root.swiftModel.telemetry.telemetryInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes }
     }
 }
 
@@ -7314,7 +7330,8 @@ public class DDTelemetryConfigurationEventTelemetry: NSObject {
     }
 
     @objc public var telemetryInfo: [String: Any] {
-        root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes
+        set { root.swiftModel.telemetry.telemetryInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.telemetry.telemetryInfo.dd.objCAttributes }
     }
 }
 
@@ -7405,7 +7422,8 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject {
     }
 
     @objc public var plugins: [DDTelemetryConfigurationEventTelemetryConfigurationPlugins]? {
-        root.swiftModel.telemetry.configuration.plugins?.map { DDTelemetryConfigurationEventTelemetryConfigurationPlugins(swiftModel: $0) }
+        set { root.swiftModel.telemetry.configuration.plugins = newValue?.map { $0.swiftModel } }
+        get { root.swiftModel.telemetry.configuration.plugins?.map { DDTelemetryConfigurationEventTelemetryConfigurationPlugins(swiftModel: $0) } }
     }
 
     @objc public var premiumSampleRate: NSNumber? {
@@ -7706,7 +7724,8 @@ public class DDTelemetryConfigurationEventTelemetryConfigurationPlugins: NSObjec
     }
 
     @objc public var pluginsInfo: [String: Any] {
-        root.swiftModel.pluginsInfo.dd.objCAttributes
+        set { root.swiftModel.pluginsInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.pluginsInfo.dd.objCAttributes }
     }
 }
 

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -3023,6 +3023,10 @@ public class DDRUMLongTaskEventLongTask: NSObject {
         root.swiftModel.longTask.scripts?.map { DDRUMLongTaskEventLongTaskScripts(swiftModel: $0) }
     }
 
+    @objc public var startTime: NSNumber? {
+        root.swiftModel.longTask.startTime as NSNumber?
+    }
+
     @objc public var styleAndLayoutStart: NSNumber? {
         root.swiftModel.longTask.styleAndLayoutStart as NSNumber?
     }
@@ -4004,6 +4008,10 @@ public class DDRUMResourceEventResource: NSObject {
 
     @objc public var method: DDRUMResourceEventResourceRUMMethod {
         .init(swift: root.swiftModel.resource.method)
+    }
+
+    @objc public var `protocol`: String? {
+        root.swiftModel.resource.protocol
     }
 
     @objc public var provider: DDRUMResourceEventResourceProvider? {
@@ -7866,4 +7874,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ec07c062cbbb2f19b49d08f72bc95703b502906d
+// Generated from https://github.com/DataDog/rum-events-format/tree/e1c6dde3793714453b5b49f17790a24e9ff9b77b

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -37,7 +37,7 @@ public struct RUMActionEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -67,7 +67,7 @@ public struct RUMActionEvent: RUMDataModel {
     public let type: String = "action"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -480,7 +480,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -495,7 +495,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public var error: Error
 
     /// Feature flags properties
-    public internal(set) var featureFlags: FeatureFlags?
+    public var featureFlags: FeatureFlags?
 
     /// Properties of App Hang and ANR errors
     public let freeze: Freeze?
@@ -519,7 +519,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public let type: String = "error"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -1008,7 +1008,7 @@ public struct RUMErrorEvent: RUMDataModel {
 
     /// Feature flags properties
     public struct FeatureFlags: Codable {
-        public internal(set) var featureFlagsInfo: [String: Encodable]
+        public var featureFlagsInfo: [String: Encodable]
     }
 
     /// Properties of App Hang and ANR errors
@@ -1129,7 +1129,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -1162,7 +1162,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
     public let type: String = "long_task"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -1376,6 +1376,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case isFrozenFrame = "is_frozen_frame"
             case renderStart = "render_start"
             case scripts = "scripts"
+            case startTime = "start_time"
             case styleAndLayoutStart = "style_and_layout_start"
         }
 
@@ -1525,7 +1526,7 @@ public struct RUMResourceEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -1558,7 +1559,7 @@ public struct RUMResourceEvent: RUMDataModel {
     public let type: String = "resource"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -1816,6 +1817,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case graphql = "graphql"
             case id = "id"
             case method = "method"
+            case `protocol` = "protocol"
             case provider = "provider"
             case redirect = "redirect"
             case renderBlockingStatus = "render_blocking_status"
@@ -2075,7 +2077,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -2087,7 +2089,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let display: Display?
 
     /// Feature flags properties
-    public internal(set) var featureFlags: FeatureFlags?
+    public var featureFlags: FeatureFlags?
 
     /// Operating system properties
     public let os: RUMOperatingSystem?
@@ -2111,7 +2113,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let type: String = "view"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -2355,7 +2357,7 @@ public struct RUMViewEvent: RUMDataModel {
 
     /// Feature flags properties
     public struct FeatureFlags: Codable {
-        public internal(set) var featureFlagsInfo: [String: Encodable]
+        public var featureFlagsInfo: [String: Encodable]
     }
 
     /// Privacy properties
@@ -2806,7 +2808,7 @@ public struct RUMVitalEvent: RUMDataModel {
     public let container: Container?
 
     /// User provided context
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -2836,7 +2838,7 @@ public struct RUMVitalEvent: RUMDataModel {
     public let type: String = "vital"
 
     /// User properties
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
 
     /// The version for this application
     public let version: String?
@@ -3126,7 +3128,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
     public let source: Source
 
     /// The telemetry log information
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
 
     /// Telemetry event type. Should specify telemetry only.
     public let type: String = "telemetry"
@@ -3223,7 +3225,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         /// Telemetry type
         public let type: String? = "log"
 
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
 
         enum StaticCodingKeys: String, CodingKey {
             case device = "device"
@@ -3328,7 +3330,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
     public let source: Source
 
     /// The telemetry log information
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
 
     /// Telemetry event type. Should specify telemetry only.
     public let type: String = "telemetry"
@@ -3422,7 +3424,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         /// Telemetry type
         public let type: String? = "log"
 
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
 
         enum StaticCodingKeys: String, CodingKey {
             case device = "device"
@@ -3601,7 +3603,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         /// Telemetry type
         public let type: String = "configuration"
 
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
 
         enum StaticCodingKeys: String, CodingKey {
             case configuration = "configuration"
@@ -3667,7 +3669,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             public var mobileVitalsUpdatePeriod: Int64?
 
             /// The list of plugins enabled
-            public internal(set) var plugins: [Plugins]?
+            public var plugins: [Plugins]?
 
             /// The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
             public let premiumSampleRate: Int64?
@@ -3987,7 +3989,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 /// The name of the plugin
                 public let name: String
 
-                public internal(set) var pluginsInfo: [String: Encodable]
+                public var pluginsInfo: [String: Encodable]
 
                 enum StaticCodingKeys: String, CodingKey {
                     case name = "name"
@@ -4133,7 +4135,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
     public let source: Source
 
     /// The telemetry usage information
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
 
     /// Telemetry event type. Should specify telemetry only.
     public let type: String = "telemetry"
@@ -4223,7 +4225,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
 
         public let usage: Usage
 
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
 
         enum StaticCodingKeys: String, CodingKey {
             case device = "device"
@@ -4632,7 +4634,7 @@ public struct RUMConnectivity: Codable {
 
 /// User provided context
 public struct RUMEventAttributes: Codable {
-    public internal(set) var contextInfo: [String: Encodable]
+    public var contextInfo: [String: Encodable]
 }
 
 extension RUMEventAttributes {
@@ -4754,7 +4756,7 @@ public struct RUMUser: Codable {
     /// Name of the user
     public let name: String?
 
-    public internal(set) var usrInfo: [String: Encodable]
+    public var usrInfo: [String: Encodable]
 
     enum StaticCodingKeys: String, CodingKey {
         case email = "email"

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -1361,6 +1361,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// A list of long scripts that were executed over the course of the long frame
         public let scripts: [Scripts]?
 
+        /// Start time of the long animation frame
+        public let startTime: Double?
+
         /// Start time of the time period spent in style and layout calculations
         public let styleAndLayoutStart: Double?
 
@@ -1771,6 +1774,9 @@ public struct RUMResourceEvent: RUMDataModel {
 
         /// HTTP method of the resource
         public let method: RUMMethod?
+
+        /// Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')
+        public let `protocol`: String?
 
         /// The provider for this resource
         public let provider: Provider?
@@ -4885,4 +4891,4 @@ public struct RUMTelemetryOperatingSystem: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ec07c062cbbb2f19b49d08f72bc95703b502906d
+// Generated from https://github.com/DataDog/rum-events-format/tree/e1c6dde3793714453b5b49f17790a24e9ff9b77b

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -220,6 +220,7 @@ internal class RUMResourceScope: RUMScope {
                 graphql: graphql,
                 id: resourceUUID.toRUMDataFormat,
                 method: resourceHTTPMethod,
+                protocol: nil,
                 provider: resourceEventProvider,
                 redirect: resourceMetrics?.redirection.map { metric in
                     .init(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -727,6 +727,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 isFrozenFrame: isFrozenFrame,
                 renderStart: nil,
                 scripts: nil,
+                startTime: nil,
                 styleAndLayoutStart: nil
             ),
             os: .init(context: context),

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -274,6 +274,7 @@ extension RUMResourceEvent: RandomMockable {
                 firstByte: .init(duration: .mockRandom(), start: .mockRandom()),
                 id: .mockRandom(),
                 method: .mockRandom(),
+                protocol: nil,
                 provider: .init(
                     domain: .mockRandom(),
                     name: .mockRandom(),
@@ -496,6 +497,7 @@ extension RUMLongTaskEvent: RandomMockable {
                 isFrozenFrame: .mockRandom(),
                 renderStart: .mockRandom(),
                 scripts: nil,
+                startTime: nil,
                 styleAndLayoutStart: nil
             ),
             os: .mockRandom(),

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -1331,4 +1331,4 @@ public enum SRRecord: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/6442ab65ccecbf5061e70edb5da9f94fecd574ea
+// Generated from https://github.com/DataDog/rum-events-format/tree/e1c6dde3793714453b5b49f17790a24e9ff9b77b

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -997,6 +997,7 @@ public class DDRUMLongTaskEventLongTask: NSObject
     @objc public var isFrozenFrame: NSNumber?
     @objc public var renderStart: NSNumber?
     @objc public var scripts: [DDRUMLongTaskEventLongTaskScripts]?
+    @objc public var startTime: NSNumber?
     @objc public var styleAndLayoutStart: NSNumber?
 public enum DDRUMLongTaskEventLongTaskEntryType: Int
     case none
@@ -1199,6 +1200,7 @@ public class DDRUMResourceEventResource: NSObject
     @objc public var graphql: DDRUMResourceEventResourceGraphql?
     @objc public var id: String?
     @objc public var method: DDRUMResourceEventResourceRUMMethod
+    @objc public var `protocol`: String?
     @objc public var provider: DDRUMResourceEventResourceProvider?
     @objc public var redirect: DDRUMResourceEventResourceRedirect?
     @objc public var renderBlockingStatus: DDRUMResourceEventResourceRenderBlockingStatus

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -716,6 +716,7 @@ public struct RUMLongTaskEvent: RUMDataModel
         public let isFrozenFrame: Bool?
         public let renderStart: Double?
         public let scripts: [Scripts]?
+        public let startTime: Double?
         public let styleAndLayoutStart: Double?
         public enum EntryType: String, Codable
             case longTask = "long-task"
@@ -832,6 +833,7 @@ public struct RUMResourceEvent: RUMDataModel
         public var graphql: Graphql?
         public let id: String?
         public let method: RUMMethod?
+        public let `protocol`: String?
         public let provider: Provider?
         public let redirect: Redirect?
         public let renderBlockingStatus: RenderBlockingStatus?

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -333,7 +333,7 @@ public struct RUMActionEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
@@ -343,7 +343,7 @@ public struct RUMActionEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "action"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public struct DD: Codable
@@ -456,12 +456,12 @@ public struct RUMErrorEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
     public var error: Error
-    public internal(set) var featureFlags: FeatureFlags?
+    public var featureFlags: FeatureFlags?
     public let freeze: Freeze?
     public let os: RUMOperatingSystem?
     public let service: String?
@@ -469,7 +469,7 @@ public struct RUMErrorEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "error"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public struct DD: Codable
@@ -621,7 +621,7 @@ public struct RUMErrorEvent: RUMDataModel
             public let stack: String
             public let state: String?
     public struct FeatureFlags: Codable
-        public internal(set) var featureFlagsInfo: [String: Encodable]
+        public var featureFlagsInfo: [String: Encodable]
     public struct Freeze: Codable
         public let duration: Int64
     public struct Session: Codable
@@ -655,7 +655,7 @@ public struct RUMLongTaskEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
@@ -666,7 +666,7 @@ public struct RUMLongTaskEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "long_task"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public struct DD: Codable
@@ -767,7 +767,7 @@ public struct RUMResourceEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
@@ -778,7 +778,7 @@ public struct RUMResourceEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "resource"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public struct DD: Codable
@@ -930,11 +930,11 @@ public struct RUMViewEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
-    public internal(set) var featureFlags: FeatureFlags?
+    public var featureFlags: FeatureFlags?
     public let os: RUMOperatingSystem?
     public let privacy: Privacy?
     public let service: String?
@@ -942,7 +942,7 @@ public struct RUMViewEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "view"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public struct DD: Codable
@@ -1004,7 +1004,7 @@ public struct RUMViewEvent: RUMDataModel
             public let height: Double
             public let width: Double
     public struct FeatureFlags: Codable
-        public internal(set) var featureFlagsInfo: [String: Encodable]
+        public var featureFlagsInfo: [String: Encodable]
     public struct Privacy: Codable
         public let replayLevel: ReplayLevel
         public enum ReplayLevel: String, Codable
@@ -1123,7 +1123,7 @@ public struct RUMVitalEvent: RUMDataModel
     public let ciTest: RUMCITest?
     public let connectivity: RUMConnectivity?
     public let container: Container?
-    public internal(set) var context: RUMEventAttributes?
+    public var context: RUMEventAttributes?
     public let date: Int64
     public let device: RUMDevice?
     public let display: Display?
@@ -1133,7 +1133,7 @@ public struct RUMVitalEvent: RUMDataModel
     public let source: Source?
     public let synthetics: RUMSyntheticsTest?
     public let type: String = "vital"
-    public internal(set) var usr: RUMUser?
+    public var usr: RUMUser?
     public let version: String?
     public var view: View
     public let vital: Vital
@@ -1211,7 +1211,7 @@ public struct TelemetryErrorEvent: RUMDataModel
     public let service: String
     public let session: Session?
     public let source: Source
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
     public let type: String = "telemetry"
     public let version: String
     public let view: View?
@@ -1238,7 +1238,7 @@ public struct TelemetryErrorEvent: RUMDataModel
         public let os: RUMTelemetryOperatingSystem?
         public let status: String = "error"
         public let type: String? = "log"
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
         public struct Error: Codable
             public let kind: String?
             public let stack: String?
@@ -1256,7 +1256,7 @@ public struct TelemetryDebugEvent: RUMDataModel
     public let service: String
     public let session: Session?
     public let source: Source
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
     public let type: String = "telemetry"
     public let version: String
     public let view: View?
@@ -1282,7 +1282,7 @@ public struct TelemetryDebugEvent: RUMDataModel
         public let os: RUMTelemetryOperatingSystem?
         public let status: String = "debug"
         public let type: String? = "log"
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
     public struct View: Codable
         public let id: String
 [?] extension TelemetryDebugEvent.Telemetry
@@ -1322,7 +1322,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
         public let device: RUMTelemetryDevice?
         public let os: RUMTelemetryOperatingSystem?
         public let type: String = "configuration"
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
         public struct Configuration: Codable
             public let actionNameAttribute: String?
             public let allowFallbackToLocalStorage: Bool?
@@ -1342,7 +1342,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public var imagePrivacyLevel: String?
             public var initializationType: String?
             public var mobileVitalsUpdatePeriod: Int64?
-            public internal(set) var plugins: [Plugins]?
+            public var plugins: [Plugins]?
             public let premiumSampleRate: Int64?
             public var reactNativeVersion: String?
             public var reactVersion: String?
@@ -1407,7 +1407,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
                 public init(from decoder: Decoder) throws
             public struct Plugins: Codable
                 public let name: String
-                public internal(set) var pluginsInfo: [String: Encodable]
+                public var pluginsInfo: [String: Encodable]
             public enum SelectedTracingPropagators: String, Codable
                 case datadog = "datadog"
                 case b3 = "b3"
@@ -1442,7 +1442,7 @@ public struct TelemetryUsageEvent: RUMDataModel
     public let service: String
     public let session: Session?
     public let source: Source
-    public internal(set) var telemetry: Telemetry
+    public var telemetry: Telemetry
     public let type: String = "telemetry"
     public let version: String
     public let view: View?
@@ -1467,7 +1467,7 @@ public struct TelemetryUsageEvent: RUMDataModel
         public let os: RUMTelemetryOperatingSystem?
         public let type: String = "usage"
         public let usage: Usage
-        public internal(set) var telemetryInfo: [String: Encodable]
+        public var telemetryInfo: [String: Encodable]
         public enum Usage: Codable
             case telemetryCommonFeaturesUsage(value: TelemetryCommonFeaturesUsage)
             case telemetryMobileFeaturesUsage(value: TelemetryMobileFeaturesUsage)
@@ -1557,7 +1557,7 @@ public struct RUMConnectivity: Codable
         case notConnected = "not_connected"
         case maybe = "maybe"
 public struct RUMEventAttributes: Codable
-    public internal(set) var contextInfo: [String: Encodable]
+    public var contextInfo: [String: Encodable]
 [?] extension RUMEventAttributes
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws
@@ -1592,7 +1592,7 @@ public struct RUMUser: Codable
     public let email: String?
     public let id: String?
     public let name: String?
-    public internal(set) var usrInfo: [String: Encodable]
+    public var usrInfo: [String: Encodable]
 [?] extension RUMUser
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws

--- a/tools/rum-models-generator/Package.swift
+++ b/tools/rum-models-generator/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     targets: [
         // CLI wrapper
-        .target(
+        .executableTarget(
             name: "rum-models-generator",
             dependencies: [
                 "CodeGeneration",

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/JSONToSwiftTypeTransformer.swift
@@ -126,7 +126,10 @@ internal class JSONToSwiftTypeTransformer {
                 let additionalPropertyName = jsonObject.name + "Info"
                 // RUMM-1420: we noticed that `additionalProperties` is used for custom user attributes which need to be
                 // sanitized by the SDK, hence it's very practical for us to generate `.mutableInternally` modifier for those.
-                let mutability: SwiftStruct.Property.Mutability = additionalProperties.isReadOnly ? .mutableInternally : .mutable
+
+                // RUM-5992: we noticed that `additionalProperties` is used for custom user attributes which needs to be
+                // sanitized by the SDK or by user-defined mappers, hence we apply `.mutable` modifier for those.
+                let mutability: SwiftStruct.Property.Mutability = .mutable
                 var `struct` = try transformJSONObjectToStruct(jsonObject)
                 `struct`.properties.append(
                     SwiftStruct.Property(

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
@@ -157,7 +157,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
                     writeLine("case nil: self = .none")
                 }
                 swiftEnum.cases.forEach { enumCase in
-                    writeLine("case .\(enumCase.label)\(objcEnumOptionality): self = .\(enumCase.label)")
+                    writeLine("case .\(enumCase.backtickLabel)\(objcEnumOptionality): self = .\(enumCase.backtickLabel)")
                 }
                 writeLine("}")
             indentLeft()
@@ -170,7 +170,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
                     writeLine("case .none: return nil")
                 }
                 swiftEnum.cases.forEach { enumCase in
-                    writeLine("case .\(enumCase.label): return .\(enumCase.label)")
+                    writeLine("case .\(enumCase.backtickLabel): return .\(enumCase.backtickLabel)")
                 }
                 writeLine("}")
             indentLeft()
@@ -215,11 +215,12 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
             ).forEach { swiftEnumCase, objcInteropAssociatedType in
                 let objcTypeName = try objcInteropTypeName(for: objcInteropAssociatedType)
                 let asObjcCast = try swiftToObjcCast(for: objcInteropAssociatedType, isOptional: swiftProperty.isOptional) ?? ""
+                let caseName = swiftEnumCase.backtickLabel
 
                 writeEmptyLine()
-                writeLine("@objc public var \(swiftEnumCase.label): \(objcTypeName)? {")
+                writeLine("@objc public var \(caseName): \(objcTypeName)? {")
                 indentRight()
-                    writeLine("guard case .\(swiftEnumCase.label)(let value) = root.swiftModel.\(propertyWrapper.keyPath) else {")
+                    writeLine("guard case .\(caseName)(let value) = root.swiftModel.\(propertyWrapper.keyPath) else {")
                     indentRight()
                         writeLine("return nil")
                     indentLeft()
@@ -265,7 +266,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcClassName = objcTypeNamesPrefix + nestedObjcClass.objcTypeName
         writeLine("@objc public var \(objcPropertyName): \(objcClassName)\(objcPropertyOptionality) {")
@@ -298,7 +299,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
 
         switch swiftProperty.mutability {
@@ -330,7 +331,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnumArray.objcTypeName
 
@@ -355,7 +356,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcClassName = objcTypeNamesPrefix + nestedObjcClass.objcTypeName
 
@@ -433,7 +434,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcClassName = objcTypeNamesPrefix + nestedObjcAssociatedTypeEnum.objcTypeName
         writeLine("@objc public var \(objcPropertyName): \(objcClassName)\(objcPropertyOptionality) {")

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
@@ -378,16 +378,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
 
     private func printPrimitivePropertyWrapper(_ propertyWrapper: ObjcInteropPropertyWrapperManagingSwiftStructProperty) throws {
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-
-        if let swiftDictionary = swiftProperty.type as? SwiftDictionary, swiftDictionary.value is SwiftPrimitiveNoObjcInteropType {
-            if swiftProperty.mutability == .mutable {
-                throw Exception.unimplemented(
-                    "Generating ObjcInterop for mutable property `\(swiftProperty.name)` is not supported."
-                )
-            }
-        }
-
-        let objcPropertyName = swiftProperty.name
+        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcTypeName = try objcInteropTypeName(for: propertyWrapper.objcInteropType)
         let asObjcCast = try swiftToObjcCast(for: propertyWrapper.objcInteropType, isOptional: swiftProperty.isOptional) ?? ""
@@ -521,7 +512,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         case let swiftDictionary as SwiftDictionary where swiftDictionary.value is SwiftPrimitive<String>:
             return nil // `[Key: String]` <> `[Key: NSString]` interoperability doesn't require casting
         case let swiftDictionary as SwiftDictionary where swiftDictionary.value is SwiftPrimitiveNoObjcInteropType:
-            return nil
+            return ".dd.swiftAttributes"
         case let swiftArray as SwiftArray:
             let elementCast = try objcToSwiftCast(for: swiftArray.element)
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftArray` with elements of type: \(type(of: swiftArray.element))"))

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
@@ -361,7 +361,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                     value: SwiftEncodable()
                                 ),
                                 isOptional: false,
-                                mutability: .mutableInternally,
+                                mutability: .mutable,
                                 defaultValue: nil,
                                 codingKey: .dynamic
                             )
@@ -369,7 +369,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    mutability: .mutableInternally,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalAnyProperties")
                 )
@@ -444,7 +444,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                     value: SwiftEncodable()
                                 ),
                                 isOptional: false,
-                                mutability: .mutableInternally,
+                                mutability: .mutable,
                                 defaultValue: nil,
                                 codingKey: .dynamic
                             ),
@@ -452,7 +452,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    mutability: .mutableInternally,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "bar")
                 )

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
@@ -21,22 +21,22 @@ final class SwiftPrinterTests: XCTestCase {
                         comment: "Description of Bar.",
                         properties: [
                             SwiftStruct.Property(
-                                name: "property1",
-                                comment: "Description of Bar's `property1`.",
+                                name: "public",
+                                comment: "Description of Bar's `public`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
                                 mutability: .immutable,
                                 defaultValue: nil,
-                                codingKey: .static(value: "property1")
+                                codingKey: .static(value: "public")
                             ),
                             SwiftStruct.Property(
-                                name: "property2",
-                                comment: "Description of Bar's `property2`.",
+                                name: "internal",
+                                comment: "Description of Bar's `internal`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
                                 mutability: .mutable,
                                 defaultValue: nil,
-                                codingKey: .static(value: "property2")
+                                codingKey: .static(value: "internal")
                             )
                         ],
                         conformance: [codableProtocol]
@@ -127,15 +127,15 @@ final class SwiftPrinterTests: XCTestCase {
 
             /// Description of Bar.
             public struct BAR: Codable {
-                /// Description of Bar's `property1`.
-                public let property1: String?
+                /// Description of Bar's `public`.
+                public let `public`: String?
 
-                /// Description of Bar's `property2`.
-                public var property2: String
+                /// Description of Bar's `internal`.
+                public var `internal`: String
 
                 enum CodingKeys: String, CodingKey {
-                    case property1 = "property1"
-                    case property2 = "property2"
+                    case `public` = "public"
+                    case `internal` = "internal"
                 }
             }
 


### PR DESCRIPTION
### What and why?

Additional properties are generated with `internal(set)` accessor, preventing users from mutating their attributes using event mappers. These changes align with Android and allow additional properties mutation in both Swift and ObjC.

### How?

- Update model generator to make additional properties mutable
- Fix Swift reserved keyword in generator; following schema change that define a property named `protocol`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
