### PR TITLE
chore: Fix dogfooding in mobile app

### DIFF
--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -263,7 +263,6 @@ if [ "$datadog_app" = "true" ]; then
     CHANGELOG=$(print_changelog "$LAST_DOGFOODED_COMMIT")
     
     # Update dd-sdk-ios version:
-    update_dependant_package_resolved "$CLONE_PATH/DatadogApp.xcworkspace/xcshareddata/swiftpm/Package.resolved"
     update_dependant_package_resolved "$CLONE_PATH/.package.resolved"
     update_dependant_sdk_version "$CLONE_PATH/Targets/DogLogger/Datadog/DogfoodingConfig.swift"
 


### PR DESCRIPTION
### What and why?

Appears that dependencies are no longer pinned in `DatadogApp.xcworkspace/xcshareddata/swiftpm/Package.resolved` but only in `.package.resolved`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
