### PR TITLE
chore: Re-enable CI Tests visibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ Unit Tests (iOS):
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
+    - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
 
 Unit Tests (tvOS):
   stage: test
@@ -116,7 +116,7 @@ Unit Tests (tvOS):
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
-    - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
+    - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
 
 UI Tests:
   stage: ui-test

--- a/DatadogCore/Tests/Datadog/Mocks/DirectoriesMock.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/DirectoriesMock.swift
@@ -70,9 +70,9 @@ extension Directory {
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: attributes)
             let initialFilesCount = try files().count
-            XCTAssert(initialFilesCount == 0, "🔥 `TestsDirectory` is not empty: \(url)", file: file, line: line)
+            XCTAssert(initialFilesCount == 0, "🔥 `Directory` is not empty: \(url)", file: file, line: line)
         } catch {
-            XCTFail("🔥 Failed to create `TestsDirectory`: \(error)", file: file, line: line)
+            XCTFail("🔥 `Directory.create()` failed: \(error)", file: file, line: line)
         }
         return self
     }
@@ -83,7 +83,7 @@ extension Directory {
             do {
                 try FileManager.default.removeItem(at: url)
             } catch {
-                XCTFail("🔥 Failed to delete `TestsDirectory`: \(error)", file: file, line: line)
+                XCTFail("🔥 `Directory.delete()` failed: \(error)", file: file, line: line)
             }
         }
     }

--- a/TestUtilities/Helpers/TestsDirectory.swift
+++ b/TestUtilities/Helpers/TestsDirectory.swift
@@ -30,9 +30,9 @@ public func CreateTemporaryDirectory(attributes: [FileAttributeKey: Any]? = nil,
         try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true, attributes: attributes)
         let files = try FileManager.default
             .contentsOfDirectory(at: temporaryDirectory, includingPropertiesForKeys: [.isRegularFileKey, .canonicalPathKey])
-        XCTAssert(files.count == 0, "🔥 `TestsDirectory` is not empty: \(temporaryDirectory)", file: file, line: line)
+        XCTAssert(files.count == 0, "🔥 `temporaryDirectory` is not empty: \(temporaryDirectory)", file: file, line: line)
     } catch {
-        XCTFail("🔥 Failed to create `TestsDirectory`: \(error)", file: file, line: line)
+        XCTFail("🔥 `CreateTemporaryDirectory()` failed: \(error)", file: file, line: line)
     }
 }
 
@@ -43,7 +43,7 @@ public func DeleteTemporaryDirectory(file: StaticString = #file, line: UInt = #l
         do {
             try FileManager.default.removeItem(at: temporaryDirectory)
         } catch {
-            XCTFail("🔥 Failed to delete `TestsDirectory`: \(error)", file: file, line: line)
+            XCTFail("🔥 `DeleteTemporaryDirectory()` failed: \(error)", file: file, line: line)
         }
     }
 }


### PR DESCRIPTION
### What and why?

📦 In #2096, we temporarily disabled CI Test instrumentation due to sporadic test failures caused by the following error:
```
🔥 Failed to delete TestsDirectory: Error Domain=NSCocoaErrorDomain Code=512 ""com.datadoghq.ios-sdk-tests-434C4A49-7195-4957-AE16-9A943737BDBF" couldn't be removed."
```

I traced the root cause to the CI Tests SDK, which exceeded the open file descriptor limit when processing coverage files for the [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis/) feature. This led to failures with the `{Error Domain=NSPOSIXErrorDomain Code=24 "Too many open files"}` error.

My whole investigation is documented here: [internal doc](https://datadoghq.atlassian.net/wiki/x/FYILBQE).

### How?

Since the issue arises only when [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis/) is enabled, I disabled it for `dd-sdk-ios` in the [CI Test Optimization Settings](https://docs.datadoghq.com/tests/test_impact_analysis/setup/swift/#activate-intelligent-test-runner-for-the-test-service) page. This stops the CI Tests SDK from processing coverage files, preventing the file descriptor limit from being exceeded.

A corresponding issue (`SDTEST-1200`) has been opened in CI Visibility for further investigation. Once resolved, we can re-enable TIA.

Additionally, this PR refines error messages related to temporary directory management, improving clarity by pointing more directly to the failing code.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
