### PR TITLE
RUM-3175 Fix possible file name conflict during consent change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Fix sporadic file overwrite during consent change, ensuring event data integrity. See [#2113][]
+
 # 2.20.0 / 14-11-2024
 
 - [FIX] Fix race condition during consent change, preventing loss of events recorded on the current thread. See [#2063][]
@@ -793,6 +795,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2104]: https://github.com/DataDog/dd-sdk-ios/pull/2104
 [#2099]: https://github.com/DataDog/dd-sdk-ios/pull/2099
 [#2063]: https://github.com/DataDog/dd-sdk-ios/pull/2063
+[#2113]: https://github.com/DataDog/dd-sdk-ios/pull/2113
 [#2092]: https://github.com/DataDog/dd-sdk-ios/pull/2092
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin


### PR DESCRIPTION
### What and why?

📦 This PR addresses a potential file name conflict issue during tracking consent changes.

Initially considered a flakiness ❄️ in [testWhenWritingEventsWithPendingConsentThenGranted_itUploadsAllEvents()](https://github.com/DataDog/dd-sdk-ios/blob/004ca93c6036c0ceead2f09fedebfae9496c9da3/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift#L81) (added in https://github.com/DataDog/dd-sdk-ios/pull/2063), it was discovered to be a real issue that can occur in certain edge cases.

The conflict happens when files are moved between `.pending` and `.granted` folders and events are written immediately before and after the consent change. If this occurs very quickly (under 1ms), the last batch in the pending folder may be named the same as the next batch in the granted folder. Since the SDK [does not check if the file exists](https://github.com/DataDog/dd-sdk-ios/blob/004ca93c6036c0ceead2f09fedebfae9496c9da3/DatadogCore/Sources/Core/Storage/Files/Directory.swift#L111-L115), the migrated file gets overwritten by the new event:

```
T - timestamp

[T0] consent: PENDING
[T1] write event A --> batch file created: intermediate/T1
[T1] change consent to GRANTED --> move intermediate/T1 to authorized/T1
[T1] write event B --> batch file created: authorized/T1 
                                           ^ 🐞 The previous T1 with event A is deleted
                                            and replaced with the new batch for event B.
```

### How?

This fix ensures that batch file names are unique, even in the edge case above, by waiting and generating a new file name when a conflict is detected. It guarantees that the new file's timestamp will be at least one precision interval (1ms) later than the existing file, preventing conflicts during consent changes.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
