### PR TITLE
RUM-7251 Static trace context caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Fix sporadic file overwrite during consent change, ensuring event data integrity. See [#2113][]
+- [FIX] Fix trace inconsistency when using `URLSessionInterceptor` or Alamofire extension. See [#2114][]
 
 # 2.20.0 / 14-11-2024
 
@@ -795,8 +796,9 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2104]: https://github.com/DataDog/dd-sdk-ios/pull/2104
 [#2099]: https://github.com/DataDog/dd-sdk-ios/pull/2099
 [#2063]: https://github.com/DataDog/dd-sdk-ios/pull/2063
-[#2113]: https://github.com/DataDog/dd-sdk-ios/pull/2113
 [#2092]: https://github.com/DataDog/dd-sdk-ios/pull/2092
+[#2113]: https://github.com/DataDog/dd-sdk-ios/pull/2113
+[#2114]: https://github.com/DataDog/dd-sdk-ios/pull/2114
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1171,6 +1171,8 @@
 		D284C7412C2059F3005142CC /* ObjcExceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */; };
 		D286626E2A43487500852CE3 /* Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286626D2A43487500852CE3 /* Datadog.swift */; };
 		D286626F2A43487500852CE3 /* Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286626D2A43487500852CE3 /* Datadog.swift */; };
+		D28ABFD62CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */; };
+		D28ABFD72CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */; };
 		D28F836529C9E69E00EF8EA2 /* DatadogTraceFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* DatadogTraceFeatureTests.swift */; };
 		D28F836629C9E6A200EF8EA2 /* DatadogTraceFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* DatadogTraceFeatureTests.swift */; };
 		D28F836829C9E71D00EF8EA2 /* DDSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */; };
@@ -2982,6 +2984,7 @@
 		D27CBD992BB5DBBB00C766AA /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionTests.swift; sourceTree = "<group>"; };
 		D286626D2A43487500852CE3 /* Datadog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Datadog.swift; sourceTree = "<group>"; };
+		D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptorTests.swift; sourceTree = "<group>"; };
 		D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
 		D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionHandlerTests.swift; sourceTree = "<group>"; };
 		D28FCC342B5EBAAF00CCC077 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -6515,6 +6518,7 @@
 				D2160CD129C0DF6700FAA9A5 /* HostsSanitizerTests.swift */,
 				D2160CD329C0DF6700FAA9A5 /* URLSessionDelegateAsSuperclassTests.swift */,
 				D2160CD229C0DF6700FAA9A5 /* URLSessionTaskInterceptionTests.swift */,
+				D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */,
 				61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */,
 				3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */,
 				61B558D32469CDD8001460D3 /* TraceIDGeneratorTests.swift */,
@@ -9808,6 +9812,7 @@
 				6174D6162BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,
 				3C0D5DF52A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4429BA168200B15732 /* TraceIDTests.swift in Sources */,
+				D28ABFD72CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */,
 				D2EBEE4329BA168200B15732 /* TraceIDGeneratorTests.swift in Sources */,
 				D2DA23A7298D58F400C6C7E6 /* AppStateHistoryTests.swift in Sources */,
 				D2DA23A5298D58F400C6C7E6 /* AnyDecodableTests.swift in Sources */,
@@ -9860,6 +9865,7 @@
 				6174D6172BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,
 				3C0D5DF62A5443B100446CF9 /* DataFormatTests.swift in Sources */,
 				D2EBEE4629BA168400B15732 /* TraceIDTests.swift in Sources */,
+				D28ABFD62CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */,
 				D2EBEE4529BA168400B15732 /* TraceIDGeneratorTests.swift in Sources */,
 				D2DA23B2298D59DC00C6C7E6 /* AppStateHistoryTests.swift in Sources */,
 				D2DA23B3298D59DC00C6C7E6 /* AnyDecodableTests.swift in Sources */,

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionInterceptorTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionInterceptorTests.swift
@@ -1,0 +1,70 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+
+import TestUtilities
+@testable import DatadogInternal
+
+class URLSessionInterceptorTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var core: SingleFeatureCoreMock<NetworkInstrumentationFeature>!
+    private var handler: URLSessionHandlerMock!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        core = SingleFeatureCoreMock()
+        handler = URLSessionHandlerMock()
+        try core.register(urlSessionHandler: handler)
+    }
+
+    override func tearDown() {
+        core = nil
+        super.tearDown()
+    }
+
+    func testTraceInterception() throws {
+        // Given
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        let trace: TraceContext = .mockWith(isKept: true)
+        let writer: TracePropagationHeadersWriter = oneOf([
+            { HTTPHeadersWriter(samplingStrategy: .headBased, traceContextInjection: .all) },
+            { B3HTTPHeadersWriter(samplingStrategy: .custom(sampleRate: 100)) },
+            { W3CHTTPHeadersWriter(samplingStrategy: .headBased) }
+        ])
+
+        let url: URL = .mockAny()
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
+
+        writer.write(traceContext: trace)
+        handler.modifiedRequest = .mockWith(url: url, headers: writer.traceHeaderFields)
+        handler.injectedTraceContext = trace
+
+        // When
+        var interceptor = try XCTUnwrap(URLSessionInterceptor.shared(in: core))
+        let request = interceptor.intercept(request: .mockWith(url: url))
+
+        let task: URLSessionTask = .mockWith(request: request)
+        interceptor = try XCTUnwrap(URLSessionInterceptor.shared(in: core))
+        interceptor.intercept(task: task)
+
+        interceptor = try XCTUnwrap(URLSessionInterceptor.shared(in: core))
+        interceptor.task(task, didCompleteWithError: nil)
+
+        handler.onInterceptionDidStart = { interception in
+            // Then
+            XCTAssertEqual(interception.trace, trace)
+        }
+
+        feature.flush()
+
+        XCTAssert(URLSessionInterceptor.contextsByTraceID.isEmpty)
+    }
+}


### PR DESCRIPTION
### What and why?

The `URLSessionInterceptor` keeps a cache of trace context but the `shared()` methods returns a new instance each time, leading to trace discontinuity.

### How?

Make the trace-context cache static.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
