### PR TITLE
Make Crash Reporter Plugin Public

### DIFF
--- a/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
@@ -165,4 +165,32 @@ internal struct CrashContext: Codable, Equatable {
             lhs.userInfo?.email == rhs.userInfo?.email &&
             lhs.appLaunchDate == rhs.appLaunchDate
     }
+
+    func merging(rumAttributes: GlobalRUMAttributes) -> Self {
+        let sourceAttribtues = lastRUMAttributes?.attributes ?? [:]
+        let mergedAttributes = sourceAttribtues.merging(rumAttributes.attributes) { new, _ in new }
+
+        return CrashContext(
+            serverTimeOffset: serverTimeOffset,
+            service: service,
+            env: env,
+            version: version,
+            buildNumber: buildNumber,
+            device: device,
+            sdkVersion: sdkVersion,
+            source: source,
+            trackingConsent: trackingConsent,
+            userInfo: userInfo,
+            networkConnectionInfo: networkConnectionInfo,
+            carrierInfo: carrierInfo,
+            lastIsAppInForeground: lastIsAppInForeground,
+            appLaunchDate: appLaunchDate,
+            lastRUMViewEvent: lastRUMViewEvent,
+            lastRUMSessionState: lastRUMSessionState,
+            lastRUMAttributes: GlobalRUMAttributes(
+                attributes: mergedAttributes
+            ),
+            lastLogAttributes: lastLogAttributes
+        )
+    }
 }

--- a/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
@@ -27,10 +27,3 @@ public protocol CrashReportingPlugin: AnyObject {
     /// It is called on a background thread and succeeding calls are synchronized.
     func inject(context: Data)
 }
-
-public class NoopCrashReportingPlugin: CrashReportingPlugin {
-    public func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) {
-        _ = completion(nil)
-    }
-    public func inject(context: Data) {}
-}

--- a/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 /// An interface for enabling crash reporting feature in Datadog SDK.
 ///
 /// The SDK calls each API on a background thread and succeeding calls are synchronized.
-internal protocol CrashReportingPlugin: AnyObject {
+public protocol CrashReportingPlugin: AnyObject {
     /// Reads unprocessed crash report if available.
     /// - Parameter completion: the completion block called with the value of `DDCrashReport` if a crash report is available
     /// or with `nil` otherwise. The value returned by the receiver should indicate if the crash report was processed correctly (`true`)
@@ -26,4 +26,11 @@ internal protocol CrashReportingPlugin: AnyObject {
     /// The SDK calls this method for each significant application state change.
     /// It is called on a background thread and succeeding calls are synchronized.
     func inject(context: Data)
+}
+
+public class NoopCrashReportingPlugin: CrashReportingPlugin {
+    public func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) {
+        _ = completion(nil)
+    }
+    public func inject(context: Data) {}
 }

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReport.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReport.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import Foundation
 import CrashReporter
 
@@ -318,3 +320,5 @@ extension StackFrame {
         }
     }
 }
+
+#endif // canImport(CrashReporter)

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReportMinifier.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReportMinifier.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import Foundation
 
 /// Reduces information in intermediate `CrashReport`:
@@ -92,3 +94,5 @@ internal struct CrashReportMinifier {
         }
     }
 }
+
+#endif

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportBuilder.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportBuilder.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import DatadogInternal
 import CrashReporter
 
@@ -23,3 +25,5 @@ internal struct DDCrashReportBuilder {
         return exporter.export(crashReport)
     }
 }
+
+#endif

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportExporter.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportExporter.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import DatadogInternal
 
 /// Exports intermediate `CrashReport` to `DDCrashReport`.
@@ -223,3 +225,5 @@ internal struct DDCrashReportExporter {
         return lines.joined(separator: "\n")
     }
 }
+
+#endif

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import Foundation
 import DatadogInternal
 @preconcurrency import CrashReporter
@@ -82,3 +84,5 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
         )
     }
 }
+
+#endif

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterPlugin.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterPlugin.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if canImport(CrashReporter)
+
 import Foundation
 import DatadogInternal
 
@@ -59,3 +61,5 @@ internal class PLCrashReporterPlugin: NSObject, CrashReportingPlugin {
         PLCrashReporterPlugin.thirdPartyCrashReporter?.inject(context: context)
     }
 }
+
+#endif


### PR DESCRIPTION
This PR makes the crash reporter public and adds some hooks to send reports at other times than startup.

---

This pull request includes several changes to the `DatadogCrashReporting` module, focusing on enhancing crash reporting functionality and improving compatibility with conditional imports. The most important changes include adding a new method to merge RUM attributes in `CrashContext`, updating the `CrashReporting` class to handle conditional imports, and making the `CrashReportingFeature` class and `CrashReportingPlugin` protocol public.

Enhancements to crash reporting functionality:

* [`DatadogCrashReporting/Sources/CrashContext/CrashContext.swift`](diffhunk://#diff-b3539333f9d72967f5061090c4d4ba9a73edadb9334e088f8815fd032199e6f0R168-R195): Added a new method `merging(rumAttributes:)` to the `CrashContext` struct for merging RUM attributes.
* [`DatadogCrashReporting/Sources/CrashReporting.swift`](diffhunk://#diff-c32640359b93857c4d85ff08e2832d1759d5dcd294491d5dedd722ef828d69aaR59-R62): Introduced a new method `send(_:attributes:in:)` to the `CrashReporting` class for sending crash reports with optional attributes.

Improvements for conditional imports:

* [`DatadogCrashReporting/Sources/CrashReporting.swift`](diffhunk://#diff-c32640359b93857c4d85ff08e2832d1759d5dcd294491d5dedd722ef828d69aaR24-R31): Updated the `enable(in:)` method to conditionally compile code based on the availability of the `CrashReporter` module. [[1]](diffhunk://#diff-c32640359b93857c4d85ff08e2832d1759d5dcd294491d5dedd722ef828d69aaR24-R31) [[2]](diffhunk://#diff-c32640359b93857c4d85ff08e2832d1759d5dcd294491d5dedd722ef828d69aaR45-R49)
* Various files in `DatadogCrashReporting/Sources/PLCrashReporterIntegration/`: Added `#if canImport(CrashReporter)` checks to conditionally compile code depending on the availability of the `CrashReporter` module. [[1]](diffhunk://#diff-bd97abaa913473bd362bf4e20b8c560f763122c1361e22e00b3d1a7ab929e07aR7-R8) [[2]](diffhunk://#diff-bd97abaa913473bd362bf4e20b8c560f763122c1361e22e00b3d1a7ab929e07aR323-R324) [[3]](diffhunk://#diff-47b3f6e87bca1bae23fc704f20a51f8dbdd18171cbeefb8061c545c4fb657654R7-R8) [[4]](diffhunk://#diff-47b3f6e87bca1bae23fc704f20a51f8dbdd18171cbeefb8061c545c4fb657654R97-R98) [[5]](diffhunk://#diff-f18159b2ed56410cd88af22dfe33406cc3ab08672b9e37c15f4cddc1be5cbbe0R7-R8) [[6]](diffhunk://#diff-f18159b2ed56410cd88af22dfe33406cc3ab08672b9e37c15f4cddc1be5cbbe0R28-R29) [[7]](diffhunk://#diff-f4aef31e1317d349b97407fcca5ced4ca39332260e6cff23c57fad3e4aaa851aR7-R8) [[8]](diffhunk://#diff-f4aef31e1317d349b97407fcca5ced4ca39332260e6cff23c57fad3e4aaa851aR228-R229) [[9]](diffhunk://#diff-ae2462de437de202b1a7d4fcc19bb98534b68ecbf312cd81540684a36a8eae78R7-R8) [[10]](diffhunk://#diff-ae2462de437de202b1a7d4fcc19bb98534b68ecbf312cd81540684a36a8eae78R87-R88) [[11]](diffhunk://#diff-8cb7517e08ef120d5f94d9e067ff28361956fbda8f941676c29243b6d0b53510R7-R8) [[12]](diffhunk://#diff-8cb7517e08ef120d5f94d9e067ff28361956fbda8f941676c29243b6d0b53510R64-R65)

Public API changes:

* [`DatadogCrashReporting/Sources/CrashReportingFeature.swift`](diffhunk://#diff-552b6319a97696000b5d646e20f1a0d2f2c68aa9f422e199007e77843b4e8a6aL10-R13): Changed the `CrashReportingFeature` class and its `name` and `messageReceiver` properties to be public. [[1]](diffhunk://#diff-552b6319a97696000b5d646e20f1a0d2f2c68aa9f422e199007e77843b4e8a6aL10-R13) [[2]](diffhunk://#diff-552b6319a97696000b5d646e20f1a0d2f2c68aa9f422e199007e77843b4e8a6aR57-R66) [[3]](diffhunk://#diff-552b6319a97696000b5d646e20f1a0d2f2c68aa9f422e199007e77843b4e8a6aL147-R157)
* [`DatadogCrashReporting/Sources/CrashReportingPlugin.swift`](diffhunk://#diff-f0a07cff9ca12bd4e3b8c439ec2c30628213fb34a2de6086eccda055296e75e9L13-R13): Made the `CrashReportingPlugin` protocol public and added a new `NoopCrashReportingPlugin` class. [[1]](diffhunk://#diff-f0a07cff9ca12bd4e3b8c439ec2c30628213fb34a2de6086eccda055296e75e9L13-R13) [[2]](diffhunk://#diff-f0a07cff9ca12bd4e3b8c439ec2c30628213fb34a2de6086eccda055296e75e9R30-R36)