### PR TITLE
RUM-7178 Support SwiftUI platform group

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1171,6 +1171,7 @@
 		D284C7412C2059F3005142CC /* ObjcExceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */; };
 		D286626E2A43487500852CE3 /* Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286626D2A43487500852CE3 /* Datadog.swift */; };
 		D286626F2A43487500852CE3 /* Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286626D2A43487500852CE3 /* Datadog.swift */; };
+		D28ABFD32CEB87C600623F27 /* UIHostingViewRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28ABFD22CEB87C600623F27 /* UIHostingViewRecorderTests.swift */; };
 		D28ABFD62CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */; };
 		D28ABFD72CECDE6B00623F27 /* URLSessionInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */; };
 		D28F836529C9E69E00EF8EA2 /* DatadogTraceFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* DatadogTraceFeatureTests.swift */; };
@@ -2996,6 +2997,7 @@
 		D27CBD992BB5DBBB00C766AA /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionTests.swift; sourceTree = "<group>"; };
 		D286626D2A43487500852CE3 /* Datadog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Datadog.swift; sourceTree = "<group>"; };
+		D28ABFD22CEB87C600623F27 /* UIHostingViewRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHostingViewRecorderTests.swift; sourceTree = "<group>"; };
 		D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptorTests.swift; sourceTree = "<group>"; };
 		D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
 		D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionHandlerTests.swift; sourceTree = "<group>"; };
@@ -4030,6 +4032,7 @@
 				61054F782A6EE1BA00AAA894 /* UITextViewRecorderTests.swift */,
 				D2BCB2A22B7B9683005C2AAB /* WKWebViewRecorderTests.swift */,
 				A7F6512F2B7655DE004B0EDB /* UIImageResourceTests.swift */,
+				D28ABFD22CEB87C600623F27 /* UIHostingViewRecorderTests.swift */,
 			);
 			path = NodeRecorders;
 			sourceTree = "<group>";
@@ -8505,6 +8508,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D28ABFD32CEB87C600623F27 /* UIHostingViewRecorderTests.swift in Sources */,
 				969B3B232C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift in Sources */,
 				61054FD42A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift in Sources */,
 				61054FB52A6EE1BA00AAA894 /* UISliderRecorderTests.swift in Sources */,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -88,18 +88,29 @@ extension DisplayList.Index.ID: Reflection {
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewInfo: Reflection {
     init(_ mirror: ReflectionMirror) throws {
-        let view = try mirror.descendant(type: UIView.self, "view")
-        let layer = try mirror.descendant(type: CALayer.self, "layer")
-
-        // do not retain the view or layer, only get values required
+        // do not retain the views or layer, only get values required
         // for building wireframe
+
+        let layer = try mirror.descendant(type: CALayer.self, "layer")
+        // The view is the rendering context of an item
+        let view = try mirror.descendant(type: UIView.self, "view")
+        // The container view is where the item is actually rendered.
+        // The container is usually the same as the view, except when applying
+        // a `.platformGroup` effect. e.g: A `SwiftUI.ScrollView` will create a
+        // `.platformGroup` effect where the `Content` is rendered in a `UIScrollView`,
+        // in this case the container is the content of the `UIScrollView`.
+        let container = try mirror.descendant(type: UIView.self, "container")
+
+        // The frame is the container's frame in the view's coordinate space.
+        // This is useful for applying the offset in a scroll-view.
+        frame = container.convert(container.bounds, to: view)
         backgroundColor = layer.backgroundColor?.safeCast
         borderColor = layer.borderColor?.safeCast
         borderWidth = layer.borderWidth
         cornerRadius = layer.cornerRadius
         alpha = view.alpha
         isHidden = layer.isHidden
-        intrinsicContentSize = view.intrinsicContentSize
+        intrinsicContentSize = container.intrinsicContentSize
     }
 }
 
@@ -169,5 +180,4 @@ extension DisplayList.Item.Value: Reflection {
         }
     }
 }
-
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
@@ -35,6 +35,9 @@ internal struct DisplayList {
         }
 
         internal struct ViewInfo {
+            /// The container view frame in this view coordinate space
+            let frame: CGRect
+
             /// Original view's `.backgorundColor`.
             let backgroundColor: CGColor?
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -68,7 +68,6 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
         case let .clip(path, _):
             let clip = context.convert(frame: path.boundingRect)
             context.clip = context.clip.intersection(clip)
-            return buildWireframes(items: list.items, context: context)
 
         case .platformGroup:
             if let viewInfo = renderer.viewCache.map[.init(id: .init(identity: item.identity))] {

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -6,6 +6,8 @@
 
 #if os(iOS)
 import Foundation
+import XCTest
+
 @_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
@@ -1253,6 +1255,17 @@ extension SRIncrementalSnapshotRecord {
         switch data {
         case .viewportResizeData(let value): return value
         default: return nil
+        }
+    }
+}
+
+extension SRWireframe {
+    var textWireframe: SRTextWireframe? {
+        switch self {
+        case .textWireframe(let value): return value
+        default:
+            XCTFail("not a SRWireframe.textWireframe")
+            return nil
         }
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -1,0 +1,102 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import XCTest
+import SwiftUI
+import DatadogInternal
+import TestUtilities
+
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+class UIHostingViewRecorderTests: XCTestCase {
+    func testTextView() throws {
+        struct MockView: View {
+            var body: some View {
+                Text("Hello, World!")
+                    .font(.system(size: 28))
+            }
+        }
+
+        let wireframes = try render(MockView())
+        XCTAssertEqual(wireframes.count, 1)
+        let wireframe = try XCTUnwrap(wireframes.first?.textWireframe)
+        XCTAssertEqual(wireframe.text, "Hello, World!")
+        XCTAssertEqual(wireframe.textStyle.color, "#000000FF")
+        XCTAssertEqual(wireframe.textStyle.family, "-apple-system, BlinkMacSystemFont, \'Roboto\', sans-serif")
+        XCTAssertEqual(wireframe.textStyle.size, 28)
+        XCTAssertEqual(wireframe.x, 74, accuracy: 5)
+        XCTAssertEqual(wireframe.y, 164, accuracy: 5)
+        XCTAssertEqual(wireframe.width, 151, accuracy: 5)
+        XCTAssertEqual(wireframe.height, 34, accuracy: 5)
+    }
+
+    @available(iOS 17.0, tvOS 17.0, *)
+    func testScrollView() throws {
+        struct MockView: View {
+            var body: some View {
+                ScrollView {
+                    VStack {
+                        Text("Hello, World!")
+                            .font(.system(size: 17))
+                    }
+                    .frame(width: 300, height: 600)
+                }
+                .contentMargins(50)
+            }
+        }
+
+        let wireframes = try render(MockView())
+        XCTAssertEqual(wireframes.count, 1)
+        let wireframe = try XCTUnwrap(wireframes.first?.textWireframe)
+        XCTAssertEqual(wireframe.text, "Hello, World!")
+        XCTAssertEqual(wireframe.x, 101, accuracy: 5)
+        XCTAssertEqual(wireframe.y, 402, accuracy: 5)
+        XCTAssertEqual(wireframe.width, 97, accuracy: 5)
+        XCTAssertEqual(wireframe.height, 20, accuracy: 5)
+    }
+}
+
+/// Renders a `SwiftUI.View` and builds a wireframe representation.
+///
+/// - Parameters:
+///   - view: The `SwiftUI.View` instance.
+///   - size: The container size.
+///   - attributes: Optional host view attributes.
+///   - context: Optional host view context.
+/// - Returns: The SessionReplay wireframes representing the view.
+@available(iOS 13.0, tvOS 13.0, *)
+private func render<V>(
+    _ view: V,
+    size: CGSize = CGSize(width: 300, height: 300),
+    with attributes: ViewAttributes = .mockAny(),
+    in context: ViewTreeRecordingContext = .mockAny()
+) throws -> [SRWireframe] where V: SwiftUI.View {
+    let recorder: UIHostingViewRecorder
+    if #available(iOS 18.0, tvOS 18.0, *) {
+        recorder = iOS18HostingViewRecorder(identifier: UUID())
+    } else {
+        recorder = UIHostingViewRecorder(identifier: UUID())
+    }
+
+    let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+    let host = UIHostingController(rootView: view)
+    window.rootViewController = host
+    window.makeKeyAndVisible()
+    defer { window.resignKey() }
+    window.layoutIfNeeded()
+
+    let semantics = recorder.semantics(of: host.view, with: attributes, in: context)
+    let builder = try XCTUnwrap(semantics?.nodes.first?.wireframesBuilder as? SwiftUIWireframesBuilder)
+    var wireframes = builder.buildWireframes(with: WireframesBuilder())
+    // remove first wireframe that represent the root hosting view
+    wireframes.removeFirst()
+    return wireframes
+}
+
+#endif


### PR DESCRIPTION
### What and why?

Support SwiftUI scroll-view offset.

### How?

The `ViewInfo` for the SwiftUI view-cache includes a `view` reference as well as a `container` reference, both of `UIView` type. In most effects, both referred to the same instance. But when the `.platformGroup` effect is applied, all the items of the subtree will be renderer in as a group in a the `container` of a platform view (aka `UIView`).

A `SwiftUI.ScrollView` creates a `.platformGroup` effect where the `view` is the a `UIScrollView` and the `container` its content. This effect place the container frame in the view's coordinate space, meaning that the container will translate when the view scrolls.

In order to support `.platformGroup`, we get the [container's frame in the view's coordinate space](https://github.com/DataDog/dd-sdk-ios/pull/2122/files#diff-a0390dca4476786f103a00506d346966f532db871d8e54007ff921cdd8107f22R94-R106) and use this as a [reference frame](https://github.com/DataDog/dd-sdk-ios/pull/2122/files#diff-42ba1f438ce640c52cf81c1e960cf881eb6c25c99beafc3eb358998b7317b998R73-R75) for all its sub-items. 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
