### PR TITLE
RUM-7316 Session Replay SwiftUI Feature Flag

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1349,6 +1349,7 @@
 		D2AD1CC92CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBE2CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift */; };
 		D2AD1CCC2CE4AE9800106C74 /* UIHostingViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CCB2CE4AE9800106C74 /* UIHostingViewRecorder.swift */; };
 		D2AD1CCF2CE4AEF600106C74 /* ReflectionMirrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */; };
+		D2AE9A5D2CF8837C00695264 /* FeatureFlagsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AE9A5C2CF8836D00695264 /* FeatureFlagsMock.swift */; };
 		D2B249942A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249952A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249972A45E10500DD4F9F /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249962A45E10500DD4F9F /* LoggerTests.swift */; };
@@ -3040,6 +3041,7 @@
 		D2AD1CC02CE4AE6600106C74 /* Text+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Reflection.swift"; sourceTree = "<group>"; };
 		D2AD1CCB2CE4AE9800106C74 /* UIHostingViewRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHostingViewRecorder.swift; sourceTree = "<group>"; };
 		D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionMirrorTests.swift; sourceTree = "<group>"; };
+		D2AE9A5C2CF8836D00695264 /* FeatureFlagsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsMock.swift; sourceTree = "<group>"; };
 		D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerProtocol+Internal.swift"; sourceTree = "<group>"; };
 		D2B249962A45E10500DD4F9F /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* TLVBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLVBlockTests.swift; sourceTree = "<group>"; };
@@ -4035,6 +4037,7 @@
 		61054F7D2A6EE1BA00AAA894 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				D2AE9A5C2CF8836D00695264 /* FeatureFlagsMock.swift */,
 				96F25A842CC7EB3700459567 /* PrivacyOverridesMock+objc.swift */,
 				3C33E4062BEE35A7003B2988 /* RUMContextMocks.swift */,
 				61054F7E2A6EE1BA00AAA894 /* UIKitMocks.swift */,
@@ -8574,6 +8577,7 @@
 				61054FD02A6EE1BA00AAA894 /* SRContextPublisherTests.swift in Sources */,
 				962C41A82CA431AA0050B747 /* DDSessionReplayOverridesTests.swift in Sources */,
 				61054F9B2A6EE1BA00AAA894 /* QueueTests.swift in Sources */,
+				D2AE9A5D2CF8837C00695264 /* FeatureFlagsMock.swift in Sources */,
 				D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */,
 				61054F992A6EE1BA00AAA894 /* ColorsTests.swift in Sources */,
 				61054FBF2A6EE1BA00AAA894 /* UIPickerViewRecorderTests.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -148,7 +148,8 @@ internal class SnapshotTestCase: XCTestCase {
 
         let recorder = try Recorder(
             snapshotProcessor: snapshotProcessor,
-            additionalNodeRecorders: []
+            additionalNodeRecorders: [],
+            featureFlags: [.swiftui: true]
         )
 
         // Set up wireframes interception:

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -45,7 +45,8 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
 
         let recorder = try Recorder(
             snapshotProcessor: snapshotProcessor,
-            additionalNodeRecorders: configuration._additionalNodeRecorders
+            additionalNodeRecorders: configuration._additionalNodeRecorders,
+            featureFlags: configuration.featureFlags
         )
 
         let scheduler = MainThreadScheduler(interval: 0.1)

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -71,12 +71,16 @@ public class Recorder: Recording {
 
     convenience init(
         snapshotProcessor: SnapshotProcessing,
-        additionalNodeRecorders: [NodeRecorder]
+        additionalNodeRecorders: [NodeRecorder],
+        featureFlags: SessionReplay.Configuration.FeatureFlags
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: additionalNodeRecorders)
+            snapshotBuilder: ViewTreeSnapshotBuilder(
+                additionalNodeRecorders: additionalNodeRecorders,
+                featureFlags: featureFlags
+            )
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(windowObserver: windowObserver)
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -26,7 +26,7 @@ internal struct UnsupportedViewRecorder: NodeRecorder {
         ]
 
         // disable swiftui based on ff
-        if !featureFlags[.swiftui, default: false] {
+        if !featureFlags[.swiftui] {
             predicates.append(
                 { _, context in context.viewControllerContext.isRootView(of: .swiftUI) }
             )

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -12,16 +12,29 @@ import SwiftUI
 internal struct UnsupportedViewRecorder: NodeRecorder {
     internal let identifier: UUID
 
-    init(identifier: UUID) {
-        self.identifier = identifier
-    }
+    private let unsupportedViewsPredicates: [(UIView, ViewTreeRecordingContext) -> Bool]
 
-    // swiftlint:disable opening_brace
-    private let unsupportedViewsPredicates: [(UIView, ViewTreeRecordingContext) -> Bool] = [
-        { _, context in context.viewControllerContext.isRootView(of: .safari) },
-        { _, context in context.viewControllerContext.isRootView(of: .activity) }
-    ]
-    // swiftlint:enable opening_brace
+    init(
+        identifier: UUID,
+        featureFlags: SessionReplay.Configuration.FeatureFlags
+    ) {
+        self.identifier = identifier
+        // swiftlint:disable opening_brace
+        var predicates: [(UIView, ViewTreeRecordingContext) -> Bool] = [
+            { _, context in context.viewControllerContext.isRootView(of: .safari) },
+            { _, context in context.viewControllerContext.isRootView(of: .activity) }
+        ]
+
+        // disable swiftui based on ff
+        if !featureFlags[.swiftui, default: false] {
+            predicates.append(
+                { _, context in context.viewControllerContext.isRootView(of: .swiftUI) }
+            )
+        }
+        // swiftlint:enable opening_brace
+
+        self.unsupportedViewsPredicates = predicates
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard unsupportedViewsPredicates.contains(where: { $0(view, context) }) else {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -64,7 +64,10 @@ extension ViewTreeSnapshotBuilder {
 /// An arrays of default node recorders executed for the root view-tree hierarchy.
 internal func createDefaultNodeRecorders(featureFlags: SessionReplay.Configuration.FeatureFlags) -> [NodeRecorder] {
     var recorders: [NodeRecorder] = [
-        UnsupportedViewRecorder(identifier: UUID(), featureFlags: featureFlags),
+        UnsupportedViewRecorder(
+            identifier: UUID(),
+            featureFlags: featureFlags
+        ),
         UIViewRecorder(identifier: UUID()),
         UILabelRecorder(identifier: UUID()),
         UIImageViewRecorder(identifier: UUID()),

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -48,18 +48,23 @@ internal struct ViewTreeSnapshotBuilder {
 }
 
 extension ViewTreeSnapshotBuilder {
-    init(additionalNodeRecorders: [NodeRecorder]) {
+    init(
+        additionalNodeRecorders: [NodeRecorder],
+        featureFlags: SessionReplay.Configuration.FeatureFlags
+    ) {
         self.init(
-            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders() + additionalNodeRecorders),
+            viewTreeRecorder: ViewTreeRecorder(
+                nodeRecorders: createDefaultNodeRecorders(featureFlags: featureFlags) + additionalNodeRecorders
+            ),
             idsGenerator: NodeIDGenerator()
         )
     }
 }
 
 /// An arrays of default node recorders executed for the root view-tree hierarchy.
-internal func createDefaultNodeRecorders() -> [NodeRecorder] {
+internal func createDefaultNodeRecorders(featureFlags: SessionReplay.Configuration.FeatureFlags) -> [NodeRecorder] {
     var recorders: [NodeRecorder] = [
-        UnsupportedViewRecorder(identifier: UUID()),
+        UnsupportedViewRecorder(identifier: UUID(), featureFlags: featureFlags),
         UIViewRecorder(identifier: UUID()),
         UILabelRecorder(identifier: UUID()),
         UIImageViewRecorder(identifier: UUID()),

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -180,6 +180,13 @@ extension SessionReplay.Configuration.FeatureFlags {
             .swiftui: false
         ]
     }
+
+    /// Accesses a feature flag value.
+    ///
+    /// Returns false by default.
+    public subscript(flag: Key) -> Bool {
+        self[flag, default: false]
+    }
 }
 
 #endif

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -67,6 +67,9 @@ extension SessionReplay {
         /// Default: `nil`.
         public var customEndpoint: URL?
 
+        /// Feature flags to preview features in Session Replay.
+        public var featureFlags: FeatureFlags
+
         // MARK: - Internal
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
@@ -81,13 +84,15 @@ extension SessionReplay {
         ///   - touchPrivacyLevel: The way user touches (e.g. tap) should be masked. Default: `.hide`.
         ///   - startRecordingImmediately: If the recording should start automatically. When `true`, the recording starts automatically; when `false` it doesn't, and the recording will need to be started manually. Default: `true`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
+        ///   - featureFlags: Experimental feature flags.
         public init(    // swiftlint:disable:this function_default_parameter_at_end
             replaySampleRate: Float = 100,
             textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
             imagePrivacyLevel: ImagePrivacyLevel,
             touchPrivacyLevel: TouchPrivacyLevel,
             startRecordingImmediately: Bool = true,
-            customEndpoint: URL? = nil
+            customEndpoint: URL? = nil,
+            featureFlags: FeatureFlags = .defaults
         ) {
             self.replaySampleRate = replaySampleRate
             self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
@@ -95,6 +100,7 @@ extension SessionReplay {
             self.touchPrivacyLevel = touchPrivacyLevel
             self.startRecordingImmediately = startRecordingImmediately
             self.customEndpoint = customEndpoint
+            self.featureFlags = featureFlags
         }
 
         /// Creates Session Replay configuration.
@@ -118,6 +124,7 @@ extension SessionReplay {
             self.touchPrivacyLevel = newPrivacyLevels.touchPrivacy
             self.startRecordingImmediately = startRecordingImmediately
             self.customEndpoint = customEndpoint
+            self.featureFlags = .defaults
         }
 
         @_spi(Internal)
@@ -155,4 +162,24 @@ extension SessionReplay {
         }
     }
 }
+
+extension SessionReplay.Configuration {
+    public typealias FeatureFlags = [FeatureFlag: Bool]
+
+    /// Feature Flag available in Session Replay
+    public enum FeatureFlag {
+        /// SwiftUI Recording
+        case swiftui
+    }
+}
+
+extension SessionReplay.Configuration.FeatureFlags {
+    /// The defaults Feature Flags applied to Session Replay Configuration
+    public static var defaults: Self {
+        [
+            .swiftui: false
+        ]
+    }
+}
+
 #endif

--- a/DatadogSessionReplay/Tests/Mocks/FeatureFlagsMock.swift
+++ b/DatadogSessionReplay/Tests/Mocks/FeatureFlagsMock.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import Foundation
+
+@testable import DatadogSessionReplay
+
+extension SessionReplay.Configuration.FeatureFlags {
+    internal static var allEnabled: Self {
+        [
+            .swiftui: true
+        ]
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -439,7 +439,7 @@ class SnapshotProcessorTests: XCTestCase {
 
     // MARK: - `ViewTreeSnapshot` generation
 
-    private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [])
+    private let snapshotBuilder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [], featureFlags: .allEnabled)
 
     private func generateViewTreeSnapshot(for viewTree: UIView, date: Date, rumContext: RUMContext) -> ViewTreeSnapshot {
         snapshotBuilder.createSnapshot(

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -58,7 +58,7 @@ class RecorderTests: XCTestCase {
         let windowObserver = AppWindowObserverMock()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
             windowObserver: windowObserver,
-            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+            snapshotBuilder: ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder], featureFlags: .allEnabled)
         )
         let touchSnapshotProducer = TouchSnapshotProducerMock()
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -14,18 +14,29 @@ import SafariServices
 
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {
-    private let recorder = UnsupportedViewRecorder(identifier: UUID())
-
     func testWhenViewIsUnsupportedViewControllersRootView() throws {
+        let recorder = UnsupportedViewRecorder(identifier: UUID(), featureFlags: .defaults)
+
         var context = ViewTreeRecordingContext.mockRandom()
         context.viewControllerContext.isRootView = true
-        context.viewControllerContext.parentType = [.safari, .activity].randomElement()
+        context.viewControllerContext.parentType = [.safari, .activity, .swiftUI].randomElement()
 
         let semantics = try XCTUnwrap(recorder.semantics(of: UIView(), with: .mock(fixture: .visible(.someAppearance)), in: context))
         XCTAssertTrue(semantics is SpecificElement)
         XCTAssertEqual(semantics.subtreeStrategy, .ignore)
         let wireframeBuilder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UnsupportedViewWireframesBuilder)
         XCTAssertNotNil(wireframeBuilder.unsupportedClassName)
+    }
+
+    func testWhenSwiftUIFeatureFlagIsEnabled() throws {
+        let recorder = UnsupportedViewRecorder(identifier: UUID(), featureFlags: [.swiftui: true])
+
+        var context = ViewTreeRecordingContext.mockRandom()
+        context.viewControllerContext.isRootView = true
+        context.viewControllerContext.parentType = .swiftUI
+
+        let semantics = recorder.semantics(of: UIView(), with: .mock(fixture: .visible(.someAppearance)), in: context)
+        XCTAssertNil(semantics)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -154,7 +154,7 @@ class ViewTreeRecorderTests: XCTestCase {
 
     func testItRecordsInvisibleViews() {
         // Given
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let views: [UIView] = [
             UIView.mock(withFixture: .invisible),
             UILabel.mock(withFixture: .invisible),
@@ -173,7 +173,7 @@ class ViewTreeRecorderTests: XCTestCase {
 
     func testItRecordsViewsWithNoAppearance() {
         // Given
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
 
         let view = UIView.mock(withFixture: .visible(.noAppearance))
         let label = UILabel.mock(withFixture: .visible(.noAppearance))
@@ -203,7 +203,7 @@ class ViewTreeRecorderTests: XCTestCase {
 
     func testItRecordsViewsWithSomeAppearance() {
         // Given
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let views: [UIView] = [
             UIView.mock(withFixture: .visible(.someAppearance)),
             UILabel.mock(withFixture: .visible(.someAppearance)),
@@ -299,7 +299,7 @@ class ViewTreeRecorderTests: XCTestCase {
 
     func testChildViewInheritsParentHideOverride() {
         // Given
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let childView = UIView.mock(withFixture: .visible(.someAppearance))
         let parentView = UIView.mock(withFixture: .visible(.someAppearance))
         parentView.addSubview(childView)
@@ -314,7 +314,7 @@ class ViewTreeRecorderTests: XCTestCase {
 
     func testChildViewHideOverrideIsTrueAndParentHideOverrideIsFalse() {
         // Given
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let childView = UIView.mock(withFixture: .visible(.someAppearance))
         childView.dd.sessionReplayPrivacyOverrides.hide = true
         let parentView = UIView.mock(withFixture: .visible(.someAppearance))
@@ -336,7 +336,7 @@ class ViewTreeRecorderTests: XCTestCase {
         parentView.addSubview(childView)
 
         // When
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
 
         // Then
@@ -354,7 +354,7 @@ class ViewTreeRecorderTests: XCTestCase {
         imageView.dd.sessionReplayPrivacyOverrides.imagePrivacy = viewImagePrivacy
 
         // When
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let nodes = recorder.record(imageView, in: context)
 
         // Then
@@ -379,7 +379,7 @@ class ViewTreeRecorderTests: XCTestCase {
         parentView.addSubview(childView)
 
         // When
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
 
         // Then
@@ -403,7 +403,7 @@ class ViewTreeRecorderTests: XCTestCase {
         parentView.addSubview(childView)
 
         // When
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .allEnabled))
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -54,7 +54,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let view = UIView(frame: .mockRandom())
         let randomRecorderContext: Recorder.Context = .mockRandom()
         let additionalNodeRecorder = SessionReplayNodeRecorderMock(resultForView: { _ in nil })
-        let builder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder])
+        let builder = ViewTreeSnapshotBuilder(additionalNodeRecorders: [additionalNodeRecorder], featureFlags: .allEnabled)
 
         // When
         let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -182,7 +182,7 @@ class ViewAttributesTests: XCTestCase {
         parentView.addSubview(childView)
         parentView.dd.sessionReplayPrivacyOverrides.hide = true
 
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .defaults))
 
         // When
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
@@ -200,7 +200,7 @@ class ViewAttributesTests: XCTestCase {
         parentView.dd.sessionReplayPrivacyOverrides.hide = true
         childView.dd.sessionReplayPrivacyOverrides.hide = false
 
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .defaults))
 
         // When
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
@@ -220,7 +220,7 @@ class ViewAttributesTests: XCTestCase {
         parentView.dd.sessionReplayPrivacyOverrides.imagePrivacy = parentOverrides.imagePrivacy
         parentView.dd.sessionReplayPrivacyOverrides.touchPrivacy = parentOverrides.touchPrivacy
 
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders(featureFlags: .defaults))
         let nodes = recorder.record(parentView, in: .mockWith(coordinateSpace: parentView))
 
         // Then


### PR DESCRIPTION
### What and why?

Enable SwiftUI recording using a feature-flag

### How?

Defines `SessionReplay.Configuration.FeatureFlags` with `.swiftui` disabled by default.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
