### PR TITLE
RUM-7462 [SR][SwiftUI] Apply global image privacy

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -691,6 +691,7 @@
 		962D72C72CF7815300F86EF0 /* ReflectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962D72C62CF7815300F86EF0 /* ReflectionMocks.swift */; };
 		969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */; };
 		969B3B232C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */; };
+		96D331ED2CFF740700649EE8 /* GraphicImagePrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D331EC2CFF740700649EE8 /* GraphicImagePrivacyTests.swift */; };
 		96E414142C2AF56F005A6119 /* UIProgressViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */; };
 		96E414162C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */; };
 		96E863722C9C547B0023BF78 /* SessionReplayOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E863712C9C547B0023BF78 /* SessionReplayOverrideTests.swift */; };
@@ -2768,6 +2769,7 @@
 		966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyOverrides.swift; sourceTree = "<group>"; };
 		969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorder.swift; sourceTree = "<group>"; };
 		969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorderTests.swift; sourceTree = "<group>"; };
+		96D331EC2CFF740700649EE8 /* GraphicImagePrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicImagePrivacyTests.swift; sourceTree = "<group>"; };
 		96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorder.swift; sourceTree = "<group>"; };
 		96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorderTests.swift; sourceTree = "<group>"; };
 		96E863712C9C547B0023BF78 /* SessionReplayOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayOverrideTests.swift; sourceTree = "<group>"; };
@@ -3969,6 +3971,7 @@
 				61054F602A6EE1BA00AAA894 /* TouchSnapshotProducer */,
 				61054F642A6EE1BA00AAA894 /* ViewTreeSnapshotProducer */,
 				61054F7B2A6EE1BA00AAA894 /* TextAndInputPrivacyLevelTests.swift */,
+				96D331EC2CFF740700649EE8 /* GraphicImagePrivacyTests.swift */,
 				61054F7C2A6EE1BA00AAA894 /* RecorderTests.swift */,
 			);
 			path = Recorder;
@@ -8542,6 +8545,7 @@
 				61054FCD2A6EE1BA00AAA894 /* SnapshotProducerMocks.swift in Sources */,
 				61054FC32A6EE1BA00AAA894 /* TextAndInputPrivacyLevelTests.swift in Sources */,
 				61054FA82A6EE1BA00AAA894 /* RecordingCoordinatorTests.swift in Sources */,
+				96D331ED2CFF740700649EE8 /* GraphicImagePrivacyTests.swift in Sources */,
 				61054FAD2A6EE1BA00AAA894 /* WindowTouchSnapshotProducerTests.swift in Sources */,
 				61054FD52A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift in Sources */,
 				61054FC12A6EE1BA00AAA894 /* ViewTreeRecorderTests.swift in Sources */,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -70,6 +70,7 @@ internal class UIHostingViewRecorder: NodeRecorder {
             renderer: renderer.renderer,
             textObfuscator: textObfuscator(context),
             fontScalingEnabled: false,
+            imagePrivacyLevel: context.recorder.imagePrivacy,
             attributes: attributes
         )
 

--- a/DatadogSessionReplay/Tests/Recorder/GraphicImagePrivacyTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/GraphicImagePrivacyTests.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import XCTest
+import DatadogInternal
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+class ImagePrivacyTests: XCTestCase {
+    func testShouldRecordImagePredicate() {
+        // Given
+        let smallImage = MockCGImage.mockWith(width: 20)
+        let smallGraphicsImage = GraphicsImage(contents: .cgImage(smallImage), scale: 1.0, orientation: .up)
+
+        // Then
+        XCTAssertTrue(ImagePrivacyLevel.maskNone.shouldRecordGraphicsImagePredicate(smallGraphicsImage))
+        XCTAssertFalse(ImagePrivacyLevel.maskAll.shouldRecordGraphicsImagePredicate(smallGraphicsImage))
+        XCTAssertTrue(ImagePrivacyLevel.maskNonBundledOnly.shouldRecordGraphicsImagePredicate(smallGraphicsImage))
+
+        // Given
+        let largeImage = MockCGImage.mockWith(width: 150)
+        let largeGraphicsImage = GraphicsImage(contents: .cgImage(largeImage), scale: 1.0, orientation: .up)
+
+        // Then
+        XCTAssertTrue(ImagePrivacyLevel.maskNone.shouldRecordGraphicsImagePredicate(largeGraphicsImage))
+        XCTAssertFalse(ImagePrivacyLevel.maskAll.shouldRecordGraphicsImagePredicate(largeGraphicsImage))
+        XCTAssertFalse(ImagePrivacyLevel.maskNonBundledOnly.shouldRecordGraphicsImagePredicate(largeGraphicsImage))
+    }
+}
+
+#endif


### PR DESCRIPTION
### What and why?

With SwiftUI images now being recorded in Session Replay, we need to apply the global privacy level set by the customer.


### How?

- Added an `ImagePrivacyLevel` property to `SwiftUIWireframesBuilder` to handle image masking logic.
- Extended `ImagePrivacyLevel` to provide a utility for resolving the correct image privacy level during image recording.
- Applied heuristics to mask images larger than 100 points when the privacy setting is `maskNonBundledOnly`, aligning with Android's implementation.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
