### PR TITLE
ISSUE-2431-MessageBusCrash

### DIFF
--- a/DatadogCore/Sources/Core/MessageBus.swift
+++ b/DatadogCore/Sources/Core/MessageBus.swift
@@ -94,7 +94,8 @@ internal final class MessageBus {
             return save(configuration: configuration)
         }
 
-        queue.async {
+        queue.async { [weak self] in
+            guard let self else { return }
             guard let core = self.core else {
                 return
             }


### PR DESCRIPTION
### What and why?

The purpose of this PR is to try to fix a crash we are seeing.

https://github.com/DataDog/dd-sdk-ios/issues/2134

I suspect that MessageBus is getting deallocated and calling Self inside an asynchronous operation can cause memory issues.  The change I am making is a standard tactic for guarding against this.

### How?

capture self and check that it exists 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) - should be covered under existing tests
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
