### PR TITLE
RUM-6584: Add dependency between "Publish Cocoapods podspecs" GitLab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,6 +359,7 @@ Publish CP podspecs (dependent):
     - !reference [.release-pipeline-20m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
+  needs: ["Publish CP podspecs (internal)"]
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
@@ -371,6 +372,7 @@ Publish CP podspecs (legacy):
     - !reference [.release-pipeline-40m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
+  needs: ["Publish CP podspecs (dependent)"]
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check


### PR DESCRIPTION
### What and why?

This PR adds relationships between the jobs that publish Cocoapods `podspecs` into the public trunk. 
We want to prevent jobs from running if their dependencies failed to run.

### How?

By using the [needs](https://docs.gitlab.com/ee/ci/yaml/#needs) job keyword we can create relationships between the CI jobs:
- `Publish CP podspecs (dependent)` depends on `Publish CP podspecs (internal)`
- `Publish CP podspecs (legacy)` depends on `Publish CP podspecs (dependent)`


### Review checklist
- [ ] ~~Feature or bugfix MUST have appropriate tests (unit, integration)~~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Add CHANGELOG entry for user facing changes~~
- [ ] ~~Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)~~
