### PR TITLE
RUM-7309 [SR] Async and Deduplicate Telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1301,6 +1301,8 @@
 		D29A9FDA29DDC6D0005C54A4 /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
 		D29A9FDB29DDC6D1005C54A4 /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
 		D29A9FE029DDC75A005C54A4 /* UIKitMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29A9FDF29DDC75A005C54A4 /* UIKitMocks.swift */; };
+		D29C9F692D00739400CD568E /* Reflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29C9F682D00739400CD568E /* Reflector.swift */; };
+		D29C9F6B2D01D5F600CD568E /* ReflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */; };
 		D29CDD3228211A2200F7DAA5 /* TLVBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* TLVBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */; };
 		D2A1EE23287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
@@ -3032,6 +3034,8 @@
 		D29A9FCB29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTAssertValidRUMUUID.swift; sourceTree = "<group>"; };
 		D29A9FCD29DDC470005C54A4 /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		D29A9FDF29DDC75A005C54A4 /* UIKitMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitMocks.swift; sourceTree = "<group>"; };
+		D29C9F682D00739400CD568E /* Reflector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reflector.swift; sourceTree = "<group>"; };
+		D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectorTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLVBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatePublisher.swift; sourceTree = "<group>"; };
@@ -3869,6 +3873,7 @@
 			children = (
 				61054E552A6EE10A00AAA894 /* CGRectExtensions.swift */,
 				61054E582A6EE10A00AAA894 /* Queue.swift */,
+				D29C9F682D00739400CD568E /* Reflector.swift */,
 				D2EA0F422C0D941900CB20F8 /* ReflectionMirror.swift */,
 				61054E592A6EE10A00AAA894 /* Errors.swift */,
 				61054E5A2A6EE10A00AAA894 /* Colors.swift */,
@@ -3986,6 +3991,7 @@
 				61054F5D2A6EE1BA00AAA894 /* UIView+SessionReplayTests.swift */,
 				61054F5F2A6EE1BA00AAA894 /* CGRect+SessionReplayTests.swift */,
 				D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */,
+				D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */,
 			);
 			path = Utilties;
 			sourceTree = "<group>";
@@ -8435,6 +8441,7 @@
 			files = (
 				D2AD1CC22CE4AE6600106C74 /* CustomDump.swift in Sources */,
 				D2AD1CC32CE4AE6600106C74 /* Color+Reflection.swift in Sources */,
+				D29C9F692D00739400CD568E /* Reflector.swift in Sources */,
 				D2AD1CC42CE4AE6600106C74 /* DisplayList+Reflection.swift in Sources */,
 				D2AD1CC52CE4AE6600106C74 /* DisplayList.swift in Sources */,
 				D2AD1CC62CE4AE6600106C74 /* Color.swift in Sources */,
@@ -8588,6 +8595,7 @@
 				61054FB92A6EE1BA00AAA894 /* UINavigationBarRecorderTests.swift in Sources */,
 				61054FA62A6EE1BA00AAA894 /* SnapshotProcessorTests.swift in Sources */,
 				61054FB72A6EE1BA00AAA894 /* UISegmentRecorderTests.swift in Sources */,
+				D29C9F6B2D01D5F600CD568E /* ReflectorTests.swift in Sources */,
 				96E863722C9C547B0023BF78 /* SessionReplayOverrideTests.swift in Sources */,
 				A7D9528A2B28BD94004C79B1 /* ResourceProcessorSpy.swift in Sources */,
 				A7D9528C2B28C18D004C79B1 /* ResourceProcessorTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -847,6 +847,8 @@
 		D2181A8F2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2181A8D2B051B7900A518C0 /* URLSessionSwizzlerTests.swift */; };
 		D21831552B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */; };
 		D21831562B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */; };
+		D218B0462D072C8400E3F82C /* SessionReplayTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D218B0452D072C8400E3F82C /* SessionReplayTelemetry.swift */; };
+		D218B0482D072CF300E3F82C /* SessionReplayTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D218B0472D072CF300E3F82C /* SessionReplayTelemetryTests.swift */; };
 		D21A94F22B8397CA00AC4256 /* WebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21A94F12B8397CA00AC4256 /* WebViewMessage.swift */; };
 		D21A94F32B8397CA00AC4256 /* WebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21A94F12B8397CA00AC4256 /* WebViewMessage.swift */; };
 		D21AE6BC29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */; };
@@ -2884,6 +2886,8 @@
 		D2181A8A2B0500BB00A518C0 /* NetworkInstrumentationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentationSwizzler.swift; sourceTree = "<group>"; };
 		D2181A8D2B051B7900A518C0 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
 		D21831542B6A57530012B3A0 /* NetworkInstrumentationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInstrumentationIntegrationTests.swift; sourceTree = "<group>"; };
+		D218B0452D072C8400E3F82C /* SessionReplayTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTelemetry.swift; sourceTree = "<group>"; };
+		D218B0472D072CF300E3F82C /* SessionReplayTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTelemetryTests.swift; sourceTree = "<group>"; };
 		D21A94F12B8397CA00AC4256 /* WebViewMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMessage.swift; sourceTree = "<group>"; };
 		D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTests.swift; sourceTree = "<group>"; };
 		D21C26C428A3B49C005DD405 /* FeatureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureStorage.swift; sourceTree = "<group>"; };
@@ -3789,6 +3793,7 @@
 				D2C5D52A2B84F6AB00B63F36 /* WebViewRecordReceiver.swift */,
 				61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */,
 				D22C5BCD2A98A65D0024CC1F /* Baggages.swift */,
+				D218B0452D072C8400E3F82C /* SessionReplayTelemetry.swift */,
 				61054E402A6EE10A00AAA894 /* RequestBuilders */,
 			);
 			path = Feature;
@@ -4090,6 +4095,7 @@
 				61054F892A6EE1BA00AAA894 /* RUMContextReceiverTests.swift */,
 				61054F8A2A6EE1BA00AAA894 /* SRContextPublisherTests.swift */,
 				D2C5D52C2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift */,
+				D218B0472D072CF300E3F82C /* SessionReplayTelemetryTests.swift */,
 				61054F8B2A6EE1BA00AAA894 /* RequestBuilder */,
 			);
 			path = Feature;
@@ -8456,6 +8462,7 @@
 				A7B932FD2B1F6A0A00AE6477 /* EnrichedResource.swift in Sources */,
 				61054E622A6EE10A00AAA894 /* RecordWriter.swift in Sources */,
 				61054E692A6EE10A00AAA894 /* UIImage+SessionReplay.swift in Sources */,
+				D218B0462D072C8400E3F82C /* SessionReplayTelemetry.swift in Sources */,
 				D2EA0F432C0D941900CB20F8 /* ReflectionMirror.swift in Sources */,
 				61054E782A6EE10A00AAA894 /* UIDatePickerRecorder.swift in Sources */,
 				61054E822A6EE10A00AAA894 /* UILabelRecorder.swift in Sources */,
@@ -8580,6 +8587,7 @@
 				61054F952A6EE1BA00AAA894 /* SessionReplayConfigurationTests.swift in Sources */,
 				61054FAC2A6EE1BA00AAA894 /* CGRect+SessionReplayTests.swift in Sources */,
 				61054FC72A6EE1BA00AAA894 /* SRDataModelsMocks.swift in Sources */,
+				D218B0482D072CF300E3F82C /* SessionReplayTelemetryTests.swift in Sources */,
 				61054FC82A6EE1BA00AAA894 /* SnapshotProcessorSpy.swift in Sources */,
 				A74A72872B10CE4100771FEB /* ResourceMocks.swift in Sources */,
 				61054FA42A6EE1BA00AAA894 /* DiffTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -807,7 +807,7 @@ extension RUMSessionScope {
         return mockWith()
     }
 
-    // swiftlint:disable:next function_default_parameter_at_end
+    // swiftlint:disable function_default_parameter_at_end
     static func mockWith(
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
@@ -826,6 +826,7 @@ extension RUMSessionScope {
             dependencies: dependencies
         )
     }
+    // swiftlint:enable function_default_parameter_at_end
 }
 
 private let mockWindow = UIWindow(frame: .zero)

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -851,7 +851,7 @@ extension RUMSessionScope {
         return mockWith()
     }
 
-    // swiftlint:disable:next function_default_parameter_at_end
+    // swiftlint:disable function_default_parameter_at_end
     static func mockWith(
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
@@ -869,6 +869,7 @@ extension RUMSessionScope {
             dependencies: dependencies
         )
     }
+    // swiftlint:enable function_default_parameter_at_end
 }
 
 extension RUMSessionState: AnyMockable, RandomMockable {

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -6,6 +6,8 @@
 
 import XCTest
 import SRFixtures
+
+import DatadogInternal
 import TestUtilities
 @_spi(Internal)
 @testable import DatadogSessionReplay
@@ -143,7 +145,7 @@ internal class SnapshotTestCase: XCTestCase {
             recordWriter: RecordWriter(core: PassthroughCoreMock()),
             resourceProcessor: resourceProcessor,
             srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
-            telemetry: TelemetryMock()
+            telemetry: NOPTelemetry()
         )
 
         let recorder = try Recorder(
@@ -175,7 +177,9 @@ internal class SnapshotTestCase: XCTestCase {
                 applicationID: "",
                 sessionID: "",
                 viewID: "",
-                viewServerTimeOffset: 0
+                viewServerTimeOffset: 0,
+                date: Date(),
+                telemetry: NOPTelemetry()
             )
         )
 

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -6,7 +6,6 @@
 
 import XCTest
 import SRFixtures
-
 import DatadogInternal
 import TestUtilities
 @_spi(Internal)

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayTelemetry.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayTelemetry.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import Foundation
+import DatadogInternal
+
+/// Session Replay Telemetry forwards telemetry events on a dedicated queue
+/// and deduplicate debug and error messages based on their ids.
+internal final class SessionReplayTelemetry {
+    private let forward: Telemetry
+    private let queue: Queue
+
+    /// Keps hash values of debug/error ids.
+    private var hashTable = Set<Int>()
+
+    init(telemetry: Telemetry, queue: Queue) {
+        self.forward = telemetry
+        self.queue = queue
+    }
+}
+
+extension SessionReplayTelemetry: Telemetry {
+    func send(telemetry: DatadogInternal.TelemetryMessage) {
+        queue.run { [weak self] in
+            guard let self else {
+                return
+            }
+
+            switch telemetry {
+            case .debug(let id, _, _), .error(let id, _, _, _):
+                let hash = id.hashValue
+
+                if self.hashTable.contains(hash) {
+                    return
+                }
+
+                self.hashTable.insert(hash)
+                self.forward.send(telemetry: telemetry)
+
+            default:
+                self.forward.send(telemetry: telemetry)
+            }
+        }
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -21,7 +21,7 @@ internal protocol Recording {
 @_spi(Internal)
 public class Recorder: Recording {
     /// The context of recording next snapshot.
-    public struct Context: Equatable {
+    public struct Context {
         /// The content recording policy for texts and inputs at the moment of requesting snapshot.
         public let textAndInputPrivacy: TextAndInputPrivacyLevel
         /// The image recording policy from the moment of requesting snapshot.
@@ -38,6 +38,8 @@ public class Recorder: Recording {
         let viewServerTimeOffset: TimeInterval?
         /// The time of requesting this snapshot.
         let date: Date
+        /// The telemetry instance to report to.
+        let telemetry: Telemetry
 
         internal init(
             textAndInputPrivacy: TextAndInputPrivacyLevel,
@@ -47,7 +49,8 @@ public class Recorder: Recording {
             sessionID: String,
             viewID: String,
             viewServerTimeOffset: TimeInterval?,
-            date: Date = Date()
+            date: Date,
+            telemetry: Telemetry
         ) {
             self.textAndInputPrivacy = textAndInputPrivacy
             self.imagePrivacy = imagePrivacy
@@ -57,6 +60,7 @@ public class Recorder: Recording {
             self.viewID = viewID
             self.viewServerTimeOffset = viewServerTimeOffset
             self.date = date
+            self.telemetry = telemetry
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -130,7 +130,9 @@ internal class RecordingCoordinator {
             applicationID: rumContext.applicationID,
             sessionID: rumContext.sessionID,
             viewID: viewID,
-            viewServerTimeOffset: rumContext.viewServerTimeOffset
+            viewServerTimeOffset: rumContext.viewServerTimeOffset,
+            date: Date(),
+            telemetry: telemetry
         )
 
         let methodCalledTrace = telemetry.startMethodCalled(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
@@ -11,18 +11,18 @@ import SwiftUI
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color._Resolved: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        linearRed = try mirror.descendant("linearRed")
-        linearGreen = try mirror.descendant("linearGreen")
-        linearBlue = try mirror.descendant("linearBlue")
-        opacity = try mirror.descendant("opacity")
+    init(from reflector: Reflector) throws {
+        linearRed = try reflector.descendant("linearRed")
+        linearGreen = try reflector.descendant("linearGreen")
+        linearBlue = try reflector.descendant("linearBlue")
+        opacity = try reflector.descendant("opacity")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension ResolvedPaint: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        paint = try? mirror.descendant("paint")
+    init(from reflector: Reflector) throws {
+        paint = reflector.descendantIfPresent("paint")
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/CustomDump.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/CustomDump.swift
@@ -30,6 +30,8 @@
 
 #if DEBUG
 
+// swiftlint:disable function_default_parameter_at_end
+
 import Foundation
 
 /// Dumps the given value's contents using its mirror to standard output.
@@ -97,7 +99,7 @@ internal func customDump<T, TargetStream>(
     )
 }
 
-@discardableResult //swiftlint:disable:next function_default_parameter_at_end
+@discardableResult
 private func _customDump<T, TargetStream>(
     _ value: T,
     to target: inout TargetStream,
@@ -411,7 +413,6 @@ private func _customDump<T, TargetStream>(
     return value
 }
 
-//swiftlint:disable:next function_default_parameter_at_end
 private func _customDump(
     _ value: Any,
     name: String?,
@@ -549,5 +550,7 @@ internal struct FileHandlerOutputStream: TextOutputStream {
         }
     }
 }
+
+// swiftlint:enable function_default_parameter_at_end
 
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -11,44 +11,44 @@ import SwiftUI
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        items = try mirror.descendant("items")
+    init(from reflector: Reflector) throws {
+        items = try reflector.descendant("items")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Identity: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        value = try mirror.descendant("value")
+    init(from reflector: Reflector) throws {
+        value = try reflector.descendant("value")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Seed: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        value = try mirror.descendant("value")
+    init(from reflector: Reflector) throws {
+        value = try reflector.descendant("value")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewRenderer: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        renderer = try mirror.descendant("renderer")
+    init(from reflector: Reflector) throws {
+        renderer = try reflector.descendant("renderer")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        viewCache = try mirror.descendant("viewCache")
-        lastList = try mirror.descendant("lastList")
+    init(from reflector: Reflector) throws {
+        viewCache = try reflector.descendant("viewCache")
+        lastList = try reflector.descendant("lastList")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Effect: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        switch (mirror.displayStyle, mirror.descendant(0)) {
+    init(from reflector: Reflector) throws {
+        switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
         case (.enum("identity"), _):
             self = .identify
 
@@ -66,40 +66,40 @@ extension DisplayList.Effect: Reflection {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewCache: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        map = try mirror.descendant("map")
+    init(from reflector: Reflector) throws {
+        map = try reflector.descendant("map")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewCache.Key: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        id = try mirror.descendant("id")
+    init(from reflector: Reflector) throws {
+        id = try reflector.descendant("id")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Index.ID: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        identity = try mirror.descendant("identity")
+    init(from reflector: Reflector) throws {
+        identity = try reflector.descendant("identity")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewInfo: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
+    init(from reflector: Reflector) throws {
         // do not retain the views or layer, only get values required
         // for building wireframe
 
-        let layer = try mirror.descendant(type: CALayer.self, "layer")
+        let layer = try reflector.descendant(type: CALayer.self, "layer")
         // The view is the rendering context of an item
-        let view = try mirror.descendant(type: UIView.self, "view")
+        let view = try reflector.descendant(type: UIView.self, "view")
         // The container view is where the item is actually rendered.
         // The container is usually the same as the view, except when applying
         // a `.platformGroup` effect. e.g: A `SwiftUI.ScrollView` will create a
         // `.platformGroup` effect where the `Content` is rendered in a `UIScrollView`,
         // in this case the container is the content of the `UIScrollView`.
-        let container = try mirror.descendant(type: UIView.self, "container")
+        let container = try reflector.descendant(type: UIView.self, "container")
 
         // The frame is the container's frame in the view's coordinate space.
         // This is useful for applying the offset in a scroll-view.
@@ -116,37 +116,33 @@ extension DisplayList.ViewUpdater.ViewInfo: Reflection {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Content: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        seed = try mirror.descendant("seed")
-        value = try mirror.descendant("value")
+    init(from reflector: Reflector) throws {
+        seed = try reflector.descendant("seed")
+        value = try reflector.descendant("value")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Content.Value: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        switch (mirror.displayStyle, mirror.descendant(0)) {
+    init(from reflector: Reflector) throws {
+        switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
         case let (.enum("shape"), tuple as (SwiftUI.Path, Any, SwiftUI.FillStyle)):
-            let paint = try ResolvedPaint(reflecting: tuple.1)
-            self = .shape(tuple.0, paint, tuple.2)
+            self = try .shape(tuple.0, reflector.reflect(tuple.1), tuple.2)
 
         case let (.enum("text"), tuple as (Any, CGSize)):
-            let view = try StyledTextContentView(reflecting: tuple.0)
-            self = .text(view, tuple.1)
+            self = try .text(reflector.reflect(tuple.0), tuple.1)
 
         case (.enum("platformView"), _):
             self = .platformView
 
-        case (.enum("image"), let graphicsImage):
-            let resolvedImage = try GraphicsImage(reflecting: graphicsImage)
-            self = .image(resolvedImage)
+        case let (.enum("image"), image):
+            self = try .image(reflector.reflect(image))
 
         case (.enum("drawing"), _):
             self = .unknown
 
         case let (.enum("color"), color):
-            let color = try Color._Resolved(reflecting: color)
-            self = .color(color)
+            self = try .color(reflector.reflect(color))
 
         default:
             self = .unknown
@@ -156,25 +152,25 @@ extension DisplayList.Content.Value: Reflection {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Item: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        identity = try mirror.descendant("identity")
-        frame = try mirror.descendant("frame")
-        value = try mirror.descendant("value")
+    init(from reflector: Reflector) throws {
+        identity = try reflector.descendant("identity")
+        frame = try reflector.descendant("frame")
+        value = try reflector.descendant("value")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Item.Value: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        switch (mirror.displayStyle, mirror.descendant(0)) {
+    init(from reflector: Reflector) throws {
+        switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
         case let (.enum("effect"), tuple as (Any, Any)):
-            let effect = try DisplayList.Effect(reflecting: tuple.0)
-            let list = try DisplayList(reflecting: tuple.1)
-            self = .effect(effect, list)
+            self = try .effect(
+                reflector.reflect(tuple.0),
+                reflector.reflect(tuple.1)
+            )
 
         case let (.enum("content"), value):
-            let content = try DisplayList.Content(reflecting: value)
-            self = .content(content)
+            self = try .content(reflector.reflect(value))
 
         default:
             self = .unknown

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Image+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Image+Reflection.swift
@@ -11,17 +11,17 @@ import SwiftUI
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        scale = try mirror.descendant("scale")
-        orientation = try mirror.descendant("orientation")
-        contents = try mirror.descendant("contents")
+    init(from reflector: Reflector) throws {
+        scale = try reflector.descendant("scale")
+        orientation = try reflector.descendant("orientation")
+        contents = try reflector.descendant("contents")
     }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.Contents: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        switch (mirror.displayStyle, mirror.descendant(0)) {
+    init(from reflector: Reflector) throws {
+        switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
         case let (.enum("cgImage"), cgImage as CGImage):
             self = .cgImage(cgImage)
         default:

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -9,6 +9,8 @@
 import Foundation
 import UIKit
 
+import DatadogInternal
+
 @available(iOS 13.0, *)
 internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     internal struct Context {
@@ -35,7 +37,7 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         let root = builder.createShapeWireframe(id: wireframeID, attributes: attributes)
         do {
-            let list = try renderer.lastList.reflect()
+            let list = try renderer.lastList.reflect(NOPTelemetry())
             let context = Context(
                 frame: attributes.frame,
                 clip: attributes.clip,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-
 import DatadogInternal
 
 @available(iOS 13.0, *)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -24,10 +24,10 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     /// Text obfuscator for masking text.
     let textObfuscator: TextObfuscating
     /// Flag that determines if font should be scaled.
-    var fontScalingEnabled: Bool
+    let fontScalingEnabled: Bool
     /// Privacy level for masking images.
     let imagePrivacyLevel: ImagePrivacyLevel
-
+    /// The Hosting view attributes.
     let attributes: ViewAttributes
 
     var wireframeRect: CGRect {
@@ -37,7 +37,7 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         let root = builder.createShapeWireframe(id: wireframeID, attributes: attributes)
         do {
-            let list = try renderer.lastList.reflect(NOPTelemetry())
+            let list = try renderer.lastList.reflect()
             let context = Context(
                 frame: attributes.frame,
                 clip: attributes.clip,
@@ -46,7 +46,6 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
 
             return [root] + buildWireframes(items: list.items, context: context)
         } catch {
-            print(error)
             return [root]
         }
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Text+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Text+Reflection.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 extension StyledTextContentView: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        text = try mirror.descendant("text")
+    init(from reflector: Reflector) throws {
+        text = try reflector.descendant("text")
     }
 }
 
 extension ResolvedStyledText.StringDrawing: Reflection {
-    init(_ mirror: ReflectionMirror) throws {
-        storage = try mirror.descendant("storage")
+    init(from reflector: Reflector) throws {
+        storage = try reflector.descendant("storage")
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 import SwiftUI
-
 import DatadogInternal
 
 @available(iOS 13, tvOS 13, *)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 import SwiftUI
 
+import DatadogInternal
+
 @available(iOS 13, tvOS 13, *)
 internal class UIHostingViewRecorder: NodeRecorder {
     let identifier: UUID
@@ -63,7 +65,8 @@ internal class UIHostingViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let renderer = try DisplayList.ViewRenderer(reflecting: subject)
+        let reflector = Reflector(subject: subject, telemetry: NOPTelemetry())
+        let renderer = try DisplayList.ViewRenderer(from: reflector)
 
         let builder = SwiftUIWireframesBuilder(
             wireframeID: nodeID,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -44,7 +44,6 @@ internal class UIHostingViewRecorder: NodeRecorder {
             let nodeID = context.ids.nodeID(view: view, nodeRecorder: self)
             return try semantics(refelecting: view, nodeID: nodeID, with: attributes, in: context)
         } catch {
-            print(error)
             return nil
         }
     }
@@ -65,7 +64,7 @@ internal class UIHostingViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let reflector = Reflector(subject: subject, telemetry: NOPTelemetry())
+        let reflector = Reflector(subject: subject, telemetry: context.recorder.telemetry)
         let renderer = try DisplayList.ViewRenderer(from: reflector)
 
         let builder = SwiftUIWireframesBuilder(

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -80,7 +80,7 @@ internal class UIHostingViewRecorder: NodeRecorder {
     }
 }
 
-@available(iOS 18, tvOS 18, *)
+@available(iOS 18.1, tvOS 18.1, *)
 internal class iOS18HostingViewRecorder: UIHostingViewRecorder {
     override func semantics(refelecting subject: AnyObject, nodeID: NodeID, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) throws -> NodeSemantics? {
         guard

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -86,7 +86,7 @@ internal func createDefaultNodeRecorders(featureFlags: SessionReplay.Configurati
         UIActivityIndicatorRecorder(identifier: UUID()),
     ]
 
-    if #available(iOS 18, tvOS 18, *) {
+    if #available(iOS 18.1, tvOS 18.1, *) {
         recorders.append(iOS18HostingViewRecorder(identifier: UUID()))
     } else if #available(iOS 13, tvOS 13, *) {
         recorders.append(UIHostingViewRecorder(identifier: UUID()))

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -76,6 +76,8 @@ extension SessionReplay {
 
         internal var _additionalNodeRecorders: [NodeRecorder] = []
 
+        // swiftlint:disable function_default_parameter_at_end
+
         /// Creates Session Replay configuration
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
@@ -85,7 +87,7 @@ extension SessionReplay {
         ///   - startRecordingImmediately: If the recording should start automatically. When `true`, the recording starts automatically; when `false` it doesn't, and the recording will need to be started manually. Default: `true`.
         ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
         ///   - featureFlags: Experimental feature flags.
-        public init(    // swiftlint:disable:this function_default_parameter_at_end
+        public init(
             replaySampleRate: SampleRate = .maxSampleRate,
             textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
             imagePrivacyLevel: ImagePrivacyLevel,
@@ -126,6 +128,8 @@ extension SessionReplay {
             self.customEndpoint = customEndpoint
             self.featureFlags = .defaults
         }
+
+        // swiftlint:enable function_default_parameter_at_end
 
         @_spi(Internal)
         public mutating func setAdditionalNodeRecorders(_ additionalNodeRecorders: [SessionReplayNodeRecorder]) {

--- a/DatadogSessionReplay/Sources/Utilities/Queue.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Queue.swift
@@ -11,23 +11,29 @@ internal protocol Queue: AnyObject {
     func run(_ block: @escaping () -> Void)
 }
 
-internal class MainAsyncQueue: Queue {
-    private let queue: DispatchQueue = .main
+internal class AsyncQueue: Queue {
+    fileprivate let queue: DispatchQueue
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
 
     func run(_ block: @escaping () -> Void) {
-        queue.async { block() }
+        queue.async(execute: block)
     }
 }
 
-internal class BackgroundAsyncQueue: Queue {
-    private let queue: DispatchQueue
-
-    init(named queueName: String) {
-        self.queue = DispatchQueue(label: queueName, qos: .utility, autoreleaseFrequency: .workItem)
+internal final class MainAsyncQueue: AsyncQueue {
+    init() {
+        super.init(queue: .main)
     }
+}
 
-    func run(_ block: @escaping () -> Void) {
-        queue.async { block() }
+internal final class BackgroundAsyncQueue: AsyncQueue {
+    init(label: String, qos: DispatchQoS = .utility, attributes: DispatchQueue.Attributes = [], autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = .workItem, target: AsyncQueue? = nil) {
+        super.init(
+            queue: DispatchQueue(label: label, qos: qos, attributes: attributes, autoreleaseFrequency: autoreleaseFrequency, target: target?.queue)
+        )
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Utilities/Reflector.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Reflector.swift
@@ -12,7 +12,7 @@ import DatadogInternal
 /// implementation and ceate ``Reflection`` objects.
 ///
 /// The `Reflector` is capabale of reporting telemetry error while
-/// reflecting descendants and procide partial results on Sequence.
+/// reflecting descendants and provide partial results on Sequence.
 internal struct Reflector {
     /// Escalated error during reflection.
     enum Error: Swift.Error {

--- a/DatadogSessionReplay/Sources/Utilities/Reflector.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Reflector.swift
@@ -26,7 +26,7 @@ internal struct Reflector {
 
     /// A `Lazy` reflection allows reflecting the subject at a later time.
     struct Lazy<T> where T: Reflection {
-        private let mirror: ReflectionMirror
+        private let reflector: Reflector
     }
 
     private let mirror: ReflectionMirror
@@ -293,15 +293,11 @@ extension Reflection {
 
 extension Reflector.Lazy: Reflection {
     init(from reflector: Reflector) throws {
-        self.mirror = reflector.mirror
+        self.reflector = reflector
     }
-    
-    /// Relect to the type `T` and report error to telemetry.
-    ///
-    /// - Parameter telemetry: The telemetry instance.
-    /// - Returns: The relection of type `T`.
-    func reflect(telemetry: Telemetry) throws -> T {
-        let reflector = Reflector(mirror: mirror, telemetry: telemetry)
-        return try T(from: reflector)
+
+    /// Relect to the type `T`.
+    func reflect() throws -> T {
+        try T(from: reflector)
     }
 }

--- a/DatadogSessionReplay/Sources/Utilities/Reflector.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Reflector.swift
@@ -1,0 +1,307 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// The `Reflector` container provides convenient methods to
+/// reflect an instance using the ``ReflectionMirror`` mirroring
+/// implementation and ceate ``Reflection`` objects.
+///
+/// The `Reflector` is capabale of reporting telemetry error while
+/// reflecting descendants and procide partial results on Sequence.
+internal struct Reflector {
+    /// Escalated error during reflection.
+    enum Error: Swift.Error {
+        struct Context {
+            let subjectType: Any.Type
+            let paths: [ReflectionMirror.Path]
+        }
+        case notFound(Context)
+        case typeMismatch(Context, expect: Any.Type, got: Any.Type)
+    }
+
+    /// A `Lazy` reflection allows reflecting the subject at a later time.
+    struct Lazy<T> where T: Reflection {
+        private let mirror: ReflectionMirror
+    }
+
+    private let mirror: ReflectionMirror
+    private let telemetry: Telemetry
+
+    /// Accessor of the mirror's display style.
+    var displayStyle: ReflectionMirror.DisplayStyle {
+        mirror.displayStyle
+    }
+
+    /// Creates a reflector.
+    ///
+    /// - Parameters:
+    ///   - mirror: The reflection mirror instance.
+    ///   - telemetry: The telemetry to report reflection errors.
+    private init(
+        mirror: ReflectionMirror,
+        telemetry: Telemetry = NOPTelemetry()
+    ) {
+        self.mirror = mirror
+        self.telemetry = telemetry
+    }
+
+    /// Reflects a subject.
+    ///
+    /// - Parameters:
+    ///   - subject: The subject instance to reflect.
+    ///   - telemetry: The telemetry to report reflection errors.
+    init(
+        subject: Any?,
+        telemetry: Telemetry
+    ) {
+        self.init(
+            mirror: ReflectionMirror(reflecting: subject as Any),
+            telemetry: telemetry
+        )
+    }
+
+    /// Get a descendant at a given path.
+    ///
+    /// - Parameter paths: The path to the descendant..
+    /// - Returns: The descendant instance if it exist at the provided path.
+    func descendant(_ paths: [ReflectionMirror.Path]) -> Any? {
+        mirror.descendant(paths)
+    }
+
+    /// Access a descendant of `Any` type by path.
+    ///
+    /// This method provide direct access to the mirror.
+    ///
+    /// - Parameters:
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    func descendantIfPresent(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> Any? {
+        descendant([first] + rest)
+    }
+
+    /// Reports a reflection error.
+    ///
+    /// - Parameter error: The error to report.
+    func report(_ error: Swift.Error) {
+        telemetry.error(error)
+    }
+}
+
+/// A `Reflection` object can intialize itself by reflecting an instance
+/// through a ``Reflector``.
+///
+/// Similar to `Decodable`, a `Reflection` can access mirroring descendant
+/// by path based in the `displayStyle`.
+internal protocol Reflection {
+    /// Creates a new instance by reflection from the given reflector.
+    ///
+    /// This initializer throws an error if reading from the reflector fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter reflector: The reflector to read descendant from.
+    init(from reflector: Reflector) throws
+}
+
+// swiftlint:disable function_default_parameter_at_end
+extension Reflector {
+    /// Access a descendant of `Any` type by path.
+    ///
+    /// This method provide direct access to the mirror.
+    ///
+    /// - Parameters:
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? {
+        descendant([first] + rest) as? T
+    }
+
+    /// Access a descendant of specified type by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected descendant type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    /// - Throws: `Reflector.Error.notFound` or `Reflector.Error.typeMismatch`
+    func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T {
+        try descendant([first] + rest)
+    }
+
+    private func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T {
+        guard let value = descendant(paths) else {
+            throw Error.notFound(.init(subjectType: mirror.subjectType, paths: paths))
+        }
+
+        guard let value = value as? T else {
+            throw Error.typeMismatch(
+                .init(subjectType: mirror.subjectType, paths: paths),
+                expect: type,
+                got: Swift.type(of: value)
+            )
+        }
+
+        return value
+    }
+}
+
+extension Reflector {
+    /// Reflect a subjec to a specified type.
+    ///
+    /// - Parameters:
+    ///   - type: The type to reflect to.
+    ///   - subject: The subject instance to reflect.
+    /// - Returns: The reflection instance.
+    func reflect<T>(type: T.Type = T.self, _ subject: Any?) throws -> T where T: Reflection {
+        let reflector = Reflector(subject: subject, telemetry: telemetry)
+        return try T(from: reflector)
+    }
+
+    /// Reflect an optional descendant to the specified type by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected descendant type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? where T: Reflection {
+        do {
+            return try descendant(type: type, [first] + rest)
+        } catch Error.notFound {
+            return nil
+        } catch {
+            report(error)
+            return nil
+        }
+    }
+
+    /// Reflect a descendant to the specified Element type by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected descendant type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
+    func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T where T: Reflection {
+        try descendant(type: type, [first] + rest)
+    }
+
+    /// Reflect a Collection descendant of the specified type by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected element type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
+    func descendant<Element>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Element] where Element: Reflection {
+        guard let subject = descendant([first] + rest) as? [Any] else {
+            throw Error.typeMismatch(
+                .init(subjectType: mirror.subjectType, paths: [first] + rest),
+                expect: [Any].self,
+                got: mirror.subjectType
+            )
+        }
+
+        return subject.compactMap {
+            do {
+                return try reflect($0)
+            } catch {
+                report(error)
+                return nil
+            }
+        }
+    }
+
+    /// Reflect a Disctionary descendant to the specified Key/Value types by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected element type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
+    func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Hashable, Value: Reflection {
+        guard let subject = descendant([first] + rest) as? [Key: Any] else {
+            throw Error.typeMismatch(
+                .init(subjectType: mirror.subjectType, paths: [first] + rest),
+                expect: [Key: Any].self,
+                got: mirror.subjectType
+            )
+        }
+
+        return subject.reduce(into: [:]) { result, element in
+            do {
+                try result[element.key] = reflect(element.value)
+            } catch {
+                report(error)
+            }
+        }
+    }
+
+    /// Reflect a Disctionary descendant to the specified Key/Value types by path.
+    ///
+    /// - Parameters:
+    ///   - type: The expected element type.
+    ///   - first: The first path element.
+    ///   - rest: The rest of the path elements.
+    /// - Returns: The descendant instance if it exist at the provided path.
+    /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
+    func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Reflection, Key: Hashable, Value: Reflection {
+        guard let subject = descendant([first] + rest) as? [AnyHashable: Any] else {
+            throw Error.typeMismatch(
+                .init(subjectType: mirror.subjectType, paths: [first] + rest),
+                expect: [AnyHashable: Any].self,
+                got: mirror.subjectType
+            )
+        }
+
+        return subject.reduce(into: [:]) { result, element in
+            do {
+                try result[reflect(element.key.base)] = reflect(element.value)
+            } catch {
+                report(error)
+            }
+        }
+    }
+
+    private func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T where T: Reflection {
+        guard let value = descendant(paths) else {
+            throw Error.notFound(.init(subjectType: mirror.subjectType, paths: paths))
+        }
+
+        let reflector = Reflector(
+            subject: value,
+            telemetry: telemetry
+        )
+
+        return try T(from: reflector)
+    }
+}
+// swiftlint:enable function_default_parameter_at_end
+
+extension Reflection {
+    typealias Lazy = Reflector.Lazy<Self>
+}
+
+extension Reflector.Lazy: Reflection {
+    init(from reflector: Reflector) throws {
+        self.mirror = reflector.mirror
+    }
+    
+    /// Relect to the type `T` and report error to telemetry.
+    ///
+    /// - Parameter telemetry: The telemetry instance.
+    /// - Returns: The relection of type `T`.
+    func reflect(telemetry: Telemetry) throws -> T {
+        let reflector = Reflector(mirror: mirror, telemetry: telemetry)
+        return try T(from: reflector)
+    }
+}

--- a/DatadogSessionReplay/Tests/Feature/SessionReplayTelemetryTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/SessionReplayTelemetryTests.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import XCTest
+import TestUtilities
+
+@testable import DatadogInternal
+@testable import DatadogSessionReplay
+
+class SessionReplayTelemetryTests: XCTestCase {
+    func testDeduplicatedMessage() {
+        // Given
+        let forwarder = TelemetryMock()
+        let telemetry = SessionReplayTelemetry(telemetry: forwarder, queue: NoQueue())
+        let errorMessage: TelemetryMessage = .error(id: "1", message: .mockRandom(), kind: .mockRandom(), stack: .mockRandom())
+        let debugMessage: TelemetryMessage = .debug(id: "1", message: .mockRandom(), attributes: nil)
+
+        // When
+        telemetry.send(telemetry: errorMessage)
+        telemetry.send(telemetry: debugMessage)
+
+        // Then
+        XCTAssertEqual(forwarder.messages.count, 1)
+        let error = forwarder.messages.firstError()
+        XCTAssertEqual(error?.message, errorMessage.asError?.message)
+    }
+
+    func testForwardMessages() {
+        // Given
+        let forwarder = TelemetryMock()
+        let telemetry = SessionReplayTelemetry(telemetry: forwarder, queue: NoQueue())
+        let metricMessage: TelemetryMessage = .metric(.init(name: "test", attributes: [:], sampleRate: 100))
+        let usageMessage: TelemetryMessage = .usage(.init(event: .addError))
+
+        // When
+        telemetry.send(telemetry: metricMessage)
+        telemetry.send(telemetry: usageMessage)
+
+        // Then
+        XCTAssertEqual(forwarder.messages.count, 2)
+        XCTAssertNotNil(forwarder.messages.firstMetric(named: "test"))
+        XCTAssertNotNil(forwarder.messages.firstUsage())
+    }
+
+    func testThreadSafety() {
+        // Given
+        let expectation = self.expectation(description: "`telemetry` received 100 calls")
+        expectation.expectedFulfillmentCount = 100
+
+        let forwarder = TelemetryMock(expectation: expectation)
+        let telemetry = SessionReplayTelemetry(telemetry: forwarder, queue: BackgroundAsyncQueue(label: "test"))
+
+        // swiftlint:disable opening_brace
+        callConcurrently(
+            closures: [
+                { telemetry.send(telemetry: .error(id: .mockRandom(), message: .mockRandom(), kind: .mockRandom(), stack: .mockRandom())) },
+                { telemetry.send(telemetry: .debug(id: .mockRandom(), message: .mockRandom(), attributes: nil)) },
+                { telemetry.send(telemetry: .debug(id: .mockRandom(), message: .mockRandom(), attributes: nil)) },
+                { telemetry.send(telemetry: .metric(.init(name: .mockRandom(), attributes: [:], sampleRate: 100))) }
+            ],
+            iterations: 25
+        )
+        // swiftlint:enable opening_brace
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -10,6 +10,7 @@ import XCTest
 import UIKit
 import WebKit
 
+import DatadogInternal
 @_spi(Internal)
 @testable import DatadogSessionReplay
 @testable import TestUtilities
@@ -505,7 +506,8 @@ extension Recorder.Context: AnyMockable, RandomMockable {
         imagePrivacy: ImagePrivacyLevel,
         touchPrivacy: TouchPrivacyLevel,
         rumContext: RUMContext,
-        date: Date = Date()
+        date: Date = Date(),
+        telemetry: Telemetry = NOPTelemetry()
     ) {
         self.init(
             textAndInputPrivacy: textAndInputPrivacy,
@@ -515,7 +517,8 @@ extension Recorder.Context: AnyMockable, RandomMockable {
             sessionID: rumContext.sessionID,
             viewID: rumContext.viewID ?? "",
             viewServerTimeOffset: rumContext.viewServerTimeOffset,
-            date: date
+            date: date,
+            telemetry: telemetry
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecorderTests.swift
@@ -49,7 +49,12 @@ class RecorderTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewTreeSnapshotProducer.succeedingContexts.count, 1)
-        XCTAssertEqual(viewTreeSnapshotProducer.succeedingContexts[0], recorderContext)
+        let context = try XCTUnwrap(viewTreeSnapshotProducer.succeedingContexts.first)
+        XCTAssertEqual(context.applicationID, recorderContext.applicationID)
+        XCTAssertEqual(context.sessionID, recorderContext.sessionID)
+        XCTAssertEqual(context.viewID, recorderContext.viewID)
+        XCTAssertEqual(context.viewServerTimeOffset, recorderContext.viewServerTimeOffset)
+        XCTAssertEqual(context.date, recorderContext.date)
     }
 
     func testWhenCapturingSnapshots_itUsesAdditionalNodeRecorders() throws {
@@ -73,8 +78,12 @@ class RecorderTests: XCTestCase {
         try recorder.captureNextRecord(recorderContext)
 
         // Then
-        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
-        XCTAssertEqual(queryContext.recorder, recorderContext)
+        let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first?.recorder)
+        XCTAssertEqual(queryContext.applicationID, recorderContext.applicationID)
+        XCTAssertEqual(queryContext.sessionID, recorderContext.sessionID)
+        XCTAssertEqual(queryContext.viewID, recorderContext.viewID)
+        XCTAssertEqual(queryContext.viewServerTimeOffset, recorderContext.viewServerTimeOffset)
+        XCTAssertEqual(queryContext.date, recorderContext.date)
     }
 
     // MARK: Touch Snapshot Recording

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ReflectionMirrorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ReflectionMirrorTests.swift
@@ -5,7 +5,6 @@
  */
 
 import XCTest
-import DatadogInternal
 
 @testable import DatadogSessionReplay
 
@@ -45,5 +44,19 @@ class ReflectionMirrorTests: XCTestCase {
         struct Mock {}
         let mirror = ReflectionMirror(reflecting: Optional.some(Mock()) as Any)
         XCTAssertEqual(mirror.displayStyle, .struct)
+    }
+
+    func testAccessingDescendant() {
+        struct Foo {
+            let bar: Bar = .init()
+        }
+
+        struct Bar {
+            let baz: String = "baz"
+        }
+
+        let mirror = ReflectionMirror(reflecting: (Foo(), Bar()))
+        XCTAssertEqual(mirror.descendant(0, "bar", "baz") as? String, "baz")
+        XCTAssertEqual(mirror.descendant(1, "baz") as? String, "baz")
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ReflectorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ReflectorTests.swift
@@ -1,0 +1,180 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+
+@testable import DatadogSessionReplay
+
+class ReflectorTests: XCTestCase {
+    func testReflectObject() throws {
+        // Given
+        struct Foo {
+            struct Bar {
+                let baz: String = "baz"
+            }
+
+            let bar: Bar = .init()
+        }
+
+        struct Echo: Reflection {
+            struct Bar: Reflection {
+                let baz: String
+
+                init(from reflector: Reflector) throws {
+                    baz = try reflector.descendant("baz")
+                }
+            }
+
+            let bar: Bar
+
+            init(from reflector: Reflector) throws {
+                bar = try reflector.descendant("bar")
+            }
+        }
+
+        // When
+        let reflector = Reflector(subject: Foo(), telemetry: NOPTelemetry())
+        let echo = try Echo(from: reflector)
+
+        // Then
+        XCTAssertEqual(echo.bar.baz, "baz")
+    }
+
+    func testReflectCollection() throws {
+        // Given
+        struct Foo {
+            struct Bar {
+                let baz: String = "baz"
+            }
+
+            let bar: [Any]
+        }
+
+        struct Echo: Reflection {
+            struct Bar: Reflection {
+                let baz: String
+
+                init(from reflector: Reflector) throws {
+                    baz = try reflector.descendant("baz")
+                }
+            }
+
+            let bar: [Bar]
+
+            init(from reflector: Reflector) throws {
+                bar = try reflector.descendant("bar")
+            }
+        }
+
+        // When
+        let telemetry = TelemetryMock()
+        // Create an array of 10 elements + an intruder
+        let foo = Foo(bar: Array(repeating: Foo.Bar(), count: 10) + ["intruder"])
+
+        let reflector = Reflector(subject: foo, telemetry: telemetry)
+        let echo = try Echo(from: reflector)
+
+        // Then
+        XCTAssertEqual(echo.bar.count, 10)
+        XCTAssertEqual(
+            telemetry.messages.firstError()?.message,
+            #"notFound(DatadogSessionReplay.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogSessionReplay.ReflectionMirror.Path.key("baz")]))"#
+        )
+    }
+
+    func testReflectDictionary() throws {
+        // Given
+        struct Foo {
+            struct Key: Hashable {
+                let index: Int
+            }
+
+            struct Bar {
+                let baz: String = "baz"
+            }
+
+            let bar: [Key: Any]
+        }
+
+        struct Echo: Reflection {
+            struct Key: Hashable, Reflection {
+                let index: Int
+                init(from reflector: Reflector) throws {
+                    index = try reflector.descendant("index")
+                }
+            }
+
+            struct Bar: Reflection {
+                let baz: String
+                init(from reflector: Reflector) throws {
+                    baz = try reflector.descendant("baz")
+                }
+            }
+
+            let bar: [Key: Bar]
+
+            init(from reflector: Reflector) throws {
+                bar = try reflector.descendant("bar")
+            }
+        }
+
+        // When
+        let telemetry = TelemetryMock()
+        // Create an dictionary of 10 elements + an intruder
+        let foo = Foo(bar: (0..<10).reduce(into: [Foo.Key(index: 10): "intruder"]) { $0[Foo.Key(index: $1)] = Foo.Bar() })
+
+        let reflector = Reflector(subject: foo, telemetry: telemetry)
+        let echo = try Echo(from: reflector)
+
+        // Then
+        XCTAssertEqual(echo.bar.count, 10)
+        XCTAssertEqual(
+            telemetry.messages.firstError()?.message,
+            #"notFound(DatadogSessionReplay.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogSessionReplay.ReflectionMirror.Path.key("baz")]))"#
+        )
+    }
+
+    func testReflectOptional() throws {
+        // Given
+        struct Foo {
+            struct Bar {
+                let baz: String? = "baz"
+                let qux: String? = nil
+            }
+
+            let bar: Bar = .init()
+        }
+
+        struct Echo: Reflection {
+            struct Bar: Reflection {
+                let baz: String?
+                let qux: String?
+
+                init(from reflector: Reflector) throws {
+                    baz = reflector.descendantIfPresent("baz")
+                    qux = reflector.descendantIfPresent("qux")
+                }
+            }
+
+            let bar: Bar
+
+            init(from reflector: Reflector) throws {
+                bar = try reflector.descendant("bar")
+            }
+        }
+
+        // When
+        let telemetry = TelemetryMock()
+        let reflector = Reflector(subject: Foo(), telemetry: telemetry)
+        let echo = try Echo(from: reflector)
+
+        // Then
+        XCTAssertEqual(echo.bar.baz, "baz")
+        XCTAssertNil(echo.bar.qux)
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -78,7 +78,7 @@ private func render<V>(
     in context: ViewTreeRecordingContext = .mockAny()
 ) throws -> [SRWireframe] where V: SwiftUI.View {
     let recorder: UIHostingViewRecorder
-    if #available(iOS 18.0, tvOS 18.0, *) {
+    if #available(iOS 18.1, tvOS 18.1, *) {
         recorder = iOS18HostingViewRecorder(identifier: UUID())
     } else {
         recorder = UIHostingViewRecorder(identifier: UUID())

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -25,11 +25,19 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
 
         // Then
-        XCTAssertEqual(snapshot.context, randomRecorderContext)
+        XCTAssertEqual(snapshot.context.applicationID, randomRecorderContext.applicationID)
+        XCTAssertEqual(snapshot.context.sessionID, randomRecorderContext.sessionID)
+        XCTAssertEqual(snapshot.context.viewID, randomRecorderContext.viewID)
+        XCTAssertEqual(snapshot.context.viewServerTimeOffset, randomRecorderContext.viewServerTimeOffset)
+        XCTAssertEqual(snapshot.context.date, randomRecorderContext.date)
 
         let queryContext = try XCTUnwrap(nodeRecorder.queryContexts.first)
         XCTAssertTrue(queryContext.coordinateSpace === view)
-        XCTAssertEqual(queryContext.recorder, randomRecorderContext)
+        XCTAssertEqual(queryContext.recorder.applicationID, randomRecorderContext.applicationID)
+        XCTAssertEqual(queryContext.recorder.sessionID, randomRecorderContext.sessionID)
+        XCTAssertEqual(queryContext.recorder.viewID, randomRecorderContext.viewID)
+        XCTAssertEqual(queryContext.recorder.viewServerTimeOffset, randomRecorderContext.viewServerTimeOffset)
+        XCTAssertEqual(queryContext.recorder.date, randomRecorderContext.date)
     }
 
     func testItAppliesServerTimeOffsetToSnapshot() {
@@ -60,11 +68,19 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
 
         // Then
-        XCTAssertEqual(snapshot.context, randomRecorderContext)
+        XCTAssertEqual(snapshot.context.applicationID, randomRecorderContext.applicationID)
+        XCTAssertEqual(snapshot.context.sessionID, randomRecorderContext.sessionID)
+        XCTAssertEqual(snapshot.context.viewID, randomRecorderContext.viewID)
+        XCTAssertEqual(snapshot.context.viewServerTimeOffset, randomRecorderContext.viewServerTimeOffset)
+        XCTAssertEqual(snapshot.context.date, randomRecorderContext.date)
 
         let queryContext = try XCTUnwrap(additionalNodeRecorder.queryContexts.first)
         XCTAssertTrue(queryContext.coordinateSpace === view)
-        XCTAssertEqual(queryContext.recorder, randomRecorderContext)
+        XCTAssertEqual(queryContext.recorder.applicationID, randomRecorderContext.applicationID)
+        XCTAssertEqual(queryContext.recorder.sessionID, randomRecorderContext.sessionID)
+        XCTAssertEqual(queryContext.recorder.viewID, randomRecorderContext.viewID)
+        XCTAssertEqual(queryContext.recorder.viewServerTimeOffset, randomRecorderContext.viewServerTimeOffset)
+        XCTAssertEqual(queryContext.recorder.date, randomRecorderContext.date)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Utilities/QueueTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/QueueTests.swift
@@ -36,7 +36,7 @@ class QueueTests: XCTestCase {
         let randomValue: Int = .mockRandom()
 
         // Given
-        let queue = BackgroundAsyncQueue(named: .mockAny())
+        let queue = BackgroundAsyncQueue(label: .mockAny())
 
         // When
         var value = randomValue

--- a/TestUtilities/Mocks/TelemetryMocks.swift
+++ b/TestUtilities/Mocks/TelemetryMocks.swift
@@ -82,6 +82,8 @@ public class TelemetryMock: Telemetry, CustomStringConvertible {
         case .usage(let usage):
             description.append("\n- [usage] \(usage)")
         }
+
+        expectation?.fulfill()
     }
 }
 
@@ -111,6 +113,11 @@ public extension Array where Element == TelemetryMessage {
     /// Returns the first configuration telemetry in this array.
     func firstConfiguration() -> ConfigurationTelemetry? {
         return compactMap { $0.asConfiguration }.first
+    }
+
+    /// Returns the first usage telemetry in this array.
+    func firstUsage() -> UsageTelemetry? {
+        return compactMap { $0.asUsage }.first
     }
 }
 
@@ -145,6 +152,13 @@ public extension TelemetryMessage {
             return nil
         }
         return metric
+    }
+
+    var asUsage: UsageTelemetry? {
+        guard case let .usage(usage) = self else {
+            return nil
+        }
+        return usage
     }
 }
 


### PR DESCRIPTION
### What and why?

Report telemetry while reflecting `SwiftUI` renderer.

Such report involved deduplication of telemetry messages.

### How?

#### `Reflection` Abstraction

The `Reflection` now takes a `Reflector` parameter to reflect descendant properties and report telemetry errors. This new container allow reflecting partial data - such as collection or dictionary - and still report failures.

#### `SessionReplayTelemetry`

This dedicated implementation of `Telemetry` offloads reports on a dedicated queue and deduplicate debug and error messages. The deduplication is important in the context of Session Replay as redundant errors can happen at each snapshot cycle. By deduplicated at the feature level, we prevent overloading the message-bus with telemetry messages.

The dedicated telemetry queue targets the processor's queue with lower QOS to minimise the telemetry impact on performances. That being said, the error formatting still happen on the caller thread.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
