### PR TITLE
RUM-6584: Make the publish of `podspecs` rely on "Build Artifacts"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,7 +359,7 @@ Publish CP podspecs (dependent):
     - !reference [.release-pipeline-20m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
-  needs: ["Publish CP podspecs (internal)"]
+  needs: ["Build Artifacts", "Publish CP podspecs (internal)"]
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check
@@ -372,7 +372,7 @@ Publish CP podspecs (legacy):
     - !reference [.release-pipeline-40m-delayed-job, rules]
   before_script:
     - *export_MAKE_release_params
-  needs: ["Publish CP podspecs (dependent)"]
+  needs: ["Build Artifacts", "Publish CP podspecs (dependent)"]
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make env-check


### PR DESCRIPTION
### What and why?

This PR fixes the pipelines to publish the `podspecs` taking into account the resources created on the `Build Artifacts` job. 

### How?

In a dry run the setup is now running successfully.

<img width="1465" alt="Publish `podspecs`" src="https://github.com/user-attachments/assets/d9f8046d-99e3-48e7-922c-52ab458cf6ce" />

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
