### PR TITLE
fix: Don't send log spam for PerformanceMetric updates

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -337,7 +337,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 dependencies.sessionEndedMetric.track(missedEventType: missedEventType, in: sessionUUID)
             }
 
-            if !(command is RUMKeepSessionAliveCommand) { // it is expected to receive 'keep alive' while no active view (when tracking WebView events)
+            if !(isSilentOffViewCommand(command: command)) {
                 // As no view scope will handle this command, warn the user on dropping it.
                 DD.logger.warn(
                 """
@@ -348,6 +348,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 )
             }
         }
+    }
+
+    private func isSilentOffViewCommand(command: RUMCommand) -> Bool {
+        // It is expected to receive 'keep alive' while no active view (when tracking WebView events), and performance metric
+        // updates are sent automatically by cross platform frameworks whether a view is active or not, resulting in log
+        // spam.
+        return command is RUMKeepSessionAliveCommand || command is RUMUpdatePerformanceMetric
     }
 
     private func startBackgroundView(on command: RUMCommand, context: DatadogContext) {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -598,7 +598,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     // MARK: - Usage
 
-    func testGivenSessionWithNoActiveScope_whenReceivingRUMCommandOtherThanKeepSessionAliveCommand_itLogsWarning() throws {
+    func testGivenSessionWithNoActiveScope_whenReceivingRUMCommand_itLogsWarning() throws {
         func recordWarningOnReceiving(command: RUMCommand) -> String? {
             // Given
             let scope: RUMSessionScope = .mockWith(
@@ -628,9 +628,36 @@ class RUMSessionScopeTests: XCTestCase {
             with `RUMMonitor.shared().startView()` and `RUMMonitor.shared().stopView()`.
             """
         )
+    }
 
-        let keepAliveCommand = RUMKeepSessionAliveCommand(time: Date(), attributes: [:])
-        let keepAliveLog = recordWarningOnReceiving(command: keepAliveCommand)
-        XCTAssertNil(keepAliveLog, "It shouldn't log warning when receiving `RUMKeepSessionAliveCommand`")
+    func testGivenSessionWithNoActiveScope_whenReceivingSilentCommand_itDoesNotLogWarning() throws {
+        func recordWarningOnReceiving(command: RUMCommand) -> String? {
+            // Given
+            let scope: RUMSessionScope = .mockWith(
+                parent: parent,
+                startTime: Date()
+            )
+            XCTAssertEqual(scope.viewScopes.count, 0)
+
+            let dd = DD.mockWith(logger: CoreLoggerMock())
+            defer { dd.reset() }
+
+            // When
+            _ = scope.process(command: command, context: context, writer: writer)
+
+            // Then
+            XCTAssertEqual(scope.viewScopes.count, 0)
+            return dd.logger.warnLog?.message
+        }
+
+        let silentCommands: [RUMCommand] = [
+            RUMKeepSessionAliveCommand(time: Date(), attributes: [:]),
+            RUMUpdatePerformanceMetric(metric: .flutterBuildTime, value: 1.0, time: Date(), attributes: [:])
+        ]
+
+        for command in silentCommands {
+            let log = recordWarningOnReceiving(command: command)
+            XCTAssertNil(log, "It shouldn't log warning when receiving silent command: \(command)")
+        }
     }
 }


### PR DESCRIPTION
### What and why?

PerformanceMetric events are triggered automatically by some of the cross platform frameworks, and can result in log spam as views transition or if no view is active. Fix it so that the performance metric event doesn't send log spam.

refs: RUM-6138

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
