### PR TITLE
Add `backgroundTasksEnabled` ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Add Datadog Configuration `backgroundTasksEnabled` ObjC API. See [#2148][]
+
 # 2.21.0 / 11-12-2024
 
 - [FIX] Fix sporadic file overwrite during consent change, ensuring event data integrity. See [#2113][]
@@ -806,6 +808,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2116]: https://github.com/DataDog/dd-sdk-ios/pull/2116
 [#2120]: https://github.com/DataDog/dd-sdk-ios/pull/2120
 [#2126]: https://github.com/DataDog/dd-sdk-ios/pull/2126
+[#2148]: https://github.com/DataDog/dd-sdk-ios/pull/2148
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDConfigurationTests.swift
@@ -24,6 +24,7 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcConfig.sdkConfiguration.additionalConfiguration.count, 0)
         XCTAssertNil(objcConfig.sdkConfiguration.encryption)
         XCTAssertNotNil(objcConfig.sdkConfiguration.serverDateProvider)
+        XCTAssertFalse(objcConfig.sdkConfiguration.backgroundTasksEnabled)
     }
 
     func testCustomizedBuilderForwardsInitializationToSwift() throws {
@@ -92,6 +93,10 @@ class DDConfigurationTests: XCTestCase {
         let serverDateProvider = ObjcServerDateProvider()
         objcConfig.setServerDateProvider(serverDateProvider)
         XCTAssertTrue((objcConfig.sdkConfiguration.serverDateProvider as? DDServerDateProviderBridge)?.objcProvider === serverDateProvider)
+
+        let fakeBackgroundTasksEnabled: Bool = .mockRandom()
+        objcConfig.backgroundTasksEnabled = fakeBackgroundTasksEnabled
+        XCTAssertEqual(objcConfig.sdkConfiguration.backgroundTasksEnabled, fakeBackgroundTasksEnabled)
     }
 
     func testDataEncryption() throws {

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -65,6 +65,7 @@
     configuration.uploadFrequency = DDUploadFrequencyAverage;
     configuration.additionalConfiguration = @{@"additional": @"config"};
     [configuration setEncryption:[CustomDDDataEncryption new]];
+    configuration.backgroundTasksEnabled = true;
 }
 
 - (void)testDatadogCrashReporterAPI {

--- a/DatadogObjc/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogObjc/Sources/DatadogConfiguration+objc.swift
@@ -263,6 +263,17 @@ public class DDConfiguration: NSObject {
         set { sdkConfiguration._internal_mutation { $0.additionalConfiguration = newValue } }
     }
 
+    /// Flag that determines if UIApplication methods [`beginBackgroundTask(expirationHandler:)`](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtaskwithexpiratio) and [`endBackgroundTask:`](https://developer.apple.com/documentation/uikit/uiapplication/1622970-endbackgroundtask)
+    /// are utilized to perform background uploads. It may extend the amount of time the app is operating in background by 30 seconds.
+    ///
+    /// Tasks are normally stopped when there's nothing to upload or when encountering any upload blocker such us no internet connection or low battery.
+    ///
+    /// `false` by default.
+    @objc public var backgroundTasksEnabled: Bool {
+        get { sdkConfiguration.backgroundTasksEnabled }
+        set { sdkConfiguration.backgroundTasksEnabled = newValue }
+    }
+
     /// Creates a Datadog SDK Configuration object.
     ///
     /// - Parameters:

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -81,6 +81,7 @@ public class DDConfiguration: NSObject
     public func setServerDateProvider(_ serverDateProvider: DDServerDateProvider)
     @objc public var bundle: Bundle
     @objc public var additionalConfiguration: [String: Any]
+    @objc public var backgroundTasksEnabled: Bool
     public init(clientToken: String, env: String)
 public enum DDSDKVerbosityLevel: Int
     case none


### PR DESCRIPTION
### What and why?

This PR adds missing `backgroundTasksEnabled` ObjC API to the Datadog configuration.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
