### PR TITLE
chore: Upgrade `dd-sdk-swift-testing` to `2.5.3-beta1`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -13904,8 +13904,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DataDog/dd-sdk-swift-testing.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.0;
+				kind = exactVersion;
+				version = "2.5.3-beta1";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
### What and why?

📦 This PR upgrades the CI Test instrumentation to 2.5.3-beta1 (dogfooding).

The new version is expected to resolve the issue with [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis/) (TIA) which we had to disable in [#2108](https://github.com/DataDog/dd-sdk-ios/pull/2108).

### How?

- Upgraded the `dd-sdk-swift-testing` version.
- Enabled TIA in the [CI Test Optimization Settings](https://docs.datadoghq.com/tests/test_impact_analysis/setup/swift/#activate-intelligent-test-runner-for-the-test-service) for `dd-sdk-ios`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
