### PR TITLE
RUM-7107 feat: Add Interaction To Next View metric in RUM 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add Time To Network Setled metric in RUM. See [#2125][]
+- [FEATURE] Add Interaction To Next View metric in RUM. See [#2153][]
 - [IMPROVEMENT] Add Datadog Configuration `backgroundTasksEnabled` ObjC API. See [#2148][]
 
 # 2.21.0 / 11-12-2024
@@ -810,6 +811,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2116]: https://github.com/DataDog/dd-sdk-ios/pull/2116
 [#2120]: https://github.com/DataDog/dd-sdk-ios/pull/2120
 [#2126]: https://github.com/DataDog/dd-sdk-ios/pull/2126
+[#2153]: https://github.com/DataDog/dd-sdk-ios/pull/2153
 [#2148]: https://github.com/DataDog/dd-sdk-ios/pull/2148
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -272,6 +272,10 @@
 		6105C4FB2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */; };
 		6105C5032CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
 		6105C5042CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
+		6105C5092CFA222400C4C5EE /* ITNVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* ITNVMetric.swift */; };
+		6105C50A2CFA222400C4C5EE /* ITNVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* ITNVMetric.swift */; };
+		6105C5142D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */; };
+		6105C5152D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */; };
 		610ABD4C2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
 		610ABD4D2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
 		61112F8E2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
@@ -2350,6 +2354,8 @@
 		6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetric.swift; sourceTree = "<group>"; };
 		6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetricTests.swift; sourceTree = "<group>"; };
 		6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLoadingMetricsTests.swift; sourceTree = "<group>"; };
+		6105C5082CFA222400C4C5EE /* ITNVMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNVMetric.swift; sourceTree = "<group>"; };
+		6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNVMetricTests.swift; sourceTree = "<group>"; };
 		610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTelemetryIntegrationTests.swift; sourceTree = "<group>"; };
 		61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDRUM+apiTests.m"; sourceTree = "<group>"; };
 		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
@@ -4145,6 +4151,7 @@
 			isa = PBXGroup;
 			children = (
 				6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */,
+				6105C5082CFA222400C4C5EE /* ITNVMetric.swift */,
 			);
 			path = RUMMetrics;
 			sourceTree = "<group>";
@@ -4153,6 +4160,7 @@
 			isa = PBXGroup;
 			children = (
 				6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */,
+				6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */,
 			);
 			path = RUMMetrics;
 			sourceTree = "<group>";
@@ -9016,6 +9024,7 @@
 				D23F8E8C29DDCD28001CFAE8 /* RUMBaggageKeys.swift in Sources */,
 				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
+				6105C50A2CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
 				3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIEventCommandFactory.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
@@ -9060,6 +9069,7 @@
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C12A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */,
+				6105C5152D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */,
 				D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CB2A3DC22700FA735A /* RUMTests.swift in Sources */,
 				D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */,
@@ -9356,6 +9366,7 @@
 				D29A9F8329DD85BB005C54A4 /* RUMBaggageKeys.swift in Sources */,
 				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
+				6105C5092CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
 				3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIEventCommandFactory.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
@@ -9400,6 +9411,7 @@
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,
+				6105C5142D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */,
 				D29A9FAA29DDB483005C54A4 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CA2A3DC22700FA735A /* RUMTests.swift in Sources */,
 				D29A9FAC29DDB483005C54A4 /* RUMActionsHandlerTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -180,4 +180,161 @@ class ViewLoadingMetricsTests: XCTestCase {
         let expectedTTNS = resource1EndTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
         XCTAssertEqual(actualTTNS, expectedTTNS, "TTNS should only reflect ACCEPTED resources.")
     }
+
+    // MARK: - Interaction To Next View
+
+    func testWhenActionOccursInPreviousView_andNextViewStarts_thenITNVIsTrackedForNextView() throws {
+        let rumTime = DateProviderMock()
+        rumConfig.dateProvider = rumTime
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (an action occurs in the previous view)
+        monitor.startView(key: "previous", name: "PreviousView")
+        rumTime.now += 2.seconds
+        monitor.addAction(type: .tap, name: "Tap in Previous View")
+
+        // When (the next view is started within the ITNV threshold after the action)
+        let expectedITNV: TimeInterval = .mockRandom(min: 0, max: ITNVMetric.Constants.maxDuration * 0.99)
+        rumTime.now += expectedITNV
+        monitor.startView(key: "next", name: "NextView")
+
+        // Then (ITNV is tracked for the next view)
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
+        let actualITNV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
+        XCTAssertEqual(TimeInterval(fromNanoseconds: actualITNV), expectedITNV, accuracy: 0.01)
+    }
+
+    func testWhenActionOccursInPreviousView_andNextViewStartsAfterThreshold_thenITNVIsNotTrackedForNextView() throws {
+        let rumTime = DateProviderMock()
+        rumConfig.dateProvider = rumTime
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (an action occurs in the previous view)
+        monitor.startView(key: "previous", name: "PreviousView")
+        rumTime.now += 2.seconds
+        monitor.addAction(type: .tap, name: "Tap in Previous View")
+
+        // When (the next view starts after exceeding the ITNV threshold)
+        rumTime.now += ITNVMetric.Constants.maxDuration + 0.01 // exceeds the max threshold
+        monitor.startView(key: "next", name: "NextView")
+
+        // Then (ITNV is not tracked for the next view)
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
+        let actualITNV = nextViewEvent.view.interactionToNextViewTime
+        XCTAssertNil(actualITNV, "The ITNV value should not be tracked when the next view starts after exceeding the threshold.")
+    }
+
+    func testWhenMultipleActionsOccursInPreviousView_thenITNVIsMeasuredFromTheLastAction() throws {
+        let rumTime = DateProviderMock()
+        rumConfig.dateProvider = rumTime
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (multiple actions occur in the previous view)
+        monitor.startView(key: "previous", name: "PreviousView")
+        rumTime.now += 0.5.seconds
+        monitor.addAction(type: .tap, name: "Tap 1")
+        rumTime.now += 2.1.seconds
+        monitor.addAction(type: .tap, name: "Tap 2")
+        rumTime.now += 3.seconds
+        monitor.startAction(type: .swipe, name: "Swipe")
+        rumTime.now += 0.75.seconds
+        monitor.stopAction(type: .swipe, name: "Swipe")
+
+        // When (the next view is started within the ITNV threshold after last action)
+        let expectedITNV: TimeInterval = .mockRandom(min: 0, max: ITNVMetric.Constants.maxDuration * 0.99)
+        rumTime.now += expectedITNV
+        monitor.startView(key: "next", name: "NextView")
+
+        // Then (ITNV is tracked for the next view)
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
+        let actualITNV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
+        XCTAssertEqual(TimeInterval(fromNanoseconds: actualITNV), expectedITNV, accuracy: 0.01)
+    }
+
+    func testWhenActionInPreviousViewIsDropped_thenITNVIsNotTracked() throws {
+        let rumTime = DateProviderMock()
+        rumConfig.dateProvider = rumTime
+        rumConfig.actionEventMapper = { event in
+            event.action.target?.name == "Tap in Previous View" ? nil : event // drop "Tap in Previous View"
+        }
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (an action occurs in the previous view - which will be dropped)
+        monitor.startView(key: "previous", name: "PreviousView")
+        rumTime.now += 2.seconds
+        monitor.addAction(type: .tap, name: "Tap in Previous View")
+
+        // When (the next view is started within the ITNV threshold after the action)
+        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        monitor.startView(key: "next", name: "NextView")
+
+        // Then (ITNV is tracked for the next view)
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
+        XCTAssertNil(nextViewEvent.view.interactionToNextViewTime, "The ITNV value should not be tracked when the action is dropped.")
+    }
+
+    func testITNVIsOnlyTrackedForViewsThatWereStartedDueToAnAction() throws {
+        let rumTime = DateProviderMock()
+        rumConfig.dateProvider = rumTime
+
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (start the previous view and add an action)
+        monitor.startView(key: "previous", name: "PreviousView")
+        rumTime.now += 2.seconds
+        monitor.addAction(type: .tap, name: "Tap in Previous View")
+
+        // When (the next view starts due to the action)
+        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        monitor.startView(key: "next", name: "NextView")
+
+        // When (a new view starts without an action)
+        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        monitor.startView(key: "nextWithoutAction", name: "NextViewWithoutAction")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
+        let nextViewWithoutAction = try XCTUnwrap(session.views.first(where: { $0.name == "NextViewWithoutAction" })?.viewEvents.last)
+        XCTAssertNotNil(nextViewEvent.view.interactionToNextViewTime, "ITNV should be tracked for view that started due to an action.")
+        XCTAssertNil(nextViewWithoutAction.view.interactionToNextViewTime, "ITNV should not be tracked for view that started without an action.")
+    }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -882,7 +882,8 @@ extension RUMViewScope {
         attributes: [AttributeKey: AttributeValue] = [:],
         customTimings: [String: Int64] = randomTimings(),
         startTime: Date = .mockAny(),
-        serverTimeOffset: TimeInterval = .zero
+        serverTimeOffset: TimeInterval = .zero,
+        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric()
     ) -> RUMViewScope {
         return RUMViewScope(
             isInitialView: isInitialView,
@@ -894,7 +895,8 @@ extension RUMViewScope {
             attributes: attributes,
             customTimings: customTimings,
             startTime: startTime,
-            serverTimeOffset: serverTimeOffset
+            serverTimeOffset: serverTimeOffset,
+            interactionToNextViewMetric: interactionToNextViewMetric
         )
     }
 }
@@ -946,6 +948,7 @@ extension RUMUserActionScope {
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
         instrumentation: InstrumentationType = .manual,
+        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(),
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(
@@ -958,6 +961,7 @@ extension RUMUserActionScope {
                 serverTimeOffset: serverTimeOffset,
                 isContinuous: isContinuous,
                 instrumentation: instrumentation,
+                interactionToNextViewMetric: interactionToNextViewMetric,
                 onActionEventSent: onActionEventSent
         )
     }

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol ITNVMetricTracking {
+    /// Tracks an action in a given view.
+    /// Actions can be tracked even if the view is no longer active. For example, a "tap" can start in one view, but be tracked
+    /// through this method even after the next view is started.
+    /// - Parameters:
+    ///   - startTime: The start time of the action.
+    ///   - endTime: The end time of the action.
+    ///   - actionType: The type of the user action.
+    ///   - viewID: The ID of the view where the action occurred.
+    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID)
+
+    /// Tracks the start of a view.
+    /// From this moment, calls to `value(for:)` for this `viewID` will return the value of ITNV.
+    /// - Parameters:
+    ///   - viewStart: The timestamp when the view starts.
+    ///   - viewID: The ID of the view that has just started.
+    func trackViewStart(at viewStart: Date, viewID: RUMUUID)
+
+    /// Marks the completion of a view.
+    /// Indicates that the view event will no longer be updated and no more calls to `value(for:)` for this `viewID` will be made.
+    /// - Parameter viewID: The ID of the view that has completed.
+    func trackViewComplete(viewID: RUMUUID)
+
+    /// Retrieves the ITNV value for a specific view.
+    /// Values are available after a view starts and before it completes.
+    /// - Parameters:
+    ///   - viewID: The ID of the view for which the ITNV value is requested.
+    /// - Returns: The ITNV value (time interval) for the specified view, or `nil` if not available (the view has been completed).
+    func value(for viewID: RUMUUID) -> TimeInterval?
+}
+
+internal final class ITNVMetric: ITNVMetricTracking {
+    enum Constants {
+        /// The maximum allowed duration for the ITNV metric. Values exceeding this threshold are ignored.
+        static let maxDuration: TimeInterval = 3
+    }
+
+    private struct ValuePair {
+        let previousViewID: RUMUUID
+        let timeToNextView: TimeInterval
+    }
+
+    /// The time of the last recorded action in the previous view.
+    private var lastActionDateByViewID: [RUMUUID: Date] = [:]
+
+    /// Stores the start times of views.
+    private var startDateByViewID: [RUMUUID: Date] = [:]
+
+    /// Tracks the previous view associated with each view.
+    private var previousViewByViewID: [RUMUUID: RUMUUID] = [:]
+
+    /// The ID of the current view.
+    private var currentViewID: RUMUUID?
+
+    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID) {
+        // Retrieve the last recorded action time for the given view
+        let lastDate = lastActionDateByViewID[viewID]
+        switch actionType {
+        case .tap, .click: // Discrete actions like tap or click should use their start time
+            lastActionDateByViewID[viewID] = max(startTime, lastDate ?? .distantPast)
+        case .swipe: // Continuous actions like swipe should use their end time
+            lastActionDateByViewID[viewID] = max(endTime, lastDate ?? .distantPast)
+        case .scroll, .custom:
+            return // Ignore scroll and custom actions for ITNV calculation
+        }
+    }
+
+    func trackViewStart(at viewStart: Date, viewID: RUMUUID) {
+        startDateByViewID[viewID] = viewStart
+        previousViewByViewID[viewID] = currentViewID
+        currentViewID = viewID
+    }
+
+    func trackViewComplete(viewID: RUMUUID) {
+        startDateByViewID[viewID] = nil
+
+        if let previousViewID = previousViewByViewID[viewID] {
+            lastActionDateByViewID[previousViewID] = nil
+        }
+        previousViewByViewID[viewID] = nil
+
+        if viewID == currentViewID {
+            currentViewID = nil
+        }
+    }
+
+    func value(for viewID: RUMUUID) -> TimeInterval? {
+        guard let viewStartDate = startDateByViewID[viewID] else {
+            return nil // View has not started yet
+        }
+
+        guard let previousViewID = previousViewByViewID[viewID] else {
+            return nil // No previous view for this one
+        }
+
+        guard let lastActionDate = lastActionDateByViewID[previousViewID] else {
+            return nil // No action recorded in the previous view
+        }
+
+        let itnvValue = viewStartDate.timeIntervalSince(lastActionDate)
+
+        guard itnvValue <= Constants.maxDuration else {
+            return nil // ITNV exceeds the maximum allowed duration, return nil
+        }
+
+        return itnvValue
+    }
+}

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -20,9 +20,9 @@ internal protocol ITNVMetricTracking {
     /// Tracks the start of a view.
     /// From this moment, calls to `value(for:)` for this `viewID` will return the value of ITNV.
     /// - Parameters:
-    ///   - viewStart: The timestamp when the view starts.
+    ///   - startTime: The timestamp when the view starts.
     ///   - viewID: The ID of the view that has just started.
-    func trackViewStart(at viewStart: Date, viewID: RUMUUID)
+    func trackViewStart(at startTime: Date, viewID: RUMUUID)
 
     /// Marks the completion of a view.
     /// Indicates that the view event will no longer be updated and no more calls to `value(for:)` for this `viewID` will be made.
@@ -68,8 +68,8 @@ internal final class ITNVMetric: ITNVMetricTracking {
         }
     }
 
-    func trackViewStart(at viewStart: Date, viewID: RUMUUID) {
-        startDateByViewID[viewID] = viewStart
+    func trackViewStart(at startTime: Date, viewID: RUMUUID) {
+        startDateByViewID[viewID] = startTime
         previousViewByViewID[viewID] = currentViewID
         currentViewID = viewID
     }

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -43,11 +43,6 @@ internal final class ITNVMetric: ITNVMetricTracking {
         static let maxDuration: TimeInterval = 3
     }
 
-    private struct ValuePair {
-        let previousViewID: RUMUUID
-        let timeToNextView: TimeInterval
-    }
-
     /// The time of the last recorded action in the previous view.
     private var lastActionDateByViewID: [RUMUUID: Date] = [:]
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -78,6 +78,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// The reason why this session has ended or `nil` if it is still active.
     private(set) var endReason: EndReason?
 
+    private let interactionToNextViewMetric: ITNVMetricTracking
+
     init(
         isInitialSession: Bool,
         parent: RUMContextProvider,
@@ -103,6 +105,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             hasTrackedAnyView: false,
             didStartWithReplay: context.hasReplay
         )
+        self.interactionToNextViewMetric = ITNVMetric()
 
         // Start tracking "RUM Session Ended" metric for this session
         dependencies.sessionEndedMetric.startMetric(
@@ -159,7 +162,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 attributes: expiredView.attributes,
                 customTimings: expiredView.customTimings,
                 startTime: startTime,
-                serverTimeOffset: context.serverTimeOffset
+                serverTimeOffset: context.serverTimeOffset,
+                interactionToNextViewMetric: interactionToNextViewMetric
             )
         }
     }
@@ -286,7 +290,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             attributes: attributes,
             customTimings: customTimings,
             startTime: startTime,
-            serverTimeOffset: serverTimeOffset
+            serverTimeOffset: serverTimeOffset,
+            interactionToNextViewMetric: interactionToNextViewMetric
         )
 
         viewScopes.append(scope)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -202,12 +202,15 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         if let event = dependencies.eventBuilder.build(from: actionEvent) {
             writer.write(value: event)
             onActionEventSent(event)
-            interactionToNextViewMetric.trackAction(
-                startTime: actionStartTime,
-                endTime: completionTime,
-                actionType: actionType,
-                in: self.context.activeViewID.orNull
-            )
+
+            if let activeViewID = self.context.activeViewID {
+                interactionToNextViewMetric.trackAction(
+                    startTime: actionStartTime,
+                    endTime: completionTime,
+                    actionType: actionType,
+                    in: activeViewID
+                )
+            }
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -60,6 +60,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     /// Number of Resources that started but not yet ended during this User Action's lifespan.
     private var activeResourcesCount: Int = 0
 
+    /// Interaction-to-Next-View metric for this view.
+    private let interactionToNextViewMetric: ITNVMetricTracking
+
     /// Callback called when a `RUMActionEvent` is submitted for storage.
     private let onActionEventSent: (RUMActionEvent) -> Void
 
@@ -73,6 +76,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         serverTimeOffset: TimeInterval,
         isContinuous: Bool,
         instrumentation: InstrumentationType,
+        interactionToNextViewMetric: ITNVMetricTracking,
         onActionEventSent: @escaping (RUMActionEvent) -> Void
     ) {
         self.parent = parent
@@ -86,6 +90,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         self.isContinuous = isContinuous
         self.lastActivityTime = startTime
         self.instrumentation = instrumentation
+        self.interactionToNextViewMetric = interactionToNextViewMetric
         self.onActionEventSent = onActionEventSent
     }
 
@@ -197,6 +202,12 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         if let event = dependencies.eventBuilder.build(from: actionEvent) {
             writer.write(value: event)
             onActionEventSent(event)
+            interactionToNextViewMetric.trackAction(
+                startTime: actionStartTime,
+                endTime: completionTime,
+                actionType: actionType,
+                in: self.context.activeViewID.orNull
+            )
         }
     }
 

--- a/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
@@ -1,0 +1,172 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogRUM
+
+class ITNVMetricTests: XCTestCase {
+    private var metric: ITNVMetric! // swiftlint:disable:this implicitly_unwrapped_optional
+    private let previousViewID: RUMUUID = .mockRandom()
+    private let currentViewID: RUMUUID = .mockRandom()
+    private let currentViewStart = Date()
+
+    override func setUp() {
+        metric = ITNVMetric()
+    }
+
+    override func tearDown() {
+        metric = nil
+    }
+
+    func testMetricValueIsCalculatedDifferentlyForEachActionType() {
+        let actionStart = Date()
+        let actionEnd = actionStart + 1.seconds
+        let viewStart = actionEnd + 1.05.seconds
+
+        func when(actionType: RUMActionType) -> TimeInterval? {
+            // Given
+            let metric = ITNVMetric()
+
+            // When
+            metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+            metric.trackAction(startTime: actionStart, endTime: actionEnd, actionType: actionType, in: previousViewID)
+            metric.trackViewStart(at: viewStart, viewID: currentViewID)
+
+            // Then
+            return metric.value(for: currentViewID)
+        }
+
+        // Then
+        let timeSinceActionStart = viewStart.timeIntervalSince(actionStart)
+        let timeSinceActionEnd = viewStart.timeIntervalSince(actionEnd)
+        XCTAssertEqual(when(actionType: .tap)!, timeSinceActionStart, accuracy: 0.01, "For TAP, the ITNV value should be calculated from the start of the action.")
+        XCTAssertEqual(when(actionType: .click)!, timeSinceActionStart, accuracy: 0.01, "For CLICK, the ITNV value should be calculated from the start of the action.")
+        XCTAssertEqual(when(actionType: .swipe)!, timeSinceActionEnd, accuracy: 0.01, "For SWIPE, the ITNV value should be calculated from the end of the action.")
+        XCTAssertNil(when(actionType: .scroll), "The value should not be calculated for SCROLL actions.")
+        XCTAssertNil(when(actionType: .custom), "The value should not be calculated for CUSTOM actions.")
+    }
+
+    func testWhenViewStarts_thenMetricValueIsAvailable() throws {
+        let (t0, t1, t2) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+
+        // When
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil before the current view starts.")
+        metric.trackViewStart(at: t2, viewID: currentViewID)
+
+        // Then
+        let itnv = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should be available after the current view starts.")
+        XCTAssertEqual(itnv, 2.5, accuracy: 0.01, "The ITNV value should match the time interval from action start to view start.")
+    }
+
+    func testWhenViewCompletes_thenMetricValueIsNoLongerAvailable() {
+        let (t0, t1, t2) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, viewID: currentViewID)
+        XCTAssertNotNil(metric.value(for: currentViewID), "The ITNV value should be available before the view completes.")
+
+        // When
+        metric.trackViewComplete(viewID: currentViewID)
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be removed once the view completes.")
+    }
+
+    func testWhenAnotherViewStarts_thenMetricValueIsAvailableUntilViewCompletes() throws {
+        let (t0, t1, t2, t3) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart, currentViewStart + 1.2)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, viewID: currentViewID)
+
+        // When
+        let itnv1 = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should be available before the current view completes.")
+        metric.trackViewStart(at: t3, viewID: .mockRandom()) // another view starts
+        let itnv2 = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should remain available before the current view completes.")
+        metric.trackViewComplete(viewID: currentViewID) // view completes
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be removed after the view completes.")
+        XCTAssertEqual(itnv1, 2.5, accuracy: 0.01, "The first ITNV value should match the time interval from action start to view start.")
+        XCTAssertEqual(itnv2, itnv2, accuracy: 0.01, "The second ITNV value should be the same as the first one, unaffected by the new view.")
+    }
+
+    func testWhenActionIsTrackedInPreviousViewAfterCurrentViewIsStarted_thenMetricValueIsUpdated() throws {
+        let (t0, t1) = (currentViewStart - 1.5, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+
+        // When
+        metric.trackViewStart(at: t1, viewID: currentViewID)
+        let itnv1 = metric.value(for: currentViewID)
+
+        metric.trackAction(startTime: t0, endTime: t0 + 0.1, actionType: .tap, in: previousViewID)
+        let itnv2 = try XCTUnwrap(metric.value(for: currentViewID))
+
+        // Then
+        XCTAssertNil(itnv1)
+        XCTAssertEqual(itnv2, 1.5, accuracy: 0.01)
+    }
+
+    func testWhenPreviousViewCompletes_thenMetricValueIsStillAvailable() throws {
+        let (t0, t1) = (currentViewStart - 1.5, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t0 + 0.1, actionType: .tap, in: previousViewID)
+        metric.trackViewStart(at: t1, viewID: currentViewID)
+
+        // When
+        metric.trackViewComplete(viewID: previousViewID)
+
+        // Then
+        XCTAssertNotNil(metric.value(for: currentViewID))
+    }
+
+    func testWhenITNVExceedsMaxDuration_thenMetricValueIsNil() {
+        let maxDuration = ITNVMetric.Constants.maxDuration + 0.01
+        let (t0, t1, t2) = (currentViewStart - maxDuration, currentViewStart - 1, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+
+        // When
+        metric.trackViewStart(at: t2, viewID: currentViewID)
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should not be stored when the duration exceeds the maximum allowed.")
+    }
+
+    func testWhenNoActionIsTracked_thenMetricHasNoValue() {
+        let (t0, t1) = (currentViewStart - 1, currentViewStart)
+
+        // Given
+        metric.trackViewStart(at: t0, viewID: previousViewID)
+
+        // When
+        metric.trackViewStart(at: t1, viewID: currentViewID)
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil when no actions are tracked.")
+    }
+
+    func testWhenNoPreviousViewIsTracked_thenMetricHasNoValue() {
+        // When
+        metric.trackViewStart(at: currentViewStart, viewID: currentViewID)
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil when no previous view is tracked.")
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -867,4 +867,34 @@ class RUMUserActionScopeTests: XCTestCase {
         let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
         XCTAssertNil(event.action.frustration)
     }
+
+    // MARK: - Updating Interaction To Next View Metric
+
+    func testWhenActionEventIsSent_itTrackActionInITNVMetric() throws {
+        let actionStartTime: Date = .mockDecember15th2019At10AMUTC()
+
+        // Given
+        let metric = ITNVMetricMock()
+        let scope = RUMUserActionScope.mockWith(
+            parent: parent,
+            actionType: .tap,
+            startTime: actionStartTime,
+            interactionToNextViewMetric: metric
+        )
+
+        // When (action is sent)
+        _ = scope.process(
+            command: RUMCommandMock(time: actionStartTime + 1),
+            context: context,
+            writer: writer
+        )
+        XCTAssertFalse(writer.events(ofType: RUMActionEvent.self).isEmpty)
+
+        // Then
+        let trackedAction = try XCTUnwrap(metric.trackedActions.first)
+        XCTAssertEqual(trackedAction.startTime, actionStartTime)
+        XCTAssertEqual(trackedAction.endTime, actionStartTime + RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+        XCTAssertEqual(trackedAction.viewID, parent.context.activeViewID)
+        XCTAssertEqual(metric.trackedActions.count, 1)
+    }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -47,7 +47,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: .mockAny(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
@@ -74,7 +75,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: .mockAny(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         _ = scope.process(
@@ -107,7 +109,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -202,7 +205,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock(mockedValue: 0.84)
         )
 
         let hasReplay: Bool = .mockRandom()
@@ -234,6 +238,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.view.error.count, 0)
         XCTAssertEqual(event.view.resource.count, 0)
         XCTAssertEqual(event.view.networkSettledTime, 420_000_000)
+        XCTAssertEqual(event.view.interactionToNextViewTime, 840_000_000)
         XCTAssertEqual(event.dd.documentVersion, 1)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
         XCTAssertEqual(event.source, .ios)
@@ -265,7 +270,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         _ = scope.process(
@@ -291,7 +297,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: ["foo": "bar", "fizz": "buzz"],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -346,7 +353,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: ["foo": "bar"],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -417,7 +425,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: ["foo": "bar"],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -490,7 +499,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: ["foo": "bar"],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -563,7 +573,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -608,7 +619,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         currentTime.addTimeInterval(1)
@@ -653,7 +665,8 @@ class RUMViewScopeTests: XCTestCase {
                 attributes: [:],
                 customTimings: [:],
                 startTime: .mockAny(),
-                serverTimeOffset: .zero
+                serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
             )
         }
 
@@ -701,7 +714,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -757,7 +771,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -826,7 +841,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // given
@@ -912,7 +928,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // given
@@ -966,7 +983,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -1049,7 +1067,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -1127,7 +1146,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1184,7 +1204,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1236,7 +1257,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1313,7 +1335,8 @@ class RUMViewScopeTests: XCTestCase {
                 attributes: [:],
                 customTimings: [:],
                 startTime: currentTime,
-                serverTimeOffset: .zero
+                serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
             )
             _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1384,7 +1407,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1457,7 +1481,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1556,7 +1581,8 @@ class RUMViewScopeTests: XCTestCase {
             ],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1609,7 +1635,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1665,7 +1692,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1724,7 +1752,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1777,7 +1806,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1815,7 +1845,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1878,7 +1909,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: startViewDate,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1949,7 +1981,8 @@ class RUMViewScopeTests: XCTestCase {
             ],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1996,7 +2029,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: startViewDate,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         XCTAssertTrue(
@@ -2036,7 +2070,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2098,7 +2133,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2144,7 +2180,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2206,7 +2243,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2250,7 +2288,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2305,7 +2344,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: currentTime,
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2361,7 +2401,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: initialDeviceTime,
-            serverTimeOffset: initialServerTimeOffset
+            serverTimeOffset: initialServerTimeOffset,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         parent.context.isSessionActive = false
 
@@ -2400,7 +2441,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: initialDeviceTime,
-            serverTimeOffset: initialServerTimeOffset
+            serverTimeOffset: initialServerTimeOffset,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -2516,7 +2558,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2621,7 +2664,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -2656,7 +2700,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: Date(),
-            serverTimeOffset: .zero
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -2696,7 +2741,8 @@ class RUMViewScopeTests: XCTestCase {
             attributes: [:],
             customTimings: [:],
             startTime: viewStartDate,
-            serverTimeOffset: .mockRandom()
+            serverTimeOffset: .mockRandom(),
+            interactionToNextViewMetric: ITNVMetricMock()
         )
 
         // When
@@ -2708,5 +2754,46 @@ class RUMViewScopeTests: XCTestCase {
 
         // Then
         XCTAssertTrue(metric.viewWasStopped)
+    }
+
+    // MARK: - Interaction To Next View Metric
+
+    func testWhenViewIsStartedThenStopped_itUpdatesITNVMetric() throws {
+        let viewStartDate = Date()
+        let viewID: RUMUUID = .mockRandom()
+
+        // Given
+        let metric = ITNVMetricMock()
+        let scope = RUMViewScope(
+            isInitialView: .mockAny(),
+            parent: parent,
+            dependencies: .mockWith(
+                rumUUIDGenerator: RUMUUIDGeneratorMock(uuid: viewID)
+            ),
+            identity: .mockViewIdentifier(),
+            path: .mockAny(),
+            name: .mockAny(),
+            attributes: [:],
+            customTimings: [:],
+            startTime: viewStartDate,
+            serverTimeOffset: .mockRandom(),
+            interactionToNextViewMetric: metric
+        )
+
+        // When
+        _ = scope.process(
+            command: RUMStopViewCommand.mockWith(identity: .mockViewIdentifier()),
+            context: context,
+            writer: writer
+        )
+
+        // Then
+        let trackedViewStart = try XCTUnwrap(metric.trackedViewStarts.first)
+        let trackedViewComplete = try XCTUnwrap(metric.trackedViewCompletes.first)
+        XCTAssertEqual(trackedViewStart.viewStart, viewStartDate)
+        XCTAssertEqual(trackedViewStart.viewID, viewID)
+        XCTAssertEqual(trackedViewComplete, viewID)
+        XCTAssertEqual(metric.trackedViewStarts.count, 1)
+        XCTAssertEqual(metric.trackedViewCompletes.count, 1)
     }
 }

--- a/TestUtilities/Helpers/SwiftExtensions.swift
+++ b/TestUtilities/Helpers/SwiftExtensions.swift
@@ -32,6 +32,12 @@ extension Date {
     }
 }
 
+extension TimeInterval {
+    public init(fromNanoseconds nanoseconds: Int64) {
+        self = TimeInterval(nanoseconds) / 1_000_000_000
+    }
+}
+
 extension String {
     public var utf8Data: Data { data(using: .utf8)! }
 


### PR DESCRIPTION
### What and why?

📦⏱️ This PR introduces the **Interaction-to-Next-View** (ITNV) metric to measure the time between the last action in a previous view and the moment the next view is started. This metric provides valuable insights into the time it takes for a view to be prepared and displayed after user interaction.

The ITNV value is reported under the following conditions:
- The value is tracked only if a `.tap`, `.click`, or `.swipe` action occurred in the previous view, and the time between the last action and the start of the next view is less than 3 seconds
- For `.tap` and `.click`, the measurement starts at the action's start time.
- For `.swipe`, the measurement starts at the action's end time.

**Example:** In the scenario below, A2 is the last action in the "Previous View." It’s a `.tap` action that occurs less than 3 seconds before the "Next View" starts. The ITNV value for "Next View" is calculated as the time from when the action starts to when the next view starts:

<img width="80%" alt="Screenshot 2024-12-18 at 11 32 51" src="https://github.com/user-attachments/assets/dcd6b9eb-0905-4e9f-90d6-ab7500f3d780" />

The ITNV value is reported in the `view.interaction_to_next_view_time` attribute, in nanoseconds.

This is the counterpart to [Android PR #2417](https://github.com/DataDog/dd-sdk-android/pull/2417).

### How?

The metric is modeled as an object implementing the `ITNVMetricTracking` interface, which tracks key events (action, view start, and view completion) and provides a method to retrieve the ITNV value:

```swift
internal protocol ITNVMetricTracking {
    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID)
    func trackViewStart(at viewStart: Date, viewID: RUMUUID)
    func trackViewComplete(viewID: RUMUUID)
    func value(for viewID: RUMUUID) -> TimeInterval?
}
```
The ITNV metric object is created and managed by `RUMSessionScope`, enabling it to track actions and views throughout the session. When a view or action starts, a reference to this object is passed to the respective RUM scopes, allowing key events to be tracked via the interface.

This design aligns with the solution implemented for the TTNS metric in https://github.com/DataDog/dd-sdk-ios/pull/2125

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
