### PR TITLE
RUM-7205 Double full snapshot bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [IMPROVEMENT] Add Datadog Configuration `backgroundTasksEnabled` ObjC API. See [#2148][]
+- [FIX] Prevent Session Replay to create two full snapshots in a row. See [#2154][]
 
 # 2.21.0 / 11-12-2024
 
@@ -809,6 +810,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2120]: https://github.com/DataDog/dd-sdk-ios/pull/2120
 [#2126]: https://github.com/DataDog/dd-sdk-ios/pull/2126
 [#2148]: https://github.com/DataDog/dd-sdk-ios/pull/2148
+[#2154]: https://github.com/DataDog/dd-sdk-ios/pull/2154
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogSessionReplay/Sources/Processor/Builders/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/Builders/RecordsBuilder.swift
@@ -66,9 +66,6 @@ internal class RecordsBuilder {
     /// In case of unexpected failure, it will fallback to creating FSR instead.
     /// If the root wireframe has changed, we trigger a full snapshot so it is added first in the replay.
     func createIncrementalSnapshotRecord(from snapshot: ViewTreeSnapshot, with wireframes: [SRWireframe], lastWireframes: [SRWireframe]) -> SRRecord? {
-        if wireframes.first?.id != lastWireframes.first?.id {
-            return createFullSnapshotRecord(from: snapshot, wireframes: wireframes)
-        }
         do {
             return try createIncrementalSnapshotRecord(from: snapshot, newWireframes: wireframes, lastWireframes: lastWireframes)
         } catch {

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -146,8 +146,8 @@ class SnapshotProcessorTests: XCTestCase {
         XCTAssertTrue(enrichedRecords[0].records[1].isFocusRecord)
         XCTAssertTrue(enrichedRecords[0].records[2].isFullSnapshotRecord)
 
-        XCTAssertEqual(enrichedRecords[1].records.count, 2, "It should follow with 'full snapshot' → 'incremental snapshot' records")
-        XCTAssertTrue(enrichedRecords[1].records[0].isFullSnapshotRecord)
+        XCTAssertEqual(enrichedRecords[1].records.count, 2, "It should follow with 'incremental snapshot' records")
+        XCTAssertTrue(enrichedRecords[1].records[0].isIncrementalSnapshotRecord)
         XCTAssertTrue(enrichedRecords[1].records[1].isIncrementalSnapshotRecord)
         XCTAssertEqual(enrichedRecords[1].records[1].incrementalSnapshot?.viewportResizeData?.height, 100)
         XCTAssertEqual(enrichedRecords[1].records[1].incrementalSnapshot?.viewportResizeData?.width, 200)


### PR DESCRIPTION
### What and why?

This PR is essentially reverting https://github.com/DataDog/dd-sdk-ios/pull/1567. Assumption made was wrong. We can expect view that from the wireframe perspective have a different root view (it can be done by fully covering the root with nontransparent view, which will remove the root during flattening process).

The reverted code was fixing some minor edge cases in React Native, although it has a serious penalty of creating double fullsnapshots in others.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
