### PR TITLE
RUM-7103 feat: Add API for classifying resources in TTNS metric

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -528,6 +528,8 @@
 		618C0FC02B482F6800266B38 /* SpanWriteContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C0FBF2B482F6800266B38 /* SpanWriteContextTests.swift */; };
 		618C0FC12B482F6800266B38 /* SpanWriteContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C0FBF2B482F6800266B38 /* SpanWriteContextTests.swift */; };
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
+		618F2B032D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */; };
+		618F2B042D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */; };
 		618F9843265BC486009959F8 /* E2EInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */; };
 		618F984E265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
 		618F984F265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
@@ -2604,6 +2606,7 @@
 		618DCFDE24C75FD300589570 /* RUMScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScopeTests.swift; sourceTree = "<group>"; };
 		618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersReader.swift; sourceTree = "<group>"; };
 		618E13B02524B8F80098C6B0 /* TracingHTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingHTTPHeaders.swift; sourceTree = "<group>"; };
+		618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettledResourcePredicate.swift; sourceTree = "<group>"; };
 		618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = E2EInstrumentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EInstrumentationTests.swift; sourceTree = "<group>"; };
 		618F9844265BC486009959F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -4151,6 +4154,7 @@
 			isa = PBXGroup;
 			children = (
 				6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */,
+				618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */,
 				6105C5082CFA222400C4C5EE /* ITNVMetric.swift */,
 			);
 			path = RUMMetrics;
@@ -9016,6 +9020,7 @@
 				D23F8E8529DDCD28001CFAE8 /* SwiftUIExtensions.swift in Sources */,
 				3CFF4F952C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */,
 				D23F8E8629DDCD28001CFAE8 /* RUMDataModelsMapping.swift in Sources */,
+				618F2B042D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */,
 				D23F8E8729DDCD28001CFAE8 /* RUMInstrumentation.swift in Sources */,
 				D23F8E8829DDCD28001CFAE8 /* VitalCPUReader.swift in Sources */,
 				D23F8E8929DDCD28001CFAE8 /* RUMOperatingSystemInfo.swift in Sources */,
@@ -9358,6 +9363,7 @@
 				D29A9F8E29DD8665005C54A4 /* SwiftUIExtensions.swift in Sources */,
 				3CFF4F942C09E63C006F191D /* WatchdogTerminationChecker.swift in Sources */,
 				D29A9F7829DD85BB005C54A4 /* RUMDataModelsMapping.swift in Sources */,
+				618F2B032D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */,
 				D29A9F6F29DD85BB005C54A4 /* RUMInstrumentation.swift in Sources */,
 				D29A9F7A29DD85BB005C54A4 /* VitalCPUReader.swift in Sources */,
 				D29A9F6729DD85BB005C54A4 /* RUMOperatingSystemInfo.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -39,7 +39,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.startView(key: "view", name: "ViewName")
         monitor.startResource(resourceKey: "resource1", url: .mockRandom())
         monitor.startResource(resourceKey: "resource2", url: .mockRandom())
-        rumTime.now.addTimeInterval(TTNSMetric.Constants.initialResourceThreshold * 0.99) // Wait no more than threshold, so next resource is still counted
+        rumTime.now.addTimeInterval(TimeBasedTTNSResourcePredicate.defaultThreshold * 0.99) // Wait no more than threshold, so next resource is still counted
         monitor.startResource(resourceKey: "resource3", url: .mockRandom())
 
         // When (end resources during the same view)
@@ -78,7 +78,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.startResource(resourceKey: "resource2", url: .mockRandom())
 
         // When (start non-initial resource after threshold)
-        rumTime.now.addTimeInterval(TTNSMetric.Constants.initialResourceThreshold * 1.01) // Wait more than threshold, so next resource is not counted
+        rumTime.now.addTimeInterval(TimeBasedTTNSResourcePredicate.defaultThreshold * 1.01) // Wait more than threshold, so next resource is not counted
         monitor.startResource(resourceKey: "resource3", url: .mockRandom())
 
         // When (end resources during the same view)

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -733,7 +733,9 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { TTNSMetric(viewName: $1, viewStartDate: $0) }
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = {
+            TTNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTTNSResourcePredicate())
+        }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -914,7 +916,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny()),
+        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTTNSResourcePredicate()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -733,7 +733,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: @escaping (Date) -> TTNSMetricTracking = { TTNSMetric(viewStartDate: $0) }
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { TTNSMetric(viewName: $1, viewStartDate: $0) }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -775,7 +775,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date) -> TTNSMetricTracking)? = nil
+        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -914,7 +914,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewStartDate: .mockAny()),
+        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -101,7 +101,13 @@ internal final class RUMFeature: DatadogRemoteFeature {
             fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope),
             sessionEndedMetric: sessionEndedMetric,
             watchdogTermination: watchdogTermination,
-            networkSettledMetricFactory: { viewStartDate in TTNSMetric(viewStartDate: viewStartDate) }
+            networkSettledMetricFactory: { viewStartDate, viewName in
+                TTNSMetric(
+                    viewName: viewName,
+                    viewStartDate: viewStartDate,
+                    resourcePredicate: TimeBasedTTNSResourcePredicate() // TODO: RUM-7103 read predicatefrom configuration
+                )
+            }
         )
 
         self.monitor = Monitor(

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -102,10 +102,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
             sessionEndedMetric: sessionEndedMetric,
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: { viewStartDate, viewName in
-                TTNSMetric(
+                return TTNSMetric(
                     viewName: viewName,
                     viewStartDate: viewStartDate,
-                    resourcePredicate: TimeBasedTTNSResourcePredicate() // TODO: RUM-7103 read predicatefrom configuration
+                    resourcePredicate: configuration.networkSettledResourcePredicate
                 )
             }
         )

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -147,6 +147,17 @@ extension RUM {
         /// Default: `.average`.
         public var vitalsUpdateFrequency: VitalsFrequency?
 
+        /// The predicate used to classify resources for the Time-to-Network-Settled (TTNS) view metric calculation.
+        ///
+        /// **Time-to-Network-Settled (TTNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
+        /// are fully loaded. This metric helps to understand how long it takes for a view to be fully ready with all required resources loaded.
+        ///
+        /// The `NetworkSettledResourcePredicate` defines which resources are included in the TTNS calculation based on their properties (e.g., start time, resource URL, etc.).
+        ///
+        /// Default: The default predicate, `TimeBasedTTNSResourcePredicate`, calculates TTNS using all resources that start within **100ms** of the view start.
+        /// This time threshold can be customized by providing a custom predicate or adjusting the threshold in the default predicate.
+        public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
+
         /// Custom mapper for RUM view events.
         ///
         /// It can be used to modify view events before they are sent. The implementation of the mapper should
@@ -345,6 +356,7 @@ extension RUM.Configuration {
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
     ///   - trackWatchdogTerminations: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
+    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-to-Network-Settled (TTNS) metric calculation. Default: `TimeBasedTTNSResourcePredicate()`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
     ///   - actionEventMapper: Custom mapper for RUM action events. Default: `nil`.
@@ -365,6 +377,7 @@ extension RUM.Configuration {
         appHangThreshold: TimeInterval? = nil,
         trackWatchdogTerminations: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
+        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
         actionEventMapper: RUM.ActionEventMapper? = nil,
@@ -384,6 +397,7 @@ extension RUM.Configuration {
         self.longTaskThreshold = longTaskThreshold
         self.appHangThreshold = appHangThreshold
         self.vitalsUpdateFrequency = vitalsUpdateFrequency
+        self.networkSettledResourcePredicate = networkSettledResourcePredicate
         self.viewEventMapper = viewEventMapper
         self.resourceEventMapper = resourceEventMapper
         self.actionEventMapper = actionEventMapper

--- a/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A struct representing the parameters of a resource that may be considered for the Time-to-Network-Settled (TTNS) metric.
+public struct TTNSResourceParams {
+    /// The URL of the resource.
+    public let url: String
+
+    /// The time elapsed from when the view started to when the resource started.
+    public let timeSinceViewStart: TimeInterval
+
+    /// The name of the view in which the resource is tracked.
+    public let viewName: String
+}
+
+/// A protocol for classifying network resources for the Time-to-Network-Settled (TTNS) metric.
+/// Implement this protocol to customize the logic for determining which resources are included in the TTNS calculation.
+///
+/// **Note:**
+/// - The `isInitialResource` method will be called on a secondary thread.
+/// - The implementation must not assume any threading behavior and should avoid blocking the thread.
+/// - The method should always return the same result for the same input parameters to ensure consistency in TTNS calculation.
+public protocol NetworkSettledResourcePredicate {
+    /// Determines if the provided resource should be included in the TTNS metric calculation.
+    ///
+    /// - Parameter resource: The parameters of the resource.
+    /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
+    func isInitialResource(resource: TTNSResourceParams) -> Bool
+}
+
+/// A predicate implementation for classifying Time-to-Network-Settled (TTNS) resources based on a time threshold.
+/// It will calculate TTNS using all resources that start within the specified threshold after the view starts.
+public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate {
+    /// The default value of the threshold.
+    public static let defaultThreshold: TimeInterval = 0.1
+
+    /// The time threshold (in seconds) used to classify a resource.
+    let threshold: TimeInterval
+
+    /// Initializes a new predicate with a specified time threshold.
+    ///
+    /// - Parameter threshold: The time threshold (in seconds) used to classify resources. The default value is 0.1 seconds.
+    public init(threshold: TimeInterval = TimeBasedTTNSResourcePredicate.defaultThreshold) {
+        self.threshold = threshold
+    }
+
+    /// Determines if the provided resource should be included in the TTNS metric calculation.
+    /// A resource is included if it starts within the specified threshold from the view start time.
+    ///
+    /// - Parameter resource: The parameters of the resource.
+    /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
+    public func isInitialResource(resource: TTNSResourceParams) -> Bool {
+        return resource.timeSinceViewStart <= threshold
+    }
+}

--- a/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
@@ -35,6 +35,8 @@ public protocol NetworkSettledResourcePredicate {
 
 /// A predicate implementation for classifying Time-to-Network-Settled (TTNS) resources based on a time threshold.
 /// It will calculate TTNS using all resources that start within the specified threshold after the view starts.
+///
+/// The default value of the threshold is 0.1s.
 public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate {
     /// The default value of the threshold.
     public static let defaultThreshold: TimeInterval = 0.1

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -91,7 +91,7 @@ internal class RUMResourceScope: RUMScope {
         self.onErrorEvent = onErrorEvent
 
         // Track this resource in view's TTNS metric:
-        networkSettledMetric.trackResourceStart(at: startTime, resourceID: resourceUUID)
+        networkSettledMetric.trackResourceStart(at: startTime, resourceID: resourceUUID, resourceURL: url)
     }
 
     // MARK: - RUMScope

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -52,8 +52,10 @@ internal struct RUMScopeDependencies {
     let watchdogTermination: WatchdogTerminationMonitor?
 
     /// A factory function that creates a `TTNSMetric` for the given view start date.
-    /// - Parameter Date: The time when the view becomes visible (device time, no NTP offset).
-    let networkSettledMetricFactory: (Date) -> TTNSMetricTracking
+    /// - Parameters:
+    ///   - Date: The time when the view becomes visible (device time, no NTP offset).
+    ///   - String: The name of the view.
+    let networkSettledMetricFactory: (Date, String) -> TTNSMetricTracking
 
     init(
         featureScope: FeatureScope,
@@ -73,7 +75,7 @@ internal struct RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying,
         sessionEndedMetric: SessionEndedMetricController,
         watchdogTermination: WatchdogTerminationMonitor?,
-        networkSettledMetricFactory: @escaping (Date) -> TTNSMetricTracking
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -142,7 +142,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 frequency: $0.frequency
             )
         }
-        self.networkSettledMetric = dependencies.networkSettledMetricFactory(viewStartTime)
+        self.networkSettledMetric = dependencies.networkSettledMetricFactory(viewStartTime, viewName)
         interactionToNextViewMetric.trackViewStart(at: startTime, viewID: viewUUID)
 
         // Notify Synthetics if needed

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -777,7 +777,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom(),
-        networkSettledMetricFactory: @escaping (Date) -> TTNSMetricTracking = { _ in TTNSMetricMock() }
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { _, _ in TTNSMetricMock() }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -819,7 +819,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date) -> TTNSMetricTracking)? = nil
+        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -985,7 +985,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewStartDate: .mockAny()),
+        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {
@@ -1214,7 +1214,7 @@ internal class TTNSMetricMock: TTNSMetricTracking {
         self.value = value
     }
 
-    func trackResourceStart(at startDate: Date, resourceID: RUMUUID) {
+    func trackResourceStart(at startDate: Date, resourceID: RUMUUID, resourceURL: String) {
         resourceStartDates[resourceID] = startDate
     }
 

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -985,7 +985,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny()),
+        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTTNSResourcePredicate()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -197,7 +197,7 @@ class RUMViewScopeTests: XCTestCase {
             isInitialView: true,
             parent: parent,
             dependencies: .mockWith(
-                networkSettledMetricFactory: { _ in TTNSMetricMock(value: 0.42) }
+                networkSettledMetricFactory: { _, _ in TTNSMetricMock(value: 0.42) }
             ),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
@@ -2723,6 +2723,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenViewIsStopped_itStopsTrackingTTNSMetric() throws {
         let viewStartDate = Date()
+        let viewName: String = .mockRandom()
 
         // Given
         let metric = TTNSMetricMock()
@@ -2730,14 +2731,15 @@ class RUMViewScopeTests: XCTestCase {
             isInitialView: .mockAny(),
             parent: parent,
             dependencies: .mockWith(
-                networkSettledMetricFactory: { date in
+                networkSettledMetricFactory: { date, name in
                     XCTAssertEqual(date, viewStartDate)
+                    XCTAssertEqual(name, viewName)
                     return metric
                 }
             ),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
-            name: "ViewController",
+            name: viewName,
             attributes: [:],
             customTimings: [:],
             startTime: viewStartDate,


### PR DESCRIPTION
### What and why?

📦 ⏱️ This PR introduces an API to customize the classification of resources for the **Time-to-Network-Settled (TTNS)** metric using a predicate-based strategy. The predicate allows users to define which resources should be considered for the TTNS calculation based on their own logic. 

This provides more flexibility in how the metric is computed, enabling users to customize resource classification for different use cases.

**Previously**, resources were included in TTNS calculation solely based on a fixed `100ms` threshold after the view starts:

<img width="75%" alt="prev" src="https://github.com/user-attachments/assets/dafc01f4-434f-4981-bc70-91706ec5f207" />

**Now**, users can customize resource classification by implementing the `NetworkSettledResourcePredicate` protocol, allowing for flexible inclusion or exclusion of resources. For example:

<img width="75%" alt="Screenshot 2024-12-20 at 12 09 00" src="https://github.com/user-attachments/assets/6c2130b2-26c7-442b-ad87-4c0759b5f500" />

Users can also use the default `TimeBasedTTNSResourcePredicate` with adjusting its `threshold`.

### How?

This PR introduces the `NetworkSettledResourcePredicate` protocol, which allows users to implement their own classification logic for TTNS resources:

```swift
public protocol NetworkSettledResourcePredicate {
    func isInitialResource(resource: TTNSResourceParams) -> Bool
}
```

The default implementation, `TimeBasedTTNSResourcePredicate`, classifies resources based on the time elapsed since the view started (default threshold of `100ms`).

The `TTNSMetric` class is updated with the predicate, making the logic for calculating TTNS more flexible and customizable.

Integration and unit tests have been updated to validate the correct behavior of the default predicate-based approach. An integration test was added to test integration of custom predicate.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
