### PR TITLE
[APMTI-2602] Move the agent_psr from the root of the span to the metrics map

### DIFF
--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -65,7 +65,6 @@ class TracerTests: XCTestCase {
         {
           "spans": [
             {
-              "_dd.agent_psr": 1,
               "trace_id": "64",
               "span_id": "64",
               "parent_id": "0",
@@ -90,6 +89,7 @@ class TracerTests: XCTestCase {
               "meta._dd.source": "abc",
               "metrics._top_level": 1,
               "metrics._sampling_priority_v1": 1,
+              "metrics._dd.agent_psr": 1,
               "meta._dd.p.tid": "a"
             }
           ],

--- a/DatadogTrace/Sources/Span/SpanEventEncoder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventEncoder.swift
@@ -155,7 +155,7 @@ internal struct SpanEventEncoder {
 
         case isRootSpan = "metrics._top_level"
         case samplingPriority = "metrics._sampling_priority_v1"
-        case samplingRate = "_dd.agent_psr"
+        case samplingRate = "metrics._dd.agent_psr"
 
         // MARK: - Meta
 


### PR DESCRIPTION
### What and why?

This PR moves the `_dd.agent_psr` field from the span's root to the metrics map. 
Also removes the logic related to _dd at the root of the span as it was only used for this field and also because this field shouldn't be set at the root.


When looking to use a stricter json schema (see ticket) for the json payload parser, we noticed that some spans would be rejected due to invalid fields that didn't comply with the established schema. This is one of those spans.

This field was added in PR #1259 but I don't know how this was tested.
I am not familiar with this repository and swift. Feedback is welcome.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
