### PR TITLE
RUM-7823 feat: Add API for classifying "last interaction" in ITNV metric

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -530,6 +530,8 @@
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
 		618F2B032D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */; };
 		618F2B042D146BB300A647C4 /* NetworkSettledResourcePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */; };
+		618F2B062D15922400A647C4 /* NextViewActionPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */; };
+		618F2B072D15922400A647C4 /* NextViewActionPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */; };
 		618F9843265BC486009959F8 /* E2EInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */; };
 		618F984E265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
 		618F984F265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
@@ -2607,6 +2609,7 @@
 		618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersReader.swift; sourceTree = "<group>"; };
 		618E13B02524B8F80098C6B0 /* TracingHTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingHTTPHeaders.swift; sourceTree = "<group>"; };
 		618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettledResourcePredicate.swift; sourceTree = "<group>"; };
+		618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextViewActionPredicate.swift; sourceTree = "<group>"; };
 		618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = E2EInstrumentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EInstrumentationTests.swift; sourceTree = "<group>"; };
 		618F9844265BC486009959F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -4156,6 +4159,7 @@
 				6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */,
 				618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */,
 				6105C5082CFA222400C4C5EE /* ITNVMetric.swift */,
+				618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */,
 			);
 			path = RUMMetrics;
 			sourceTree = "<group>";
@@ -9028,6 +9032,7 @@
 				D23F8E8B29DDCD28001CFAE8 /* RUMContext.swift in Sources */,
 				D23F8E8C29DDCD28001CFAE8 /* RUMBaggageKeys.swift in Sources */,
 				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
+				618F2B072D15922400A647C4 /* NextViewActionPredicate.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
 				6105C50A2CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
 				3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
@@ -9371,6 +9376,7 @@
 				D29A9F5029DD85BA005C54A4 /* RUMContext.swift in Sources */,
 				D29A9F8329DD85BB005C54A4 /* RUMBaggageKeys.swift in Sources */,
 				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
+				618F2B062D15922400A647C4 /* NextViewActionPredicate.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
 				6105C5092CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
 				3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -205,8 +205,8 @@ class ViewLoadingMetricsTests: XCTestCase {
         struct CustomPredicate: NetworkSettledResourcePredicate {
             let viewLoadingURLs: Set<URL>
 
-            func isInitialResource(resource: TTNSResourceParams) -> Bool {
-                resource.viewName == "FooView" && viewLoadingURLs.contains(URL(string: resource.url)!)
+            func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+                resourceParams.viewName == "FooView" && viewLoadingURLs.contains(URL(string: resourceParams.url)!)
             }
         }
 
@@ -432,8 +432,8 @@ class ViewLoadingMetricsTests: XCTestCase {
         // - A0, A2 - other actions; ignored by predicate
 
         struct CustomITNVPredicate: NextViewActionPredicate {
-            func isLastAction(action: ITNVActionParams) -> Bool {
-                return action.name == "Sign Up" && action.nextViewName == "WelcomeView"
+            func isLastAction(from actionParams: ITNVActionParams) -> Bool {
+                return actionParams.name == "Sign Up" && actionParams.nextViewName == "WelcomeView"
             }
         }
 

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -261,7 +261,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given
+        // Given (default ITNV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -272,7 +272,9 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
         // When (the next view is started within the ITNV threshold after the action)
-        let expectedITNV: TimeInterval = .mockRandom(min: 0, max: ITNVMetric.Constants.maxDuration * 0.99)
+        let expectedITNV: TimeInterval = .mockRandom(
+            min: 0, max: TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.99
+        )
         rumTime.now += expectedITNV
         monitor.startView(key: "next", name: "NextView")
 
@@ -290,7 +292,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given
+        // Given (default ITNV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -301,7 +303,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
         // When (the next view starts after exceeding the ITNV threshold)
-        rumTime.now += ITNVMetric.Constants.maxDuration + 0.01 // exceeds the max threshold
+        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView + 0.01 // exceeds the max threshold
         monitor.startView(key: "next", name: "NextView")
 
         // Then (ITNV is not tracked for the next view)
@@ -318,7 +320,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given
+        // Given (default ITNV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -335,7 +337,9 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.stopAction(type: .swipe, name: "Swipe")
 
         // When (the next view is started within the ITNV threshold after last action)
-        let expectedITNV: TimeInterval = .mockRandom(min: 0, max: ITNVMetric.Constants.maxDuration * 0.99)
+        let expectedITNV: TimeInterval = .mockRandom(
+            min: 0, max: TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.99
+        )
         rumTime.now += expectedITNV
         monitor.startView(key: "next", name: "NextView")
 
@@ -356,7 +360,7 @@ class ViewLoadingMetricsTests: XCTestCase {
             event.action.target?.name == "Tap in Previous View" ? nil : event // drop "Tap in Previous View"
         }
 
-        // Given
+        // Given (default ITNV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -367,7 +371,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
         // When (the next view is started within the ITNV threshold after the action)
-        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "next", name: "NextView")
 
         // Then (ITNV is tracked for the next view)
@@ -383,7 +387,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given
+        // Given (default ITNV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -394,11 +398,11 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
         // When (the next view starts due to the action)
-        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "next", name: "NextView")
 
         // When (a new view starts without an action)
-        rumTime.now += ITNVMetric.Constants.maxDuration * 0.5
+        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "nextWithoutAction", name: "NextViewWithoutAction")
 
         // Then
@@ -410,5 +414,9 @@ class ViewLoadingMetricsTests: XCTestCase {
         let nextViewWithoutAction = try XCTUnwrap(session.views.first(where: { $0.name == "NextViewWithoutAction" })?.viewEvents.last)
         XCTAssertNotNil(nextViewEvent.view.interactionToNextViewTime, "ITNV should be tracked for view that started due to an action.")
         XCTAssertNil(nextViewWithoutAction.view.interactionToNextViewTime, "ITNV should not be tracked for view that started without an action.")
+    }
+
+    func testGivenCustomITNVActionPredicate_whenNextViewStarts_thenITNVMetricIsCalculatedFromClassifiedActions() throws {
+        // TODO: RUM-7823
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -735,6 +735,9 @@ extension RUMScopeDependencies {
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = {
             TTNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTTNSResourcePredicate())
+        },
+        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking = {
+            ITNVMetric(predicate: TimeBasedITNVActionPredicate())
         }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -755,7 +758,8 @@ extension RUMScopeDependencies {
             fatalErrorContext: fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric,
             watchdogTermination: watchdogTermination,
-            networkSettledMetricFactory: networkSettledMetricFactory
+            networkSettledMetricFactory: networkSettledMetricFactory,
+            interactionToNextViewMetricFactory: interactionToNextViewMetricFactory
         )
     }
 
@@ -777,7 +781,8 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil
+        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
+        interactionToNextViewMetricFactory: (() -> ITNVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -797,7 +802,8 @@ extension RUMScopeDependencies {
             fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric,
             watchdogTermination: watchdogTermination ?? self.watchdogTermination,
-            networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory
+            networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory,
+            interactionToNextViewMetricFactory: interactionToNextViewMetricFactory ?? self.interactionToNextViewMetricFactory
         )
     }
 }
@@ -885,7 +891,7 @@ extension RUMViewScope {
         customTimings: [String: Int64] = randomTimings(),
         startTime: Date = .mockAny(),
         serverTimeOffset: TimeInterval = .zero,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric()
+        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(predicate: TimeBasedITNVActionPredicate())
     ) -> RUMViewScope {
         return RUMViewScope(
             isInitialView: isInitialView,
@@ -950,7 +956,7 @@ extension RUMUserActionScope {
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
         instrumentation: InstrumentationType = .manual,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(),
+        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(predicate: TimeBasedITNVActionPredicate()),
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -107,6 +107,11 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     viewStartDate: viewStartDate,
                     resourcePredicate: configuration.networkSettledResourcePredicate
                 )
+            },
+            interactionToNextViewMetricFactory: {
+                return ITNVMetric(
+                    predicate: configuration.nextViewActionPredicate
+                )
             }
         )
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -147,9 +147,9 @@ extension RUM {
         /// Default: `.average`.
         public var vitalsUpdateFrequency: VitalsFrequency?
 
-        /// The predicate used to classify resources for the Time-to-Network-Settled (TTNS) view metric calculation.
+        /// The predicate used to classify resources for the Time-To-Network-Settled (TTNS) view metric calculation.
         ///
-        /// **Time-to-Network-Settled (TTNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
+        /// **Time-To-Network-Settled (TTNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
         /// are fully loaded. This metric helps to understand how long it takes for a view to be fully ready with all required resources loaded.
         ///
         /// The `NetworkSettledResourcePredicate` defines which resources are included in the TTNS calculation based on their properties (e.g., start time, resource URL, etc.).
@@ -157,6 +157,18 @@ extension RUM {
         /// Default: The default predicate, `TimeBasedTTNSResourcePredicate`, calculates TTNS using all resources that start within **100ms** of the view start.
         /// This time threshold can be customized by providing a custom predicate or adjusting the threshold in the default predicate.
         public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
+
+        /// The predicate used to classify the "last interaction" for the Interaction-To-Next-View (ITNV) metric.
+        ///
+        /// **Interaction-To-Next-View (ITNV)** is a metric that measures how long it takes from the last user interaction in a previous view
+        /// until the next view starts. It provides insight into how quickly a new view is displayed after a user’s action.
+        ///
+        /// The `NextViewActionPredicate` determines which action in the previous view should be considered the "last interaction" for ITNV,
+        /// based on properties such as action type, name, or timing relative to the next view’s start.
+        ///
+        /// Default: The default predicate, `TimeBasedITNVActionPredicate`, classifies actions as the last interaction if they occur within a
+        /// 3-second threshold before the next view starts. You can customize this time threshold or provide your own predicate.
+        public var nextViewActionPredicate: NextViewActionPredicate
 
         /// Custom mapper for RUM view events.
         ///
@@ -356,7 +368,10 @@ extension RUM.Configuration {
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
     ///   - trackWatchdogTerminations: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
-    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-to-Network-Settled (TTNS) metric calculation. Default: `TimeBasedTTNSResourcePredicate()`.
+    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-To-Network-Settled (TTNS) metric calculation.
+    ///     Default: `TimeBasedTTNSResourcePredicate()`.
+    ///   - nextViewActionPredicate: The predicate used to classify which action in the previous view is considered the "last interaction"
+    ///     for the Interaction-To-Next-View (ITNV) metric. Default: `TimeBasedITNVActionPredicate()`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
     ///   - actionEventMapper: Custom mapper for RUM action events. Default: `nil`.
@@ -378,6 +393,7 @@ extension RUM.Configuration {
         trackWatchdogTerminations: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
         networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),
+        nextViewActionPredicate: NextViewActionPredicate = TimeBasedITNVActionPredicate(),
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
         actionEventMapper: RUM.ActionEventMapper? = nil,
@@ -398,6 +414,7 @@ extension RUM.Configuration {
         self.appHangThreshold = appHangThreshold
         self.vitalsUpdateFrequency = vitalsUpdateFrequency
         self.networkSettledResourcePredicate = networkSettledResourcePredicate
+        self.nextViewActionPredicate = nextViewActionPredicate
         self.viewEventMapper = viewEventMapper
         self.resourceEventMapper = resourceEventMapper
         self.actionEventMapper = actionEventMapper

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -8,104 +8,165 @@ import Foundation
 
 internal protocol ITNVMetricTracking {
     /// Tracks an action in a given view.
-    /// Actions can be tracked even if the view is no longer active. For example, a "tap" can start in one view, but be tracked
-    /// through this method even after the next view is started.
+    ///
+    /// An action can start in one view but still be tracked through this method even after the next view begins.
+    /// For instance, a tap might begin in one view but end after the next view is already displayed.
+    ///
     /// - Parameters:
-    ///   - startTime: The start time of the action.
-    ///   - endTime: The end time of the action.
-    ///   - actionType: The type of the user action.
-    ///   - viewID: The ID of the view where the action occurred.
-    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID)
+    ///   - startTime: The time when the action started (device time, no NTP offset).
+    ///   - endTime: The time when the action ended (device time, no NTP offset).
+    ///   - name: A string identifying the action (e.g., button label).
+    ///   - type: The specific type of the action (e.g., tap, swipe).
+    ///   - viewID: The unique identifier of the view where the action was initiated.
+    func trackAction(startTime: Date, endTime: Date, name: String, type: RUMActionType, in viewID: RUMUUID)
 
     /// Tracks the start of a view.
-    /// From this moment, calls to `value(for:)` for this `viewID` will return the value of ITNV.
+    ///
+    /// From this point forward, calling `value(for:)` with this `viewID` can return an ITNV value, until the view is completed.
+    ///
     /// - Parameters:
-    ///   - startTime: The timestamp when the view starts.
-    ///   - viewID: The ID of the view that has just started.
-    func trackViewStart(at startTime: Date, viewID: RUMUUID)
+    ///   - startTime: The time when the view becomes active (device time, no NTP offset).
+    ///   - name: A human-readable name of the view.
+    ///   - viewID: The unique identifier of the newly started view.
+    func trackViewStart(at startTime: Date, name: String, viewID: RUMUUID)
 
     /// Marks the completion of a view.
-    /// Indicates that the view event will no longer be updated and no more calls to `value(for:)` for this `viewID` will be made.
-    /// - Parameter viewID: The ID of the view that has completed.
+    ///
+    /// Indicates that the view is no longer updated and that `value(for:)` calls for this `viewID` will no longer occur.
+    ///
+    /// - Parameter viewID: The unique identifier of the view that has been completed.
     func trackViewComplete(viewID: RUMUUID)
 
-    /// Retrieves the ITNV value for a specific view.
-    /// Values are available after a view starts and before it completes.
-    /// - Parameters:
-    ///   - viewID: The ID of the view for which the ITNV value is requested.
-    /// - Returns: The ITNV value (time interval) for the specified view, or `nil` if not available (the view has been completed).
+    /// Retrieves the ITNV value for a specified view.
+    ///
+    /// The ITNV value is available only after the view has started and before it’s marked completed.
+    ///
+    /// - Parameter viewID: The unique identifier of the view for which the metric is requested.
+    /// - Returns: The ITNV value (time interval) for the specified view, or `nil` if unavailable.
     func value(for viewID: RUMUUID) -> TimeInterval?
 }
 
 internal final class ITNVMetric: ITNVMetricTracking {
-    enum Constants {
-        /// The maximum allowed duration for the ITNV metric. Values exceeding this threshold are ignored.
-        static let maxDuration: TimeInterval = 3
+    /// Represents a user action.
+    private struct Action {
+        let type: RUMActionType
+        let name: String
+        let date: Date
+        let duration: TimeInterval
     }
 
-    /// The time of the last recorded action in the previous view.
-    private var lastActionDateByViewID: [RUMUUID: Date] = [:]
+    /// Represents a view in the ITNV workflow.
+    private struct View {
+        let name: String
+        let startTime: Date
+        /// Holds the identifier of the previous view, so we can compute ITNV from the previous view's action to this view's start.
+        let previousViewID: RUMUUID?
+        /// Stores actions tracked during this view.
+        var actions: [Action] = []
+    }
 
-    /// Stores the start times of views.
-    private var startDateByViewID: [RUMUUID: Date] = [:]
+    /// Holds all tracked views by their unique identifiers.
+    private var viewsByID: [RUMUUID: View] = [:]
 
-    /// Tracks the previous view associated with each view.
-    private var previousViewByViewID: [RUMUUID: RUMUUID] = [:]
-
-    /// The ID of the current view.
+    /// The identifier of the currently active view.
     private var currentViewID: RUMUUID?
 
-    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID) {
-        // Retrieve the last recorded action time for the given view
-        let lastDate = lastActionDateByViewID[viewID]
-        switch actionType {
-        case .tap, .click: // Discrete actions like tap or click should use their start time
-            lastActionDateByViewID[viewID] = max(startTime, lastDate ?? .distantPast)
-        case .swipe: // Continuous actions like swipe should use their end time
-            lastActionDateByViewID[viewID] = max(endTime, lastDate ?? .distantPast)
-        case .scroll, .custom:
-            return // Ignore scroll and custom actions for ITNV calculation
-        }
+    /// Predicate for determining which action qualifies as the "last interaction" for the ITNV metric.
+    private let predicate: NextViewActionPredicate
+
+    /// Initializes the ITNV metric system with an optional custom predicate.
+    ///
+    /// - Parameter predicate: A predicate defining which action is considered the "last interaction" in the previous view.
+    init(predicate: NextViewActionPredicate = TimeBasedITNVActionPredicate()) {
+        self.predicate = predicate
     }
 
-    func trackViewStart(at startTime: Date, viewID: RUMUUID) {
-        startDateByViewID[viewID] = startTime
-        previousViewByViewID[viewID] = currentViewID
+    func trackAction(startTime: Date, endTime: Date, name: String, type: RUMActionType, in viewID: RUMUUID) {
+        guard var view = viewsByID[viewID] else {
+            return // The view has not been started or is unknown.
+        }
+        defer { viewsByID[viewID] = view } // Update the stored view after modifications.
+
+        guard startTime >= view.startTime else {
+            return // Ignore actions that occurred before the view started.
+        }
+
+        let action = Action(
+            type: type,
+            name: name,
+            date: startTime,
+            duration: endTime.timeIntervalSince(startTime)
+        )
+        view.actions.append(action)
+    }
+
+    func trackViewStart(at startTime: Date, name: String, viewID: RUMUUID) {
+        // Create and store a new view, referencing the previously active view.
+        viewsByID[viewID] = View(name: name, startTime: startTime, previousViewID: currentViewID)
         currentViewID = viewID
     }
 
     func trackViewComplete(viewID: RUMUUID) {
-        startDateByViewID[viewID] = nil
-
-        if let previousViewID = previousViewByViewID[viewID] {
-            lastActionDateByViewID[previousViewID] = nil
+        // When this view completes, remove its previous view entry because it’s no longer needed.
+        // We still keep the current view entry, as it may be needed to compute ITNV for the next view.
+        guard let view = viewsByID[viewID], let previousViewID = view.previousViewID else {
+            return
         }
-        previousViewByViewID[viewID] = nil
-
-        if viewID == currentViewID {
-            currentViewID = nil
-        }
+        viewsByID[previousViewID] = nil
     }
 
     func value(for viewID: RUMUUID) -> TimeInterval? {
-        guard let viewStartDate = startDateByViewID[viewID] else {
-            return nil // View has not started yet
+        guard let view = viewsByID[viewID] else {
+            return nil // The view was never started or no longer exists.
         }
 
-        guard let previousViewID = previousViewByViewID[viewID] else {
-            return nil // No previous view for this one
+        guard let previousViewID = view.previousViewID else {
+            return nil // There is no preceding view to compute ITNV from.
         }
 
-        guard let lastActionDate = lastActionDateByViewID[previousViewID] else {
-            return nil // No action recorded in the previous view
+        guard var previousView = viewsByID[previousViewID] else {
+            return nil // The previous view has been removed.
+        }
+        defer { viewsByID[previousViewID] = previousView } // Update the stored view after modifications.
+
+        // Find the most recent action in the previous view that the predicate accepts as "last interaction."
+        let lastAction = previousView.actions
+            .reversed()
+            .first { action in
+                let params = actionParams(for: action, nextViewStart: view.startTime, nextViewName: view.name)
+                return predicate.isLastAction(action: params)
+            }
+
+        guard let lastAction = lastAction else {
+            previousView.actions = [] // No "last interaction"; remove all actions so we don't ask again
+            return nil
         }
 
-        let itnvValue = viewStartDate.timeIntervalSince(lastActionDate)
+        // Keep only the action classified as "last interaction." Future actions can still be appended after this one.
+        previousView.actions = [lastAction]
 
-        guard itnvValue <= Constants.maxDuration else {
-            return nil // ITNV exceeds the maximum allowed duration, return nil
+        return timeToNextView(for: lastAction, nextViewStart: view.startTime)
+    }
+
+    /// Creates the params object for the given action, to be inspected by the `NextViewActionPredicate`.
+    private func actionParams(for action: Action, nextViewStart: Date, nextViewName: String) -> ITNVActionParams {
+        return ITNVActionParams(
+            type: action.type,
+            name: action.name,
+            timeToNextView: timeToNextView(for: action, nextViewStart: nextViewStart),
+            nextViewName: nextViewName
+        )
+    }
+
+    /// Computes the interval from the user action to the start of the next view, depending on the action type.
+    /// For some action types (tap, click, custom), the relevant start time is `action.date`.
+    /// For others (scroll, swipe), we account for the action's duration.
+    private func timeToNextView(for action: Action, nextViewStart: Date) -> TimeInterval {
+        switch action.type {
+        case .tap, .click, .custom:
+            return nextViewStart.timeIntervalSince(action.date)
+        case .scroll, .swipe:
+            return nextViewStart.timeIntervalSince(action.date + action.duration)
         }
-
-        return itnvValue
     }
 }

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -129,12 +129,14 @@ internal final class ITNVMetric: ITNVMetricTracking {
         }
         defer { viewsByID[previousViewID] = previousView } // Update the stored view after modifications.
 
-        // Find the most recent action in the previous view that the predicate accepts as "last interaction."
+        // We iterate actions in reverse chronological order, stopping on the first match.
+        // This reflects the ITNV contract that the "last interaction" is determined by
+        // checking the most recent actions first.
         let lastAction = previousView.actions
             .reversed()
             .first { action in
                 let params = actionParams(for: action, nextViewStart: view.startTime, nextViewName: view.name)
-                return predicate.isLastAction(action: params)
+                return predicate.isLastAction(from: params)
             }
 
         guard let lastAction = lastAction else {

--- a/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/ITNVMetric.swift
@@ -77,7 +77,7 @@ internal final class ITNVMetric: ITNVMetricTracking {
     /// Initializes the ITNV metric system with an optional custom predicate.
     ///
     /// - Parameter predicate: A predicate defining which action is considered the "last interaction" in the previous view.
-    init(predicate: NextViewActionPredicate = TimeBasedITNVActionPredicate()) {
+    init(predicate: NextViewActionPredicate) {
         self.predicate = predicate
     }
 

--- a/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
@@ -22,15 +22,15 @@ public struct TTNSResourceParams {
 /// Implement this protocol to customize the logic for determining which resources are included in the TTNS calculation.
 ///
 /// **Note:**
-/// - The `isInitialResource(resource:)` method will be called on a secondary thread.
+/// - The `isInitialResource(from:)` method will be called on a secondary thread.
 /// - The implementation must not assume any threading behavior and should avoid blocking the thread.
 /// - The method should always return the same result for the same input parameters to ensure consistency in TTNS calculation.
 public protocol NetworkSettledResourcePredicate {
     /// Determines if the provided resource should be included in the TTNS metric calculation.
     ///
-    /// - Parameter resource: The parameters of the resource.
+    /// - Parameter resourceParams: The parameters of the resource.
     /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
-    func isInitialResource(resource: TTNSResourceParams) -> Bool
+    func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool
 }
 
 /// A predicate implementation for classifying Time-to-Network-Settled (TTNS) resources based on a time threshold.
@@ -54,9 +54,9 @@ public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate {
     /// Determines if the provided resource should be included in the TTNS metric calculation.
     /// A resource is included if it starts within the specified threshold from the view start time.
     ///
-    /// - Parameter resource: The parameters of the resource.
+    /// - Parameter resourceParams: The parameters of the resource.
     /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
-    public func isInitialResource(resource: TTNSResourceParams) -> Bool {
-        return resource.timeSinceViewStart <= threshold
+    public func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+        return resourceParams.timeSinceViewStart <= threshold
     }
 }

--- a/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
@@ -22,7 +22,7 @@ public struct TTNSResourceParams {
 /// Implement this protocol to customize the logic for determining which resources are included in the TTNS calculation.
 ///
 /// **Note:**
-/// - The `isInitialResource` method will be called on a secondary thread.
+/// - The `isInitialResource(resource:)` method will be called on a secondary thread.
 /// - The implementation must not assume any threading behavior and should avoid blocking the thread.
 /// - The method should always return the same result for the same input parameters to ensure consistency in TTNS calculation.
 public protocol NetworkSettledResourcePredicate {

--- a/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
@@ -30,7 +30,7 @@ public struct ITNVActionParams {
 /// in the subsequent view will be measured from this action’s time to the new view’s start.
 ///
 /// **Note:**
-/// - The `isLastAction(action:)` method will be called on a secondary thread.
+/// - The `isLastAction(from:)` method will be called on a secondary thread.
 /// - The implementation must not assume any specific threading behavior and should avoid blocking.
 /// - The method should always return the same result for identical input parameters to ensure consistent ITNV calculation.
 public protocol NextViewActionPredicate {
@@ -39,9 +39,9 @@ public protocol NextViewActionPredicate {
     /// This method is invoked in reverse chronological order for all actions in the previous view. Once `true` is returned,
     /// the iteration stops, and the accepted action defines the starting point for the ITNV metric.
     ///
-    /// - Parameter action: The parameters of the action (type, name, time to next view, and next view name).
+    /// - Parameter actionParams: The parameters of the action (type, name, time to next view, and next view name).
     /// - Returns: `true` if this action is the "last interaction" for ITNV, `false` otherwise.
-    func isLastAction(action: ITNVActionParams) -> Bool
+    func isLastAction(from actionParams: ITNVActionParams) -> Bool
 }
 
 /// A predicate implementation for classifying the "last interaction" for the Interaction-To-Next-View (ITNV) metric
@@ -66,17 +66,17 @@ public struct TimeBasedITNVActionPredicate: NextViewActionPredicate {
 
     /// Determines if the provided action should be considered the "last interaction" for ITNV, based on its action type and timing.
     ///
-    /// - Parameter action: The parameters of the action (type, name, time to next view, and next view name).
+    /// - Parameter actionParams: The parameters of the action (type, name, time to next view, and next view name).
     /// - Returns: `true` if the action’s `timeToNextView` is within `maxTimeToNextView` and its type is `tap`, `click`, or `swipe`;
     ///            otherwise, `false`.
-    public func isLastAction(action: ITNVActionParams) -> Bool {
+    public func isLastAction(from actionParams: ITNVActionParams) -> Bool {
         // Action must occur within the allowed time range
-        guard action.timeToNextView >= 0, action.timeToNextView <= maxTimeToNextView else {
+        guard actionParams.timeToNextView >= 0, actionParams.timeToNextView <= maxTimeToNextView else {
             return false
         }
 
         // Only specific action types qualify as the "last interaction"
-        switch action.type {
+        switch actionParams.type {
         case .tap, .click, .swipe:
             return true
         case .scroll, .custom:

--- a/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
@@ -1,0 +1,86 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A struct representing the parameters of a RUM action that may be considered the "last interaction" in the previous view
+/// for the Interaction-To-Next-View (ITNV) metric.
+public struct ITNVActionParams {
+    /// The type of the action (e.g., tap, swipe, click).
+    public let type: RUMActionType
+
+    /// The name of the action.
+    public let name: String
+
+    /// The time elapsed between this action and the start of the next view.
+    public let timeToNextView: TimeInterval
+
+    /// The name of the next view.
+    public let nextViewName: String
+}
+
+/// A protocol for classifying which action in the previous view should be considered the "last interaction" for the
+/// Interaction-To-Next-View (ITNV) metric.
+///
+/// This predicate is called in reverse chronological order for each action in the previous view until an implementation
+/// returns `true`. The action for which `true` is returned will be classified as the "last interaction," and the ITNV metric
+/// in the subsequent view will be measured from this action’s time to the new view’s start.
+///
+/// **Note:**
+/// - The `isLastAction(action:)` method will be called on a secondary thread.
+/// - The implementation must not assume any specific threading behavior and should avoid blocking.
+/// - The method should always return the same result for identical input parameters to ensure consistent ITNV calculation.
+public protocol NextViewActionPredicate {
+    /// Determines whether the provided action should be classified as the "last interaction" in the previous view for ITNV calculation.
+    ///
+    /// This method is invoked in reverse chronological order for all actions in the previous view. Once `true` is returned,
+    /// the iteration stops, and the accepted action defines the starting point for the ITNV metric.
+    ///
+    /// - Parameter action: The parameters of the action (type, name, time to next view, and next view name).
+    /// - Returns: `true` if this action is the "last interaction" for ITNV, `false` otherwise.
+    func isLastAction(action: ITNVActionParams) -> Bool
+}
+
+/// A predicate implementation for classifying the "last interaction" for the Interaction-To-Next-View (ITNV) metric
+/// based on a time threshold and action type. This predicate considers tap, click, or swipe actions in the previous view
+/// as valid if the interval between the action and the next view’s start (`timeToNextView`) is within `maxTimeToNextView`.
+///
+/// The default value of `maxTimeToNextView` is `3` seconds.
+public struct TimeBasedITNVActionPredicate: NextViewActionPredicate {
+    /// The default maximum time interval for considering an action as the "last interaction."
+    public static let defaultMaxTimeToNextView: TimeInterval = 3
+
+    /// The maximum duration (in seconds) from the action to the next view’s start. Actions exceeding this duration are ignored.
+    let maxTimeToNextView: TimeInterval
+
+    /// Initializes a new predicate with a specified maximum time interval.
+    ///
+    /// - Parameter maxTimeToNextView: The maximum time interval (in seconds) from the action to the next view’s start.
+    ///                                The default value is `3` seconds.
+    public init(maxTimeToNextView: TimeInterval = TimeBasedITNVActionPredicate.defaultMaxTimeToNextView) {
+        self.maxTimeToNextView = maxTimeToNextView
+    }
+
+    /// Determines if the provided action should be considered the "last interaction" for ITNV, based on its action type and timing.
+    ///
+    /// - Parameter action: The parameters of the action (type, name, time to next view, and next view name).
+    /// - Returns: `true` if the action’s `timeToNextView` is within `maxTimeToNextView` and its type is `tap`, `click`, or `swipe`;
+    ///            otherwise, `false`.
+    public func isLastAction(action: ITNVActionParams) -> Bool {
+        // Action must occur within the allowed time range
+        guard action.timeToNextView >= 0, action.timeToNextView <= maxTimeToNextView else {
+            return false
+        }
+
+        // Only specific action types qualify as the "last interaction"
+        switch action.type {
+        case .tap, .click, .swipe:
+            return true
+        case .scroll, .custom:
+            return false
+        }
+    }
+}

--- a/DatadogRUM/Sources/RUMMetrics/TTNSMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/TTNSMetric.swift
@@ -104,7 +104,7 @@ internal final class TTNSMetric: TTNSMetricTracking {
             timeSinceViewStart: startDate.timeIntervalSince(viewStartDate),
             viewName: viewName
         )
-        if resourcePredicate.isInitialResource(resource: resourceParams) {
+        if resourcePredicate.isInitialResource(from: resourceParams) {
             pendingResourcesStartDates[resourceID] = startDate
         }
     }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -57,6 +57,9 @@ internal struct RUMScopeDependencies {
     ///   - String: The name of the view.
     let networkSettledMetricFactory: (Date, String) -> TTNSMetricTracking
 
+    /// A factory function that creates a `ITNVMetric` when session starts.
+    let interactionToNextViewMetricFactory: () -> ITNVMetricTracking
+
     init(
         featureScope: FeatureScope,
         rumApplicationID: String,
@@ -75,7 +78,8 @@ internal struct RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying,
         sessionEndedMetric: SessionEndedMetricController,
         watchdogTermination: WatchdogTerminationMonitor?,
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking,
+        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID
@@ -96,6 +100,7 @@ internal struct RUMScopeDependencies {
         self.sessionEndedMetric = sessionEndedMetric
         self.watchdogTermination = watchdogTermination
         self.networkSettledMetricFactory = networkSettledMetricFactory
+        self.interactionToNextViewMetricFactory = interactionToNextViewMetricFactory
 
         if ciTest != nil {
             self.sessionType = .ciTest

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -105,7 +105,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             hasTrackedAnyView: false,
             didStartWithReplay: context.hasReplay
         )
-        self.interactionToNextViewMetric = ITNVMetric()
+        self.interactionToNextViewMetric = dependencies.interactionToNextViewMetricFactory()
 
         // Start tracking "RUM Session Ended" metric for this session
         dependencies.sessionEndedMetric.startMetric(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -207,7 +207,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 interactionToNextViewMetric.trackAction(
                     startTime: actionStartTime,
                     endTime: completionTime,
-                    actionType: actionType,
+                    name: name,
+                    type: actionType,
                     in: activeViewID
                 )
             }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -143,7 +143,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         }
         self.networkSettledMetric = dependencies.networkSettledMetricFactory(viewStartTime, viewName)
-        interactionToNextViewMetric.trackViewStart(at: startTime, viewID: viewUUID)
+        interactionToNextViewMetric.trackViewStart(at: startTime, name: name, viewID: viewUUID)
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -1236,10 +1236,10 @@ internal class TTNSMetricMock: TTNSMetricTracking {
 }
 
 internal class ITNVMetricMock: ITNVMetricTracking {
-    /// Tracks calls to `trackAction(startTime:endTime:actionType:in:)`.
-    var trackedActions: [(startTime: Date, endTime: Date, actionType: RUMActionType, viewID: RUMUUID)] = []
-    /// Tracks calls to `trackViewStart(at:viewID:)`.
-    var trackedViewStarts: [(viewStart: Date, viewID: RUMUUID)] = []
+    /// Tracks calls to `trackAction(startTime:endTime:name:type:in:)`.
+    var trackedActions: [(startTime: Date, endTime: Date, actionName: String, actionType: RUMActionType, viewID: RUMUUID)] = []
+    /// Tracks calls to `trackViewStart(at:name:viewID:)`.
+    var trackedViewStarts: [(viewStart: Date, viewName: String, viewID: RUMUUID)] = []
     /// Tracks calls to `trackViewComplete(viewID:)`.
     var trackedViewCompletes: Set<RUMUUID> = []
     /// Mocked value returned by this metric.
@@ -1249,12 +1249,12 @@ internal class ITNVMetricMock: ITNVMetricTracking {
         self.mockedValue = mockedValue
     }
 
-    func trackAction(startTime: Date, endTime: Date, actionType: RUMActionType, in viewID: RUMUUID) {
-        trackedActions.append((startTime: startTime, endTime: endTime, actionType: actionType, viewID: viewID))
+    func trackAction(startTime: Date, endTime: Date, name: String, type: RUMActionType, in viewID: RUMUUID) {
+        trackedActions.append((startTime: startTime, endTime: endTime, actionName: name, actionType: type, viewID: viewID))
     }
 
-    func trackViewStart(at viewStart: Date, viewID: RUMUUID) {
-        trackedViewStarts.append((viewStart: viewStart, viewID: viewID))
+    func trackViewStart(at viewStart: Date, name: String, viewID: RUMUUID) {
+        trackedViewStarts.append((viewStart: viewStart, viewName: name, viewID: viewID))
     }
 
     func trackViewComplete(viewID: RUMUUID) {

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -777,7 +777,8 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom(),
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { _, _ in TTNSMetricMock() }
+        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { _, _ in TTNSMetricMock() },
+        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking = { ITNVMetricMock() }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -797,7 +798,8 @@ extension RUMScopeDependencies {
             fatalErrorContext: fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric,
             watchdogTermination: watchdogTermination,
-            networkSettledMetricFactory: networkSettledMetricFactory
+            networkSettledMetricFactory: networkSettledMetricFactory,
+            interactionToNextViewMetricFactory: interactionToNextViewMetricFactory
         )
     }
 
@@ -819,7 +821,8 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil
+        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
+        interactionToNextViewMetricFactory: (() -> ITNVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -839,7 +842,8 @@ extension RUMScopeDependencies {
             fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric,
             watchdogTermination: watchdogTermination,
-            networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory
+            networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory,
+            interactionToNextViewMetricFactory: interactionToNextViewMetricFactory ?? self.interactionToNextViewMetricFactory
         )
     }
 }

--- a/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
@@ -11,8 +11,8 @@ import TestUtilities
 private struct NextViewActionPredicateMock: NextViewActionPredicate {
     let shouldConsiderLastAction: (ITNVActionParams) -> Bool
 
-    func isLastAction(action: ITNVActionParams) -> Bool {
-        shouldConsiderLastAction(action)
+    func isLastAction(from actionParams: ITNVActionParams) -> Bool {
+        shouldConsiderLastAction(actionParams)
     }
 }
 

--- a/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/ITNVMetricTests.swift
@@ -5,21 +5,122 @@
  */
 
 import XCTest
+import TestUtilities
 @testable import DatadogRUM
 
+private struct NextViewActionPredicateMock: NextViewActionPredicate {
+    let shouldConsiderLastAction: (ITNVActionParams) -> Bool
+
+    func isLastAction(action: ITNVActionParams) -> Bool {
+        shouldConsiderLastAction(action)
+    }
+}
+
 class ITNVMetricTests: XCTestCase {
-    private var metric: ITNVMetric! // swiftlint:disable:this implicitly_unwrapped_optional
     private let previousViewID: RUMUUID = .mockRandom()
     private let currentViewID: RUMUUID = .mockRandom()
     private let currentViewStart = Date()
 
-    override func setUp() {
-        metric = ITNVMetric()
+    /// Mock predicate that accepts all actions as the "last" one.
+    private let mockAcceptAllActionsPredicate = NextViewActionPredicateMock(shouldConsiderLastAction: { _ in true })
+    /// Mock predicate that rejects all actions as the "last" one.
+    private let mockRejectAllActionsPredicate = NextViewActionPredicateMock(shouldConsiderLastAction: { _ in false })
+
+    /// Creates `ITNVMetric` instance for testing.
+    private func createMetric(nextViewActionPredicate: NextViewActionPredicate) -> ITNVMetric {
+        return ITNVMetric(predicate: nextViewActionPredicate)
     }
 
-    override func tearDown() {
-        metric = nil
+    // MARK: - "Last Action" Classification
+
+    func testGivenTimeBasedActionPredicate_whenViewStartsSoonerThanThreshold_thenMetricValueIsAvailable() throws {
+        let threshold = TimeBasedITNVActionPredicate.defaultMaxTimeToNextView
+
+        func when(timeToNextView: TimeInterval) -> TimeInterval? {
+            // Given
+            let predicate = TimeBasedITNVActionPredicate(maxTimeToNextView: threshold)
+            let metric = createMetric(nextViewActionPredicate: predicate)
+
+            // When
+            let actionStartTime = currentViewStart - timeToNextView
+            metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+            metric.trackAction(startTime: actionStartTime, endTime: actionStartTime, name: .mockAny(), type: .tap, in: previousViewID)
+            metric.trackViewComplete(viewID: previousViewID)
+            metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
+
+            // Then
+            return metric.value(for: currentViewID)
+        }
+
+        XCTAssertNotNil(when(timeToNextView: threshold))
+        XCTAssertNotNil(when(timeToNextView: threshold * 0.5))
+        XCTAssertNotNil(when(timeToNextView: threshold * 0.99))
+
+        XCTAssertNil(when(timeToNextView: threshold * 1.01))
+        XCTAssertNil(when(timeToNextView: -threshold))
+        XCTAssertNil(when(timeToNextView: threshold * 10))
     }
+
+    // MARK: - "Last Action" Classification With Custom Predicate
+
+    func testWhenActionIsAcceptedByPredicate_thenMetricValueIsAvailable() {
+        let (t0, t1, t2) = (currentViewStart - 10, currentViewStart - 5, currentViewStart)
+        let predicate = mockAcceptAllActionsPredicate
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: predicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+
+        // When
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
+
+        // Then
+        XCTAssertNotNil(metric.value(for: currentViewID), "The ITNV value should be available if any action was accepted.")
+    }
+
+    func testWhenActionIsRejectedByPredicate_thenMetricValueIsNotAvailable() {
+        let (t0, t1, t2) = (currentViewStart - 10, currentViewStart - 5, currentViewStart)
+        let predicate = mockRejectAllActionsPredicate
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: predicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+
+        // When
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
+
+        // Then
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should not be available if no action was accepted.")
+    }
+
+    func testMetricValueIsComputedFromAcceptedAction() throws {
+        let actions: [(date: Date, name: String)] = [
+            (currentViewStart - 5, "Action 1"),
+            (currentViewStart - 4, "Action 2"),
+            (currentViewStart - 3, "Action 3"),
+            (currentViewStart - 2, "Action 4"),
+            (currentViewStart - 1, "Action 5"),
+        ]
+        let predicate = NextViewActionPredicateMock(shouldConsiderLastAction: { $0.name == "Action 3" })
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: predicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        actions.forEach {
+            metric.trackAction(startTime: $0.date, endTime: $0.date, name: $0.name, type: .tap, in: previousViewID)
+        }
+
+        // When
+        metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
+
+        // Then
+        let itnv = try XCTUnwrap(metric.value(for: currentViewID))
+        XCTAssertEqual(itnv, 3, accuracy: 0.01, "The ITNV value should be computed from accepted action (Action 3).")
+    }
+
+    // MARK: - Metric Value
 
     func testMetricValueIsCalculatedDifferentlyForEachActionType() {
         let actionStart = Date()
@@ -28,12 +129,12 @@ class ITNVMetricTests: XCTestCase {
 
         func when(actionType: RUMActionType) -> TimeInterval? {
             // Given
-            let metric = ITNVMetric()
+            let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
 
             // When
-            metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-            metric.trackAction(startTime: actionStart, endTime: actionEnd, actionType: actionType, in: previousViewID)
-            metric.trackViewStart(at: viewStart, viewID: currentViewID)
+            metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+            metric.trackAction(startTime: actionStart, endTime: actionEnd, name: .mockAny(), type: actionType, in: previousViewID)
+            metric.trackViewStart(at: viewStart, name: .mockAny(), viewID: currentViewID)
 
             // Then
             return metric.value(for: currentViewID)
@@ -45,20 +146,41 @@ class ITNVMetricTests: XCTestCase {
         XCTAssertEqual(when(actionType: .tap)!, timeSinceActionStart, accuracy: 0.01, "For TAP, the ITNV value should be calculated from the start of the action.")
         XCTAssertEqual(when(actionType: .click)!, timeSinceActionStart, accuracy: 0.01, "For CLICK, the ITNV value should be calculated from the start of the action.")
         XCTAssertEqual(when(actionType: .swipe)!, timeSinceActionEnd, accuracy: 0.01, "For SWIPE, the ITNV value should be calculated from the end of the action.")
-        XCTAssertNil(when(actionType: .scroll), "The value should not be calculated for SCROLL actions.")
-        XCTAssertNil(when(actionType: .custom), "The value should not be calculated for CUSTOM actions.")
+        XCTAssertEqual(when(actionType: .scroll)!, timeSinceActionEnd, accuracy: 0.01, "For SCROLL, the ITNV value should be calculated from the end of the action.")
+        XCTAssertEqual(when(actionType: .custom)!, timeSinceActionStart, accuracy: 0.01, "For CUSTOM actions, the ITNV value should be calculated from the start of the action.")
     }
 
-    func testWhenViewStarts_thenMetricValueIsAvailable() throws {
+    // MARK: - Value Availability vs View Completion
+
+    func testWhenViewStartsBeforePreviousViewCompletes_thenMetricValueIsAvailable() throws {
         let (t0, t1, t2) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart)
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
 
         // When
         XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil before the current view starts.")
-        metric.trackViewStart(at: t2, viewID: currentViewID)
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
+
+        // Then
+        let itnv = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should be available after the current view starts.")
+        XCTAssertEqual(itnv, 2.5, accuracy: 0.01, "The ITNV value should match the time interval from action start to view start.")
+    }
+
+    func testWhenViewStartsAfterPreviousViewCompletes_thenMetricValueIsAvailable() throws {
+        let (t0, t1, t2) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart)
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
+
+        // When
+        metric.trackViewComplete(viewID: previousViewID)
+        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil before the current view starts.")
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
 
         // Then
         let itnv = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should be available after the current view starts.")
@@ -69,9 +191,10 @@ class ITNVMetricTests: XCTestCase {
         let (t0, t1, t2) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart)
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
-        metric.trackViewStart(at: t2, viewID: currentViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
         XCTAssertNotNil(metric.value(for: currentViewID), "The ITNV value should be available before the view completes.")
 
         // When
@@ -85,13 +208,14 @@ class ITNVMetricTests: XCTestCase {
         let (t0, t1, t2, t3) = (currentViewStart - 2.5, currentViewStart - 1, currentViewStart, currentViewStart + 1.2)
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
-        metric.trackViewStart(at: t2, viewID: currentViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t1, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: t2, name: .mockAny(), viewID: currentViewID)
 
         // When
         let itnv1 = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should be available before the current view completes.")
-        metric.trackViewStart(at: t3, viewID: .mockRandom()) // another view starts
+        metric.trackViewStart(at: t3, name: .mockAny(), viewID: .mockRandom()) // another view starts
         let itnv2 = try XCTUnwrap(metric.value(for: currentViewID), "The ITNV value should remain available before the current view completes.")
         metric.trackViewComplete(viewID: currentViewID) // view completes
 
@@ -105,13 +229,14 @@ class ITNVMetricTests: XCTestCase {
         let (t0, t1) = (currentViewStart - 1.5, currentViewStart)
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
 
         // When
-        metric.trackViewStart(at: t1, viewID: currentViewID)
+        metric.trackViewStart(at: t1, name: .mockAny(), viewID: currentViewID)
         let itnv1 = metric.value(for: currentViewID)
 
-        metric.trackAction(startTime: t0, endTime: t0 + 0.1, actionType: .tap, in: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t0 + 0.1, name: .mockAny(), type: .tap, in: previousViewID)
         let itnv2 = try XCTUnwrap(metric.value(for: currentViewID))
 
         // Then
@@ -123,9 +248,10 @@ class ITNVMetricTests: XCTestCase {
         let (t0, t1) = (currentViewStart - 1.5, currentViewStart)
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-        metric.trackAction(startTime: t0, endTime: t0 + 0.1, actionType: .tap, in: previousViewID)
-        metric.trackViewStart(at: t1, viewID: currentViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: t0, endTime: t0 + 0.1, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: t1, name: .mockAny(), viewID: currentViewID)
 
         // When
         metric.trackViewComplete(viewID: previousViewID)
@@ -134,29 +260,127 @@ class ITNVMetricTests: XCTestCase {
         XCTAssertNotNil(metric.value(for: currentViewID))
     }
 
-    func testWhenITNVExceedsMaxDuration_thenMetricValueIsNil() {
-        let maxDuration = ITNVMetric.Constants.maxDuration + 0.01
-        let (t0, t1, t2) = (currentViewStart - maxDuration, currentViewStart - 1, currentViewStart)
+    // MARK: - Interaction With Predicate
+
+    func testWhenComputingMetricValue_itCallsPredicateWithAllActionsOnlyOnce() throws {
+        let actions: [(date: Date, name: String)] = [
+            (currentViewStart - 5, "Action 1"),
+            (currentViewStart - 4, "Action 2"),
+            (currentViewStart - 3, "Action 3"),
+            (currentViewStart - 2, "Action 4"),
+            (currentViewStart - 1, "Action 5"),
+        ]
+        var actionNamesInPredicate: [String] = []
+        let predicate = NextViewActionPredicateMock(shouldConsiderLastAction: {
+            actionNamesInPredicate.append($0.name) // track each
+            return false // accept none
+        })
 
         // Given
-        metric.trackViewStart(at: .distantPast, viewID: previousViewID)
-        metric.trackAction(startTime: t0, endTime: t1, actionType: .tap, in: previousViewID)
+        let metric = createMetric(nextViewActionPredicate: predicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        actions.forEach {
+            metric.trackAction(startTime: $0.date, endTime: $0.date, name: $0.name, type: .tap, in: previousViewID)
+        }
+        metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
 
-        // When
-        metric.trackViewStart(at: t2, viewID: currentViewID)
+        // When (compute metric multiple times)
+        _ = metric.value(for: currentViewID)
+        _ = metric.value(for: currentViewID)
+        _ = metric.value(for: currentViewID)
 
         // Then
-        XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should not be stored when the duration exceeds the maximum allowed.")
+        let expectedActions = Array(actions.map({ $0.name }).reversed())
+        XCTAssertEqual(actionNamesInPredicate, expectedActions, "It should call predicate with all actions, starting from the youngest one")
     }
+
+    func testWhenComputingMetricValue_itCallsPredicateWithAllActionsFromPreviousView() throws {
+        struct ActionFixture {
+            let name: String
+            let type: RUMActionType = .tap
+            let startTime: Date
+            var endTime: Date { startTime + 0.1 }
+        }
+
+        struct ViewFixture {
+            let id: RUMUUID = .mockRandom()
+            let name: String
+            let startTime: Date
+            let actions: [ActionFixture]
+        }
+
+        let view1Start = Date()
+        let view2Start = view1Start + 10
+        let view3Start = view2Start + 10
+
+        let viewFixtures: [ViewFixture] = [
+            ViewFixture(
+                name: "View 1",
+                startTime: view1Start,
+                actions: [
+                    ActionFixture(name: "Action 1A", startTime: view1Start + 1),
+                    ActionFixture(name: "Action 1B", startTime: view1Start + 2),
+                    ActionFixture(name: "Action 1C", startTime: view1Start + 3),
+                ]
+            ),
+            ViewFixture(
+                name: "View 2",
+                startTime: view2Start,
+                actions: [
+                    ActionFixture(name: "Action 2A", startTime: view2Start + 1),
+                    ActionFixture(name: "Action 2B", startTime: view2Start + 2),
+                ]
+            ),
+            ViewFixture(
+                name: "View 3",
+                startTime: view3Start,
+                actions: [
+                    ActionFixture(name: "Action 3A", startTime: view3Start + 1),
+                ]
+            )
+        ]
+
+        var actionsInPredicate: [ITNVActionParams] = []
+        let predicate = NextViewActionPredicateMock(shouldConsiderLastAction: {
+            actionsInPredicate.append($0) // track all
+            return false // accept none
+        })
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: predicate)
+
+        for view in viewFixtures {
+            metric.trackViewStart(at: view.startTime, name: view.name, viewID: view.id)
+
+            // When
+            _ = metric.value(for: view.id)
+
+            for action in view.actions {
+                metric.trackAction(startTime: action.startTime, endTime: action.endTime, name: action.name, type: action.type, in: view.id)
+            }
+            metric.trackViewComplete(viewID: view.id)
+        }
+
+        // Then
+        XCTAssertEqual(actionsInPredicate.count, 5)
+        DDAssertReflectionEqual(actionsInPredicate[0], ITNVActionParams(type: .tap, name: "Action 1C", timeToNextView: 7, nextViewName: "View 2"))
+        DDAssertReflectionEqual(actionsInPredicate[1], ITNVActionParams(type: .tap, name: "Action 1B", timeToNextView: 8, nextViewName: "View 2"))
+        DDAssertReflectionEqual(actionsInPredicate[2], ITNVActionParams(type: .tap, name: "Action 1A", timeToNextView: 9, nextViewName: "View 2"))
+        DDAssertReflectionEqual(actionsInPredicate[3], ITNVActionParams(type: .tap, name: "Action 2B", timeToNextView: 8, nextViewName: "View 3"))
+        DDAssertReflectionEqual(actionsInPredicate[4], ITNVActionParams(type: .tap, name: "Action 2A", timeToNextView: 9, nextViewName: "View 3"))
+    }
+
+    // MARK: - Edge Cases
 
     func testWhenNoActionIsTracked_thenMetricHasNoValue() {
         let (t0, t1) = (currentViewStart - 1, currentViewStart)
 
         // Given
-        metric.trackViewStart(at: t0, viewID: previousViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: t0, name: .mockAny(), viewID: previousViewID)
 
         // When
-        metric.trackViewStart(at: t1, viewID: currentViewID)
+        metric.trackViewStart(at: t1, name: .mockAny(), viewID: currentViewID)
 
         // Then
         XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil when no actions are tracked.")
@@ -164,9 +388,45 @@ class ITNVMetricTests: XCTestCase {
 
     func testWhenNoPreviousViewIsTracked_thenMetricHasNoValue() {
         // When
-        metric.trackViewStart(at: currentViewStart, viewID: currentViewID)
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
 
         // Then
         XCTAssertNil(metric.value(for: currentViewID), "The ITNV value should be nil when no previous view is tracked.")
+    }
+
+    func testWhenActionIsEarlierThanPreviousViewStart_thenItIsIgnored() throws {
+        let previousViewStart = currentViewStart - 10
+        let invalidActionDate = previousViewStart - 5
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: previousViewStart, name: .mockAny(), viewID: previousViewID)
+
+        // When
+        metric.trackAction(startTime: invalidActionDate, endTime: invalidActionDate, name: .mockAny(), type: .tap, in: previousViewID)
+
+        // Then
+        metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
+        XCTAssertNil(metric.value(for: currentViewID))
+    }
+
+    func testTrackingActionsInNotStartedViewsHasNoEffect() throws {
+        let actionDate = currentViewStart - 1
+
+        // Given
+        let metric = createMetric(nextViewActionPredicate: mockAcceptAllActionsPredicate)
+        metric.trackViewStart(at: .distantPast, name: .mockAny(), viewID: previousViewID)
+        metric.trackAction(startTime: actionDate, endTime: actionDate, name: .mockAny(), type: .tap, in: previousViewID)
+        metric.trackViewStart(at: currentViewStart, name: .mockAny(), viewID: currentViewID)
+
+        // When
+        let notStartedViewID: RUMUUID = .mockRandom()
+        metric.trackAction(startTime: .mockRandom(), endTime: .mockRandom(), name: .mockAny(), type: .tap, in: notStartedViewID)
+
+        // Then
+        let actualITNV = try XCTUnwrap(metric.value(for: currentViewID))
+        let expectedITNV = currentViewStart.timeIntervalSince(actionDate)
+        XCTAssertEqual(actualITNV, expectedITNV, accuracy: 0.01)
     }
 }

--- a/DatadogRUM/Tests/RUMMetrics/TTNSMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/TTNSMetricTests.swift
@@ -19,8 +19,8 @@ private extension RUMUUID {
 private struct ResourcePredicateMock: NetworkSettledResourcePredicate {
     let shouldConsiderInitialResource: (TTNSResourceParams) -> Bool
 
-    func isInitialResource(resource: TTNSResourceParams) -> Bool {
-        shouldConsiderInitialResource(resource)
+    func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+        shouldConsiderInitialResource(resourceParams)
     }
 }
 

--- a/DatadogRUM/Tests/RUMMetrics/TTNSMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/TTNSMetricTests.swift
@@ -45,9 +45,11 @@ class TTNSMetricTests: XCTestCase {
     // MARK: - "Initial Resource" Classification
 
     func testGivenTimeBasedResourcePredicate_whenResourceStartsWithinThreshold_thenItIsTracked() throws {
+        let threshold = TimeBasedTTNSResourcePredicate.defaultThreshold
+
         func when(resourceStartOffset offset: TimeInterval) -> TimeInterval? {
             // Given
-            let predicate = TimeBasedTTNSResourcePredicate(threshold: t100ms)
+            let predicate = TimeBasedTTNSResourcePredicate(threshold: threshold)
             let metric = createMetric(viewStartDate: viewStartDate, resourcePredicate: predicate)
 
             // When
@@ -62,13 +64,13 @@ class TTNSMetricTests: XCTestCase {
 
         // When resource starts within threshold (initial resource), it should be tracked:
         XCTAssertNotNil(when(resourceStartOffset: 0), "Resource starting at `view start` should be tracked as an initial resource.")
-        XCTAssertNotNil(when(resourceStartOffset: t100ms * 0.5), "Resource starting at `view start + \(t100ms * 0.5)s` should be tracked as an initial resource.")
-        XCTAssertNotNil(when(resourceStartOffset: t100ms * 0.999), "Resource starting at `view start + \(t100ms * 0.999)s` should be tracked as an initial resource.")
+        XCTAssertNotNil(when(resourceStartOffset: threshold * 0.5), "Resource starting at `view start + \(threshold * 0.5)s` should be tracked as an initial resource.")
+        XCTAssertNotNil(when(resourceStartOffset: threshold * 0.999), "Resource starting at `view start + \(threshold * 0.999)s` should be tracked as an initial resource.")
 
         // When resource starts outside threshold (other resource), it should not be tracked:
-        XCTAssertNil(when(resourceStartOffset: t100ms), "Resource starting at `view start + \(t100ms)s` should not be tracked as an initial resource.")
-        XCTAssertNil(when(resourceStartOffset: -t100ms), "Resource starting at `view start + \(-t100ms)s` should not be tracked as an initial resource.")
-        XCTAssertNil(when(resourceStartOffset: t100ms * 10), "Resource starting at `view start + \(t100ms * 10)s` should not be tracked as an initial resource.")
+        XCTAssertNil(when(resourceStartOffset: threshold), "Resource starting at `view start + \(threshold)s` should not be tracked as an initial resource.")
+        XCTAssertNil(when(resourceStartOffset: -threshold), "Resource starting at `view start + \(-threshold)s` should not be tracked as an initial resource.")
+        XCTAssertNil(when(resourceStartOffset: threshold * 10), "Resource starting at `view start + \(threshold * 10)s` should not be tracked as an initial resource.")
     }
 
     // MARK: - Metric Value vs Resource Completion

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -872,12 +872,15 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhenActionEventIsSent_itTrackActionInITNVMetric() throws {
         let actionStartTime: Date = .mockDecember15th2019At10AMUTC()
+        let actionName: String = .mockRandom()
+        let actionType: RUMActionType = .tap
 
         // Given
         let metric = ITNVMetricMock()
         let scope = RUMUserActionScope.mockWith(
             parent: parent,
-            actionType: .tap,
+            name: actionName,
+            actionType: actionType,
             startTime: actionStartTime,
             interactionToNextViewMetric: metric
         )
@@ -894,6 +897,8 @@ class RUMUserActionScopeTests: XCTestCase {
         let trackedAction = try XCTUnwrap(metric.trackedActions.first)
         XCTAssertEqual(trackedAction.startTime, actionStartTime)
         XCTAssertEqual(trackedAction.endTime, actionStartTime + RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+        XCTAssertEqual(trackedAction.actionName, actionName)
+        XCTAssertEqual(trackedAction.actionType, actionType)
         XCTAssertEqual(trackedAction.viewID, parent.context.activeViewID)
         XCTAssertEqual(metric.trackedActions.count, 1)
     }


### PR DESCRIPTION
### What and why?

📦 ⏱️ This PR introduces an API to customize the classification of interactions for the **Interaction-To-Next-View (ITNV)** metric using a predicate-based strategy. The predicate enables users to define which RUM actions in the previous view should be considered as the "last interaction" for calculating ITNV value (how long it takes to reach the next view).

This approach is similar to the TTNS metric API introduced in #2160.

**Previously**, ITNV was computed by fixed rules, always selecting the last "tap," "click," or "swipe" occurring within 3 seconds before the next view started. For example:

<img width="75%" alt="Screenshot 2024-12-31 at 14 06 52" src="https://github.com/user-attachments/assets/161fa4f1-e943-4585-832f-0804c12065e6" />

**Now**, with the `NextViewActionPredicate` protocol, developers can implement custom logic to classify the "last interaction." For example, they might choose actions based on a certain name:

<img width="75%" alt="Screenshot 2024-12-31 at 14 06 57" src="https://github.com/user-attachments/assets/ba8025b8-a110-439d-9845-cef327ef51ac" />

Users can also use the default `TimeBasedITNVActionPredicate` and adjust the `maxTimeToNextView` threshold.

### How?

This PR introduces the `NextViewActionPredicate` protocol, enabling custom classification logic:
```swift
public protocol NextViewActionPredicate {
    func isLastAction(from actionParams: ITNVActionParams) -> Bool
}
```
The default implementation, `TimeBasedITNVActionPredicate`, classifies an action as the "last interaction" if:
- It occurs within a configurable time threshold (default: 3s) before the next view starts.
- Its action type is one of: "tap", "click", or "swipe".

The `ITNVMetric` class now consumes this predicate, making ITNV calculations flexible and customizable. If no custom predicate is provided, the default time-based logic applies.

Lastly, integration and unit tests confirm the correct behavior of both the default and custom predicates.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
