### PR TITLE
chore: Fix CHANGELOG after 2.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.22.0 / 02-01-2025
+
 - [IMPROVEMENT] Add Datadog Configuration `backgroundTasksEnabled` ObjC API. See [#2148][]
 - [FIX] Prevent Session Replay to create two full snapshots in a row. See [#2154][]
 


### PR DESCRIPTION
### What and why?

🧽 `CHANGELOG.md` was not updated with 2.22.0 release.

### How?

Inserting `2.22.0` bar.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
