### PR TITLE
RUM-7106 refactor: Rename TTNS + ITNV to TNS + INV

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -274,10 +274,10 @@
 		6105C4FB2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */; };
 		6105C5032CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
 		6105C5042CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
-		6105C5092CFA222400C4C5EE /* ITNVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* ITNVMetric.swift */; };
-		6105C50A2CFA222400C4C5EE /* ITNVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* ITNVMetric.swift */; };
-		6105C5142D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */; };
-		6105C5152D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */; };
+		6105C5092CFA222400C4C5EE /* INVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* INVMetric.swift */; };
+		6105C50A2CFA222400C4C5EE /* INVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* INVMetric.swift */; };
+		6105C5142D0C584F00C4C5EE /* INVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */; };
+		6105C5152D0C584F00C4C5EE /* INVMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */; };
 		610ABD4C2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
 		610ABD4D2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */; };
 		61112F8E2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
@@ -2369,8 +2369,8 @@
 		6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetric.swift; sourceTree = "<group>"; };
 		6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetricTests.swift; sourceTree = "<group>"; };
 		6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLoadingMetricsTests.swift; sourceTree = "<group>"; };
-		6105C5082CFA222400C4C5EE /* ITNVMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNVMetric.swift; sourceTree = "<group>"; };
-		6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNVMetricTests.swift; sourceTree = "<group>"; };
+		6105C5082CFA222400C4C5EE /* INVMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INVMetric.swift; sourceTree = "<group>"; };
+		6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INVMetricTests.swift; sourceTree = "<group>"; };
 		610ABD4B2A6930CA00AFEA34 /* CoreTelemetryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTelemetryIntegrationTests.swift; sourceTree = "<group>"; };
 		61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDRUM+apiTests.m"; sourceTree = "<group>"; };
 		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
@@ -4180,7 +4180,7 @@
 			children = (
 				6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */,
 				618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */,
-				6105C5082CFA222400C4C5EE /* ITNVMetric.swift */,
+				6105C5082CFA222400C4C5EE /* INVMetric.swift */,
 				618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */,
 			);
 			path = RUMMetrics;
@@ -4190,7 +4190,7 @@
 			isa = PBXGroup;
 			children = (
 				6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */,
-				6105C5132D0C584F00C4C5EE /* ITNVMetricTests.swift */,
+				6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */,
 			);
 			path = RUMMetrics;
 			sourceTree = "<group>";
@@ -9087,7 +9087,7 @@
 				6174D6212C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				618F2B072D15922400A647C4 /* NextViewActionPredicate.swift in Sources */,
 				D23F8E8D29DDCD28001CFAE8 /* VitalRefreshRateReader.swift in Sources */,
-				6105C50A2CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
+				6105C50A2CFA222400C4C5EE /* INVMetric.swift in Sources */,
 				3CFF4F8C2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D23F8E8E29DDCD28001CFAE8 /* UIEventCommandFactory.swift in Sources */,
 				D23F8E8F29DDCD28001CFAE8 /* RUMUUIDGenerator.swift in Sources */,
@@ -9132,7 +9132,7 @@
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C12A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */,
-				6105C5152D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */,
+				6105C5152D0C584F00C4C5EE /* INVMetricTests.swift in Sources */,
 				D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CB2A3DC22700FA735A /* RUMTests.swift in Sources */,
 				D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */,
@@ -9431,7 +9431,7 @@
 				6174D6202C009C6300EC7469 /* SessionEndedMetricController.swift in Sources */,
 				618F2B062D15922400A647C4 /* NextViewActionPredicate.swift in Sources */,
 				D29A9F8929DD85BB005C54A4 /* VitalRefreshRateReader.swift in Sources */,
-				6105C5092CFA222400C4C5EE /* ITNVMetric.swift in Sources */,
+				6105C5092CFA222400C4C5EE /* INVMetric.swift in Sources */,
 				3CFF4F8B2C09E61A006F191D /* WatchdogTerminationAppState.swift in Sources */,
 				D29A9F6929DD85BB005C54A4 /* UIEventCommandFactory.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
@@ -9476,7 +9476,7 @@
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,
-				6105C5142D0C584F00C4C5EE /* ITNVMetricTests.swift in Sources */,
+				6105C5142D0C584F00C4C5EE /* INVMetricTests.swift in Sources */,
 				D29A9FAA29DDB483005C54A4 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CA2A3DC22700FA735A /* RUMTests.swift in Sources */,
 				D29A9FAC29DDB483005C54A4 /* RUMActionsHandlerTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -268,10 +268,10 @@
 		61054FD32A6EE1BA00AAA894 /* MultipartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F902A6EE1BA00AAA894 /* MultipartFormDataTests.swift */; };
 		61054FD42A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F912A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift */; };
 		61054FD52A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054F932A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift */; };
-		6105C4F62CEBA7A100C4C5EE /* TTNSMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */; };
-		6105C4F72CEBA7A100C4C5EE /* TTNSMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */; };
-		6105C4FA2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */; };
-		6105C4FB2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */; };
+		6105C4F62CEBA7A100C4C5EE /* TNSMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F52CEBA7A100C4C5EE /* TNSMetric.swift */; };
+		6105C4F72CEBA7A100C4C5EE /* TNSMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F52CEBA7A100C4C5EE /* TNSMetric.swift */; };
+		6105C4FA2CEBD72600C4C5EE /* TNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TNSMetricTests.swift */; };
+		6105C4FB2CEBD72600C4C5EE /* TNSMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C4F92CEBD72600C4C5EE /* TNSMetricTests.swift */; };
 		6105C5032CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
 		6105C5042CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */; };
 		6105C5092CFA222400C4C5EE /* INVMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C5082CFA222400C4C5EE /* INVMetric.swift */; };
@@ -2366,8 +2366,8 @@
 		61054F902A6EE1BA00AAA894 /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		61054F912A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentRequestBuilderTests.swift; sourceTree = "<group>"; };
 		61054F932A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssertRectsEqual.swift; sourceTree = "<group>"; };
-		6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetric.swift; sourceTree = "<group>"; };
-		6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTNSMetricTests.swift; sourceTree = "<group>"; };
+		6105C4F52CEBA7A100C4C5EE /* TNSMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TNSMetric.swift; sourceTree = "<group>"; };
+		6105C4F92CEBD72600C4C5EE /* TNSMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TNSMetricTests.swift; sourceTree = "<group>"; };
 		6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLoadingMetricsTests.swift; sourceTree = "<group>"; };
 		6105C5082CFA222400C4C5EE /* INVMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INVMetric.swift; sourceTree = "<group>"; };
 		6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INVMetricTests.swift; sourceTree = "<group>"; };
@@ -4178,7 +4178,7 @@
 		6105C4F42CEBA76000C4C5EE /* RUMMetrics */ = {
 			isa = PBXGroup;
 			children = (
-				6105C4F52CEBA7A100C4C5EE /* TTNSMetric.swift */,
+				6105C4F52CEBA7A100C4C5EE /* TNSMetric.swift */,
 				618F2B022D146BB300A647C4 /* NetworkSettledResourcePredicate.swift */,
 				6105C5082CFA222400C4C5EE /* INVMetric.swift */,
 				618F2B052D15922400A647C4 /* NextViewActionPredicate.swift */,
@@ -4189,7 +4189,7 @@
 		6105C4F82CEBD70300C4C5EE /* RUMMetrics */ = {
 			isa = PBXGroup;
 			children = (
-				6105C4F92CEBD72600C4C5EE /* TTNSMetricTests.swift */,
+				6105C4F92CEBD72600C4C5EE /* TNSMetricTests.swift */,
 				6105C5132D0C584F00C4C5EE /* INVMetricTests.swift */,
 			);
 			path = RUMMetrics;
@@ -9049,7 +9049,7 @@
 				D23F8E7329DDCD28001CFAE8 /* SwiftUIActionModifier.swift in Sources */,
 				D23F8E7429DDCD28001CFAE8 /* RUMCommandSubscriber.swift in Sources */,
 				6194B92B2BB4116A00179430 /* RUMDataStore.swift in Sources */,
-				6105C4F72CEBA7A100C4C5EE /* TTNSMetric.swift in Sources */,
+				6105C4F72CEBA7A100C4C5EE /* TNSMetric.swift in Sources */,
 				6194B9312BB451C100179430 /* NonFatalAppHangsHandler.swift in Sources */,
 				D23F8E7529DDCD28001CFAE8 /* RUMUserActionScope.swift in Sources */,
 				6194B92E2BB43F9C00179430 /* FatalErrorContextNotifier.swift in Sources */,
@@ -9138,7 +9138,7 @@
 				D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */,
 				D23F8EB929DDCD38001CFAE8 /* RUMFeatureMocks.swift in Sources */,
 				61C713AE2A3B793E00FA735A /* RUMMonitorProtocolTests.swift in Sources */,
-				6105C4FB2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */,
+				6105C4FB2CEBD72600C4C5EE /* TNSMetricTests.swift in Sources */,
 				D23F8EBA29DDCD38001CFAE8 /* ViewIdentifierTests.swift in Sources */,
 				D23F8EBE29DDCD38001CFAE8 /* WebViewEventReceiverTests.swift in Sources */,
 				D23F8EBF29DDCD38001CFAE8 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
@@ -9393,7 +9393,7 @@
 				D29A9F8729DD85BB005C54A4 /* SwiftUIActionModifier.swift in Sources */,
 				D29A9F5D29DD85BB005C54A4 /* RUMCommandSubscriber.swift in Sources */,
 				6194B92A2BB4116A00179430 /* RUMDataStore.swift in Sources */,
-				6105C4F62CEBA7A100C4C5EE /* TTNSMetric.swift in Sources */,
+				6105C4F62CEBA7A100C4C5EE /* TNSMetric.swift in Sources */,
 				6194B9302BB451C100179430 /* NonFatalAppHangsHandler.swift in Sources */,
 				D29A9F6529DD85BB005C54A4 /* RUMUserActionScope.swift in Sources */,
 				6194B92D2BB43F9C00179430 /* FatalErrorContextNotifier.swift in Sources */,
@@ -9482,7 +9482,7 @@
 				D29A9FAC29DDB483005C54A4 /* RUMActionsHandlerTests.swift in Sources */,
 				D29A9FC029DDB540005C54A4 /* RUMFeatureMocks.swift in Sources */,
 				61C713AD2A3B793E00FA735A /* RUMMonitorProtocolTests.swift in Sources */,
-				6105C4FA2CEBD72600C4C5EE /* TTNSMetricTests.swift in Sources */,
+				6105C4FA2CEBD72600C4C5EE /* TNSMetricTests.swift in Sources */,
 				D29A9FB729DDB483005C54A4 /* ViewIdentifierTests.swift in Sources */,
 				D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */,
 				D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -257,11 +257,11 @@ class ViewLoadingMetricsTests: XCTestCase {
 
     // MARK: - Interaction To Next View
 
-    func testWhenActionOccursInPreviousView_andNextViewStarts_thenITNVIsTrackedForNextView() throws {
+    func testWhenActionOccursInPreviousView_andNextViewStarts_thenINVIsTrackedForNextView() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default ITNV action predicate)
+        // Given (default INV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -271,28 +271,28 @@ class ViewLoadingMetricsTests: XCTestCase {
         rumTime.now += 2.seconds
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
-        // When (the next view is started within the ITNV threshold after the action)
-        let expectedITNV: TimeInterval = .mockRandom(
-            min: 0, max: TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.99
+        // When (the next view is started within the INV threshold after the action)
+        let expectedINV: TimeInterval = .mockRandom(
+            min: 0, max: TimeBasedINVActionPredicate.defaultMaxTimeToNextView * 0.99
         )
-        rumTime.now += expectedITNV
+        rumTime.now += expectedINV
         monitor.startView(key: "next", name: "NextView")
 
-        // Then (ITNV is tracked for the next view)
+        // Then (INV is tracked for the next view)
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
-        let actualITNV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
-        XCTAssertEqual(TimeInterval(fromNanoseconds: actualITNV), expectedITNV, accuracy: 0.01)
+        let actualINV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
+        XCTAssertEqual(TimeInterval(fromNanoseconds: actualINV), expectedINV, accuracy: 0.01)
     }
 
-    func testWhenActionOccursInPreviousView_andNextViewStartsAfterThreshold_thenITNVIsNotTrackedForNextView() throws {
+    func testWhenActionOccursInPreviousView_andNextViewStartsAfterThreshold_thenINVIsNotTrackedForNextView() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default ITNV action predicate)
+        // Given (default INV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -302,25 +302,25 @@ class ViewLoadingMetricsTests: XCTestCase {
         rumTime.now += 2.seconds
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
-        // When (the next view starts after exceeding the ITNV threshold)
-        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView + 0.01 // exceeds the max threshold
+        // When (the next view starts after exceeding the INV threshold)
+        rumTime.now += TimeBasedINVActionPredicate.defaultMaxTimeToNextView + 0.01 // exceeds the max threshold
         monitor.startView(key: "next", name: "NextView")
 
-        // Then (ITNV is not tracked for the next view)
+        // Then (INV is not tracked for the next view)
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
-        let actualITNV = nextViewEvent.view.interactionToNextViewTime
-        XCTAssertNil(actualITNV, "The ITNV value should not be tracked when the next view starts after exceeding the threshold.")
+        let actualINV = nextViewEvent.view.interactionToNextViewTime
+        XCTAssertNil(actualINV, "The INV value should not be tracked when the next view starts after exceeding the threshold.")
     }
 
-    func testWhenMultipleActionsOccursInPreviousView_thenITNVIsMeasuredFromTheLastAction() throws {
+    func testWhenMultipleActionsOccursInPreviousView_thenINVIsMeasuredFromTheLastAction() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default ITNV action predicate)
+        // Given (default INV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -336,31 +336,31 @@ class ViewLoadingMetricsTests: XCTestCase {
         rumTime.now += 0.75.seconds
         monitor.stopAction(type: .swipe, name: "Swipe")
 
-        // When (the next view is started within the ITNV threshold after last action)
-        let expectedITNV: TimeInterval = .mockRandom(
-            min: 0, max: TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.99
+        // When (the next view is started within the INV threshold after last action)
+        let expectedINV: TimeInterval = .mockRandom(
+            min: 0, max: TimeBasedINVActionPredicate.defaultMaxTimeToNextView * 0.99
         )
-        rumTime.now += expectedITNV
+        rumTime.now += expectedINV
         monitor.startView(key: "next", name: "NextView")
 
-        // Then (ITNV is tracked for the next view)
+        // Then (INV is tracked for the next view)
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
-        let actualITNV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
-        XCTAssertEqual(TimeInterval(fromNanoseconds: actualITNV), expectedITNV, accuracy: 0.01)
+        let actualINV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
+        XCTAssertEqual(TimeInterval(fromNanoseconds: actualINV), expectedINV, accuracy: 0.01)
     }
 
-    func testWhenActionInPreviousViewIsDropped_thenITNVIsNotTracked() throws {
+    func testWhenActionInPreviousViewIsDropped_thenINVIsNotTracked() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
         rumConfig.actionEventMapper = { event in
             event.action.target?.name == "Tap in Previous View" ? nil : event // drop "Tap in Previous View"
         }
 
-        // Given (default ITNV action predicate)
+        // Given (default INV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -370,24 +370,24 @@ class ViewLoadingMetricsTests: XCTestCase {
         rumTime.now += 2.seconds
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
-        // When (the next view is started within the ITNV threshold after the action)
-        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
+        // When (the next view is started within the INV threshold after the action)
+        rumTime.now += TimeBasedINVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "next", name: "NextView")
 
-        // Then (ITNV is tracked for the next view)
+        // Then (INV is tracked for the next view)
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
-        XCTAssertNil(nextViewEvent.view.interactionToNextViewTime, "The ITNV value should not be tracked when the action is dropped.")
+        XCTAssertNil(nextViewEvent.view.interactionToNextViewTime, "The INV value should not be tracked when the action is dropped.")
     }
 
-    func testITNVIsOnlyTrackedForViewsThatWereStartedDueToAnAction() throws {
+    func testINVIsOnlyTrackedForViewsThatWereStartedDueToAnAction() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default ITNV action predicate)
+        // Given (default INV action predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -398,11 +398,11 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.addAction(type: .tap, name: "Tap in Previous View")
 
         // When (the next view starts due to the action)
-        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
+        rumTime.now += TimeBasedINVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "next", name: "NextView")
 
         // When (a new view starts without an action)
-        rumTime.now += TimeBasedITNVActionPredicate.defaultMaxTimeToNextView * 0.5
+        rumTime.now += TimeBasedINVActionPredicate.defaultMaxTimeToNextView * 0.5
         monitor.startView(key: "nextWithoutAction", name: "NextViewWithoutAction")
 
         // Then
@@ -412,33 +412,33 @@ class ViewLoadingMetricsTests: XCTestCase {
 
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "NextView" })?.viewEvents.last)
         let nextViewWithoutAction = try XCTUnwrap(session.views.first(where: { $0.name == "NextViewWithoutAction" })?.viewEvents.last)
-        XCTAssertNotNil(nextViewEvent.view.interactionToNextViewTime, "ITNV should be tracked for view that started due to an action.")
-        XCTAssertNil(nextViewWithoutAction.view.interactionToNextViewTime, "ITNV should not be tracked for view that started without an action.")
+        XCTAssertNotNil(nextViewEvent.view.interactionToNextViewTime, "INV should be tracked for view that started due to an action.")
+        XCTAssertNil(nextViewWithoutAction.view.interactionToNextViewTime, "INV should not be tracked for view that started without an action.")
     }
 
-    func testGivenCustomITNVActionPredicate_whenNextViewStarts_thenITNVMetricIsCalculatedFromClassifiedActions() throws {
+    func testGivenCustomINVActionPredicate_whenNextViewStarts_thenINVMetricIsCalculatedFromClassifiedActions() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // We expect ITNV for "WelcomeView" to be calculated from "Sign Up" action:
+        // We expect INV for "WelcomeView" to be calculated from "Sign Up" action:
         //
         // [········· LoginView ·········][········· WelcomeView ·········]
         //    (A0)        (A1)  (A2)
-        //                |---- ITNV -----|
+        //                |---- INV -----|
         //                ^ "last interaction"
         //`                               ^ Start of the next view
         //
         // - A1 - "Sign Up" action; classified by predicate
         // - A0, A2 - other actions; ignored by predicate
 
-        struct CustomITNVPredicate: NextViewActionPredicate {
-            func isLastAction(from actionParams: ITNVActionParams) -> Bool {
+        struct CustomINVPredicate: NextViewActionPredicate {
+            func isLastAction(from actionParams: INVActionParams) -> Bool {
                 return actionParams.name == "Sign Up" && actionParams.nextViewName == "WelcomeView"
             }
         }
 
         // Use the custom predicate
-        rumConfig.nextViewActionPredicate = CustomITNVPredicate()
+        rumConfig.nextViewActionPredicate = CustomINVPredicate()
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -454,12 +454,12 @@ class ViewLoadingMetricsTests: XCTestCase {
         rumTime.now += 0.5.seconds
         monitor.addAction(type: .tap, name: "Sign Up")
 
-        let expectedITNV: TimeInterval = 2.0
-        rumTime.now += expectedITNV * 0.25
+        let expectedINV: TimeInterval = 2.0
+        rumTime.now += expectedINV * 0.25
         monitor.addAction(type: .tap, name: "A1")
 
         // After 2 seconds, start the next view with name "WelcomeView"
-        rumTime.now += expectedITNV * 0.75
+        rumTime.now += expectedINV * 0.75
         monitor.startView(key: "welcome", name: "WelcomeView")
 
         // Collect and inspect RUM events
@@ -470,13 +470,13 @@ class ViewLoadingMetricsTests: XCTestCase {
         // Find the final `view` event for "WelcomeView"
         let nextViewEvent = try XCTUnwrap(session.views.first(where: { $0.name == "WelcomeView" })?.viewEvents.last)
 
-        // Check the ITNV metric
-        let actualITNV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
+        // Check the INV metric
+        let actualINV = try XCTUnwrap(nextViewEvent.view.interactionToNextViewTime)
         XCTAssertEqual(
-            TimeInterval(fromNanoseconds: actualITNV),
-            expectedITNV,
+            TimeInterval(fromNanoseconds: actualINV),
+            expectedINV,
             accuracy: 0.01,
-            "The ITNV value should be computed from the last 'Sign Up' action that leads to 'WelcomeView'."
+            "The INV value should be computed from the last 'Sign Up' action that leads to 'WelcomeView'."
         )
     }
 }

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -25,11 +25,11 @@ class ViewLoadingMetricsTests: XCTestCase {
 
     // MARK: - Time To Network Settled
 
-    func testWhenResourcesStartBeforeThreshold_thenTheyAreIncludedInTTNSMetric() throws {
+    func testWhenResourcesStartBeforeThreshold_thenTheyAreIncludedInTNSMetric() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default TTNS resource predicate)
+        // Given (default TNS resource predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -39,7 +39,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.startView(key: "view", name: "ViewName")
         monitor.startResource(resourceKey: "resource1", url: .mockRandom())
         monitor.startResource(resourceKey: "resource2", url: .mockRandom())
-        rumTime.now.addTimeInterval(TimeBasedTTNSResourcePredicate.defaultThreshold * 0.99) // Wait no more than threshold, so next resource is still counted
+        rumTime.now.addTimeInterval(TimeBasedTNSResourcePredicate.defaultThreshold * 0.99) // Wait no more than threshold, so next resource is still counted
         monitor.startResource(resourceKey: "resource3", url: .mockRandom())
 
         // When (end resources during the same view)
@@ -57,16 +57,16 @@ class ViewLoadingMetricsTests: XCTestCase {
             .takeSingle()
 
         let lastViewEvent = try XCTUnwrap(session.views.last?.viewEvents.last)
-        let actualTTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TTNS should be reported after initial resources complete loading.")
-        let expectedTTNS = lastResourceTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
-        XCTAssertEqual(actualTTNS, expectedTTNS, "TTNS should span from the view start to the last completed initial resource.")
+        let actualTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TNS should be reported after initial resources complete loading.")
+        let expectedTNS = lastResourceTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
+        XCTAssertEqual(actualTNS, expectedTNS, "TNS should span from the view start to the last completed initial resource.")
     }
 
-    func testWhenAnotherResourceStartsAfterThreshold_thenItIsNotIncludedInTTNSMetric() throws {
+    func testWhenAnotherResourceStartsAfterThreshold_thenItIsNotIncludedInTNSMetric() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default TTNS resource predicate)
+        // Given (default TNS resource predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -78,7 +78,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         monitor.startResource(resourceKey: "resource2", url: .mockRandom())
 
         // When (start non-initial resource after threshold)
-        rumTime.now.addTimeInterval(TimeBasedTTNSResourcePredicate.defaultThreshold * 1.01) // Wait more than threshold, so next resource is not counted
+        rumTime.now.addTimeInterval(TimeBasedTNSResourcePredicate.defaultThreshold * 1.01) // Wait more than threshold, so next resource is not counted
         monitor.startResource(resourceKey: "resource3", url: .mockRandom())
 
         // When (end resources during the same view)
@@ -96,16 +96,16 @@ class ViewLoadingMetricsTests: XCTestCase {
             .takeSingle()
 
         let lastViewEvent = try XCTUnwrap(session.views.last?.viewEvents.last)
-        let actualTTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TTNS should be reported after initial resources complete loading.")
-        let expectedTTNS = lastInitialResourceTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
-        XCTAssertEqual(actualTTNS, expectedTTNS, "TTNS should span from the view start to the last completed initial resource.")
+        let actualTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TNS should be reported after initial resources complete loading.")
+        let expectedTNS = lastInitialResourceTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
+        XCTAssertEqual(actualTNS, expectedTNS, "TNS should span from the view start to the last completed initial resource.")
     }
 
-    func testWhenViewIsStopped_thenTTNSIsNotReported() throws {
+    func testWhenViewIsStopped_thenTNSIsNotReported() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
-        // Given (default TTNS resource predicate)
+        // Given (default TNS resource predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -134,10 +134,10 @@ class ViewLoadingMetricsTests: XCTestCase {
 
         let firstView = try XCTUnwrap(session.views.first(where: { $0.name == "FirstView" }))
         let lastViewEvent = try XCTUnwrap(firstView.viewEvents.last)
-        XCTAssertNil(lastViewEvent.view.networkSettledTime, "TTNS should not be reported if view was stopped during resource loading.")
+        XCTAssertNil(lastViewEvent.view.networkSettledTime, "TNS should not be reported if view was stopped during resource loading.")
     }
 
-    func testWhenResourceIsDropped_thenItIsExcludedFromTTNSMetric() throws {
+    func testWhenResourceIsDropped_thenItIsExcludedFromTNSMetric() throws {
         let droppedResourceURL: URL = .mockRandom()
 
         let rumTime = DateProviderMock()
@@ -149,7 +149,7 @@ class ViewLoadingMetricsTests: XCTestCase {
             event.error.resource?.url == droppedResourceURL.absoluteString ? nil : event
         }
 
-        // Given (default TTNS resource predicate)
+        // Given (default TNS resource predicate)
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
@@ -176,12 +176,12 @@ class ViewLoadingMetricsTests: XCTestCase {
             .takeSingle()
 
         let lastViewEvent = try XCTUnwrap(session.views.last?.viewEvents.last)
-        let actualTTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TTNS should be reported after initial resources end.")
-        let expectedTTNS = resource1EndTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
-        XCTAssertEqual(actualTTNS, expectedTTNS, "TTNS should only reflect ACCEPTED resources.")
+        let actualTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TNS should be reported after initial resources end.")
+        let expectedTNS = resource1EndTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
+        XCTAssertEqual(actualTNS, expectedTNS, "TNS should only reflect ACCEPTED resources.")
     }
 
-    func testGivenCustomTTNSResourcePredicate_whenViewCompletes_thenTTNSMetricIsCalculatedFromClassifiedResources() throws {
+    func testGivenCustomTNSResourcePredicate_whenViewCompletes_thenTNSMetricIsCalculatedFromClassifiedResources() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime
 
@@ -191,10 +191,10 @@ class ViewLoadingMetricsTests: XCTestCase {
         let viewLoadingURL3: URL = .mockRandom()
         let otherURL: URL = .mockRandom()
 
-        // We expect TTNS to be calculated for URLs 1-3, ignoring other URLs.
+        // We expect TNS to be calculated for URLs 1-3, ignoring other URLs.
         // In this test, resources are started and completed as follows:
         //
-        // |-------------- TTNS --------------|
+        // |-------------- TNS --------------|
         // |   [··· URL 1 ···]
         // |        [·········· OTHER URL ··········]
         // |                  [···· URL 2 ····]
@@ -205,7 +205,7 @@ class ViewLoadingMetricsTests: XCTestCase {
         struct CustomPredicate: NetworkSettledResourcePredicate {
             let viewLoadingURLs: Set<URL>
 
-            func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+            func isInitialResource(from resourceParams: TNSResourceParams) -> Bool {
                 resourceParams.viewName == "FooView" && viewLoadingURLs.contains(URL(string: resourceParams.url)!)
             }
         }
@@ -250,9 +250,9 @@ class ViewLoadingMetricsTests: XCTestCase {
             .takeSingle()
 
         let lastViewEvent = try XCTUnwrap(session.views.last?.viewEvents.last)
-        let actualTTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TTNS should be reported after initial resources complete loading.")
-        let expectedTTNS = lastInitialResourceCompletionTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
-        XCTAssertEqual(actualTTNS, expectedTTNS, "TTNS should span from the view start to the completion of last classified resource.")
+        let actualTNS = try XCTUnwrap(lastViewEvent.view.networkSettledTime, "TNS should be reported after initial resources complete loading.")
+        let expectedTNS = lastInitialResourceCompletionTime.timeIntervalSince(viewStartTime).toInt64Nanoseconds
+        XCTAssertEqual(actualTNS, expectedTNS, "TNS should span from the view start to the completion of last classified resource.")
     }
 
     // MARK: - Interaction To Next View

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -790,8 +790,8 @@ extension RUMScopeDependencies {
         networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = {
             TTNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTTNSResourcePredicate())
         },
-        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking = {
-            ITNVMetric(predicate: TimeBasedITNVActionPredicate())
+        interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = {
+            INVMetric(predicate: TimeBasedINVActionPredicate())
         }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -836,7 +836,7 @@ extension RUMScopeDependencies {
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
-        interactionToNextViewMetricFactory: (() -> ITNVMetricTracking)? = nil
+        interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -945,7 +945,7 @@ extension RUMViewScope {
         customTimings: [String: Int64] = randomTimings(),
         startTime: Date = .mockAny(),
         serverTimeOffset: TimeInterval = .zero,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(predicate: TimeBasedITNVActionPredicate())
+        interactionToNextViewMetric: INVMetricTracking = INVMetric(predicate: TimeBasedINVActionPredicate())
     ) -> RUMViewScope {
         return RUMViewScope(
             isInitialView: isInitialView,
@@ -1009,7 +1009,7 @@ extension RUMUserActionScope {
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
         instrumentation: InstrumentationType = .manual,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetric(predicate: TimeBasedITNVActionPredicate()),
+        interactionToNextViewMetric: INVMetricTracking = INVMetric(predicate: TimeBasedINVActionPredicate()),
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -787,8 +787,8 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = {
-            TTNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTTNSResourcePredicate())
+        networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking = {
+            TNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTNSResourcePredicate())
         },
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = {
             INVMetric(predicate: TimeBasedINVActionPredicate())
@@ -835,7 +835,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
+        networkSettledMetricFactory: ((Date, String) -> TNSMetricTracking)? = nil,
         interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -976,7 +976,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTTNSResourcePredicate()),
+        networkSettledMetric: TNSMetricTracking = TNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTNSResourcePredicate()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -102,7 +102,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             sessionEndedMetric: sessionEndedMetric,
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: { viewStartDate, viewName in
-                return TTNSMetric(
+                return TNSMetric(
                     viewName: viewName,
                     viewStartDate: viewStartDate,
                     resourcePredicate: configuration.networkSettledResourcePredicate

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -109,7 +109,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 )
             },
             interactionToNextViewMetricFactory: {
-                return ITNVMetric(
+                return INVMetric(
                     predicate: configuration.nextViewActionPredicate
                 )
             }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -147,14 +147,14 @@ extension RUM {
         /// Default: `.average`.
         public var vitalsUpdateFrequency: VitalsFrequency?
 
-        /// The predicate used to classify resources for the Time-To-Network-Settled (TTNS) view metric calculation.
+        /// The predicate used to classify resources for the Time-To-Network-Settled (TNS) view metric calculation.
         ///
-        /// **Time-To-Network-Settled (TTNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
+        /// **Time-To-Network-Settled (TNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
         /// are fully loaded. This metric helps to understand how long it takes for a view to be fully ready with all required resources loaded.
         ///
-        /// The `NetworkSettledResourcePredicate` defines which resources are included in the TTNS calculation based on their properties (e.g., start time, resource URL, etc.).
+        /// The `NetworkSettledResourcePredicate` defines which resources are included in the TNS calculation based on their properties (e.g., start time, resource URL, etc.).
         ///
-        /// Default: The default predicate, `TimeBasedTTNSResourcePredicate`, calculates TTNS using all resources that start within **100ms** of the view start.
+        /// Default: The default predicate, `TimeBasedTNSResourcePredicate`, calculates TNS using all resources that start within **100ms** of the view start.
         /// This time threshold can be customized by providing a custom predicate or adjusting the threshold in the default predicate.
         public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
 
@@ -368,8 +368,8 @@ extension RUM.Configuration {
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
     ///   - trackWatchdogTerminations: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
-    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-To-Network-Settled (TTNS) metric calculation.
-    ///     Default: `TimeBasedTTNSResourcePredicate()`.
+    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-To-Network-Settled (TNS) metric calculation.
+    ///     Default: `TimeBasedTNSResourcePredicate()`.
     ///   - nextViewActionPredicate: The predicate used to classify which action in the previous view is considered the "last interaction"
     ///     for the Interaction-To-Next-View (INV) metric. Default: `TimeBasedINVActionPredicate()`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
@@ -392,7 +392,7 @@ extension RUM.Configuration {
         appHangThreshold: TimeInterval? = nil,
         trackWatchdogTerminations: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
-        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),
+        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),
         nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -158,15 +158,15 @@ extension RUM {
         /// This time threshold can be customized by providing a custom predicate or adjusting the threshold in the default predicate.
         public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
 
-        /// The predicate used to classify the "last interaction" for the Interaction-To-Next-View (ITNV) metric.
+        /// The predicate used to classify the "last interaction" for the Interaction-To-Next-View (INV) metric.
         ///
-        /// **Interaction-To-Next-View (ITNV)** is a metric that measures how long it takes from the last user interaction in a previous view
+        /// **Interaction-To-Next-View (INV)** is a metric that measures how long it takes from the last user interaction in a previous view
         /// until the next view starts. It provides insight into how quickly a new view is displayed after a user’s action.
         ///
-        /// The `NextViewActionPredicate` determines which action in the previous view should be considered the "last interaction" for ITNV,
+        /// The `NextViewActionPredicate` determines which action in the previous view should be considered the "last interaction" for INV,
         /// based on properties such as action type, name, or timing relative to the next view’s start.
         ///
-        /// Default: The default predicate, `TimeBasedITNVActionPredicate`, classifies actions as the last interaction if they occur within a
+        /// Default: The default predicate, `TimeBasedINVActionPredicate`, classifies actions as the last interaction if they occur within a
         /// 3-second threshold before the next view starts. You can customize this time threshold or provide your own predicate.
         public var nextViewActionPredicate: NextViewActionPredicate
 
@@ -371,7 +371,7 @@ extension RUM.Configuration {
     ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-To-Network-Settled (TTNS) metric calculation.
     ///     Default: `TimeBasedTTNSResourcePredicate()`.
     ///   - nextViewActionPredicate: The predicate used to classify which action in the previous view is considered the "last interaction"
-    ///     for the Interaction-To-Next-View (ITNV) metric. Default: `TimeBasedITNVActionPredicate()`.
+    ///     for the Interaction-To-Next-View (INV) metric. Default: `TimeBasedINVActionPredicate()`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
     ///   - actionEventMapper: Custom mapper for RUM action events. Default: `nil`.
@@ -393,7 +393,7 @@ extension RUM.Configuration {
         trackWatchdogTerminations: Bool = false,
         vitalsUpdateFrequency: VitalsFrequency? = .average,
         networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),
-        nextViewActionPredicate: NextViewActionPredicate = TimeBasedITNVActionPredicate(),
+        nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),
         viewEventMapper: RUM.ViewEventMapper? = nil,
         resourceEventMapper: RUM.ResourceEventMapper? = nil,
         actionEventMapper: RUM.ActionEventMapper? = nil,

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -147,9 +147,9 @@ extension RUM {
         /// Default: `.average`.
         public var vitalsUpdateFrequency: VitalsFrequency?
 
-        /// The predicate used to classify resources for the Time-To-Network-Settled (TNS) view metric calculation.
+        /// The predicate used to classify resources for the Time-to-Network-Settled (TNS) view metric calculation.
         ///
-        /// **Time-To-Network-Settled (TNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
+        /// **Time-to-Network-Settled (TNS)** is a metric that measures the time from when a view becomes visible until all resources considered part of the view loading process
         /// are fully loaded. This metric helps to understand how long it takes for a view to be fully ready with all required resources loaded.
         ///
         /// The `NetworkSettledResourcePredicate` defines which resources are included in the TNS calculation based on their properties (e.g., start time, resource URL, etc.).
@@ -158,9 +158,9 @@ extension RUM {
         /// This time threshold can be customized by providing a custom predicate or adjusting the threshold in the default predicate.
         public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
 
-        /// The predicate used to classify the "last interaction" for the Interaction-To-Next-View (INV) metric.
+        /// The predicate used to classify the "last interaction" for the Interaction-to-Next-View (INV) metric.
         ///
-        /// **Interaction-To-Next-View (INV)** is a metric that measures how long it takes from the last user interaction in a previous view
+        /// **Interaction-to-Next-View (INV)** is a metric that measures how long it takes from the last user interaction in a previous view
         /// until the next view starts. It provides insight into how quickly a new view is displayed after a user’s action.
         ///
         /// The `NextViewActionPredicate` determines which action in the previous view should be considered the "last interaction" for INV,
@@ -368,10 +368,10 @@ extension RUM.Configuration {
     ///   - appHangThreshold: The threshold for App Hangs monitoring (in seconds). Default: `nil`.
     ///   - trackWatchdogTerminations: Determines whether the SDK should track application termination by the watchdog. Default: `false`.
     ///   - vitalsUpdateFrequency: The preferred frequency for collecting RUM vitals. Default: `.average`.
-    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-To-Network-Settled (TNS) metric calculation.
+    ///   - networkSettledResourcePredicate: Predicate used to classify resources for the Time-to-Network-Settled (TNS) metric calculation.
     ///     Default: `TimeBasedTNSResourcePredicate()`.
     ///   - nextViewActionPredicate: The predicate used to classify which action in the previous view is considered the "last interaction"
-    ///     for the Interaction-To-Next-View (INV) metric. Default: `TimeBasedINVActionPredicate()`.
+    ///     for the Interaction-to-Next-View (INV) metric. Default: `TimeBasedINVActionPredicate()`.
     ///   - viewEventMapper: Custom mapper for RUM view events. Default: `nil`.
     ///   - resourceEventMapper: Custom mapper for RUM resource events. Default: `nil`.
     ///   - actionEventMapper: Custom mapper for RUM action events. Default: `nil`.

--- a/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NetworkSettledResourcePredicate.swift
@@ -6,8 +6,8 @@
 
 import Foundation
 
-/// A struct representing the parameters of a resource that may be considered for the Time-to-Network-Settled (TTNS) metric.
-public struct TTNSResourceParams {
+/// A struct representing the parameters of a resource that may be considered for the Time-to-Network-Settled (TNS) metric.
+public struct TNSResourceParams {
     /// The URL of the resource.
     public let url: String
 
@@ -18,26 +18,26 @@ public struct TTNSResourceParams {
     public let viewName: String
 }
 
-/// A protocol for classifying network resources for the Time-to-Network-Settled (TTNS) metric.
-/// Implement this protocol to customize the logic for determining which resources are included in the TTNS calculation.
+/// A protocol for classifying network resources for the Time-to-Network-Settled (TNS) metric.
+/// Implement this protocol to customize the logic for determining which resources are included in the TNS calculation.
 ///
 /// **Note:**
 /// - The `isInitialResource(from:)` method will be called on a secondary thread.
 /// - The implementation must not assume any threading behavior and should avoid blocking the thread.
-/// - The method should always return the same result for the same input parameters to ensure consistency in TTNS calculation.
+/// - The method should always return the same result for the same input parameters to ensure consistency in TNS calculation.
 public protocol NetworkSettledResourcePredicate {
-    /// Determines if the provided resource should be included in the TTNS metric calculation.
+    /// Determines if the provided resource should be included in the TNS metric calculation.
     ///
     /// - Parameter resourceParams: The parameters of the resource.
-    /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
-    func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool
+    /// - Returns: `true` if the resource qualifies for TNS metric calculation, `false` otherwise.
+    func isInitialResource(from resourceParams: TNSResourceParams) -> Bool
 }
 
-/// A predicate implementation for classifying Time-to-Network-Settled (TTNS) resources based on a time threshold.
-/// It will calculate TTNS using all resources that start within the specified threshold after the view starts.
+/// A predicate implementation for classifying Time-to-Network-Settled (TNS) resources based on a time threshold.
+/// It will calculate TNS using all resources that start within the specified threshold after the view starts.
 ///
 /// The default value of the threshold is 0.1s.
-public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate {
+public struct TimeBasedTNSResourcePredicate: NetworkSettledResourcePredicate {
     /// The default value of the threshold.
     public static let defaultThreshold: TimeInterval = 0.1
 
@@ -47,16 +47,16 @@ public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate {
     /// Initializes a new predicate with a specified time threshold.
     ///
     /// - Parameter threshold: The time threshold (in seconds) used to classify resources. The default value is 0.1 seconds.
-    public init(threshold: TimeInterval = TimeBasedTTNSResourcePredicate.defaultThreshold) {
+    public init(threshold: TimeInterval = TimeBasedTNSResourcePredicate.defaultThreshold) {
         self.threshold = threshold
     }
 
-    /// Determines if the provided resource should be included in the TTNS metric calculation.
+    /// Determines if the provided resource should be included in the TNS metric calculation.
     /// A resource is included if it starts within the specified threshold from the view start time.
     ///
     /// - Parameter resourceParams: The parameters of the resource.
-    /// - Returns: `true` if the resource qualifies for TTNS metric calculation, `false` otherwise.
-    public func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+    /// - Returns: `true` if the resource qualifies for TNS metric calculation, `false` otherwise.
+    public func isInitialResource(from resourceParams: TNSResourceParams) -> Bool {
         return resourceParams.timeSinceViewStart <= threshold
     }
 }

--- a/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 /// A struct representing the parameters of a RUM action that may be considered the "last interaction" in the previous view
-/// for the Interaction-To-Next-View (ITNV) metric.
-public struct ITNVActionParams {
+/// for the Interaction-To-Next-View (INV) metric.
+public struct INVActionParams {
     /// The type of the action (e.g., tap, swipe, click).
     public let type: RUMActionType
 
@@ -23,33 +23,33 @@ public struct ITNVActionParams {
 }
 
 /// A protocol for classifying which action in the previous view should be considered the "last interaction" for the
-/// Interaction-To-Next-View (ITNV) metric.
+/// Interaction-To-Next-View (INV) metric.
 ///
 /// This predicate is called in reverse chronological order for each action in the previous view until an implementation
-/// returns `true`. The action for which `true` is returned will be classified as the "last interaction," and the ITNV metric
+/// returns `true`. The action for which `true` is returned will be classified as the "last interaction," and the INV metric
 /// in the subsequent view will be measured from this action’s time to the new view’s start.
 ///
 /// **Note:**
 /// - The `isLastAction(from:)` method will be called on a secondary thread.
 /// - The implementation must not assume any specific threading behavior and should avoid blocking.
-/// - The method should always return the same result for identical input parameters to ensure consistent ITNV calculation.
+/// - The method should always return the same result for identical input parameters to ensure consistent INV calculation.
 public protocol NextViewActionPredicate {
-    /// Determines whether the provided action should be classified as the "last interaction" in the previous view for ITNV calculation.
+    /// Determines whether the provided action should be classified as the "last interaction" in the previous view for INV calculation.
     ///
     /// This method is invoked in reverse chronological order for all actions in the previous view. Once `true` is returned,
-    /// the iteration stops, and the accepted action defines the starting point for the ITNV metric.
+    /// the iteration stops, and the accepted action defines the starting point for the INV metric.
     ///
     /// - Parameter actionParams: The parameters of the action (type, name, time to next view, and next view name).
-    /// - Returns: `true` if this action is the "last interaction" for ITNV, `false` otherwise.
-    func isLastAction(from actionParams: ITNVActionParams) -> Bool
+    /// - Returns: `true` if this action is the "last interaction" for INV, `false` otherwise.
+    func isLastAction(from actionParams: INVActionParams) -> Bool
 }
 
-/// A predicate implementation for classifying the "last interaction" for the Interaction-To-Next-View (ITNV) metric
+/// A predicate implementation for classifying the "last interaction" for the Interaction-To-Next-View (INV) metric
 /// based on a time threshold and action type. This predicate considers tap, click, or swipe actions in the previous view
 /// as valid if the interval between the action and the next view’s start (`timeToNextView`) is within `maxTimeToNextView`.
 ///
 /// The default value of `maxTimeToNextView` is `3` seconds.
-public struct TimeBasedITNVActionPredicate: NextViewActionPredicate {
+public struct TimeBasedINVActionPredicate: NextViewActionPredicate {
     /// The default maximum time interval for considering an action as the "last interaction."
     public static let defaultMaxTimeToNextView: TimeInterval = 3
 
@@ -60,16 +60,16 @@ public struct TimeBasedITNVActionPredicate: NextViewActionPredicate {
     ///
     /// - Parameter maxTimeToNextView: The maximum time interval (in seconds) from the action to the next view’s start.
     ///                                The default value is `3` seconds.
-    public init(maxTimeToNextView: TimeInterval = TimeBasedITNVActionPredicate.defaultMaxTimeToNextView) {
+    public init(maxTimeToNextView: TimeInterval = TimeBasedINVActionPredicate.defaultMaxTimeToNextView) {
         self.maxTimeToNextView = maxTimeToNextView
     }
 
-    /// Determines if the provided action should be considered the "last interaction" for ITNV, based on its action type and timing.
+    /// Determines if the provided action should be considered the "last interaction" for INV, based on its action type and timing.
     ///
     /// - Parameter actionParams: The parameters of the action (type, name, time to next view, and next view name).
     /// - Returns: `true` if the action’s `timeToNextView` is within `maxTimeToNextView` and its type is `tap`, `click`, or `swipe`;
     ///            otherwise, `false`.
-    public func isLastAction(from actionParams: ITNVActionParams) -> Bool {
+    public func isLastAction(from actionParams: INVActionParams) -> Bool {
         // Action must occur within the allowed time range
         guard actionParams.timeToNextView >= 0, actionParams.timeToNextView <= maxTimeToNextView else {
             return false

--- a/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
+++ b/DatadogRUM/Sources/RUMMetrics/NextViewActionPredicate.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A struct representing the parameters of a RUM action that may be considered the "last interaction" in the previous view
-/// for the Interaction-To-Next-View (INV) metric.
+/// for the Interaction-to-Next-View (INV) metric.
 public struct INVActionParams {
     /// The type of the action (e.g., tap, swipe, click).
     public let type: RUMActionType
@@ -23,7 +23,7 @@ public struct INVActionParams {
 }
 
 /// A protocol for classifying which action in the previous view should be considered the "last interaction" for the
-/// Interaction-To-Next-View (INV) metric.
+/// Interaction-to-Next-View (INV) metric.
 ///
 /// This predicate is called in reverse chronological order for each action in the previous view until an implementation
 /// returns `true`. The action for which `true` is returned will be classified as the "last interaction," and the INV metric
@@ -44,7 +44,7 @@ public protocol NextViewActionPredicate {
     func isLastAction(from actionParams: INVActionParams) -> Bool
 }
 
-/// A predicate implementation for classifying the "last interaction" for the Interaction-To-Next-View (INV) metric
+/// A predicate implementation for classifying the "last interaction" for the Interaction-to-Next-View (INV) metric
 /// based on a time threshold and action type. This predicate considers tap, click, or swipe actions in the previous view
 /// as valid if the interval between the action and the next view’s start (`timeToNextView`) is within `maxTimeToNextView`.
 ///

--- a/DatadogRUM/Sources/RUMMetrics/TNSMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/TNSMetric.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-internal protocol TTNSMetricTracking {
+internal protocol TNSMetricTracking {
     /// Tracks the start time of a resource identified by its `resourceID`.
     ///
     /// - Parameters:
@@ -33,25 +33,25 @@ internal protocol TTNSMetricTracking {
     /// Marks the view as stopped, preventing further resource tracking.
     func trackViewWasStopped()
 
-    /// Returns the value for the TTNS metric.
+    /// Returns the value for the TNS metric.
     ///
     /// - Parameters:
     ///   - time: The current time (device time, no NTP offset).
     ///   - appStateHistory: The history of app state transitions.
-    /// - Returns: The value for the TTNS metric, or `nil` if the metric cannot be calculated.
+    /// - Returns: The value for the TNS metric, or `nil` if the metric cannot be calculated.
     func value(at time: Date, appStateHistory: AppStateHistory) -> TimeInterval?
 }
 
-/// A metric (**Time-to-Network-Settled**, or TTNS) that measures the time from when the view becomes visible until all initial resources are loaded.
+/// A metric (**Time-to-Network-Settled**, or TNS) that measures the time from when the view becomes visible until all initial resources are loaded.
 /// "Initial resources" are now classified using a customizable predicate.
-internal final class TTNSMetric: TTNSMetricTracking {
+internal final class TNSMetric: TNSMetricTracking {
     /// The name of the view this metric is tracked for.
     private let viewName: String
 
     /// The time when the view tracking this metric becomes visible (device time, no NTP offset).
     private let viewStartDate: Date
 
-    /// The predicate used to classify resources as "initial" for TTNS.
+    /// The predicate used to classify resources as "initial" for TNS.
     private let resourcePredicate: NetworkSettledResourcePredicate
 
     /// Indicates whether the view is active (`true`) or stopped (`false`).
@@ -63,17 +63,17 @@ internal final class TTNSMetric: TTNSMetricTracking {
     /// The time when the last of the initial resources completes.
     private var latestResourceEndDate: Date?
 
-    /// Stores the last computed value for the TTNS metric.
+    /// Stores the last computed value for the TNS metric.
     /// This is used to return the same value for subsequent calls to `value(at:appStateHistory:)`
     /// while some resources are still pending.
     private var lastReturnedValue: TimeInterval?
 
-    /// Initializes a new TTNSMetric instance for a view with a customizable predicate.
+    /// Initializes a new TNSMetric instance for a view with a customizable predicate.
     ///
     /// - Parameters:
     ///   - viewName: The name of the view this metric is tracked for.
     ///   - viewStartDate: The time when the view becomes visible (device time, no NTP offset).
-    ///   - resourcePredicate: A predicate used to classify resources as "initial" for TTNS.
+    ///   - resourcePredicate: A predicate used to classify resources as "initial" for TNS.
     init(
         viewName: String,
         viewStartDate: Date,
@@ -99,7 +99,7 @@ internal final class TTNSMetric: TTNSMetricTracking {
             return // Sanity check to ensure resource is being tracked after view start
         }
 
-        let resourceParams = TTNSResourceParams(
+        let resourceParams = TNSResourceParams(
             url: resourceURL,
             timeSinceViewStart: startDate.timeIntervalSince(viewStartDate),
             viewName: viewName
@@ -145,7 +145,7 @@ internal final class TTNSMetric: TTNSMetricTracking {
         isViewActive = false
     }
 
-    /// Returns the value for the TTNS metric.
+    /// Returns the value for the TNS metric.
     /// - The value is only available after all initial resources have completed loading.
     /// - The value is not updated after view is stopped.
     /// - The value is only tracked if the app was in "active" state during view loading.
@@ -153,7 +153,7 @@ internal final class TTNSMetric: TTNSMetricTracking {
     /// - Parameters:
     ///   - time: The current time (device time, no NTP offset).
     ///   - appStateHistory: The history of app state transitions.
-    /// - Returns: The value for TTNS metric.
+    /// - Returns: The value for TNS metric.
     func value(at time: Date, appStateHistory: AppStateHistory) -> TimeInterval? {
         guard pendingResourcesStartDates.isEmpty else {
             return lastReturnedValue // No new value until all pending resources are completed

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -52,7 +52,7 @@ internal class RUMResourceScope: RUMScope {
     private let spanContext: RUMSpanContext?
 
     /// The Time-to-Network-Settled metric for the view that tracks this resource.
-    private let networkSettledMetric: TTNSMetricTracking
+    private let networkSettledMetric: TNSMetricTracking
 
     /// Callback called when a `RUMResourceEvent` is submitted for storage.
     private let onResourceEvent: (_ sent: Bool) -> Void
@@ -69,7 +69,7 @@ internal class RUMResourceScope: RUMScope {
         httpMethod: RUMMethod,
         resourceKindBasedOnRequest: RUMResourceType?,
         spanContext: RUMSpanContext?,
-        networkSettledMetric: TTNSMetricTracking,
+        networkSettledMetric: TNSMetricTracking,
         onResourceEvent: @escaping (Bool) -> Void,
         onErrorEvent: @escaping (Bool) -> Void
     ) {
@@ -88,7 +88,7 @@ internal class RUMResourceScope: RUMScope {
         self.onResourceEvent = onResourceEvent
         self.onErrorEvent = onErrorEvent
 
-        // Track this resource in view's TTNS metric:
+        // Track this resource in view's TNS metric:
         networkSettledMetric.trackResourceStart(at: startTime, resourceID: resourceUUID, resourceURL: url)
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -51,11 +51,11 @@ internal struct RUMScopeDependencies {
     let sessionEndedMetric: SessionEndedMetricController
     let watchdogTermination: WatchdogTerminationMonitor?
 
-    /// A factory function that creates a `TTNSMetric` for the given view start date.
+    /// A factory function that creates a `TNSMetric` for the given view start date.
     /// - Parameters:
     ///   - Date: The time when the view becomes visible (device time, no NTP offset).
     ///   - String: The name of the view.
-    let networkSettledMetricFactory: (Date, String) -> TTNSMetricTracking
+    let networkSettledMetricFactory: (Date, String) -> TNSMetricTracking
 
     /// A factory function that creates a `INVMetric` when session starts.
     let interactionToNextViewMetricFactory: () -> INVMetricTracking
@@ -78,7 +78,7 @@ internal struct RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying,
         sessionEndedMetric: SessionEndedMetricController,
         watchdogTermination: WatchdogTerminationMonitor?,
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking,
+        networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking,
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking
     ) {
         self.featureScope = featureScope

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -57,8 +57,8 @@ internal struct RUMScopeDependencies {
     ///   - String: The name of the view.
     let networkSettledMetricFactory: (Date, String) -> TTNSMetricTracking
 
-    /// A factory function that creates a `ITNVMetric` when session starts.
-    let interactionToNextViewMetricFactory: () -> ITNVMetricTracking
+    /// A factory function that creates a `INVMetric` when session starts.
+    let interactionToNextViewMetricFactory: () -> INVMetricTracking
 
     init(
         featureScope: FeatureScope,
@@ -79,7 +79,7 @@ internal struct RUMScopeDependencies {
         sessionEndedMetric: SessionEndedMetricController,
         watchdogTermination: WatchdogTerminationMonitor?,
         networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking,
-        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking
+        interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -78,7 +78,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// The reason why this session has ended or `nil` if it is still active.
     private(set) var endReason: EndReason?
 
-    private let interactionToNextViewMetric: ITNVMetricTracking
+    private let interactionToNextViewMetric: INVMetricTracking
 
     init(
         isInitialSession: Bool,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -61,7 +61,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     private var activeResourcesCount: Int = 0
 
     /// Interaction-to-Next-View metric for this view.
-    private let interactionToNextViewMetric: ITNVMetricTracking
+    private let interactionToNextViewMetric: INVMetricTracking
 
     /// Callback called when a `RUMActionEvent` is submitted for storage.
     private let onActionEventSent: (RUMActionEvent) -> Void
@@ -76,7 +76,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         serverTimeOffset: TimeInterval,
         isContinuous: Bool,
         instrumentation: InstrumentationType,
-        interactionToNextViewMetric: ITNVMetricTracking,
+        interactionToNextViewMetric: INVMetricTracking,
         onActionEventSent: @escaping (RUMActionEvent) -> Void
     ) {
         self.parent = parent

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -106,7 +106,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// Time-to-Network-Settled metric for this view.
     private let networkSettledMetric: TTNSMetricTracking
     /// Interaction-to-Next-View metric for this view.
-    private let interactionToNextViewMetric: ITNVMetricTracking
+    private let interactionToNextViewMetric: INVMetricTracking
 
     init(
         isInitialView: Bool,
@@ -118,7 +118,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         customTimings: [String: Int64],
         startTime: Date,
         serverTimeOffset: TimeInterval,
-        interactionToNextViewMetric: ITNVMetricTracking
+        interactionToNextViewMetric: INVMetricTracking
     ) {
         self.parent = parent
         self.dependencies = dependencies

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -104,7 +104,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private var viewPerformanceMetrics: [PerformanceMetric: VitalInfo] = [:]
 
     /// Time-to-Network-Settled metric for this view.
-    private let networkSettledMetric: TTNSMetricTracking
+    private let networkSettledMetric: TNSMetricTracking
     /// Interaction-to-Next-View metric for this view.
     private let interactionToNextViewMetric: INVMetricTracking
 

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -804,7 +804,7 @@ extension RUMScopeDependencies {
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom(),
         networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { _, _ in TTNSMetricMock() },
-        interactionToNextViewMetricFactory: @escaping () -> ITNVMetricTracking = { ITNVMetricMock() }
+        interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = { INVMetricMock() }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -848,7 +848,7 @@ extension RUMScopeDependencies {
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
-        interactionToNextViewMetricFactory: (() -> ITNVMetricTracking)? = nil
+        interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: self.featureScope,
@@ -984,7 +984,7 @@ extension RUMViewScope {
         customTimings: [String: Int64] = randomTimings(),
         startTime: Date = .mockAny(),
         serverTimeOffset: TimeInterval = .zero,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetricMock()
+        interactionToNextViewMetric: INVMetricTracking = INVMetricMock()
     ) -> RUMViewScope {
         return RUMViewScope(
             isInitialView: isInitialView,
@@ -1046,7 +1046,7 @@ extension RUMUserActionScope {
         serverTimeOffset: TimeInterval = .zero,
         isContinuous: Bool = .mockAny(),
         instrumentation: InstrumentationType = .manual,
-        interactionToNextViewMetric: ITNVMetricTracking = ITNVMetricMock(),
+        interactionToNextViewMetric: INVMetricTracking = INVMetricMock(),
         onActionEventSent: @escaping (RUMActionEvent) -> Void = { _ in }
     ) -> RUMUserActionScope {
         return RUMUserActionScope(
@@ -1262,7 +1262,7 @@ internal class TTNSMetricMock: TTNSMetricTracking {
     }
 }
 
-internal class ITNVMetricMock: ITNVMetricTracking {
+internal class INVMetricMock: INVMetricTracking {
     /// Tracks calls to `trackAction(startTime:endTime:name:type:in:)`.
     var trackedActions: [(startTime: Date, endTime: Date, actionName: String, actionType: RUMActionType, viewID: RUMUUID)] = []
     /// Tracks calls to `trackViewStart(at:name:viewID:)`.

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -803,7 +803,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom(),
-        networkSettledMetricFactory: @escaping (Date, String) -> TTNSMetricTracking = { _, _ in TTNSMetricMock() },
+        networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking = { _, _ in TNSMetricMock() },
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = { INVMetricMock() }
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -847,7 +847,7 @@ extension RUMScopeDependencies {
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
-        networkSettledMetricFactory: ((Date, String) -> TTNSMetricTracking)? = nil,
+        networkSettledMetricFactory: ((Date, String) -> TNSMetricTracking)? = nil,
         interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -1013,7 +1013,7 @@ extension RUMResourceScope {
         isFirstPartyResource: Bool? = nil,
         resourceKindBasedOnRequest: RUMResourceType? = nil,
         spanContext: RUMSpanContext? = .mockAny(),
-        networkSettledMetric: TTNSMetricTracking = TTNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTTNSResourcePredicate()),
+        networkSettledMetric: TNSMetricTracking = TNSMetric(viewName: .mockAny(), viewStartDate: .mockAny(), resourcePredicate: TimeBasedTNSResourcePredicate()),
         onResourceEvent: @escaping (Bool) -> Void = { _ in },
         onErrorEvent: @escaping (Bool) -> Void = { _ in }
     ) -> RUMResourceScope {
@@ -1225,7 +1225,7 @@ extension AppHang.BacktraceGenerationResult: AnyMockable, RandomMockable {
 
 // MARK: - View Loading Metrics
 
-internal class TTNSMetricMock: TTNSMetricTracking {
+internal class TNSMetricMock: TNSMetricTracking {
     /// Tracks calls to `trackResourceStart(at:resourceID:)`.
     var resourceStartDates: [RUMUUID: Date] = [:]
     /// Tracks calls to `trackResourceEnd(at:resourceID:resourceDuration:)`.

--- a/DatadogRUM/Tests/RUMMetrics/TNSMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/TNSMetricTests.swift
@@ -17,14 +17,14 @@ private extension RUMUUID {
 }
 
 private struct ResourcePredicateMock: NetworkSettledResourcePredicate {
-    let shouldConsiderInitialResource: (TTNSResourceParams) -> Bool
+    let shouldConsiderInitialResource: (TNSResourceParams) -> Bool
 
-    func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool {
+    func isInitialResource(from resourceParams: TNSResourceParams) -> Bool {
         shouldConsiderInitialResource(resourceParams)
     }
 }
 
-class TTNSMetricTests: XCTestCase {
+class TNSMetricTests: XCTestCase {
     /// Represents 100ms.
     private let t100ms: TimeInterval = 0.1
     /// The start of the view tracked by tested metric.
@@ -36,20 +36,20 @@ class TTNSMetricTests: XCTestCase {
         ResourcePredicateMock(shouldConsiderInitialResource: { $0.url == initialResourcesURL })
     }
     // swiftlint:disable function_default_parameter_at_end
-    /// Creates `TTNSMetric` instance for testing.
-    private func createMetric(viewName: String = .mockAny(), viewStartDate: Date, resourcePredicate: NetworkSettledResourcePredicate) -> TTNSMetric {
-        return TTNSMetric(viewName: viewName, viewStartDate: viewStartDate, resourcePredicate: resourcePredicate)
+    /// Creates `TNSMetric` instance for testing.
+    private func createMetric(viewName: String = .mockAny(), viewStartDate: Date, resourcePredicate: NetworkSettledResourcePredicate) -> TNSMetric {
+        return TNSMetric(viewName: viewName, viewStartDate: viewStartDate, resourcePredicate: resourcePredicate)
     }
     // swiftlint:enable function_default_parameter_at_end
 
     // MARK: - "Initial Resource" Classification
 
     func testGivenTimeBasedResourcePredicate_whenResourceStartsWithinThreshold_thenItIsTracked() throws {
-        let threshold = TimeBasedTTNSResourcePredicate.defaultThreshold
+        let threshold = TimeBasedTNSResourcePredicate.defaultThreshold
 
         func when(resourceStartOffset offset: TimeInterval) -> TimeInterval? {
             // Given
-            let predicate = TimeBasedTTNSResourcePredicate(threshold: threshold)
+            let predicate = TimeBasedTNSResourcePredicate(threshold: threshold)
             let metric = createMetric(viewStartDate: viewStartDate, resourcePredicate: predicate)
 
             // When

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1332,14 +1332,14 @@ class RUMResourceScopeTests: XCTestCase {
 
     // MARK: - Updating Time To Network Settled Metric
 
-    func testWhenResourceLoadingEnds_itTrackStartAndStopInTTNSMetric() throws {
+    func testWhenResourceLoadingEnds_itTrackStartAndStopInTNSMetric() throws {
         let resourceKey = "resource"
         let resourceDuration: TimeInterval = 2
         let viewStartDate = Date()
         let resourceUUID = RUMUUID(rawValue: UUID())
 
         // Given
-        let metric = TTNSMetricMock()
+        let metric = TNSMetricMock()
         let scope = RUMResourceScope(
             context: .mockAny(),
             dependencies: .mockWith(
@@ -1373,14 +1373,14 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(metric.resourceEndDates[resourceUUID]?.1, resourceDuration)
     }
 
-    func testWhenResourceLoadingEndsWithError_thenItsDurationTrackedInTTNSMetric() throws {
+    func testWhenResourceLoadingEndsWithError_thenItsDurationTrackedInTNSMetric() throws {
         let resourceKey = "resource"
         let resourceDuration: TimeInterval = 2
         let viewStartDate = Date()
         let resourceUUID = RUMUUID(rawValue: UUID())
 
         // Given
-        let metric = TTNSMetricMock()
+        let metric = TNSMetricMock()
         let scope = RUMResourceScope(
             context: .mockAny(),
             dependencies: .mockWith(
@@ -1414,13 +1414,13 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(metric.resourceEndDates[resourceUUID]?.1)
     }
 
-    func testWhenResourceLoadingEndsAndResourceIsDropped_itTrackStoppedInTTNSMetric() throws {
+    func testWhenResourceLoadingEndsAndResourceIsDropped_itTrackStoppedInTNSMetric() throws {
         let resourceKey = "resource"
         let viewStartDate = Date()
         let resourceUUID = RUMUUID(rawValue: UUID())
 
         // Given
-        let metric = TTNSMetricMock()
+        let metric = TNSMetricMock()
         let scope = RUMResourceScope(
             context: .mockAny(),
             dependencies: .mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -870,13 +870,13 @@ class RUMUserActionScopeTests: XCTestCase {
 
     // MARK: - Updating Interaction To Next View Metric
 
-    func testWhenActionEventIsSent_itTrackActionInITNVMetric() throws {
+    func testWhenActionEventIsSent_itTrackActionInINVMetric() throws {
         let actionStartTime: Date = .mockDecember15th2019At10AMUTC()
         let actionName: String = .mockRandom()
         let actionType: RUMActionType = .tap
 
         // Given
-        let metric = ITNVMetricMock()
+        let metric = INVMetricMock()
         let scope = RUMUserActionScope.mockWith(
             parent: parent,
             name: actionName,

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -194,7 +194,7 @@ class RUMViewScopeTests: XCTestCase {
             isInitialView: true,
             parent: parent,
             dependencies: .mockWith(
-                networkSettledMetricFactory: { _, _ in TTNSMetricMock(value: 0.42) }
+                networkSettledMetricFactory: { _, _ in TNSMetricMock(value: 0.42) }
             ),
             identity: .mockViewIdentifier(),
             path: "UIViewController",
@@ -2755,12 +2755,12 @@ class RUMViewScopeTests: XCTestCase {
 
     // MARK: - Tracking Time To Network Settled Metric
 
-    func testWhenViewIsStopped_itStopsTrackingTTNSMetric() throws {
+    func testWhenViewIsStopped_itStopsTrackingTNSMetric() throws {
         let viewStartDate = Date()
         let viewName: String = .mockRandom()
 
         // Given
-        let metric = TTNSMetricMock()
+        let metric = TNSMetricMock()
         let scope = RUMViewScope(
             isInitialView: .mockAny(),
             parent: parent,

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -47,7 +47,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: .mockAny(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
@@ -74,7 +74,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: .mockAny(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         _ = scope.process(
@@ -107,7 +107,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -202,7 +202,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock(mockedValue: 0.84)
+            interactionToNextViewMetric: INVMetricMock(mockedValue: 0.84)
         )
 
         let hasReplay: Bool = .mockRandom()
@@ -266,7 +266,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         _ = scope.process(
@@ -292,7 +292,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -347,7 +347,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -423,7 +423,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -480,7 +480,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -557,7 +557,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -634,7 +634,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -679,7 +679,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         currentTime.addTimeInterval(1)
@@ -724,7 +724,7 @@ class RUMViewScopeTests: XCTestCase {
                 customTimings: [:],
                 startTime: .mockAny(),
                 serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
             )
         }
 
@@ -772,7 +772,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -828,7 +828,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -897,7 +897,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // given
@@ -983,7 +983,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // given
@@ -1037,7 +1037,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -1120,7 +1120,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -1198,7 +1198,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1255,7 +1255,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1307,7 +1307,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1384,7 +1384,7 @@ class RUMViewScopeTests: XCTestCase {
                 customTimings: [:],
                 startTime: currentTime,
                 serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
             )
             _ = scope.process(
                 command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
@@ -1455,7 +1455,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1528,7 +1528,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1624,7 +1624,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1684,7 +1684,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1740,7 +1740,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1799,7 +1799,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1852,7 +1852,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1890,7 +1890,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -1953,7 +1953,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: startViewDate,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -2021,7 +2021,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -2075,7 +2075,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: startViewDate,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         XCTAssertTrue(
@@ -2115,7 +2115,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2177,7 +2177,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2223,7 +2223,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2285,7 +2285,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2329,7 +2329,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2384,7 +2384,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2440,7 +2440,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: initialDeviceTime,
             serverTimeOffset: initialServerTimeOffset,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         parent.context.isSessionActive = false
 
@@ -2479,7 +2479,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: initialDeviceTime,
             serverTimeOffset: initialServerTimeOffset,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -2595,7 +2595,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
         XCTAssertTrue(
             scope.process(
@@ -2700,7 +2700,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -2735,7 +2735,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date(),
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -2777,7 +2777,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: viewStartDate,
             serverTimeOffset: .mockRandom(),
-            interactionToNextViewMetric: ITNVMetricMock()
+            interactionToNextViewMetric: INVMetricMock()
         )
 
         // When
@@ -2793,12 +2793,12 @@ class RUMViewScopeTests: XCTestCase {
 
     // MARK: - Interaction To Next View Metric
 
-    func testWhenViewIsStartedThenStopped_itUpdatesITNVMetric() throws {
+    func testWhenViewIsStartedThenStopped_itUpdatesINVMetric() throws {
         let viewStartDate = Date()
         let viewID: RUMUUID = .mockRandom()
 
         // Given
-        let metric = ITNVMetricMock()
+        let metric = INVMetricMock()
         let scope = RUMViewScope(
             isInitialView: .mockAny(),
             parent: parent,

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1749,7 +1749,7 @@ public enum RUM
         case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate = TimeBasedITNVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,telemetrySampleRate: SampleRate = 20)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,telemetrySampleRate: SampleRate = 20)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
 public struct TTNSResourceParams
@@ -1762,17 +1762,17 @@ public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate
     public static let defaultThreshold: TimeInterval = 0.1
     public init(threshold: TimeInterval = TimeBasedTTNSResourcePredicate.defaultThreshold)
     public func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool
-public struct ITNVActionParams
+public struct INVActionParams
     public let type: RUMActionType
     public let name: String
     public let timeToNextView: TimeInterval
     public let nextViewName: String
 public protocol NextViewActionPredicate
-    func isLastAction(from actionParams: ITNVActionParams) -> Bool
-public struct TimeBasedITNVActionPredicate: NextViewActionPredicate
+    func isLastAction(from actionParams: INVActionParams) -> Bool
+public struct TimeBasedINVActionPredicate: NextViewActionPredicate
     public static let defaultMaxTimeToNextView: TimeInterval = 3
-    public init(maxTimeToNextView: TimeInterval = TimeBasedITNVActionPredicate.defaultMaxTimeToNextView)
-    public func isLastAction(from actionParams: ITNVActionParams) -> Bool
+    public init(maxTimeToNextView: TimeInterval = TimeBasedINVActionPredicate.defaultMaxTimeToNextView)
+    public func isLastAction(from actionParams: INVActionParams) -> Bool
 public class RUMMonitor
     public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> RUMMonitorProtocol
 public extension RUMMonitorProtocol

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1749,19 +1749,19 @@ public enum RUM
         case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,telemetrySampleRate: SampleRate = 20)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,telemetrySampleRate: SampleRate = 20)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
-public struct TTNSResourceParams
+public struct TNSResourceParams
     public let url: String
     public let timeSinceViewStart: TimeInterval
     public let viewName: String
 public protocol NetworkSettledResourcePredicate
-    func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool
-public struct TimeBasedTTNSResourcePredicate: NetworkSettledResourcePredicate
+    func isInitialResource(from resourceParams: TNSResourceParams) -> Bool
+public struct TimeBasedTNSResourcePredicate: NetworkSettledResourcePredicate
     public static let defaultThreshold: TimeInterval = 0.1
-    public init(threshold: TimeInterval = TimeBasedTTNSResourcePredicate.defaultThreshold)
-    public func isInitialResource(from resourceParams: TTNSResourceParams) -> Bool
+    public init(threshold: TimeInterval = TimeBasedTNSResourcePredicate.defaultThreshold)
+    public func isInitialResource(from resourceParams: TNSResourceParams) -> Bool
 public struct INVActionParams
     public let type: RUMActionType
     public let name: String


### PR DESCRIPTION
### What and why?

📦 During documentation, we decided that TNS (Time-to-Network-Settled) and INV (Interaction-to-Next-View) are better acronyms than T**T**NS and I**T**NV. Since these acronyms appeared in some public type names, this PR updates the naming accordingly

This change is not breaking because the updated APIs have not been released yet.

### How?

A basic string replacement across the codebase.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
