### PR TITLE
RUM-7691: Add `addAttributes` and `removeAttributes` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FEATURE] Add Time To Network Setled metric in RUM. See [#2125][]
 - [FEATURE] Add Interaction To Next View metric in RUM. See [#2153][]
 - [FIX] Fix SwiftUI placeholder in Session Replay when Feature Flag is disabled. See [#2170][]
+- [IMPROVEMENT] Add `addAttributes` and `removeAttributes` APIs. See [#2177][]
 
 # 2.22.0 / 02-01-2025
 
@@ -816,9 +817,11 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2116]: https://github.com/DataDog/dd-sdk-ios/pull/2116
 [#2120]: https://github.com/DataDog/dd-sdk-ios/pull/2120
 [#2126]: https://github.com/DataDog/dd-sdk-ios/pull/2126
-[#2153]: https://github.com/DataDog/dd-sdk-ios/pull/2153
 [#2148]: https://github.com/DataDog/dd-sdk-ios/pull/2148
+[#2153]: https://github.com/DataDog/dd-sdk-ios/pull/2153
 [#2154]: https://github.com/DataDog/dd-sdk-ios/pull/2154
+[#2170]: https://github.com/DataDog/dd-sdk-ios/pull/2170
+[#2177]: https://github.com/DataDog/dd-sdk-ios/pull/2177
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -75,7 +75,10 @@
     [monitor startActionWithType:DDRUMActionTypeSwipe name:@"" attributes:@{}];
     [monitor stopActionWithType:DDRUMActionTypeSwipe name:nil attributes:@{}];
     [monitor addActionWithType:DDRUMActionTypeTap name:@"" attributes:@{}];
-    [monitor addAttributeForKey:@"" value:@""];
+    [monitor addAttributeForKey:@"key" value:@"value"];
+    [monitor removeAttributeForKey:@"key"];
+    [monitor addAttributes:@{@"string": @"value", @"integer": @1, @"boolean": @true}];
+    [monitor removeAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
 
     [monitor setDebug:YES];

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -656,8 +656,18 @@ public class DDRUMMonitor: NSObject {
     }
 
     @objc
+    public func addAttributes(_ attributes: [String: Any]) {
+        swiftRUMMonitor.addAttributes(attributes.dd.swiftAttributes)
+    }
+
+    @objc
     public func removeAttribute(forKey key: String) {
         swiftRUMMonitor.removeAttribute(forKey: key)
+    }
+
+    @objc
+    public func removeAttributes(forKeys keys: [String]) {
+        swiftRUMMonitor.removeAttributes(forKeys: keys)
     }
 
     @objc

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -38,7 +38,7 @@ public enum RUMErrorSource {
 public protocol RUMMonitorProtocol: AnyObject {
     // MARK: - attributes
 
-    /// Adds a custom attribute to next RUM events.
+    /// Adds a custom attribute to the next RUM events.
     /// - Parameters:
     ///   - key: key for this attribute. See `AttributeKey` documentation for information about
     ///   nesting attribute values using dot `.` syntax.
@@ -46,10 +46,19 @@ public protocol RUMMonitorProtocol: AnyObject {
     ///   for information about nested encoding containers limitation.
     func addAttribute(forKey key: AttributeKey, value: AttributeValue)
 
-    /// Removes an attribute from next RUM events.
+    /// Adds multiple attributes to the next RUM events.
+    /// - Parameter attributes: dictionary with attributes. Each attribute is defined by a key `AttributeKey` and a value that conforms to `Encodable`.
+    func addAttributes(_ attributes: [AttributeKey: AttributeValue])
+
+    /// Removes an attribute from the next RUM events.
     /// Events created prior to this call will not lose this attribute.
     /// - Parameter key: key for the attribute that will be removed.
     func removeAttribute(forKey key: AttributeKey)
+
+    /// Removes multiple attributes from the next RUM events.
+    /// Events created prior to this call will not lose these attributes.
+    /// - Parameter keys: array of attribute keys that will be removed.
+    func removeAttributes(forKeys keys: [AttributeKey])
 
     // MARK: - session
 
@@ -347,7 +356,9 @@ internal class NOPMonitor: RUMMonitorProtocol {
 
     func currentSessionID(completion: (String?) -> Void) { completion(nil) }
     func addAttribute(forKey key: AttributeKey, value: AttributeValue) { warn() }
+    func addAttributes(_ attributes: [AttributeKey: AttributeValue]) { warn() }
     func removeAttribute(forKey key: AttributeKey) { warn() }
+    func removeAttributes(forKeys keys: [AttributeKey]) {warn() }
     func stopSession() { warn() }
     func startView(viewController: UIViewController, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) { warn() }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -777,7 +777,7 @@ func mockNoOpSessionListener() -> RUM.SessionListener {
 internal class FatalErrorContextNotifierMock: FatalErrorContextNotifying {
     var sessionState: RUMSessionState?
     var view: RUMViewEvent?
-    var globalAttributes: [String: Encodable] = [:]
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
 }
 
 extension RUMScopeDependencies {

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -38,6 +38,74 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertNil(lastView.attribute(forKey: "attribute"))
     }
 
+    func testAddingMultipleGlobalAttributes() throws {
+        // Given
+        let mockAttributes: [AttributeKey: AttributeValue] = (0...99).reduce(into: [:]) { $0[String(describing: $1)] = $1 }
+
+        // When
+        monitor.notifySDKInit()
+        monitor.addAttributes(mockAttributes)
+        monitor.startView(key: "IgnoredView")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let appLaunchViewEvent = try XCTUnwrap(viewEvents.last(where: { $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }))
+        XCTAssertTrue(appLaunchViewEvent.numberOfAttributes == 100)
+    }
+
+    func testAddingAndRemovingMultipleGlobalAttributes() throws {
+        // Given
+        let mockAttributes: [AttributeKey: AttributeValue] = (0...99).reduce(into: [:]) { $0[String(describing: $1)] = $1 }
+
+        // When
+        monitor.notifySDKInit()
+        monitor.addAttributes(mockAttributes)
+        monitor.removeAttributes(forKeys: Array(mockAttributes.keys))
+        monitor.startView(key: "IgnoredView")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let appLaunchViewEvent = try XCTUnwrap(viewEvents.last(where: { $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }))
+        XCTAssertTrue(appLaunchViewEvent.numberOfAttributes == 0)
+    }
+
+    func testAddingIsolatedAttributesAndRemovingMultipleAttributes() throws {
+        // Given
+        let attributeKeys: [AttributeKey] = (0...99).map { "key\($0)" }
+
+        // When
+        monitor.notifySDKInit()
+        attributeKeys.forEach {
+            monitor.addAttribute(forKey: $0, value: "value")
+        }
+        monitor.removeAttributes(forKeys: attributeKeys)
+        monitor.startView(key: "IgnoredView")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let appLaunchViewEvent = try XCTUnwrap(viewEvents.last(where: { $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }))
+        XCTAssertTrue(appLaunchViewEvent.numberOfAttributes == 0)
+    }
+
+    func testAddingMultipleAttributesAndRemovingSomeAttributes() throws {
+        // Given
+        let mockAttributes: [AttributeKey: AttributeValue] = (0...99).reduce(into: [:]) { $0[String(describing: $1)] = $1 }
+        let keyToRemove = try XCTUnwrap(mockAttributes.first?.key)
+        var expectedAttributes = mockAttributes
+        expectedAttributes.removeValue(forKey: keyToRemove)
+
+        // When
+        monitor.notifySDKInit()
+        monitor.addAttributes(mockAttributes)
+        monitor.removeAttribute(forKey: keyToRemove)
+        monitor.startView(key: "IgnoredView")
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let appLaunchViewEvent = try XCTUnwrap(viewEvents.last(where: { $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }))
+        XCTAssertTrue(appLaunchViewEvent.numberOfAttributes == mockAttributes.count - 1)
+    }
+
     func testAddingGlobalAttributeAfterSDKInit_thenStartingView() throws {
         // Given
         monitor.notifySDKInit()
@@ -236,9 +304,13 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Given
         monitor.notifySDKInit()
         monitor.startView(key: "View1")
-        monitor.addAttribute(forKey: "attribute1", value: "value1")
-        monitor.addAttribute(forKey: "attribute2", value: "value2")
-        monitor.addAttribute(forKey: "attribute3", value: "value3")
+        monitor.addAttributes(
+            [
+                "attribute1": "value1",
+                "attribute2": "value2",
+                "attribute3": "value3"
+            ]
+        )
 
         // When
         monitor.startView(key: "View2")
@@ -269,9 +341,13 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Given
         monitor.notifySDKInit()
         monitor.startView(key: "View1")
-        monitor.addAttribute(forKey: "attribute1", value: "value1")
-        monitor.addAttribute(forKey: "attribute2", value: "value2")
-        monitor.addAttribute(forKey: "attribute3", value: "value3")
+        monitor.addAttributes(
+            [
+                "attribute1": "value1",
+                "attribute2": "value2",
+                "attribute3": "value3"
+            ]
+        )
 
         // When
         monitor.startView(key: "View2")
@@ -578,6 +654,26 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(fatalErrorContext.globalAttributes.count, 1)
     }
 
+    func testGivenSDKInitialized_whenMultipleGlobalAttributesAreAdded_thenFatalErrorContextIsUpdatedWithNewAttributes() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifierMock()
+        let mockAttributes: [AttributeKey: AttributeValue] = (0...99).reduce(into: [:]) { $0[String(describing: $1)] = $1 }
+        monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope, fatalErrorContext: fatalErrorContext),
+            dateProvider: SystemDateProvider()
+        )
+        monitor.notifySDKInit()
+
+        // When
+        monitor.addAttributes(mockAttributes)
+
+        // Then
+        XCTAssertEqual(fatalErrorContext.globalAttributes.count, mockAttributes.count)
+        fatalErrorContext.globalAttributes.forEach {
+            XCTAssertEqual(mockAttributes[$0.key] as? String, $0.value as? String)
+        }
+    }
+
     func testGivenSDKInitialized_whenGlobalAttributesAreAddedAndRemoved_thenFatalErrorContextIsUpdatedWithNewAttributes() throws {
         let fatalErrorContext = FatalErrorContextNotifierMock()
 
@@ -596,6 +692,28 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Then
         XCTAssertEqual(fatalErrorContext.globalAttributes["attribute2"] as? String, "value2")
         XCTAssertEqual(fatalErrorContext.globalAttributes.count, 1)
+    }
+
+    func testGivenSDKInitialized_whenMultipleGlobalAttributesAreAddedAndRemoved_thenFatalErrorContextIsUpdatedWithNewAttributes() throws {
+        // Given
+        let fatalErrorContext = FatalErrorContextNotifierMock()
+        let mockAttributes: [AttributeKey: AttributeValue] = (0...99).reduce(into: [:]) { $0[String(describing: $1)] = $1 }
+        let keysToRemove = [try XCTUnwrap(mockAttributes.first?.key)]
+        monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope, fatalErrorContext: fatalErrorContext),
+            dateProvider: SystemDateProvider()
+        )
+        monitor.notifySDKInit()
+
+        // When
+        monitor.addAttributes(mockAttributes)
+        monitor.removeAttributes(forKeys: keysToRemove)
+
+        // Then
+        XCTAssertEqual(fatalErrorContext.globalAttributes.count, (mockAttributes.count - keysToRemove.count))
+        keysToRemove.forEach {
+            XCTAssertNil(fatalErrorContext.globalAttributes[$0])
+        }
     }
 }
 

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -376,7 +376,9 @@ public class DDRUMMonitor: NSObject
     public func stopAction(type: DDRUMActionType,name: String?,attributes: [String: Any])
     public func addAction(type: DDRUMActionType,name: String,attributes: [String: Any])
     public func addAttribute(forKey key: String,value: Any)
+    public func addAttributes(_ attributes: [String: Any])
     public func removeAttribute(forKey key: String)
+    public func removeAttributes(forKeys keys: [String])
     public func addFeatureFlagEvaluation(name: String, value: Any)
     @objc public var debug: Bool
 public class DDRUMActionEvent: NSObject

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1814,7 +1814,9 @@ public enum RUMErrorSource
     case custom
 public protocol RUMMonitorProtocol: AnyObject
     func addAttribute(forKey key: AttributeKey, value: AttributeValue)
+    func addAttributes(_ attributes: [AttributeKey: AttributeValue])
     func removeAttribute(forKey key: AttributeKey)
+    func removeAttributes(forKeys keys: [AttributeKey])
     func currentSessionID(completion: @escaping (String?) -> Void)
     func stopSession()
     func startView(viewController: UIViewController,name: String?,attributes: [AttributeKey: AttributeValue])


### PR DESCRIPTION
### What and why?

This PR introduces a new interface to add and remove multiple attributes simultaneously. 
This enhancement reduces threading pressure on the Message Bus when handling multiple attributes at once.

### How?

The new interfaces to handle multiple attributes are:

```swift
func addAttributes(_ attributes: [AttributeKey: AttributeValue])

func removeAttributes(forKeys keys: [AttributeKey])
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
