### PR TITLE
RUM-7112 chore: Add "RUM View Ended" telemetry to track TNS' and INV's quality

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -430,6 +430,10 @@
 		615D52BF2C88A98300F8B8FC /* SynchronizedTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615D52BD2C88A98300F8B8FC /* SynchronizedTagsTests.swift */; };
 		615D52C12C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615D52C02C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift */; };
 		615D52C22C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615D52C02C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift */; };
+		615E2B8E2D39444300D85243 /* ViewEndedMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B8D2D39444300D85243 /* ViewEndedMetricController.swift */; };
+		615E2B8F2D39444300D85243 /* ViewEndedMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B8D2D39444300D85243 /* ViewEndedMetricController.swift */; };
+		615E2B952D425F5600D85243 /* ViewEndedMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B942D425F5600D85243 /* ViewEndedMetric.swift */; };
+		615E2B962D425F5600D85243 /* ViewEndedMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B942D425F5600D85243 /* ViewEndedMetric.swift */; };
 		6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C79226665D6900D4CF07 /* E2EUtils.swift */; };
 		6167C7952666622800D4CF07 /* LoggingE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */; };
 		6167E6D32B7F8B3300C3CA2D /* AppHangsMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D22B7F8B3300C3CA2D /* AppHangsMonitor.swift */; };
@@ -2535,6 +2539,8 @@
 		615D52BD2C88A98300F8B8FC /* SynchronizedTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedTagsTests.swift; sourceTree = "<group>"; };
 		615D52C02C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedAttributesTests.swift; sourceTree = "<group>"; };
 		615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReporting.xcconfig; sourceTree = "<group>"; };
+		615E2B8D2D39444300D85243 /* ViewEndedMetricController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewEndedMetricController.swift; sourceTree = "<group>"; };
+		615E2B942D425F5600D85243 /* ViewEndedMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewEndedMetric.swift; sourceTree = "<group>"; };
 		615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		6161247825CA9CA6009901BE /* CrashReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporting.swift; sourceTree = "<group>"; };
 		6161249D25CAB340009901BE /* CrashContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContext.swift; sourceTree = "<group>"; };
@@ -5127,6 +5133,8 @@
 			children = (
 				6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */,
 				6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */,
+				615E2B942D425F5600D85243 /* ViewEndedMetric.swift */,
+				615E2B8D2D39444300D85243 /* ViewEndedMetricController.swift */,
 			);
 			path = SDKMetrics;
 			sourceTree = "<group>";
@@ -9002,6 +9010,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6167E6D42B7F8B3300C3CA2D /* AppHangsMonitor.swift in Sources */,
+				615E2B8F2D39444300D85243 /* ViewEndedMetricController.swift in Sources */,
 				D23F8E5229DDCD28001CFAE8 /* UIViewControllerHandler.swift in Sources */,
 				D23F8E5329DDCD28001CFAE8 /* RUMCommand.swift in Sources */,
 				D23F8E5429DDCD28001CFAE8 /* ValuePublisher.swift in Sources */,
@@ -9061,6 +9070,7 @@
 				D23F8E7729DDCD28001CFAE8 /* UIKitRUMViewsPredicate.swift in Sources */,
 				61C713A62A3B78F900FA735A /* RUMMonitorProtocol+Internal.swift in Sources */,
 				D23F8E7829DDCD28001CFAE8 /* LongTaskObserver.swift in Sources */,
+				615E2B962D425F5600D85243 /* ViewEndedMetric.swift in Sources */,
 				D23F8E7A29DDCD28001CFAE8 /* SessionReplayDependency.swift in Sources */,
 				616F8C282BB1CD990061EA53 /* ProcessIdentifier.swift in Sources */,
 				D23F8E7B29DDCD28001CFAE8 /* RUMDeviceInfo.swift in Sources */,
@@ -9346,6 +9356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6167E6D32B7F8B3300C3CA2D /* AppHangsMonitor.swift in Sources */,
+				615E2B8E2D39444300D85243 /* ViewEndedMetricController.swift in Sources */,
 				D29A9F8029DD85BB005C54A4 /* UIViewControllerHandler.swift in Sources */,
 				D29A9F5929DD85BB005C54A4 /* RUMCommand.swift in Sources */,
 				D29A9F8C29DD861C005C54A4 /* ValuePublisher.swift in Sources */,
@@ -9405,6 +9416,7 @@
 				D29A9F5E29DD85BB005C54A4 /* UIKitRUMViewsPredicate.swift in Sources */,
 				61C713A52A3B78F900FA735A /* RUMMonitorProtocol+Internal.swift in Sources */,
 				D29A9F5129DD85BB005C54A4 /* LongTaskObserver.swift in Sources */,
+				615E2B952D425F5600D85243 /* ViewEndedMetric.swift in Sources */,
 				D29A9F8629DD85BB005C54A4 /* SessionReplayDependency.swift in Sources */,
 				616F8C272BB1CD990061EA53 /* ProcessIdentifier.swift in Sources */,
 				D29A9F7129DD85BB005C54A4 /* RUMDeviceInfo.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -666,6 +666,8 @@
 		61DCC84B2C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */; };
 		61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
 		61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
+		61E141EF2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E141EE2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift */; };
+		61E141F02D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E141EE2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
@@ -2751,6 +2753,7 @@
 		61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionEndedMetricIntegrationTests.swift; sourceTree = "<group>"; };
 		61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryInterceptor.swift; sourceTree = "<group>"; };
 		61DE333525C8278A008E3EC2 /* CrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingPlugin.swift; sourceTree = "<group>"; };
+		61E141EE2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewEndedMetricIntegrationTests.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventBuilderTests.swift; sourceTree = "<group>"; };
 		61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataMatcher.swift; sourceTree = "<group>"; };
@@ -5565,6 +5568,7 @@
 			isa = PBXGroup;
 			children = (
 				61DCC8492C05D4D600CB59E5 /* RUMSessionEndedMetricIntegrationTests.swift */,
+				61E141EE2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift */,
 			);
 			path = SDKMetrics;
 			sourceTree = "<group>";
@@ -8341,6 +8345,7 @@
 				6167E6DD2B811A8300C3CA2D /* AppHangsMonitoringTests.swift in Sources */,
 				612C13D02AA772FA0086B5D1 /* SRRequestMatcher.swift in Sources */,
 				61A1A44929643254007909E7 /* DatadogCoreProxy.swift in Sources */,
+				61E141EF2D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift in Sources */,
 				D2A1EE3B287EECC000D28DFB /* CarrierInfoPublisherTests.swift in Sources */,
 				D22743D829DEB8B4001A7EF9 /* VitalInfoTests.swift in Sources */,
 				D2C5D5302B84F71200B63F36 /* WebRecordIntegrationTests.swift in Sources */,
@@ -9766,6 +9771,7 @@
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,
 				D2CB6F3B27C520D400A62B57 /* NSURLSessionBridge.m in Sources */,
 				D2A1EE452886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */,
+				61E141F02D42BC74008C8851 /* RUMViewEndedMetricIntegrationTests.swift in Sources */,
 				61A2CC222A443D330000FF25 /* DDRUMConfigurationTests.swift in Sources */,
 				6128F5852BA8CAAB00D35B08 /* DataStoreFileWriterTests.swift in Sources */,
 				6176991C2A86121B0030022B /* HTTPClientMock.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -22,6 +22,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         )
         rumConfig = RUM.Configuration(applicationID: .mockAny())
         rumConfig.telemetrySampleRate = .maxSampleRate
+        rumConfig.sessionEndedMetricSampleRate = .maxSampleRate
         rumConfig.dateProvider = dateProvider
     }
 
@@ -37,7 +38,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
 
         // When
@@ -52,7 +53,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key1", name: "View1")
 
         // When
@@ -68,7 +69,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
 
         // When
@@ -88,7 +89,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
 
         // When
@@ -106,7 +107,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
         monitor.currentSessionID { currentSessionID = $0 }
         monitor.stopView(key: "key")
@@ -126,7 +127,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         dateProvider.now += 5.seconds
         monitor.startView(key: "key1", name: "View1")
         dateProvider.now += 5.seconds
@@ -150,7 +151,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         (0..<3).forEach { _ in
             // Simulate app in foreground:
             core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: dateProvider.now))
@@ -189,7 +190,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
 
         core.flush()
@@ -222,7 +223,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
 
         // When
@@ -240,7 +241,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         RUM.enable(with: rumConfig, in: core)
 
         // Given
-        let monitor = self.rumMonitor()
+        let monitor = RUMMonitor.shared(in: core)
         monitor.startView(key: "key", name: "View")
         monitor.stopView(key: "key") // no active view
 
@@ -259,14 +260,6 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         XCTAssertEqual(metric.attributes?.noViewEventsCount.resources, expectedCount)
         XCTAssertEqual(metric.attributes?.noViewEventsCount.errors, expectedCount)
         XCTAssertEqual(metric.attributes?.noViewEventsCount.longTasks, expectedCount)
-    }
-}
-
-private extension RUMSessionEndedMetricIntegrationTests {
-    func rumMonitor(with sessionEndedSampleRate: SampleRate = .maxSampleRate) -> RUMMonitorProtocol {
-        let monitor = RUMMonitor.shared(in: core)
-        monitor.dd.scopes.dependencies.sessionEndedMetric.sampleRate = sessionEndedSampleRate
-        return monitor
     }
 }
 

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -22,7 +22,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         )
         rumConfig = RUM.Configuration(applicationID: .mockAny())
         rumConfig.telemetrySampleRate = .maxSampleRate
-        rumConfig.sessionEndedMetricSampleRate = .maxSampleRate
+        rumConfig.sessionEndedSampleRate = .maxSampleRate
         rumConfig.dateProvider = dateProvider
     }
 

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
@@ -1,0 +1,190 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@_spi(Experimental)
+@testable import DatadogRUM
+@testable import DatadogInternal
+
+class RUMViewEndedMetricIntegrationTests: XCTestCase {
+    private let dateProvider = DateProviderMock()
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var rumConfig: RUM.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        core = DatadogCoreProxy()
+        core.context = .mockWith(
+            launchTime: .mockWith(launchDate: dateProvider.now),
+            applicationStateHistory: .mockAppInForeground(since: dateProvider.now)
+        )
+        rumConfig = RUM.Configuration(applicationID: .mockAny())
+        rumConfig.telemetrySampleRate = .maxSampleRate
+        rumConfig.viewEndedMetricSampleRate = .maxSampleRate
+        rumConfig.dateProvider = dateProvider
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        rumConfig = nil
+    }
+
+    // MARK: - Conditions For Sending The Metric
+
+    func testWhenViewIsStopped() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: "View")
+        monitor.stopView(key: "key")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(metrics[0].attributes?.viewType, .applicationLaunch)
+        XCTAssertEqual(metrics[1].attributes?.viewType, .custom)
+    }
+
+    func testWhenAnotherViewIsStarted() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        monitor.startView(key: "key1", name: "View1")
+
+        // When
+        monitor.startView(key: "key2", name: "View2")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(metrics[0].attributes?.viewType, .applicationLaunch)
+        XCTAssertEqual(metrics[1].attributes?.viewType, .custom)
+    }
+
+    // MARK: - Reporting View Attributes
+
+    func testReportingViewTypeAndDuration() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+        dateProvider.now += 1
+
+        // When
+        monitor.startView(key: "key1", name: "View1")
+        dateProvider.now += 3
+        monitor.startView(key: "key2", name: "View2")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(metrics[0].attributes?.viewType, .applicationLaunch)
+        XCTAssertNil(metrics[0].attributes?.instrumentationType)
+        XCTAssertEqual(metrics[0].attributes?.duration, 1_000_000_000)
+        XCTAssertEqual(metrics[1].attributes?.viewType, .custom)
+        XCTAssertEqual(metrics[1].attributes?.instrumentationType, .manual)
+        XCTAssertEqual(metrics[1].attributes?.duration, 3_000_000_000)
+    }
+
+    func testReportingTNSValue() throws {
+        rumConfig.networkSettledResourcePredicate = TimeBasedTNSResourcePredicate(threshold: 2)
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (view with TNS)
+        monitor.startView(key: "key", name: "View1")
+        dateProvider.now += 1 // less than threshold: 2s
+        monitor.startResource(resourceKey: "resource", url: .mockAny())
+        dateProvider.now += 4.2
+        monitor.stopResource(resourceKey: "resource", response: .mockAny())
+        dateProvider.now += 1
+        monitor.stopView(key: "key")
+
+        // When (view with no TNS)
+        monitor.startView(key: "key", name: "View2")
+        dateProvider.now += 1
+        monitor.stopView(key: "key")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 3)
+        XCTAssertEqual(metrics[1].attributes?.tns?.config, "time_based_custom")
+        XCTAssertEqual(try XCTUnwrap(metrics[1].attributes?.tns?.value).nanosecondsToSeconds, 5.2.seconds, accuracy: 0.01)
+        XCTAssertEqual(metrics[2].attributes?.tns?.config, "time_based_custom")
+        XCTAssertEqual(try XCTUnwrap(metrics[2].attributes?.tns?.noValueReason), "no_resources")
+    }
+
+    func testReportingINVValue() throws {
+        rumConfig.nextViewActionPredicate = TimeBasedINVActionPredicate(maxTimeToNextView: 5)
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When (view with no INV)
+        monitor.startView(key: "key", name: "View1")
+        dateProvider.now += 1
+        monitor.addAction(type: .tap, name: "Go to View2")
+        dateProvider.now += 4.42 // less than maxTimeToNextView: 5
+        monitor.stopView(key: "key")
+
+        // When (view with INV)
+        monitor.startView(key: "key", name: "View2")
+        monitor.stopView(key: "key")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 3)
+        XCTAssertEqual(metrics[1].attributes?.inv?.config, "time_based_custom")
+        XCTAssertEqual(try XCTUnwrap(metrics[1].attributes?.inv?.noValueReason), "no_action")
+        XCTAssertEqual(metrics[2].attributes?.inv?.config, "time_based_custom")
+        XCTAssertEqual(try XCTUnwrap(metrics[2].attributes?.inv?.value).nanosecondsToSeconds, 4.42.seconds, accuracy: 0.01)
+    }
+
+    func testReportingLoadingTimeValue() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: "View")
+        dateProvider.now += 1.52
+        monitor.addViewLoadingTime(overwrite: false)
+        monitor.stopView(key: "key")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(try XCTUnwrap(metrics[1].attributes?.loadingTime?.value).nanosecondsToSeconds, 1.52.seconds, accuracy: 0.01)
+    }
+}
+
+// MARK: - Helpers
+
+private extension DatadogCoreProxy {
+    func waitAndReturnViewEndedMetricEvents() -> [TelemetryDebugEvent] {
+        let events = waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        return events.filter { $0.telemetry.message == "[Mobile Metric] \(ViewEndedMetric.Constants.name)" }
+    }
+}
+
+private extension TelemetryDebugEvent {
+    var attributes: ViewEndedMetric.Attributes? {
+        return telemetry.telemetryInfo[ViewEndedMetric.Constants.rveKey] as? ViewEndedMetric.Attributes
+    }
+}
+
+private extension Int64 {
+    var nanosecondsToSeconds: TimeInterval { TimeInterval(fromNanoseconds: self) }
+}

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
@@ -23,7 +23,7 @@ class RUMViewEndedMetricIntegrationTests: XCTestCase {
         )
         rumConfig = RUM.Configuration(applicationID: .mockAny())
         rumConfig.telemetrySampleRate = .maxSampleRate
-        rumConfig.viewEndedMetricSampleRate = .maxSampleRate
+        rumConfig.viewEndedSampleRate = .maxSampleRate
         rumConfig.dateProvider = dateProvider
     }
 

--- a/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -786,6 +786,9 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache(dateProvider: SystemDateProvider()),
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
+        viewEndedMetricFactory: @escaping () -> ViewEndedMetricController = {
+            ViewEndedMetricController(tnsPredicateType: .custom, invPredicateType: .custom, telemetry: NOPTelemetry(), sampleRate: 0)
+        },
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking = {
             TNSMetric(viewName: $1, viewStartDate: $0, resourcePredicate: TimeBasedTNSResourcePredicate())
@@ -811,6 +814,7 @@ extension RUMScopeDependencies {
             viewCache: viewCache,
             fatalErrorContext: fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric,
+            viewEndedMetricFactory: viewEndedMetricFactory,
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: networkSettledMetricFactory,
             interactionToNextViewMetricFactory: interactionToNextViewMetricFactory
@@ -834,6 +838,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil,
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
+        viewEndedMetricFactory: (() -> ViewEndedMetricController)? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: ((Date, String) -> TNSMetricTracking)? = nil,
         interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
@@ -855,6 +860,7 @@ extension RUMScopeDependencies {
             viewCache: viewCache ?? self.viewCache,
             fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric,
+            viewEndedMetricFactory: viewEndedMetricFactory ?? self.viewEndedMetricFactory,
             watchdogTermination: watchdogTermination ?? self.watchdogTermination,
             networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory,
             interactionToNextViewMetricFactory: interactionToNextViewMetricFactory ?? self.interactionToNextViewMetricFactory

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -89,8 +89,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             backtraceReporter: core.backtraceReporter,
             ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
             syntheticsTest: {
-                if let testId = configuration.syntheticsTestId,
-                   let resultId = configuration.syntheticsResultId {
+                if let testId = configuration.syntheticsTestId, let resultId = configuration.syntheticsResultId {
                     return RUMSyntheticsTest(injected: nil, resultId: resultId, testId: testId)
                 } else {
                     return nil

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -38,7 +38,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         let featureScope = core.scope(for: RUMFeature.self)
         let sessionEndedMetric = SessionEndedMetricController(
             telemetry: core.telemetry,
-            sampleRate: SessionEndedMetricController.defaultSampleRate
+            sampleRate: configuration.sessionEndedMetricSampleRate
         )
         let tnsPredicateType = configuration.networkSettledResourcePredicate.metricPredicateType
         let invPredicateType = configuration.nextViewActionPredicate.metricPredicateType
@@ -111,7 +111,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     tnsPredicateType: tnsPredicateType,
                     invPredicateType: invPredicateType,
                     telemetry: featureScope.telemetry,
-                    sampleRate: ViewEndedMetricController.defaultSampleRate
+                    sampleRate: configuration.viewEndedMetricSampleRate
                 )
             },
             watchdogTermination: watchdogTermination,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -38,7 +38,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         let featureScope = core.scope(for: RUMFeature.self)
         let sessionEndedMetric = SessionEndedMetricController(
             telemetry: core.telemetry,
-            sampleRate: configuration.sessionEndedMetricSampleRate
+            sampleRate: configuration.sessionEndedSampleRate
         )
         let tnsPredicateType = configuration.networkSettledResourcePredicate.metricPredicateType
         let invPredicateType = configuration.nextViewActionPredicate.metricPredicateType
@@ -110,7 +110,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     tnsPredicateType: tnsPredicateType,
                     invPredicateType: invPredicateType,
                     telemetry: featureScope.telemetry,
-                    sampleRate: configuration.viewEndedMetricSampleRate
+                    sampleRate: configuration.viewEndedSampleRate
                 )
             },
             watchdogTermination: watchdogTermination,

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -290,9 +290,9 @@ extension RUM {
         /// An extra sampling rate for configuration telemetry events. It is applied on top of the value configured in public `telemetrySampleRate`.
         internal var configurationTelemetrySampleRate: SampleRate = 20.0
         /// Sample rate for "view ended" metric in telemetry.
-        internal var viewEndedMetricSampleRate = ViewEndedMetricController.defaultSampleRate
+        internal var viewEndedSampleRate = ViewEndedMetricController.defaultSampleRate
         /// Sample rate for "session ended" metric in telemetry.
-        internal var sessionEndedMetricSampleRate = SessionEndedMetricController.defaultSampleRate
+        internal var sessionEndedSampleRate = SessionEndedMetricController.defaultSampleRate
 
         internal var uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -289,6 +289,10 @@ extension RUM {
 
         /// An extra sampling rate for configuration telemetry events. It is applied on top of the value configured in public `telemetrySampleRate`.
         internal var configurationTelemetrySampleRate: SampleRate = 20.0
+        /// Sample rate for "view ended" metric in telemetry.
+        internal var viewEndedMetricSampleRate = ViewEndedMetricController.defaultSampleRate
+        /// Sample rate for "session ended" metric in telemetry.
+        internal var sessionEndedMetricSampleRate = SessionEndedMetricController.defaultSampleRate
 
         internal var uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -51,6 +51,9 @@ internal struct RUMScopeDependencies {
     let sessionEndedMetric: SessionEndedMetricController
     let watchdogTermination: WatchdogTerminationMonitor?
 
+    /// A factory function that creates `ViewEndedMetricController` for each new view started.
+    let viewEndedMetricFactory: () -> ViewEndedMetricController
+
     /// A factory function that creates a `TNSMetric` for the given view start date.
     /// - Parameters:
     ///   - Date: The time when the view becomes visible (device time, no NTP offset).
@@ -77,6 +80,7 @@ internal struct RUMScopeDependencies {
         viewCache: ViewCache,
         fatalErrorContext: FatalErrorContextNotifying,
         sessionEndedMetric: SessionEndedMetricController,
+        viewEndedMetricFactory: @escaping () -> ViewEndedMetricController,
         watchdogTermination: WatchdogTerminationMonitor?,
         networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking,
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking
@@ -98,6 +102,7 @@ internal struct RUMScopeDependencies {
         self.fatalErrorContext = fatalErrorContext
         self.telemetry = featureScope.telemetry
         self.sessionEndedMetric = sessionEndedMetric
+        self.viewEndedMetricFactory = viewEndedMetricFactory
         self.watchdogTermination = watchdogTermination
         self.networkSettledMetricFactory = networkSettledMetricFactory
         self.interactionToNextViewMetricFactory = interactionToNextViewMetricFactory

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -628,7 +628,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies.fatalErrorContext.view = event
 
             // Track this view in Session Ended metric:
-            let instrumentationType = (command as? RUMStartViewCommand)?.instrumentationType
+            var instrumentationType: SessionEndedMetric.ViewInstrumentationType?
+            if let command = command as? RUMStartViewCommand, command.identity == identity {
+                instrumentationType = command.instrumentationType
+            }
             dependencies.sessionEndedMetric.track(
                 view: event,
                 instrumentationType: instrumentationType,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -516,7 +516,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let memoryInfo = vitalInfoSampler?.memory
         let refreshRateInfo = vitalInfoSampler?.refreshRate
         let isSlowRendered = refreshRateInfo?.meanValue.map { $0 < Constants.slowRenderingThresholdFPS }
-        let networkSettledTime = networkSettledMetric.value(at: command.time, appStateHistory: context.applicationStateHistory)
+        let networkSettledTime = networkSettledMetric.value(with: context.applicationStateHistory)
         let interactionToNextViewTime = interactionToNextViewMetric.value(for: viewUUID)
 
         let viewEvent = RUMViewEvent(
@@ -606,7 +606,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 memoryAverage: memoryInfo?.meanValue,
                 memoryMax: memoryInfo?.maxValue,
                 name: viewName,
-                networkSettledTime: networkSettledTime?.toInt64Nanoseconds,
+                networkSettledTime: networkSettledTime.value?.toInt64Nanoseconds,
                 referrer: nil,
                 refreshRateAverage: refreshRateInfo?.meanValue,
                 refreshRateMin: refreshRateInfo?.minValue,
@@ -858,4 +858,13 @@ private extension VitalInfo {
 
 /// A protocol for `RUMCommand`s that can propagate their attributes to the `RUMViewScope``.
 internal protocol RUMViewScopePropagatableAttributes where Self: RUMCommand {
+}
+
+private extension Result {
+    var value: Success? {
+        switch self {
+        case .success(let success): return success
+        case .failure: return nil
+        }
+    }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -593,7 +593,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 interactionToNextPaint: nil,
                 interactionToNextPaintTargetSelector: nil,
                 interactionToNextPaintTime: nil,
-                interactionToNextViewTime: interactionToNextViewTime?.toInt64Nanoseconds,
+                interactionToNextViewTime: interactionToNextViewTime.value?.toInt64Nanoseconds,
                 isActive: isActive,
                 isSlowRendered: isSlowRendered ?? false,
                 jsRefreshRate: viewPerformanceMetrics[.jsFrameTimeSeconds]?.asJsRefreshRate(),

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -8,8 +8,8 @@ import Foundation
 import DatadogInternal
 
 /// A controller responsible for managing "RUM Session Ended" metrics.
-internal final class SessionEndedMetricController: SampledTelemetry {
-    /// The default sample rate for session ended metric (15%), applied in addition to the telemetry sample rate (20% by default).
+internal final class SessionEndedMetricController {
+    /// The default sample rate for "session ended" metric (15%), applied in addition to the telemetry sample rate (20% by default).
     static let defaultSampleRate: SampleRate = 15
 
     /// Dictionary to keep track of pending metrics, keyed by session ID.
@@ -29,7 +29,7 @@ internal final class SessionEndedMetricController: SampledTelemetry {
     ///    - telemetry: The telemetry endpoint used for sending metrics.
     ///    - sampleRate: The sample rate for "RUM Session Ended" metric.
 
-    init(telemetry: Telemetry, sampleRate: SampleRate = SessionEndedMetricController.defaultSampleRate) {
+    init(telemetry: Telemetry, sampleRate: SampleRate) {
         self.telemetry = telemetry
         self.sampleRate = sampleRate
     }

--- a/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
@@ -60,7 +60,7 @@ internal final class ViewEndedMetric {
     // MARK: - Exporting Attributes
 
     /// A container for encoding "RUM View Ended" according to the spec.
-    private struct Attributes: Encodable {
+    internal struct Attributes: Encodable {
         struct MetricValue: Encodable {
             /// Metric value in nanoseconds.
             var value: Int64?

--- a/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
@@ -1,0 +1,171 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Tracks the state of RUM view and exports attributes for "RUM View Ended" telemetry.
+///
+/// It is a reference type and contains mutable state, but thread safety is assured by only accessing it from `RUMViewScope`.
+internal final class ViewEndedMetric {
+    /// Definition of fields in "RUM View Ended" telemetry, following the "RUM View Ended" telemetry spec.
+    internal enum Constants {
+        /// The name of this metric, included in telemetry log.
+        /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+        static let name = "RUM View Ended"
+        /// Metric type value.
+        static let typeValue = "rum view ended"
+        /// Namespace for bundling metric attributes ("rve" = "RUM View Ended").
+        static let rveKey = "rve"
+    }
+
+    internal enum MetricPredicateType: String {
+        case timeBasedDefault = "time_based_default"
+        case timeBasedCustom = "time_based_custom"
+        case custom = "custom"
+    }
+
+    /// The view URL as reported in RUM data.
+    var viewURL: String?
+    /// The type of instrumentation that started this view.
+    /// It can be `nil` if view was started implicitly by RUM, which is the case for "ApplicationLaunch" and "Background" views.
+    var instrumentationType: SessionEndedMetric.ViewInstrumentationType?
+    /// Duration of the view in nanoseconds (equal to `@view.time_spent`).
+    var durationNs: Int64?
+
+    /// The value of `@view.loading_time`.
+    var loadingTime: Int64?
+
+    /// The value or "no value reason" for `@view.network_settled_time` (Time-to-Network-Settled, TNS).
+    var tnsResult: Result<TimeInterval, TNSNoValueReason>?
+    /// The type of `NetworkSettledResourcePredicate` used for TNS tracking.
+    let tnsConfigPredicate: MetricPredicateType
+
+    /// The value or "no value reason" for `@view.interaction_to_next_view_time` (Interaction-to-Next-View, INV).
+    var invResult: Result<TimeInterval, INVNoValueReason>?
+    /// The type of `NextViewActionPredicate` used for TNS tracking.
+    let invConfigPredicate: MetricPredicateType
+
+    init(
+        tnsConfigPredicate: MetricPredicateType,
+        invConfigPredicate: MetricPredicateType
+    ) {
+        self.tnsConfigPredicate = tnsConfigPredicate
+        self.invConfigPredicate = invConfigPredicate
+    }
+
+    // MARK: - Exporting Attributes
+
+    /// A container for encoding "RUM View Ended" according to the spec.
+    private struct Attributes: Encodable {
+        struct MetricValue: Encodable {
+            /// Metric value in nanoseconds.
+            var value: Int64?
+            /// Reason for missing value.
+            var noValueReason: String?
+            /// Strategy for computing value in this metric.
+            var config: String?
+
+            enum CodingKeys: String, CodingKey {
+                case value = "value"
+                case noValueReason = "no_value_reason"
+                case config = "config"
+            }
+        }
+
+        enum ViewType: String, Encodable {
+            case applicationLaunch = "application_launch"
+            case background = "background"
+            case custom = "custom"
+        }
+
+        /// Duration of the view in nanoseconds (equal to `view.time_spent`).
+        var duration: Int64
+        /// Tracks `@view.loading_time` metric.
+        var loadingTime: MetricValue?
+        /// Tracks `@view.network_settled_time` metric.
+        var tns: MetricValue?
+        /// Tracks `@view.interaction_to_next_view_time` metric.
+        var inv: MetricValue?
+        /// The type of the view.
+        var viewType: ViewType?
+        /// The type of instrumentation that this view was started by.
+        var instrumentationType: SessionEndedMetric.ViewInstrumentationType?
+
+        enum CodingKeys: String, CodingKey {
+            case duration = "duration"
+            case loadingTime = "loading_time"
+            case tns = "tns"
+            case inv = "inv"
+            case viewType = "view_type"
+            case instrumentationType = "instrumentation_type"
+        }
+    }
+
+    func asMetricAttributes() -> [String: Encodable]? {
+        guard let durationNs else {
+            return nil
+        }
+
+        let loadingTime = loadingTime.map { Attributes.MetricValue(value: $0) }
+        var tns = Attributes.MetricValue(config: tnsConfigPredicate.rawValue)
+        var inv = Attributes.MetricValue(config: invConfigPredicate.rawValue)
+
+        switch tnsResult {
+        case .success(let value): tns.value = value.toInt64Nanoseconds
+        case .failure(let noValueReason): tns.noValueReason = noValueReason.rawValue
+        default: break
+        }
+
+        switch invResult {
+        case .success(let value): inv.value = value.toInt64Nanoseconds
+        case .failure(let noValueReason): inv.noValueReason = noValueReason.rawValue
+        default: break
+        }
+
+        var viewType: Attributes.ViewType?
+        switch viewURL {
+        case RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL: viewType = .applicationLaunch
+        case RUMOffViewEventsHandlingRule.Constants.backgroundViewURL: viewType = .background
+        case .some: viewType = .custom
+        default: break
+        }
+
+        return [
+            SDKMetricFields.typeKey: Constants.typeValue,
+            Constants.rveKey: Attributes(
+                duration: durationNs,
+                loadingTime: loadingTime,
+                tns: tns,
+                inv: inv,
+                viewType: viewType,
+                instrumentationType: instrumentationType
+            )
+        ]
+    }
+}
+
+internal extension NetworkSettledResourcePredicate {
+    var metricPredicateType: ViewEndedMetric.MetricPredicateType {
+        switch self {
+        case let timeBased as TimeBasedTNSResourcePredicate:
+            return timeBased.threshold == TimeBasedTNSResourcePredicate.defaultThreshold ? .timeBasedDefault : .timeBasedCustom
+        default:
+            return .custom
+        }
+    }
+}
+
+internal extension NextViewActionPredicate {
+    var metricPredicateType: ViewEndedMetric.MetricPredicateType {
+        switch self {
+        case let timeBased as TimeBasedINVActionPredicate:
+            return timeBased.maxTimeToNextView == TimeBasedINVActionPredicate.defaultMaxTimeToNextView ? .timeBasedDefault : .timeBasedCustom
+        default:
+            return .custom
+        }
+    }
+}

--- a/DatadogRUM/Sources/SDKMetrics/ViewEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/ViewEndedMetricController.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+internal final class ViewEndedMetricController {
+    /// The default sample rate for "view ended" metric (0.75%), applied in addition to the telemetry sample rate (20% by default).
+    static let defaultSampleRate: SampleRate = 0.75
+
+    /// Telemetry endpoint for sending metrics.
+    private let telemetry: Telemetry
+    /// The sample rate for "RUM View Ended" metric.
+    internal var sampleRate: SampleRate
+    /// Metric data for current view.
+    private var metric: ViewEndedMetric
+    /// If the metric was sent to telemetry.
+    private var wasSent = false
+
+    init(
+        tnsPredicateType: ViewEndedMetric.MetricPredicateType,
+        invPredicateType: ViewEndedMetric.MetricPredicateType,
+        telemetry: Telemetry,
+        sampleRate: SampleRate = ViewEndedMetricController.defaultSampleRate
+    ) {
+        self.telemetry = telemetry
+        self.sampleRate = sampleRate
+        self.metric = ViewEndedMetric(tnsConfigPredicate: tnsPredicateType, invConfigPredicate: invPredicateType)
+    }
+
+    /// Tracks the view update event.
+    /// - Parameters:
+    ///   - view: the view update event to track
+    ///   - instrumentationType: the type of instrumentation used to start this view (only the first value for each `view.id` is tracked; succeeding values
+    ///   will be ignored so it is okay to pass value on first call and then follow with `nil` for next updates of given `view.id`)
+    func track(
+        viewEvent: RUMViewEvent,
+        instrumentationType: SessionEndedMetric.ViewInstrumentationType?
+    ) {
+        metric.instrumentationType = instrumentationType ?? metric.instrumentationType
+        metric.viewURL = viewEvent.view.url
+        metric.durationNs = viewEvent.view.timeSpent
+        metric.loadingTime = viewEvent.view.loadingTime
+    }
+
+    /// Tracks the value computed for the Time-to-Network-Settled (TNS) metric.
+    func track(networkSettledResult: Result<TimeInterval, TNSNoValueReason>) {
+        metric.tnsResult = networkSettledResult
+    }
+
+    /// Tracks the value computed for the Interaction-to-Next-View (INV) metric.
+    func track(interactionToNextViewResult: Result<TimeInterval, INVNoValueReason>) {
+        metric.invResult = interactionToNextViewResult
+    }
+
+    /// Sends the "view ended" metric telemetry.
+    ///
+    /// - Note: This method is expected to be called exactly once per view to report metrics associated with the view's lifecycle.
+    func send() {
+        guard !wasSent else { // sanity check
+            telemetry.debug("Trying to send 'view ended' more than once")
+            return
+        }
+        guard let attributes = metric.asMetricAttributes() else {
+            telemetry.debug("Failed to compute attributes fo 'view ended'")
+            return
+        }
+
+        telemetry.metric(name: ViewEndedMetric.Constants.name, attributes: attributes, sampleRate: sampleRate)
+        wasSent = true
+    }
+}

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -1270,9 +1270,9 @@ internal class INVMetricMock: INVMetricTracking {
     /// Tracks calls to `trackViewComplete(viewID:)`.
     var trackedViewCompletes: Set<RUMUUID> = []
     /// Mocked value returned by this metric.
-    var mockedValue: TimeInterval?
+    var mockedValue: Result<TimeInterval, INVNoValueReason>
 
-    init(mockedValue: TimeInterval? = nil) {
+    init(mockedValue: Result<TimeInterval, INVNoValueReason> = .failure(.noTrackedActions)) {
         self.mockedValue = mockedValue
     }
 
@@ -1288,7 +1288,7 @@ internal class INVMetricMock: INVMetricTracking {
         trackedViewCompletes.insert(viewID)
     }
 
-    func value(for viewID: RUMUUID) -> TimeInterval? {
+    func value(for viewID: RUMUUID) -> Result<TimeInterval, INVNoValueReason> {
         return mockedValue
     }
 }

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -802,6 +802,9 @@ extension RUMScopeDependencies {
         viewCache: ViewCache = ViewCache(dateProvider: SystemDateProvider()),
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
         sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
+        viewEndedMetricFactory: @escaping () -> ViewEndedMetricController = {
+            ViewEndedMetricController(tnsPredicateType: .custom, invPredicateType: .custom, telemetry: NOPTelemetry(), sampleRate: 0)
+        },
         watchdogTermination: WatchdogTerminationMonitor = .mockRandom(),
         networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking = { _, _ in TNSMetricMock() },
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = { INVMetricMock() }
@@ -823,6 +826,7 @@ extension RUMScopeDependencies {
             viewCache: viewCache,
             fatalErrorContext: fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric,
+            viewEndedMetricFactory: viewEndedMetricFactory,
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: networkSettledMetricFactory,
             interactionToNextViewMetricFactory: interactionToNextViewMetricFactory
@@ -846,6 +850,7 @@ extension RUMScopeDependencies {
         viewCache: ViewCache? = nil,
         fatalErrorContext: FatalErrorContextNotifying? = nil,
         sessionEndedMetric: SessionEndedMetricController? = nil,
+        viewEndedMetricFactory: (() -> ViewEndedMetricController)? = nil,
         watchdogTermination: WatchdogTerminationMonitor? = nil,
         networkSettledMetricFactory: ((Date, String) -> TNSMetricTracking)? = nil,
         interactionToNextViewMetricFactory: (() -> INVMetricTracking)? = nil
@@ -867,6 +872,7 @@ extension RUMScopeDependencies {
             viewCache: viewCache ?? self.viewCache,
             fatalErrorContext: fatalErrorContext ?? self.fatalErrorContext,
             sessionEndedMetric: sessionEndedMetric ?? self.sessionEndedMetric,
+            viewEndedMetricFactory: viewEndedMetricFactory ?? self.viewEndedMetricFactory,
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: networkSettledMetricFactory ?? self.networkSettledMetricFactory,
             interactionToNextViewMetricFactory: interactionToNextViewMetricFactory ?? self.interactionToNextViewMetricFactory

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -1235,9 +1235,9 @@ internal class TNSMetricMock: TNSMetricTracking {
     /// Tracks if `trackViewWasStopped()` was called.
     var viewWasStopped = false
     /// Mocked value returned by this metric.
-    var value: TimeInterval?
+    var value: Result<TimeInterval, TNSNoValueReason>
 
-    init(value: TimeInterval? = nil) {
+    init(value: Result<TimeInterval, TNSNoValueReason> = .failure(.unknown)) {
         self.value = value
     }
 
@@ -1257,7 +1257,7 @@ internal class TNSMetricMock: TNSMetricTracking {
         viewWasStopped = true
     }
 
-    func value(at time: Date, appStateHistory: AppStateHistory) -> TimeInterval? {
+    func value(with appStateHistory: AppStateHistory) -> Result<TimeInterval, TNSNoValueReason> {
         return value
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -202,7 +202,7 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: INVMetricMock(mockedValue: 0.84)
+            interactionToNextViewMetric: INVMetricMock(mockedValue: .success(0.84))
         )
 
         let hasReplay: Bool = .mockRandom()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -194,7 +194,7 @@ class RUMViewScopeTests: XCTestCase {
             isInitialView: true,
             parent: parent,
             dependencies: .mockWith(
-                networkSettledMetricFactory: { _, _ in TNSMetricMock(value: 0.42) }
+                networkSettledMetricFactory: { _, _ in TNSMetricMock(value: .success(0.42)) }
             ),
             identity: .mockViewIdentifier(),
             path: "UIViewController",

--- a/TestUtilities/Helpers/SwiftExtensions.swift
+++ b/TestUtilities/Helpers/SwiftExtensions.swift
@@ -193,3 +193,21 @@ extension Dictionary where Key == Int, Value == String {
         lhs.merging(rhs) { _, new in new }
     }
 }
+
+public extension Result {
+    /// Indicates whether the result is a success.
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+
+    /// Indicates whether the result is a failure.
+    var isFailure: Bool {
+        if case .failure = self {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
### What and why?

📦 🔭 Following the [spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4534173727/RUM+View+Ended+Telemetry+-+Spec) (internal), this PR introduces "RUM View Ended" telemetry. The primary goal is to measure the quality of view timings (INV, TNS, and addViewLoadingTime()), laying the groundwork for overall view monitoring — similar to how ["RUM Session Ended"](https://github.com/DataDog/dd-sdk-ios/pull/1866) provides session insights.

### How?

#### TNS and INV Changes

First, this PR refactors `TNSMetric` and `INVMetric` to report their values through `Result<TimeInterval, NoValueReason>` rather than a simple `TimeInterval?`. This gives finer-grained insight into why a metric might be unavailable, using new enums `TNSNoValueReason` and `INVNoValueReason`:

```diff
// TNSMetric
- func value(with appStateHistory: AppStateHistory) -> TimeInterval?
+ func value(with appStateHistory: AppStateHistory) -> Result<TimeInterval, TNSNoValueReason>

// INVMetric
- func value(for viewID: RUMUUID) -> TimeInterval?
+ func value(for viewID: RUMUUID) -> Result<TimeInterval, INVNoValueReason>
```
To accommodate the range of "no value" reasons, the internal implementations of both metrics were refactored. `TNSMetric` in particular underwent more significant changes due to its broader set of edge cases — but thanks to good existing test coverage, this refactoring remains well-validated.

#### `ViewEndedMetric`

Second, this PR introduces "RUM View Ended" telemetry, which is sent whenever a view ends with **effective sample rate of 0.15%**.

- The design follows the pattern established in "RUM Session Ended".
- The metric tracks various view-level attributes, including newly captured TNS and INV values (or the corresponding "no value reasons").

```swift
internal final class ViewEndedMetricController {
    func track(viewEvent: RUMViewEvent, instrumentationType: ViewInstrumentationType?)
    func track(networkSettledResult: Result<TimeInterval, TNSNoValueReason>)
    func track(interactionToNextViewResult: Result<TimeInterval, INVNoValueReason>)
    func send()
}
```
```swift
class ViewEndedMetric {
    // ...

    /// Duration of the view in nanoseconds (equal to `@view.time_spent`).
    var durationNs: Int64?

    /// The value or "no value reason" for `@view.network_settled_time` (Time-to-Network-Settled, TNS).
    var tnsResult: Result<TimeInterval, TNSNoValueReason>?

    /// The value or "no value reason" for `@view.interaction_to_next_view_time` (Interaction-to-Next-View, INV).
    var invResult: Result<TimeInterval, INVNoValueReason>?

    // ...
}
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
