### PR TITLE
RUM-5176 [CP] Allow reporting RUM error in sync

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1862,6 +1862,8 @@
 		D2EFA869286DA85700F1FAA6 /* DatadogContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFA867286DA85700F1FAA6 /* DatadogContextProvider.swift */; };
 		D2EFA875286E011900F1FAA6 /* DatadogContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFA874286E011900F1FAA6 /* DatadogContextProviderTests.swift */; };
 		D2EFA876286E011900F1FAA6 /* DatadogContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFA874286E011900F1FAA6 /* DatadogContextProviderTests.swift */; };
+		D2F448E12D43A3DC007BB995 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F448E02D43A3DC007BB995 /* CompletionHandler.swift */; };
+		D2F448E22D43A3DC007BB995 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F448E02D43A3DC007BB995 /* CompletionHandler.swift */; };
 		D2F44FB8299AA1DA0074B0D9 /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D2F44FB9299AA1DB0074B0D9 /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D2F44FC2299BD5600074B0D9 /* UIViewController+KeyboardControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F44FC1299BD5600074B0D9 /* UIViewController+KeyboardControlling.swift */; };
@@ -3313,6 +3315,7 @@
 		D2EFA874286E011900F1FAA6 /* DatadogContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogContextProviderTests.swift; sourceTree = "<group>"; };
 		D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandler.swift; sourceTree = "<group>"; };
 		D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopTracerTests.swift; sourceTree = "<group>"; };
+		D2F448E02D43A3DC007BB995 /* CompletionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHandler.swift; sourceTree = "<group>"; };
 		D2F44FC1299BD5600074B0D9 /* UIViewController+KeyboardControlling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+KeyboardControlling.swift"; sourceTree = "<group>"; };
 		D2F8235229915E12003C7E99 /* DatadogSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogSite.swift; sourceTree = "<group>"; };
 		D2FB1253292E0E92005B13F8 /* TrackingConsentPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingConsentPublisher.swift; sourceTree = "<group>"; };
@@ -6321,6 +6324,7 @@
 				D23039DB298D5235001A1FA3 /* ReadWriteLock.swift */,
 				618031F72D6DC430007027E3 /* Threading.swift */,
 				D2432CF829EDB22C00D93657 /* Flushable.swift */,
+				D2F448E02D43A3DC007BB995 /* CompletionHandler.swift */,
 			);
 			path = Concurrency;
 			sourceTree = "<group>";
@@ -8914,6 +8918,7 @@
 				614A708E2BF754D800D9AF42 /* ImmutableRequest.swift in Sources */,
 				D2160CF429C0EDFC00FAA9A5 /* UploadPerformancePreset.swift in Sources */,
 				D23039E1298D5236001A1FA3 /* AppState.swift in Sources */,
+				D2F448E22D43A3DC007BB995 /* CompletionHandler.swift in Sources */,
 				D2DE63532A30A7CA00441A54 /* CoreRegistry.swift in Sources */,
 				D2D748402DC24F1100C61353 /* Crash.swift in Sources */,
 				E2AA55EA2C32C76A002FEF28 /* WatchKitExtensions.swift in Sources */,
@@ -10041,6 +10046,7 @@
 				D2160CF529C0EDFC00FAA9A5 /* UploadPerformancePreset.swift in Sources */,
 				D2DA236C298D57AA00C6C7E6 /* AppState.swift in Sources */,
 				D28FB6972DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */,
+				D2F448E12D43A3DC007BB995 /* CompletionHandler.swift in Sources */,
 				D2DE63542A30A7CA00441A54 /* CoreRegistry.swift in Sources */,
 				E2AA55EC2C32C78B002FEF28 /* WatchKitExtensions.swift in Sources */,
 				D2EBEE3629BA161100B15732 /* W3CHTTPHeadersWriter.swift in Sources */,

--- a/DatadogCore/Sources/Core/Storage/Writing/AsyncWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/AsyncWriter.swift
@@ -17,12 +17,13 @@ internal struct AsyncWriter: Writer {
         self.queue = queue
     }
 
-    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
-        queue.async { writer.write(value: value, metadata: metadata) }
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?, completion: @escaping CompletionHandler) {
+        queue.async { writer.write(value: value, metadata: metadata, completion: completion) }
     }
 }
 
 internal struct NOPWriter: Writer {
-    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?, completion: @escaping CompletionHandler) {
+        completion()
     }
 }

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -36,7 +36,9 @@ internal struct FileWriter: Writer {
     /// - Parameters:
     ///  - value: Encodable value to write.
     ///  - metadata: Encodable metadata to write.
-    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?, completion: @escaping CompletionHandler) {
+        defer { completion() }
+
         var encoded: Data = .init()
         if let metadata = metadata {
             do {

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -24,6 +24,9 @@ class FileWriterTests: XCTestCase {
     }
 
     func testItWritesDataWithMetadataToSingleFileInTLVFormat() throws {
+        let expectation = expectation(description: "Writes complete")
+        expectation.expectedFulfillmentCount = 3
+
         let writer = FileWriter(
             orchestrator: FilesOrchestrator(
                 directory: directory,
@@ -35,9 +38,9 @@ class FileWriterTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        writer.write(value: ["key1": "value1"], metadata: ["meta1": "metaValue1"])
-        writer.write(value: ["key2": "value2"]) // skipped metadata here
-        writer.write(value: ["key3": "value3"], metadata: ["meta3": "metaValue3"])
+        writer.write(value: ["key1": "value1"], metadata: ["meta1": "metaValue1"], completion: expectation.fulfill)
+        writer.write(value: ["key2": "value2"], completion: expectation.fulfill) // skipped metadata here
+        writer.write(value: ["key3": "value3"], metadata: ["meta3": "metaValue3"], completion: expectation.fulfill)
 
         XCTAssertEqual(try directory.files().count, 1)
         let stream = try directory.files()[0].stream()
@@ -58,6 +61,8 @@ class FileWriterTests: XCTestCase {
         block = try reader.next()
         XCTAssertEqual(block?.type, .event)
         XCTAssertEqual(block?.data, #"{"key3":"value3"}"#.utf8Data)
+
+        wait(for: [expectation], timeout: 0)
     }
 
     func testItWritesEncryptedDataWithMetadataToSingleFileInTLVFormat() throws {
@@ -102,6 +107,9 @@ class FileWriterTests: XCTestCase {
     }
 
     func testItWritesDataToSingleFileInTLVFormat() throws {
+        let expectation = expectation(description: "Writes complete")
+        expectation.expectedFulfillmentCount = 3
+
         let writer = FileWriter(
             orchestrator: FilesOrchestrator(
                 directory: directory,
@@ -113,9 +121,9 @@ class FileWriterTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        writer.write(value: ["key1": "value1"])
-        writer.write(value: ["key2": "value2"])
-        writer.write(value: ["key3": "value3"])
+        writer.write(value: ["key1": "value1"], completion: expectation.fulfill)
+        writer.write(value: ["key2": "value2"], completion: expectation.fulfill)
+        writer.write(value: ["key3": "value3"], completion: expectation.fulfill)
 
         XCTAssertEqual(try directory.files().count, 1)
         let stream = try directory.files()[0].stream()
@@ -130,9 +138,14 @@ class FileWriterTests: XCTestCase {
         block = try reader.next()
         XCTAssertEqual(block?.type, .event)
         XCTAssertEqual(block?.data, #"{"key3":"value3"}"#.utf8Data)
+
+        wait(for: [expectation], timeout: 0)
     }
 
     func testGivenErrorVerbosity_whenIndividualDataExceedsMaxWriteSize_itDropsDataAndPrintsError() throws {
+        let expectation = expectation(description: "Writes complete")
+        expectation.expectedFulfillmentCount = 2
+
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
@@ -161,7 +174,7 @@ class FileWriterTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        writer.write(value: ["key1": "value1"]) // will be written
+        writer.write(value: ["key1": "value1"], completion: expectation.fulfill) // will be written
 
         XCTAssertEqual(try directory.files().count, 1)
         var reader = try BatchDataBlockReader(input: directory.files()[0].stream())
@@ -169,16 +182,20 @@ class FileWriterTests: XCTestCase {
         XCTAssertEqual(blocks.count, 1)
         XCTAssertEqual(blocks[0].data, #"{"key1":"value1"}"#.utf8Data)
 
-        writer.write(value: ["key2": "value3 that makes it exceed 23 bytes"]) // will be dropped
+        writer.write(value: ["key2": "value3 that makes it exceed 23 bytes"], completion: expectation.fulfill) // will be dropped
 
         reader = try BatchDataBlockReader(input: directory.files()[0].stream())
         blocks = try XCTUnwrap(reader.all())
         XCTAssertEqual(blocks.count, 1) // same content as before
         XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to encode value")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, "DataBlock with \(47) bytes exceeds limit of \(23) bytes")
+
+        wait(for: [expectation], timeout: 0)
     }
 
     func testGivenErrorVerbosity_whenDataCannotBeEncoded_itPrintsError() throws {
+        let expectation = expectation(description: "Writes complete")
+
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
@@ -199,13 +216,18 @@ class FileWriterTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        writer.write(value: FailingEncodableMock(errorMessage: "failed to encode `FailingEncodable`."))
+        writer.write(value: FailingEncodableMock(errorMessage: "failed to encode `FailingEncodable`."), completion: expectation.fulfill)
 
         XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to encode value")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, "failed to encode `FailingEncodable`.")
+
+        wait(for: [expectation], timeout: 0)
     }
 
     func testGivenErrorVerbosity_whenIOExceptionIsThrown_itPrintsError() throws {
+        let expectation = expectation(description: "Writes complete")
+        expectation.expectedFulfillmentCount = 2
+
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
@@ -226,13 +248,15 @@ class FileWriterTests: XCTestCase {
             telemetry: NOPTelemetry()
         )
 
-        writer.write(value: ["ok"]) // will create the file
+        writer.write(value: ["ok"], completion: expectation.fulfill) // will create the file
         try? directory.files()[0].makeReadonly()
-        writer.write(value: ["won't be written"])
+        writer.write(value: ["won't be written"], completion: expectation.fulfill)
         try? directory.files()[0].makeReadWrite()
 
         XCTAssertEqual(dd.logger.errorLog?.message, "(rum) Failed to write 26 bytes to file")
         XCTAssertTrue(dd.logger.errorLog!.error!.message.contains("You don’t have permission"))
+
+        wait(for: [expectation], timeout: 0)
     }
 
     /// NOTE: Test added after incident-4797

--- a/DatadogCore/Tests/Datadog/Mocks/RUM/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUM/RUMFeatureMocks.swift
@@ -275,13 +275,15 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
         error: Error = ErrorMock(),
         source: RUMInternalErrorSource = .source,
         globalAttributes: [AttributeKey: AttributeValue] = [:],
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        completionHandler: @escaping CompletionHandler = NOPCompletionHandler
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
             time: time,
             error: error,
             source: source,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 
@@ -291,7 +293,8 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
         type: String? = .mockAny(),
         source: RUMInternalErrorSource = .source,
         stack: String? = "Foo.swift:10",
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        completionHandler: @escaping CompletionHandler = NOPCompletionHandler
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
             time: time,
@@ -299,7 +302,8 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
             type: type,
             stack: stack,
             source: source,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 }

--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -388,10 +388,12 @@ class DDRUMMonitorTests: XCTestCase {
         objcRUMMonitor.addError(error: error, source: .custom, attributes: ["event-attribute1": "foo1"])
         objcRUMMonitor.addError(message: "error message", stack: "error stack", source: .source, attributes: [:])
 
+        objcRUMMonitor._internal_sync_addError(NSError.mockAny(), source: .custom, attributes: [:])
+
         let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
 
         let errorEvents = rumEventMatchers.filterRUMEvents(ofType: RUMErrorEvent.self)
-        XCTAssertEqual(errorEvents.count, 4)
+        XCTAssertEqual(errorEvents.count, 5)
 
         let event1Matcher = errorEvents[0]
         let event1: RUMErrorEvent = try event1Matcher.model()
@@ -426,6 +428,12 @@ class DDRUMMonitorTests: XCTestCase {
         XCTAssertEqual(event4.error.message, "error message")
         XCTAssertEqual(event4.error.source, .source)
         XCTAssertEqual(event4.error.stack, "error stack")
+
+        let event5Matcher = errorEvents[4]
+        let event5: RUMErrorEvent = try event5Matcher.model()
+        XCTAssertEqual(event5.error.type, "abc - 0")
+        XCTAssertEqual(event5.error.source, .custom)
+        XCTAssertEqual(event5.error.message, #"Error Domain=abc Code=0 "(null)""#)
     }
 
     func testSendingActionEvents() throws {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -82,6 +82,9 @@
     [monitor removeAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
 
+    [monitor _internal_sync_addError:[NSError errorWithDomain:NSCocoaErrorDomain code:-100 userInfo:nil]
+                              source:DDRUMErrorSourceCustom attributes:@{}];
+
     [monitor setDebug:YES];
     [monitor setDebug:NO];
 }

--- a/DatadogInternal/Sources/Concurrency/CompletionHandler.swift
+++ b/DatadogInternal/Sources/Concurrency/CompletionHandler.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Alias from completion closure with no parameter.
+public typealias CompletionHandler = () -> Void
+
+/// No-op completion function.
+///
+/// Using a function prevent allocating a closure when applying a placeholder.
+public func NOPCompletionHandler() {}

--- a/DatadogInternal/Sources/Storage/Writer.swift
+++ b/DatadogInternal/Sources/Storage/Writer.swift
@@ -11,7 +11,7 @@ public protocol Writer {
     /// Encodes given encodable value and metadata, and writes to the destination.
     /// - Parameters:
     ///   - value: Encodable value to write.
-    ///   -  metadata: Encodable metadata to write.
+    ///   - metadata: Encodable metadata to write.
     ///   - completion: The block to execute after the write task is completed.
     func write<T: Encodable, M: Encodable>(value: T, metadata: M?, completion: @escaping CompletionHandler)
 }
@@ -39,7 +39,7 @@ extension Writer {
     /// Encodes given encodable value and metadata, and writes to the destination.
     /// - Parameters:
     ///   - value: Encodable value to write.
-    ///   -  metadata: Encodable metadata to write.
+    ///   - metadata: Encodable metadata to write.
     public func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
         write(value: value, metadata: metadata, completion: {})
     }

--- a/DatadogInternal/Sources/Storage/Writer.swift
+++ b/DatadogInternal/Sources/Storage/Writer.swift
@@ -9,17 +9,38 @@ import Foundation
 /// A type, writing data.
 public protocol Writer {
     /// Encodes given encodable value and metadata, and writes to the destination.
-    /// - Parameter value: Encodable value to write.
-    /// - Parameter metadata: Encodable metadata to write.
-    func write<T: Encodable, M: Encodable>(value: T, metadata: M?)
+    /// - Parameters:
+    ///   - value: Encodable value to write.
+    ///   -  metadata: Encodable metadata to write.
+    ///   - completion: The block to execute after the write task is completed.
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?, completion: @escaping CompletionHandler)
 }
 
 extension Writer {
     /// Encodes given encodable value and writes to the destination.
     /// Uses `write(value:metadata:)` with `nil` metadata.
+    ///
     /// - Parameter value: Encodable value to write.
     public func write<T: Encodable>(value: T) {
+        write(value: value, completion: {})
+    }
+
+    /// Encodes given encodable value and writes to the destination.
+    /// Uses `write(value:metadata:)` with `nil` metadata.
+    ///
+    /// - Parameters:
+    ///   - value: Encodable value to write.
+    ///   - completion: The block to execute after the write task is completed.
+    public func write<T: Encodable>(value: T, completion: @escaping CompletionHandler) {
         let metadata: Data? = nil
-        write(value: value, metadata: metadata)
+        write(value: value, metadata: metadata, completion: completion)
+    }
+
+    /// Encodes given encodable value and metadata, and writes to the destination.
+    /// - Parameters:
+    ///   - value: Encodable value to write.
+    ///   -  metadata: Encodable metadata to write.
+    public func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+        write(value: value, metadata: metadata, completion: {})
     }
 }

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -9,7 +9,6 @@ import UIKit
 @_spi(objc)
 import DatadogInternal
 
-
 internal struct UIKitRUMViewsPredicateBridge: UIKitRUMViewsPredicate {
     let objcPredicate: objc_UIKitRUMViewsPredicate
 
@@ -692,7 +691,7 @@ public class objc_RUMMonitor: NSObject {
     }
 }
 
-extension DDRUMMonitor {
+extension objc_RUMMonitor {
     /// **For Datadog internal use only. Subject to changes.**
     ///
     /// Adds RUM error to current RUM view in sync.
@@ -706,7 +705,7 @@ extension DDRUMMonitor {
     @objc
     public func _internal_sync_addError(
         _ error: Error,
-        source: DDRUMErrorSource,
+        source: objc_RUMErrorSource,
         attributes: [String: Any]
     ) {
         let semaphore = DispatchSemaphore(value: 0)

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -499,6 +499,7 @@ extension Monitor: RUMMonitorProtocol {
                 time: dateProvider.now,
                 error: error,
                 source: RUMInternalErrorSource(source),
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 completionHandler: completionHandler
             )

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -485,6 +485,25 @@ extension Monitor: RUMMonitorProtocol {
             debugging != nil
         }
     }
+
+    // MARK: - Internal
+
+    func addError(
+        error: Error,
+        source: RUMErrorSource,
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
+    ) {
+        process(
+            command: RUMAddCurrentViewErrorCommand(
+                time: dateProvider.now,
+                error: error,
+                source: RUMInternalErrorSource(source),
+                attributes: attributes,
+                completionHandler: completionHandler
+            )
+        )
+    }
 }
 
 // MARK: - View

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -269,7 +269,8 @@ extension Monitor: RUMMonitorProtocol {
                 stack: stack,
                 source: RUMInternalErrorSource(source),
                 globalAttributes: self.attributes,
-                attributes: attributes
+                attributes: attributes,
+                completionHandler: NOPCompletionHandler
             )
         )
     }
@@ -281,7 +282,8 @@ extension Monitor: RUMMonitorProtocol {
                 error: error,
                 source: RUMInternalErrorSource(source),
                 globalAttributes: self.attributes,
-                attributes: attributes
+                attributes: attributes,
+                completionHandler: NOPCompletionHandler
             )
         )
     }
@@ -611,7 +613,8 @@ extension Monitor {
                 stack: stack,
                 source: source,
                 globalAttributes: self.attributes,
-                attributes: attributes
+                attributes: attributes,
+                completionHandler: NOPCompletionHandler
             )
         )
     }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -213,6 +213,9 @@ internal protocol RUMErrorCommand: RUMCommand {
     var binaryImages: [BinaryImage]? { get }
     /// Indicates whether any stack trace information in `stack` or `threads` was truncated due to stack trace minimization.
     var isStackTraceTruncated: Bool? { get }
+    /// A completion closure called when processing the command is completed.
+    /// Processing the command includes writting data.
+    var completionHandler: CompletionHandler { get }
 }
 
 /// Adds exception error to current view.
@@ -240,6 +243,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
     let binaryImages: [BinaryImage]?
     let isStackTraceTruncated: Bool?
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
+    let completionHandler: CompletionHandler
 
     /// Constructor dedicated to errors defined by message, type and stack.
     init(
@@ -249,7 +253,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
         stack: String?,
         source: RUMInternalErrorSource,
         globalAttributes: [AttributeKey: AttributeValue],
-        attributes: [AttributeKey: AttributeValue]
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
     ) {
         self.init(
             time: time,
@@ -262,7 +267,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
             binaryImages: nil,
             isStackTraceTruncated: nil,
             globalAttributes: globalAttributes,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 
@@ -272,7 +278,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
         error: Error,
         source: RUMInternalErrorSource,
         globalAttributes: [AttributeKey: AttributeValue],
-        attributes: [AttributeKey: AttributeValue]
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
     ) {
         let dderror = DDError(error: error)
         self.init(
@@ -286,7 +293,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
             binaryImages: nil,
             isStackTraceTruncated: nil,
             globalAttributes: globalAttributes,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 
@@ -302,7 +310,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
         binaryImages: [BinaryImage]?,
         isStackTraceTruncated: Bool?,
         globalAttributes: [AttributeKey: AttributeValue],
-        attributes: [AttributeKey: AttributeValue]
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
     ) {
         var attributes = attributes
         let isCrossPlatformCrash: Bool? = attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash)?.dd.decode()
@@ -320,6 +329,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMErrorCommand {
         self.threads = threads
         self.binaryImages = binaryImages
         self.isStackTraceTruncated = isStackTraceTruncated
+        self.completionHandler = completionHandler
     }
 }
 
@@ -351,6 +361,8 @@ internal struct RUMAddCurrentViewAppHangCommand: RUMErrorCommand {
     /// The duration of hang.
     let hangDuration: TimeInterval
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
+
+    let completionHandler: CompletionHandler = NOPCompletionHandler
 }
 
 internal struct RUMAddCurrentViewMemoryWarningCommand: RUMErrorCommand {
@@ -376,6 +388,8 @@ internal struct RUMAddCurrentViewMemoryWarningCommand: RUMErrorCommand {
     let isStackTraceTruncated: Bool?
 
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
+
+    let completionHandler: CompletionHandler = NOPCompletionHandler
 }
 
 internal struct RUMAddViewLoadingTime: RUMCommand {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -598,7 +598,10 @@ extension RUMViewScope {
             attributes = self.attributes
         }
 
-        let isCrash = (command as? RUMErrorCommand).map { $0.isCrash ?? false } ?? false
+        let errorCommand = command as? RUMErrorCommand
+        let isCrash = errorCommand?.isCrash ?? false
+        let completionHandler = errorCommand?.completionHandler ?? NOPCompletionHandler
+
         // RUMM-1779 Keep view active as long as we have ongoing resources
         let isActive = isActiveView || !resourceScopes.isEmpty
         // RUMM-2079 `time_spent` can't be lower than 1ns
@@ -753,7 +756,11 @@ extension RUMViewScope {
         )
 
         if let event = dependencies.eventBuilder.build(from: viewEvent) {
-            writer.write(value: event, metadata: event.metadata(viewIndexInSession: viewIndexInSession))
+            writer.write(
+                value: event, 
+                metadata: event.metadata(viewIndexInSession: viewIndexInSession),
+                completion: completionHandler
+            )
 
             // Update fatal error context with recent RUM view:
             dependencies.fatalErrorContext.view = event
@@ -780,6 +787,7 @@ extension RUMViewScope {
             dependencies.watchdogTermination?.update(viewEvent: event)
         } else { // if event was dropped by mapper
             version -= 1
+            completionHandler()
         }
     }
 
@@ -877,6 +885,10 @@ extension RUMViewScope {
             needsViewUpdate = true
         } else {
             errorsCount -= 1
+            // Call the completion when the event is discarded.
+            // When the error is kept, the completion is called when the
+            // view update is written.
+            command.completionHandler()
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -757,7 +757,7 @@ extension RUMViewScope {
 
         if let event = dependencies.eventBuilder.build(from: viewEvent) {
             writer.write(
-                value: event, 
+                value: event,
                 metadata: event.metadata(viewIndexInSession: viewIndexInSession),
                 completion: completionHandler
             )

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -50,7 +50,8 @@ public struct DatadogInternalInterface {
             binaryImages: binaryImages,
             isStackTraceTruncated: nil,
             globalAttributes: globalAttributes,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: NOPCompletionHandler
         )
         monitor.process(command: addErrorCommand)
     }

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -399,7 +399,7 @@ extension RUMMonitorViewProtocol {
     }
 }
 
-// MARK: - NOP moniotor
+// MARK: - NOP monitor
 
 internal class NOPMonitor: RUMMonitorProtocol {
     private func warn(method: StaticString = #function) {

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -287,6 +287,23 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     ///
     /// The default value is false.
     var debug: Bool { set get }
+
+    // MARK: - Internal
+
+    /// Adds RUM error to current RUM view.
+    /// 
+    /// - Parameters:
+    ///   - error: the `Error` object. It will be used to infer error details.
+    ///   - source: the origin of the error.
+    ///   - attributes: custom attributes to attach to this error.
+    ///   - completionHandler: A completion closure called when reporting the error is completed.
+    @_spi(Internal)
+    func addError(
+        error: Error,
+        source: RUMErrorSource,
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
+    )
 }
 
 // MARK: - View Interface
@@ -370,6 +387,16 @@ extension RUMMonitorViewProtocol {
     func addViewLoadingTime(overwrite: Bool) {
         // no-op
     }
+
+    /// It cannot be declared '@_spi' without a default implementation in a protocol extension
+    func addError(
+        error: Error,
+        source: RUMErrorSource,
+        attributes: [AttributeKey: AttributeValue],
+        completionHandler: @escaping CompletionHandler
+    ) {
+        completionHandler()
+    }
 }
 
 // MARK: - NOP moniotor
@@ -405,6 +432,11 @@ internal class NOPMonitor: RUMMonitorProtocol {
     func startAction(type: RUMActionType, name: String, attributes: [AttributeKey: AttributeValue]) { warn() }
     func stopAction(type: RUMActionType, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func addFeatureFlagEvaluation(name: String, value: Encodable) { warn() }
+    func addError(error: Error, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue], completionHandler: () -> Void) {
+        warn()
+        completionHandler()
+    }
+
     var debug: Bool {
         set { warn() }
         get {

--- a/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
@@ -30,7 +30,8 @@ class RUMCommandTests: XCTestCase {
             error: SwiftError(),
             source: .source,
             globalAttributes: [:],
-            attributes: [:]
+            attributes: [:],
+            completionHandler: NOPCompletionHandler
         )
 
         XCTAssertEqual(command.type, "SwiftError")
@@ -42,7 +43,8 @@ class RUMCommandTests: XCTestCase {
             error: SwiftEnumeratedError.errorLabel,
             source: .source,
             globalAttributes: [:],
-            attributes: [:]
+            attributes: [:],
+            completionHandler: NOPCompletionHandler
         )
 
         XCTAssertEqual(command.type, "SwiftEnumeratedError")
@@ -54,7 +56,8 @@ class RUMCommandTests: XCTestCase {
             error: nsError,
             source: .source,
             globalAttributes: [:],
-            attributes: [:]
+            attributes: [:],
+            completionHandler: NOPCompletionHandler
         )
 
         XCTAssertEqual(command.type, "custom-domain - 10")

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2860,7 +2860,8 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime,
             serverTimeOffset: .zero,
-            interactionToNextViewMetric: INVMetricMock()
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
         )
 
         XCTAssertTrue(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2100,6 +2100,8 @@ class RUMViewScopeTests: XCTestCase {
     // MARK: - Error Tracking
 
     func testWhenViewErrorIsAdded_itSendsErrorEventAndViewUpdateEvent() throws {
+        let completionExpectation = expectation(description: "Error processing completion")
+
         let hasReplay: Bool = .mockRandom()
         var context = self.context
         context.set(additionalContext: SessionReplayCoreContext.HasReplay(value: hasReplay))
@@ -2131,11 +2133,19 @@ class RUMViewScopeTests: XCTestCase {
 
         XCTAssertTrue(
             scope.process(
-                command: RUMAddCurrentViewErrorCommand.mockWithErrorMessage(time: currentTime, message: "view error", source: .source, stack: nil),
+                command: RUMAddCurrentViewErrorCommand.mockWithErrorMessage(
+                    time: currentTime,
+                    message: "view error",
+                    source: .source,
+                    stack: nil,
+                    completionHandler: completionExpectation.fulfill
+                ),
                 context: context,
                 writer: writer
             )
         )
+
+        wait(for: [completionExpectation], timeout: 0)
 
         let error = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).last)
         XCTAssertEqual(error.date, Date.mockDecember15th2019At10AMUTC(addingTimeInterval: 1).timeIntervalSince1970.toInt64Milliseconds)
@@ -2218,6 +2228,8 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     func testGivenStartedView_whenCrossPlatformErrorIsAdded_itSendsCorrectErrorEvent() throws {
+        let completionExpectation = expectation(description: "Error processing completion")
+
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         let customSource = String.mockAnySource()
@@ -2250,12 +2262,15 @@ class RUMViewScopeTests: XCTestCase {
                     attributes: [
                         CrossPlatformAttributes.errorSourceType: customSourceType,
                         CrossPlatformAttributes.errorIsCrash: true
-                    ]
+                    ],
+                    completionHandler: completionExpectation.fulfill
                 ),
                 context: customContext,
                 writer: writer
             )
         )
+
+        wait(for: [completionExpectation], timeout: 0)
 
         let error = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).last)
         XCTAssertEqual(error.error.sourceType, expectedSourceType)
@@ -2825,6 +2840,56 @@ class RUMViewScopeTests: XCTestCase {
         // The rate is only calculated in the Stop View event
         let stopViewEvent = viewEvents.last
         XCTAssertEqual(stopViewEvent?.view.freezeRate, 0.5.hours)
+    }
+
+    func testWhenViewErrorIsAdded_ButErrorEventDiscarded_itCallsCompletionHandler() throws {
+        let completionExpectation = expectation(description: "Error processing completion")
+
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockWith(
+                eventBuilder: RUMEventBuilder(
+                    eventsMapper: .mockWith(errorEventMapper: { _ in nil })
+                )
+            ),
+            identity: .mockViewIdentifier(),
+            path: "UIViewController",
+            name: "ViewName",
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock()
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: .mockViewIdentifier()),
+                context: context,
+                writer: writer
+            )
+        )
+
+        currentTime.addTimeInterval(1)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddCurrentViewErrorCommand.mockWithErrorMessage(
+                    time: currentTime,
+                    message: "view error",
+                    source: .source,
+                    stack: nil,
+                    completionHandler: completionExpectation.fulfill
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        wait(for: [completionExpectation], timeout: 0)
+        XCTAssertTrue(writer.events(ofType: RUMErrorEvent.self).isEmpty)
+        XCTAssertFalse(writer.events(ofType: RUMViewEvent.self).isEmpty)
     }
 
     // MARK: - App Hangs

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
@@ -12,8 +12,9 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
         weak var scope: FeatureScopeMock?
         let bypassConsent: Bool
 
-        func write<T, M>(value: T, metadata: M?) where T: Encodable, M: Encodable {
+        func write<T, M>(value: T, metadata: M?, completion: @escaping CompletionHandler) where T: Encodable, M: Encodable {
             scope?.events.append((value, metadata, bypassConsent))
+            completion()
         }
     }
 

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FileWriterMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FileWriterMock.swift
@@ -16,8 +16,9 @@ public class FileWriterMock: Writer {
     /// Adds an `Encodable` event to the events stack.
     ///
     /// - Parameter value: The event value to record.
-    public func write<T: Encodable, M: Encodable>(value: T, metadata: M) {
+    public func write<T: Encodable, M: Encodable>(value: T, metadata: M, completion: @escaping CompletionHandler) {
         events.append(value)
+        completion()
     }
 
     /// Returns all events of the given type.

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -426,14 +426,16 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
         error: Error = ErrorMock(),
         source: RUMInternalErrorSource = .source,
         globalAttributes: [AttributeKey: AttributeValue] = [:],
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        completionHandler: @escaping CompletionHandler = NOPCompletionHandler
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
             time: time,
             error: error,
             source: source,
             globalAttributes: globalAttributes,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 
@@ -444,7 +446,8 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
         source: RUMInternalErrorSource = .source,
         stack: String? = "Foo.swift:10",
         globalAttributes: [AttributeKey: AttributeValue] = [:],
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        completionHandler: @escaping CompletionHandler = NOPCompletionHandler
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
             time: time,
@@ -453,7 +456,8 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
             stack: stack,
             source: source,
             globalAttributes: globalAttributes,
-            attributes: attributes
+            attributes: attributes,
+            completionHandler: completionHandler
         )
     }
 }

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -195,11 +195,11 @@ private final class FeatureScopeInterceptor: @unchecked Sendable {
         let actualWriter: Writer
         unowned var interception: FeatureScopeInterceptor?
 
-        func write<T: Encodable, M: Encodable>(value: T, metadata: M) {
+        func write<T: Encodable, M: Encodable>(value: T, metadata: M, completion: @escaping () -> Void) {
             group.enter()
             defer { group.leave() }
 
-            actualWriter.write(value: value, metadata: metadata)
+            actualWriter.write(value: value, metadata: metadata, completion: completion)
 
             let event = value
             let data = try! InterceptingWriter.jsonEncoder.encode(value)


### PR DESCRIPTION
### What and why?

Cross-platform SDKs can report fatal errors before the native process crashes. However, RUM and the Core execute processing and write asynchronously, and the crash can suspend these executions, leading to the loss of the cross-platform error information.

We should let cross-platform SDKs to report error in sync, blocking the caller-thread.

### How?

The change involve changes at different layers:

#### Core module

Add `completion` argument to `Writer` interface. The completion callback is called when the data is written to disk.

#### RUM Module

Add `completionHandler` property to `RUMErrorCommand`. The `RUMViewScope` calls the completion handler after writing the error event and the view update.

The RUM Monitor now expose a method to report an error with a completion handler, The method is exposed using the `@_spi(Internal)` attribute.

```swift
/// Adds RUM error to current RUM view.
/// 
/// - Parameters:
///   - error: the `Error` object. It will be used to infer error details.
///   - source: the origin of the error.
///   - attributes: custom attributes to attach to this error.
///   - completionHandler: A completion closure called when reporting the error is completed.
@_spi(Internal)
func addError(
    error: Error,
    source: RUMErrorSource,
    attributes: [AttributeKey: AttributeValue],
    completionHandler: @escaping CompletionHandler
)
```

#### Objc Module

The `DDRUMMonitor` now expose a `_internal_sync_addError` to report an error in sync. This method will wait for the underlying completion handler to be called before returning.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
