### PR TITLE
Fix echo box on iTerm

### DIFF
--- a/tools/utils/echo-color.sh
+++ b/tools/utils/echo-color.sh
@@ -52,9 +52,9 @@ echo_box() {
   local len=$((${#text}+2))
   local separator=$(printf '.%.0s' {1..$len})
   echo -e " ${COLOR}${separator}${RESET}"
-  echo -e "${COLOR}┌$(printf '%*s' $len | tr ' ' '─')┐${RESET}"
+  echo -e "${COLOR}┌$(printf '\u2500%.0s' $(seq 1 $len))┐${RESET}"
   echo -e "${COLOR}│ ${BOLD}$text${RESET}${COLOR} │${RESET}"
-  echo -e "${COLOR}└$(printf '%*s' $len | tr ' ' '─')┘${RESET}"
+  echo -e "${COLOR}└$(printf '\u2500%.0s' $(seq 1 $len))┘${RESET}"
 }
 
 echo_title() {


### PR DESCRIPTION
Super minor, but I couldn't help it :)

On iTerm there was an issue rendering the box.

Before:
<img width="278" alt="Screenshot 2025-01-24 at 16 03 00" src="https://github.com/user-attachments/assets/3dadbaaf-2cc9-44d4-a6ae-48e5ac79ac68" />

After:
<img width="281" alt="Screenshot 2025-01-24 at 16 36 39" src="https://github.com/user-attachments/assets/ec6bba82-406f-478e-8509-cfcd46b0ee5d" />
