### PR TITLE
RUM-8371 chore: Make `context.launchTime` non-optional

### DIFF
--- a/DatadogCore/Private/include/ObjcAppLaunchHandler.h
+++ b/DatadogCore/Private/include/ObjcAppLaunchHandler.h
@@ -8,36 +8,41 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// `AppLaunchHandler` aims to track some times as part of the sequence
-/// described in Apple's "About the App Launch Sequence"
-///
-/// ref. https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence
+/// `AppLaunchHandler` tracks key timestamps in the app launch sequence,
+/// as described in Apple's documentation:
+/// https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence
 @interface __dd_private_AppLaunchHandler : NSObject
 
 typedef void (^UIApplicationDidBecomeActiveCallback) (NSTimeInterval);
 
-/// Sole instance of the Application Launch Handler.
+/// The singleton instance of `AppLaunchHandler`.
 @property (class, readonly) __dd_private_AppLaunchHandler *shared;
 
-/// Returns the Application process launch date.
+/// The timestamp when the application process was launched.
 @property (atomic, readonly) NSDate* launchDate;
 
-/// Returns the time interval in seconds between startup of the application process and the
-/// `UIApplicationDidBecomeActiveNotification`. Or `nil` If the
-/// `UIApplicationDidBecomeActiveNotification` has not been reached yet.
+/// The time interval (in seconds) between the app process launch and
+/// the `UIApplicationDidBecomeActiveNotification`. Returns `nil` if
+/// the notification has not yet been received.
 @property (atomic, readonly, nullable) NSNumber* launchTime;
 
-/// Returns `true` when the application is pre-warmed.
-///
-/// System sets environment variable `ActivePrewarm` to 1 when app is pre-warmed.
+/// Indicates whether the application was prewarmed by the system.
 @property (atomic, readonly) BOOL isActivePrewarm;
 
-/// Sets the callback to be invoked when the application becomes active.
+/// Creates and initializes an instance of `AppLaunchHandler`.
 ///
-/// The closure get the updated handler as argument. You will not get any
-/// notification if the application became active before setting the callback
-/// 
-/// - Parameter callback: The callback closure.
+/// - Parameters:
+///   - processInfo: The `NSProcessInfo` instance used to retrieve environment variables.
+///   - notificationCenter: The `NSNotificationCenter` used to observe application state changes.
++ (instancetype)createWithProcessInfo:(NSProcessInfo *)processInfo
+                   notificationCenter:(NSNotificationCenter *)notificationCenter;
+
+/// Sets a callback to be invoked when the application becomes active.
+///
+/// The callback receives the time interval from launch to activation.
+/// If the application became active before setting the callback, it will not be triggered.
+///
+/// - Parameter callback: A closure executed upon app activation.
 - (void)setApplicationDidBecomeActiveCallback:(UIApplicationDidBecomeActiveCallback)callback;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/DatadogCore/Private/include/ObjcAppLaunchHandler.h
+++ b/DatadogCore/Private/include/ObjcAppLaunchHandler.h
@@ -29,13 +29,18 @@ typedef void (^UIApplicationDidBecomeActiveCallback) (NSTimeInterval);
 /// Indicates whether the application was prewarmed by the system.
 @property (atomic, readonly) BOOL isActivePrewarm;
 
-/// Creates and initializes an instance of `AppLaunchHandler`.
+/// Initializes an instance of `AppLaunchHandler` with the given process information.
 ///
-/// - Parameters:
-///   - processInfo: The `NSProcessInfo` instance used to retrieve environment variables.
-///   - notificationCenter: The `NSNotificationCenter` used to observe application state changes.
-+ (instancetype)createWithProcessInfo:(NSProcessInfo *)processInfo
-                   notificationCenter:(NSNotificationCenter *)notificationCenter;
+/// - Parameter processInfo: The `NSProcessInfo` instance used to retrieve environment variables,
+///   including information about whether the app was prewarmed.
+- (instancetype)initWithProcessInfo:(NSProcessInfo *)processInfo;
+
+/// Observes the given notification center for application lifecycle events.
+///
+/// This method listens for the application becoming active and updates launch-related timestamps accordingly.
+///
+/// - Parameter notificationCenter: The `NSNotificationCenter` instance used to observe application state changes.
+- (void)observeNotificationCenter:(NSNotificationCenter *)notificationCenter;
 
 /// Sets a callback to be invoked when the application becomes active.
 ///

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -409,6 +409,7 @@ extension DatadogContextProvider {
         dateProvider: DateProvider,
         serverDateProvider: ServerDateProvider,
         notificationCenter: NotificationCenter,
+        appLaunchHandler: AppLaunchHandling,
         appStateProvider: AppStateProvider
     ) {
         let context = DatadogContext(
@@ -429,6 +430,7 @@ extension DatadogContextProvider {
             sdkInitDate: dateProvider.now,
             device: device,
             nativeSourceOverride: nativeSourceOverride,
+            launchTime: appLaunchHandler.currentValue,
             // this is a placeholder waiting for the `ApplicationStatePublisher`
             // to be initialized on the main thread, this value will be overrided
             // as soon as the subscription is made.
@@ -440,7 +442,7 @@ extension DatadogContextProvider {
         subscribe(\.serverTimeOffset, to: ServerOffsetPublisher(provider: serverDateProvider))
 
         #if !os(macOS)
-        subscribe(\.launchTime, to: LaunchTimePublisher())
+        subscribe(\.launchTime, to: LaunchTimePublisher(handler: appLaunchHandler))
         #endif
 
         subscribe(\.networkConnectionInfo, to: NWPathMonitorPublisher())

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -230,6 +230,9 @@ public enum Datadog {
         /// The default notification center used for subscribing to app lifecycle events and system notifications.
         internal var notificationCenter: NotificationCenter = .default
 
+        /// The default app launch handler for tracking application startup time.
+        internal var appLaunchHandler: AppLaunchHandling = AppLaunchHandler.shared
+
         /// The default application state provider for accessing [application state](https://developer.apple.com/documentation/uikit/uiapplication/state).
         internal var appStateProvider: AppStateProvider = DefaultAppStateProvider()
     }
@@ -557,6 +560,7 @@ extension DatadogCore {
                 dateProvider: configuration.dateProvider,
                 serverDateProvider: configuration.serverDateProvider,
                 notificationCenter: configuration.notificationCenter,
+                appLaunchHandler: configuration.appLaunchHandler,
                 appStateProvider: configuration.appStateProvider
             ),
             applicationVersion: applicationVersion,

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -302,7 +302,7 @@ class CrashContextProviderTests: XCTestCase {
     // MARK: - Helpers
 
     private func DDAssert(crashContext: CrashContext, includes sdkContext: DatadogContext, file: StaticString = #filePath, line: UInt = #line) {
-        XCTAssertEqual(crashContext.appLaunchDate, sdkContext.launchTime?.launchDate, file: file, line: line)
+        XCTAssertEqual(crashContext.appLaunchDate, sdkContext.launchTime.launchDate, file: file, line: line)
         XCTAssertEqual(crashContext.serverTimeOffset, sdkContext.serverTimeOffset, file: file, line: line)
         XCTAssertEqual(crashContext.service, sdkContext.service, file: file, line: line)
         XCTAssertEqual(crashContext.env, sdkContext.env, file: file, line: line)

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchTimePublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchTimePublisherTests.swift
@@ -86,14 +86,8 @@ class AppLaunchHandlerTests: XCTestCase {
 
     func testActivePrewarm() {
         // When
-        let handler1 = AppLaunchHandler.create(
-            with: ProcessInfoMock(environment: ["ActivePrewarm": "1"]),
-            notificationCenter: notificationCenter
-        )
-        let handler2 = AppLaunchHandler.create(
-            with: ProcessInfoMock(environment: [:]),
-            notificationCenter: notificationCenter
-        )
+        let handler1 = AppLaunchHandler(processInfo: ProcessInfoMock(environment: ["ActivePrewarm": "1"]))
+        let handler2 = AppLaunchHandler(processInfo: ProcessInfoMock(environment: [:]))
 
         // Then
         XCTAssertTrue(handler1.currentValue.isActivePrewarm)
@@ -102,10 +96,11 @@ class AppLaunchHandlerTests: XCTestCase {
 
     func testLaunchTime() {
         // Given
-        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
+        let handler = AppLaunchHandler(processInfo: processInfo)
         XCTAssertNil(handler.launchTime)
 
         // When
+        handler.observe(notificationCenter)
         notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
 
         // Then
@@ -114,11 +109,12 @@ class AppLaunchHandlerTests: XCTestCase {
 
     func testSetApplicationDidBecomeActiveCallback() {
         // Given
-        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
+        let handler = AppLaunchHandler(processInfo: processInfo)
         let callbackNotified = expectation(description: "Notify setApplicationDidBecomeActiveCallback()")
         handler.setApplicationDidBecomeActiveCallback { _ in callbackNotified.fulfill() }
 
         // When
+        handler.observe(notificationCenter)
         notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
 
         // Then
@@ -126,7 +122,7 @@ class AppLaunchHandlerTests: XCTestCase {
     }
 
     func testThreadSafety() {
-        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
+        let handler = AppLaunchHandler(processInfo: processInfo)
 
         // swiftlint:disable opening_brace
         callConcurrently(

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchTimePublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchTimePublisherTests.swift
@@ -6,27 +6,127 @@
 
 import XCTest
 import TestUtilities
+import DatadogInternal
 @testable import DatadogCore
 
 class LaunchTimePublisherTests: XCTestCase {
-    override func tearDown() {
-        super.tearDown()
-        setenv("ActivePrewarm", "", 1)
-    }
+    func testInitialValueWhenTimeToDidBecomeActiveIsYetNotAvailable() {
+        let launchDate: Date = .mockRandom()
+        let isActivePrewarm: Bool = .mockRandom()
 
-    func testGivenStartedApplication_itHasLaunchDate() throws {
         // Given
-        let publisher = LaunchTimePublisher()
+        let handler = AppLaunchHandlerMock(
+            launchDate: launchDate,
+            timeToDidBecomeActive: nil, // not yet available
+            isActivePrewarm: isActivePrewarm
+        )
 
         // When
-        let launchTime = publisher.initialValue
+        let publisher = LaunchTimePublisher(handler: handler)
 
         // Then
-        XCTAssertNotNil(launchTime?.launchDate)
+        XCTAssertEqual(publisher.initialValue.launchDate, launchDate)
+        XCTAssertEqual(publisher.initialValue.isActivePrewarm, isActivePrewarm)
+        XCTAssertNil(publisher.initialValue.launchTime)
+    }
+
+    func testInitialValueWhenTimeToDidBecomeActiveIsAlreadyAvailable() {
+        let launchDate: Date = .mockRandom()
+        let isActivePrewarm: Bool = .mockRandom()
+        let timeToDidBecomeActive: TimeInterval = .mockRandom(min: 1, max: 10)
+
+        // Given
+        let handler = AppLaunchHandlerMock(
+            launchDate: launchDate,
+            timeToDidBecomeActive: timeToDidBecomeActive,
+            isActivePrewarm: isActivePrewarm
+        )
+
+        // When
+        let publisher = LaunchTimePublisher(handler: handler)
+
+        // Then
+        XCTAssertEqual(publisher.initialValue.launchDate, launchDate)
+        XCTAssertEqual(publisher.initialValue.isActivePrewarm, isActivePrewarm)
+        XCTAssertEqual(publisher.initialValue.launchTime, timeToDidBecomeActive)
+    }
+
+    func testUpdatingValue() {
+        let launchDate: Date = .mockRandom()
+        let isActivePrewarm: Bool = .mockRandom()
+        let timeToDidBecomeActive: TimeInterval = .mockRandom(min: 1, max: 10)
+
+        // Given
+        let handler = AppLaunchHandlerMock(
+            launchDate: launchDate,
+            timeToDidBecomeActive: nil, // it will be lazy updated
+            isActivePrewarm: isActivePrewarm
+        )
+        let contextUpdated = expectation(description: "Update context receiver")
+        let publisher = LaunchTimePublisher(handler: handler)
+
+        publisher.publish { launchTime in
+            XCTAssertEqual(launchTime.launchDate, launchDate)
+            XCTAssertEqual(launchTime.isActivePrewarm, isActivePrewarm)
+            XCTAssertEqual(launchTime.launchTime, timeToDidBecomeActive)
+            contextUpdated.fulfill()
+        }
+
+        // When
+        handler.simulateDidBecomeActive(timeInterval: timeToDidBecomeActive)
+
+        // Then
+        waitForExpectations(timeout: 1)
+    }
+}
+
+class AppLaunchHandlerTests: XCTestCase {
+    let notificationCenter = NotificationCenter()
+    let processInfo = ProcessInfoMock()
+
+    func testActivePrewarm() {
+        // When
+        let handler1 = AppLaunchHandler.create(
+            with: ProcessInfoMock(environment: ["ActivePrewarm": "1"]),
+            notificationCenter: notificationCenter
+        )
+        let handler2 = AppLaunchHandler.create(
+            with: ProcessInfoMock(environment: [:]),
+            notificationCenter: notificationCenter
+        )
+
+        // Then
+        XCTAssertTrue(handler1.currentValue.isActivePrewarm)
+        XCTAssertFalse(handler2.currentValue.isActivePrewarm)
+    }
+
+    func testLaunchTime() {
+        // Given
+        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
+        XCTAssertNil(handler.launchTime)
+
+        // When
+        notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+
+        // Then
+        XCTAssertNotNil(handler.launchTime)
+    }
+
+    func testSetApplicationDidBecomeActiveCallback() {
+        // Given
+        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
+        let callbackNotified = expectation(description: "Notify setApplicationDidBecomeActiveCallback()")
+        handler.setApplicationDidBecomeActiveCallback { _ in callbackNotified.fulfill() }
+
+        // When
+        notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+
+        // Then
+        waitForExpectations(timeout: 1)
     }
 
     func testThreadSafety() {
-        let handler = __dd_private_AppLaunchHandler.shared
+        let handler = AppLaunchHandler.create(with: processInfo, notificationCenter: notificationCenter)
 
         // swiftlint:disable opening_brace
         callConcurrently(
@@ -39,28 +139,5 @@ class LaunchTimePublisherTests: XCTestCase {
             iterations: 1_000
         )
         // swiftlint:enable opening_brace
-    }
-
-    func testIsActivePrewarm_returnsTrue() {
-        // Given
-        setenv("ActivePrewarm", "1", 1)
-        NSClassFromString("__dd_private_AppLaunchHandler")?.load()
-
-        // When
-        let publisher = LaunchTimePublisher()
-
-        // Then
-        XCTAssertTrue(publisher.initialValue?.isActivePrewarm ?? false)
-    }
-
-    func testIsActivePrewarm_returnsFalse() {
-        // Given
-        NSClassFromString("__dd_private_AppLaunchHandler")?.load()
-
-        // When
-        let publisher = LaunchTimePublisher()
-
-        // Then
-        XCTAssertFalse(publisher.initialValue?.isActivePrewarm ?? true)
     }
 }

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -379,3 +379,48 @@ class MockHostsSanitizer: HostsSanitizing {
         return hostsWithTracingHeaderTypes
     }
 }
+
+internal class AppLaunchHandlerMock: AppLaunchHandling {
+    /// Indicates whether the application was prewarmed by the system.
+    let isActivePrewarm: Bool
+    /// The timestamp when the application process was launched.
+    let launchDate: Date
+    /// The time interval between the app process launch and the `UIApplication.didBecomeActiveNotification`.
+    /// Returns `nil` if the notification has not yet been received.
+    var timeToDidBecomeActive: TimeInterval?
+    /// Stores the callback to be invoked when the application becomes active.
+    private var didBecomeActiveCallback: UIApplicationDidBecomeActiveCallback?
+
+    init(
+        launchDate: Date,
+        timeToDidBecomeActive: TimeInterval?,
+        isActivePrewarm: Bool
+    ) {
+        self.launchDate = launchDate
+        self.timeToDidBecomeActive = timeToDidBecomeActive
+        self.isActivePrewarm = isActivePrewarm
+    }
+
+    func setApplicationDidBecomeActiveCallback(_ callback: @escaping UIApplicationDidBecomeActiveCallback) {
+        guard timeToDidBecomeActive == nil else {
+            // The app is already active; do nothing as per the interface contract.
+            return
+        }
+        didBecomeActiveCallback = callback
+    }
+
+    /// Simulates the application becoming active.
+    ///
+    /// This method can be called in tests to simulate the `UIApplication.didBecomeActiveNotification`.
+    /// If a callback has been set before activation, it will be invoked.
+    ///
+    /// - Parameter timeInterval: The time interval from launch to activation.
+    func simulateDidBecomeActive(timeInterval: TimeInterval) {
+        guard timeToDidBecomeActive == nil else {
+            return
+        }
+
+        timeToDidBecomeActive = timeInterval
+        didBecomeActiveCallback?(timeInterval)
+    }
+}

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
@@ -146,7 +146,7 @@ internal struct CrashContext: Codable, Equatable {
         self.lastRUMAttributes = lastRUMAttributes
         self.lastLogAttributes = lastLogAttributes
 
-        self.appLaunchDate = context.launchTime?.launchDate
+        self.appLaunchDate = context.launchTime.launchDate
     }
 
     static func == (lhs: CrashContext, rhs: CrashContext) -> Bool {

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -77,10 +77,8 @@ public struct DatadogContext {
     /// The user's consent to data collection
     public var trackingConsent: TrackingConsent = .pending
 
-    /// Application launch time.
-    ///
-    /// Can be `nil` if the launch could not yet been evaluated.
-    public var launchTime: LaunchTime?
+    /// Application launch time info.
+    public var launchTime: LaunchTime
 
     /// Provides the history of app foreground / background states.
     public var applicationStateHistory: AppStateHistory
@@ -134,7 +132,7 @@ public struct DatadogContext {
         nativeSourceOverride: String? = nil,
         userInfo: UserInfo? = nil,
         trackingConsent: TrackingConsent = .pending,
-        launchTime: LaunchTime? = nil,
+        launchTime: LaunchTime,
         applicationStateHistory: AppStateHistory,
         networkConnectionInfo: NetworkConnectionInfo? = nil,
         carrierInfo: CarrierInfo? = nil,

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
@@ -42,7 +42,7 @@ internal final class FatalAppHangsHandler {
                 serverTimeOffset: context.serverTimeOffset,
                 lastRUMView: lastRUMView,
                 trackingConsent: context.trackingConsent,
-                appLaunchDate: context.launchTime?.launchDate
+                appLaunchDate: context.launchTime.launchDate
             )
             dataStore.setValue(fatalHang, forKey: .fatalAppHangKey)
         }

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -26,7 +26,6 @@ internal final class WatchdogTerminationMonitor {
         static let failedToReadViewEvent = "Failed to read the view event from the data store"
         static let rumViewEventUpdated = "RUM View event updated"
         static let failedToSendWatchdogTermination = "Failed to send Watchdog Termination event"
-        static let launchTimeFailure = "Failed to send Watchdog Termination event due to not being able to get the launch time"
         static let failedToDecodeLaunchReport = "Fails to decode LaunchReport in RUM"
     }
 
@@ -119,14 +118,8 @@ internal final class WatchdogTerminationMonitor {
     /// - Parameter state: The app state when the Watchdog Termination occurred.
     private func sendWatchTermination(state: WatchdogTerminationAppState, completion: @escaping () -> Void) {
         feature.context { [weak self] context in
-            guard let launchTime = context.launchTime else {
-                DD.logger.error(ErrorMessages.launchTimeFailure)
-                completion()
-                return
-            }
-
             do {
-                let likelyCrashedAt = try self?.storage?.mostRecentModifiedFileAt(before: launchTime.launchDate)
+                let likelyCrashedAt = try self?.storage?.mostRecentModifiedFileAt(before: context.launchTime.launchDate)
                 self?.feature.rumDataStore.value(forKey: .watchdogRUMViewEvent) { [weak self] (viewEvent: RUMViewEvent?) in
                     guard let viewEvent = viewEvent else {
                         DD.logger.error(ErrorMessages.failedToReadViewEvent)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -60,7 +60,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             createInitialSession(with: context, on: command)
 
             // If the app was started by a user (foreground & not prewarmed):
-            if context.applicationStateHistory.currentSnapshot.state == .active && context.launchTime?.isActivePrewarm == false {
+            if context.applicationStateHistory.currentSnapshot.state == .active && !context.launchTime.isActivePrewarm {
                 // Start "ApplicationLaunch" view immediatelly:
                 startApplicationLaunchView(on: command, context: context, writer: writer)
             }
@@ -148,7 +148,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        if context.launchTime?.isActivePrewarm == true {
+        if context.launchTime.isActivePrewarm {
             startPrecondition = .prewarm
         } else if context.applicationStateHistory.currentSnapshot.state == .background {
             startPrecondition = .backgroundLaunch

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -276,9 +276,7 @@ internal class RUMResourceScope: RUMScope {
 
     private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand, context: DatadogContext, writer: Writer) {
         let errorFingerprint: String? = attributes.removeValue(forKey: RUM.Attributes.errorFingerprint)?.dd.decode()
-        let timeSinceAppStart = context.launchTime.map {
-            command.time.timeIntervalSince($0.launchDate).toInt64Milliseconds
-        }
+        let timeSinceAppStart = command.time.timeIntervalSince(context.launchTime.launchDate).toInt64Milliseconds
 
         // Write error event
         let errorEvent = RUMErrorEvent(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -302,10 +302,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }
 
     private func startApplicationLaunchView(on command: RUMApplicationStartCommand, context: DatadogContext, writer: Writer) {
-        var startTime = sessionStartTime
-        if context.launchTime?.isActivePrewarm == false, let processStartTime = context.launchTime?.launchDate {
-            startTime = processStartTime
-        }
+        let isActivePrewarm = context.launchTime.isActivePrewarm
+        let startTime = isActivePrewarm ? sessionStartTime : context.launchTime.launchDate
 
         startView(
             isInitialView: true,

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -91,7 +91,7 @@ extension DatadogContext: AnyMockable {
             device: .mockRandom(),
             userInfo: .mockRandom(),
             trackingConsent: .mockRandom(),
-            launchTime: nil,
+            launchTime: .mockRandom(),
             applicationStateHistory: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
             carrierInfo: .mockRandom(),
@@ -188,7 +188,7 @@ extension UserInfo: AnyMockable, RandomMockable {
     }
 }
 
-extension LaunchTime: AnyMockable {
+extension LaunchTime: AnyMockable, RandomMockable {
     public static func mockAny() -> LaunchTime {
         .init(
             launchTime: .mockAny(),
@@ -206,6 +206,14 @@ extension LaunchTime: AnyMockable {
             launchTime: launchTime,
             launchDate: launchDate,
             isActivePrewarm: isActivePrewarm
+        )
+    }
+
+    public static func mockRandom() -> LaunchTime {
+        return .init(
+            launchTime: .mockRandom(),
+            launchDate: .mockRandom(),
+            isActivePrewarm: .mockRandom()
         )
     }
 }


### PR DESCRIPTION
### What and why?

📦 This is a refactoring PR that makes `context.launchTime` a non-optional property in `DatadogContext`:

```diff
- public var launchTime: LaunchTime?
+ public var launchTime: LaunchTime
```

The `LaunchTime` structure encapsulates key details about the application startup, including:
- Whether the app was pre-warmed.
- When the app was launched.
- How long the startup process took.

This refactoring streamlines and simplifies dependent SDK logic by eliminating multiple `if let` and `guard let` cases that previously led to unreachable control flows.


### How?

Units involved in this refactoring:
- `ApplicationLaunchHandler` – An Objective-C component that tracks key timestamps in the app launch sequence.
- `LaunchTimePublisher` – Listens for changes in `ApplicationLaunchHandler` and updates the SDK context.

Previously, `LaunchTimePublisher` owned the `ApplicationLaunchHandler` dependency exclusively, accessing it internally via the `.shared` singleton. Because publisher sets context lazily, the `context.launchTime` had to be defined as optional.

Now, `ApplicationLaunchHandler` is injected into `LaunchTimePublisher` from the root configuration. This allows the initial value of `LaunchTime` to be set immediately in `DatadogContext`, making it non-optional.

Additionally, this dependency injection will facilitate future integration testing, enabling simulation of different application launch environments

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
