### PR TITLE
Fix OpenTracing doc

### DIFF
--- a/DatadogTrace/Sources/OpenTracing/OTSpan.swift
+++ b/DatadogTrace/Sources/OpenTracing/OTSpan.swift
@@ -52,10 +52,10 @@ public protocol OTSpan {
     ///     let span1 = tracer.startSpan(operationName: "root").setActive()
     ///
     ///     // As `span2` has no explicit parent, it becomes the child of the active `span1`:
-    ///     let span2 = tracer.startSpan(operationName: "child of `span1`")
+    ///     let span2 = tracer.startSpan(operationName: "child of `span1`").setActive()
     ///
-    ///     // As `span3` has the explicit parent (nil) it won't become the child of the active span:
-    ///     let span3 = tracer.startSpan(operationName: "another root", childOf: nil)
+    ///     // As `span3` is a root span, it won't become the child of the active span:
+    ///     let span3 = tracer.startRootSpan(operationName: "another root").setActive()
     ///
     @discardableResult
     func setActive() -> OTSpan


### PR DESCRIPTION
### What and why?

The following statement in OpenTracing doc is not true: If span has `nil` parent, it becomes the child of the active span.

```swift
// As `span3` has the explicit parent (nil) it won't become the child of the active span:
let span3 = tracer.startSpan(operationName: "another root", childOf: nil)
```

### How?

Update the doc and mention `startRootSpan` instead.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
