### PR TITLE
RUM-8042 Add pending batches to batch deleted metric

### DIFF
--- a/DatadogCore/Sources/Core/Storage/Files/Directory.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/Directory.swift
@@ -129,6 +129,13 @@ internal struct Directory: DirectoryProtocol {
         return File(url: fileURL)
     }
 
+    /// Returns count of files in this directory.
+    func filesCount() throws -> Int {
+        return try FileManager.default
+            .contentsOfDirectory(at: url, includingPropertiesForKeys: [.isRegularFileKey])
+            .count
+    }
+
     /// Returns all files of this directory.
     func files() throws -> [File] {
         return try FileManager.default

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -187,8 +187,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
             pendingBatches = files.count
 
             let filesFromOldest = try files
-                .map { (file: $0, fileCreationDate: fileCreationDateFrom(fileName: $0.name)) }
-                .compactMap { try deleteFileIfItsObsolete(file: $0.file, fileCreationDate: $0.fileCreationDate) }
+                .compactMap { try deleteFileIfItsObsolete(file: $0, fileCreationDate: fileCreationDateFrom(fileName: $0.name)) }
                 .sorted(by: { $0.fileCreationDate < $1.fileCreationDate })
 
             if ignoreFilesAgeWhenReading {

--- a/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
+++ b/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
@@ -59,6 +59,9 @@ internal enum BatchDeletedMetric {
     /// If the background tasks were enabled.
     static let backgroundTasksEnabled = "background_tasks_enabled"
 
+    /// Count of pending batches left on track.
+    static let pendingBatches = "pending_batches"
+
     /// Allowed values for `batchRemovalReasonKey`.
     enum RemovalReason {
         /// The batch was delivered to Intake and deleted upon receiving given `responseCode`.

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -64,7 +64,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
-        DDAssertReflectionEqual(metric.attributes, [
+        DDAssertJSONEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
             "consent": "consent value",
@@ -96,7 +96,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
-        DDAssertReflectionEqual(metric.attributes, [
+        DDAssertJSONEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
             "consent": "consent value",
@@ -131,7 +131,7 @@ class FilesOrchestrator_MetricsTests: XCTestCase {
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
-        DDAssertReflectionEqual(metric.attributes, [
+        DDAssertJSONEqual(metric.attributes, [
             "metric_type": "batch deleted",
             "track": "track name",
             "consent": "consent value",


### PR DESCRIPTION
### What and why?

Add pending batches attribute to Batch Deleted Metric.
This attribute will help drawing distribution of pending batches throughout sessions.

### How?

`FilesOrchestrator` keeps track of pending batches and send it as part of `BatchDeletedMetric` telemetry.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
