### PR TITLE
RUM-8042 Collect Upload Quality Metric

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -898,6 +898,8 @@
 		D22743EA29DEC9A9001A7EF9 /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */; };
 		D22743EB29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61411B0F24EC15AC0012EAB2 /* Casting+RUM.swift */; };
 		D22743EC29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61411B0F24EC15AC0012EAB2 /* Casting+RUM.swift */; };
+		D22789362D64A0D7007E9DB0 /* UploadQualityMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22789352D64A0D3007E9DB0 /* UploadQualityMetric.swift */; };
+		D22789372D64A0D7007E9DB0 /* UploadQualityMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22789352D64A0D3007E9DB0 /* UploadQualityMetric.swift */; };
 		D227A0A42C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */; };
 		D227A0A52C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */; };
 		D22C5BC82A98A0B20024CC1F /* Baggages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C5BC52A989D130024CC1F /* Baggages.swift */; };
@@ -2845,6 +2847,7 @@
 		D22442C42CA301DA002E71E4 /* UIColor+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SessionReplay.swift"; sourceTree = "<group>"; };
 		D224430C29E95D6600274EC7 /* CrashReportReceiverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportReceiverTests.swift; sourceTree = "<group>"; };
 		D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
+		D22789352D64A0D3007E9DB0 /* UploadQualityMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadQualityMetric.swift; sourceTree = "<group>"; };
 		D227A0A32C7622EA00C83324 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D22C5BC52A989D130024CC1F /* Baggages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Baggages.swift; sourceTree = "<group>"; };
@@ -4977,6 +4980,7 @@
 			children = (
 				6174D60B2BFDDEDF00EC7469 /* SDKMetricFields.swift */,
 				A7FA98CD2BA1A6930018D6B5 /* MethodCalledMetric.swift */,
+				D22789352D64A0D3007E9DB0 /* UploadQualityMetric.swift */,
 			);
 			path = SDKMetrics;
 			sourceTree = "<group>";
@@ -8486,6 +8490,7 @@
 				D2160CA229C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift in Sources */,
 				D2EBEE1F29BA160F00B15732 /* HTTPHeadersReader.swift in Sources */,
 				E2AA55E72C32C6D9002FEF28 /* ApplicationNotifications.swift in Sources */,
+				D22789372D64A0D7007E9DB0 /* UploadQualityMetric.swift in Sources */,
 				D263BCAF29DAFFEB00FA0E21 /* PerformancePresetOverride.swift in Sources */,
 				D23039E7298D5236001A1FA3 /* NetworkConnectionInfo.swift in Sources */,
 				D23039E9298D5236001A1FA3 /* TrackingConsent.swift in Sources */,
@@ -9498,6 +9503,7 @@
 				D2160CA329C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift in Sources */,
 				D2EBEE2D29BA161100B15732 /* HTTPHeadersReader.swift in Sources */,
 				E2AA55E82C32C6D9002FEF28 /* ApplicationNotifications.swift in Sources */,
+				D22789362D64A0D7007E9DB0 /* UploadQualityMetric.swift in Sources */,
 				D263BCB029DAFFEB00FA0E21 /* PerformancePresetOverride.swift in Sources */,
 				D2DA2359298D57AA00C6C7E6 /* NetworkConnectionInfo.swift in Sources */,
 				D2DA235A298D57AA00C6C7E6 /* TrackingConsent.swift in Sources */,

--- a/DatadogCore/Sources/Core/Upload/DataUploadStatus.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadStatus.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-private enum HTTPResponseStatusCode: Int {
+internal enum HTTPResponseStatusCode: Int {
     /// The request has been accepted for processing.
     case accepted = 202
     /// The server cannot or will not process the request (client error).
@@ -105,54 +105,27 @@ extension DataUploadStatus {
 // MARK: - Data Upload Errors
 
 internal enum DataUploadError: Error, Equatable {
-    case unauthorized
-    case httpError(statusCode: Int)
+    case httpError(statusCode: HTTPResponseStatusCode)
     case networkError(error: NSError)
 }
 
-/// A list of known NSURLError codes which should not produce error in Telemetry.
-/// Receiving these codes doesn't mean SDK issue, but the network transportation scenario where the connection interrupted due to external factors.
-/// These list should evolve and we may want to add more codes in there.
-///
-/// Ref.: https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes
-private let ignoredNSURLErrorCodes = Set([
-    NSURLErrorNetworkConnectionLost, // -1005
-    NSURLErrorTimedOut, // -1001
-    NSURLErrorCannotParseResponse, // - 1017
-    NSURLErrorNotConnectedToInternet, // -1009
-    NSURLErrorCannotFindHost, // -1003
-    NSURLErrorSecureConnectionFailed, // -1200
-    NSURLErrorDataNotAllowed, // -1020
-    NSURLErrorCannotConnectToHost, // -1004
-])
-
 extension DataUploadError {
     init?(status code: Int) {
-        guard let responseStatusCode = HTTPResponseStatusCode(rawValue: code) else {
-            // If status code is unexpected, do not produce an error for internal Telemetry - otherwise monitoring may
-            // become too verbose for old installations if we introduce a new status code in the API.
+        guard let statusCode = HTTPResponseStatusCode(rawValue: code) else {
             return nil
         }
 
-        switch responseStatusCode {
+        switch statusCode {
         case .accepted:
             return nil
-        case .unauthorized, .forbidden:
-            self = .unauthorized
-        case .internalServerError, .serviceUnavailable, .badGateway, .gatewayTimeout, .insufficientStorage:
-            // These codes indicate Datadog service issue - so do not produce error as there is no fix reqiured for SDK
-            return nil
-        case .badRequest, .payloadTooLarge, .tooManyRequests, .requestTimeout:
-            // These codes might indicate SDK issue - so produce an error so we send it through telemetry.
-            self = .httpError(statusCode: code)
-        case .unexpected:
-            return nil
+        default:
+            self = .httpError(statusCode: statusCode)
         }
     }
 
     init?(networkError: Error) {
         let nsError = networkError as NSError
-        guard nsError.domain == NSURLErrorDomain, !ignoredNSURLErrorCodes.contains(nsError.code) else {
+        guard nsError.domain == NSURLErrorDomain else {
             return nil
         }
 

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -233,7 +233,8 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
     private func sendUploadQualityMetric(blockers: [DataUploadConditions.Blocker]) {
         sendUploadQualityMetric(
-            failure: blockers.first.map {
+            failure: "blocker",
+            blockers: blockers.map {
                 switch $0 {
                 case .battery: return "low_battery"
                 case .lowPowerModeOn: return "lpm"
@@ -254,12 +255,13 @@ internal class DataUploadWorker: DataUploadWorkerType {
         )
     }
 
-    private func sendUploadQualityMetric(failure: String?) {
+    private func sendUploadQualityMetric(failure: String?, blockers: [String] = []) {
         telemetry.metric(
             name: UploadQualityMetric.name,
             attributes: [
                 UploadQualityMetric.track: featureName,
-                UploadQualityMetric.failure: failure
+                UploadQualityMetric.failure: failure,
+                UploadQualityMetric.blockers: blockers
             ]
         )
     }

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -256,10 +256,10 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
     private func sendUploadQualityMetric(failure: String?) {
         telemetry.metric(
-            name: SDKMetricFields.UploadQuality.name,
+            name: UploadQualityMetric.name,
             attributes: [
-                SDKMetricFields.UploadQuality.track: featureName,
-                SDKMetricFields.UploadQuality.failure: failure
+                UploadQualityMetric.track: featureName,
+                UploadQualityMetric.failure: failure
             ]
         )
     }

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -42,9 +42,11 @@ class DataUploadWorkerTests: XCTestCase {
 
     // MARK: - Data Uploads
 
-    func testItUploadsAllData() {
+    func testItUploadsAllData() throws {
         let uploadExpectation = self.expectation(description: "Make 3 uploads")
         uploadExpectation.expectedFulfillmentCount = 3
+
+        let telemetry = TelemetryMock()
 
         let dataUploader = DataUploaderMock(
             uploadStatus: DataUploadStatus(
@@ -64,6 +66,7 @@ class DataUploadWorkerTests: XCTestCase {
         writer.write(value: ["k3": "v3"])
 
         // When
+        let featureName: String = .mockAny()
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
@@ -72,7 +75,7 @@ class DataUploadWorkerTests: XCTestCase {
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
-            telemetry: NOPTelemetry(),
+            telemetry: telemetry,
             maxBatchesPerUpload: 1
         )
 
@@ -84,11 +87,17 @@ class DataUploadWorkerTests: XCTestCase {
 
         worker.cancelSynchronously()
         XCTAssertEqual(try orchestrator.directory.files().count, 0)
+
+        XCTAssertEqual(telemetry.messages.count, 3)
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 
-    func testItUploadsDataSequentiallyWithoutDelay_whenMaxBatchesPerUploadIsSet() {
+    func testItUploadsDataSequentiallyWithoutDelay_whenMaxBatchesPerUploadIsSet() throws {
         let uploadExpectation = self.expectation(description: "Make 2 uploads")
         uploadExpectation.expectedFulfillmentCount = 2
+
+        let telemetry = TelemetryMock()
 
         let dataUploader = DataUploaderMock(
             uploadStatus: DataUploadStatus(
@@ -108,6 +117,7 @@ class DataUploadWorkerTests: XCTestCase {
         writer.write(value: ["k3": "v3"])
 
         // When
+        let featureName: String = .mockAny()
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
@@ -115,8 +125,8 @@ class DataUploadWorkerTests: XCTestCase {
             contextProvider: .mockAny(),
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
-            featureName: .mockAny(),
-            telemetry: NOPTelemetry(),
+            featureName: featureName,
+            telemetry: telemetry,
             maxBatchesPerUpload: 2
         )
 
@@ -128,6 +138,10 @@ class DataUploadWorkerTests: XCTestCase {
 
         worker.cancelSynchronously()
         XCTAssertEqual(try orchestrator.directory.files().count, 1)
+
+        XCTAssertEqual(telemetry.messages.count, 2)
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 
     func testGivenDataToUpload_whenUploadFinishesAndDoesNotNeedToBeRetried_thenDataIsDeleted() {
@@ -301,7 +315,7 @@ class DataUploadWorkerTests: XCTestCase {
             fileReader: reader,
             dataUploader: DataUploaderMock(uploadStatus: .mockWith()),
             contextProvider: .mockAny(),
-            uploadConditions: DataUploadConditions.neverUpload(),
+            uploadConditions: .neverUpload(),
             delay: delay,
             featureName: .mockAny(),
             telemetry: NOPTelemetry(),
@@ -504,31 +518,73 @@ class DataUploadWorkerTests: XCTestCase {
         )
     }
 
+    func testWhenUploadIsBlocked_itDoesSendUploadQualityTelemetry() throws {
+        // Given
+        let telemetry = TelemetryMock()
+
+        // When
+        let uploadExpectation = self.expectation(description: "Upload has started")
+        uploadExpectation.isInverted = true
+
+        let mockDataUploader = DataUploaderMock(uploadStatus: .mockRandom()) { _ in
+            uploadExpectation.fulfill()
+        }
+
+        let featureName: String = .mockRandom()
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            contextProvider: .mockWith(
+                context: .mockWith(
+                    batteryStatus: .mockWith(
+                        state: .unplugged,
+                        level: 0.05
+                    )
+                )
+            ),
+            uploadConditions: .neverUpload(),
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
+            featureName: featureName,
+            telemetry: telemetry,
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
+        )
+
+        wait(for: [uploadExpectation], timeout: 0.5)
+        worker.cancelSynchronously()
+
+        // Then
+        XCTAssertEqual(telemetry.messages.count, 1)
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "low_battery")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
+    }
+
     func testWhenDataIsUploadedWithServerError_itDoesNotSendErrorTelemetry() throws {
         // Given
         let telemetry = TelemetryMock()
 
         writer.write(value: ["key": "value"])
-        let randomUploadStatus: DataUploadStatus = .mockWith(
-            error: .httpError(
-                statusCode: [
-                    .internalServerError,
-                    .serviceUnavailable,
-                    .badGateway,
-                    .gatewayTimeout,
-                    .insufficientStorage
-                ].randomElement()!
-            )
-        )
+        let randomStatusCode: HTTPResponseStatusCode = [
+            .internalServerError,
+            .serviceUnavailable,
+            .badGateway,
+            .gatewayTimeout,
+            .insufficientStorage
+        ].randomElement()!
 
         // When
         let startUploadExpectation = self.expectation(description: "Upload has started")
-        let mockDataUploader = DataUploaderMock(uploadStatus: randomUploadStatus)
+        let mockDataUploader = DataUploaderMock(
+            uploadStatus: .mockWith(error: .httpError(statusCode: randomStatusCode))
+        )
+
         mockDataUploader.onUpload = { previousUploadStatus in
             XCTAssertNil(previousUploadStatus)
             startUploadExpectation.fulfill()
         }
 
+        let featureName: String = .mockRandom()
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
@@ -536,7 +592,7 @@ class DataUploadWorkerTests: XCTestCase {
             contextProvider: .mockAny(),
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
-            featureName: .mockRandom(),
+            featureName: featureName,
             telemetry: telemetry,
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
@@ -545,7 +601,10 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
 
         // Then
-        XCTAssertEqual(telemetry.messages.count, 0)
+        XCTAssertEqual(telemetry.messages.count, 1)
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "\(randomStatusCode)")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 
     func testWhenDataIsUploadedWithAlertingStatusCode_itSendsErrorTelemetry() throws {
@@ -572,6 +631,7 @@ class DataUploadWorkerTests: XCTestCase {
             startUploadExpectation.fulfill()
         }
 
+        let featureName: String = .mockRandom()
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
@@ -579,7 +639,7 @@ class DataUploadWorkerTests: XCTestCase {
             contextProvider: .mockAny(),
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
-            featureName: .mockRandom(),
+            featureName: featureName,
             telemetry: telemetry,
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
@@ -588,10 +648,14 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
 
         // Then
-        XCTAssertEqual(telemetry.messages.count, 1)
+        XCTAssertEqual(telemetry.messages.count, 2)
 
-        let error = try XCTUnwrap(telemetry.messages.first?.asError, "An error should be send to `telemetry`.")
+        let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
         XCTAssertEqual(error.message,"Data upload finished with status code: \(randomStatusCode.rawValue)")
+
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "\(randomStatusCode)")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 
     func testWhenDataCannotBeUploadedDueToNetworkError_itSendsErrorTelemetry() throws {
@@ -599,16 +663,20 @@ class DataUploadWorkerTests: XCTestCase {
         let telemetry = TelemetryMock()
 
         writer.write(value: ["key": "value"])
-        let randomUploadStatus: DataUploadStatus = .mockWith(error: .networkError(error: .mockAny()))
+
+        let nserror: NSError = .mockAny()
 
         // When
         let startUploadExpectation = self.expectation(description: "Upload has started")
-        let mockDataUploader = DataUploaderMock(uploadStatus: randomUploadStatus)
+        let mockDataUploader = DataUploaderMock(
+            uploadStatus: .mockWith(error: .networkError(error: nserror))
+        )
         mockDataUploader.onUpload = { previousUploadStatus in
             XCTAssertNil(previousUploadStatus)
             startUploadExpectation.fulfill()
         }
 
+        let featureName: String = .mockRandom()
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
@@ -616,7 +684,7 @@ class DataUploadWorkerTests: XCTestCase {
             contextProvider: .mockAny(),
             uploadConditions: .alwaysUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
-            featureName: .mockRandom(),
+            featureName: featureName,
             telemetry: telemetry,
             maxBatchesPerUpload: .mockRandom(min: 1, max: 100)
         )
@@ -625,10 +693,14 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
 
         // Then
-        XCTAssertEqual(telemetry.messages.count, 1)
+        XCTAssertEqual(telemetry.messages.count, 2)
 
-        let error = try XCTUnwrap(telemetry.messages.first?.asError, "An error should be send to `telemetry`.")
+        let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
         XCTAssertEqual(error.message, #"Data upload finished with error - Error Domain=abc Code=0 "(null)""#)
+
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "\(nserror.code)")
+        XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 
     func testWhenDataCannotBePreparedForUpload_itSendsErrorTelemetry() throws {
@@ -662,10 +734,14 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
 
         // Then
-        XCTAssertEqual(telemetry.messages.count, 1)
+        XCTAssertEqual(telemetry.messages.count, 2)
 
-        let error = try XCTUnwrap(telemetry.messages.first?.asError, "An error should be send to `telemetry`.")
+        let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
         XCTAssertEqual(error.message, #"Failed to initiate 'some-feature' data upload - Failed to prepare upload"#)
+
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "invalid")
+        XCTAssertEqual(metric.attributes["track"] as? String, "some-feature")
     }
 
     // MARK: - Tearing Down
@@ -684,7 +760,7 @@ class DataUploadWorkerTests: XCTestCase {
             fileReader: reader,
             dataUploader: dataUploader,
             contextProvider: .mockAny(),
-            uploadConditions: DataUploadConditions.neverUpload(),
+            uploadConditions: .neverUpload(),
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
             featureName: .mockAny(),
             telemetry: NOPTelemetry(),

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -91,6 +91,8 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 3)
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["track"] as? String, featureName)
+        XCTAssertNil(metric.attributes["failure"])
+        XCTAssertNil(metric.attributes["blockers"])
     }
 
     func testItUploadsDataSequentiallyWithoutDelay_whenMaxBatchesPerUploadIsSet() throws {
@@ -142,6 +144,8 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["track"] as? String, featureName)
+        XCTAssertNil(metric.attributes["failure"])
+        XCTAssertNil(metric.attributes["blockers"])
     }
 
     func testGivenDataToUpload_whenUploadFinishesAndDoesNotNeedToBeRetried_thenDataIsDeleted() {

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -537,6 +537,9 @@ class DataUploadWorkerTests: XCTestCase {
             dataUploader: mockDataUploader,
             contextProvider: .mockWith(
                 context: .mockWith(
+                    networkConnectionInfo: .mockWith(
+                        reachability: .no
+                    ),
                     batteryStatus: .mockWith(
                         state: .unplugged,
                         level: 0.05
@@ -556,7 +559,8 @@ class DataUploadWorkerTests: XCTestCase {
         // Then
         XCTAssertEqual(telemetry.messages.count, 1)
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
-        XCTAssertEqual(metric.attributes["failure"] as? String, "low_battery")
+        XCTAssertEqual(metric.attributes["failure"] as? String, "blocker")
+        XCTAssertEqual(metric.attributes["blockers"] as? [String], ["offline", "low_battery"])
         XCTAssertEqual(metric.attributes["track"] as? String, featureName)
     }
 

--- a/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
+++ b/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
@@ -17,13 +17,4 @@ public enum SDKMetricFields {
     /// When attached to metric attributes, the value of this key (session ID) will be used to replace
     /// the ID of session that the metric was collected in. The key itself is dropped before the metric is sent.
     public static let sessionIDOverrideKey = "session_id_override"
-
-    public enum UploadQuality {
-        /// Metric's name
-        public static let name = "upload_quality"
-        /// The Metrics' upload track, or feature name.
-        public static let track = "track"
-        /// The upload's failure description.
-        public static let failure = "failure"
-    }
 }

--- a/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
+++ b/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
@@ -12,10 +12,18 @@ public enum SDKMetricFields {
     public static let typeKey = "metric_type"
     /// The first sample rate applied to the metric.
     public static let headSampleRate = "head_sample_rate"
-
     /// Key referencing the session ID (`String`) that the metric should be sent with. It expects `String` value.
     ///
     /// When attached to metric attributes, the value of this key (session ID) will be used to replace
     /// the ID of session that the metric was collected in. The key itself is dropped before the metric is sent.
     public static let sessionIDOverrideKey = "session_id_override"
+
+    public enum UploadQuality {
+        /// Metric's name
+        public static let name = "upload_quality"
+        /// The Metrics' upload track, or feature name.
+        public static let track = "track"
+        /// The upload's failure description.
+        public static let failure = "failure"
+    }
 }

--- a/DatadogInternal/Sources/SDKMetrics/UploadQualityMetric.swift
+++ b/DatadogInternal/Sources/SDKMetrics/UploadQualityMetric.swift
@@ -18,4 +18,6 @@ public enum UploadQualityMetric {
     public static let track = "track"
     /// The upload's failure description.
     public static let failure = "failure"
+    /// The upload's blockers list.
+    public static let blockers = "blockers"
 }

--- a/DatadogInternal/Sources/SDKMetrics/UploadQualityMetric.swift
+++ b/DatadogInternal/Sources/SDKMetrics/UploadQualityMetric.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Fields of the Upload Quality Metric.
+///
+/// This metric is not sent to Telemetry as-is, values are sent on the message-bus
+/// and aggregated internally by RUM's message receiver. The aggregate is sent as an
+/// attribute of the "RUM Session Ended" metric.
+public enum UploadQualityMetric {
+    /// Metric's name
+    public static let name = "upload_quality"
+    /// The Metrics' upload track, or feature name.
+    public static let track = "track"
+    /// The upload's failure description.
+    public static let failure = "failure"
+}

--- a/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
@@ -21,7 +21,7 @@ internal struct TelemetryInterceptor: FeatureMessageReceiver {
         case .error(let id, let message, let kind, let stack):
             interceptError(id: id, message: message, kind: kind, stack: stack)
         case .metric(let metric) where metric.name == SDKMetricFields.UploadQuality.name:
-            interceptUploadQualityMetric(attributes: metric.attributes, sampleRate: metric.sampleRate)
+            interceptUploadQualityMetric(attributes: metric.attributes)
             return true
 
         default:
@@ -35,6 +35,7 @@ internal struct TelemetryInterceptor: FeatureMessageReceiver {
         sessionEndedMetric.track(sdkErrorKind: kind, in: nil) // `nil` - track in current session
     }
 
-    private func interceptUploadQualityMetric(attributes: [String: Encodable], sampleRate: SampleRate) {
+    private func interceptUploadQualityMetric(attributes: [String: Encodable]) {
+        sessionEndedMetric.track(uploadQuality: attributes, in: nil) // `nil` - track in current session
     }
 }

--- a/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
@@ -20,9 +20,11 @@ internal struct TelemetryInterceptor: FeatureMessageReceiver {
         switch telemetry {
         case .error(let id, let message, let kind, let stack):
             interceptError(id: id, message: message, kind: kind, stack: stack)
-        case .metric(let metric) where metric.name == SDKMetricFields.UploadQuality.name:
+        case .metric(let metric) where metric.name == UploadQualityMetric.name:
+            // Intercept the 'upload_quality' metric for aggregation in the rse
+            // metric
             interceptUploadQualityMetric(attributes: metric.attributes)
-            return true
+            return true // do not forward the message
 
         default:
             break

--- a/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryInterceptor.swift
@@ -20,6 +20,10 @@ internal struct TelemetryInterceptor: FeatureMessageReceiver {
         switch telemetry {
         case .error(let id, let message, let kind, let stack):
             interceptError(id: id, message: message, kind: kind, stack: stack)
+        case .metric(let metric) where metric.name == SDKMetricFields.UploadQuality.name:
+            interceptUploadQualityMetric(attributes: metric.attributes, sampleRate: metric.sampleRate)
+            return true
+
         default:
             break
         }
@@ -29,5 +33,8 @@ internal struct TelemetryInterceptor: FeatureMessageReceiver {
 
     private func interceptError(id: String, message: String, kind: String, stack: String) {
         sessionEndedMetric.track(sdkErrorKind: kind, in: nil) // `nil` - track in current session
+    }
+
+    private func interceptUploadQualityMetric(attributes: [String: Encodable], sampleRate: SampleRate) {
     }
 }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -203,14 +203,14 @@ internal class SessionEndedMetric {
         wasStopped = true
     }
 
-    /// Tracks the upload qualiy metric for aggregation.
+    /// Tracks the upload quality metric for aggregation.
     ///
     /// - Parameters:
     ///   - attributes: The upload quality attributes
     func track(uploadQuality attributes: [String: Encodable]) {
         uploadQuality = Attributes.UploadQuality(
             uploadCycleCount: uploadQuality.uploadCycleCount + 1,
-            uploadFailureCount: attributes[SDKMetricFields.UploadQuality.failure]
+            uploadFailureCount: attributes[UploadQualityMetric.failure]
                 .flatMap { $0 as? String }
                 // Merge by incrementing values
                 .map { uploadQuality.uploadFailureCount.merging([$0: 1], uniquingKeysWith: +) }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -104,6 +104,14 @@ internal final class SessionEndedMetricController {
         }
     }
 
+    /// Tracks the upload qualiy metric for aggregation.
+    ///
+    /// - Parameters:
+    ///   - attributes: The upload quality attributes
+    func track(uploadQuality attributes: [String: Encodable], in sessionID: RUMUUID?) {
+        updateMetric(for: sessionID) { $0?.track(uploadQuality: attributes) }
+    }
+
     private func updateMetric(for sessionID: RUMUUID?, _ mutation: (inout SessionEndedMetric?) throws -> Void) {
         _metricsBySessionID.mutate { metrics in
             guard let sessionID = (sessionID ?? pendingSessionIDs.last) else {

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetricController.swift
@@ -104,7 +104,7 @@ internal final class SessionEndedMetricController {
         }
     }
 
-    /// Tracks the upload qualiy metric for aggregation.
+    /// Tracks the upload quality metric for aggregation.
     ///
     /// - Parameters:
     ///   - attributes: The upload quality attributes

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -49,6 +49,6 @@ class TelemetryInterceptorTests: XCTestCase {
         metricController.endMetric(sessionID: sessionID, with: .mockRandom())
         let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
         let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
-        XCTAssertEqual(rse.uploadQuality.uploadCycleCount, 1)
+        XCTAssertEqual(rse.uploadQuality.cycleCount, 1)
     }
 }

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -41,7 +41,7 @@ class TelemetryInterceptorTests: XCTestCase {
 
         // When
         metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny(), tracksBackgroundEvents: .mockRandom())
-        let metricTelemetry: TelemetryMessage = .metric(MetricTelemetry(name: SDKMetricFields.UploadQuality.name, attributes: mockRandomAttributes(), sampleRate: .mockRandom()))
+        let metricTelemetry: TelemetryMessage = .metric(MetricTelemetry(name: UploadQualityMetric.name, attributes: mockRandomAttributes(), sampleRate: .mockRandom()))
         let result = interceptor.receive(message: .telemetry(metricTelemetry), from: NOPDatadogCore())
         XCTAssertTrue(result)
 

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 import TestUtilities
-import DatadogInternal
+@testable import DatadogInternal
 @testable import DatadogRUM
 
 class TelemetryInterceptorTests: XCTestCase {
@@ -30,5 +30,25 @@ class TelemetryInterceptorTests: XCTestCase {
         let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
         let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
         XCTAssertEqual(rse.sdkErrorsCount.total, 1)
+    }
+
+    func testWhenInterceptingUploadQualityMetric_itItUpdatesSessionEndedMetric() throws {
+        let sessionID: RUMUUID = .mockRandom()
+
+        // Given
+        let metricController = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
+
+        // When
+        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny(), tracksBackgroundEvents: .mockRandom())
+        let metricTelemetry: TelemetryMessage = .metric(MetricTelemetry(name: SDKMetricFields.UploadQuality.name, attributes: mockRandomAttributes(), sampleRate: .mockRandom()))
+        let result = interceptor.receive(message: .telemetry(metricTelemetry), from: NOPDatadogCore())
+        XCTAssertTrue(result)
+
+        // Then
+        metricController.endMetric(sessionID: sessionID, with: .mockRandom())
+        let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
+        let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
+        XCTAssertEqual(rse.uploadQuality.uploadCycleCount, 1)
     }
 }

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -114,6 +114,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
                 { controller.track(missedEventType: .action, in: sessionIDs.randomElement()!) },
                 { controller.track(missedEventType: .resource, in: nil) },
                 { controller.trackWasStopped(sessionID: nil) },
+                { controller.track(uploadQuality: mockRandomAttributes(), in: nil) },
                 { controller.endMetric(sessionID: sessionIDs.randomElement()!, with: .mockRandom()) },
             ],
             iterations: 100

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -503,7 +503,8 @@ class SessionEndedMetricTests: XCTestCase {
 
         metric.track(uploadQuality: [
             UploadQualityMetric.track: String.mockRandom(),
-            UploadQualityMetric.failure: "error1"
+            UploadQualityMetric.failure: "error1",
+            UploadQualityMetric.blockers: ["blocker1", "blocker2"]
         ])
 
         metric.track(uploadQuality: [
@@ -512,15 +513,18 @@ class SessionEndedMetricTests: XCTestCase {
 
         metric.track(uploadQuality: [
             UploadQualityMetric.track: String.mockRandom(),
-            UploadQualityMetric.failure: "error2"
+            UploadQualityMetric.failure: "error2",
+            UploadQualityMetric.blockers: ["blocker1"]
         ])
 
         // When
         let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))
 
-        XCTAssertEqual(try matcher.value("rse.upload_quality.upload_cycle_count") as Int, 4)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.upload_failure_count.error1") as Int, 2)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.upload_failure_count.error2") as Int, 1)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.cycle_count") as Int, 4)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.failure_count.error1") as Int, 2)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.failure_count.error2") as Int, 1)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.blocker_count.blocker1") as Int, 2)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.blocker_count.blocker2") as Int, 1)
     }
 
     // MARK: - Metric Spec
@@ -557,7 +561,7 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.resources") as Int)
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.errors") as Int)
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.long_tasks") as Int)
-        XCTAssertNotNil(try matcher.value("rse.upload_quality.upload_cycle_count") as Int)
+        XCTAssertNotNil(try matcher.value("rse.upload_quality.cycle_count") as Int)
     }
 }
 

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -497,22 +497,22 @@ class SessionEndedMetricTests: XCTestCase {
     func testUploadQualityMetricAggregation() throws {
         let metric = SessionEndedMetric.with(sessionID: sessionID, context: .mockWith(applicationBundleType: .iOSApp))
         metric.track(uploadQuality: [
-            SDKMetricFields.UploadQuality.track: String.mockRandom(),
-            SDKMetricFields.UploadQuality.failure: "error1"
+            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.failure: "error1"
         ])
 
         metric.track(uploadQuality: [
-            SDKMetricFields.UploadQuality.track: String.mockRandom(),
-            SDKMetricFields.UploadQuality.failure: "error1"
+            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.failure: "error1"
         ])
 
         metric.track(uploadQuality: [
-            SDKMetricFields.UploadQuality.track: String.mockRandom(),
+            UploadQualityMetric.track: String.mockRandom(),
         ])
 
         metric.track(uploadQuality: [
-            SDKMetricFields.UploadQuality.track: String.mockRandom(),
-            SDKMetricFields.UploadQuality.failure: "error2"
+            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.failure: "error2"
         ])
 
         // When
@@ -531,7 +531,7 @@ class SessionEndedMetricTests: XCTestCase {
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .manual)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .swiftui)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .uikit)
-        metric.track(uploadQuality: [SDKMetricFields.UploadQuality.track: String.mockRandom()])
+        metric.track(uploadQuality: [UploadQualityMetric.track: String.mockRandom()])
 
         // When
         let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))


### PR DESCRIPTION
### What and why?

Collect, aggregate, and report the Upload Quality Metric as specified in [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4609049834/RFC+-+Additional+telemetry+for+uploader+improvements).

### How?

- The `DataUploadWorker` will report each upload cycle through 'Upload Quality' metric telemetry. This metric will include a failure description if applicable.
- The `TelemetryInterceptor` will intercept and forward the 'Upload Quality' metric's attributes to the `SessionEndedMetricController`.
- The `SessionEndedMetricController` will count upload cycle and failures to report the final `upload_quality` attribute of the 'RUM Session Ended' metric telemetry.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
