### PR TITLE
RUM-8039 Reset Upload Delay After Backoff

### DIFF
--- a/DatadogCore/Sources/Core/Upload/DataUploadDelay.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadDelay.swift
@@ -22,8 +22,8 @@ internal class DataUploadDelay {
         self.current = performance.initialUploadDelay
     }
 
-    func decrease() {
-        current = max(minDelay, current * (1.0 - changeRate))
+    func reset() {
+        current = minDelay
     }
 
     func increase() {

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -132,7 +132,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
                     DD.logger.debug("   → (\(self.featureName)) accepted, won't be retransmitted: \(uploadStatus.userDebugDescription)")
                     if files.isEmpty {
-                        self.delay.decrease()
+                        self.delay.reset()
                     }
 
                     self.fileReader.markBatchAsRead(

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadDelayTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadDelayTests.swift
@@ -21,23 +21,11 @@ class DataUploadDelayTests: XCTestCase {
         XCTAssertEqual(delay.current, mockPerformance.initialUploadDelay)
     }
 
-    func testWhenDecreasing_itGoesDownToMinimumDelay() {
+    func testWhenReset_itGoesDownToMinimumDelay() {
         let delay = DataUploadDelay(performance: mockPerformance)
-        var previousValue: TimeInterval = delay.current
-
-        while previousValue > mockPerformance.minUploadDelay {
-            delay.decrease()
-
-            let nextValue = delay.current
-            XCTAssertEqual(
-                nextValue / previousValue,
-                1.0 - mockPerformance.uploadDelayChangeRate,
-                accuracy: 0.1
-            )
-            XCTAssertLessThanOrEqual(nextValue, max(previousValue, mockPerformance.minUploadDelay))
-
-            previousValue = nextValue
-        }
+        delay.increase()
+        delay.reset()
+        XCTAssertEqual(delay.current, mockPerformance.minUploadDelay)
     }
 
     func testWhenIncreasing_itClampsToMaximumDelay() {

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -390,24 +390,31 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
     }
 
-    func testWhenBatchSucceeds_thenIntervalDecreases() {
-        let delayChangeExpectation = expectation(description: "Upload delay is decreased")
-        let initialUploadDelay = 0.05
+    func testWhenBatchSucceeds_thenIntervalResets() {
+        let startUploadExpectation = expectation(description: "Upload started")
+        let minUploadDelay: Double = .mockRandom(min: 1, max: 2)
         let delay = DataUploadDelay(
             performance: UploadPerformanceMock(
-                initialUploadDelay: initialUploadDelay,
-                minUploadDelay: 0,
-                maxUploadDelay: 1,
+                initialUploadDelay: 0.05,
+                minUploadDelay: minUploadDelay,
+                maxUploadDelay: 2,
                 uploadDelayChangeRate: 0.01
             )
         )
+
+        let dataUploader = DataUploaderMock(uploadStatus: .mockWith(responseCode: 202)) { status in
+            XCTAssertNil(status)
+            startUploadExpectation.fulfill()
+        }
+
         // When
+        // Given
         writer.write(value: ["k1": "v1"])
 
         let worker = DataUploadWorker(
             queue: uploaderQueue,
             fileReader: reader,
-            dataUploader: DataUploaderMock(uploadStatus: .mockWith(needsRetry: false)),
+            dataUploader: dataUploader,
             contextProvider: .mockAny(),
             uploadConditions: DataUploadConditions.alwaysUpload(),
             delay: delay,
@@ -417,13 +424,10 @@ class DataUploadWorkerTests: XCTestCase {
         )
 
         // Then
-        wait(until: { [uploaderQueue] in
-            uploaderQueue.sync {
-                delay.current < initialUploadDelay
-            }
-        }, andThenFulfill: delayChangeExpectation)
-        wait(for: [delayChangeExpectation], timeout: 0.5)
+        wait(for: [startUploadExpectation], timeout: 0.5)
         worker.cancelSynchronously()
+
+        XCTAssertEqual(delay.current, minUploadDelay)
     }
 
     // MARK: - Notifying Upload Progress


### PR DESCRIPTION
### What and why?

Reset upload delay when the SDK recovers from a backoff state (upload blocked).

More context in [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4672979222/RFC+-+Mobile+uploader+improvements+to+reduce+batch+loss+rate)

### How?

Simply reset the delay to minimum after a successful upload.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
