### PR TITLE
RUM-8774 SessionReplay Image recording uses correct frame calculation for scaleAspectFill

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CGSize+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CGSize+SessionReplay.swift
@@ -16,14 +16,8 @@ internal extension DatadogExtension where ExtendedType == CGSize {
     }
 
     func scaleAspectFillRect(for contentSize: CGSize) -> CGRect {
-        let scale: CGFloat
-        if (contentSize.width - type.width) < (contentSize.height - type.height) {
-            scale = type.width / contentSize.width
-        } else {
-            scale = type.height / contentSize.height
-        }
+        let scale = max(type.width / contentSize.width, type.height / contentSize.height)
         let size = CGSize(width: contentSize.width * scale, height: contentSize.height * scale)
-
         return CGRect(
             x: (type.width - size.width) / 2,
             y: (type.height - size.height) / 2,
@@ -34,7 +28,6 @@ internal extension DatadogExtension where ExtendedType == CGSize {
 
     func scaleAspectFitRect(for contentSize: CGSize) -> CGRect {
         let imageAspectRatio = contentSize.height / contentSize.width
-
         var x, y, width, height: CGFloat
         if imageAspectRatio > aspectRatio {
             height = type.height

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/CGRect+SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/CGRect+SessionReplayTests.swift
@@ -191,5 +191,26 @@ class CGRectSessionReplayTests: XCTestCase {
             accuracy: accuracy
         )
     }
+
+    func testBigContentFrameWithAtypicalContainerFrameForScaleAspectFill() {
+        let frame = CGRect(x: 0, y: 0, width: 300, height: 200)
+        let contentSize = CGSize(width: 400, height: 280)
+
+        XCTAssertRectsEqual(
+            frame.dd.contentFrame(for: contentSize, using: .scaleAspectFill),
+            CGRect(x: 0, y: -5, width: 300, height: 210),
+            accuracy: accuracy
+        )
+    }
+
+    func testSmallContentFrameWithAtypicalContainerFrameForScaleAspectFill() {
+        let frame = CGRect(x: 0, y: 0, width: 300, height: 200)
+        let contentSize = CGSize(width: 100, height: 50)
+        XCTAssertRectsEqual(
+            frame.dd.contentFrame(for: contentSize, using: .scaleAspectFill),
+            CGRect(x: -50, y: 0, width: 400, height: 200),
+            accuracy: accuracy
+        )
+    }
 }
 #endif


### PR DESCRIPTION
### What and why?

What?
In Session Replay when capturing images from `UIImageView` with `contentMode` `scaleAspectFill`, in some condition the computed `CGRect` which represent what the customer will see on Session Replay Player, did not match what was displayed on device.

Why?
The condition used to find which dimension "scaling factor" to apply (height or width), was comparing the distance (in points) difference between the container and the content, instead of comparing the scaling factors required so that the image fill properly the container for both dimensions.  

### How?

The fix change this condition to now compute both the `x` and `y` scaling factor needed so the content image fills the container, and select the biggest of the two (using `max`), ensuring the image always fill the container in both dimensions.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes