### PR TITLE
RUM-8409 Propagate RUM session ID in request headers

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -806,6 +806,10 @@
 		A7FA98CF2BA1A6930018D6B5 /* MethodCalledMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FA98CD2BA1A6930018D6B5 /* MethodCalledMetric.swift */; };
 		B3C27A082CE6342C006580F9 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C27A072CE6342C006580F9 /* DeterministicSamplerTests.swift */; };
 		B3C27A092CE6342C006580F9 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C27A072CE6342C006580F9 /* DeterministicSamplerTests.swift */; };
+		B3E46CAB2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */; };
+		B3E46CAC2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */; };
+		B3E46CAE2D91B40000BABF66 /* NetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */; };
+		B3E46CAF2D91B40000BABF66 /* NetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */; };
 		D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A4287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
@@ -2850,6 +2854,8 @@
 		B3BBBCB0265E71C600943419 /* VitalMemoryReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReader.swift; sourceTree = "<group>"; };
 		B3BBBCBB265E71D100943419 /* VitalMemoryReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReaderTests.swift; sourceTree = "<group>"; };
 		B3C27A072CE6342C006580F9 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
+		B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkContextProvider.swift; sourceTree = "<group>"; };
+		B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkContext.swift; sourceTree = "<group>"; };
 		B3FC3C0626526EFF00DEED9E /* VitalInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalInfo.swift; sourceTree = "<group>"; };
 		B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoTests.swift; sourceTree = "<group>"; };
 		D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireframesBuilderTests.swift; sourceTree = "<group>"; };
@@ -6498,6 +6504,8 @@
 		D2EBEE1D29BA15BC00B15732 /* NetworkInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
+				B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */,
+				B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */,
 				D2160C9829C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift */,
 				D2160CEC29C0E0E600FAA9A5 /* DatadogURLSessionHandler.swift */,
 				6175C3502BCE66DB006FAAB0 /* TraceContext.swift */,
@@ -8593,6 +8601,7 @@
 				3CBDE6742AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift in Sources */,
 				D23039E4298D5236001A1FA3 /* CarrierInfo.swift in Sources */,
 				D2303A03298D5236001A1FA3 /* DDError.swift in Sources */,
+				B3E46CAB2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */,
 				D23039F4298D5236001A1FA3 /* AnyCodable.swift in Sources */,
 				D29A9F9529DDB1DB005C54A4 /* UIKitExtensions.swift in Sources */,
 				6167E6E82B8122E900C3CA2D /* BacktraceReport.swift in Sources */,
@@ -8666,6 +8675,7 @@
 				D23039E5298D5236001A1FA3 /* DateProvider.swift in Sources */,
 				D23039E0298D5235001A1FA3 /* DatadogCoreProtocol.swift in Sources */,
 				D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */,
+				B3E46CAE2D91B40000BABF66 /* NetworkContext.swift in Sources */,
 				D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */,
 				6167E6F92B81E95900C3CA2D /* BinaryImage.swift in Sources */,
 				6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
@@ -9636,6 +9646,7 @@
 				3CBDE6752AA08C2F00F6A7B6 /* URLSessionInstrumentation.swift in Sources */,
 				D2DA235F298D57AA00C6C7E6 /* CarrierInfo.swift in Sources */,
 				D2DA2360298D57AA00C6C7E6 /* DDError.swift in Sources */,
+				B3E46CAC2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */,
 				D2DA2361298D57AA00C6C7E6 /* AnyCodable.swift in Sources */,
 				D29A9F9629DDB1DB005C54A4 /* UIKitExtensions.swift in Sources */,
 				6167E6E92B8122E900C3CA2D /* BacktraceReport.swift in Sources */,
@@ -9709,6 +9720,7 @@
 				D2DA237C298D57AA00C6C7E6 /* DatadogCoreProtocol.swift in Sources */,
 				D2DA237D298D57AA00C6C7E6 /* DataCompression.swift in Sources */,
 				D2C9A26A2C0F3F5A007526F5 /* SessionReplayConfiguration.swift in Sources */,
+				B3E46CAF2D91B40000BABF66 /* NetworkContext.swift in Sources */,
 				6167E6FA2B81E95900C3CA2D /* BinaryImage.swift in Sources */,
 				6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
 				D2DA237E298D57AA00C6C7E6 /* AnyEncoder.swift in Sources */,

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -75,6 +75,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
             with: RUM.Configuration(
                 applicationID: Environment.readRUMApplicationID(),
                 urlSessionTracking: .init(
+                    firstPartyHostsTracing: .traceWithHeaders(hostsWithHeaders: ["api.shopist.io": [.datadog]],sampleRate: 100),
                     resourceAttributesProvider: { req, resp, data, err in
                         print("⭐️ [Attributes Provider] data: \(String(describing: data))")
                         return [:]

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -82,6 +82,9 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
             traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceContext.traceID.idLo)
             traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(traceContext.spanID, representation: .decimal)
             traceHeaderFields[TracingHTTPHeaders.tagsField] = "_dd.p.tid=\(traceContext.traceID.idHiHex)"
+            if let sessionId = traceContext.rumSessionId {
+                traceHeaderFields[W3CHTTPHeaders.baggage] = "\(W3CHTTPHeaders.Constants.rumSessionBaggageKey)=\(sessionId)"
+            }
         case (.sampled, false):
             break
         }

--- a/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
@@ -16,9 +16,10 @@ public protocol DatadogURLSessionHandler {
     /// - Parameters:
     ///   - request: The request to be modified.
     ///   - headerTypes: The types of tracing headers to inject into the request.
+    ///   - networkContext: The context around the network request
     /// - Returns: A tuple containing the modified request and the injected TraceContext. If no trace is injected (e.g., due to sampling),
     ///            the returned request remains unmodified, and the trace context will be nil.
-    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> (URLRequest, TraceContext?)
+    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?)
 
     /// Notifies the handler that the interception has started.
     ///
@@ -36,7 +37,8 @@ extension DatadogCoreProtocol {
     ///
     /// - Parameter urlSessionHandler: The `URLSession` handler to register.
     public func register(urlSessionHandler: DatadogURLSessionHandler) throws {
-        let feature = get(feature: NetworkInstrumentationFeature.self) ?? .init()
+        let contextProvider = NetworkContextCoreProvider()
+        let feature = get(feature: NetworkInstrumentationFeature.self) ?? .init(networkContextProvider: contextProvider, messageReceiver: contextProvider)
         feature.handlers.append(urlSessionHandler)
         try register(feature: feature)
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkContext.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkContext.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Describes current Datadog SDK context, so the app state information can be attached to
+/// instrumented Network traces.
+public struct NetworkContext {
+    public struct RUMContext: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "session.id"
+        }
+        public let sessionID: String
+    }
+
+    /// Provides the current active RUM context, if any
+    public var rumContext: RUMContext?
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkContextProvider.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkContextProvider.swift
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An interface for writing and reading  the `NetworkContext`
+internal protocol NetworkContextProvider: AnyObject {
+    /// Returns current `NetworkContext` value.
+    var currentNetworkContext: NetworkContext? { get }
+}
+
+/// Manages the `NetworkContext` reads and writes in a thread-safe manner.
+internal class NetworkContextCoreProvider: NetworkContextProvider {
+    // MARK: - NetworkContextProviderType
+    @ReadWriteLock
+    var currentNetworkContext: NetworkContext?
+}
+
+extension NetworkContextCoreProvider: FeatureMessageReceiver {
+    /// Defines keys referencing RUM baggage in `DatadogContext.featuresAttributes`.
+    internal enum RUMBaggageKeys {
+        /// The key references RUM view event.
+        /// The view event associated with the key conforms to `Codable`.
+        static let viewEvent = "rum-view-event"
+
+        /// The key references a `true` value if the RUM view is reset.
+        static let viewReset = "rum-view-reset"
+
+        /// The key references RUM session state.
+        /// The state associated with the key conforms to `Codable`.
+        static let sessionState = "rum-session-state"
+
+        /// This key references the global log attributes
+        static let logAttributes = "global-log-attributes"
+
+        /// The key referencing ``DatadogInternal.GlobalRUMAttributes`` value holding RUM global attributes.
+        static let rumAttributes = "global-rum-attributes"
+    }
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        switch message {
+        case .context(let context):
+            update(context: context, to: core)
+        default:
+            return false
+        }
+
+        return true
+    }
+
+    /// Updates crash context.
+    ///
+    /// - Parameter context: The updated core context.
+    private func update(context: DatadogContext, to core: DatadogCoreProtocol) {
+        do {
+            self.currentNetworkContext = NetworkContext(rumContext: try context.baggages["rum"]?.decode())
+        } catch {
+            core.telemetry
+                .error("Fails to decode RUM Context from Trace", error: error)
+        }
+    }
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/TraceContext.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TraceContext.swift
@@ -21,6 +21,9 @@ public struct TraceContext: Equatable {
     /// Indicates whether this span was sampled or rejected by the sampler.
     public let isKept: Bool
 
+    /// The unique identifier for the current RUM Session, if any.
+    public let rumSessionId: String?
+
     /// Initializes a `TraceContext` instance with the provided parameters.
     ///
     /// - Parameters:
@@ -34,12 +37,14 @@ public struct TraceContext: Equatable {
         spanID: SpanID,
         parentSpanID: SpanID?,
         sampleRate: Float,
-        isKept: Bool
+        isKept: Bool,
+        rumSessionId: String?
     ) {
         self.traceID = traceID
         self.spanID = spanID
         self.parentSpanID = parentSpanID
         self.sampleRate = sampleRate
         self.isKept = isKept
+        self.rumSessionId = rumSessionId
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
@@ -45,6 +45,9 @@ public enum W3CHTTPHeaders {
     /// also conveys information about the request’s position in multiple distributed tracing graphs.
     public static let tracestate = "tracestate"
 
+    /// The baggage header represents a set of user-defined properties associated with a distributed request.
+    public static let baggage = "baggage"
+
     public enum Constants {
         public static let version = "00"
         public static let sampledValue = "01"
@@ -59,5 +62,6 @@ public enum W3CHTTPHeaders {
         public static let parentId = "p"
         public static let tracestateKeyValueSeparator = ":"
         public static let tracestatePairSeparator = ";"
+        public static let rumSessionBaggageKey = "session.id"
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -110,6 +110,10 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
                 .joined(separator: Constants.tracestatePairSeparator)
 
             traceHeaderFields[W3CHTTPHeaders.tracestate] = "\(Constants.dd)=\(ddtracestate)"
+
+            if let sessionId = traceContext.rumSessionId {
+                traceHeaderFields[W3CHTTPHeaders.baggage] = "\(Constants.rumSessionBaggageKey)=\(sessionId)"
+            }
         case (.sampled, false):
             break
         }

--- a/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/HTTPHeadersWriterTests.swift
@@ -16,7 +16,8 @@ class HTTPHeadersWriterTests: XCTestCase {
             traceContext: .mockWith(
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
-                isKept: true
+                isKept: true,
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
@@ -25,6 +26,7 @@ class HTTPHeadersWriterTests: XCTestCase {
         XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "1234")
         XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "2345")
         XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testWritingDroppedTraceContext_withHeadBasedSamplingStrategy() {
@@ -52,7 +54,8 @@ class HTTPHeadersWriterTests: XCTestCase {
             traceContext: .mockWith(
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
-                isKept: .random()
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
@@ -61,6 +64,7 @@ class HTTPHeadersWriterTests: XCTestCase {
         XCTAssertEqual(headers[TracingHTTPHeaders.traceIDField], "1234")
         XCTAssertEqual(headers[TracingHTTPHeaders.parentSpanIDField], "2345")
         XCTAssertEqual(headers[TracingHTTPHeaders.tagsField], "_dd.p.tid=4d2")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testWritingDroppedTraceContext_withCustomSamplingStrategy() {

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -68,7 +68,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
-        handler.onRequestMutation = { _, _ in notifyRequestMutation.fulfill() }
+        handler.onRequestMutation = { _, _, _ in notifyRequestMutation.fulfill() }
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
@@ -469,9 +469,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testWhenInterceptingTaskWithMultipleTraceContexts_itTakesTheFirstContext() throws {
         let traceContexts = [
-            TraceContext(traceID: .mock(1, 1), spanID: .mock(2), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
-            TraceContext(traceID: .mock(2, 2), spanID: .mock(3), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
-            TraceContext(traceID: .mock(3, 3), spanID: .mock(4), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom()),
+            TraceContext(traceID: .mock(1, 1), spanID: .mock(2), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom(), rumSessionId: .mockAny()),
+            TraceContext(traceID: .mock(2, 2), spanID: .mock(3), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom(), rumSessionId: .mockAny()),
+            TraceContext(traceID: .mock(3, 3), spanID: .mock(4), parentSpanID: nil, sampleRate: .mockRandom(), isKept: .mockRandom(), rumSessionId: .mockAny()),
         ]
 
         // When

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -22,13 +22,15 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
             traceContext: .mockWith(
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
-                isKept: true
+                isKept: true,
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testWritingDroppedTraceContext_withHeadBasedSamplingStrategy() {
@@ -45,13 +47,15 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
                 parentSpanID: 5_678,
-                isKept: false
+                isKept: false,
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-00")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testWritingSampledTraceContext_withCustomSamplingStrategy() {
@@ -67,13 +71,15 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
             traceContext: .mockWith(
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
-                isKept: .random()
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testWritingDroppedTraceContext_withCustomSamplingStrategy() {
@@ -90,12 +96,14 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
                 traceID: .init(idHi: 1_234, idLo: 1_234),
                 spanID: 2_345,
                 parentSpanID: 5_678,
-                isKept: .random()
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
             )
         )
 
         let headers = writer.traceHeaderFields
         XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-00")
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -69,8 +69,8 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 
     // MARK: - DatadogURLSessionHandler
 
-    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> (URLRequest, TraceContext?) {
-        distributedTracing?.modify(request: request, headerTypes: headerTypes) ?? (request, nil)
+    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?) {
+        distributedTracing?.modify(request: request, headerTypes: headerTypes, rumSessionId: networkContext?.rumContext?.sessionID) ?? (request, nil)
     }
 
     func interceptionDidStart(interception: DatadogInternal.URLSessionTaskInterception) {
@@ -148,7 +148,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 }
 
 extension DistributedTracing {
-    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> (URLRequest, TraceContext?) {
+    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, rumSessionId: String?) -> (URLRequest, TraceContext?) {
         let traceID = traceIDGenerator.generate()
         let spanID = spanIDGenerator.generate()
         let injectedSpanContext = TraceContext(
@@ -156,7 +156,8 @@ extension DistributedTracing {
             spanID: spanID,
             parentSpanID: nil,
             sampleRate: sampler.samplingRate,
-            isKept: sampler.sample()
+            isKept: sampler.sample(),
+            rumSessionId: rumSessionId
         )
 
         var request = request

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -43,7 +43,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.datadog]
+            headerTypes: [.datadog],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField), "rum")
@@ -51,6 +52,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField), "_dd.p.tid=a")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField), "100")
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.baggage), "session.id=abcdef01-2345-6789-abcd-ef0123456789")
 
         let injectedTraceContext = try XCTUnwrap(traceContext, "It must return injected trace context")
         XCTAssertEqual(injectedTraceContext.traceID, .init(idHi: 10, idLo: 100))
@@ -58,6 +60,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(injectedTraceContext.parentSpanID)
         XCTAssertEqual(injectedTraceContext.sampleRate, 100)
         XCTAssertTrue(injectedTraceContext.isKept)
+        XCTAssertEqual(injectedTraceContext.rumSessionId, "abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectB3TraceHeaders() throws {
@@ -75,7 +78,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.b3]
+            headerTypes: [.b3],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -87,6 +91,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(injectedTraceContext.parentSpanID)
         XCTAssertEqual(injectedTraceContext.sampleRate, 100)
         XCTAssertTrue(injectedTraceContext.isKept)
+        XCTAssertEqual(injectedTraceContext.rumSessionId, "abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectB3MultiTraceHeaders() throws {
@@ -104,7 +109,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.b3multi]
+            headerTypes: [.b3multi],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -119,6 +125,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(injectedTraceContext.parentSpanID)
         XCTAssertEqual(injectedTraceContext.sampleRate, 100)
         XCTAssertTrue(injectedTraceContext.isKept)
+        XCTAssertEqual(injectedTraceContext.rumSessionId, "abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testGivenFirstPartyInterception_withSampledTrace_itInjectW3CTraceHeaders() throws {
@@ -136,7 +143,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.tracecontext]
+            headerTypes: [.tracecontext],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -148,6 +156,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(injectedTraceContext.parentSpanID)
         XCTAssertEqual(injectedTraceContext.sampleRate, 100)
         XCTAssertTrue(injectedTraceContext.isKept)
+        XCTAssertEqual(injectedTraceContext.rumSessionId, "abcdef01-2345-6789-abcd-ef0123456789")
     }
 
     func testGivenFirstPartyInterception_withRejectedTrace_itDoesNotInjectDDTraceHeaders() throws {
@@ -165,7 +174,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.datadog]
+            headerTypes: [.datadog],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField), "rum")
@@ -191,7 +201,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.b3]
+            headerTypes: [.b3],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -215,7 +226,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.b3multi]
+            headerTypes: [.b3multi],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -242,7 +254,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         let (request, traceContext) = handler.modify(
             request: .mockWith(url: "https://www.example.com"),
-            headerTypes: [.tracecontext]
+            headerTypes: [.tracecontext],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.originField))
@@ -276,6 +289,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         orgRequest.setValue("custom", forHTTPHeaderField: B3HTTPHeaders.Single.b3Field)
         orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.traceparent)
         orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.tracestate)
+        orgRequest.setValue("custom", forHTTPHeaderField: W3CHTTPHeaders.baggage)
 
         let (request, traceContext) = handler.modify(
             request: orgRequest,
@@ -284,7 +298,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
                 .b3,
                 .b3multi,
                 .tracecontext
-            ]
+            ],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "custom")
@@ -298,6 +313,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: B3HTTPHeaders.Single.b3Field), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.traceparent), "custom")
         XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.tracestate), "custom")
+        XCTAssertEqual(request.value(forHTTPHeaderField: W3CHTTPHeaders.baggage), "custom")
 
         XCTAssertNil(traceContext, "It must return no trace context")
     }
@@ -352,7 +368,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             spanID: 200,
             parentSpanID: nil,
             sampleRate: .mockAny(),
-            isKept: .mockAny()
+            isKept: .mockAny(),
+            rumSessionId: .mockAny()
         ))
         XCTAssertNotNil(taskInterception.trace)
 
@@ -530,7 +547,11 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             )
         )
         let request: URLRequest = .mockWith(httpMethod: "GET")
-        let (modifiedRequest, _) = handler.modify(request: request, headerTypes: [.datadog, .tracecontext, .b3, .b3multi])
+        let (modifiedRequest, _) = handler.modify(
+            request: request,
+            headerTypes: [.datadog, .tracecontext, .b3, .b3multi],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
+        )
 
         XCTAssertEqual(
             modifiedRequest.allHTTPHeaderFields,
@@ -545,7 +566,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
                 "x-datadog-parent-id": "100",
                 "x-datadog-sampling-priority": "1",
                 "x-datadog-origin": "rum",
-                "x-datadog-tags": "_dd.p.tid=a"
+                "x-datadog-tags": "_dd.p.tid=a",
+                "baggage": "session.id=abcdef01-2345-6789-abcd-ef0123456789",
             ]
         )
     }

--- a/DatadogTrace/Sources/DDFormat.swift
+++ b/DatadogTrace/Sources/DDFormat.swift
@@ -26,7 +26,8 @@ extension TracePropagationHeadersWriter where Self: OTFormatWriter {
                 spanID: spanContext.spanID,
                 parentSpanID: spanContext.parentSpanID,
                 sampleRate: spanContext.sampleRate,
-                isKept: spanContext.isKept
+                isKept: spanContext.isKept,
+                rumSessionId: nil
             )
         )
     }

--- a/DatadogTrace/Sources/Feature/MessageReceivers.swift
+++ b/DatadogTrace/Sources/Feature/MessageReceivers.swift
@@ -8,8 +8,18 @@ import Foundation
 import DatadogInternal
 
 internal struct CoreContext {
+    struct RUMContext: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "session.id"
+        }
+        let sessionID: String
+    }
+
     /// Provides the history of app foreground / background states.
     var applicationStateHistory: AppStateHistory?
+
+    /// Provides the current active RUM context, if any
+    var rumContext: RUMContext?
 }
 
 internal final class ContextMessageReceiver: FeatureMessageReceiver {
@@ -39,6 +49,12 @@ internal final class ContextMessageReceiver: FeatureMessageReceiver {
     private func update(context: DatadogContext, from core: DatadogCoreProtocol) -> Bool {
         _context.mutate {
             $0.applicationStateHistory = context.applicationStateHistory
+            do {
+                $0.rumContext = try context.baggages["rum"]?.decode()
+            } catch {
+                core.telemetry
+                    .error("Fails to decode RUM Context from Trace", error: error)
+            }
         }
 
         return true

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -33,7 +33,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         self.traceContextInjection = traceContextInjection
     }
 
-    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>) -> (URLRequest, TraceContext?) {
+    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?) {
         guard let tracer = tracer else {
             return (request, nil)
         }
@@ -50,7 +50,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             spanID: spanContext.spanID,
             parentSpanID: spanContext.parentSpanID,
             sampleRate: spanContext.sampleRate,
-            isKept: spanContext.isKept
+            isKept: spanContext.isKept,
+            rumSessionId: contextReceiver.context.rumContext?.sessionID
         )
 
         var request = request

--- a/DatadogTrace/Tests/DatadogTracer+InjectAndExtract.swift
+++ b/DatadogTrace/Tests/DatadogTracer+InjectAndExtract.swift
@@ -61,7 +61,8 @@ class DatadogTracer_InjectAndExtract: XCTestCase {
             spanID: spanContext.spanID,
             parentSpanID: spanContext.parentSpanID,
             sampleRate: spanContext.sampleRate,
-            isKept: spanContext.isKept
+            isKept: spanContext.isKept,
+            rumSessionId: nil
         )
         XCTAssertEqual(writer.injectedTraceContext, expectedTraceContext)
     }

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -62,7 +62,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 .b3,
                 .b3multi,
                 .tracecontext
-            ]
+            ],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "100")
@@ -116,7 +117,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 .b3,
                 .b3multi,
                 .tracecontext
-            ]
+            ],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField), "custom")
@@ -152,7 +154,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 .b3,
                 .b3multi,
                 .tracecontext
-            ]
+            ],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         XCTAssertNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.traceIDField))
@@ -189,7 +192,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 .b3,
                 .b3multi,
                 .tracecontext
-            ]
+            ],
+            networkContext: NetworkContext(rumContext: .init(sessionID: "abcdef01-2345-6789-abcd-ef0123456789"))
         )
 
         span.finish()
@@ -237,7 +241,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             spanID: 200,
             parentSpanID: nil,
             sampleRate: sampleRate,
-            isKept: isKept
+            isKept: isKept,
+            rumSessionId: nil
         ))
 
         // When

--- a/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Mocks/NetworkInstrumentationMocks.swift
@@ -63,14 +63,16 @@ extension TraceContext: AnyMockable, RandomMockable {
         spanID: SpanID = .mockAny(),
         parentSpanID: SpanID? = nil,
         sampleRate: Float = .mockAny(),
-        isKept: Bool = .mockAny()
+        isKept: Bool = .mockAny(),
+        rumSessionId: String? = .mockAny()
     ) -> TraceContext {
         return TraceContext(
             traceID: traceID,
             spanID: spanID,
             parentSpanID: parentSpanID,
             sampleRate: sampleRate,
-            isKept: isKept
+            isKept: isKept,
+            rumSessionId: rumSessionId
         )
     }
 }
@@ -130,7 +132,7 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     public var injectedTraceContext: TraceContext?
     public var shouldInterceptRequest: ((URLRequest) -> Bool)?
 
-    public var onRequestMutation: ((URLRequest, Set<TracingHeaderType>) -> Void)?
+    public var onRequestMutation: ((URLRequest, Set<TracingHeaderType>, NetworkContext?) -> Void)?
     public var onRequestInterception: ((URLRequest) -> Void)?
     public var onInterceptionDidStart: ((URLSessionTaskInterception) -> Void)?
     public var onInterceptionDidComplete: ((URLSessionTaskInterception) -> Void)?
@@ -150,8 +152,8 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
         interceptions.values.first { $0.request.url == url }
     }
 
-    public func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> (URLRequest, TraceContext?) {
-        onRequestMutation?(request, headerTypes)
+    public func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?) {
+        onRequestMutation?(request, headerTypes, networkContext)
         return (modifiedRequest ?? request, injectedTraceContext)
     }
 


### PR DESCRIPTION
### What and why?

Propagate the RUM Session ID in traced requests headeres (DD & W3C)

### How?

We use the `FeatureMessage` to track the current RUM Session ID and use it in the tags in DD and W3C headers.  