### PR TITLE
RUM-1871 Reduced view update may miss `hasReplay` flag set before

### DIFF
--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2833,7 +2833,7 @@ class RUMViewScopeTests: XCTestCase {
 
     // MARK: - Has replay
 
-    func testViewUpdate_changesHasReplayFlag_onlyWhenReplayIsPresent() throws {
+    func testViewUpdate_onceHasReplayIsTrueItRemainsTrue() throws {
         // Given
         context.baggages = try .mockSessionReplayAttributes(hasReplay: false)
 


### PR DESCRIPTION
### What and why?

RUM backend has a special handling for `hasReplay` flag - once it is sent to true in any view update it cannot go back to false.

On the client side, however, we reduce the views, keeping only the last view update for a given `viewId` in the batch. If this view had originally `hasReplay: true` and then last view update has `hasReplay:false` (because by the time view update is sent session replay is disabled) we will miss session replay info for this view.

### How?

Introduction of a new private attribute `hasReplay` in the `RUMViewScope` class that is set each time a new View event is built. In the case that it has once been set to true, each following `RUMViewEvent` that is created will keep `hasReplay` set to true.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
