### PR TITLE
RUM-7419: Make crash report size configurable

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "microsoft/plcrashreporter" ~> 1.11.2
+github "microsoft/plcrashreporter" ~> 1.12.0
 binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.6.0"
-github "microsoft/plcrashreporter" "1.11.2"
+github "microsoft/plcrashreporter" "1.12.0"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'PLCrashReporter', '~> 1.11.2'
+  s.dependency 'PLCrashReporter', '~> 1.12.0'
 
   s.resource_bundle = {
     "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"

--- a/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -491,4 +491,26 @@ class DDCrashReportExporterTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Validate size of the Crash report
+
+    func testPLCrashReporterWithSmallSizeForTheReport() throws {
+        // Given
+        let maxReportBytes: UInt = 1_024
+
+        // When
+        let crashReporter = try PLCrashReporter(configuration: .ddConfiguration(maxReportBytes: maxReportBytes))
+
+        // Then
+        var plCrashReport: PLCrashReport?
+        do {
+            // The generated report is bigger than the defined maxReportBytes
+            let data = try crashReporter?.generateLiveReportAndReturnError()
+            plCrashReport = try PLCrashReport(data: data)
+        } catch {
+            XCTAssertTrue(error.localizedDescription.matches(regex: "Could not decode crash report with size of (\\d+) bytes."))
+        }
+
+        XCTAssertNil(plCrashReport)
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2"),
+        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.12.0"),
         .package(url: opentelemetry.url, exact: "1.6.0"),
     ],
     targets: [


### PR DESCRIPTION
### What and why?

It updates the version of PLCR to [1.12.0](https://github.com/microsoft/plcrashreporter/releases/tag/1.12.0).
Now it is possible to define dynamically the size of the crash report. It's 2MB as a default.

### How?

All package manager specifications (SPM, CocoaPods, Carthage) were updated to take this new version into consideration.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
