### PR TITLE
RUM-8371 chore: Synchronize app state observers across the SDK

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -512,6 +512,8 @@
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
 		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
+		618031F82D6DC430007027E3 /* Threading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618031F72D6DC430007027E3 /* Threading.swift */; };
+		618031F92D6DC430007027E3 /* Threading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618031F72D6DC430007027E3 /* Threading.swift */; };
 		618032042D6F1214007027E3 /* Assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618032032D6F1214007027E3 /* Assert.swift */; };
 		618032052D6F1214007027E3 /* Assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618032032D6F1214007027E3 /* Assert.swift */; };
 		618236892710560900125326 /* DebugWebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618236882710560900125326 /* DebugWebviewViewController.swift */; };
@@ -2532,6 +2534,7 @@
 		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
 		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
+		618031F72D6DC430007027E3 /* Threading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Threading.swift; sourceTree = "<group>"; };
 		618032032D6F1214007027E3 /* Assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assert.swift; sourceTree = "<group>"; };
 		618236882710560900125326 /* DebugWebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugWebviewViewController.swift; sourceTree = "<group>"; };
 		618353BB2A69470A0085F84A /* CoreMetricsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMetricsIntegrationTests.swift; sourceTree = "<group>"; };
@@ -5927,6 +5930,7 @@
 			isa = PBXGroup;
 			children = (
 				D23039DB298D5235001A1FA3 /* ReadWriteLock.swift */,
+				618031F72D6DC430007027E3 /* Threading.swift */,
 				D2432CF829EDB22C00D93657 /* Flushable.swift */,
 			);
 			path = Concurrency;
@@ -8587,6 +8591,7 @@
 				D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */,
 				D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */,
 				6167E6F92B81E95900C3CA2D /* BinaryImage.swift in Sources */,
+				618031F82D6DC430007027E3 /* Threading.swift in Sources */,
 				6174D60C2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
 				D23039F0298D5236001A1FA3 /* AnyEncoder.swift in Sources */,
 				D2A783D429A5309F003B03BB /* SwiftExtensions.swift in Sources */,
@@ -9601,6 +9606,7 @@
 				D2DA237D298D57AA00C6C7E6 /* DataCompression.swift in Sources */,
 				D2C9A26A2C0F3F5A007526F5 /* SessionReplayConfiguration.swift in Sources */,
 				6167E6FA2B81E95900C3CA2D /* BinaryImage.swift in Sources */,
+				618031F92D6DC430007027E3 /* Threading.swift in Sources */,
 				6174D60D2BFDDEDF00EC7469 /* SDKMetricFields.swift in Sources */,
 				D2DA237E298D57AA00C6C7E6 /* AnyEncoder.swift in Sources */,
 				D2A783D529A530A0003B03BB /* SwiftExtensions.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -512,6 +512,8 @@
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
 		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
+		618032042D6F1214007027E3 /* Assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618032032D6F1214007027E3 /* Assert.swift */; };
+		618032052D6F1214007027E3 /* Assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618032032D6F1214007027E3 /* Assert.swift */; };
 		618236892710560900125326 /* DebugWebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618236882710560900125326 /* DebugWebviewViewController.swift */; };
 		618353BC2A69470A0085F84A /* CoreMetricsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618353BB2A69470A0085F84A /* CoreMetricsIntegrationTests.swift */; };
 		618353BD2A69470A0085F84A /* CoreMetricsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618353BB2A69470A0085F84A /* CoreMetricsIntegrationTests.swift */; };
@@ -2530,6 +2532,7 @@
 		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
 		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
+		618032032D6F1214007027E3 /* Assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assert.swift; sourceTree = "<group>"; };
 		618236882710560900125326 /* DebugWebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugWebviewViewController.swift; sourceTree = "<group>"; };
 		618353BB2A69470A0085F84A /* CoreMetricsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMetricsIntegrationTests.swift; sourceTree = "<group>"; };
 		6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTestsObserver.swift; sourceTree = "<group>"; };
@@ -6279,6 +6282,7 @@
 				E2AA55E92C32C76A002FEF28 /* WatchKitExtensions.swift */,
 				61133BBA2423979B00786299 /* SwiftExtensions.swift */,
 				D29A9F9429DDB1DB005C54A4 /* UIKitExtensions.swift */,
+				618032032D6F1214007027E3 /* Assert.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -8554,6 +8558,7 @@
 				D2160C9A29C0DE5700FAA9A5 /* FirstPartyHosts.swift in Sources */,
 				D2EBEE2229BA160F00B15732 /* TracePropagationHeadersReader.swift in Sources */,
 				D2303A02298D5236001A1FA3 /* ReadWriteLock.swift in Sources */,
+				618032042D6F1214007027E3 /* Assert.swift in Sources */,
 				D2EBEE2429BA160F00B15732 /* W3CHTTPHeadersReader.swift in Sources */,
 				A7FA98CE2BA1A6930018D6B5 /* MethodCalledMetric.swift in Sources */,
 				D23039E8298D5236001A1FA3 /* DatadogContext.swift in Sources */,
@@ -9567,6 +9572,7 @@
 				D2160C9B29C0DE5700FAA9A5 /* FirstPartyHosts.swift in Sources */,
 				D2EBEE3029BA161100B15732 /* TracePropagationHeadersReader.swift in Sources */,
 				D2DA2373298D57AA00C6C7E6 /* ReadWriteLock.swift in Sources */,
+				618032052D6F1214007027E3 /* Assert.swift in Sources */,
 				D2EBEE3229BA161100B15732 /* W3CHTTPHeadersReader.swift in Sources */,
 				A7FA98CF2BA1A6930018D6B5 /* MethodCalledMetric.swift in Sources */,
 				D2DA2374298D57AA00C6C7E6 /* DatadogContext.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
@@ -18,7 +18,7 @@ class WebLogIntegrationTests: XCTestCase {
     private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
     private var controller: WKUserContentControllerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
-    override func setUp() {
+    override func setUpWithError() throws {
         core = DatadogCoreProxy(
             context: .mockWith(
                 env: "test",
@@ -29,7 +29,7 @@ class WebLogIntegrationTests: XCTestCase {
 
         controller = WKUserContentControllerMock()
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: [],
             hostsSanitizer: HostsSanitizer(),

--- a/Datadog/IntegrationUnitTests/RUM/StartingRUMSessionTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/StartingRUMSessionTests.swift
@@ -214,12 +214,10 @@ class StartingRUMSessionTests: XCTestCase {
                 launchDate: processStartTime,
                 isActivePrewarm: true
             ),
-            applicationStateHistory: AppStateHistory(
-                initialSnapshot: .init(state: .background, date: processStartTime), // active prewarm implies background
-                recentDate: firstRUMTime,
-                snapshots: [
-                    .init(state: .active, date: firstRUMTime.addingTimeInterval(-0.5)) // become active shortly before view is started
-                ]
+            applicationStateHistory: .mockWith(
+                initialState: .background, // active prewarm implies background
+                date: processStartTime,
+                transitions: [(state: .active, date: firstRUMTime.addingTimeInterval(-0.5))] // become active shortly before view is started
             )
         )
         let rumTime = DateProviderMock()

--- a/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
@@ -17,7 +17,7 @@ class WebEventIntegrationTests: XCTestCase {
     private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
     private var controller: WKUserContentControllerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
-    override func setUp() {
+    override func setUpWithError() throws {
         core = DatadogCoreProxy(
             context: .mockWith(
                 env: "test",
@@ -28,7 +28,7 @@ class WebEventIntegrationTests: XCTestCase {
 
         controller = WKUserContentControllerMock()
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: [],
             hostsSanitizer: HostsSanitizer(),

--- a/DatadogCore/Sources/Core/Context/ApplicationStatePublisher.swift
+++ b/DatadogCore/Sources/Core/Context/ApplicationStatePublisher.swift
@@ -12,12 +12,6 @@ import WatchKit
 #endif
 
 internal final class ApplicationStatePublisher: ContextValuePublisher {
-    /// The default publisher queue.
-    private static let defaultQueue = DispatchQueue(
-        label: "com.datadoghq.app-state-publisher",
-        target: .global(qos: .utility)
-    )
-
     /// The initial history value.
     let initialValue: AppStateHistory
 
@@ -31,18 +25,13 @@ internal final class ApplicationStatePublisher: ContextValuePublisher {
     /// The date provider for the Application state snapshot timestamp.
     private let dateProvider: DateProvider
 
-    /// The queue used to serialise access to the `history` and
-    /// to publish the new history.
-    private let queue: DispatchQueue
-
     /// The current application state history.
     ///
-    /// To mutate in the `queue` only.
+    /// **Note**: It must be accessed from the main thread.
     private var history: AppStateHistory
 
     /// The receiver for publishing the state history.
-    ///
-    /// To mutate in the `queue` only.
+    @ReadWriteLock
     private var receiver: ContextValueReceiver<AppStateHistory>?
 
     /// Creates a Application state publisher for publishing application state
@@ -51,30 +40,28 @@ internal final class ApplicationStatePublisher: ContextValuePublisher {
     /// **Note**: It must be called on the main thread.
     ///
     /// - Parameters:
-    ///   - appStateProvider: The provider to access the current application state.
+    ///   - appStateHistory: The history of app state and their transitions over time.
     ///   - notificationCenter: The notification center where this publisher observes `UIApplication` notifications.
     ///   - dateProvider: The date provider for the Application state snapshot timestamp.
     ///   - queue: The queue for publishing the history.
     init(
-        appStateProvider: AppStateProvider,
+        appStateHistory: AppStateHistory,
         notificationCenter: NotificationCenter,
-        dateProvider: DateProvider,
-        queue: DispatchQueue = ApplicationStatePublisher.defaultQueue
+        dateProvider: DateProvider
     ) {
-        let initialValue = AppStateHistory(
-            initialState: appStateProvider.current,
-            date: dateProvider.now
-        )
-
-        self.initialValue = initialValue
+        self.initialValue = appStateHistory
         self.history = initialValue
-        self.queue = queue
         self.dateProvider = dateProvider
         self.notificationCenter = notificationCenter
     }
 
     func publish(to receiver: @escaping ContextValueReceiver<AppStateHistory>) {
-        queue.async { self.receiver = receiver }
+        // The `notificationCenter` must be subscribed to on the main thread to ensure a deterministic subscription order.
+        // By synchronizing on the main thread, Core will always receive app state change notifications before Features,
+        // even if Features implement their own subscriptions (Core is always enabled before Features).
+        dd_assert(Thread.isMainThread, "Must be called on the main thread")
+
+        self.receiver = receiver
         notificationCenter.addObserver(self, selector: #selector(applicationDidBecomeActive), name: ApplicationNotifications.didBecomeActive, object: nil)
         notificationCenter.addObserver(self, selector: #selector(applicationWillResignActive), name: ApplicationNotifications.willResignActive, object: nil)
         notificationCenter.addObserver(self, selector: #selector(applicationDidEnterBackground), name: ApplicationNotifications.didEnterBackground, object: nil)
@@ -102,11 +89,13 @@ internal final class ApplicationStatePublisher: ContextValuePublisher {
     }
 
     private func append(state: AppState) {
-        let now = dateProvider.now
-        queue.async {
-            self.history.append(state: state, at: now)
-            self.receiver?(self.history)
-        }
+        // This must run on the main thread for two reasons:
+        // - For maximum performance, `history` is lock-free and relies on synchronization through a single thread.
+        // - `receiver` must be updated from the main thread to ensure the new app state is always available
+        //   for the next `eventWriteContext {}` and `context {}` request on this thread.
+        dd_assert(Thread.isMainThread, "Must be called on main thread")
+        history.append(state: state, at: dateProvider.now)
+        receiver?(history)
     }
 
     func cancel() {
@@ -114,7 +103,7 @@ internal final class ApplicationStatePublisher: ContextValuePublisher {
         notificationCenter.removeObserver(self, name: ApplicationNotifications.willResignActive, object: nil)
         notificationCenter.removeObserver(self, name: ApplicationNotifications.didEnterBackground, object: nil)
         notificationCenter.removeObserver(self, name: ApplicationNotifications.willEnterForeground, object: nil)
-        queue.async { self.receiver = nil }
+        receiver = nil
     }
 }
 

--- a/DatadogCore/Sources/Core/Context/ApplicationStatePublisher.swift
+++ b/DatadogCore/Sources/Core/Context/ApplicationStatePublisher.swift
@@ -12,8 +12,6 @@ import WatchKit
 #endif
 
 internal final class ApplicationStatePublisher: ContextValuePublisher {
-    typealias Snapshot = AppStateHistory.Snapshot
-
     /// The default publisher queue.
     private static let defaultQueue = DispatchQueue(
         label: "com.datadoghq.app-state-publisher",
@@ -104,9 +102,9 @@ internal final class ApplicationStatePublisher: ContextValuePublisher {
     }
 
     private func append(state: AppState) {
-        let snapshot = Snapshot(state: state, date: dateProvider.now)
+        let now = dateProvider.now
         queue.async {
-            self.history.append(snapshot)
+            self.history.append(state: state, at: now)
             self.receiver?(self.history)
         }
     }

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -420,6 +420,15 @@ extension DatadogContextProvider {
         appLaunchHandler: AppLaunchHandling,
         appStateProvider: AppStateProvider
     ) {
+        // `ContextProvider` must be initialized on the main thread for two key reasons:
+        // - It interacts with UIKit APIs to read the initial app state, which is only safe on the main thread.
+        // - It subscribes to app state change notifications, and we need this subscription to occur
+        //   before any Feature subscriptions. This ensures that Core always processes state changes first.
+        dd_assert(Thread.isMainThread, "Must be called on main thread")
+
+        let initialAppState = appStateProvider.current
+        let appStateHistory = AppStateHistory(initialState: initialAppState, date: dateProvider.now)
+
         let context = DatadogContext(
             site: site,
             clientToken: clientToken,
@@ -439,10 +448,7 @@ extension DatadogContextProvider {
             device: device,
             nativeSourceOverride: nativeSourceOverride,
             launchTime: appLaunchHandler.currentValue,
-            // this is a placeholder waiting for the `ApplicationStatePublisher`
-            // to be initialized on the main thread, this value will be overrided
-            // as soon as the subscription is made.
-            applicationStateHistory: .active(since: dateProvider.now)
+            applicationStateHistory: appStateHistory
         )
 
         self.init(context: context)
@@ -465,15 +471,12 @@ extension DatadogContextProvider {
         #endif
 
         #if os(iOS) || os(tvOS)
-        DispatchQueue.main.async {
-            // must be call on the main thread to read `UIApplication.State`
-            let applicationStatePublisher = ApplicationStatePublisher(
-                appStateProvider: appStateProvider,
-                notificationCenter: notificationCenter,
-                dateProvider: dateProvider
-            )
-            self.subscribe(\.applicationStateHistory, to: applicationStatePublisher)
-        }
+        let applicationStatePublisher = ApplicationStatePublisher(
+            appStateHistory: appStateHistory,
+            notificationCenter: notificationCenter,
+            dateProvider: dateProvider
+        )
+        self.subscribe(\.applicationStateHistory, to: applicationStatePublisher)
         #endif
     }
 }

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -390,11 +390,16 @@ public enum Datadog {
         #endif
 
         do {
-            return try initializeOrThrow(
-                with: configuration,
-                trackingConsent: trackingConsent,
-                instanceName: instanceName
-            )
+            // To safely instrument the application lifecycle observer and other providers,
+            // SDK initialization must occur on the main thread. This enforcement is also present
+            // in all Features, ensuring a proper registration order.
+            return try runOnMainThreadSync {
+                return try initializeOrThrow(
+                    with: configuration,
+                    trackingConsent: trackingConsent,
+                    instanceName: instanceName
+                )
+            }
         } catch {
             consolePrint("\(error)", .error)
             return NOPDatadogCore()

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -315,6 +315,6 @@ class CrashContextProviderTests: XCTestCase {
         DDAssertReflectionEqual(crashContext.userInfo, sdkContext.userInfo, file: file, line: line)
         XCTAssertEqual(crashContext.networkConnectionInfo, sdkContext.networkConnectionInfo, file: file, line: line)
         XCTAssertEqual(crashContext.carrierInfo, sdkContext.carrierInfo, file: file, line: line)
-        XCTAssertEqual(crashContext.lastIsAppInForeground, sdkContext.applicationStateHistory.currentSnapshot.state.isRunningInForeground, file: file, line: line)
+        XCTAssertEqual(crashContext.lastIsAppInForeground, sdkContext.applicationStateHistory.currentState.isRunningInForeground, file: file, line: line)
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/ApplicationStatePublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/ApplicationStatePublisherTests.swift
@@ -37,7 +37,7 @@ class ApplicationStatePublisherTests: XCTestCase {
         publisher.publish { state in
             // Then
             XCTAssertEqual(
-                state.currentSnapshot.state,
+                state.currentState,
                 notification.expectedState,
                 "It must record \(notification.expectedState) after receiving '\(notification.name)'"
             )
@@ -69,7 +69,7 @@ class ApplicationStatePublisherTests: XCTestCase {
 
         // When
         publisher.publish { state in
-            receivedHistoryStates.append(state.currentSnapshot.state)
+            receivedHistoryStates.append(state.currentState)
             expectation.fulfill()
         }
 

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/ApplicationStatePublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/ApplicationStatePublisherTests.swift
@@ -10,78 +10,47 @@ import TestUtilities
 @testable import DatadogCore
 
 class ApplicationStatePublisherTests: XCTestCase {
-    private let notificationCenter = NotificationCenter()
-
-    private let supportedNotifications = [
-        (name: UIApplication.didBecomeActiveNotification, expectedState: AppState.active),
-        (name: UIApplication.willResignActiveNotification, expectedState: AppState.inactive),
-        (name: UIApplication.didEnterBackgroundNotification, expectedState: AppState.background),
-        (name: UIApplication.willEnterForegroundNotification, expectedState: AppState.inactive),
-    ]
-
-    // MARK: - Handling UIApplication Notifications
-
-    func testWhenReceivingAppLifecycleNotification_itRecordsItsState() {
-        let expectation = expectation(description: "app state publisher publishes value")
+    func testWhenReceivingAppLifecycleNotification_itUpdatesStatesHistory() throws {
+        let date = Date()
+        let dateProvider = DateProviderMock(now: date)
+        let notificationCenter = NotificationCenter()
 
         // Given
         let publisher = ApplicationStatePublisher(
-            appStateProvider: AppStateProviderMock(state: .mockRandom()),
+            appStateHistory: .mockWith(initialState: .inactive, date: dateProvider.now),
             notificationCenter: notificationCenter,
-            dateProvider: SystemDateProvider()
+            dateProvider: dateProvider
         )
 
-        // When
-        let notification = supportedNotifications.randomElement()!
+        var lastPublishedValue: AppStateHistory?
+        publisher.publish { lastPublishedValue = $0 }
 
-        publisher.publish { state in
-            // Then
-            XCTAssertEqual(
-                state.currentState,
-                notification.expectedState,
-                "It must record \(notification.expectedState) after receiving '\(notification.name)'"
-            )
-            expectation.fulfill()
-        }
+        // When / Then
+        dateProvider.now += 1
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+        XCTAssertEqual(lastPublishedValue?.currentState, .inactive)
 
-        notificationCenter.post(name: notification.name, object: nil)
+        dateProvider.now += 1
+        notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+        XCTAssertEqual(lastPublishedValue?.currentState, .active)
 
-        waitForExpectations(timeout: 1)
-    }
+        dateProvider.now += 1
+        notificationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
+        XCTAssertEqual(lastPublishedValue?.currentState, .inactive)
 
-    // MARK: - Recording History
+        dateProvider.now += 1
+        notificationCenter.post(name: ApplicationNotifications.didEnterBackground, object: nil)
+        XCTAssertEqual(lastPublishedValue?.currentState, .background)
 
-    func testWhenReceivingStateChangeNotifications_itRecordsHistoryOfAppStates() {
-        let expectation = expectation(description: "app state publisher publishes values")
-        expectation.expectedFulfillmentCount = 100
+        let history = try XCTUnwrap(lastPublishedValue)
+        XCTAssertEqual(history.state(at: date), .inactive)
+        XCTAssertEqual(history.state(at: date + 1), .inactive)
+        XCTAssertEqual(history.state(at: date + 2), .active)
+        XCTAssertEqual(history.state(at: date + 3), .inactive)
+        XCTAssertEqual(history.state(at: date + 4), .background)
 
-        // Given
-        let publisher = ApplicationStatePublisher(
-            appStateProvider: AppStateProviderMock(state: .mockRandom()),
-            notificationCenter: notificationCenter,
-            dateProvider: RelativeDateProvider(startingFrom: .mockRandomInThePast(), advancingBySeconds: 1.0)
-        )
-
-        var receivedHistoryStates: [AppState?] = []
-        let expectedNotifications = (0..<expectation.expectedFulfillmentCount).map { _ in
-            supportedNotifications.randomElement()!
-        }
-
-        // When
-        publisher.publish { state in
-            receivedHistoryStates.append(state.currentState)
-            expectation.fulfill()
-        }
-
-        DispatchQueue.concurrentPerform(iterations: expectation.expectedFulfillmentCount) { iteration in
-            notificationCenter.post(name: expectedNotifications[iteration].name, object: nil)
-        }
-
-        waitForExpectations(timeout: 5)
-
-        // Then
-        let expectedHistoryStates = expectedNotifications.map { $0.expectedState }
-        XCTAssertEqual(receivedHistoryStates.count, expectedHistoryStates.count)
-        XCTAssertEqual(Set(receivedHistoryStates), Set(expectedHistoryStates), "It must record all app state changes")
+        XCTAssertNil(history.state(at: date - 1))
+        XCTAssertEqual(history.initialState, .inactive)
+        XCTAssertEqual(history.state(at: .distantFuture), .background)
     }
 }

--- a/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
+++ b/DatadogCrashReporting/Sources/CrashContext/CrashContext.swift
@@ -139,7 +139,7 @@ internal struct CrashContext: Codable, Equatable {
         self.userInfo = context.userInfo
         self.networkConnectionInfo = context.networkConnectionInfo
         self.carrierInfo = context.carrierInfo
-        self.lastIsAppInForeground = context.applicationStateHistory.currentSnapshot.state.isRunningInForeground
+        self.lastIsAppInForeground = context.applicationStateHistory.currentState.isRunningInForeground
 
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState

--- a/DatadogInternal/Sources/Concurrency/Threading.swift
+++ b/DatadogInternal/Sources/Concurrency/Threading.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Ensures the provided block is executed on the main thread, synchronously, rethrowing any error.
+/// - Parameter block: A closure that may throw an error.
+/// - Returns: The value produced by the closure.
+/// - Throws: Whatever the closure itself might throw.
+public func runOnMainThreadSync<T>(_ block: () throws -> T) rethrows -> T {
+    if Thread.isMainThread {
+        return try block()
+    } else {
+        return try DispatchQueue.main.sync(execute: block)
+    }
+}

--- a/DatadogInternal/Sources/Context/AppState.swift
+++ b/DatadogInternal/Sources/Context/AppState.swift
@@ -38,107 +38,112 @@ public enum AppState: Codable, PassthroughAnyCodable {
     }
 }
 
-/// A data structure to represent recorded app states in a given period of time
+/// Records app state transitions over time.
 public struct AppStateHistory: Codable, Equatable, PassthroughAnyCodable {
-    /// Snapshot of the app state at `date`
-    public struct Snapshot: Codable, Equatable {
-        /// The app state at this `date`.
-        public let state: AppState
-        /// Date of recording this snapshot.
-        public let date: Date
+    /// A snapshot representing the app state at a specific point in time.
+    private struct Snapshot: Codable, Equatable {
+        let state: AppState
+        let date: Date
+    }
 
-        public init(state: AppState, date: Date) {
-            self.state = state
-            self.date = date
+    /// The initial state of the app when this history instance was created.
+    public let initialState: AppState
+    /// A chronologically ordered list of app state snapshots. It includes the `initialState`.
+    private var snapshots: [Snapshot]
+    /// The most recent recorded app state.
+    public var currentState: AppState { snapshots.last?.state ?? initialState }
+
+    /// Creates a new `AppStateHistory` with an initial state.
+    ///
+    /// - Parameters:
+    ///   - initialState: The starting `AppState` of the app.
+    ///   - date: The timestamp when the initial state was recorded.
+    public init(initialState: AppState, date: Date) {
+        let initialSnapshot = Snapshot(state: initialState, date: date)
+        self.initialState = initialState
+        self.snapshots = [initialSnapshot]
+    }
+
+    /// Appends a new app state transition to the history.
+    ///
+    /// - Parameters:
+    ///   - state: The new `AppState` to be recorded.
+    ///   - date: The timestamp when the state transition occurred.
+    ///
+    /// It is optimised for monothonic dates. If the provided `date` is earlier than one for an existing state, then states are re-sorted to maintain chronological order.
+    public mutating func append(state: AppState, at date: Date) {
+        let lastSnapshotDate = snapshots.last?.date ?? .distantPast
+        let newSnapshot = Snapshot(state: state, date: date)
+        snapshots.append(newSnapshot)
+
+        if newSnapshot.date < lastSnapshotDate {
+            // Ensure snapshots remain chronologically ordered.
+            // Under normal conditions, this should never be needed, as app state
+            // transitions are tracked based on real-time system events.
+            snapshots.sort { $0.date < $1.date }
         }
     }
 
-    public private(set) var initialSnapshot: Snapshot
-    public private(set) var snapshots: [Snapshot]
-
-    /// Date of the last update to `AppStateHistory`.
-    public private(set) var recentDate: Date
-
-    /// The most recent app state `Snapshot`.
-    public var currentSnapshot: Snapshot {
-        return Snapshot(
-            state: (snapshots.last ?? initialSnapshot).state,
-            date: recentDate
-        )
+    /// Returns the app state at a specific point in time, if available.
+    ///
+    /// - Parameter date: The timestamp for which to retrieve the app state.
+    /// - Returns: The `AppState` that was active at the given time, or `nil` if `date`
+    ///   is earlier than the date of initial state.
+    public func state(at date: Date) -> AppState? {
+        // Iterate in reverse order, as recent states are more likely to match.
+        let snapshot = snapshots.reversed().first { $0.date <= date }
+        return snapshot?.state
     }
 
-    public init(
-        initialSnapshot: Snapshot,
-        recentDate: Date,
-        snapshots: [Snapshot] = []
-    ) {
-        self.initialSnapshot = initialSnapshot
-        self.snapshots = snapshots
-        self.recentDate = recentDate
+    /// Checks whether the app was in a specific state within the given time range.
+    ///
+    /// - Parameters:
+    ///   - range: The time period to check.
+    ///   - predicate: A closure that evaluates whether a given `AppState` matches the desired condition.
+    /// - Returns: `true` if any state within `range` satisfies the predicate, otherwise `false`.
+    public func containsState(during range: ClosedRange<Date>, where predicate: (AppState) -> Bool) -> Bool {
+        var contains = false
+        iterateStates(in: range) { state, _ in
+            contains = contains || predicate(state)
+        }
+        return contains
     }
 
-    public init(
-        initialState: AppState,
-        date: Date,
-        snapshots: [Snapshot] = []
-    ) {
-        self.init(
-            initialSnapshot: .init(state: initialState, date: date),
-            recentDate: date,
-            snapshots: snapshots
-        )
-    }
-
-    /// Limits or extrapolates app state history to the given range
-    /// This is useful when you record between 0...3t but you are concerned of t...2t only
-    /// - Parameter range: if outside of initial and final states, it extrapolates; otherwise it limits
-    /// - Returns: a history instance spanning the given range
-    public func take(between range: ClosedRange<Date>) -> AppStateHistory {
-        .init(
-            // move initial state to lowerBound
-            initialSnapshot: Snapshot(
-                state: state(at: range.lowerBound),
-                date: range.lowerBound
-            ),
-            // move final state to upperBound
-            recentDate: range.upperBound,
-            // filter changes outside of the range
-            snapshots: snapshots.filter { range.contains($0.date) }
-        )
-    }
-
-    public mutating func append(_ snapshot: Snapshot) {
-        snapshots.append(snapshot)
-    }
-
-    public var foregroundDuration: TimeInterval {
-        var duration: TimeInterval = 0.0
-        var lastActiveStartDate: Date?
-        let allEvents = [initialSnapshot] + snapshots + [currentSnapshot]
-        for event in allEvents {
-            if let startDate = lastActiveStartDate {
-                duration += event.date.timeIntervalSince(startDate)
-            }
-            if event.state.isRunningInForeground {
-                lastActiveStartDate = event.date
-            } else {
-                lastActiveStartDate = nil
+    /// Computes the total duration the app was running in the foreground within the given time range.
+    ///
+    /// - Parameter range: The time period to analyze.
+    /// - Returns: The total time (in seconds) spent in foreground states.
+    public func foregroundDuration(during range: ClosedRange<Date>) -> TimeInterval {
+        var total: TimeInterval = 0
+        iterateStates(in: range) { state, duration in
+            if state.isRunningInForeground {
+                total += duration
             }
         }
-        return duration
+        return total
     }
 
-    private func state(at date: Date) -> AppState {
-        for snapshot in snapshots.reversed() {
-            if snapshot.date > date {
-                continue
+    /// Iterates through states and their intervals within a specified time range.
+    ///   - If a snapshot **falls entirely outside** the range, it is ignored.
+    ///   - If a snapshot **extends beyond `range.upperBound`**, it is clamped to `range.upperBound`.
+    ///   - If a snapshot **starts before `range.lowerBound`**, it is not clamped.
+    ///
+    /// - Parameters:
+    ///   - range: The time range to analyze states in.
+    ///   - iterator: A closure that receives each `AppState` and its associated duration, clamped to the provided `range`.
+    private func iterateStates(in range: ClosedRange<Date>, perform iterator: (AppState, TimeInterval) -> Void) {
+        let finalState = snapshots.last?.state ?? initialState
+        let finalSnapshot = Snapshot(state: finalState, date: .distantFuture)
+        let allSnapshots = snapshots + [finalSnapshot]
+
+        for (current, next) in zip(allSnapshots, allSnapshots.dropFirst()) {
+            let start = max(current.date, range.lowerBound)
+            let end = min(next.date, range.upperBound)
+            if end > start {
+                let duration = end.timeIntervalSince(start)
+                iterator(current.state, duration)
             }
-
-            return snapshot.state
         }
-
-        // we assume there was no change before initial state
-        return initialSnapshot.state
     }
 }
 

--- a/DatadogInternal/Sources/Context/AppState.swift
+++ b/DatadogInternal/Sources/Context/AppState.swift
@@ -147,15 +147,6 @@ public struct AppStateHistory: Codable, Equatable, PassthroughAnyCodable {
     }
 }
 
-extension AppStateHistory {
-    /// Return a history with an active initial state.
-    ///
-    /// - Parameter date: The date since the application is considred active.
-    public static func active(since date: Date) -> AppStateHistory {
-        .init(initialState: .active, date: date)
-    }
-}
-
 #if canImport(WatchKit)
 
 import WatchKit

--- a/DatadogInternal/Sources/Utils/Assert.swift
+++ b/DatadogInternal/Sources/Utils/Assert.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Datadog assertion helper.
+///
+/// - Ensures assumptions that should **never** be violated.
+/// - **Fails only in development** to catch mistakes early.
+/// - **Never** crashes customer apps in production, even if they enable assertions in Release builds.
+///
+/// ## Why it fails only in development?
+/// - This function uses `assert()`, which is **completely removed** in Release builds by default.
+/// - Some apps may opt into assertions in Release using `-Xfrontend -enable-assertions`, but this function explicitly restricts assertions to **Debug** builds only.
+/// - In production, the check is stripped out, ensuring zero impact on customer apps.
+@inline(__always)
+public func dd_assert(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    #if DEBUG
+    assert(condition(), message(), file: file, line: line)
+    #endif
+}

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -188,7 +188,7 @@ extension WatchdogTerminationMonitor: FeatureMessageReceiver {
         case .baggage, .webview, .telemetry:
             break
         case .context(let context):
-            let state = context.applicationStateHistory.currentSnapshot.state
+            let state = context.applicationStateHistory.currentState
             appStateManager.updateAppState(state: state)
         }
 

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -20,10 +20,14 @@ public enum RUM {
         with configuration: RUM.Configuration, in core: DatadogCoreProtocol = CoreRegistry.default
     ) {
         do {
-            try enableOrThrow(with: configuration, in: core)
+            // To ensure the correct registration order between Core and Features,
+            // the entire initialization flow is synchronized on the main thread.
+            try runOnMainThreadSync {
+                try enableOrThrow(with: configuration, in: core)
+            }
         } catch let error {
             consolePrint("\(error)", .error)
-       }
+        }
     }
 
     internal static func enableOrThrow(

--- a/DatadogRUM/Sources/RUMMetrics/TNSMetric.swift
+++ b/DatadogRUM/Sources/RUMMetrics/TNSMetric.swift
@@ -228,8 +228,7 @@ internal final class TNSMetric: TNSMetricTracking {
 
         // Check if the app stayed foregrounded through the resource load time.
         let loadingEndDate = viewStartDate.addingTimeInterval(tnsValue)
-        let loadingStates = appStateHistory.take(between: viewStartDate...loadingEndDate)
-        let wasAlwaysForeground = !loadingStates.snapshots.contains { $0.state != .active }
+        let wasAlwaysForeground = !appStateHistory.containsState(during: viewStartDate...loadingEndDate) { $0 != .active }
 
         guard wasAlwaysForeground else {
             return .failure(.appNotInForeground)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -60,7 +60,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             createInitialSession(with: context, on: command)
 
             // If the app was started by a user (foreground & not prewarmed):
-            if context.applicationStateHistory.currentSnapshot.state == .active && !context.launchTime.isActivePrewarm {
+            if context.applicationStateHistory.currentState == .active && !context.launchTime.isActivePrewarm {
                 // Start "ApplicationLaunch" view immediatelly:
                 startApplicationLaunchView(on: command, context: context, writer: writer)
             }
@@ -150,7 +150,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
         if context.launchTime.isActivePrewarm {
             startPrecondition = .prewarm
-        } else if context.applicationStateHistory.currentSnapshot.state == .background {
+        } else if context.applicationStateHistory.currentState == .background {
             startPrecondition = .backgroundLaunch
         } else {
             startPrecondition = .userAppLaunch
@@ -239,7 +239,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         applicationActive = true
 
-        guard context.applicationStateHistory.currentSnapshot.state != .background else {
+        guard context.applicationStateHistory.currentState != .background else {
             return
         }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -321,7 +321,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private func handleOffViewCommand(command: RUMCommand, context: DatadogContext) {
         let handlingRule = RUMOffViewEventsHandlingRule(
             sessionState: state,
-            isAppInForeground: context.applicationStateHistory.currentSnapshot.state.isRunningInForeground,
+            isAppInForeground: context.applicationStateHistory.currentState.isRunningInForeground,
             isBETEnabled: trackBackgroundEvents
         )
 

--- a/DatadogRUM/Tests/RUMMetrics/TNSMetricTests.swift
+++ b/DatadogRUM/Tests/RUMMetrics/TNSMetricTests.swift
@@ -300,11 +300,7 @@ class TNSMetricTests: XCTestCase {
         metric.trackResourceEnd(at: resourceEnd, resourceID: .resource1, resourceDuration: nil)
 
         // When
-        let appStateHistory = AppStateHistory(
-            initialSnapshot: .init(state: .active, date: .distantPast),
-            recentDate: .distantFuture,
-            snapshots: [.init(state: .active, date: .distantFuture)]
-        )
+        let appStateHistory = AppStateHistory(initialState: .active, date: .distantPast)
 
         // Then
         let ttns = try metric.value(with: appStateHistory).get()
@@ -321,14 +317,9 @@ class TNSMetricTests: XCTestCase {
         metric.trackResourceEnd(at: resourceEnd, resourceID: .resource1, resourceDuration: resourceDuration)
 
         // When
-        let appStateHistory = AppStateHistory(
-            initialSnapshot: .init(state: .active, date: .distantPast),
-            recentDate: .distantFuture,
-            snapshots: [
-                .init(state: [.inactive, .background].randomElement()!, date: resourceStart + resourceDuration * 0.25),
-                .init(state: .active, date: resourceStart + resourceDuration * 0.5),
-            ]
-        )
+        var appStateHistory = AppStateHistory(initialState: .active, date: .distantPast)
+        appStateHistory.append(state: [.inactive, .background].randomElement()!, at: resourceStart + resourceDuration * 0.25)
+        appStateHistory.append(state: .active, at: resourceStart + resourceDuration * 0.5)
 
         // Then
         XCTAssertEqual(metric.value(with: appStateHistory), .failure(.appNotInForeground))

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -24,10 +24,14 @@ public enum SessionReplay {
         in core: DatadogCoreProtocol = CoreRegistry.default
     ) {
         do {
-            try enableOrThrow(with: configuration, in: core)
+            // To ensure the correct registration order between Core and Features,
+            // the entire initialization flow is synchronized on the main thread.
+            try runOnMainThreadSync {
+                try enableOrThrow(with: configuration, in: core)
+            }
         } catch let error {
             consolePrint("\(error)", .error)
-       }
+        }
     }
 
     /// Starts the recording manually.

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -167,14 +167,12 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         }
 
         if let history = contextReceiver.context.applicationStateHistory {
-            let appStateHistory = history.take(
-                between: resourceMetrics.fetch.start...resourceMetrics.fetch.end
-            )
+            let fetchDuration = resourceMetrics.fetch.start...resourceMetrics.fetch.end
+            let foregroundDuration = history.foregroundDuration(during: fetchDuration)
+            span.setTag(key: SpanTags.foregroundDuration, value: foregroundDuration.toNanoseconds)
 
-            span.setTag(key: SpanTags.foregroundDuration, value: appStateHistory.foregroundDuration.toNanoseconds)
-
-            let didStartInBackground = appStateHistory.initialSnapshot.state == .background
-            let doesEndInBackground = appStateHistory.currentSnapshot.state == .background
+            let didStartInBackground = history.state(at: resourceMetrics.fetch.start) == .background
+            let doesEndInBackground = history.state(at: resourceMetrics.fetch.end) == .background
             span.setTag(key: SpanTags.isBackground, value: didStartInBackground || doesEndInBackground)
         }
 

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -20,10 +20,14 @@ public enum Trace {
         with configuration: Trace.Configuration = .init(), in core: DatadogCoreProtocol = CoreRegistry.default
     ) {
         do {
-            try enableOrThrow(with: configuration, in: core)
+            // To ensure the correct registration order between Core and Features,
+            // the entire initialization flow is synchronized on the main thread.
+            try runOnMainThreadSync {
+                try enableOrThrow(with: configuration, in: core)
+            }
         } catch let error {
             consolePrint("\(error)", .error)
-       }
+        }
     }
 
     internal static func enableOrThrow(

--- a/DatadogTrace/Tests/ContextMessageReceiverTests.swift
+++ b/DatadogTrace/Tests/ContextMessageReceiverTests.swift
@@ -19,12 +19,12 @@ class ContextMessageReceiverTests: XCTestCase {
             messageReceiver: receiver
         )
 
-        XCTAssertEqual(receiver.context.applicationStateHistory?.initialSnapshot.state, .background)
+        XCTAssertEqual(receiver.context.applicationStateHistory?.currentState, .background)
 
         // When
-        core.context.applicationStateHistory.append(.init(state: .active, date: Date()))
+        core.context.applicationStateHistory.append(state: .active, at: Date())
 
         // Then
-        XCTAssertEqual(receiver.context.applicationStateHistory?.currentSnapshot.state, .active)
+        XCTAssertEqual(receiver.context.applicationStateHistory?.currentState, .active)
     }
 }

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -19,7 +19,7 @@ class WebViewTrackingTests: XCTestCase {
 
         let host: String = .mockRandom()
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: [host],
             hostsSanitizer: mockSanitizer,
@@ -71,7 +71,7 @@ class WebViewTrackingTests: XCTestCase {
             touchPrivacy: sr.touchPrivacyLevel
         )
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: [host],
             hostsSanitizer: mockSanitizer,
@@ -105,7 +105,7 @@ class WebViewTrackingTests: XCTestCase {
 
         let initialUserScriptCount = controller.userScripts.count
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: ["datadoghq.com"],
             hostsSanitizer: mockSanitizer,
@@ -135,8 +135,8 @@ class WebViewTrackingTests: XCTestCase {
         let initialUserScriptCount = controller.userScripts.count
 
         let multipleTimes = 5
-        (0..<multipleTimes).forEach { _ in
-            WebViewTracking.enable(
+        try (0..<multipleTimes).forEach { _ in
+            try WebViewTracking.enableOrThrow(
                 tracking: controller,
                 hosts: ["datadoghq.com"],
                 hostsSanitizer: mockSanitizer,
@@ -214,7 +214,7 @@ class WebViewTrackingTests: XCTestCase {
         )
 
         let controller = DDUserContentController()
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),
@@ -266,7 +266,7 @@ class WebViewTrackingTests: XCTestCase {
         )
 
         let controller = DDUserContentController()
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),
@@ -358,7 +358,7 @@ class WebViewTrackingTests: XCTestCase {
             }
         )
 
-        WebViewTracking.enable(
+        try WebViewTracking.enableOrThrow(
             tracking: controller,
             hosts: ["datadoghq.com"],
             hostsSanitizer: HostsSanitizerMock(),

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -238,15 +238,21 @@ extension AppStateHistory: AnyMockable {
     }
 
     public static func mockAppInForeground(since date: Date = Date()) -> Self {
-        return .init(initialSnapshot: .init(state: .active, date: date), recentDate: date)
+        return .init(initialState: .active, date: date)
     }
 
     public static func mockAppInBackground(since date: Date = Date()) -> Self {
-        return .init(initialSnapshot: .init(state: .background, date: date), recentDate: date)
+        return .init(initialState: .background, date: date)
     }
 
     public static func mockRandom(since date: Date = Date()) -> Self {
         return Bool.random() ? mockAppInForeground(since: date) : mockAppInBackground(since: date)
+    }
+
+    public static func mockWith(initialState: AppState, date: Date, transitions: [(state: AppState, date: Date)] = []) -> Self {
+        var history = AppStateHistory(initialState: initialState, date: date)
+        transitions.forEach { history.append(state: $0.state, at: $0.date) }
+        return history
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR refines how the SDK observes application state changes across Core and all Features. It streamlines this logic to ensure consistent state change notifications across different products

### How?

#### 1️⃣ Synchronized App State Updates

The main improvement ensures that all subsystems receive app state updates in a controlled order — **first Core, then Features**, respecting their `enable()` order. This is achieved by synchronizing initialization across all subsystems on the main thread, using a new helper in `DatadogInternal`:
```swift
/// Ensures the provided block is executed on the main thread, synchronously, rethrowing any error.
/// ...
public func runOnMainThreadSync<T>(_ block: () throws -> T) rethrows -> T {
    if Thread.isMainThread {
        return try block()
    } else {
        return try DispatchQueue.main.sync(execute: block)
    }
}
```
⏱️  For clients who already initialize the SDK on the main thread, this introduces no performance impact.

#### 2️⃣ Refactored `ApplicationStatePublisher`

- Removed the `queue`, ensuring state changes are synchronized via the main thread.
- Guarantees that Core processes state changes before Features.

#### 3️⃣ Streamlined `AppStateHistory` Interface

The `AppStateHistory` type has been simplified to better align with the [Interface Segregation Principle (ISP)](https://en.wikipedia.org/wiki/Interface_segregation_principle).

- **Before**, the interface exposed numerous public methods, making it harder to use correctly:
```swift
public struct AppStateHistory {    
    public struct Snapshot {
	public let state: AppState
	public let date: Date
        public init(state:date:)
    }

    public var initialSnapshot: Snapshot { get }
    public var snapshots: [Snapshot] { get }
    public var recentDate: Date { get }
    public var currentSnapshot: Snapshot { get }

    public init(initialSnapshot:recentDate:snapshots:) {}
    public init(initialState:date:snapshots:) {}
    public static func active(since:) -> AppStateHistory {}

    public func take(between:) -> AppStateHistory {}
    public mutating func append(snapshot:) {}
    public var foregroundDuration: TimeInterval { get }
}
```
- **Now**, the API is more concise, with only necessary public methods:
```swift
public struct AppStateHistory {
    public let initialState: AppState
    public var currentState: AppState { get }

    public init(initialState:date:) {}

    public mutating func append(state:at:) {}

    public func state(at:) -> AppState? {}
    public func containsState(during:where:) -> Bool {}
    public func foregroundDuration(during:) -> TimeInterval {}
}
```

#### 🎁 New `DatadogInternal` Assertion Helper
This PR also introduces a new Datadog assertion helper to validate threading assumptions during initialization. It is designed to be generic, allowing other products to use it for validating their own assumptions as well:
```swift
/// Datadog assertion helper.
///
/// - Ensures assumptions that should **never** be violated.
/// - **Fails only in development** to catch mistakes early.
/// - **Never** crashes customer apps in production, even if they enable assertions in Release builds.
public func dd_assert(_:_:) { /**/ }
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
