### PR TITLE
[RUM-8413] Move Reflection code to internal module

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -684,6 +684,11 @@
 		61FDBA15269722B4001D9D43 /* CrashReportMinifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDBA14269722B4001D9D43 /* CrashReportMinifierTests.swift */; };
 		61FDBA1726974CA9001D9D43 /* DDCrashReportBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDBA1626974CA9001D9D43 /* DDCrashReportBuilderTests.swift */; };
 		61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
+		960A0D3B2D6E2490004BB999 /* Reflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D3A2D6E2490004BB999 /* Reflector.swift */; };
+		960A0D3C2D6E2490004BB999 /* CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D382D6E2490004BB999 /* CustomDump.swift */; };
+		960A0D3D2D6E2490004BB999 /* ReflectionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D392D6E2490004BB999 /* ReflectionMirror.swift */; };
+		960A0D402D6F88A0004BB999 /* ReflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D3F2D6F88A0004BB999 /* ReflectorTests.swift */; };
+		960A0D422D6F88DE004BB999 /* ReflectionMirrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D412D6F88DE004BB999 /* ReflectionMirrorTests.swift */; };
 		960B26C02D0360EE00D7196F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 960B26BF2D0360EE00D7196F /* Assets.xcassets */; };
 		960B26C32D075BD200D7196F /* DisplayListReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960B26C22D075BD200D7196F /* DisplayListReflectionTests.swift */; };
 		962C41A72CA431370050B747 /* SessionReplayPrivacyOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */; };
@@ -1303,8 +1308,6 @@
 		D29A9FDA29DDC6D0005C54A4 /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
 		D29A9FDB29DDC6D1005C54A4 /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
 		D29A9FE029DDC75A005C54A4 /* UIKitMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29A9FDF29DDC75A005C54A4 /* UIKitMocks.swift */; };
-		D29C9F692D00739400CD568E /* Reflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29C9F682D00739400CD568E /* Reflector.swift */; };
-		D29C9F6B2D01D5F600CD568E /* ReflectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */; };
 		D29CDD3228211A2200F7DAA5 /* TLVBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* TLVBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */; };
 		D2A1EE23287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
@@ -1351,7 +1354,6 @@
 		D2A7A9002BA1C24A00F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A8FE2BA1C24A00F46845 /* PrivacyInfo.xcprivacy */; };
 		D2A7A9022BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */; };
 		D2A7A9032BA1C4B100F46845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */; };
-		D2AD1CC22CE4AE6600106C74 /* CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBB2CE4AE6600106C74 /* CustomDump.swift */; };
 		D2AD1CC32CE4AE6600106C74 /* Color+Reflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBA2CE4AE6600106C74 /* Color+Reflection.swift */; };
 		D2AD1CC42CE4AE6600106C74 /* DisplayList+Reflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBD2CE4AE6600106C74 /* DisplayList+Reflection.swift */; };
 		D2AD1CC52CE4AE6600106C74 /* DisplayList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBC2CE4AE6600106C74 /* DisplayList.swift */; };
@@ -1360,7 +1362,6 @@
 		D2AD1CC82CE4AE6600106C74 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBF2CE4AE6600106C74 /* Text.swift */; };
 		D2AD1CC92CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CBE2CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift */; };
 		D2AD1CCC2CE4AE9800106C74 /* UIHostingViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CCB2CE4AE9800106C74 /* UIHostingViewRecorder.swift */; };
-		D2AD1CCF2CE4AEF600106C74 /* ReflectionMirrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */; };
 		D2AE9A5D2CF8837C00695264 /* FeatureFlagsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AE9A5C2CF8836D00695264 /* FeatureFlagsMock.swift */; };
 		D2B249942A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
 		D2B249952A4598FE00DD4F9F /* LoggerProtocol+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */; };
@@ -1676,7 +1677,6 @@
 		D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
 		D2DE63532A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
 		D2DE63542A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
-		D2EA0F432C0D941900CB20F8 /* ReflectionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F422C0D941900CB20F8 /* ReflectionMirror.swift */; };
 		D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */; };
 		D2EBEE1F29BA160F00B15732 /* HTTPHeadersReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */; };
 		D2EBEE2029BA160F00B15732 /* TracePropagationHeadersWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */; };
@@ -2711,6 +2711,11 @@
 		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
 		61FF416125EE5FF400CE35EC /* CrashLogReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogReceiverTests.swift; sourceTree = "<group>"; };
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
+		960A0D382D6E2490004BB999 /* CustomDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDump.swift; sourceTree = "<group>"; };
+		960A0D392D6E2490004BB999 /* ReflectionMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionMirror.swift; sourceTree = "<group>"; };
+		960A0D3A2D6E2490004BB999 /* Reflector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reflector.swift; sourceTree = "<group>"; };
+		960A0D3F2D6F88A0004BB999 /* ReflectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectorTests.swift; sourceTree = "<group>"; };
+		960A0D412D6F88DE004BB999 /* ReflectionMirrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionMirrorTests.swift; sourceTree = "<group>"; };
 		960B26BF2D0360EE00D7196F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		960B26C22D075BD200D7196F /* DisplayListReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayListReflectionTests.swift; sourceTree = "<group>"; };
 		962D72BA2CF6436600F86EF0 /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
@@ -2988,8 +2993,6 @@
 		D29A9FCB29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTAssertValidRUMUUID.swift; sourceTree = "<group>"; };
 		D29A9FCD29DDC470005C54A4 /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		D29A9FDF29DDC75A005C54A4 /* UIKitMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitMocks.swift; sourceTree = "<group>"; };
-		D29C9F682D00739400CD568E /* Reflector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reflector.swift; sourceTree = "<group>"; };
-		D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectorTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* TLVBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLVBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatePublisher.swift; sourceTree = "<group>"; };
@@ -3008,14 +3011,12 @@
 		D2A7A9012BA1C4B100F46845 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D2AD1CB92CE4AE6600106C74 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		D2AD1CBA2CE4AE6600106C74 /* Color+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Reflection.swift"; sourceTree = "<group>"; };
-		D2AD1CBB2CE4AE6600106C74 /* CustomDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDump.swift; sourceTree = "<group>"; };
 		D2AD1CBC2CE4AE6600106C74 /* DisplayList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayList.swift; sourceTree = "<group>"; };
 		D2AD1CBD2CE4AE6600106C74 /* DisplayList+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DisplayList+Reflection.swift"; sourceTree = "<group>"; };
 		D2AD1CBE2CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIWireframesBuilder.swift; sourceTree = "<group>"; };
 		D2AD1CBF2CE4AE6600106C74 /* Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		D2AD1CC02CE4AE6600106C74 /* Text+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Reflection.swift"; sourceTree = "<group>"; };
 		D2AD1CCB2CE4AE9800106C74 /* UIHostingViewRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHostingViewRecorder.swift; sourceTree = "<group>"; };
-		D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionMirrorTests.swift; sourceTree = "<group>"; };
 		D2AE9A5C2CF8836D00695264 /* FeatureFlagsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsMock.swift; sourceTree = "<group>"; };
 		D2B249932A4598FE00DD4F9F /* LoggerProtocol+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerProtocol+Internal.swift"; sourceTree = "<group>"; };
 		D2B249962A45E10500DD4F9F /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
@@ -3066,7 +3067,6 @@
 		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRegistry.swift; sourceTree = "<group>"; };
 		D2E8D59728C7AB90007E5DE1 /* ContextMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMessageReceiverTests.swift; sourceTree = "<group>"; };
-		D2EA0F422C0D941900CB20F8 /* ReflectionMirror.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReflectionMirror.swift; sourceTree = "<group>"; };
 		D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayConfiguration.swift; sourceTree = "<group>"; };
 		D2EBEDCC29B893D800B15732 /* TraceID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceID.swift; sourceTree = "<group>"; };
 		D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracePropagationHeadersWriter.swift; sourceTree = "<group>"; };
@@ -3796,8 +3796,6 @@
 			children = (
 				61054E552A6EE10A00AAA894 /* CGRectExtensions.swift */,
 				61054E582A6EE10A00AAA894 /* Queue.swift */,
-				D29C9F682D00739400CD568E /* Reflector.swift */,
-				D2EA0F422C0D941900CB20F8 /* ReflectionMirror.swift */,
 				61054E592A6EE10A00AAA894 /* Errors.swift */,
 				61054E5A2A6EE10A00AAA894 /* Colors.swift */,
 				61054E5B2A6EE10A00AAA894 /* Schedulers */,
@@ -3913,8 +3911,6 @@
 			children = (
 				61054F5D2A6EE1BA00AAA894 /* UIView+SessionReplayTests.swift */,
 				61054F5F2A6EE1BA00AAA894 /* CGRect+SessionReplayTests.swift */,
-				D2AD1CCE2CE4AEF600106C74 /* ReflectionMirrorTests.swift */,
-				D29C9F6A2D01D5F600CD568E /* ReflectorTests.swift */,
 			);
 			path = Utilties;
 			sourceTree = "<group>";
@@ -6273,6 +6269,9 @@
 		D2A783D329A53049003B03BB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				960A0D382D6E2490004BB999 /* CustomDump.swift */,
+				960A0D392D6E2490004BB999 /* ReflectionMirror.swift */,
+				960A0D3A2D6E2490004BB999 /* Reflector.swift */,
 				D23039D9298D5235001A1FA3 /* DateFormatting.swift */,
 				613C6B8F2768FDDE00870CBF /* Sampler.swift */,
 				D23039DC298D5235001A1FA3 /* DDError.swift */,
@@ -6291,6 +6290,8 @@
 				116F84052CFDD06700705755 /* SampleRateTests.swift */,
 				613C6B912768FF3100870CBF /* SamplerTests.swift */,
 				9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */,
+				960A0D3F2D6F88A0004BB999 /* ReflectorTests.swift */,
+				960A0D412D6F88DE004BB999 /* ReflectionMirrorTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -6334,7 +6335,6 @@
 			children = (
 				D2AD1CB92CE4AE6600106C74 /* Color.swift */,
 				D2AD1CBA2CE4AE6600106C74 /* Color+Reflection.swift */,
-				D2AD1CBB2CE4AE6600106C74 /* CustomDump.swift */,
 				D2AD1CBC2CE4AE6600106C74 /* DisplayList.swift */,
 				D2AD1CBD2CE4AE6600106C74 /* DisplayList+Reflection.swift */,
 				D2AD1CBE2CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift */,
@@ -8158,9 +8158,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D2AD1CC22CE4AE6600106C74 /* CustomDump.swift in Sources */,
 				D2AD1CC32CE4AE6600106C74 /* Color+Reflection.swift in Sources */,
-				D29C9F692D00739400CD568E /* Reflector.swift in Sources */,
 				D2AD1CC42CE4AE6600106C74 /* DisplayList+Reflection.swift in Sources */,
 				D2AD1CC52CE4AE6600106C74 /* DisplayList.swift in Sources */,
 				D2AD1CC62CE4AE6600106C74 /* Color.swift in Sources */,
@@ -8176,7 +8174,6 @@
 				61054E622A6EE10A00AAA894 /* RecordWriter.swift in Sources */,
 				61054E692A6EE10A00AAA894 /* UIImage+SessionReplay.swift in Sources */,
 				D218B0462D072C8400E3F82C /* SessionReplayTelemetry.swift in Sources */,
-				D2EA0F432C0D941900CB20F8 /* ReflectionMirror.swift in Sources */,
 				61054E782A6EE10A00AAA894 /* UIDatePickerRecorder.swift in Sources */,
 				61054E822A6EE10A00AAA894 /* UILabelRecorder.swift in Sources */,
 				A73A54982B16406900E1F7E3 /* ResourcesFeature.swift in Sources */,
@@ -8285,7 +8282,6 @@
 				61054FC12A6EE1BA00AAA894 /* ViewTreeRecorderTests.swift in Sources */,
 				61054F982A6EE1BA00AAA894 /* CGRectExtensionsTests.swift in Sources */,
 				D25C834C2B8657CF008E73B1 /* SegmentJSONTests.swift in Sources */,
-				D2AD1CCF2CE4AEF600106C74 /* ReflectionMirrorTests.swift in Sources */,
 				96867B992D08826B004AE0BC /* TextReflectionTests.swift in Sources */,
 				61054FB42A6EE1BA00AAA894 /* UITabBarRecorderTests.swift in Sources */,
 				61054FA22A6EE1BA00AAA894 /* TextObfuscatorTests.swift in Sources */,
@@ -8323,7 +8319,6 @@
 				61054FB92A6EE1BA00AAA894 /* UINavigationBarRecorderTests.swift in Sources */,
 				61054FA62A6EE1BA00AAA894 /* SnapshotProcessorTests.swift in Sources */,
 				61054FB72A6EE1BA00AAA894 /* UISegmentRecorderTests.swift in Sources */,
-				D29C9F6B2D01D5F600CD568E /* ReflectorTests.swift in Sources */,
 				96E863722C9C547B0023BF78 /* SessionReplayOverrideTests.swift in Sources */,
 				A7D9528A2B28BD94004C79B1 /* ResourceProcessorSpy.swift in Sources */,
 				A7D9528C2B28C18D004C79B1 /* ResourceProcessorTests.swift in Sources */,
@@ -8513,6 +8508,9 @@
 				D23039F4298D5236001A1FA3 /* AnyCodable.swift in Sources */,
 				D29A9F9529DDB1DB005C54A4 /* UIKitExtensions.swift in Sources */,
 				6167E6E82B8122E900C3CA2D /* BacktraceReport.swift in Sources */,
+				960A0D3B2D6E2490004BB999 /* Reflector.swift in Sources */,
+				960A0D3C2D6E2490004BB999 /* CustomDump.swift in Sources */,
+				960A0D3D2D6E2490004BB999 /* ReflectionMirror.swift in Sources */,
 				D2BEEDB52B3360820065F3AC /* URLSessionSwizzler.swift in Sources */,
 				D2EBEE2529BA160F00B15732 /* TraceID.swift in Sources */,
 				D2EBEE2129BA160F00B15732 /* W3CHTTPHeaders.swift in Sources */,
@@ -9617,6 +9615,7 @@
 				D2DA23A3298D58F400C6C7E6 /* AnyEncodableTests.swift in Sources */,
 				3CCECDAF2BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB429DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
+				960A0D402D6F88A0004BB999 /* ReflectorTests.swift in Sources */,
 				6174D6162BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,
 				116F84062CFDD06700705755 /* SampleRateTests.swift in Sources */,
 				3C0D5DF52A5443B100446CF9 /* DataFormatTests.swift in Sources */,
@@ -9628,6 +9627,7 @@
 				D2EBEE3D29BA163E00B15732 /* W3CHTTPHeadersWriterTests.swift in Sources */,
 				D2DA23A4298D58F400C6C7E6 /* AnyCodableTests.swift in Sources */,
 				D2160CDE29C0DF6700FAA9A5 /* URLSessionTaskInterceptionTests.swift in Sources */,
+				960A0D422D6F88DE004BB999 /* ReflectionMirrorTests.swift in Sources */,
 				D270CDE02B46E5A50002EACD /* URLSessionDataDelegateSwizzlerTests.swift in Sources */,
 				B3C27A082CE6342C006580F9 /* DeterministicSamplerTests.swift in Sources */,
 				D2DA23A1298D58F400C6C7E6 /* ReadWriteLockTests.swift in Sources */,

--- a/DatadogInternal/Sources/Utils/CustomDump.swift
+++ b/DatadogInternal/Sources/Utils/CustomDump.swift
@@ -80,7 +80,7 @@ internal struct ObjectTracker {
 ///     components. The default is `Int.max`.
 /// - Returns: The instance passed as `value`.
 @discardableResult
-internal func customDump<T, TargetStream>(
+public func customDump<T, TargetStream>(
     _ value: T,
     to target: inout TargetStream,
     name: String? = nil,
@@ -534,16 +534,16 @@ extension NSDictionary: _UnorderedCollection {}
 extension NSSet: _UnorderedCollection {}
 extension Set: _UnorderedCollection {}
 
-internal struct FileHandlerOutputStream: TextOutputStream {
+public struct FileHandlerOutputStream: TextOutputStream {
     private let handle: FileHandle
     let encoding: String.Encoding
 
-    init(_ handle: FileHandle, encoding: String.Encoding = .utf8) {
+    public init(_ handle: FileHandle, encoding: String.Encoding = .utf8) {
         self.handle = handle
         self.encoding = encoding
     }
 
-    mutating func write(_ string: String) {
+    public mutating func write(_ string: String) {
         if let data = string.data(using: encoding) {
             handle.seekToEndOfFile()
             handle.write(data)

--- a/DatadogInternal/Sources/Utils/ReflectionMirror.swift
+++ b/DatadogInternal/Sources/Utils/ReflectionMirror.swift
@@ -9,7 +9,7 @@ import Foundation
 /// A representation of the substructure and display style of an instance of
 /// any type.
 ///
-/// The `ReflectionMirror` defers from the standard ``Mirror`` in some key
+/// The `ReflectionMirror` differs from the standard ``Mirror`` in some key
 /// aspect of its implementation:
 ///
 /// ## Display style
@@ -25,7 +25,7 @@ import Foundation
 /// value instead of the subject itself.
 ///
 /// ## Lazy inspection
-/// All inspection endpoints are lazily loading child value, even when accessing property by key (this
+/// All inspection endpoints are lazily loading child values, even when accessing property by key (this
 /// is not the case with the standard `Mirror`). This is made possible by only loading the
 /// fields metadata but not their values.
 ///
@@ -36,7 +36,7 @@ import Foundation
 /// The `ReflectionMirror` ignores the ``CustomReflectable`` or ``CustomLeafReflectable``
 /// protocols and treat any conforming objects as `Any.Type`.
 ///
-internal struct ReflectionMirror {
+public struct ReflectionMirror {
     /// An element of the reflected instance's structure.
     ///
     /// When the `label` component in not `nil`, it may represent the name of a
@@ -47,7 +47,7 @@ internal struct ReflectionMirror {
     typealias Children = AnyCollection<Child>
 
     /// A suggestion of how a mirror's subject is to be interpreted.
-    enum DisplayStyle: Equatable {
+    public enum DisplayStyle: Equatable {
         case `struct`
         case `class`
         case `enum`(case: String)
@@ -56,7 +56,7 @@ internal struct ReflectionMirror {
         case opaque
     }
 
-    enum Path {
+    public enum Path {
         case index(Int)
         case key(String)
     }
@@ -70,25 +70,25 @@ internal struct ReflectionMirror {
         }
     }
 
-    let subject: Any
+    internal let subject: Any
 
     /// The static type of the subject being reflected.
     ///
     /// This type may differ from the subject's dynamic type when this mirror
     /// is the `superclassMirror` of another mirror.
-    let subjectType: Any.Type
+    internal let subjectType: Any.Type
 
     /// A suggested display style for the reflected subject.
     let displayStyle: DisplayStyle
 
     /// A collection of `Child` elements describing the structure of the
     /// reflected subject.
-    let children: Children
+    internal let children: Children
 
     /// A mirror of the subject's superclass, if one exists.
-    var superclassMirror: ReflectionMirror? { _superclassMirror.lazy }
+    internal var superclassMirror: ReflectionMirror? { _superclassMirror.lazy }
 
-    var keyPaths: [String: Int]? { _keyPaths.lazy }
+    internal var keyPaths: [String: Int]? { _keyPaths.lazy }
 
     private let _superclassMirror: LazyBox<ReflectionMirror?>
     private let _keyPaths: LazyBox<[String: Int]?>
@@ -114,7 +114,7 @@ extension ReflectionMirror {
     /// Creates a mirror that reflects on the given instance.
     ///
     /// - Parameter subject: The instance for which to create a mirror.
-    init(
+    public init(
         reflecting subject: Any,
         subjectType: Any.Type? = nil
     ) {
@@ -281,13 +281,13 @@ extension ReflectionMirror {
 }
 
 extension ReflectionMirror.Path: ExpressibleByIntegerLiteral {
-    init(integerLiteral value: Int) {
+    public init(integerLiteral value: Int) {
         self = .index(value)
     }
 }
 
 extension ReflectionMirror.Path: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         self = .key(value)
     }
 }

--- a/DatadogInternal/Sources/Utils/ReflectionMirror.swift
+++ b/DatadogInternal/Sources/Utils/ReflectionMirror.swift
@@ -41,10 +41,10 @@ public struct ReflectionMirror {
     ///
     /// When the `label` component in not `nil`, it may represent the name of a
     /// stored property or an active `enum` case.
-    typealias Child = (label: String?, value: Any)
+    public typealias Child = (label: String?, value: Any)
 
     /// The type used to represent substructure.
-    typealias Children = AnyCollection<Child>
+    public typealias Children = AnyCollection<Child>
 
     /// A suggestion of how a mirror's subject is to be interpreted.
     public enum DisplayStyle: Equatable {
@@ -70,25 +70,25 @@ public struct ReflectionMirror {
         }
     }
 
-    internal let subject: Any
+    public let subject: Any
 
     /// The static type of the subject being reflected.
     ///
     /// This type may differ from the subject's dynamic type when this mirror
     /// is the `superclassMirror` of another mirror.
-    internal let subjectType: Any.Type
+    public let subjectType: Any.Type
 
     /// A suggested display style for the reflected subject.
-    let displayStyle: DisplayStyle
+    public let displayStyle: DisplayStyle
 
     /// A collection of `Child` elements describing the structure of the
     /// reflected subject.
-    internal let children: Children
+    public let children: Children
 
     /// A mirror of the subject's superclass, if one exists.
-    internal var superclassMirror: ReflectionMirror? { _superclassMirror.lazy }
+    public var superclassMirror: ReflectionMirror? { _superclassMirror.lazy }
 
-    internal var keyPaths: [String: Int]? { _keyPaths.lazy }
+    public var keyPaths: [String: Int]? { _keyPaths.lazy }
 
     private let _superclassMirror: LazyBox<ReflectionMirror?>
     private let _keyPaths: LazyBox<[String: Int]?>

--- a/DatadogInternal/Sources/Utils/Reflector.swift
+++ b/DatadogInternal/Sources/Utils/Reflector.swift
@@ -5,18 +5,17 @@
  */
 
 import Foundation
-import DatadogInternal
 
 /// The `Reflector` container provides convenient methods to
 /// reflect an instance using the ``ReflectionMirror`` mirroring
-/// implementation and ceate ``Reflection`` objects.
+/// implementation and create ``Reflection`` objects.
 ///
-/// The `Reflector` is capabale of reporting telemetry error while
+/// The `Reflector` is capable of reporting telemetry error while
 /// reflecting descendants and provide partial results on Sequence.
-internal struct Reflector {
+public struct Reflector {
     /// Escalated error during reflection.
-    enum Error: Swift.Error {
-        struct Context {
+    public enum Error: Swift.Error {
+        public struct Context {
             let subjectType: Any.Type
             let paths: [ReflectionMirror.Path]
         }
@@ -25,16 +24,16 @@ internal struct Reflector {
     }
 
     /// A `Lazy` reflection allows reflecting the subject at a later time.
-    struct Lazy<T> where T: Reflection {
-        /// Relect to the type `T`.
-        let reflect: () throws -> T
+    public struct Lazy<T> where T: Reflection {
+        /// Reflect to the type `T`.
+        public let reflect: () throws -> T
     }
 
     private let mirror: ReflectionMirror
     private let telemetry: Telemetry
 
     /// Accessor of the mirror's display style.
-    var displayStyle: ReflectionMirror.DisplayStyle {
+    public var displayStyle: ReflectionMirror.DisplayStyle {
         mirror.displayStyle
     }
 
@@ -43,7 +42,7 @@ internal struct Reflector {
     /// - Parameters:
     ///   - mirror: The reflection mirror instance.
     ///   - telemetry: The telemetry to report reflection errors.
-    private init(
+    public init(
         mirror: ReflectionMirror,
         telemetry: Telemetry = NOPTelemetry()
     ) {
@@ -56,7 +55,7 @@ internal struct Reflector {
     /// - Parameters:
     ///   - subject: The subject instance to reflect.
     ///   - telemetry: The telemetry to report reflection errors.
-    init(
+    public init(
         subject: Any?,
         telemetry: Telemetry
     ) {
@@ -70,7 +69,7 @@ internal struct Reflector {
     ///
     /// - Parameter paths: The path to the descendant..
     /// - Returns: The descendant instance if it exist at the provided path.
-    func descendant(_ paths: [ReflectionMirror.Path]) -> Any? {
+    public func descendant(_ paths: [ReflectionMirror.Path]) -> Any? {
         mirror.descendant(paths)
     }
 
@@ -82,14 +81,14 @@ internal struct Reflector {
     ///   - first: The first path element.
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
-    func descendantIfPresent(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> Any? {
+    public func descendantIfPresent(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> Any? {
         descendant([first] + rest)
     }
 
     /// Reports a reflection error.
     ///
     /// - Parameter error: The error to report.
-    func report(_ error: Swift.Error) {
+    public func report(_ error: Swift.Error) {
         telemetry.error(error)
     }
 }
@@ -99,7 +98,7 @@ internal struct Reflector {
 ///
 /// Similar to `Decodable`, a `Reflection` can access mirroring descendant
 /// by path based in the `displayStyle`.
-internal protocol Reflection {
+public protocol Reflection {
     /// Creates a new instance by reflection from the given reflector.
     ///
     /// This initializer throws an error if reading from the reflector fails, or
@@ -119,7 +118,7 @@ extension Reflector {
     ///   - first: The first path element.
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
-    func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? {
+    public func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? {
         descendant([first] + rest) as? T
     }
 
@@ -131,11 +130,11 @@ extension Reflector {
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
     /// - Throws: `Reflector.Error.notFound` or `Reflector.Error.typeMismatch`
-    func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T {
+    public func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T {
         try descendant([first] + rest)
     }
 
-    private func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T {
+    public func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T {
         guard let value = descendant(paths) else {
             throw Error.notFound(.init(subjectType: mirror.subjectType, paths: paths))
         }
@@ -153,13 +152,13 @@ extension Reflector {
 }
 
 extension Reflector {
-    /// Reflect a subjec to a specified type.
+    /// Reflect a subject to a specified type.
     ///
     /// - Parameters:
     ///   - type: The type to reflect to.
     ///   - subject: The subject instance to reflect.
     /// - Returns: The reflection instance.
-    func reflect<T>(type: T.Type = T.self, _ subject: Any?) throws -> T where T: Reflection {
+    public func reflect<T>(type: T.Type = T.self, _ subject: Any?) throws -> T where T: Reflection {
         let reflector = Reflector(subject: subject, telemetry: telemetry)
         return try T(from: reflector)
     }
@@ -171,7 +170,7 @@ extension Reflector {
     ///   - first: The first path element.
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
-    func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? where T: Reflection {
+    public func descendantIfPresent<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) -> T? where T: Reflection {
         do {
             return try descendant(type: type, [first] + rest)
         } catch Error.notFound {
@@ -190,7 +189,7 @@ extension Reflector {
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
     /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
-    func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T where T: Reflection {
+    public func descendant<T>(type: T.Type = T.self, _ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> T where T: Reflection {
         try descendant(type: type, [first] + rest)
     }
 
@@ -202,7 +201,7 @@ extension Reflector {
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
     /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
-    func descendant<Element>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Element] where Element: Reflection {
+    public func descendant<Element>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Element] where Element: Reflection {
         guard let subject = descendant([first] + rest) as? [Any] else {
             throw Error.typeMismatch(
                 .init(subjectType: mirror.subjectType, paths: [first] + rest),
@@ -221,7 +220,7 @@ extension Reflector {
         }
     }
 
-    /// Reflect a Disctionary descendant to the specified Key/Value types by path.
+    /// Reflect a Dictionary descendant to the specified Key/Value types by path.
     ///
     /// - Parameters:
     ///   - type: The expected element type.
@@ -229,7 +228,7 @@ extension Reflector {
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
     /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
-    func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Hashable, Value: Reflection {
+    public func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Hashable, Value: Reflection {
         guard let subject = descendant([first] + rest) as? [Key: Any] else {
             throw Error.typeMismatch(
                 .init(subjectType: mirror.subjectType, paths: [first] + rest),
@@ -247,7 +246,7 @@ extension Reflector {
         }
     }
 
-    /// Reflect a Disctionary descendant to the specified Key/Value types by path.
+    /// Reflect a Dictionary descendant to the specified Key/Value types by path.
     ///
     /// - Parameters:
     ///   - type: The expected element type.
@@ -255,7 +254,7 @@ extension Reflector {
     ///   - rest: The rest of the path elements.
     /// - Returns: The descendant instance if it exist at the provided path.
     /// - Throws: `Reflector.Error` or any other error from the `Reflection` type.
-    func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Reflection, Key: Hashable, Value: Reflection {
+    public func descendant<Key, Value>(_ first: ReflectionMirror.Path, _ rest: ReflectionMirror.Path...) throws -> [Key: Value] where Key: Reflection, Key: Hashable, Value: Reflection {
         guard let subject = descendant([first] + rest) as? [AnyHashable: Any] else {
             throw Error.typeMismatch(
                 .init(subjectType: mirror.subjectType, paths: [first] + rest),
@@ -273,7 +272,7 @@ extension Reflector {
         }
     }
 
-    private func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T where T: Reflection {
+    public func descendant<T>(type: T.Type = T.self, _ paths: [ReflectionMirror.Path]) throws -> T where T: Reflection {
         guard let value = descendant(paths) else {
             throw Error.notFound(.init(subjectType: mirror.subjectType, paths: paths))
         }
@@ -289,17 +288,17 @@ extension Reflector {
 // swiftlint:enable function_default_parameter_at_end
 
 extension Reflection {
-    typealias Lazy = Reflector.Lazy<Self>
+    public typealias Lazy = Reflector.Lazy<Self>
 }
 
 extension Reflector.Lazy: Reflection {
-    init(from reflector: Reflector) throws {
+    public init(from reflector: Reflector) throws {
         reflect = { try T(from: reflector) }
     }
 }
 
 extension Reflector.Lazy {
-    init(_ reflection: T) {
+    public init(_ reflection: T) {
         reflect = { reflection }
     }
 }

--- a/DatadogInternal/Tests/Utils/ReflectionMirrorTests.swift
+++ b/DatadogInternal/Tests/Utils/ReflectionMirrorTests.swift
@@ -5,8 +5,7 @@
  */
 
 import XCTest
-
-@testable import DatadogSessionReplay
+@testable import DatadogInternal
 
 class ReflectionMirrorTests: XCTestCase {
     func testClassDisplay() {

--- a/DatadogInternal/Tests/Utils/ReflectorTests.swift
+++ b/DatadogInternal/Tests/Utils/ReflectorTests.swift
@@ -5,10 +5,8 @@
  */
 
 import XCTest
-import DatadogInternal
 import TestUtilities
-
-@testable import DatadogSessionReplay
+@testable import DatadogInternal
 
 class ReflectorTests: XCTestCase {
     func testReflectObject() throws {
@@ -83,7 +81,7 @@ class ReflectorTests: XCTestCase {
         XCTAssertEqual(echo.bar.count, 10)
         XCTAssertEqual(
             telemetry.messages.firstError()?.message,
-            #"notFound(DatadogSessionReplay.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogSessionReplay.ReflectionMirror.Path.key("baz")]))"#
+            #"notFound(DatadogInternal.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogInternal.ReflectionMirror.Path.key("baz")]))"#
         )
     }
 
@@ -135,7 +133,7 @@ class ReflectorTests: XCTestCase {
         XCTAssertEqual(echo.bar.count, 10)
         XCTAssertEqual(
             telemetry.messages.firstError()?.message,
-            #"notFound(DatadogSessionReplay.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogSessionReplay.ReflectionMirror.Path.key("baz")]))"#
+            #"notFound(DatadogInternal.Reflector.Error.Context(subjectType: Swift.String, paths: [DatadogInternal.ReflectionMirror.Path.key("baz")]))"#
         )
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import DatadogInternal
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color._Resolved: Reflection {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import DatadogInternal
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList: Reflection {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Image+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Image+Reflection.swift
@@ -8,6 +8,7 @@
 
 import CoreGraphics
 import SwiftUI
+import DatadogInternal
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage: Reflection {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Text+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Text+Reflection.swift
@@ -7,6 +7,7 @@
 #if os(iOS)
 
 import Foundation
+import DatadogInternal
 
 extension StyledTextContentView: Reflection {
     init(from reflector: Reflector) throws {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -41,13 +41,13 @@ internal class UIHostingViewRecorder: NodeRecorder {
 
         do {
             let nodeID = context.ids.nodeID(view: view, nodeRecorder: self)
-            return try semantics(refelecting: view, nodeID: nodeID, with: attributes, in: context)
+            return try semantics(reflecting: view, nodeID: nodeID, with: attributes, in: context)
         } catch {
             return nil
         }
     }
 
-    func semantics(refelecting subject: AnyObject, nodeID: NodeID, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) throws -> NodeSemantics? {
+    func semantics(reflecting subject: AnyObject, nodeID: NodeID, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) throws -> NodeSemantics? {
         guard
             let ivar = class_getInstanceVariable(type(of: subject), "renderer"),
             let renderer = object_getIvar(subject, ivar) as? AnyObject
@@ -82,7 +82,7 @@ internal class UIHostingViewRecorder: NodeRecorder {
 
 @available(iOS 18.1, tvOS 18.1, *)
 internal class iOS18HostingViewRecorder: UIHostingViewRecorder {
-    override func semantics(refelecting subject: AnyObject, nodeID: NodeID, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) throws -> NodeSemantics? {
+    override func semantics(reflecting subject: AnyObject, nodeID: NodeID, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) throws -> NodeSemantics? {
         guard
             let ivar = class_getInstanceVariable(type(of: subject), "_base"),
             let _base = object_getIvar(subject, ivar) as? AnyObject
@@ -90,7 +90,7 @@ internal class iOS18HostingViewRecorder: UIHostingViewRecorder {
             return nil
         }
 
-        return try super.semantics(refelecting: _base, nodeID: nodeID, with: attributes, in: context)
+        return try super.semantics(reflecting: _base, nodeID: nodeID, with: attributes, in: context)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
@@ -9,11 +9,11 @@ import XCTest
 #if os(iOS)
 import XCTest
 import SwiftUI
-import DatadogInternal
 import TestUtilities
 
 @_spi(Internal)
 @testable import DatadogSessionReplay
+@testable import DatadogInternal
 
 @available(iOS 13.0, tvOS 13.0, *)
 class SwiftUIWireframesBuilderTests: XCTestCase {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -7,7 +7,6 @@
 #if os(iOS)
 import XCTest
 import SwiftUI
-import DatadogInternal
 import TestUtilities
 
 @_spi(Internal)


### PR DESCRIPTION
### What and why?

This PR moves the reflection logic in the `SessionReplay` module to the `Internal` module. The goal is to make this code available to both `SessionReplay` and `RUM` modules, in anticipation of the Auto-instrumentation work.

### How?

- Moving `Reflector` and `ReflectionMirror` to the internal module
- Making core reflection types and methods `public` where necessary

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
