### PR TITLE
RUM-8855 Increase Batch Processing Levels

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -272,7 +272,6 @@ extension DatadogCore: DatadogCoreProtocol {
                 httpClient: httpClient,
                 performance: performancePreset,
                 backgroundTasksEnabled: backgroundTasksEnabled,
-                maxBatchesPerUpload: maxBatchesPerUpload,
                 isRunFromExtension: isRunFromExtension,
                 telemetry: telemetry
             )

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -19,7 +19,6 @@ internal struct FeatureUpload {
         httpClient: HTTPClient,
         performance: PerformancePreset,
         backgroundTasksEnabled: Bool,
-        maxBatchesPerUpload: Int,
         isRunFromExtension: Bool,
         telemetry: Telemetry
     ) {
@@ -62,7 +61,7 @@ internal struct FeatureUpload {
                 delay: DataUploadDelay(performance: performance),
                 featureName: featureName,
                 telemetry: telemetry,
-                maxBatchesPerUpload: maxBatchesPerUpload,
+                maxBatchesPerUpload: performance.maxBatchesPerUpload,
                 backgroundTaskCoordinator: backgroundTaskCoordinator
             )
         )

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -64,9 +64,9 @@ public enum Datadog {
             var maxBatchesPerUpload: Int {
                 switch self {
                 case .low:
-                    return 1
+                    return 5
                 case .medium:
-                    return 10
+                    return 20
                 case .high:
                     return 100
                 }
@@ -538,7 +538,8 @@ extension DatadogCore {
         let performance = PerformancePreset(
             batchSize: debug ? .small : configuration.batchSize,
             uploadFrequency: debug ? .frequent : configuration.uploadFrequency,
-            bundleType: bundleType
+            bundleType: bundleType,
+            batchProcessingLevel: configuration.batchProcessingLevel
         )
         let isRunFromExtension = bundleType == .iOSAppExtension
 

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -65,13 +65,15 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let minUploadDelay: TimeInterval
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
+    let maxBatchesPerUpload: Int
 }
 
 internal extension PerformancePreset {
     init(
         batchSize: Datadog.Configuration.BatchSize,
         uploadFrequency: Datadog.Configuration.UploadFrequency,
-        bundleType: BundleType
+        bundleType: BundleType,
+        batchProcessingLevel: Datadog.Configuration.BatchProcessingLevel
     ) {
         let meanFileAgeInSeconds: TimeInterval = {
             switch (bundleType, batchSize) {
@@ -113,14 +115,16 @@ internal extension PerformancePreset {
         self.init(
             meanFileAge: meanFileAgeInSeconds,
             minUploadDelay: minUploadDelayInSeconds,
-            uploadDelayFactors: uploadDelayFactors
+            uploadDelayFactors: uploadDelayFactors,
+            maxBatchesPerUpload: batchProcessingLevel.maxBatchesPerUpload
         )
     }
 
     init(
         meanFileAge: TimeInterval,
         minUploadDelay: TimeInterval,
-        uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double)
+        uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double),
+        maxBatchesPerUpload: Int
     ) {
         self.maxFileSize = 4.MB.asUInt32()
         self.maxDirectorySize = 512.MB.asUInt32()
@@ -133,6 +137,7 @@ internal extension PerformancePreset {
         self.minUploadDelay = minUploadDelay * uploadDelayFactors.min
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate
+        self.maxBatchesPerUpload = maxBatchesPerUpload
     }
 
     func updated(with override: PerformancePresetOverride) -> PerformancePreset {
@@ -147,7 +152,8 @@ internal extension PerformancePreset {
             initialUploadDelay: override.initialUploadDelay ?? initialUploadDelay,
             minUploadDelay: override.minUploadDelay ?? minUploadDelay,
             maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
-            uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate
+            uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate,
+            maxBatchesPerUpload: maxBatchesPerUpload
         )
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
@@ -11,39 +11,42 @@ import DatadogInternal
 
 class PerformancePresetTests: XCTestCase {
     func testIOSAppPresets() {
-        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSApp, batchProcessingLevel: .low)
         XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 2.85, accuracy: 0.01)
         XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 3.15, accuracy: 0.01)
         XCTAssertEqual(smallBatchAnyFrequency.uploaderWindow, 3.0)
+        XCTAssertEqual(smallBatchAnyFrequency.maxBatchesPerUpload, 5)
         assertPresetCommonValues(in: smallBatchAnyFrequency)
 
-        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSApp, batchProcessingLevel: .medium)
         XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 9.5)
         XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 10.5)
         XCTAssertEqual(mediumBatchAnyFrequency.uploaderWindow, 10.0)
+        XCTAssertEqual(mediumBatchAnyFrequency.maxBatchesPerUpload, 20)
         assertPresetCommonValues(in: mediumBatchAnyFrequency)
 
-        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSApp, batchProcessingLevel: .high)
         XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 33.25)
         XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 36.75)
         XCTAssertEqual(largeBatchAnyFrequency.uploaderWindow, 35)
+        XCTAssertEqual(largeBatchAnyFrequency.maxBatchesPerUpload, 100)
         assertPresetCommonValues(in: largeBatchAnyFrequency)
 
-        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSApp)
+        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSApp, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 2.5)
         XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 5.0)
         XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.1)
         assertPresetCommonValues(in: frequentUploadAnyBatch)
 
-        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSApp)
+        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSApp, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 10.0)
         XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 2.0)
         XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 20.0)
         XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.1)
         assertPresetCommonValues(in: averageUploadAnyBatch)
 
-        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSApp)
+        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSApp, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 25.0)
         XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 5.0)
         XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 50.0)
@@ -52,39 +55,39 @@ class PerformancePresetTests: XCTestCase {
     }
 
     func testIOSAppExtensionPresets() {
-        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 0.95)
         XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 1.05)
         XCTAssertEqual(smallBatchAnyFrequency.uploaderWindow, 1)
         assertPresetCommonValues(in: smallBatchAnyFrequency)
 
-        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 0.95, accuracy: 0.01)
         XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 1.05, accuracy: 0.01)
         XCTAssertEqual(mediumBatchAnyFrequency.uploaderWindow, 1)
         assertPresetCommonValues(in: mediumBatchAnyFrequency)
 
-        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 0.95, accuracy: 0.01)
         XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 1.05, accuracy: 0.01)
         XCTAssertEqual(largeBatchAnyFrequency.uploaderWindow, 1)
         assertPresetCommonValues(in: largeBatchAnyFrequency)
 
-        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSAppExtension)
+        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 0.25)
         XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 2.5)
         XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.5)
         assertPresetCommonValues(in: frequentUploadAnyBatch)
 
-        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSAppExtension)
+        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 0.25)
         XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 2.5)
         XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.5)
         assertPresetCommonValues(in: averageUploadAnyBatch)
 
-        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSAppExtension)
+        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSAppExtension, batchProcessingLevel: .mockRandom())
         XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 0.25)
         XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 2.5)
@@ -101,10 +104,11 @@ class PerformancePresetTests: XCTestCase {
     }
 
     func testPresetsConsistency() {
-        let allPossiblePresets: [PerformancePreset] = BatchSize.allCases
-            .combined(with: UploadFrequency.allCases)
-            .combined(with: BundleType.allCases)
-            .map { PerformancePreset(batchSize: $0.0, uploadFrequency: $0.1, bundleType: $1) }
+        let allPossiblePresets: [PerformancePreset] = zip(
+            zip(BatchSize.allCases, UploadFrequency.allCases),
+            zip(BundleType.allCases, Datadog.Configuration.BatchProcessingLevel.allCases)
+        )
+            .map { PerformancePreset(batchSize: $0.0, uploadFrequency: $0.1, bundleType: $1.0, batchProcessingLevel: $1.1) }
 
         allPossiblePresets.forEach { preset in
             XCTAssertLessThan(
@@ -157,7 +161,7 @@ class PerformancePresetTests: XCTestCase {
         )
 
         // When
-        let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom())
+        let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom(), batchProcessingLevel: .mockRandom())
         let updatedPreset = preset.updated(
             with: PerformancePresetOverride(
                 maxFileSize: maxFileSizeOverride,

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadDelayTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadDelayTests.swift
@@ -12,7 +12,8 @@ class DataUploadDelayTests: XCTestCase {
         initialUploadDelay: 3,
         minUploadDelay: 1,
         maxUploadDelay: 20,
-        uploadDelayChangeRate: 0.1
+        uploadDelayChangeRate: 0.1,
+        maxBatchesPerUpload: .mockAny()
     )
 
     func testWhenNotModified_itReturnsInitialDelay() {

--- a/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
+++ b/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
@@ -18,4 +18,6 @@ public protocol UploadPerformancePreset {
     /// If upload succeeds or fails, current interval is changed by this rate. Should be less or equal `1.0`.
     /// E.g: if rate is `0.1` then `delay` can be increased or decreased by `delay * 0.1`.
     var uploadDelayChangeRate: Double { get }
+    /// Number of batches to process during one upload cycle.
+    var maxBatchesPerUpload: Int { get }
 }

--- a/TestUtilities/Helpers/SwiftExtensions.swift
+++ b/TestUtilities/Helpers/SwiftExtensions.swift
@@ -163,10 +163,6 @@ extension URLSessionTask.State {
 /// Combines two arrays together, e.g. `["a", "b"].combined(with: [1, 2, 3])` gives
 /// `[("a", 1), ("a", 2), ("a", 3), ("b", 1), ("b", 2), ("b", 3)]`.
 public extension Array {
-    func combined<B>(with other: [B]) -> [(Element, B)] {
-        return self.flatMap { a in other.map { b in (a, b) } }
-    }
-
     /// Returns first element of the array which is of type `T`.
     /// - Parameters:
     ///   - type: the type of element to lookup

--- a/TestUtilities/Mocks/UploadMocks.swift
+++ b/TestUtilities/Mocks/UploadMocks.swift
@@ -12,19 +12,28 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
     public let minUploadDelay: TimeInterval
     public let maxUploadDelay: TimeInterval
     public let uploadDelayChangeRate: Double
+    public let maxBatchesPerUpload: Int
 
-    public init(initialUploadDelay: TimeInterval, minUploadDelay: TimeInterval, maxUploadDelay: TimeInterval, uploadDelayChangeRate: Double) {
+    public init(
+        initialUploadDelay: TimeInterval,
+        minUploadDelay: TimeInterval,
+        maxUploadDelay: TimeInterval,
+        uploadDelayChangeRate: Double,
+        maxBatchesPerUpload: Int
+    ) {
         self.initialUploadDelay = initialUploadDelay
         self.minUploadDelay = minUploadDelay
         self.maxUploadDelay = maxUploadDelay
         self.uploadDelayChangeRate = uploadDelayChangeRate
+        self.maxBatchesPerUpload = maxBatchesPerUpload
     }
 
     public static let noOp = UploadPerformanceMock(
         initialUploadDelay: .distantFuture,
         minUploadDelay: .distantFuture,
         maxUploadDelay: .distantFuture,
-        uploadDelayChangeRate: 0
+        uploadDelayChangeRate: 0,
+        maxBatchesPerUpload: 0
     )
 
     /// Optimized for performing very fast uploads in unit tests.
@@ -32,7 +41,8 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         initialUploadDelay: 0.05,
         minUploadDelay: 0.05,
         maxUploadDelay: 0.05,
-        uploadDelayChangeRate: 0
+        uploadDelayChangeRate: 0,
+        maxBatchesPerUpload: 10
     )
 
     /// Optimized for performing very fast first upload and then changing to unrealistically long intervals.
@@ -40,7 +50,8 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         initialUploadDelay: 0.05,
         minUploadDelay: 60,
         maxUploadDelay: 60,
-        uploadDelayChangeRate: 60 / 0.05
+        uploadDelayChangeRate: 60 / 0.05,
+        maxBatchesPerUpload: 10
     )
 }
 


### PR DESCRIPTION
### What and why?

Increase batch processing levels.

More context in [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4672979222/RFC+-+Mobile+uploader+improvements+to+reduce+batch+loss+rate)

### How?

```swift
/// Defines the maximum amount of batches processed sequentially without a delay within one reading/uploading cycle.
public enum BatchProcessingLevel {
    case low
    case medium
    case high

    var maxBatchesPerUpload: Int {
        switch self {
        case .low:
            return 5
        case .medium:
            return 20
        case .high:
            return 100
        }
    }
}
```

I took the opportunity to add the `maxBatchesPerUpload` to the `UploadPerformancePreset` protocol, which could be used for overrides.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)