### PR TITLE
RUM-8042 Split Upload Quality Metric per Track

### DIFF
--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -103,7 +103,7 @@ internal class SessionEndedMetric {
     private var wasStopped = false
 
     /// Information about the upload quality during the session.
-    private var uploadQuality: Attributes.UploadQuality
+    private var uploadQuality: [String: Attributes.UploadQuality] = [:]
 
     /// If `RUM.Configuration.trackBackgroundEvents` was enabled for this session.
     private let tracksBackgroundEvents: Bool
@@ -142,11 +142,6 @@ internal class SessionEndedMetric {
         self.precondition = precondition
         self.tracksBackgroundEvents = tracksBackgroundEvents
         self.ntpOffsetAtStart = context.serverTimeOffset
-        self.uploadQuality = Attributes.UploadQuality(
-            cycleCount: 0,
-            failureCount: [:],
-            blockerCount: [:]
-        )
     }
 
     /// Tracks the view event that occurred during the session.
@@ -212,6 +207,16 @@ internal class SessionEndedMetric {
     /// - Parameters:
     ///   - attributes: The upload quality attributes
     func track(uploadQuality attributes: [String: Encodable]) {
+        guard let track = attributes[UploadQualityMetric.track] as? String else {
+            return
+        }
+
+        let uploadQuality = self.uploadQuality[track] ?? Attributes.UploadQuality(
+            cycleCount: 0,
+            failureCount: [:],
+            blockerCount: [:]
+        )
+
         var failureCount = uploadQuality.failureCount
         var blockerCount = uploadQuality.blockerCount
 
@@ -227,7 +232,7 @@ internal class SessionEndedMetric {
             }
         }
 
-        uploadQuality = Attributes.UploadQuality(
+        self.uploadQuality[track] = Attributes.UploadQuality(
             cycleCount: uploadQuality.cycleCount + 1,
             failureCount: failureCount,
             blockerCount: blockerCount
@@ -344,7 +349,8 @@ internal class SessionEndedMetric {
         }
 
         /// Information about the upload quality during the session.
-        let uploadQuality: UploadQuality
+        /// The upload quality is splitting between upload track name.
+        let uploadQuality: [String: UploadQuality]
 
         enum CodingKeys: String, CodingKey {
             case processType = "process_type"

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -41,7 +41,7 @@ class TelemetryInterceptorTests: XCTestCase {
 
         // When
         metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny(), tracksBackgroundEvents: .mockRandom())
-        let metricTelemetry: TelemetryMessage = .metric(MetricTelemetry(name: UploadQualityMetric.name, attributes: mockRandomAttributes(), sampleRate: .mockRandom()))
+        let metricTelemetry: TelemetryMessage = .metric(MetricTelemetry(name: UploadQualityMetric.name, attributes: [UploadQualityMetric.track: "feature"], sampleRate: .mockRandom()))
         let result = interceptor.receive(message: .telemetry(metricTelemetry), from: NOPDatadogCore())
         XCTAssertTrue(result)
 
@@ -49,6 +49,6 @@ class TelemetryInterceptorTests: XCTestCase {
         metricController.endMetric(sessionID: sessionID, with: .mockRandom())
         let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
         let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
-        XCTAssertEqual(rse.uploadQuality.cycleCount, 1)
+        XCTAssertEqual(rse.uploadQuality["feature"]?.cycleCount, 1)
     }
 }

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -497,22 +497,22 @@ class SessionEndedMetricTests: XCTestCase {
     func testUploadQualityMetricAggregation() throws {
         let metric = SessionEndedMetric.with(sessionID: sessionID, context: .mockWith(applicationBundleType: .iOSApp))
         metric.track(uploadQuality: [
-            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.track: "feature",
             UploadQualityMetric.failure: "error1"
         ])
 
         metric.track(uploadQuality: [
-            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.track: "feature",
             UploadQualityMetric.failure: "error1",
             UploadQualityMetric.blockers: ["blocker1", "blocker2"]
         ])
 
         metric.track(uploadQuality: [
-            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.track: "feature",
         ])
 
         metric.track(uploadQuality: [
-            UploadQualityMetric.track: String.mockRandom(),
+            UploadQualityMetric.track: "feature",
             UploadQualityMetric.failure: "error2",
             UploadQualityMetric.blockers: ["blocker1"]
         ])
@@ -520,11 +520,11 @@ class SessionEndedMetricTests: XCTestCase {
         // When
         let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))
 
-        XCTAssertEqual(try matcher.value("rse.upload_quality.cycle_count") as Int, 4)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.failure_count.error1") as Int, 2)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.failure_count.error2") as Int, 1)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.blocker_count.blocker1") as Int, 2)
-        XCTAssertEqual(try matcher.value("rse.upload_quality.blocker_count.blocker2") as Int, 1)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.feature.cycle_count") as Int, 4)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.feature.failure_count.error1") as Int, 2)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.feature.failure_count.error2") as Int, 1)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.feature.blocker_count.blocker1") as Int, 2)
+        XCTAssertEqual(try matcher.value("rse.upload_quality.feature.blocker_count.blocker2") as Int, 1)
     }
 
     // MARK: - Metric Spec
@@ -535,7 +535,7 @@ class SessionEndedMetricTests: XCTestCase {
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .manual)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .swiftui)
         try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .uikit)
-        metric.track(uploadQuality: [UploadQualityMetric.track: String.mockRandom()])
+        metric.track(uploadQuality: [UploadQualityMetric.track: "feature"])
 
         // When
         let matcher = try JSONObjectMatcher(AnyEncodable(metric.asMetricAttributes()))
@@ -561,7 +561,7 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.resources") as Int)
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.errors") as Int)
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.long_tasks") as Int)
-        XCTAssertNotNil(try matcher.value("rse.upload_quality.cycle_count") as Int)
+        XCTAssertNotNil(try matcher.value("rse.upload_quality.feature.cycle_count") as Int)
     }
 }
 


### PR DESCRIPTION
### What and why?

Aggregated upload quality of all tracks will be difficult to analyse, especially in term of blockers: upload blocker will bock all tracks simultaneously.

We should split de metric per track

### How?

Each upload worker already provide the track name while reporting their upload metric. The aggregation in the `SessionEndedMetric` takes it into account to split the `upload_quality` attribute.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
