### PR TITLE
RUM-8558 Update DatadogTrace to OTel API `1.13.0`

### DIFF
--- a/BenchmarkTests/Benchmarks/Package.swift
+++ b/BenchmarkTests/Benchmarks/Package.swift
@@ -22,6 +22,8 @@ func addOpenTelemetryDependency(_ version: Version) {
     // sub directories, in this case the project will depend on the default
     // 'DataDog/opentelemetry-swift-packages' depedency.
     if ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil {
+        package.platforms = [.iOS(.v13), .tvOS(.v13)]
+
         package.dependencies = [
             .package(url: "https://github.com/open-telemetry/opentelemetry-swift", exact: version)
         ]
@@ -38,6 +40,8 @@ func addOpenTelemetryDependency(_ version: Version) {
             )
         ]
     } else {
+        package.platforms = [.iOS(.v12), .tvOS(.v12)]
+
         package.dependencies = [
             .package(url: "https://github.com/DataDog/opentelemetry-swift-packages", exact: version)
         ]

--- a/BenchmarkTests/Benchmarks/Package.swift
+++ b/BenchmarkTests/Benchmarks/Package.swift
@@ -54,4 +54,4 @@ func addOpenTelemetryDependency(_ version: Version) {
     }
 }
 
-addOpenTelemetryDependency("1.6.0")
+addOpenTelemetryDependency("1.13.0")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [FEATURE] Adds anonymous identifier configuration for RUM Sessions linking. See [#2172][]
+- [FEATURE] Update `DatadogTrace` to OpenTelemetryApi 1.13.0. See [#2217][]
 - [FIX] Session Replay: Fix captured displayed image frame computation when `UIImageView.contentMode` is `scaleAspectFill`. See [#2200][]
 - [IMPROVEMENT] Updates `setUserInfo` to require `id` parameter. See [#2195][]
 
@@ -834,6 +835,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2169]: https://github.com/DataDog/dd-sdk-ios/pull/2169
 [#2170]: https://github.com/DataDog/dd-sdk-ios/pull/2170
 [#2177]: https://github.com/DataDog/dd-sdk-ios/pull/2177
+[#2217]: https://github.com/DataDog/dd-sdk-ios/pull/2217
 [#2182]: https://github.com/DataDog/dd-sdk-ios/pull/2182
 [#2195]: https://github.com/DataDog/dd-sdk-ios/pull/2195
 [@00fa9a]: https://github.com/00FA9A

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "microsoft/plcrashreporter" ~> 1.12.0
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.6.0
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.13.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.6.0"
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.13.0"
 github "microsoft/plcrashreporter" "1.12.0"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogTrace iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogTrace iOS.xcscheme
@@ -199,11 +199,6 @@
                BlueprintName = "DatadogTraceTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "OTelSpanTests/testSetActive_givenParentSpan()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogTrace tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogTrace tvOS.xcscheme
@@ -199,11 +199,6 @@
                BlueprintName = "DatadogTraceTests tvOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "OTelSpanTests/testSetActive_givenParentSpan()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -23,5 +23,5 @@ Pod::Spec.new do |s|
   s.source_files = ["DatadogTrace/Sources/**/*.swift"]
 
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'OpenTelemetrySwiftApi', '1.6.0'
+  s.dependency 'OpenTelemetrySwiftApi', '1.13.0'
 end

--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
@@ -44,4 +44,12 @@ internal class NOPOTelSpan: Span {
     func end(time: Date) {
         end()
     }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException) {}
 }

--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
@@ -45,9 +45,9 @@ internal class NOPOTelSpan: Span {
         end()
     }
 
-    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {}
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {}
 
-    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {}
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue]) {}
 
     func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date) {}
 

--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
@@ -55,4 +55,20 @@ internal class NOPOTelSpanBuilder: SpanBuilder {
     func setActive(_ active: Bool) -> Self {
         return self
     }
+
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) throws -> T) rethrows -> T {
+        let span = startSpan()
+        defer { span.end() }
+        return try operation(span)
+    }
+
+#if canImport(_Concurrency)
+    /// Ref.: https://github.com/open-telemetry/opentelemetry-swift/issues/578
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
+        let span = startSpan()
+        defer { span.end() }
+        return try await operation(span)
+    }
+#endif
 }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelAttributeValue+Datadog.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelAttributeValue+Datadog.swift
@@ -64,6 +64,14 @@ extension Dictionary where Key == String, Value == OpenTelemetryApi.AttributeVal
                         tags["\(key).\(nestedKey)"] = nestedValue
                     }
                 }
+            case .array(let array):
+                if array.values.isEmpty {
+                    tags[key] = ""
+                } else {
+                    for (index, element) in array.values.enumerated() {
+                        tags["\(key).\(index)"] = element.description
+                    }
+                }
             @unknown default:
                 break
             }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -154,13 +154,13 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
-    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {
         // RUM-8558: `recordException()` should be based on `addEvent()` which we currently don't support.
         // Ref.: https://github.com/open-telemetry/opentelemetry-swift/blob/1.13.0/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift#L356
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
-    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue]) {
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
@@ -171,7 +171,6 @@ internal class OTelSpan: OpenTelemetryApi.Span {
     func recordException(_ exception: any OpenTelemetryApi.SpanException) {
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
-
 
     func end() {
         end(time: Date())

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -154,6 +154,25 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {
+        // RUM-8558: `recordException()` should be based on `addEvent()` which we currently don't support.
+        // Ref.: https://github.com/open-telemetry/opentelemetry-swift/blob/1.13.0/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift#L356
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+
     func end() {
         end(time: Date())
     }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
@@ -144,4 +144,18 @@ internal class OTelSpanBuilder: OpenTelemetryApi.SpanBuilder {
         attributes[key] = value
         return self
     }
+
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) throws -> T) rethrows -> T {
+        // TODO: RUM-8558 - implement
+        fatalError()
+    }
+
+#if canImport(_Concurrency)
+    /// Ref.: https://github.com/open-telemetry/opentelemetry-swift/issues/578
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
+        // TODO: RUM-8558 - implement
+        fatalError()
+    }
+#endif
 }

--- a/DatadogTrace/Tests/OpenTelemetry/OTelAttributeValue+DatadogTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelAttributeValue+DatadogTests.swift
@@ -71,15 +71,12 @@ final class OTelAttributeValueDatadogTests: XCTestCase {
             "key2": .string("value1"),
             "key3": .int(2),
             "key4": .double(3.0),
-            "key5": .stringArray(["value5", "value6"]),
-            "key6": .boolArray([true, false]),
-            "key7": .intArray([7, 8]),
-            "key8": .doubleArray([8.0, 9.0]),
+            "key5": .array(.init(values: [.string("value5"), .string("value6")])),
+            "key6": .array(.init(values: [.bool(true), .bool(false)])),
+            "key7": .array(.init(values: [.int(7), .int(8)])),
+            "key8": .array(.init(values: [.double(8.0), .double(9.0)])),
             "key9": .set(.init(labels: [:])),
-            "key10": .stringArray([]),
-            "key11": .boolArray([]),
-            "key12": .intArray([]),
-            "key13": .doubleArray([]),
+            "key10": .array(.init(values: [])),
         ]
 
         // When
@@ -102,9 +99,6 @@ final class OTelAttributeValueDatadogTests: XCTestCase {
             "key8.1": "9.0",
             "key9": "",
             "key10": "",
-            "key11": "",
-            "key12": "",
-            "key13": "",
         ]
         DDAssertDictionariesEqual(expectedTags, tags)
     }
@@ -121,10 +115,10 @@ final class OTelAttributeValueDatadogTests: XCTestCase {
             "key\(level)-1": .string("value1"),
             "key\(level)-2": .int(2),
             "key\(level)-3": .double(3.0),
-            "key\(level)-4": .stringArray(["value4", "value5"]),
-            "key\(level)-5": .boolArray([true, false]),
-            "key\(level)-6": .intArray([7, 8]),
-            "key\(level)-7": .doubleArray([7.0, 8.0]),
+            "key\(level)-4": .array(.init(values: [.string("value4"), .string("value5")])),
+            "key\(level)-5": .array(.init(values: [.bool(true), .bool(false)])),
+            "key\(level)-6": .array(.init(values: [.int(7), .int(8)])),
+            "key\(level)-7": .array(.init(values: [.double(7.0), .double(8.0)])),
             "key\(level)-8": .set(.init(labels: makeAttributes(level: level - 1)))
         ]
     }

--- a/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
@@ -228,6 +228,26 @@ final class OTelSpanTests: XCTestCase {
         XCTAssertEqual(child.parentID, parent.spanID)
     }
 
+    func testWithActiveSpan() throws {
+        // Given
+        let tracer: DatadogTracer = .mockWith(featureScope: featureScope)
+
+        // When
+        tracer.spanBuilder(spanName: "Parent").withActiveSpan { _ in
+            let childSpan = tracer.spanBuilder(spanName: "Child").startSpan()
+            childSpan.end()
+        }
+
+        // Then
+        let recordedSpans = try featureScope.spanEventsWritten()
+        XCTAssertEqual(recordedSpans.count, 2)
+        let child = recordedSpans.first!
+        let parent = recordedSpans.last!
+        XCTAssertEqual(child.traceID, parent.traceID)
+        XCTAssertNil(parent.parentID)
+        XCTAssertEqual(child.parentID, parent.spanID)
+    }
+
     func testParentIds_givenDisjointSpans() throws {
         // Given
         let tracer: DatadogTracer = .mockWith(featureScope: featureScope)

--- a/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
+++ b/DatadogTrace/Tests/OpenTelemetry/OTelSpanTests.swift
@@ -207,7 +207,6 @@ final class OTelSpanTests: XCTestCase {
         XCTAssertEqual(child.parentID, nil)
     }
 
-    /// TODO: RUM-4795 This test is currently disabled as it proves to be flaky.
     func testSetActive_givenParentSpan() throws {
         // Given
         let tracer: DatadogTracer = .mockWith(featureScope: featureScope)

--- a/Package.swift
+++ b/Package.swift
@@ -3,21 +3,34 @@
 import PackageDescription
 import Foundation
 
-let opentelemetry = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil ? 
+// If the `OTEL_SWIFT` environment variable is set, `dd-sdk-ios` will be compiled against `OpenTelemetryApi` 
+// from https://github.com/open-telemetry/opentelemetry-swift, which includes the full OpenTelemetry SDK.
+// Otherwise, it will use our lightweight mirror from https://github.com/DataDog/opentelemetry-swift-packages.
+//
+// This split is driven by feedback from https://github.com/DataDog/dd-sdk-ios/issues/1877, where 
+// users reported that fetching the full OpenTelemetry SDK significantly increased dependency size. 
+//
+// By using this environment variable, `dd-sdk-ios` consumers can choose whether to depend on the entire 
+// OpenTelemetry SDK or just the API. This remains necessary until OpenTelemetry officially separates 
+// the API and SDK packages (see https://github.com/open-telemetry/opentelemetry-swift/issues/486).
+let useOTelSwiftPackage = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil
+
+let opentelemetry = useOTelSwiftPackage ? 
     (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git") :
     (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git")
+
+// `dd-sdk-ios` supports a broader range of platform versions than `OpenTelemetryApi`. 
+// When compiled in `OTEL_SWIFT` mode, we need to adjust the supported platforms accordingly.
+let platforms: [SupportedPlatform] = useOTelSwiftPackage ?
+    [.iOS(.v13), .tvOS(.v13), .macOS(.v12), .watchOS(.v7)] :
+    [.iOS(.v12), .tvOS(.v12), .macOS(.v12), .watchOS(.v7)]
 
 let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["DD_BENCHMARK"] != nil ?
     [.define("DD_BENCHMARK")] : []
 
 let package = Package(
     name: "Datadog",
-    platforms: [
-        .iOS(.v12),
-        .tvOS(.v12),
-        .macOS(.v12),
-        .watchOS(.v7)
-    ],
+    platforms: platforms,
     products: [
         .library(
             name: "DatadogCore",

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.12.0"),
-        .package(url: opentelemetry.url, exact: "1.6.0"),
+        .package(url: opentelemetry.url, exact: "1.13.0"),
     ],
     targets: [
         .target(

--- a/SmokeTests/cocoapods/Podfile.src
+++ b/SmokeTests/cocoapods/Podfile.src
@@ -1,5 +1,5 @@
 abstract_target 'Common' do
-  pod 'OpenTelemetrySwiftApi', '1.6.0'
+  pod 'OpenTelemetrySwiftApi', '1.13.0'
   pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE
   pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE
   pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE


### PR DESCRIPTION
### What and why?

📦 This PR updates `DatadogTrace` to use `OpenTelemetryApi` [**1.13.0**](https://github.com/DataDog/opentelemetry-swift-packages/releases/tag/1.13.0).

This addresses [#2190](https://github.com/DataDog/dd-sdk-ios/issues/2190).

### How?

The new `OpenTelemetryApi` version was published in [opentelemetry-swift-packages#27](https://github.com/DataDog/opentelemetry-swift-packages/pull/27), and this PR integrates it into `dd-sdk-ios`.

#### Platform Versions Alignment

Since `1.6.0` (our previous `OpenTelemetryApi` dependency version), `open-telemetry-swift` introduced a breaking change in supported platforms, raising the minimum deployment targets from `.iOS(11)` and `.tvOS(11)` to `.iOS(13)` and `.tvOS(13)`. Because our SDK supports `.iOS(12)` and `.tvOS(12)`, this required adding a patch in `Package.swift` to conditionally adjust `platforms` when the `OTEL_SWIFT` environment variable is set. I used this as an opportunity to add comments and better document this flag. In our repository, this is leveraged in `BenchmarkTests`.

#### New `OTelSpanBuilder` APIs

This update introduces the following `OTelSpanBuilder` APIs. Their implementation in this PR follows [otel-swift](https://github.com/open-telemetry/opentelemetry-swift/blob/af8a035d3c462fcbcdb0b96b862966bb7b68eca7/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift#L164-L187), delegating active span management to `OpenTelemetry.instance.contextProvider`:

```swift
func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) throws -> T) rethrows -> T

func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T
```

This PR adds test coverage for these new APIs and also re-enables `OTelSpanTests/testSetActive_givenParentSpan()`, which was disabled in [#1881](https://github.com/DataDog/dd-sdk-ios/pull/1881) due to flaky performance. The updated `OpenTelemetryApi` refines active span management, so performance should now be stable.

#### New `OTelSpan` APIs

The update also introduces new `OTelSpan` APIs:
```swift
func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date)

func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String: OpenTelemetryApi.AttributeValue])

func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date)

func recordException(_ exception: any OpenTelemetryApi.SpanException)
```

These APIs are **not implemented** in this PR because their proper implementation [depends on](https://github.com/open-telemetry/opentelemetry-swift/blob/1.13.0/Sources/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift#L356) the `addEvent()` API, which is not yet supported in our OTel integration.

#### Deprecated OTel APIs

The latest `OpenTelemetryApi` deprecates the following attribute array creation methods:
```swift
.stringArray(_:)
.boolArray(_:)
.intArray(_:)
.doubleArray(_:)
```
These have been replaced with a more uniform `.array(.init(values: []))` API. This PR updates our test suite to use the new `.array()` format and removes dependencies on deprecated APIs.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
