### PR TITLE
RUM-8442 Add Benchmark Metric Meters

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		D231DCF52C73356E00F3F66C /* WebViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D231DCAA2C73356D00F3F66C /* WebViewController.storyboard */; };
 		D231DCF62C73356E00F3F66C /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DCAB2C73356D00F3F66C /* WebViewController.swift */; };
 		D231DCF92C7342D500F3F66C /* ModuleBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DCF82C7342D500F3F66C /* ModuleBundle.swift */; };
+		D23734972D773DD8004CCAED /* BenchmarkMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23734962D773DD1004CCAED /* BenchmarkMeter.swift */; };
 		D23DD32D2C58D80C00B90C4C /* DatadogBenchmarks in Frameworks */ = {isa = PBXBuildFile; productRef = D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */; };
 		D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */; };
 		D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */; };
@@ -312,6 +313,7 @@
 		D231DCAB2C73356D00F3F66C /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		D231DCF82C7342D500F3F66C /* ModuleBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleBundle.swift; sourceTree = "<group>"; };
 		D231DCFA2C735FC200F3F66C /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		D23734962D773DD1004CCAED /* BenchmarkMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMeter.swift; sourceTree = "<group>"; };
 		D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticScenario.swift; sourceTree = "<group>"; };
 		D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
 		D26DD6E62D0C774000D96148 /* DatadogMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogMonitor.swift; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				D29F754F2C4AA07E00288638 /* AppDelegate.swift */,
 				D276069D2C514F37002D2A14 /* AppConfiguration.swift */,
 				D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */,
+				D23734962D773DD1004CCAED /* BenchmarkMeter.swift */,
 				D276069C2C514F37002D2A14 /* Scenarios */,
 				D29F755D2C4AA08000288638 /* Info.plist */,
 			);
@@ -1285,6 +1288,7 @@
 				D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */,
 				D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */,
 				D27606A32C514F37002D2A14 /* Scenario.swift in Sources */,
+				D23734972D773DD8004CCAED /* BenchmarkMeter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -13,9 +13,6 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import DatadogExporter
 
-let instrumentationName = "benchmarks"
-let instrumentationVersion = "1.0.0"
-
 /// Benchmark entrypoint to configure opentelemetry with metrics meters
 /// and tracer.
 public enum Benchmarks {
@@ -75,79 +72,38 @@ public enum Benchmarks {
         }
     }
 
-    /// Configure OpenTelemetry metrics meter and start measuring Memory.
+    /// Configure an OpenTelemetry meter provider.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func enableMetrics(with configuration: Configuration) {
+    public static func metricsProvider(with configuration: Configuration) -> MeterProvider {
         let metricExporter = MetricExporter(
             configuration: MetricExporter.Configuration(
                 apiKey: configuration.apiKey,
-                version: instrumentationVersion
+                version: configuration.context.applicationVersion
             )
         )
 
-        let meterProvider = MeterProviderBuilder()
+        return MeterProviderBuilder()
             .with(pushInterval: 10)
             .with(processor: MetricProcessorSdk())
             .with(exporter: metricExporter)
-            .with(resource: Resource())
+            .with(resource: Resource(attributes: [
+                "device_model": .string(configuration.context.deviceModel),
+                "os": .string(configuration.context.osName),
+                "os_version": .string(configuration.context.osVersion),
+                "run": .string(configuration.context.run),
+                "scenario": .string(configuration.context.scenario),
+                "application_id": .string(configuration.context.applicationIdentifier),
+                "sdk_version": .string(configuration.context.sdkVersion),
+                "branch": .string(configuration.context.branch),
+            ]))
             .build()
-
-        let meter = meterProvider.get(
-            instrumentationName: instrumentationName,
-            instrumentationVersion: instrumentationVersion
-        )
-
-        let labels = [
-            "device_model": configuration.context.deviceModel,
-            "os": configuration.context.osName,
-            "os_version": configuration.context.osVersion,
-            "run": configuration.context.run,
-            "scenario": configuration.context.scenario,
-            "application_id": configuration.context.applicationIdentifier,
-            "sdk_version": configuration.context.sdkVersion,
-            "branch": configuration.context.branch,
-        ]
-
-        let queue = DispatchQueue(label: "com.datadoghq.benchmarks.metrics", qos: .utility)
-
-        let memory = Memory(queue: queue)
-        _ = meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
-            // report the maximum memory footprint that was recorded during push interval
-            if let value = memory.aggregation?.max {
-                metric.observe(value: value, labels: labels)
-            }
-
-            memory.reset()
-        }
-
-        let cpu = CPU(queue: queue)
-        _ = meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
-            // report the average cpu usage that was recorded during push interval
-            if let value = cpu.aggregation?.avg {
-                metric.observe(value: value, labels: labels)
-            }
-
-            cpu.reset()
-        }
-
-        let fps = FPS()
-        _ = meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
-            // report the minimum frame rate that was recorded during push interval
-            if let value = fps.aggregation?.min {
-                metric.observe(value: value, labels: labels)
-            }
-
-            fps.reset()
-        }
-
-        OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
     }
 
-    /// Configure and register a OpenTelemetry Tracer.
+    /// Configure an OpenTelemetry tracer provider.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func enableTracer(with configuration: Configuration) {
+    public static func tracerProvider(with configuration: Configuration) -> TracerProvider {
         let exporterConfiguration = ExporterConfiguration(
             serviceName: configuration.context.applicationIdentifier,
             resource: "Benchmark Tracer",
@@ -162,10 +118,8 @@ public enum Benchmarks {
         let exporter = try! DatadogExporter(config: exporterConfiguration)
         let processor = SimpleSpanProcessor(spanExporter: exporter)
 
-        let provider = TracerProviderBuilder()
+        return TracerProviderBuilder()
             .add(spanProcessor: processor)
             .build()
-
-        OpenTelemetry.registerTracerProvider(tracerProvider: provider)
     }
 }

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -75,7 +75,7 @@ public enum Benchmarks {
     /// Configure an OpenTelemetry meter provider.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func metricsProvider(with configuration: Configuration) -> MeterProvider {
+    public static func meterProvider(with configuration: Configuration) -> MeterProvider {
         let metricExporter = MetricExporter(
             configuration: MetricExporter.Configuration(
                 apiKey: configuration.apiKey,

--- a/BenchmarkTests/Benchmarks/Sources/Metrics.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Metrics.swift
@@ -12,33 +12,33 @@ import QuartzCore
 let TASK_VM_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
 let TASK_VM_INFO_REV1_COUNT = mach_msg_type_number_t(MemoryLayout.offset(of: \task_vm_info_data_t.min_address)! / MemoryLayout<integer_t>.size)
 
-internal enum MachError: Error {
+public enum MachError: Error {
     case task_info(return: kern_return_t)
     case task_threads(return: kern_return_t)
     case thread_info(return: kern_return_t)
 }
 
 /// Aggregate metric values and compute `min`, `max`, `sum`, `avg`, and `count`.
-internal class MetricAggregator<T> where T: Numeric {
-    internal struct Aggregation {
-        let min: T
-        let max: T
-        let sum: T
-        let count: Int
-        let avg: Double
+public class MetricAggregator<T> where T: Numeric {
+    public struct Aggregation {
+        public let min: T
+        public let max: T
+        public let sum: T
+        public let count: Int
+        public let avg: Double
     }
 
     private var mutex = pthread_mutex_t()
     private var _aggregation: Aggregation?
 
-    var aggregation: Aggregation? {
+    public var aggregation: Aggregation? {
         pthread_mutex_lock(&mutex)
         defer { pthread_mutex_unlock(&mutex) }
         return _aggregation
     }
 
     /// Resets the minimum frame rate to `nil`.
-    func reset() {
+    public func reset() {
         pthread_mutex_lock(&mutex)
         _aggregation = nil
         pthread_mutex_unlock(&mutex)
@@ -53,7 +53,7 @@ extension MetricAggregator where T: BinaryInteger {
     /// Records a `BinaryInteger` value.
     ///
     /// - Parameter value: The value to record.
-    func record(value: T) {
+    public func record(value: T) {
         pthread_mutex_lock(&mutex)
         _aggregation = _aggregation.map {
             let sum = $0.sum + value
@@ -74,7 +74,7 @@ extension MetricAggregator where T: BinaryFloatingPoint {
     /// Records a `BinaryFloatingPoint` value.
     ///
     /// - Parameter value: The value to record.
-    func record(value: T) {
+    internal func record(value: T) {
         pthread_mutex_lock(&mutex)
         _aggregation = _aggregation.map {
             let sum = $0.sum + value
@@ -94,7 +94,7 @@ extension MetricAggregator where T: BinaryFloatingPoint {
 /// Collect Memory footprint metric.
 ///
 /// Based on a timer, the `Memory` aggregator will periodically record the memory footprint.
-internal final class Memory: MetricAggregator<Double> {
+public final class Memory: MetricAggregator<Double> {
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
 
@@ -107,7 +107,7 @@ internal final class Memory: MetricAggregator<Double> {
     ///   - queue: The queue on which to execute the timer handler.
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
-    required init(
+    public required init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
@@ -158,7 +158,7 @@ internal final class Memory: MetricAggregator<Double> {
 /// Collect CPU usage metric.
 ///
 /// Based on a timer, the `CPU` aggregator will periodically record the CPU usage.
-internal final class CPU: MetricAggregator<Double> {
+public final class CPU: MetricAggregator<Double> {
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
 
@@ -171,7 +171,7 @@ internal final class CPU: MetricAggregator<Double> {
     ///   - queue: The queue on which to execute the timer handler.
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
-    init(
+    public required init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
@@ -241,7 +241,7 @@ internal final class CPU: MetricAggregator<Double> {
 }
 
 /// Collect Frame rate metric based on ``CADisplayLinker`` timer.
-internal final class FPS: MetricAggregator<Int> {
+public final class FPS: MetricAggregator<Int> {
     private class CADisplayLinker {
         weak var fps: FPS?
 
@@ -260,7 +260,7 @@ internal final class FPS: MetricAggregator<Int> {
 
     private var displayLink: CADisplayLink
 
-    override init() {
+    override public init() {
         let linker = CADisplayLinker()
         displayLink = CADisplayLink(target: linker, selector: #selector(CADisplayLinker.tick(link:)))
         super.init()

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Collect metrics during all run
         let meter = Meter(
-            provider: Benchmarks.metricsProvider(
+            provider: Benchmarks.meterProvider(
                 with: Benchmarks.Configuration(
                     info: applicationInfo,
                     scenario: scenario,

--- a/BenchmarkTests/Runner/BenchmarkMeter.swift
+++ b/BenchmarkTests/Runner/BenchmarkMeter.swift
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+import DatadogBenchmarks
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+internal final class Meter: DatadogInternal.BenchmarkMeter {
+    let meter: OpenTelemetryApi.Meter
+
+    let queue = DispatchQueue(label: "com.datadoghq.benchmarks.metrics", target: .global(qos: .utility))
+
+    init(provider: MeterProvider) {
+        self.meter = provider.get(
+            instrumentationName: "benchmarks",
+            instrumentationVersion: nil
+        )
+    }
+
+    @discardableResult
+    func observeMemory() -> OpenTelemetryApi.DoubleObserverMetric {
+        let memory = Memory(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
+            // report the maximum memory footprint that was recorded during push interval
+            if let value = memory.aggregation?.max {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            memory.reset()
+        }
+    }
+
+    @discardableResult
+    func observeCPU() -> OpenTelemetryApi.DoubleObserverMetric {
+        let cpu = CPU(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
+            // report the average cpu usage that was recorded during push interval
+            if let value = cpu.aggregation?.avg {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            cpu.reset()
+        }
+    }
+
+    @discardableResult
+    func observeFPS() -> OpenTelemetryApi.IntObserverMetric {
+        let fps = FPS()
+        return meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
+            // report the minimum frame rate that was recorded during push interval
+            if let value = fps.aggregation?.min {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            fps.reset()
+        }
+    }
+
+    func counter(metric: @autoclosure () -> String) -> any DatadogInternal.BenchmarkIntegerCounter {
+        let counter = meter.createIntCounter(name: metric())
+        return CounterWrapper(counter: counter)
+    }
+}
+
+private final class CounterWrapper<Value> {
+    let counter: OpenTelemetryApi.AnyCounterMetric<Value>
+
+    init(counter: AnyCounterMetric<Value>) {
+        self.counter = counter
+    }
+}
+
+extension CounterWrapper: DatadogInternal.BenchmarkIntegerCounter where Value: BinaryInteger {
+    func add(value: Int, attributes: @autoclosure () -> [String: String]) {
+        counter.add(value: Value(value), labelset: LabelSet(labels: attributes()))
+    }
+}

--- a/BenchmarkTests/Runner/BenchmarkMeter.swift
+++ b/BenchmarkTests/Runner/BenchmarkMeter.swift
@@ -61,22 +61,23 @@ internal final class Meter: DatadogInternal.BenchmarkMeter {
         }
     }
 
-    func counter(metric: @autoclosure () -> String) -> any DatadogInternal.BenchmarkIntegerCounter {
-        let counter = meter.createIntCounter(name: metric())
-        return CounterWrapper(counter: counter)
+    func counter(metric: @autoclosure () -> String) -> DatadogInternal.BenchmarkCounter {
+        meter.createDoubleCounter(name: metric())
+    }
+
+    func gauge(metric: @autoclosure () -> String) -> DatadogInternal.BenchmarkGauge {
+        meter.createDoubleMeasure(name: metric())
     }
 }
 
-private final class CounterWrapper<Value> {
-    let counter: OpenTelemetryApi.AnyCounterMetric<Value>
-
-    init(counter: AnyCounterMetric<Value>) {
-        self.counter = counter
+extension AnyCounterMetric<Double>: DatadogInternal.BenchmarkCounter {
+    public func add(value: Double, attributes: @autoclosure () -> [String: String]) {
+        add(value: value, labelset: LabelSet(labels: attributes()))
     }
 }
 
-extension CounterWrapper: DatadogInternal.BenchmarkIntegerCounter where Value: BinaryInteger {
-    func add(value: Int, attributes: @autoclosure () -> [String: String]) {
-        counter.add(value: Value(value), labelset: LabelSet(labels: attributes()))
+extension AnyMeasureMetric<Double>: DatadogInternal.BenchmarkGauge {
+    public func record(value: Double, attributes: @autoclosure () -> [String: String]) {
+        record(value: value, labelset: LabelSet(labels: attributes()))
     }
 }

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -72,6 +72,8 @@ internal struct FileWriter: Writer {
 
         do {
             try file.append(data: encoded)
+            bench.meter.counter(metric: "ios.benchmark.bytes_written")
+                .add(value: encoded.count, attributes: ["track": orchestrator.trackName])
         } catch {
             DD.logger.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)
             telemetry.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -72,8 +72,10 @@ internal struct FileWriter: Writer {
 
         do {
             try file.append(data: encoded)
+#if DD_BENCHMARK
             bench.meter.counter(metric: "ios.benchmark.bytes_written")
-                .add(value: encoded.count, attributes: ["track": orchestrator.trackName])
+                .increment(by: encoded.count, attributes: ["track": orchestrator.trackName])
+#endif
         } catch {
             DD.logger.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)
             telemetry.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)


### PR DESCRIPTION
### What and why?

To measure the upload capacity of the SDK, we plan to gather more metrics from its internals during benchmarking. This involves designing an interface to create simple meters during benchmark runs, allowing us to track internal metrics like bytes written per feature.

### How?

#### `Benchmarks` Library Interface

This update involves refactoring the [Benchmarks Library](BenchmarkTests/Benchmarks/Sources/Benchmarks.swift) to create only the `MetricProvider` and `TracerProvider` using the provided configuration.

Now, the CPU, Memory, and FPS measurements are handled by the `Runner` application using the created `MetricProvider`.

#### `BenchmarkMeter` protocol

The `DatadogInternal` now provides the `BenchmarkMeter` protocol, which modules can use to create meters for specific metrics. The concrete implementation of `BenchmarkMeter` is accessible via the static variable `bench.meter`.

The `DatadogCore` module includes an example demonstrating how to use a counter:

```swift
bench.meter.counter(metric: "ios.benchmark.bytes_written")
     .increment(by: encoded.count, attributes: ["track": orchestrator.trackName])
```

#### `BenchmarkProfiler` implementation

Not related to metric meters, this PR also include an actual implementation of `BenchmarkProfiler` using otel tracer.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
