### PR TITLE
RUM-8448 Benchmarks Additional Metrics

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1691,6 +1691,8 @@
 		D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
 		D2DE63532A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
 		D2DE63542A30A7CA00441A54 /* CoreRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */; };
+		D2E6E8FB2D8039BB00FF1398 /* BenchmarkURLSessionTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6E8FA2D8039B200FF1398 /* BenchmarkURLSessionTaskDelegate.swift */; };
+		D2E6E8FC2D8039BB00FF1398 /* BenchmarkURLSessionTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6E8FA2D8039B200FF1398 /* BenchmarkURLSessionTaskDelegate.swift */; };
 		D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */; };
 		D2EBEE1F29BA160F00B15732 /* HTTPHeadersReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */; };
 		D2EBEE2029BA160F00B15732 /* TracePropagationHeadersWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */; };
@@ -3087,6 +3089,7 @@
 		D2DA23C9298D5C1300C6C7E6 /* UIKitMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitMocks.swift; sourceTree = "<group>"; };
 		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2DE63522A30A7CA00441A54 /* CoreRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRegistry.swift; sourceTree = "<group>"; };
+		D2E6E8FA2D8039B200FF1398 /* BenchmarkURLSessionTaskDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkURLSessionTaskDelegate.swift; sourceTree = "<group>"; };
 		D2E8D59728C7AB90007E5DE1 /* ContextMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayConfiguration.swift; sourceTree = "<group>"; };
 		D2EBEDCC29B893D800B15732 /* TraceID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceID.swift; sourceTree = "<group>"; };
@@ -4999,6 +5002,7 @@
 		6174D6082BFDDD1E00EC7469 /* SDKMetrics */ = {
 			isa = PBXGroup;
 			children = (
+				D2E6E8FA2D8039B200FF1398 /* BenchmarkURLSessionTaskDelegate.swift */,
 				614396712A67D74F00197326 /* BatchMetrics.swift */,
 			);
 			path = SDKMetrics;
@@ -7967,6 +7971,7 @@
 				D2FB1254292E0E96005B13F8 /* TrackingConsentPublisher.swift in Sources */,
 				61D3E0D6277B23F1008BE766 /* KronosClock.swift in Sources */,
 				D2A7841129A53B2F003B03BB /* File.swift in Sources */,
+				D2E6E8FB2D8039BB00FF1398 /* BenchmarkURLSessionTaskDelegate.swift in Sources */,
 				D286626E2A43487500852CE3 /* Datadog.swift in Sources */,
 				61F930C22BA1C41A005F0EE2 /* TLVBlockReader.swift in Sources */,
 				613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */,
@@ -9284,6 +9289,7 @@
 				D2CB6E5527C50EAE00A62B57 /* KronosNSTimer+ClosureKit.swift in Sources */,
 				D2CB6E6627C50EAE00A62B57 /* Reader.swift in Sources */,
 				D2CB6E6927C50EAE00A62B57 /* KronosDNSResolver.swift in Sources */,
+				D2E6E8FC2D8039BB00FF1398 /* BenchmarkURLSessionTaskDelegate.swift in Sources */,
 				D286626F2A43487500852CE3 /* Datadog.swift in Sources */,
 				61F930C32BA1C41A005F0EE2 /* TLVBlockReader.swift in Sources */,
 				D2A7841229A53B2F003B03BB /* File.swift in Sources */,

--- a/DatadogCore/Sources/Core/Storage/Files/File.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/File.swift
@@ -35,6 +35,9 @@ internal protocol ReadableFile {
     /// Name of this file.
     var name: String { get }
 
+    /// Current size of this file.
+    func size() throws -> UInt64
+
     /// Creates InputStream for reading the available data from this file.
     func stream() throws -> InputStream
 

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -211,6 +211,12 @@ internal class FilesOrchestrator: FilesOrchestratorType {
 
     func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) {
         do {
+#if DD_BENCHMARK
+            if case .intakeCode = deletionReason {
+                try bench.meter.counter(metric: "ios.benchmark.bytes_deleted")
+                    .increment(by: readableFile.size(), attributes: ["track": trackName])
+            }
+#endif
             try readableFile.delete()
             // Decrement pending batches at each batch deletion
             _pendingBatches.mutate { $0 -= 1 }

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -80,6 +80,15 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         self.dateProvider = dateProvider
         self.telemetry = telemetry
         self.metricsData = metricsData
+
+#if DD_BENCHMARK
+        bench.meter.observe(metric: "ios.benchmark.batch_count") {[weak self] gauge in
+            if let self {
+                let files = try? directory.files()
+                files.map { gauge.record($0.count, attributes: ["track": self.trackName]) }
+            }
+        }
+#endif
     }
 
     // MARK: - `WritableFile` orchestration

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -139,6 +139,10 @@ internal class DataUploadWorker: DataUploadWorkerType {
                         batch,
                         reason: .intakeCode(responseCode: uploadStatus.responseCode)
                     )
+#if DD_BENCHMARK
+                    bench.meter.counter(metric: "ios.benchmark.upload_count")
+                        .increment(attributes: ["track": self.featureName])
+#endif
 
                     previousUploadStatus = nil
 

--- a/DatadogCore/Sources/Core/Upload/DataUploader.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploader.swift
@@ -58,7 +58,13 @@ internal final class DataUploader: DataUploaderType {
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        httpClient.send(request: request) { result in
+#if DD_BENCHMARK
+        let delegate: URLSessionTaskDelegate = BenchmarkURLSessionTaskDelegate(track: featureName)
+#else
+        let delegate: URLSessionTaskDelegate? = nil
+#endif
+
+        httpClient.send(request: request, delegate: delegate) { result in
             switch result {
             case .success(let httpResponse):
                 uploadStatus = DataUploadStatus(

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -30,7 +30,8 @@ internal struct FeatureUpload {
 
         let dataUploader = DataUploader(
             httpClient: httpClient,
-            requestBuilder: requestBuilder
+            requestBuilder: requestBuilder,
+            featureName: featureName
         )
 
         #if canImport(UIKit)

--- a/DatadogCore/Sources/Core/Upload/HTTPClient.swift
+++ b/DatadogCore/Sources/Core/Upload/HTTPClient.swift
@@ -11,6 +11,17 @@ internal protocol HTTPClient {
     /// Sends the provided request using HTTP.
     /// - Parameters:
     ///   - request: The request to be sent.
+    ///   - delegate: The task-specific delegate.
     ///   - completion: A closure that receives a Result containing either an HTTPURLResponse or an Error.
-    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+}
+
+extension HTTPClient {
+    /// Sends the provided request using HTTP.
+    /// - Parameters:
+    ///   - request: The request to be sent.
+    ///   - completion: A closure that receives a Result containing either an HTTPURLResponse or an Error.
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        self.send(request: request, delegate: nil, completion: completion)
+    }
 }

--- a/DatadogCore/Sources/Core/Upload/URLSessionClient.swift
+++ b/DatadogCore/Sources/Core/Upload/URLSessionClient.swift
@@ -35,9 +35,12 @@ internal class URLSessionClient: HTTPClient {
         self.session = session
     }
 
-    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
         let task = session.dataTask(with: request) { data, response, error in
             completion(httpClientResult(for: (data, response, error)))
+        }
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, *) {
+            task.delegate = delegate
         }
         task.resume()
     }

--- a/DatadogCore/Sources/SDKMetrics/BenchmarkURLSessionTaskDelegate.swift
+++ b/DatadogCore/Sources/SDKMetrics/BenchmarkURLSessionTaskDelegate.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Common definitions forcallencting metrics during benchmark execution..
+internal final class BenchmarkURLSessionTaskDelegate: NSObject, URLSessionTaskDelegate {
+    let track: String
+
+    init(track: String) {
+        self.track = track
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        bench.meter.gauge(metric: "ios.benchmark.reponse_latency")
+            .record(metrics.taskInterval.duration, attributes: ["track": track])
+    }
+}

--- a/DatadogCore/Sources/SDKMetrics/BenchmarkURLSessionTaskDelegate.swift
+++ b/DatadogCore/Sources/SDKMetrics/BenchmarkURLSessionTaskDelegate.swift
@@ -4,10 +4,12 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if DD_BENCHMARK
+
 import Foundation
 import DatadogInternal
 
-/// Common definitions forcallencting metrics during benchmark execution..
+/// `URLSessionTaskDelegate` implementation to collect network request metrics during benchmark execution.
 internal final class BenchmarkURLSessionTaskDelegate: NSObject, URLSessionTaskDelegate {
     let track: String
 
@@ -20,3 +22,5 @@ internal final class BenchmarkURLSessionTaskDelegate: NSObject, URLSessionTaskDe
             .record(metrics.taskInterval.duration, attributes: ["track": track])
     }
 }
+
+#endif

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -765,7 +765,8 @@ class DataUploadWorkerTests: XCTestCase {
 
         let dataUploader = DataUploader(
             httpClient: httpClient,
-            requestBuilder: FeatureRequestBuilderMock()
+            requestBuilder: FeatureRequestBuilderMock(),
+            featureName: .mockRandom()
         )
         let worker = DataUploadWorker(
             queue: uploaderQueue,

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -21,7 +21,8 @@ class DataUploaderTests: XCTestCase {
 
         let uploader = DataUploader(
             httpClient: HTTPClientMock(response: randomResponse),
-            requestBuilder: FeatureRequestBuilderMock(request: randomRequest)
+            requestBuilder: FeatureRequestBuilderMock(request: randomRequest),
+            featureName: .mockRandom()
         )
 
         // When
@@ -50,7 +51,8 @@ class DataUploaderTests: XCTestCase {
 
         let uploader = DataUploader(
             httpClient: HTTPClientMock(error: randomError),
-            requestBuilder: FeatureRequestBuilderMock(request: randomRequest)
+            requestBuilder: FeatureRequestBuilderMock(request: randomRequest),
+            featureName: .mockRandom()
         )
 
         // When
@@ -72,7 +74,8 @@ class DataUploaderTests: XCTestCase {
 
         let uploader = DataUploader(
             httpClient: HTTPClientMock(),
-            requestBuilder: FailingRequestBuilderMock(error: error)
+            requestBuilder: FailingRequestBuilderMock(error: error),
+            featureName: .mockRandom()
         )
 
         // When & Then

--- a/DatadogCore/Tests/Datadog/Mocks/HTTPClientMock.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/HTTPClientMock.swift
@@ -42,7 +42,7 @@ internal class HTTPClientMock: HTTPClient {
 
     // MARK: - HTTPClient conformance
 
-    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    func send(request: URLRequest, delegate: URLSessionTaskDelegate?, completion: @escaping (Result<HTTPURLResponse, any Error>) -> Void) {
         queue.async {
             completion(self.result(request))
             self.requests.append(request)

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -56,6 +56,8 @@ public protocol BenchmarkMeter {
     /// - Parameter metric: The metric name.
     /// - Returns: The gauge instance.
     func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge
+
+    func observe(metric: @autoclosure () -> String, callback: @escaping (BenchmarkGauge) -> Void )
 }
 
 /// The Benchmark Tracer will create and start spans in a benchmark environment.
@@ -136,6 +138,8 @@ private final class NOPBench: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan,
     func counter(metric: @autoclosure () -> String) -> BenchmarkCounter { self }
     /// no-op
     func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge { self }
+    /// no-op
+    func observe(metric: @autoclosure () -> String, callback: @escaping (any BenchmarkGauge) -> Void) { }
     /// no-op
     func add(value: Double, attributes: @autoclosure () -> [String: String]) { }
     /// no-op

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -57,6 +57,11 @@ public protocol BenchmarkMeter {
     /// - Returns: The gauge instance.
     func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge
 
+    /// Observe a measure value.
+    ///
+    /// - Parameters:
+    ///   - metric: The metric name.
+    ///   - callback: Callback providing a gauge instance to record a value.
     func observe(metric: @autoclosure () -> String, callback: @escaping (BenchmarkGauge) -> Void )
 }
 

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -87,6 +87,11 @@ public protocol BenchmarkCounter {
 }
 
 extension BenchmarkCounter {
+    /// Increment the counter by one.
+    public func increment(attributes: @autoclosure () -> [String: String] = [:]) {
+        add(value: 1, attributes: attributes())
+    }
+
     /// Increment the counter.
     ///
     /// - parameters:
@@ -99,7 +104,7 @@ extension BenchmarkCounter {
     ///
     /// - parameters:
     ///     - by: Amount to increment by.
-    public func increment<Integer>(by amount: Integer = 1, attributes: @autoclosure () -> [String: String] = [:]) where Integer: BinaryInteger {
+    public func increment<Integer>(by amount: Integer, attributes: @autoclosure () -> [String: String] = [:]) where Integer: BinaryInteger {
         add(value: Double(amount), attributes: attributes())
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,7 @@ let package = Package(
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")
             ],
-            swiftSettings: [.define("SPM_BUILD")]
+            swiftSettings: [.define("SPM_BUILD")] + internalSwiftSettings
         ),
         .target(
             name: "DatadogObjc",


### PR DESCRIPTION
### What and why?

Measure Upload Capacity during benchmarks.

### How?

Add custom metrics:
- Bytes Deleted Metric
- Request Count
- Batch Count
- Bytes Uploaded
- Response Latency

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
