### PR TITLE
Fix non-deterministic order in pickers in Benchmark app

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BENCHMARK_SCENARIO"
-            value = "logsCustom"
+            value = "logsHeavyTraffic"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsCustomContentView.swift
+++ b/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsCustomContentView.swift
@@ -38,13 +38,13 @@ struct LogsCustomContentView: View {
                 Section(header: Text("Log Configuration")) {
                     TextField("Log Message", text: $logMessage)
                     Picker("Log Level", selection: $logLevel) {
-                        ForEach(Array(logLevels.keys), id: \.self) { level in
-                            Text(level)
+                        ForEach(logLevels, id: \.1) { level in
+                            Text(level.0).tag(level.0)
                         }
                     }
                     Picker("Payload Size", selection: $payloadSize) {
-                        ForEach(Array(payloadSizes.keys), id: \.self) { size in
-                            Text(size)
+                        ForEach(payloadSizes, id: \.0) { size in
+                            Text(size.0).tag(size.0)
                         }
                     }
                 }
@@ -126,8 +126,8 @@ struct LogsCustomContentView: View {
     func startLogging() {
         isLogging = true
 
-        guard let selectedLogLevel = logLevels[logLevel],
-              let attributes = payloadSizes[payloadSize] else { return }
+        guard let selectedLogLevel = logLevels.first(where: { $0.0 == self.logLevel }),
+              let attributes = payloadSizes.first(where: { $0.0 == self.payloadSize }) else { return }
 
         if isRepeating {
             Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { timer in
@@ -135,10 +135,10 @@ struct LogsCustomContentView: View {
                     timer.invalidate()
                     return
                 }
-                self.logBatch(selectedLogLevel: selectedLogLevel, attributes: attributes)
+                self.logBatch(selectedLogLevel: selectedLogLevel.1, attributes: attributes.1)
             }
         } else {
-            logBatch(selectedLogLevel: selectedLogLevel, attributes: attributes)
+            logBatch(selectedLogLevel: selectedLogLevel.1, attributes: attributes.1)
             isLogging = false
         }
     }

--- a/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsHeavyTrafficContentView.swift
+++ b/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsHeavyTrafficContentView.swift
@@ -47,11 +47,11 @@ struct LogsHeavyTrafficContentView: View {
 
     /// Sends a batch of log messages using the current configuration.
     func log() {
-        guard let selectedLogLevel = logLevels[logLevel],
-              let attributes = payloadSizes[payloadSize] else { return }
+        guard let selectedLogLevel = logLevels.first(where: { $0.0 == self.logLevel }),
+              let attributes = payloadSizes.first(where: { $0.0 == self.payloadSize }) else { return }
 
         for _ in 1 ... self.logsPerBatch {
-            self.logger.log(level: selectedLogLevel, message: self.logMessage, error: nil, attributes: attributes)
+            self.logger.log(level: selectedLogLevel.1, message: self.logMessage, error: nil, attributes: attributes.1)
         }
     }
 }
@@ -104,13 +104,13 @@ struct LogsHeavyTrafficConfigView: View {
                 Section(header: Text("Log Configuration")) {
                     TextField("Log Message", text: $logMessage)
                     Picker("Log Level", selection: $logLevel) {
-                        ForEach(Array(logLevels.keys), id: \.self) { level in
-                            Text(level)
+                        ForEach(logLevels, id: \.1) { level in
+                            Text(level.0).tag(level.0)
                         }
                     }
                     Picker("Payload Size", selection: $payloadSize) {
-                        ForEach(Array(payloadSizes.keys), id: \.self) { size in
-                            Text(size)
+                        ForEach(payloadSizes, id: \.0) { size in
+                            Text(size.0).tag(size.0)
                         }
                     }
                 }

--- a/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsUtils.swift
+++ b/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsUtils.swift
@@ -7,20 +7,20 @@
 import DatadogLogs
 import Foundation
 
-var logLevels: [String: LogLevel] = [
-    "DEBUG": .debug,
-    "INFO": .info,
-    "NOTICE": .notice,
-    "WARN": .warn,
-    "ERROR": .error,
-    "CRITICAL": .critical,
+var logLevels: [(String, LogLevel)] = [
+    ("DEBUG", .debug),
+    ("INFO", .info),
+    ("NOTICE", .notice),
+    ("WARN", .warn),
+    ("ERROR", .error),
+    ("CRITICAL", .critical),
 ]
 
-var payloadSizes: [String: [String: Encodable]] = [
-    "Small": [
+var payloadSizes: [(String, [String: Encodable])] = [
+    ("Small", [
         "log_type": "simple",
-    ],
-    "Medium": [
+    ]),
+    ("Medium", [
         "user": [
             "id": UUID().uuidString,
             "name": "John Doe",
@@ -31,8 +31,8 @@ var payloadSizes: [String: [String: Encodable]] = [
             "os": "iOS 17.0",
         ],
         "log_type": "user_event",
-    ],
-    "Large": [
+    ]),
+    ("Large", [
         "log_type": "user_event",
         "session": [
             "id": UUID().uuidString,
@@ -61,5 +61,5 @@ var payloadSizes: [String: [String: Encodable]] = [
             "stackTrace": "Error at module XYZ -> function ABC",
             "crashType": "NullPointerException",
         ],
-    ],
+    ]),
 ]


### PR DESCRIPTION
### What and why?

The `logLevel` and `payloadSize` pickers did not maintain a consistent order for their options, causing them to reorder each time the app was relaunched. This made running repeatable scenarios in Synthetics very tedious. This PR ensures a deterministic order for these pickers.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
