### PR TITLE
RUM-8656: Update RUM schema and add App Hitches to View events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		116200352D786ED0001C2A51 /* RUMFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116200312D786ED0001C2A51 /* RUMFeatureMocks.swift */; };
 		116F84062CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
 		116F84072CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
+		11BA765D2D7F0EF30058C21C /* RUMViewHitchesIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA765C2D7F0EE40058C21C /* RUMViewHitchesIntegrationTests.swift */; };
+		11BA765E2D7F0EF30058C21C /* RUMViewHitchesIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA765C2D7F0EE40058C21C /* RUMViewHitchesIntegrationTests.swift */; };
 		1434A4612B7F73110072E3BB /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; };
 		1434A4622B7F73110072E3BB /* OpenTelemetryApi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1434A4632B7F73170072E3BB /* OpenTelemetryApi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C1F88222B767CE200821579 /* OpenTelemetryApi.xcframework */; };
@@ -2139,6 +2141,7 @@
 		116200302D786ED0001C2A51 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		116200312D786ED0001C2A51 /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		116F84052CFDD06700705755 /* SampleRateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRateTests.swift; sourceTree = "<group>"; };
+		11BA765C2D7F0EE40058C21C /* RUMViewHitchesIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewHitchesIntegrationTests.swift; sourceTree = "<group>"; };
 		1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOTelTracingViewController.swift; sourceTree = "<group>"; };
 		3C08F9CF2C2D652D002B0FF2 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporter.swift; sourceTree = "<group>"; };
@@ -5430,10 +5433,11 @@
 				A757AE8F2D3815AC00C772FA /* AnonymousIdentifierTests.swift */,
 				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
 				1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */,
+				11BA765C2D7F0EE40058C21C /* RUMViewHitchesIntegrationTests.swift */,
 				61E8C5072B28898800E709B4 /* StartingRUMSessionTests.swift */,
+				6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */,
 				3CA00B062C2AE52400E6FE01 /* WatchdogTerminationsMonitoringTests.swift */,
 				D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */,
-				6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */,
 				61DCC84C2C05D4E500CB59E5 /* SDKMetrics */,
 			);
 			path = RUM;
@@ -8131,6 +8135,7 @@
 				D244B3A3271EDACD003E1B29 /* SwiftUIExtensionsTests.swift in Sources */,
 				D24C9C6429A7CB7B002057CF /* CrashLogReceiverTests.swift in Sources */,
 				61B5E42126DF85C7000B0A5F /* DDRUMMonitor+apiTests.m in Sources */,
+				11BA765D2D7F0EF30058C21C /* RUMViewHitchesIntegrationTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				3CF673362B4807490016CE17 /* OTelSpanTests.swift in Sources */,
 				61F3E36D2BC7D66700C7881E /* HeadBasedSamplingTests.swift in Sources */,
@@ -9383,6 +9388,7 @@
 				D2CB6F2027C520D400A62B57 /* DatadogConfigurationTests.swift in Sources */,
 				D2CB6F2127C520D400A62B57 /* URLSessionClientTests.swift in Sources */,
 				D2CB6F2227C520D400A62B57 /* DatadogTests.swift in Sources */,
+				11BA765E2D7F0EF30058C21C /* RUMViewHitchesIntegrationTests.swift in Sources */,
 				61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */,
 				614798972A459AA80095CB02 /* DDTraceTests.swift in Sources */,
 				D2CB6F2627C520D400A62B57 /* DataUploadDelayTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/RUMViewHitchesIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMViewHitchesIntegrationTests.swift
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogRUM
+@testable import DatadogInternal
+
+final class RUMViewHitchesIntegrationTests: XCTestCase {
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy()
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        super.tearDown()
+    }
+
+    func testViewHitchesNotCollected_whenFeatureFlagIsDisabled() throws {
+        // Given
+        let viewName = "MyView"
+        let rumConfig = RUM.Configuration(applicationID: .mockAny(), featureFlags: [.viewHitches: false])
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        let stopViewEvent = try XCTUnwrap(customView.viewEvents.last) // stopView event
+        XCTAssertNil(stopViewEvent.view.slowFrames)
+    }
+
+    func testViewHitchesCollected_whenFeatureFlagIsEnabled() throws {
+        // Given
+        let viewName = "MyView"
+        let rumConfig = RUM.Configuration(applicationID: .mockAny(), featureFlags: [.viewHitches: true])
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+
+        let completion = expectation(description: "Wait for some slow frames")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            // sleep main thread to have some slow frames
+            Thread.sleep(forTimeInterval: 0.1)
+
+            // schedule completion to the next runloop
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { completion.fulfill() }
+        }
+
+        wait(for: [completion], timeout: 2)
+
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        let stopViewEvent = try XCTUnwrap(customView.viewEvents.last)
+
+        XCTAssertGreaterThan(stopViewEvent.view.slowFrames?.count ?? 0, 0)
+    }
+}

--- a/DatadogCore/Tests/Datadog/Mocks/RUM/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUM/RUMDataModelMocks.swift
@@ -112,6 +112,12 @@ extension RUMViewEvent.DD.Configuration: RandomMockable {
     }
 }
 
+extension RUMViewEvent.View.SlowFrames: RandomMockable {
+    public static func mockRandom() -> RUMViewEvent.View.SlowFrames {
+        .init(duration: .mockRandom(), start: .mockRandom())
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     public static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()
@@ -126,6 +132,7 @@ extension RUMViewEvent: RandomMockable {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
+                cls: nil,
                 configuration: .mockRandom(),
                 documentVersion: .mockRandom(),
                 pageStates: nil,
@@ -179,6 +186,7 @@ extension RUMViewEvent: RandomMockable {
                 firstInputTime: .mockRandom(),
                 flutterBuildTime: nil,
                 flutterRasterTime: nil,
+                freezeRate: .mockRandom(),
                 frozenFrame: .init(count: .mockRandom()),
                 frustration: nil,
                 id: .mockRandom(),
@@ -209,6 +217,8 @@ extension RUMViewEvent: RandomMockable {
                 refreshRateAverage: .mockRandom(),
                 refreshRateMin: .mockRandom(),
                 resource: .init(count: .mockRandom()),
+                slowFrames: .mockRandom(),
+                slowFramesRate: .mockRandom(),
                 timeSpent: viewTimeSpent,
                 url: .mockRandom()
             )

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -4891,6 +4891,10 @@ public class DDRUMViewEventDD: NSObject {
         root.swiftModel.dd.browserSdkVersion
     }
 
+    @objc public var cls: DDRUMViewEventDDCLS? {
+        root.swiftModel.dd.cls != nil ? DDRUMViewEventDDCLS(root: root) : nil
+    }
+
     @objc public var configuration: DDRUMViewEventDDConfiguration? {
         root.swiftModel.dd.configuration != nil ? DDRUMViewEventDDConfiguration(root: root) : nil
     }
@@ -4913,6 +4917,19 @@ public class DDRUMViewEventDD: NSObject {
 
     @objc public var session: DDRUMViewEventDDSession? {
         root.swiftModel.dd.session != nil ? DDRUMViewEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMViewEventDDCLS: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var devicePixelRatio: NSNumber? {
+        root.swiftModel.dd.cls!.devicePixelRatio as NSNumber?
     }
 }
 
@@ -5777,6 +5794,10 @@ public class DDRUMViewEventView: NSObject {
         root.swiftModel.view.flutterRasterTime != nil ? DDRUMViewEventViewFlutterRasterTime(root: root) : nil
     }
 
+    @objc public var freezeRate: NSNumber? {
+        root.swiftModel.view.freezeRate as NSNumber?
+    }
+
     @objc public var frozenFrame: DDRUMViewEventViewFrozenFrame? {
         root.swiftModel.view.frozenFrame != nil ? DDRUMViewEventViewFrozenFrame(root: root) : nil
     }
@@ -5881,6 +5902,14 @@ public class DDRUMViewEventView: NSObject {
 
     @objc public var resource: DDRUMViewEventViewResource {
         DDRUMViewEventViewResource(root: root)
+    }
+
+    @objc public var slowFrames: [DDRUMViewEventViewSlowFrames]? {
+        root.swiftModel.view.slowFrames?.map { DDRUMViewEventViewSlowFrames(swiftModel: $0) }
+    }
+
+    @objc public var slowFramesRate: NSNumber? {
+        root.swiftModel.view.slowFramesRate as NSNumber?
     }
 
     @objc public var timeSpent: NSNumber {
@@ -6317,6 +6346,24 @@ public class DDRUMViewEventViewResource: NSObject {
 
     @objc public var count: NSNumber {
         root.swiftModel.view.resource.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewSlowFrames: NSObject {
+    internal var swiftModel: RUMViewEvent.View.SlowFrames
+    internal var root: DDRUMViewEventViewSlowFrames { self }
+
+    internal init(swiftModel: RUMViewEvent.View.SlowFrames) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.start as NSNumber
     }
 }
 
@@ -8467,4 +8514,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/69147431d689b3e59bff87e15bb0088a9bb319a9
+// Generated from https://github.com/DataDog/rum-events-format/tree/45a80c1390b8ec886534f5f1b43763a6d9d0a643

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -2418,6 +2418,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// Browser SDK version
         public let browserSdkVersion: String?
 
+        /// Additional information of the reported Cumulative Layout Shift
+        public let cls: CLS?
+
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
@@ -2438,12 +2441,23 @@ public struct RUMViewEvent: RUMDataModel {
 
         enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
+            case cls = "cls"
             case configuration = "configuration"
             case documentVersion = "document_version"
             case formatVersion = "format_version"
             case pageStates = "page_states"
             case replayStats = "replay_stats"
             case session = "session"
+        }
+
+        /// Additional information of the reported Cumulative Layout Shift
+        public struct CLS: Codable {
+            /// Pixel ratio of the device where the layout shift was reported
+            public let devicePixelRatio: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case devicePixelRatio = "device_pixel_ratio"
+            }
         }
 
         /// Subset of the SDK configuration options in use during its execution
@@ -2757,6 +2771,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// Time taken for Flutter to rasterize the view.
         public let flutterRasterTime: FlutterRasterTime?
 
+        /// Rate of freezes during the view’s lifetime (in seconds per hour)
+        public let freezeRate: Double?
+
         /// Properties of the frozen frames of the view
         public let frozenFrame: FrozenFrame?
 
@@ -2835,6 +2852,12 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the resources of the view
         public let resource: Resource
 
+        /// List of slow frames during the view’s lifetime
+        public let slowFrames: [SlowFrames]?
+
+        /// Rate of slow frames during the view’s lifetime (in milliseconds per second)
+        public let slowFramesRate: Double?
+
         /// Time spent on the view in ns
         public let timeSpent: Int64
 
@@ -2861,6 +2884,7 @@ public struct RUMViewEvent: RUMDataModel {
             case firstInputTime = "first_input_time"
             case flutterBuildTime = "flutter_build_time"
             case flutterRasterTime = "flutter_raster_time"
+            case freezeRate = "freeze_rate"
             case frozenFrame = "frozen_frame"
             case frustration = "frustration"
             case id = "id"
@@ -2887,6 +2911,8 @@ public struct RUMViewEvent: RUMDataModel {
             case refreshRateAverage = "refresh_rate_average"
             case refreshRateMin = "refresh_rate_min"
             case resource = "resource"
+            case slowFrames = "slow_frames"
+            case slowFramesRate = "slow_frames_rate"
             case timeSpent = "time_spent"
             case url = "url"
         }
@@ -3224,6 +3250,20 @@ public struct RUMViewEvent: RUMDataModel {
 
             enum CodingKeys: String, CodingKey {
                 case count = "count"
+            }
+        }
+
+        /// Properties of the slow frames
+        public struct SlowFrames: Codable {
+            /// Duration in ns of the slow frame
+            public let duration: Int64
+
+            /// Duration in ns between start of the view and the start of the slow frame
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
             }
         }
     }
@@ -5591,4 +5631,4 @@ public struct RUMTelemetryOperatingSystem: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/69147431d689b3e59bff87e15bb0088a9bb319a9
+// Generated from https://github.com/DataDog/rum-events-format/tree/45a80c1390b8ec886534f5f1b43763a6d9d0a643

--- a/DatadogRUM/Sources/FatalErrorBuilder.swift
+++ b/DatadogRUM/Sources/FatalErrorBuilder.swift
@@ -144,6 +144,7 @@ internal struct FatalErrorBuilder {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: original.dd.browserSdkVersion,
+                cls: original.dd.cls,
                 configuration: original.dd.configuration,
                 documentVersion: original.dd.documentVersion + 1,
                 pageStates: original.dd.pageStates,
@@ -198,6 +199,7 @@ internal struct FatalErrorBuilder {
                 firstInputTime: original.view.firstInputTime,
                 flutterBuildTime: original.view.flutterBuildTime,
                 flutterRasterTime: original.view.flutterRasterTime,
+                freezeRate: original.view.freezeRate,
                 frozenFrame: original.view.frozenFrame,
                 frustration: original.view.frustration,
                 id: original.view.id,
@@ -223,6 +225,8 @@ internal struct FatalErrorBuilder {
                 refreshRateAverage: original.view.refreshRateAverage,
                 refreshRateMin: original.view.refreshRateMin,
                 resource: original.view.resource,
+                slowFrames: original.view.slowFrames,
+                slowFramesRate: original.view.slowFramesRate,
                 timeSpent: original.view.timeSpent,
                 url: original.view.url
             )

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -98,7 +98,11 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 }
             }(),
             renderLoopObserver: DisplayLinker(notificationCenter: configuration.notificationCenter),
-            viewHitchesMetricFactory: { ViewHitchesReader(hangThreshold: configuration.appHangThreshold) },
+            viewHitchesMetricFactory: {
+                configuration.featureFlags[.viewHitches]
+                ? ViewHitchesReader(hangThreshold: configuration.appHangThreshold)
+                : nil
+            },
             vitalsReaders: configuration.vitalsUpdateFrequency.map {
                 VitalsReaders(
                     frequency: $0.timeInterval,

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -362,6 +362,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
+                cls: nil,
                 configuration: .init(
                     sessionReplaySampleRate: nil,
                     sessionSampleRate: Double(self.sessionSampler.samplingRate),
@@ -431,6 +432,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 firstInputTime: nil,
                 flutterBuildTime: nil,
                 flutterRasterTime: nil,
+                freezeRate: nil,
                 frozenFrame: .init(count: 0),
                 frustration: .init(count: 0),
                 id: viewUUID.toRUMDataFormat,
@@ -456,6 +458,8 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 refreshRateAverage: nil,
                 refreshRateMin: nil,
                 resource: .init(count: 0),
+                slowFrames: nil,
+                slowFramesRate: nil,
                 timeSpent: 1, // arbitrary, 1ns duration
                 url: viewURL
             )

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -474,7 +474,7 @@ extension RUM.Configuration {
 }
 
 extension RUM.Configuration.FeatureFlags {
-    /// The defaults Feature Flags applied to Session Replay Configuration
+    /// The defaults Feature Flags applied to RUM Configuration
     public static var defaults: Self {
         [
             .viewHitches: false

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -251,6 +251,9 @@ extension RUM {
         /// and 100 means all telemetry will be uploaded. The default value is 20.0.
         public var telemetrySampleRate: SampleRate
 
+        /// Feature flags to preview features in RUM.
+        public var featureFlags: FeatureFlags
+
         // MARK: - Nested Types
 
         /// Configuration of automatic RUM resources tracking.
@@ -395,6 +398,7 @@ extension RUM.Configuration {
     ///   - onSessionStart: RUM session start callback. Default: `nil`.
     ///   - customEndpoint: Custom server url for sending RUM data. Default: `nil`.
     ///   - telemetrySampleRate: The sampling rate for SDK internal telemetry utilized by Datadog. Must be a value between `0` and `100`. Default: `20`.
+    ///   - featureFlags: Experimental feature flags.
     public init(
         applicationID: String,
         sessionSampleRate: SampleRate = .maxSampleRate,
@@ -417,7 +421,8 @@ extension RUM.Configuration {
         onSessionStart: RUM.SessionListener? = nil,
         customEndpoint: URL? = nil,
         trackAnonymousUser: Bool = true,
-        telemetrySampleRate: SampleRate = 20
+        telemetrySampleRate: SampleRate = 20,
+        featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
         self.sessionSampleRate = sessionSampleRate
@@ -441,6 +446,7 @@ extension RUM.Configuration {
         self.trackAnonymousUser = trackAnonymousUser
         self.telemetrySampleRate = telemetrySampleRate
         self.trackWatchdogTerminations = trackWatchdogTerminations
+        self.featureFlags = featureFlags
     }
 }
 
@@ -454,5 +460,31 @@ extension InternalExtension where ExtendedType == RUM.Configuration {
     public var configurationTelemetrySampleRate: Float {
         get { type.configurationTelemetrySampleRate }
         set { type.configurationTelemetrySampleRate = newValue }
+    }
+}
+
+extension RUM.Configuration {
+    public typealias FeatureFlags = [FeatureFlag: Bool]
+
+    /// Feature Flag available in RUM
+    public enum FeatureFlag: String {
+        /// View Hitches
+        case viewHitches
+    }
+}
+
+extension RUM.Configuration.FeatureFlags {
+    /// The defaults Feature Flags applied to Session Replay Configuration
+    public static var defaults: Self {
+        [
+            .viewHitches: false
+        ]
+    }
+
+    /// Accesses the feature flag value.
+    ///
+    /// Return:  false by default.
+    public subscript(flag: Key) -> Bool {
+        self[flag, default: false]
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -41,7 +41,7 @@ internal struct RUMScopeDependencies {
     let ciTest: RUMCITest?
     let syntheticsTest: RUMSyntheticsTest?
     let renderLoopObserver: RenderLoopObserver?
-    let viewHitchesMetricFactory: () -> ViewHitchesMetric & RenderLoopReader
+    let viewHitchesMetricFactory: () -> (ViewHitchesMetric & RenderLoopReader)?
     let vitalsReaders: VitalsReaders?
     let onSessionStart: RUM.SessionListener?
     let viewCache: ViewCache
@@ -78,7 +78,7 @@ internal struct RUMScopeDependencies {
         ciTest: RUMCITest?,
         syntheticsTest: RUMSyntheticsTest?,
         renderLoopObserver: RenderLoopObserver?,
-        viewHitchesMetricFactory: @escaping () -> ViewHitchesMetric & RenderLoopReader,
+        viewHitchesMetricFactory: @escaping () -> (ViewHitchesMetric & RenderLoopReader)?,
         vitalsReaders: VitalsReaders?,
         onSessionStart: RUM.SessionListener?,
         viewCache: ViewCache,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -565,6 +565,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let viewEvent = RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
+                cls: nil,
                 configuration: .init(
                     sessionReplaySampleRate: nil,
                     sessionSampleRate: Double(dependencies.sessionSampler.samplingRate),
@@ -629,6 +630,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 firstInputTime: nil,
                 flutterBuildTime: viewPerformanceMetrics[.flutterBuildTime]?.asFlutterBuildTime(),
                 flutterRasterTime: viewPerformanceMetrics[.flutterRasterTime]?.asFlutterRasterTime(),
+                freezeRate: nil,
                 frozenFrame: .init(count: frozenFramesCount),
                 frustration: .init(count: frustrationCount),
                 id: viewUUID.toRUMDataFormat,
@@ -655,6 +657,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 refreshRateAverage: refreshRateInfo?.meanValue,
                 refreshRateMin: refreshRateInfo?.minValue,
                 resource: .init(count: resourcesCount.toInt64),
+                slowFrames: nil,
+                slowFramesRate: nil,
                 timeSpent: timeSpent.toInt64Nanoseconds,
                 url: viewPath
             )

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -114,6 +114,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private var interactionToNextViewMetric: INVMetricTracking?
     /// Tracks "RUM View Ended" metric for this view.
     private let viewEndedMetric: ViewEndedMetricController
+    /// Tracks "View Hitches" for this view.
+    private let viewHitchesMetric: (ViewHitchesMetric & RenderLoopReader)?
 
     init(
         isInitialView: Bool,
@@ -152,6 +154,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         interactionToNextViewMetric?.trackViewStart(at: startTime, name: name, viewID: viewUUID)
 
         self.viewEndedMetric = dependencies.viewEndedMetricFactory()
+        self.viewHitchesMetric = dependencies.viewHitchesMetricFactory()
+
+        if let viewHitchesMetric { dependencies.renderLoopObserver?.register(viewHitchesMetric) }
 
         // Notify Synthetics if needed
         if dependencies.syntheticsTest != nil && self.context.sessionID != .nullUUID {
@@ -298,6 +303,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         if shouldComplete {
             interactionToNextViewMetric?.trackViewComplete(viewID: viewUUID)
             viewEndedMetric.send()
+            if let viewHitchesMetric { dependencies.renderLoopObserver?.unregister(viewHitchesMetric) }
         }
 
         return !shouldComplete
@@ -657,7 +663,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 refreshRateAverage: refreshRateInfo?.meanValue,
                 refreshRateMin: refreshRateInfo?.minValue,
                 resource: .init(count: resourcesCount.toInt64),
-                slowFrames: nil,
+                slowFrames: viewHitchesMetric?.hitchesDataModel.hitches.map { .init(duration: $0.duration, start: $0.start) },
                 slowFramesRate: nil,
                 timeSpent: timeSpent.toInt64Nanoseconds,
                 url: viewPath

--- a/DatadogRUM/Sources/RUMVitals/RenderLoop/ViewHitchesReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/RenderLoop/ViewHitchesReader.swift
@@ -6,7 +6,17 @@
 
 import UIKit
 
+/**
+ - parameters:
+   - start: Hitch duration in ns from the start of the view
+   - duration: Hitch duration in ns
+ */
 internal typealias Hitch = (start: Int64, duration: Int64)
+/**
+ - parameters:
+   - hitches: Array of view hitches (slow frames)
+   - hitchesDuration: Cumulative duration in ms of the view hitches
+ */
 internal typealias HitchesDataModel = (hitches: [Hitch], hitchesDuration: Double)
 
 internal protocol ViewHitchesMetric {

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -125,6 +125,12 @@ extension RUMViewEvent.DD.Configuration: RandomMockable {
     }
 }
 
+extension RUMViewEvent.View.SlowFrames: RandomMockable {
+    public static func mockRandom() -> RUMViewEvent.View.SlowFrames {
+        .init(duration: .mockRandom(), start: .mockRandom())
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     public static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()
@@ -144,6 +150,7 @@ extension RUMViewEvent: RandomMockable {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
+                cls: nil,
                 configuration: .mockRandom(),
                 documentVersion: .mockRandom(),
                 pageStates: nil,
@@ -197,6 +204,7 @@ extension RUMViewEvent: RandomMockable {
                 firstInputTime: .mockRandom(),
                 flutterBuildTime: nil,
                 flutterRasterTime: nil,
+                freezeRate: nil,
                 frozenFrame: .init(count: .mockRandom()),
                 frustration: nil,
                 id: viewID,
@@ -227,6 +235,8 @@ extension RUMViewEvent: RandomMockable {
                 refreshRateAverage: .mockRandom(),
                 refreshRateMin: .mockRandom(),
                 resource: .init(count: .mockRandom()),
+                slowFrames: .mockRandom(),
+                slowFramesRate: .mockRandom(),
                 timeSpent: viewTimeSpent,
                 url: viewURL
             )

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -1314,9 +1314,9 @@ internal class INVMetricMock: INVMetricTracking {
 }
 
 final class ViewHitchesMock: ViewHitchesMetric {
-    var hitchesDataModel: HitchesDataModel = ([], 0.0)
+    var hitchesDataModel: HitchesDataModel
 
-    init(hitchesDataModel: HitchesDataModel) {
+    init(hitchesDataModel: HitchesDataModel = ([], 0)) {
         self.hitchesDataModel = hitchesDataModel
     }
 }
@@ -1331,7 +1331,7 @@ extension ViewHitchesMock: RenderLoopReader {
 
 extension ViewHitchesMock: AnyMockable, RandomMockable {
     static func mockAny() -> Self {
-        ViewHitchesMock(hitchesDataModel: ([(1, 10), (20, 10)], 100.0)) as! Self
+        ViewHitchesMock(hitchesDataModel: ([(1, 10), (20, 10)], 100)) as! Self
     }
 
     static func mockRandom() -> Self {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -1877,7 +1877,7 @@ class RUMViewScopeTests: XCTestCase {
 
     // MARK: - View Hitches
 
-    func testWhenThereAreHitches_theViewUpdatesTheViewEvents() {
+    func testWhenThereAreHitches_theViewUpdatesContainsSlowFrames() {
         // Given
         var hitches: [Hitch] = []
         (0...Int.mockRandom(min: 0, max: 1_000)).forEach {

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -33,6 +33,7 @@ public class DDDatadog: NSObject
     public static func initialize(configuration: DDConfiguration,trackingConsent: DDTrackingConsent)
     public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel)
     public static func verbosityLevel() -> DDSDKVerbosityLevel
+    public static func setUserInfo(userId: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
     public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
     public static func addUserExtraInfo(_ extraInfo: [String: Any])
     public static func setTrackingConsent(consent: DDTrackingConsent)
@@ -384,6 +385,7 @@ public class DDRUMMonitor: NSObject
     @objc public var debug: Bool
 public class DDRUMActionEvent: NSObject
     @objc public var dd: DDRUMActionEventDD
+    @objc public var account: DDRUMActionEventAccount?
     @objc public var action: DDRUMActionEventAction
     @objc public var application: DDRUMActionEventApplication
     @objc public var buildId: String?
@@ -448,6 +450,10 @@ public enum DDRUMActionEventDDSessionRUMSessionPrecondition: Int
     case prewarm
     case fromNonInteractiveSession
     case explicitStop
+public class DDRUMActionEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMActionEventAction: NSObject
     @objc public var crash: DDRUMActionEventActionCrash?
     @objc public var error: DDRUMActionEventActionError?
@@ -593,6 +599,7 @@ public class DDRUMActionEventView: NSObject
     @objc public var url: String
 public class DDRUMErrorEvent: NSObject
     @objc public var dd: DDRUMErrorEventDD
+    @objc public var account: DDRUMErrorEventAccount?
     @objc public var action: DDRUMErrorEventAction?
     @objc public var application: DDRUMErrorEventApplication
     @objc public var buildId: String?
@@ -640,6 +647,10 @@ public enum DDRUMErrorEventDDSessionRUMSessionPrecondition: Int
     case prewarm
     case fromNonInteractiveSession
     case explicitStop
+public class DDRUMErrorEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMErrorEventAction: NSObject
     @objc public var id: DDRUMErrorEventActionRUMActionID
 public class DDRUMErrorEventActionRUMActionID: NSObject
@@ -884,6 +895,7 @@ public class DDRUMErrorEventView: NSObject
     @objc public var url: String
 public class DDRUMLongTaskEvent: NSObject
     @objc public var dd: DDRUMLongTaskEventDD
+    @objc public var account: DDRUMLongTaskEventAccount?
     @objc public var action: DDRUMLongTaskEventAction?
     @objc public var application: DDRUMLongTaskEventApplication
     @objc public var buildId: String?
@@ -930,6 +942,10 @@ public enum DDRUMLongTaskEventDDSessionRUMSessionPrecondition: Int
     case prewarm
     case fromNonInteractiveSession
     case explicitStop
+public class DDRUMLongTaskEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMLongTaskEventAction: NSObject
     @objc public var id: DDRUMLongTaskEventActionRUMActionID
 public class DDRUMLongTaskEventActionRUMActionID: NSObject
@@ -1078,6 +1094,7 @@ public class DDRUMLongTaskEventView: NSObject
     @objc public var url: String
 public class DDRUMResourceEvent: NSObject
     @objc public var dd: DDRUMResourceEventDD
+    @objc public var account: DDRUMResourceEventAccount?
     @objc public var action: DDRUMResourceEventAction?
     @objc public var application: DDRUMResourceEventApplication
     @objc public var buildId: String?
@@ -1127,6 +1144,10 @@ public enum DDRUMResourceEventDDSessionRUMSessionPrecondition: Int
     case prewarm
     case fromNonInteractiveSession
     case explicitStop
+public class DDRUMResourceEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMResourceEventAction: NSObject
     @objc public var id: DDRUMResourceEventActionRUMActionID
 public class DDRUMResourceEventActionRUMActionID: NSObject
@@ -1345,6 +1366,7 @@ public class DDRUMResourceEventView: NSObject
     @objc public var url: String
 public class DDRUMViewEvent: NSObject
     @objc public var dd: DDRUMViewEventDD
+    @objc public var account: DDRUMViewEventAccount?
     @objc public var application: DDRUMViewEventApplication
     @objc public var buildId: String?
     @objc public var buildVersion: String?
@@ -1407,6 +1429,10 @@ public enum DDRUMViewEventDDSessionRUMSessionPrecondition: Int
     case prewarm
     case fromNonInteractiveSession
     case explicitStop
+public class DDRUMViewEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMViewEventApplication: NSObject
     @objc public var id: String
 public class DDRUMViewEventRUMCITest: NSObject
@@ -1565,6 +1591,7 @@ public class DDRUMViewEventView: NSObject
     @objc public var memoryMax: NSNumber?
     @objc public var name: String?
     @objc public var networkSettledTime: NSNumber?
+    @objc public var performance: DDRUMViewEventViewPerformance?
     @objc public var referrer: String?
     @objc public var refreshRateAverage: NSNumber?
     @objc public var refreshRateMin: NSNumber?
@@ -1611,10 +1638,50 @@ public enum DDRUMViewEventViewLoadingType: Int
     case viewControllerRedisplay
 public class DDRUMViewEventViewLongTask: NSObject
     @objc public var count: NSNumber
+public class DDRUMViewEventViewPerformance: NSObject
+    @objc public var cls: DDRUMViewEventViewPerformanceCLS?
+    @objc public var fbc: DDRUMViewEventViewPerformanceFBC?
+    @objc public var fcp: DDRUMViewEventViewPerformanceFCP?
+    @objc public var fid: DDRUMViewEventViewPerformanceFID?
+    @objc public var inp: DDRUMViewEventViewPerformanceINP?
+    @objc public var lcp: DDRUMViewEventViewPerformanceLCP?
+public class DDRUMViewEventViewPerformanceCLS: NSObject
+    @objc public var currentRect: DDRUMViewEventViewPerformanceCLSCurrentRect?
+    @objc public var previousRect: DDRUMViewEventViewPerformanceCLSPreviousRect?
+    @objc public var score: NSNumber
+    @objc public var targetSelector: String?
+    @objc public var timestamp: NSNumber?
+public class DDRUMViewEventViewPerformanceCLSCurrentRect: NSObject
+    @objc public var height: NSNumber
+    @objc public var width: NSNumber
+    @objc public var x: NSNumber
+    @objc public var y: NSNumber
+public class DDRUMViewEventViewPerformanceCLSPreviousRect: NSObject
+    @objc public var height: NSNumber
+    @objc public var width: NSNumber
+    @objc public var x: NSNumber
+    @objc public var y: NSNumber
+public class DDRUMViewEventViewPerformanceFBC: NSObject
+    @objc public var timestamp: NSNumber
+public class DDRUMViewEventViewPerformanceFCP: NSObject
+    @objc public var timestamp: NSNumber
+public class DDRUMViewEventViewPerformanceFID: NSObject
+    @objc public var duration: NSNumber
+    @objc public var targetSelector: String?
+    @objc public var timestamp: NSNumber
+public class DDRUMViewEventViewPerformanceINP: NSObject
+    @objc public var duration: NSNumber
+    @objc public var targetSelector: String?
+    @objc public var timestamp: NSNumber?
+public class DDRUMViewEventViewPerformanceLCP: NSObject
+    @objc public var resourceUrl: String?
+    @objc public var targetSelector: String?
+    @objc public var timestamp: NSNumber
 public class DDRUMViewEventViewResource: NSObject
     @objc public var count: NSNumber
 public class DDRUMVitalEvent: NSObject
     @objc public var dd: DDRUMVitalEventDD
+    @objc public var account: DDRUMVitalEventAccount?
     @objc public var application: DDRUMVitalEventApplication
     @objc public var buildId: String?
     @objc public var buildVersion: String?
@@ -1662,6 +1729,10 @@ public enum DDRUMVitalEventDDSessionRUMSessionPrecondition: Int
     case explicitStop
 public class DDRUMVitalEventDDVital: NSObject
     @objc public var computedValue: NSNumber?
+public class DDRUMVitalEventAccount: NSObject
+    @objc public var id: String
+    @objc public var name: String?
+    @objc public var accountInfo: [String: Any]
 public class DDRUMVitalEventApplication: NSObject
     @objc public var id: String
 public class DDRUMVitalEventRUMCITest: NSObject
@@ -1770,7 +1841,7 @@ public class DDRUMVitalEventView: NSObject
     @objc public var url: String
 public class DDRUMVitalEventVital: NSObject
     @objc public var custom: [String: NSNumber]?
-    @objc public var details: String?
+    @objc public var vitalDescription: String?
     @objc public var duration: NSNumber?
     @objc public var id: String
     @objc public var name: String?
@@ -1920,7 +1991,6 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var batchProcessingLevel: NSNumber?
     @objc public var batchSize: NSNumber?
     @objc public var batchUploadFrequency: NSNumber?
-    @objc public var collectFeatureFlagsOn: [Int]?
     @objc public var compressIntakeRequests: NSNumber?
     @objc public var dartVersion: String?
     @objc public var defaultPrivacyLevel: String?
@@ -1930,6 +2000,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var forwardReports: DDTelemetryConfigurationEventTelemetryConfigurationForwardReports?
     @objc public var imagePrivacyLevel: String?
     @objc public var initializationType: String?
+    @objc public var invTimeThresholdMs: NSNumber?
     @objc public var isMainProcess: NSNumber?
     @objc public var mobileVitalsUpdatePeriod: NSNumber?
     @objc public var plugins: [DDTelemetryConfigurationEventTelemetryConfigurationPlugins]?
@@ -1939,6 +2010,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var replaySampleRate: NSNumber?
     @objc public var selectedTracingPropagators: [Int]?
     @objc public var sendLogsAfterSessionExpiration: NSNumber?
+    @objc public var sessionPersistence: DDTelemetryConfigurationEventTelemetryConfigurationSessionPersistence
     @objc public var sessionReplaySampleRate: NSNumber?
     @objc public var sessionSampleRate: NSNumber?
     @objc public var silentMultipleInit: NSNumber?
@@ -1949,14 +2021,17 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var telemetrySampleRate: NSNumber?
     @objc public var telemetryUsageSampleRate: NSNumber?
     @objc public var textAndInputPrivacyLevel: String?
+    @objc public var tnsTimeThresholdMs: NSNumber?
     @objc public var touchPrivacyLevel: String?
     @objc public var traceContextInjection: DDTelemetryConfigurationEventTelemetryConfigurationTraceContextInjection
     @objc public var traceSampleRate: NSNumber?
     @objc public var tracerApi: String?
     @objc public var tracerApiVersion: String?
+    @objc public var trackAnonymousUser: NSNumber?
     @objc public var trackBackgroundEvents: NSNumber?
     @objc public var trackCrossPlatformLongTasks: NSNumber?
     @objc public var trackErrors: NSNumber?
+    @objc public var trackFeatureFlagsForEvents: [Int]?
     @objc public var trackFlutterPerformance: NSNumber?
     @objc public var trackFrustrations: NSNumber?
     @objc public var trackInteractions: NSNumber?
@@ -1985,11 +2060,6 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var useTracing: NSNumber?
     @objc public var useWorkerUrl: NSNumber?
     @objc public var viewTrackingStrategy: DDTelemetryConfigurationEventTelemetryConfigurationViewTrackingStrategy
-public enum DDTelemetryConfigurationEventTelemetryConfigurationCollectFeatureFlagsOn: Int
-    case none
-    case view
-    case error
-    case vital
 public class DDTelemetryConfigurationEventTelemetryConfigurationForwardConsoleLogs: NSObject
     @objc public var stringsArray: [String]?
     @objc public var string: String?
@@ -2005,10 +2075,20 @@ public enum DDTelemetryConfigurationEventTelemetryConfigurationSelectedTracingPr
     case b3
     case b3multi
     case tracecontext
+public enum DDTelemetryConfigurationEventTelemetryConfigurationSessionPersistence: Int
+    case none
+    case localStorage
+    case cookie
 public enum DDTelemetryConfigurationEventTelemetryConfigurationTraceContextInjection: Int
     case none
     case all
     case sampled
+public enum DDTelemetryConfigurationEventTelemetryConfigurationTrackFeatureFlagsForEvents: Int
+    case none
+    case vital
+    case resource
+    case action
+    case longTask
 public enum DDTelemetryConfigurationEventTelemetryConfigurationTrackingConsent: Int
     case none
     case granted

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -46,6 +46,7 @@ public enum Datadog
     public static var verbosityLevel: CoreLoggerLevel?
     public static func isInitialized(instanceName name: String = CoreRegistry.defaultInstanceName) -> Bool
     public static func sdkInstance(named name: String) -> DatadogCoreProtocol
+    public static func setUserInfo(id: String,name: String? = nil,email: String? = nil,extraInfo: [AttributeKey: AttributeValue] = [:],in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func setUserInfo(id: String? = nil,name: String? = nil,email: String? = nil,extraInfo: [AttributeKey: AttributeValue] = [:],in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func addUserExtraInfo(_ extraInfo: [AttributeKey: AttributeValue?],in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func set(trackingConsent: TrackingConsent, in core: DatadogCoreProtocol = CoreRegistry.default)
@@ -344,6 +345,7 @@ public class Tracer
 
 public struct RUMActionEvent: RUMDataModel
     public var dd: DD
+    public var account: Account?
     public var action: Action
     public let application: Application
     public let buildId: String?
@@ -397,6 +399,10 @@ public struct RUMActionEvent: RUMDataModel
             public enum Plan: Int, Codable
                 case plan1 = 1
                 case plan2 = 2
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Action: Codable
         public let crash: Crash?
         public let error: Error?
@@ -473,8 +479,12 @@ public struct RUMActionEvent: RUMDataModel
         public var name: String?
         public var referrer: String?
         public var url: String
+[?] extension RUMActionEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 public struct RUMErrorEvent: RUMDataModel
     public let dd: DD
+    public var account: Account?
     public let action: Action?
     public let application: Application
     public let buildId: String?
@@ -512,6 +522,10 @@ public struct RUMErrorEvent: RUMDataModel
             public enum Plan: Int, Codable
                 case plan1 = 1
                 case plan2 = 2
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Action: Codable
         public let id: RUMActionID
     public struct Application: Codable
@@ -669,11 +683,15 @@ public struct RUMErrorEvent: RUMDataModel
         public var name: String?
         public var referrer: String?
         public var url: String
+[?] extension RUMErrorEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 [?] extension RUMErrorEvent.FeatureFlags
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws
 public struct RUMLongTaskEvent: RUMDataModel
     public let dd: DD
+    public var account: Account?
     public let action: Action?
     public let application: Application
     public let buildId: String?
@@ -710,6 +728,10 @@ public struct RUMLongTaskEvent: RUMDataModel
             public enum Plan: Int, Codable
                 case plan1 = 1
                 case plan2 = 2
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Action: Codable
         public let id: RUMActionID
     public struct Application: Codable
@@ -784,8 +806,12 @@ public struct RUMLongTaskEvent: RUMDataModel
         public var name: String?
         public var referrer: String?
         public var url: String
+[?] extension RUMLongTaskEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 public struct RUMResourceEvent: RUMDataModel
     public let dd: DD
+    public var account: Account?
     public let action: Action?
     public let application: Application
     public let buildId: String?
@@ -825,6 +851,10 @@ public struct RUMResourceEvent: RUMDataModel
             public enum Plan: Int, Codable
                 case plan1 = 1
                 case plan2 = 2
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Action: Codable
         public let id: RUMActionID
     public struct Application: Codable
@@ -957,8 +987,12 @@ public struct RUMResourceEvent: RUMDataModel
         public var name: String?
         public var referrer: String?
         public var url: String
+[?] extension RUMResourceEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 public struct RUMViewEvent: RUMDataModel
     public let dd: DD
+    public var account: Account?
     public let application: Application
     public let buildId: String?
     public let buildVersion: String?
@@ -1011,6 +1045,10 @@ public struct RUMViewEvent: RUMDataModel
             public enum Plan: Int, Codable
                 case plan1 = 1
                 case plan2 = 2
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Application: Codable
         public let id: String
     public struct Container: Codable
@@ -1102,6 +1140,7 @@ public struct RUMViewEvent: RUMDataModel
         public let memoryMax: Double?
         public var name: String?
         public let networkSettledTime: Int64?
+        public var performance: Performance?
         public var referrer: String?
         public let refreshRateAverage: Double?
         public let refreshRateMin: Double?
@@ -1147,13 +1186,56 @@ public struct RUMViewEvent: RUMDataModel
             case viewControllerRedisplay = "view_controller_redisplay"
         public struct LongTask: Codable
             public let count: Int64
+        public struct Performance: Codable
+            public let cls: CLS?
+            public let fbc: FBC?
+            public let fcp: FCP?
+            public let fid: FID?
+            public let inp: INP?
+            public var lcp: LCP?
+            public struct CLS: Codable
+                public let currentRect: CurrentRect?
+                public let previousRect: PreviousRect?
+                public let score: Double
+                public let targetSelector: String?
+                public let timestamp: Int64?
+                public struct CurrentRect: Codable
+                    public let height: Double
+                    public let width: Double
+                    public let x: Double
+                    public let y: Double
+                public struct PreviousRect: Codable
+                    public let height: Double
+                    public let width: Double
+                    public let x: Double
+                    public let y: Double
+            public struct FBC: Codable
+                public let timestamp: Int64
+            public struct FCP: Codable
+                public let timestamp: Int64
+            public struct FID: Codable
+                public let duration: Int64
+                public let targetSelector: String?
+                public let timestamp: Int64
+            public struct INP: Codable
+                public let duration: Int64
+                public let targetSelector: String?
+                public let timestamp: Int64?
+            public struct LCP: Codable
+                public var resourceUrl: String?
+                public let targetSelector: String?
+                public let timestamp: Int64
         public struct Resource: Codable
             public let count: Int64
+[?] extension RUMViewEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 [?] extension RUMViewEvent.FeatureFlags
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws
 public struct RUMVitalEvent: RUMDataModel
     public let dd: DD
+    public var account: Account?
     public let application: Application
     public let buildId: String?
     public let buildVersion: String?
@@ -1191,6 +1273,10 @@ public struct RUMVitalEvent: RUMDataModel
                 case plan2 = 2
         public struct Vital: Codable
             public let computedValue: Bool?
+    public struct Account: Codable
+        public let id: String
+        public let name: String?
+        public var accountInfo: [String: Encodable]
     public struct Application: Codable
         public let id: String
     public struct Container: Codable
@@ -1232,13 +1318,16 @@ public struct RUMVitalEvent: RUMDataModel
         public var url: String
     public struct Vital: Codable
         public let custom: [String: Double]?
-        public let details: String?
+        public let vitalDescription: String?
         public let duration: Double?
         public let id: String
         public let name: String?
         public let type: VitalType
         public enum VitalType: String, Codable
             case duration = "duration"
+[?] extension RUMVitalEvent.Account
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
 public struct TelemetryErrorEvent: RUMDataModel
     public let dd: DD
     public let action: Action?
@@ -1372,7 +1461,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let batchProcessingLevel: Int64?
             public let batchSize: Int64?
             public let batchUploadFrequency: Int64?
-            public let collectFeatureFlagsOn: [CollectFeatureFlagsOn]?
             public let compressIntakeRequests: Bool?
             public var dartVersion: String?
             public var defaultPrivacyLevel: String?
@@ -1382,6 +1470,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let forwardReports: ForwardReports?
             public var imagePrivacyLevel: String?
             public var initializationType: String?
+            public let invTimeThresholdMs: Int64?
             public let isMainProcess: Bool?
             public var mobileVitalsUpdatePeriod: Int64?
             public var plugins: [Plugins]?
@@ -1391,6 +1480,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let replaySampleRate: Int64?
             public let selectedTracingPropagators: [SelectedTracingPropagators]?
             public var sendLogsAfterSessionExpiration: Bool?
+            public let sessionPersistence: SessionPersistence?
             public var sessionReplaySampleRate: Int64?
             public let sessionSampleRate: Int64?
             public let silentMultipleInit: Bool?
@@ -1401,14 +1491,17 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let telemetrySampleRate: Int64?
             public let telemetryUsageSampleRate: Int64?
             public var textAndInputPrivacyLevel: String?
+            public let tnsTimeThresholdMs: Int64?
             public var touchPrivacyLevel: String?
             public var traceContextInjection: TraceContextInjection?
             public let traceSampleRate: Int64?
             public var tracerApi: String?
             public var tracerApiVersion: String?
+            public var trackAnonymousUser: Bool?
             public var trackBackgroundEvents: Bool?
             public var trackCrossPlatformLongTasks: Bool?
             public var trackErrors: Bool?
+            public let trackFeatureFlagsForEvents: [TrackFeatureFlagsForEvents]?
             public var trackFlutterPerformance: Bool?
             public var trackFrustrations: Bool?
             public var trackInteractions: Bool?
@@ -1437,10 +1530,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel
             public let useTracing: Bool?
             public let useWorkerUrl: Bool?
             public let viewTrackingStrategy: ViewTrackingStrategy?
-            public enum CollectFeatureFlagsOn: String, Codable
-                case view = "view"
-                case error = "error"
-                case vital = "vital"
             public enum ForwardConsoleLogs: Codable
                 case stringsArray(value: [String])
                 case string(value: String)
@@ -1459,9 +1548,17 @@ public struct TelemetryConfigurationEvent: RUMDataModel
                 case b3 = "b3"
                 case b3multi = "b3multi"
                 case tracecontext = "tracecontext"
+            public enum SessionPersistence: String, Codable
+                case localStorage = "local-storage"
+                case cookie = "cookie"
             public enum TraceContextInjection: String, Codable
                 case all = "all"
                 case sampled = "sampled"
+            public enum TrackFeatureFlagsForEvents: String, Codable
+                case vital = "vital"
+                case resource = "resource"
+                case action = "action"
+                case longTask = "long_task"
             public enum TrackingConsent: String, Codable
                 case granted = "granted"
                 case notGranted = "not-granted"
@@ -1524,10 +1621,15 @@ public struct TelemetryUsageEvent: RUMDataModel
                 case setTrackingConsent(value: SetTrackingConsent)
                 case stopSession(value: StopSession)
                 case startView(value: StartView)
+                case setViewContext(value: SetViewContext)
+                case setViewContextProperty(value: SetViewContextProperty)
+                case setViewName(value: SetViewName)
+                case getViewContext(value: GetViewContext)
                 case addAction(value: AddAction)
                 case addError(value: AddError)
                 case setGlobalContext(value: SetGlobalContext)
                 case setUser(value: SetUser)
+                case setAccount(value: SetAccount)
                 case addFeatureFlagEvaluation(value: AddFeatureFlagEvaluation)
                 public func encode(to encoder: Encoder) throws
                 public init(from decoder: Decoder) throws
@@ -1542,6 +1644,14 @@ public struct TelemetryUsageEvent: RUMDataModel
                     public let feature: String = "stop-session"
                 public struct StartView: Codable
                     public let feature: String = "start-view"
+                public struct SetViewContext: Codable
+                    public let feature: String = "set-view-context"
+                public struct SetViewContextProperty: Codable
+                    public let feature: String = "set-view-context-property"
+                public struct SetViewName: Codable
+                    public let feature: String = "set-view-name"
+                public struct GetViewContext: Codable
+                    public let feature: String = "get-view-context"
                 public struct AddAction: Codable
                     public let feature: String = "add-action"
                 public struct AddError: Codable
@@ -1550,6 +1660,8 @@ public struct TelemetryUsageEvent: RUMDataModel
                     public let feature: String = "set-global-context"
                 public struct SetUser: Codable
                     public let feature: String = "set-user"
+                public struct SetAccount: Codable
+                    public let feature: String = "set-account"
                 public struct AddFeatureFlagEvaluation: Codable
                     public let feature: String = "add-feature-flag-evaluation"
             public enum TelemetryMobileFeaturesUsage: Codable
@@ -1585,7 +1697,7 @@ public struct RUMConnectivity: Codable
         public let carrierName: String?
         public let technology: String?
     public enum EffectiveType: String, Codable
-        case slow2g = "slow_2g"
+        case slow2g = "slow-2g"
         case effectiveType2g = "2g"
         case effectiveType3g = "3g"
         case effectiveType4g = "4g"
@@ -1727,7 +1839,7 @@ public enum RUM
         public var appHangThreshold: TimeInterval?
         public var vitalsUpdateFrequency: VitalsFrequency?
         public var networkSettledResourcePredicate: NetworkSettledResourcePredicate
-        public var nextViewActionPredicate: NextViewActionPredicate
+        public var nextViewActionPredicate: NextViewActionPredicate?
         public var viewEventMapper: RUM.ViewEventMapper?
         public var resourceEventMapper: RUM.ResourceEventMapper?
         public var actionEventMapper: RUM.ActionEventMapper?
@@ -1750,7 +1862,7 @@ public enum RUM
         case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = 20,traceControlInjection: TraceContextInjection = .all)
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,telemetrySampleRate: SampleRate = 20)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,telemetrySampleRate: SampleRate = 20)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
 public struct TNSResourceParams
@@ -1799,6 +1911,7 @@ public extension RUMMonitorProtocol
 public struct DatadogInternalInterface
     public func addLongTask(at time: Date,duration: TimeInterval,attributes: [AttributeKey: AttributeValue] = [:])
     public func updatePerformanceMetric(at time: Date,metric: PerformanceMetric,value: Double,attributes: [AttributeKey: AttributeValue] = [:])
+    public func setInternalViewAttribute(at time: Date,key: AttributeKey,value: AttributeValue)
     public func addResourceMetrics(at time: Date,resourceKey: String,fetch: (start: Date, end: Date),redirection: (start: Date, end: Date)?,dns: (start: Date, end: Date)?,connect: (start: Date, end: Date)?,ssl: (start: Date, end: Date)?,firstByte: (start: Date, end: Date)?,download: (start: Date, end: Date)?,responseSize: Int64?,attributes: [AttributeKey: AttributeValue] = [:])
 public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
 public enum RUMActionType
@@ -2315,7 +2428,6 @@ public enum objc_TouchPrivacyLevelOverride: Int
 [?] extension DatadogExtension where ExtendedType: UIView
     public var sessionReplayPrivacyOverrides: SessionReplayPrivacyOverrides
 public final class SessionReplayPrivacyOverrides
-    public init(_ view: UIView)
     public var textAndInputPrivacy: TextAndInputPrivacyLevel?
     public var imagePrivacy: ImagePrivacyLevel?
     public var touchPrivacy: TouchPrivacyLevel?


### PR DESCRIPTION
### What and why?

This PR updates the View events with information about View Hitches (Slow frames).
The proposed solution is defined in the [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4722163962/RFC+-+UI+Slowness).

### How?

- Updates the RUM `DataModels` schema to have the View events with the `slow_frames` definition.
- Proposes a new configuration, `FeatureFlags`, to enable the capture of View Hitches.
- Populates the View events with View Hitches.

This is the second part of the Slow frames integration. The first PR focused on the engine to observe the render loop and can be found [here](https://github.com/DataDog/dd-sdk-ios/pull/2214).
This part focus on updating the View events with the observed Slow frames. The image below depicts the architecture of entities that capture the data to be sent to the backend:
- The `RUMViewScope` owns the `VitalInfoSampler` and the `ViewHitchesReader` to collect information about the render loop.
- `ViewHitchesReader` is exposed as a `ViewHitchesMetric` that has the Hitches information needed for the View events. 
- Each `RUMViewScope` will have its `ViewHitchesMetric` that is built by the `ViewHitchesMetricFactory`.

<img width="923" alt="arch" src="https://github.com/user-attachments/assets/d6f9a21e-e17b-494d-b084-e562c2a02483" />


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
