### PR TITLE
Remove unnecessary log list to reduce memory usage in the logs benchmark scenario

### DIFF
--- a/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsCustomContentView.swift
+++ b/BenchmarkTests/Runner/Scenarios/Logs/UI/LogsCustomContentView.swift
@@ -14,7 +14,6 @@ struct LogsCustomContentView: View {
     @State private var interval: Double
     @State private var isRepeating: Bool
     @State private var payloadSize: String
-    @State private var logs: [String]
     @State private var isLogging: Bool
 
     private let logger: LoggerProtocol
@@ -26,7 +25,6 @@ struct LogsCustomContentView: View {
         interval = 5
         isRepeating = false
         payloadSize = "Small"
-        logs = []
         isLogging = false
 
         logger = Logger.create()
@@ -86,14 +84,6 @@ struct LogsCustomContentView: View {
                 }
                 .listRowBackground(EmptyView())
                 .listRowInsets(EdgeInsets())
-
-                Section(header: Text("Console output:")) {
-                    ForEach(logs, id: \.self) { log in
-                        Text(log)
-                            .lineLimit(nil)
-                            .font(.footnote)
-                    }
-                }
             }
             .listSectionSpacing(10)
         }
@@ -105,17 +95,8 @@ struct LogsCustomContentView: View {
     ///   - attributes: The payload attributes corresponding to the selected payload size.
     func logBatch(selectedLogLevel: LogLevel, attributes: [String: Encodable]) {
         DispatchQueue.global(qos: .userInitiated).async {
-            var newLogEntries: [String] = []
-
             for _ in 1...self.logsPerBatch {
-                let logEntry = "\(Date()) [\(self.logLevel)] \(self.logMessage) - \(self.payloadSize)"
-                newLogEntries.append(logEntry)
-
                 self.logger.log(level: selectedLogLevel, message: self.logMessage, error: nil, attributes: attributes)
-            }
-
-            DispatchQueue.main.async {
-                self.logs.insert(contentsOf: newLogEntries, at: 0)
             }
         }
     }


### PR DESCRIPTION
### What and why?

This PR fixes a bug in the logs benchmark scenario where the UI was using excessive memory due to an unnecessary in-memory list storing logs. Since the purpose of this benchmark is to measure the SDK’s performance, the UI should not introduce additional overhead.

### How?

The issue was resolved by completely removing the in-memory log list, as it was not necessary.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
