### PR TITLE
RUM-8442 Fix Benchmark Metrics Exporter

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		D231DCF52C73356E00F3F66C /* WebViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D231DCAA2C73356D00F3F66C /* WebViewController.storyboard */; };
 		D231DCF62C73356E00F3F66C /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DCAB2C73356D00F3F66C /* WebViewController.swift */; };
 		D231DCF92C7342D500F3F66C /* ModuleBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DCF82C7342D500F3F66C /* ModuleBundle.swift */; };
+		D23734972D773DD8004CCAED /* BenchmarkMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23734962D773DD1004CCAED /* BenchmarkMeter.swift */; };
 		D23DD32D2C58D80C00B90C4C /* DatadogBenchmarks in Frameworks */ = {isa = PBXBuildFile; productRef = D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */; };
 		D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */; };
 		D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */; };
@@ -312,6 +313,7 @@
 		D231DCAB2C73356D00F3F66C /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		D231DCF82C7342D500F3F66C /* ModuleBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleBundle.swift; sourceTree = "<group>"; };
 		D231DCFA2C735FC200F3F66C /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		D23734962D773DD1004CCAED /* BenchmarkMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMeter.swift; sourceTree = "<group>"; };
 		D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticScenario.swift; sourceTree = "<group>"; };
 		D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
 		D26DD6E62D0C774000D96148 /* DatadogMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogMonitor.swift; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				D29F754F2C4AA07E00288638 /* AppDelegate.swift */,
 				D276069D2C514F37002D2A14 /* AppConfiguration.swift */,
 				D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */,
+				D23734962D773DD1004CCAED /* BenchmarkMeter.swift */,
 				D276069C2C514F37002D2A14 /* Scenarios */,
 				D29F755D2C4AA08000288638 /* Info.plist */,
 			);
@@ -1285,6 +1288,7 @@
 				D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */,
 				D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */,
 				D27606A32C514F37002D2A14 /* Scenario.swift in Sources */,
+				D23734972D773DD8004CCAED /* BenchmarkMeter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -13,9 +13,6 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import DatadogExporter
 
-let instrumentationName = "benchmarks"
-let instrumentationVersion = "1.0.0"
-
 /// Benchmark entrypoint to configure opentelemetry with metrics meters
 /// and tracer.
 public enum Benchmarks {
@@ -75,79 +72,41 @@ public enum Benchmarks {
         }
     }
 
-    /// Configure OpenTelemetry metrics meter and start measuring Memory.
+    /// Configure an OpenTelemetry meter provider.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func enableMetrics(with configuration: Configuration) {
+    public static func meterProvider(with configuration: Configuration) -> MeterProvider {
         let metricExporter = MetricExporter(
             configuration: MetricExporter.Configuration(
                 apiKey: configuration.apiKey,
-                version: instrumentationVersion
+                version: configuration.context.applicationVersion
             )
         )
 
-        let meterProvider = MeterProviderBuilder()
+        let provider = MeterProviderBuilder()
             .with(pushInterval: 10)
             .with(processor: MetricProcessorSdk())
             .with(exporter: metricExporter)
-            .with(resource: Resource())
+            .with(resource: Resource(attributes: [
+                "device_model": .string(configuration.context.deviceModel),
+                "os": .string(configuration.context.osName),
+                "os_version": .string(configuration.context.osVersion),
+                "run": .string(configuration.context.run),
+                "scenario": .string(configuration.context.scenario),
+                "application_id": .string(configuration.context.applicationIdentifier),
+                "sdk_version": .string(configuration.context.sdkVersion),
+                "branch": .string(configuration.context.branch),
+            ]))
             .build()
 
-        let meter = meterProvider.get(
-            instrumentationName: instrumentationName,
-            instrumentationVersion: instrumentationVersion
-        )
-
-        let labels = [
-            "device_model": configuration.context.deviceModel,
-            "os": configuration.context.osName,
-            "os_version": configuration.context.osVersion,
-            "run": configuration.context.run,
-            "scenario": configuration.context.scenario,
-            "application_id": configuration.context.applicationIdentifier,
-            "sdk_version": configuration.context.sdkVersion,
-            "branch": configuration.context.branch,
-        ]
-
-        let queue = DispatchQueue(label: "com.datadoghq.benchmarks.metrics", qos: .utility)
-
-        let memory = Memory(queue: queue)
-        _ = meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
-            // report the maximum memory footprint that was recorded during push interval
-            if let value = memory.aggregation?.max {
-                metric.observe(value: value, labels: labels)
-            }
-
-            memory.reset()
-        }
-
-        let cpu = CPU(queue: queue)
-        _ = meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
-            // report the average cpu usage that was recorded during push interval
-            if let value = cpu.aggregation?.avg {
-                metric.observe(value: value, labels: labels)
-            }
-
-            cpu.reset()
-        }
-
-        let fps = FPS()
-        _ = meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
-            // report the minimum frame rate that was recorded during push interval
-            if let value = fps.aggregation?.min {
-                metric.observe(value: value, labels: labels)
-            }
-
-            fps.reset()
-        }
-
-        OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
+        OpenTelemetry.registerMeterProvider(meterProvider: provider)
+        return provider
     }
 
-    /// Configure and register a OpenTelemetry Tracer.
+    /// Configure an OpenTelemetry tracer provider.
     ///
     /// - Parameter configuration: The Benchmark configuration.
-    public static func enableTracer(with configuration: Configuration) {
+    public static func tracerProvider(with configuration: Configuration) -> TracerProvider {
         let exporterConfiguration = ExporterConfiguration(
             serviceName: configuration.context.applicationIdentifier,
             resource: "Benchmark Tracer",
@@ -167,5 +126,6 @@ public enum Benchmarks {
             .build()
 
         OpenTelemetry.registerTracerProvider(tracerProvider: provider)
+        return provider
     }
 }

--- a/BenchmarkTests/Benchmarks/Sources/MetricExporter.swift
+++ b/BenchmarkTests/Benchmarks/Sources/MetricExporter.swift
@@ -83,7 +83,7 @@ final class MetricExporter: OpenTelemetrySdk.MetricExporter {
     /// - Parameter metric: The otel metric
     /// - Returns: The timeserie.
     func transform(_ metric: Metric) throws -> Serie {
-        var tags: Set<String> = []
+        var tags = Set(metric.resource.attributes.map { "\($0):\($1)" })
 
         let points: [Serie.Point] = try metric.data.map { data in
             let timestamp = Int64(data.timestamp.timeIntervalSince1970)

--- a/BenchmarkTests/Benchmarks/Sources/Metrics.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Metrics.swift
@@ -12,33 +12,33 @@ import QuartzCore
 let TASK_VM_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
 let TASK_VM_INFO_REV1_COUNT = mach_msg_type_number_t(MemoryLayout.offset(of: \task_vm_info_data_t.min_address)! / MemoryLayout<integer_t>.size)
 
-internal enum MachError: Error {
+public enum MachError: Error {
     case task_info(return: kern_return_t)
     case task_threads(return: kern_return_t)
     case thread_info(return: kern_return_t)
 }
 
 /// Aggregate metric values and compute `min`, `max`, `sum`, `avg`, and `count`.
-internal class MetricAggregator<T> where T: Numeric {
-    internal struct Aggregation {
-        let min: T
-        let max: T
-        let sum: T
-        let count: Int
-        let avg: Double
+public class MetricAggregator<T> where T: Numeric {
+    public struct Aggregation {
+        public let min: T
+        public let max: T
+        public let sum: T
+        public let count: Int
+        public let avg: Double
     }
 
     private var mutex = pthread_mutex_t()
     private var _aggregation: Aggregation?
 
-    var aggregation: Aggregation? {
+    public var aggregation: Aggregation? {
         pthread_mutex_lock(&mutex)
         defer { pthread_mutex_unlock(&mutex) }
         return _aggregation
     }
 
     /// Resets the minimum frame rate to `nil`.
-    func reset() {
+    public func reset() {
         pthread_mutex_lock(&mutex)
         _aggregation = nil
         pthread_mutex_unlock(&mutex)
@@ -53,7 +53,7 @@ extension MetricAggregator where T: BinaryInteger {
     /// Records a `BinaryInteger` value.
     ///
     /// - Parameter value: The value to record.
-    func record(value: T) {
+    public func record(value: T) {
         pthread_mutex_lock(&mutex)
         _aggregation = _aggregation.map {
             let sum = $0.sum + value
@@ -74,7 +74,7 @@ extension MetricAggregator where T: BinaryFloatingPoint {
     /// Records a `BinaryFloatingPoint` value.
     ///
     /// - Parameter value: The value to record.
-    func record(value: T) {
+    internal func record(value: T) {
         pthread_mutex_lock(&mutex)
         _aggregation = _aggregation.map {
             let sum = $0.sum + value
@@ -94,7 +94,7 @@ extension MetricAggregator where T: BinaryFloatingPoint {
 /// Collect Memory footprint metric.
 ///
 /// Based on a timer, the `Memory` aggregator will periodically record the memory footprint.
-internal final class Memory: MetricAggregator<Double> {
+public final class Memory: MetricAggregator<Double> {
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
 
@@ -107,7 +107,7 @@ internal final class Memory: MetricAggregator<Double> {
     ///   - queue: The queue on which to execute the timer handler.
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
-    required init(
+    public required init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
@@ -158,7 +158,7 @@ internal final class Memory: MetricAggregator<Double> {
 /// Collect CPU usage metric.
 ///
 /// Based on a timer, the `CPU` aggregator will periodically record the CPU usage.
-internal final class CPU: MetricAggregator<Double> {
+public final class CPU: MetricAggregator<Double> {
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
 
@@ -171,7 +171,7 @@ internal final class CPU: MetricAggregator<Double> {
     ///   - queue: The queue on which to execute the timer handler.
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
-    init(
+    public required init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
@@ -241,7 +241,7 @@ internal final class CPU: MetricAggregator<Double> {
 }
 
 /// Collect Frame rate metric based on ``CADisplayLinker`` timer.
-internal final class FPS: MetricAggregator<Int> {
+public final class FPS: MetricAggregator<Int> {
     private class CADisplayLinker {
         weak var fps: FPS?
 
@@ -260,7 +260,7 @@ internal final class FPS: MetricAggregator<Int> {
 
     private var displayLink: CADisplayLink
 
-    override init() {
+    override public init() {
         let linker = CADisplayLinker()
         displayLink = CADisplayLink(target: linker, selector: #selector(CADisplayLinker.tick(link:)))
         super.init()

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -20,27 +20,36 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let run = SyntheticRun()
         let applicationInfo = try! AppInfo() // crash if info are missing or malformed
 
-        switch run {
-        case .baseline, .instrumented:
-            // measure metrics during baseline and metrics runs
-            Benchmarks.enableMetrics(
+        // Collect metrics during all run
+        let meter = Meter(
+            provider: Benchmarks.meterProvider(
                 with: Benchmarks.Configuration(
                     info: applicationInfo,
                     scenario: scenario,
                     run: run
                 )
             )
+        )
+
+        switch run {
+        case .baseline, .instrumented:
+            meter.observeCPU()
+            meter.observeMemory()
+            meter.observeFPS()
+
         case .profiling:
             // Collect traces during profiling run
-            Benchmarks.enableTracer(
-                with: Benchmarks.Configuration(
-                    info: applicationInfo,
-                    scenario: scenario,
-                    run: run
+            let profiler = Profiler(
+                provider: Benchmarks.tracerProvider(
+                    with: Benchmarks.Configuration(
+                        info: applicationInfo,
+                        scenario: scenario,
+                        run: run
+                    )
                 )
             )
 
-            DatadogInternal.profiler = Profiler()
+            DatadogInternal.bench = (profiler, meter)
         case .none:
             break
         }

--- a/BenchmarkTests/Runner/BenchmarkMeter.swift
+++ b/BenchmarkTests/Runner/BenchmarkMeter.swift
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+import DatadogBenchmarks
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+internal final class Meter: DatadogInternal.BenchmarkMeter {
+    let meter: OpenTelemetryApi.Meter
+
+    let queue = DispatchQueue(label: "com.datadoghq.benchmarks.metrics", target: .global(qos: .utility))
+
+    init(provider: MeterProvider) {
+        self.meter = provider.get(
+            instrumentationName: "benchmarks",
+            instrumentationVersion: nil
+        )
+    }
+
+    @discardableResult
+    func observeMemory() -> OpenTelemetryApi.DoubleObserverMetric {
+        let memory = Memory(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
+            // report the maximum memory footprint that was recorded during push interval
+            if let value = memory.aggregation?.max {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            memory.reset()
+        }
+    }
+
+    @discardableResult
+    func observeCPU() -> OpenTelemetryApi.DoubleObserverMetric {
+        let cpu = CPU(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
+            // report the average cpu usage that was recorded during push interval
+            if let value = cpu.aggregation?.avg {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            cpu.reset()
+        }
+    }
+
+    @discardableResult
+    func observeFPS() -> OpenTelemetryApi.IntObserverMetric {
+        let fps = FPS()
+        return meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
+            // report the minimum frame rate that was recorded during push interval
+            if let value = fps.aggregation?.min {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            fps.reset()
+        }
+    }
+
+    func counter(metric: @autoclosure () -> String) -> DatadogInternal.BenchmarkCounter {
+        meter.createDoubleCounter(name: metric())
+    }
+
+    func gauge(metric: @autoclosure () -> String) -> DatadogInternal.BenchmarkGauge {
+        meter.createDoubleMeasure(name: metric())
+    }
+}
+
+extension AnyCounterMetric<Double>: DatadogInternal.BenchmarkCounter {
+    public func add(value: Double, attributes: @autoclosure () -> [String: String]) {
+        add(value: value, labelset: LabelSet(labels: attributes()))
+    }
+}
+
+extension AnyMeasureMetric<Double>: DatadogInternal.BenchmarkGauge {
+    public func record(value: Double, attributes: @autoclosure () -> [String: String]) {
+        record(value: value, labelset: LabelSet(labels: attributes()))
+    }
+}

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -72,6 +72,10 @@ internal struct FileWriter: Writer {
 
         do {
             try file.append(data: encoded)
+#if DD_BENCHMARK
+            bench.meter.counter(metric: "ios.benchmark.bytes_written")
+                .increment(by: encoded.count, attributes: ["track": orchestrator.trackName])
+#endif
         } catch {
             DD.logger.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)
             telemetry.error("(\(orchestrator.trackName)) Failed to write \(writeSize) bytes to file", error: error)

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -7,12 +7,12 @@
 import Foundation
 
 #if DD_BENCHMARK
-/// The profiler endpoint to collect data for benchmarking.
-public var profiler: BenchmarkProfiler = NOPBenchmarkProfiler()
+/// The benchmark endpoint to collect data for benchmarking.
+public var bench: (profiler: BenchmarkProfiler, meter: BenchmarkMeter) = (NOPBench(), NOPBench())
 #else
-/// The profiler endpoint to collect data for benchmarking. This static variable can only
+/// The benchmark endpoint to collect data for benchmarking. This static variable can only
 /// be mutated in the benchmark environment.
-public let profiler: BenchmarkProfiler = NOPBenchmarkProfiler()
+public let bench: (profiler: BenchmarkProfiler, meter: BenchmarkMeter) = (NOPBench(), NOPBench())
 #endif
 
 /// The Benchmark Profiler provides interfaces to collect data in a benchmark
@@ -31,6 +31,31 @@ public protocol BenchmarkProfiler {
     /// to not intialise the value if the profiler is no-op.
     /// - Returns: The tracer instance.
     func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer
+}
+
+/// The Benchmark Meter provides interfaces to collect data in a benchmark
+/// environment.
+///
+/// During benchmarking, a concrete implementation of the meter will be
+/// injected to collect data during execution of the SDK.
+///
+/// In production, the profiler is no-op and immutable.
+public protocol BenchmarkMeter {
+    /// Returns a `BenchmarkCounter` instance for a given metric name.
+    ///
+    /// The counter metric will sum up added values.
+    ///
+    /// - Parameter metric: The metric name.
+    /// - Returns: The counter instance.
+    func counter(metric: @autoclosure () -> String) -> BenchmarkCounter
+
+    /// Returns a `BenchmarkGauge` instance for a given metric name.
+    ///
+    /// The gauge metric will keep the latest value.
+    ///
+    /// - Parameter metric: The metric name.
+    /// - Returns: The gauge instance.
+    func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge
 }
 
 /// The Benchmark Tracer will create and start spans in a benchmark environment.
@@ -53,9 +78,63 @@ public protocol BenchmarkSpan {
     func stop()
 }
 
-private final class NOPBenchmarkProfiler: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan {
+/// The Benchmark Counter is a counter metric aggregator.
+///
+/// This meter can be used to count measures of the SDK.
+/// In production, the Benchmark Counter is no-op.
+public protocol BenchmarkCounter {
+    func add(value: Double, attributes: @autoclosure () -> [String: String])
+}
+
+extension BenchmarkCounter {
+    /// Increment the counter.
+    ///
+    /// - parameters:
+    ///     - by: Amount to increment by.
+    public func increment<FloatingPoint>(by amount: FloatingPoint = 1, attributes: @autoclosure () -> [String: String] = [:]) where FloatingPoint: BinaryFloatingPoint {
+        add(value: Double(amount), attributes: attributes())
+    }
+
+    /// Increment the counter.
+    ///
+    /// - parameters:
+    ///     - by: Amount to increment by.
+    public func increment<Integer>(by amount: Integer = 1, attributes: @autoclosure () -> [String: String] = [:]) where Integer: BinaryInteger {
+        add(value: Double(amount), attributes: attributes())
+    }
+}
+
+/// The Benchmark Gauge is a gauge metric aggregator.
+///
+/// This meter can be used to track measures of the SDK.
+/// In production, the Benchmark Gauge is no-op.
+public protocol BenchmarkGauge {
+    func record(value: Double, attributes: @autoclosure () -> [String: String])
+}
+
+extension BenchmarkGauge {
+    /// Record value.
+    public func record<FloatingPoint>(_ value: FloatingPoint, attributes: @autoclosure () -> [String: String] = [:]) where FloatingPoint: BinaryFloatingPoint {
+        record(value: Double(value), attributes: attributes())
+    }
+
+    /// Record value.
+    public func record<Integer>(_ value: Integer, attributes: @autoclosure () -> [String: String] = [:]) where Integer: BinaryInteger {
+        record(value: Double(value), attributes: attributes())
+    }
+}
+
+private final class NOPBench: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan, BenchmarkMeter, BenchmarkCounter, BenchmarkGauge {
     /// no-op
     func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer { self }
+    /// no-op
+    func counter(metric: @autoclosure () -> String) -> BenchmarkCounter { self }
+    /// no-op
+    func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge { self }
+    /// no-op
+    func add(value: Double, attributes: @autoclosure () -> [String: String]) { }
+    /// no-op
+    func record(value: Double, attributes: @autoclosure () -> [String: String]) { }
     /// no-op
     func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan { self }
     /// no-op


### PR DESCRIPTION
### What and why?

Fix metrics tags issue introduced in https://github.com/DataDog/dd-sdk-ios/pull/2218

### How?

- Merge the Otel Metric Provider's resources with tags.
- Register the `MeterProvider` and `TracerProvider` 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
