### PR TITLE
RUM-8847 Remove automatic `RUMUntrackedModal`

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
@@ -242,17 +242,6 @@ extension RUMViewsHandler: UIViewControllerHandler {
                     instrumentationType: .swiftui
                 )
             )
-        } else if #available(iOS 13, tvOS 13, *), viewController.isModalInPresentation {
-            add(
-                view: .init(
-                    identity: identity,
-                    name: "RUMUntrackedModal",
-                    path: viewController.canonicalClassName,
-                    isUntrackedModal: true,
-                    attributes: [:],
-                    instrumentationType: .uikit
-                )
-            )
         }
     }
 

--- a/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
@@ -440,57 +440,6 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(startCommand2.identity == ViewIdentifier(someView))
     }
 
-    func testGiveniOS13AppearedView_whenTransitioningToModal_viewDoesStop() throws {
-        if #available(iOS 13, tvOS 13, *) {
-            // Given
-            let someView = createMockViewInWindow()
-            let untrackedModal = createMockViewInWindow()
-            untrackedModal.isModalInPresentation = true
-
-            let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
-            let handler = createHandler(uiKitPredicate: uiKitPredicate)
-
-            // When
-            handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
-            handler.notify_viewDidAppear(viewController: untrackedModal, animated: .mockAny())
-
-            XCTAssertEqual(commandSubscriber.receivedCommands.count, 2)
-
-            let startCommand = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
-            let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
-
-            XCTAssertTrue(startCommand.identity == ViewIdentifier(someView))
-            XCTAssertTrue(stopCommand.identity == ViewIdentifier(someView))
-        }
-    }
-
-    func testGiveniOS13Modal_whenTransitioningToAppearedView_viewDoesStart() throws {
-        if #available(iOS 13, tvOS 13, *) {
-            // Given
-            let someView = createMockViewInWindow()
-            let untrackedModal = createMockViewInWindow()
-            untrackedModal.isModalInPresentation = true
-
-            let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
-            let handler = createHandler(uiKitPredicate: uiKitPredicate)
-
-            // When
-            handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
-            handler.notify_viewDidAppear(viewController: untrackedModal, animated: .mockAny())
-            handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
-
-            XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
-
-            let startCommand = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
-            let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
-            let startCommand2 = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
-
-            XCTAssertTrue(startCommand.identity == ViewIdentifier(someView))
-            XCTAssertTrue(stopCommand.identity == ViewIdentifier(someView))
-            XCTAssertTrue(startCommand2.identity == ViewIdentifier(someView))
-        }
-    }
-
     // MARK: - Handling Manual SwiftUI Instrumentation `.onAppear`
 
     func testWhenOnAppear_itStartsRUMView() throws {

--- a/IntegrationTests/Runner/Scenarios/RUM/SwiftUIInstrumentation/SwiftUIRootViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/SwiftUIInstrumentation/SwiftUIRootViewController.swift
@@ -94,8 +94,11 @@ struct ScreenView: View {
 
     var body: some View {
         VStack(spacing: 32) {
-            NavigationLink("Push to Next View", destination: destination)
-                .trackRUMTapAction(name: "Tap Push to Next View")
+            NavigationLink(
+                "Push to Next View",
+                destination: destination.dd_interactiveDismissDisabled()
+            )
+            .trackRUMTapAction(name: "Tap Push to Next View")
 
             Text("This is a Label")
 
@@ -185,6 +188,17 @@ class UIScreenViewController: UIViewController {
             } else {
                 ScreenView(index: index + 1)
             }
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension View {
+    func dd_interactiveDismissDisabled(_ isDisabled: Bool = true) -> some View {
+        if #available(iOS 15.0, *) {
+            return interactiveDismissDisabled(isDisabled)
+        } else {
+            return self
         }
     }
 }


### PR DESCRIPTION
### What and why?

The logic to ignore modal presentation automatically seems wrong and prone to issue such as #2209.
Ignoring a view by returning `isUntrackedModal: true` in the predicate is correct but ignoring a view-controller automatically when it has `isModalInPresentation: true` is not.

From Apple documentation:
> The default value of this property is [false](https://developer.apple.com/documentation/swift/false). When you set it to [true](https://developer.apple.com/documentation/swift/true), UIKit ignores events outside the view controller's bounds and prevents the interactive dismissal of the view controller while it is onscreen.

The `isModalInPresentation` is about dismissal interaction, but the view-controller could be in any navigation stack. 

### How?

Remove ignoring view-controllers with `isModalInPresentation: true` in the view auto-instrumentation.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
