### PR TITLE
mariedm/rum 8416 add auto view tracking option in rum config

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -160,6 +160,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             featureScope: featureScope,
             uiKitRUMViewsPredicate: configuration.uiKitViewsPredicate,
             uiKitRUMActionsPredicate: configuration.uiKitActionsPredicate,
+            swiftUIRUMViewsPredicate: configuration.swiftUIViewsPredicate,
             longTaskThreshold: configuration.longTaskThreshold,
             appHangThreshold: configuration.appHangThreshold,
             mainQueue: configuration.mainQueue,

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -48,6 +48,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         featureScope: FeatureScope,
         uiKitRUMViewsPredicate: UIKitRUMViewsPredicate?,
         uiKitRUMActionsPredicate: UIKitRUMActionsPredicate?,
+        swiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate?,
         longTaskThreshold: TimeInterval?,
         appHangThreshold: TimeInterval?,
         mainQueue: DispatchQueue,
@@ -59,20 +60,16 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         watchdogTermination: WatchdogTerminationMonitor?,
         memoryWarningMonitor: MemoryWarningMonitor
     ) {
-        // MARK: TODO: RUM-8416 - Remove after we add SwiftUI view instrumentation option
-        // Always create views handler (we can't know if it will be used by SwiftUI instrumentation)
-        // and only swizzle `UIViewController` if UIKit instrumentation is configured:
         let viewsHandler = RUMViewsHandler(
             dateProvider: dateProvider,
             uiKitPredicate: uiKitRUMViewsPredicate,
-            swiftUIPredicate: nil,
-            swiftUIViewNameExtractor: nil,
+            swiftUIPredicate: swiftUIRUMViewsPredicate,
+            swiftUIViewNameExtractor: SwiftUIReflectionBasedViewNameExtractor(),
             notificationCenter: notificationCenter
         )
         let viewControllerSwizzler: UIViewControllerSwizzler? = {
             do {
-                // MARK: TODO: RUM-8416 - Check both predicates after we add SwiftUI view instrumentation option
-                if uiKitRUMViewsPredicate != nil {
+                if uiKitRUMViewsPredicate != nil || swiftUIRUMViewsPredicate != nil {
                     return try UIViewControllerSwizzler(handler: viewsHandler)
                 }
             } catch {

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -84,6 +84,19 @@ extension RUM {
         /// Default: `nil` - which means automatic RUM action tracking is not enabled by default.
         public var uiKitActionsPredicate: UIKitRUMActionsPredicate?
 
+        /// The predicate for automatically tracking `UIViewControllers` as RUM views.
+        ///
+        /// RUM will query this predicate for each `UIViewController` presented in the app. The predicate implementation
+        /// should return RUM view parameters if the given controller should start a view, or `nil` to ignore it.
+        ///
+        /// You can use `DefaultSwiftUIRUMViewsPredicate` or create your own predicate by implementing `SwiftUIRUMViewsPredicate`.
+        ///
+        /// Note: Automatic RUM views tracking involves swizzling the `UIViewController` lifecycle methods.
+        ///
+        /// Default: `nil` - which means automatic RUM view tracking is not enabled by default.
+        @available(*, message: "This API is experimental and may change in future releases")
+        public var swiftUIViewsPredicate: SwiftUIRUMViewsPredicate?
+
         /// The configuration for automatic RUM resources tracking.
         ///
         /// RUM resources tracking requires enabling `URLSessionInstrumentation`. See
@@ -179,7 +192,7 @@ extension RUM {
         /// and do not make any assumptions on the thread used to run it.
         ///
         /// Note: This mapper ensures that all views are sent by preventing the return of `nil`. To drop certain automatically
-        /// collected RUM views, adjust the implementation of the view predicate (see the `uiKitViewsPredicate` option).
+        /// collected RUM views, adjust the implementation of the view predicate (see the `uiKitViewsPredicate` and `swiftUIPredicate` options).
         ///
         /// Default: `nil`.
         public var viewEventMapper: RUM.ViewEventMapper?
@@ -377,8 +390,9 @@ extension RUM.Configuration {
     /// - Parameters:
     ///   - applicationID: The RUM application identifier.
     ///   - sessionSampleRate: The sampling rate for RUM sessions. Must be a value between `0` and `100`. Default: `100`.
-    ///   - uiKitViewsPredicate: The predicate for automatically tracking `UIViewControllers` as RUM views. Default: `nil`.
+    ///   - uiKitViewsPredicate: The predicate for automatically tracking `UIViewControllers` in `UIKit` as RUM views. Default: `nil`.
     ///   - uiKitActionsPredicate: The predicate for automatically tracking `UITouch` events as RUM actions. Default: `nil`.
+    ///   - swiftUIViewsPredicate: The predicate for automatically tracking `UIViewControllers` in `SwiftUI` as RUM views. Default: `nil`.
     ///   - urlSessionTracking: The configuration for automatic RUM resources tracking. Default: `nil`.
     ///   - trackFrustrations: Determines whether automatic tracking of user frustrations should be enabled. Default: `true`.
     ///   - trackBackgroundEvents: Determines whether RUM events should be tracked when no view is active. Default: `false`.
@@ -404,6 +418,7 @@ extension RUM.Configuration {
         sessionSampleRate: SampleRate = .maxSampleRate,
         uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,
         uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,
+        swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,
         urlSessionTracking: URLSessionTracking? = nil,
         trackFrustrations: Bool = true,
         trackBackgroundEvents: Bool = false,
@@ -428,6 +443,7 @@ extension RUM.Configuration {
         self.sessionSampleRate = sessionSampleRate
         self.uiKitViewsPredicate = uiKitViewsPredicate
         self.uiKitActionsPredicate = uiKitActionsPredicate
+        self.swiftUIViewsPredicate = swiftUIViewsPredicate
         self.urlSessionTracking = urlSessionTracking
         self.trackFrustrations = trackFrustrations
         self.trackBackgroundEvents = trackBackgroundEvents

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -192,7 +192,7 @@ extension RUM {
         /// and do not make any assumptions on the thread used to run it.
         ///
         /// Note: This mapper ensures that all views are sent by preventing the return of `nil`. To drop certain automatically
-        /// collected RUM views, adjust the implementation of the view predicate (see the `uiKitViewsPredicate` and `swiftUIPredicate` options).
+        /// collected RUM views, adjust the implementations of the view predicates (see the `uiKitViewsPredicate` and `swiftUIViewsPredicate` options).
         ///
         /// Default: `nil`.
         public var viewEventMapper: RUM.ViewEventMapper?

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -18,6 +18,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: UIKitRUMViewsPredicateMock(),
             uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: nil,
             appHangThreshold: .mockAny(),
             mainQueue: .main,
@@ -46,6 +47,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: UIKitRUMActionsPredicateMock(),
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: nil,
             appHangThreshold: .mockAny(),
             mainQueue: .main,
@@ -65,12 +67,42 @@ class RUMInstrumentationTests: XCTestCase {
         }
     }
 
+    func testWhenOnlySwiftUIViewsPredicateIsConfigured_itInstrumentsUIViewController() throws {
+        // When
+        let instrumentation = RUMInstrumentation(
+            featureScope: NOPFeatureScope(),
+            uiKitRUMViewsPredicate: nil,
+            uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicateMock(),
+            longTaskThreshold: nil,
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
+            processID: .mockAny(),
+            notificationCenter: .default,
+            watchdogTermination: .mockRandom(),
+            memoryWarningMonitor: .mockRandom()
+        )
+
+        // Then
+        withExtendedLifetime(instrumentation) {
+            DDAssertActiveSwizzlings([
+                "viewDidAppear:",
+                "viewDidDisappear:",
+            ])
+            XCTAssertNil(instrumentation.longTasks)
+        }
+    }
+
     func testWhenOnlyLongTasksThresholdIsConfigured_itInstrumentsRunLoop() throws {
         // When
         let instrumentation = RUMInstrumentation(
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: 0.5,
             appHangThreshold: .mockAny(),
             mainQueue: .main,
@@ -99,6 +131,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: .mockRandom(min: -100, max: 0),
             appHangThreshold: .mockAny(),
             mainQueue: .main,
@@ -123,6 +156,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: .mockRandom(min: -100, max: 0),
             appHangThreshold: 2,
             mainQueue: .main,
@@ -147,6 +181,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: nil,
             uiKitRUMActionsPredicate: nil,
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: .mockRandom(min: -100, max: 0),
             appHangThreshold: nil,
             mainQueue: .main,
@@ -171,6 +206,7 @@ class RUMInstrumentationTests: XCTestCase {
             featureScope: NOPFeatureScope(),
             uiKitRUMViewsPredicate: UIKitRUMViewsPredicateMock(),
             uiKitRUMActionsPredicate: UIKitRUMActionsPredicateMock(),
+            swiftUIRUMViewsPredicate: nil,
             longTaskThreshold: 0.5,
             appHangThreshold: 2,
             mainQueue: .main,

--- a/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
@@ -11,30 +11,35 @@ import TestUtilities
 class RUMViewsHandlerTests: XCTestCase {
     private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
     private let commandSubscriber = RUMCommandSubscriberMock()
-    private let predicate = UIKitRUMViewsPredicateMock()
     private let notificationCenter = NotificationCenter()
 
-    private lazy var handler: RUMViewsHandler = {
+    // MARK: - Helper
+    private func createHandler(
+        uiKitPredicate: UIKitRUMViewsPredicate? = nil,
+        swiftUIPredicate: SwiftUIRUMViewsPredicate? = nil,
+        swiftUIViewNameExtractor: SwiftUIViewNameExtractor? = nil
+    ) -> RUMViewsHandler {
         let handler = RUMViewsHandler(
             dateProvider: dateProvider,
-            uiKitPredicate: predicate,
-            swiftUIPredicate: nil,
-            swiftUIViewNameExtractor: nil,
+            uiKitPredicate: uiKitPredicate,
+            swiftUIPredicate: swiftUIPredicate,
+            swiftUIViewNameExtractor: swiftUIViewNameExtractor,
             notificationCenter: notificationCenter
         )
         handler.publish(to: commandSubscriber)
         return handler
-    }()
+    }
 
     // MARK: - Handling `viewDidAppear`
 
-    func testGivenAcceptingPredicate_whenViewDidAppear_itStartsRUMView() throws {
+    func testGivenUIKitPredicate_whenViewDidAppear_itStartsRUMView() throws {
         let viewName: String = .mockRandom()
         let viewControllerClassName: String = .mockRandom()
         let view = createMockView(viewControllerClassName: viewControllerClassName)
 
         // Given
-        predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: viewName, attributes: ["foo": "bar"]))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
@@ -47,18 +52,21 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertEqual(command.path, viewControllerClassName)
         XCTAssertEqual(command.name, viewName)
         XCTAssertEqual(command.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(command.instrumentationType, .uikit)
         XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
     }
 
-    func testGivenAcceptingPredicate_whenViewDidAppear_itStopsPreviousRUMView() throws {
+    func testGivenUIKitPredicate_whenViewDidAppear_itStopsPreviousRUMView() throws {
         let view1 = createMockViewInWindow()
         let view2 = createMockViewInWindow()
 
         // Given
-        predicate.resultByViewController = [
+        let uiKitPredicate = UIKitRUMViewsPredicateMock()
+        uiKitPredicate.resultByViewController = [
             view1: .init(name: .mockRandom(), attributes: ["key1": "val1"]),
             view2: .init(name: .mockRandom(), attributes: ["key2": "val2"]),
         ]
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidAppear(viewController: view1, animated: .mockAny())
@@ -78,11 +86,12 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertEqual(startCommand2.attributes as? [String: String], ["key2": "val2"])
     }
 
-    func testGivenAcceptingPredicate_whenViewDidAppear_itDoesNotStartTheSameRUMViewTwice() {
+    func testGivenUIKitPredicate_whenViewDidAppear_itDoesNotStartTheSameRUMViewTwice() {
         let view = createMockViewInWindow()
 
         // Given
-        predicate.result = .init(name: .mockRandom())
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: .mockRandom()))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
@@ -93,17 +102,167 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(commandSubscriber.receivedCommands[0] is RUMStartViewCommand)
     }
 
-    func testGivenRejectingPredicate_whenViewDidAppear_itDoesNotStartAnyRUMView() {
+    func testGivenNoUIKitPredicate_whenViewDidAppear_itDoesNotStartAnyRUMView() {
         let view = createMockViewInWindow()
 
         // Given
-        predicate.result = nil
+        let handler = createHandler()
 
         // When
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
+    }
+
+    func testGivenSwiftUIPredicateAndNameExtractor_whenViewDidAppear_itStartsRUMView() throws {
+        let viewController = createMockViewInWindow()
+        let extractedName = "MySwiftUIView"
+        let viewName = "CustomizedName"
+
+        // Given
+        let swiftUIViewNameExtractor = SwiftUIViewNameExtractorMock(defaultResult: extractedName)
+        let swiftUIPredicate = SwiftUIRUMViewsPredicateMock(result: .init(name: viewName, attributes: ["foo": "bar"]))
+
+        let handler = createHandler(
+            swiftUIPredicate: swiftUIPredicate,
+            swiftUIViewNameExtractor: swiftUIViewNameExtractor
+        )
+
+        // When
+        handler.notify_viewDidAppear(viewController: viewController, animated: .mockAny())
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+        let command = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        XCTAssertTrue(command.identity == ViewIdentifier(viewController))
+        XCTAssertEqual(command.path, viewController.canonicalClassName)
+        XCTAssertEqual(command.name, viewName)
+        XCTAssertEqual(command.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(command.instrumentationType, .swiftui)
+        XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
+    }
+
+    func testGivenSwiftUIPredicateAndNoNameExtractor_whenViewDidAppear_itDoesNotStartView() {
+        let viewController = createMockViewInWindow()
+
+        // Given
+        let swiftUIPredicate = SwiftUIRUMViewsPredicateMock(result: .init(name: "ShouldNotBeCalled"))
+
+        let handler = createHandler(
+            swiftUIPredicate: swiftUIPredicate,
+            swiftUIViewNameExtractor: nil
+        )
+
+        // When
+        handler.notify_viewDidAppear(viewController: viewController, animated: true)
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
+    }
+
+    func testGivenNameExtractorButNoSwiftUIPredicate_whenViewDidAppear_itDoesNotStartView() {
+        let viewController = createMockViewInWindow()
+
+        // Given
+        let swiftUIViewNameExtractor = SwiftUIViewNameExtractorMock(defaultResult: "MySwiftUIView")
+
+        let handler = createHandler(
+            swiftUIPredicate: nil,
+            swiftUIViewNameExtractor: swiftUIViewNameExtractor
+        )
+
+        // When
+        handler.notify_viewDidAppear(viewController: viewController, animated: true)
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
+    }
+
+    func testGivenSwiftUIPredicate_whenViewDidAppear_itStopsPreviousRUMView() throws {
+        let view1 = createMockViewInWindow()
+        let view2 = createMockViewInWindow()
+
+        // Given
+        let swiftUIViewNameExtractor = SwiftUIViewNameExtractorMock()
+        swiftUIViewNameExtractor.resultByViewController = [
+            view1: "view1",
+            view2: "view2"
+        ]
+
+        let swiftUIPredicate = SwiftUIRUMViewsPredicateMock()
+        swiftUIPredicate.resultByViewName = [
+            "view1": .init(name: .mockRandom(), attributes: ["key1": "val1"]),
+            "view2": .init(name: .mockRandom(), attributes: ["key2": "val2"]),
+        ]
+        let handler = createHandler(swiftUIPredicate: swiftUIPredicate, swiftUIViewNameExtractor: swiftUIViewNameExtractor)
+
+        // When
+        handler.notify_viewDidAppear(viewController: view1, animated: .mockAny())
+        handler.notify_viewDidAppear(viewController: view2, animated: .mockAny())
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
+
+        let startCommand1 = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
+        let startCommand2 = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
+
+        XCTAssertTrue(startCommand1.identity == ViewIdentifier(view1))
+        XCTAssertEqual(startCommand1.attributes as? [String: String], ["key1": "val1"])
+        XCTAssertEqual(startCommand1.instrumentationType, .swiftui)
+        XCTAssertTrue(stopCommand.identity == ViewIdentifier(view1))
+        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertTrue(startCommand2.identity == ViewIdentifier(view2))
+        XCTAssertEqual(startCommand2.attributes as? [String: String], ["key2": "val2"])
+        XCTAssertEqual(startCommand2.instrumentationType, .swiftui)
+    }
+
+    func testGivenBothPredicates_whenViewDidAppear_itUsesUIKitPredicate() throws {
+        let viewController = createMockViewInWindow()
+
+        // Given
+        let swiftUIViewNameExtractor = SwiftUIViewNameExtractorMock(defaultResult: "MySwiftUIView")
+        let swiftUIPredicate = SwiftUIRUMViewsPredicateMock(result: .init(name: "SwiftUIName"))
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: "UIKitName"))
+
+        let handler = createHandler(
+            uiKitPredicate: uiKitPredicate,
+            swiftUIPredicate: swiftUIPredicate,
+            swiftUIViewNameExtractor: swiftUIViewNameExtractor
+        )
+
+        // When
+        handler.notify_viewDidAppear(viewController: viewController, animated: true)
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+        let command = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        XCTAssertEqual(command.name, "UIKitName")
+        XCTAssertEqual(command.instrumentationType, .uikit)
+    }
+
+    func testGivenNoUIKitPredicate_whenViewDidAppear_itFallsBackToSwiftUIPredicate() throws {
+        let viewController = createMockViewInWindow()
+
+        // Given
+        let swiftUIViewNameExtractor = SwiftUIViewNameExtractorMock(defaultResult: "MySwiftUIView")
+        let swiftUIPredicate = SwiftUIRUMViewsPredicateMock(result: .init(name: "SwiftUIName"))
+
+        let handler = createHandler(
+            swiftUIPredicate: swiftUIPredicate,
+            swiftUIViewNameExtractor: swiftUIViewNameExtractor
+        )
+        handler.publish(to: commandSubscriber)
+
+        // When
+        handler.notify_viewDidAppear(viewController: viewController, animated: true)
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+        let command = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        XCTAssertEqual(command.name, "SwiftUIName")
+        XCTAssertEqual(command.instrumentationType, .swiftui)
     }
 
     // MARK: - Handling `viewDidDisappear`
@@ -114,7 +273,8 @@ class RUMViewsHandlerTests: XCTestCase {
         let view2 = createMockViewInWindow()
 
         // When
-        predicate.result = .init(name: .mockRandom())
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: .mockRandom()))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
         handler.notify_viewDidAppear(viewController: view1, animated: .mockAny())
         handler.notify_viewDidAppear(viewController: view2, animated: .mockAny())
         handler.notify_viewDidDisappear(viewController: view2, animated: .mockAny())
@@ -135,11 +295,12 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(startCommand3.identity == ViewIdentifier(view1))
     }
 
-    func testGivenAcceptingPredicate_whenViewDidDisappearButPreviousView_itDoesNotStartAnyRUMView() {
+    func testGivenNoActiveView_whenViewDidDisappear_itDoesNotStartAnyRUMView() {
         let view = createMockViewInWindow()
 
         // Given
-        predicate.result = .init(name: .mockRandom())
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: .mockRandom()))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidDisappear(viewController: view, animated: .mockAny())
@@ -148,12 +309,12 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
     }
 
-    func testGivenRejectingPredicate_whenViewDidDisappear_itDoesNotStartAnyRUMView() {
+    func testGivenNoPredicates_whenViewDidDisappear_itDoesNotStartAnyRUMView() {
         let view1 = createMockViewInWindow()
         let view2 = createMockViewInWindow()
 
         // Given
-        predicate.result = nil
+        let handler = createHandler()
 
         // When
         handler.notify_viewDidAppear(viewController: view1, animated: .mockAny())
@@ -170,7 +331,8 @@ class RUMViewsHandlerTests: XCTestCase {
         let view = createMockView(viewControllerClassName: viewControllerClassName)
 
         // Given
-        predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: viewName, attributes: ["foo": "bar"]))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // When
@@ -199,7 +361,8 @@ class RUMViewsHandlerTests: XCTestCase {
         let viewName: String = .mockRandom()
 
         // Given
-        predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
+        let uiKitPredicate = UIKitRUMViewsPredicateMock(result: .init(name: viewName, attributes: ["foo": "bar"]))
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
         handler.notify_viewDidDisappear(viewController: view, animated: .mockAny())
 
         // When
@@ -214,22 +377,8 @@ class RUMViewsHandlerTests: XCTestCase {
     // MARK: - Interacting with predicate
 
     func testGivenAppearedView_whenTransitioningBackAndForthFromThisViewToAnother_thenPredicateIsCalledOnlyTwice() {
-        class Predicate: UIKitRUMViewsPredicate {
-            var numberOfCalls = 0
-
-            func rumView(for viewController: UIViewController) -> RUMView? {
-                numberOfCalls += 1
-                return .init(name: .mockRandom())
-            }
-        }
-        let predicate = Predicate()
-        let handler = RUMViewsHandler(
-            dateProvider: dateProvider,
-            uiKitPredicate: predicate,
-            swiftUIPredicate: nil,
-            swiftUIViewNameExtractor: nil,
-            notificationCenter: .default
-        )
+        let uiKitPredicate = UIKitPredicateWithTrackingMock()
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // Given
         let someView = createMockViewInWindow()
@@ -243,36 +392,16 @@ class RUMViewsHandlerTests: XCTestCase {
         handler.notify_viewDidAppear(viewController: anotherView, animated: .mockAny()) // 5th: `anotherView` receives "did appear"
 
         // Then
-        XCTAssertEqual(predicate.numberOfCalls, 2)
+        XCTAssertEqual(uiKitPredicate.numberOfCalls, 2)
     }
 
     func testGivenAppearedView_whenTransitioningToUntrackedModal_viewDoesStop() throws {
-        class Predicate: UIKitRUMViewsPredicate {
-            let untrackedModal: UIViewController
-
-            init(untrackedModal: UIViewController) {
-                self.untrackedModal = untrackedModal
-            }
-
-            func rumView(for viewController: UIViewController) -> RUMView? {
-                let isUntrackedModal = viewController == untrackedModal
-
-                return .init(name: .mockRandom(), isUntrackedModal: isUntrackedModal)
-            }
-        }
         // Given
         let someView = createMockViewInWindow()
         let untrackedModal = createMockViewInWindow()
 
-        let predicate = Predicate(untrackedModal: untrackedModal)
-        let handler = RUMViewsHandler(
-            dateProvider: dateProvider,
-            uiKitPredicate: predicate,
-            swiftUIPredicate: nil,
-            swiftUIViewNameExtractor: nil,
-            notificationCenter: .default
-        )
-        handler.publish(to: commandSubscriber)
+        let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
@@ -288,32 +417,12 @@ class RUMViewsHandlerTests: XCTestCase {
     }
 
     func testGivenUntrackedModal_whenTransitioningToAppearedView_viewDoesStart() throws {
-        class Predicate: UIKitRUMViewsPredicate {
-            let untrackedModal: UIViewController
-
-            init(untrackedModal: UIViewController) {
-                self.untrackedModal = untrackedModal
-            }
-
-            func rumView(for viewController: UIViewController) -> RUMView? {
-                let isUntrackedModal = viewController == untrackedModal
-
-                return .init(name: .mockRandom(), isUntrackedModal: isUntrackedModal)
-            }
-        }
         // Given
         let someView = createMockViewInWindow()
         let untrackedModal = createMockViewInWindow()
 
-        let predicate = Predicate(untrackedModal: untrackedModal)
-        let handler = RUMViewsHandler(
-            dateProvider: dateProvider,
-            uiKitPredicate: predicate,
-            swiftUIPredicate: nil,
-            swiftUIViewNameExtractor: nil,
-            notificationCenter: .default
-        )
-        handler.publish(to: commandSubscriber)
+        let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
+        let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
         // When
         handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
@@ -333,33 +442,13 @@ class RUMViewsHandlerTests: XCTestCase {
 
     func testGiveniOS13AppearedView_whenTransitioningToModal_viewDoesStop() throws {
         if #available(iOS 13, tvOS 13, *) {
-            class Predicate: UIKitRUMViewsPredicate {
-                let untrackedModal: UIViewController
-
-                init(untrackedModal: UIViewController) {
-                    self.untrackedModal = untrackedModal
-                }
-
-                func rumView(for viewController: UIViewController) -> RUMView? {
-                    let isUntrackedModal = viewController == untrackedModal
-
-                    return .init(name: .mockRandom(), isUntrackedModal: isUntrackedModal)
-                }
-            }
             // Given
             let someView = createMockViewInWindow()
             let untrackedModal = createMockViewInWindow()
             untrackedModal.isModalInPresentation = true
 
-            let predicate = Predicate(untrackedModal: untrackedModal)
-            let handler = RUMViewsHandler(
-                dateProvider: dateProvider,
-                uiKitPredicate: predicate,
-                swiftUIPredicate: nil,
-                swiftUIViewNameExtractor: nil,
-                notificationCenter: .default
-            )
-            handler.publish(to: commandSubscriber)
+            let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
+            let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
             // When
             handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
@@ -377,35 +466,13 @@ class RUMViewsHandlerTests: XCTestCase {
 
     func testGiveniOS13Modal_whenTransitioningToAppearedView_viewDoesStart() throws {
         if #available(iOS 13, tvOS 13, *) {
-            class Predicate: UIKitRUMViewsPredicate {
-                let untrackedModal: UIViewController
-
-                init(untrackedModal: UIViewController) {
-                    self.untrackedModal = untrackedModal
-                }
-
-                func rumView(for viewController: UIViewController) -> RUMView? {
-                    if viewController == untrackedModal {
-                        return nil
-                    }
-
-                    return .init(name: .mockRandom())
-                }
-            }
             // Given
             let someView = createMockViewInWindow()
             let untrackedModal = createMockViewInWindow()
             untrackedModal.isModalInPresentation = true
 
-            let predicate = Predicate(untrackedModal: untrackedModal)
-            let handler = RUMViewsHandler(
-                dateProvider: dateProvider,
-                uiKitPredicate: predicate,
-                swiftUIPredicate: nil,
-                swiftUIViewNameExtractor: nil,
-                notificationCenter: .default
-            )
-            handler.publish(to: commandSubscriber)
+            let uiKitPredicate = UIKitPredicateWithModalMock(untrackedModal: untrackedModal)
+            let handler = createHandler(uiKitPredicate: uiKitPredicate)
 
             // When
             handler.notify_viewDidAppear(viewController: someView, animated: .mockAny())
@@ -424,7 +491,7 @@ class RUMViewsHandlerTests: XCTestCase {
         }
     }
 
-    // MARK: - Handling SwiftUI `.onAppear`
+    // MARK: - Handling Manual SwiftUI Instrumentation `.onAppear`
 
     func testWhenOnAppear_itStartsRUMView() throws {
         // Given
@@ -434,6 +501,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let viewAttributes = mockRandomAttributes()
 
         // When
+        let handler = createHandler()
         handler.notify_onAppear(
             identity: viewIdentity,
             name: viewName,
@@ -463,6 +531,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let view2Name: String = .mockRandom()
         let view2Path: String = .mockRandom()
         let view2Attributes = mockRandomAttributes()
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -500,6 +569,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let viewName: String = .mockRandom()
         let viewPath: String = .mockRandom()
         let viewAttributes = mockRandomAttributes()
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -521,11 +591,12 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(commandSubscriber.receivedCommands[0] is RUMStartViewCommand)
     }
 
-    // MARK: - Handling SwiftUI `onDisappear`
+    // MARK: - Handling Manual SwiftUI Instrumentation `onDisappear`
 
     func testWhenOnDisappear_itDoesNotSendAnyCommand() {
         // Given
         let viewIdentity: String = UUID().uuidString
+        let handler = createHandler()
 
         // When
         handler.notify_onDisappear(identity: viewIdentity)
@@ -540,6 +611,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let viewName: String = .mockRandom()
         let viewPath: String = .mockRandom()
         let viewAttributes = mockRandomAttributes()
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -574,6 +646,8 @@ class RUMViewsHandlerTests: XCTestCase {
         let view2Name: String = .mockRandom()
         let view2Path: String = .mockRandom()
         let view2Attributes = mockRandomAttributes()
+
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -617,6 +691,8 @@ class RUMViewsHandlerTests: XCTestCase {
         let view2Name: String = .mockRandom()
         let view2Path: String = .mockRandom()
         let view2Attributes = mockRandomAttributes()
+
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -662,6 +738,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let viewName: String = .mockRandom()
         let viewPath: String = .mockRandom()
         let viewAttributes = mockRandomAttributes()
+        let handler = createHandler()
 
         // When
         handler.notify_onAppear(
@@ -693,6 +770,7 @@ class RUMViewsHandlerTests: XCTestCase {
     func testGivenSwiftUIViewDidNotStart_whenAppStateChanges_itDoesNothing() throws {
         // Given
         let viewIdentity: String = UUID().uuidString
+        let handler = createHandler()
 
         // When
         handler.notify_onDisappear(identity: viewIdentity)

--- a/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMFeatureMocks.swift
@@ -1124,6 +1124,54 @@ class UIKitRUMViewsPredicateMock: UIKitRUMViewsPredicate {
     }
 }
 
+class UIKitPredicateWithTrackingMock: UIKitRUMViewsPredicate {
+    var numberOfCalls = 0
+
+    func rumView(for viewController: UIViewController) -> RUMView? {
+        numberOfCalls += 1
+        return .init(name: .mockRandom())
+    }
+}
+
+class UIKitPredicateWithModalMock: UIKitRUMViewsPredicate {
+    let untrackedModal: UIViewController
+
+    init(untrackedModal: UIViewController) {
+        self.untrackedModal = untrackedModal
+    }
+
+    func rumView(for viewController: UIViewController) -> RUMView? {
+        let isUntrackedModal = viewController == untrackedModal
+        return .init(name: .mockRandom(), isUntrackedModal: isUntrackedModal)
+    }
+}
+
+class SwiftUIRUMViewsPredicateMock: SwiftUIRUMViewsPredicate {
+    var resultByViewName: [String: RUMView] = [:]
+    var result: RUMView?
+
+    init(result: RUMView? = nil) {
+        self.result = result
+    }
+
+    func rumView(for extractedViewName: String) -> RUMView? {
+        return resultByViewName[extractedViewName] ?? result
+    }
+}
+
+class SwiftUIViewNameExtractorMock: SwiftUIViewNameExtractor {
+    var resultByViewController: [UIViewController: String] = [:]
+    var defaultResult: String?
+
+    init(defaultResult: String? = nil) {
+        self.defaultResult = defaultResult
+    }
+
+    func extractName(from viewController: UIViewController) -> String? {
+        return resultByViewController[viewController] ?? defaultResult
+    }
+}
+
 #if os(tvOS)
 typealias UIKitRUMActionsPredicateMock = UIPressRUMActionsPredicateMock
 #else

--- a/DatadogRUM/Tests/RUMConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfigurationTests.swift
@@ -18,6 +18,7 @@ class RUMConfigurationTests: XCTestCase {
         XCTAssertEqual(config.telemetrySampleRate, 20)
         XCTAssertNil(config.uiKitViewsPredicate)
         XCTAssertNil(config.uiKitActionsPredicate)
+        XCTAssertNil(config.swiftUIViewsPredicate)
         XCTAssertNil(config.urlSessionTracking)
         XCTAssertTrue(config.trackFrustrations)
         XCTAssertFalse(config.trackBackgroundEvents)


### PR DESCRIPTION
- **RUM-8416 - Add view tracking option for SwiftUI**
- **RUM-8416 Add auto-tracking option for SwiftUI in RUM Configuration**

### What and why?

A short description of what changes this PR introduces and why.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
