### PR TITLE
GH-2239 chore: Refine errors printed from `clearAllData()`

### DIFF
--- a/DatadogCore/Sources/Core/DataStore/FeatureDataStore.swift
+++ b/DatadogCore/Sources/Core/DataStore/FeatureDataStore.swift
@@ -90,8 +90,8 @@ internal final class FeatureDataStore: DataStore {
     func clearAllData() {
         queue.async {
             do {
-                let directory = try self.coreDirectory.coreDirectory.subdirectory(path: self.directoryPath)
-                try directory.deleteAllFiles()
+                let directory = try self.coreDirectory.coreDirectory.subdirectoryIfExists(path: self.directoryPath)
+                try directory?.deleteAllFiles()
             } catch let error {
                 DD.logger.error("[Data Store] Error on clearing all data for `\(self.feature)`", error: error)
                 self.telemetry.error("[Data Store] Error on clearing all data for `\(self.feature)`", error: DDError(error: error))

--- a/DatadogCore/Sources/Core/Storage/Files/Directory.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/Directory.swift
@@ -107,6 +107,21 @@ internal struct Directory: DirectoryProtocol {
         }
     }
 
+    /// Returns directory at given path if it exists or `nil` otherwise. Throws if `path` exists but is not a directory.
+    func subdirectoryIfExists(path: String) throws -> Directory? {
+        let directoryURL = url.appendingPathComponent(path, isDirectory: true)
+        var isDirectory = ObjCBool(false)
+        let exists = FileManager.default.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory)
+
+        guard exists else {
+            return nil
+        }
+        guard isDirectory.boolValue else {
+            throw InternalError(description: "Path is not a directory: \(directoryURL)")
+        }
+        return Directory(url: directoryURL)
+    }
+
     /// Creates file with given name.
     func createFile(named fileName: String) throws -> File {
         let fileURL = url.appendingPathComponent(fileName, isDirectory: false)

--- a/DatadogCore/Tests/Datadog/Core/Persistence/Files/DirectoryTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/Files/DirectoryTests.swift
@@ -55,9 +55,11 @@ class DirectoryTests: XCTestCase {
 
         let uniqueName = uniqueSubdirectoryName()
         let expectedDirectory = try directory.createSubdirectory(path: uniqueName)
-        let actualDirectory = try directory.subdirectory(path: uniqueName)
+        let actualDirectory1 = try directory.subdirectory(path: uniqueName)
+        let actualDirectory2 = try directory.subdirectoryIfExists(path: uniqueName)
 
-        XCTAssertEqual(expectedDirectory.url, actualDirectory.url)
+        XCTAssertEqual(expectedDirectory.url, actualDirectory1.url)
+        XCTAssertEqual(expectedDirectory.url, actualDirectory2?.url)
     }
 
     func testItThrowsWhenAskedForSubdirectoryWhichDoesNotExist() throws {
@@ -68,6 +70,19 @@ class DirectoryTests: XCTestCase {
         XCTAssertThrowsError(try directory.subdirectory(path: "abc")) { error in
             XCTAssertTrue(error is InternalError, "It should throw as directory at given path doesn't exist")
         }
+
+        _ = try directory.createFile(named: "file-instead-of-directory")
+        XCTAssertThrowsError(try directory.subdirectory(path: "file-instead-of-directory")) { error in
+            XCTAssertTrue(error is InternalError, "It should throw as given path is a file, not directory")
+        }
+    }
+
+    func testReturnsNilWhenAskedForSubdirectoryWhichDoesNotExist() throws {
+        let directory = Directory(url: temporaryDirectory)
+        CreateTemporaryDirectory()
+        defer { DeleteTemporaryDirectory() }
+
+        XCTAssertNil(try directory.subdirectoryIfExists(path: "abc"))
 
         _ = try directory.createFile(named: "file-instead-of-directory")
         XCTAssertThrowsError(try directory.subdirectory(path: "file-instead-of-directory")) { error in


### PR DESCRIPTION
### What and why?

📦 This PR limits errors printed from `clearAllData()` API when SDK `.debug` verbosity is enabled.

Fixes https://github.com/DataDog/dd-sdk-ios/issues/2239

Before:
```swift
// Given
Datadog.initialize(with: coreConfig, trackingConsent: .pending)
Logs.enable()
Trace.enable()
RUM.enable(with: rumConfig)

// When
Datadog.clearAllData()

// Then, if run in freshly installed app, it was printing errors like:
// """
/// Path doesn't exist or is not a directory: file:///Users/.../Caches/com.datadoghq/v2/.../1/logging
/// """
```

Now, no errors are printed.

### How?

The issue was caused by an incorrect assumption in `FeatureDataStore.clearAllData()`: it presumed the directory would always exist, which isn't the case when the SDK launches for the first time.

The fix involves adding an existence check (`ifExist`) to verify the directory's presence before attempting to clear its contents.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
