### PR TITLE
Add public initializer for SwiftUI view predicate

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIRUMViewsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIRUMViewsPredicate.swift
@@ -24,6 +24,8 @@ public protocol SwiftUIRUMViewsPredicate {
 /// This implementation tracks all detected SwiftUI views with their extracted names.
 /// The view name in RUM Explorer will match the name extracted from the SwiftUI view.
 public struct DefaultSwiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate {
+    public init() {}
+
     public func rumView(for extractedViewName: String) -> RUMView? {
         return RUMView(name: extractedViewName)
     }


### PR DESCRIPTION
### What and why?

The default SwiftUI view predicate is missing a public initializer, making it unusable for RUM configuration. 

### How?

Adding public initializer. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
