### PR TITLE
RUM-9224 Upgrade to OTelApi 1.13.1

### DIFF
--- a/BenchmarkTests/Benchmarks/Package.swift
+++ b/BenchmarkTests/Benchmarks/Package.swift
@@ -58,4 +58,10 @@ func addOpenTelemetryDependency(_ version: Version) {
     }
 }
 
-addOpenTelemetryDependency("1.13.1")
+if ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil {
+    // RUM-9224: This condition was added to use DataDog/opentelemetry-swift-packages hotfix
+    // release. It should be removed with the next upgrade of OTelApi.
+    addOpenTelemetryDependency("1.13.0")
+} else {
+    addOpenTelemetryDependency("1.13.1")
+}

--- a/BenchmarkTests/Benchmarks/Package.swift
+++ b/BenchmarkTests/Benchmarks/Package.swift
@@ -58,4 +58,4 @@ func addOpenTelemetryDependency(_ version: Version) {
     }
 }
 
-addOpenTelemetryDependency("1.13.0")
+addOpenTelemetryDependency("1.13.1")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 2.24.1 / 31-04-2025
+
+- [FIX] Do not enforce dynamic linking for OpenTelemetryApi in `DatadogTrace`. See [#2244][]
+
 # 2.24.0 / 06-03-2025
 
 - [FEATURE] Adds anonymous identifier configuration for RUM Sessions linking. See [#2172][]
@@ -840,6 +844,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2177]: https://github.com/DataDog/dd-sdk-ios/pull/2177
 [#2217]: https://github.com/DataDog/dd-sdk-ios/pull/2217
 [#2182]: https://github.com/DataDog/dd-sdk-ios/pull/2182
+[#2244]: https://github.com/DataDog/dd-sdk-ios/pull/2244
 [#2200]: https://github.com/DataDog/dd-sdk-ios/pull/2200
 [#2195]: https://github.com/DataDog/dd-sdk-ios/pull/2195
 [@00fa9a]: https://github.com/00FA9A

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "microsoft/plcrashreporter" ~> 1.12.0
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.13.0
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" == 1.13.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.13.0"
+binary "https://raw.githubusercontent.com/DataDog/opentelemetry-swift-packages/main/OpenTelemetryApi.json" "1.13.1"
 github "microsoft/plcrashreporter" "1.12.0"

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -23,5 +23,5 @@ Pod::Spec.new do |s|
   s.source_files = ["DatadogTrace/Sources/**/*.swift"]
 
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'OpenTelemetrySwiftApi', '1.13.0'
+  s.dependency 'OpenTelemetrySwiftApi', '1.13.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.12.0"),
-        .package(url: opentelemetry.url, exact: "1.13.0"),
+        .package(url: opentelemetry.url, exact: "1.13.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ import Foundation
 let useOTelSwiftPackage = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil
 
 let opentelemetry = useOTelSwiftPackage ? 
-    (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git") :
-    (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git")
+    (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git", version: Version("1.13.0")) :
+    (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git", version: Version("1.13.1"))
 
 // `dd-sdk-ios` supports a broader range of platform versions than `OpenTelemetryApi`. 
 // When compiled in `OTEL_SWIFT` mode, we need to adjust the supported platforms accordingly.
@@ -67,7 +67,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.12.0"),
-        .package(url: opentelemetry.url, exact: "1.13.1"),
+        .package(url: opentelemetry.url, exact: opentelemetry.version),
     ],
     targets: [
         .target(

--- a/SmokeTests/cocoapods/Podfile.src
+++ b/SmokeTests/cocoapods/Podfile.src
@@ -1,5 +1,5 @@
 abstract_target 'Common' do
-  pod 'OpenTelemetrySwiftApi', '1.13.0'
+  pod 'OpenTelemetrySwiftApi', '1.13.1'
   pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE
   pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE
   pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :GIT_REFERENCE


### PR DESCRIPTION
### What and why?

📦 This PR updates `DatadogTrace` to OpenTelemetryApi 1.13.1 where we removed the enforcement of dynamic linking type for SPM. See: https://github.com/DataDog/opentelemetry-swift-packages/pull/28

This change will be shipped as `2.24.1` hotfix.

### How?

Bumping OTelApi version.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
