### PR TITLE
fix: Benchmark CatalogUIKit Storyboards

### DIFF
--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ActivityIndicatorViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ActivityIndicatorViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Activity Indicators-->
         <scene sceneID="umG-hc-QKi">
             <objects>
-                <tableViewController id="YvC-vN-mSd" customClass="ActivityIndicatorViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="YvC-vN-mSd" customClass="ActivityIndicatorViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="Udh-X7-hOc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/AlertControllerViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/AlertControllerViewController.storyboard
@@ -9,7 +9,7 @@
         <!--Alert Controllers-->
         <scene sceneID="KTf-Aj-rDo">
             <objects>
-                <tableViewController id="Va4-Ge-jQn" customClass="AlertControllerViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Va4-Ge-jQn" customClass="AlertControllerViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="iro-ev-0xV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ButtonViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ButtonViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Buttons-->
         <scene sceneID="q2O-rM-1tM">
             <objects>
-                <tableViewController id="gl0-hM-EWg" customClass="ButtonViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="gl0-hM-EWg" customClass="ButtonViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="gDs-OX-aHt">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ColorPickerViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ColorPickerViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Color Picker-->
         <scene sceneID="gkd-fd-9L5">
             <objects>
-                <viewController storyboardIdentifier="ColorPickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="ColorPickerViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ColorPickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="ColorPickerViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EB5-Ny-mbq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/CustomPageControlViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/CustomPageControlViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Custom Page Control-->
         <scene sceneID="udW-QU-LPM">
             <objects>
-                <viewController storyboardIdentifier="CustomPageControlViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="u2L-Jd-VCE" userLabel="Custom Page Control" customClass="CustomPageControlViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CustomPageControlViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="u2L-Jd-VCE" userLabel="Custom Page Control" customClass="CustomPageControlViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="t2L-wD-sqn">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/CustomSearchBarViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/CustomSearchBarViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Custom Search Bar-->
         <scene sceneID="dd9-nR-VNk">
             <objects>
-                <viewController storyboardIdentifier="CustomSearchBarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Mhd-Bs-sIn" customClass="CustomSearchBarViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CustomSearchBarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Mhd-Bs-sIn" customClass="CustomSearchBarViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YVy-et-UAQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/CustomToolbarViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/CustomToolbarViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Custom Toolbar-->
         <scene sceneID="WJu-sj-7Ti">
             <objects>
-                <viewController storyboardIdentifier="CustomToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="cTo-Y6-RL4" customClass="CustomToolbarViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CustomToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="cTo-Y6-RL4" customClass="CustomToolbarViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YY9-uv-rey">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/DatePickerController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/DatePickerController.storyboard
@@ -11,7 +11,7 @@
         <!--Date Picker-->
         <scene sceneID="zWi-9k-VNG">
             <objects>
-                <viewController storyboardIdentifier="DatePickerController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7Xn-ho-KP8" customClass="DatePickerController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DatePickerController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7Xn-ho-KP8" customClass="DatePickerController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="LFl-gd-u3P">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultPageControlViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultPageControlViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Page Control-->
         <scene sceneID="dMs-Pg-XoX">
             <objects>
-                <viewController storyboardIdentifier="PageControlViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="srd-Os-5SR" customClass="PageControlViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PageControlViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="srd-Os-5SR" customClass="PageControlViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KHl-03-rZm">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultSearchBarViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultSearchBarViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Default Search Bar-->
         <scene sceneID="mvP-iV-Ror">
             <objects>
-                <viewController storyboardIdentifier="DefaultSearchBarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aTT-8g-UdL" customClass="DefaultSearchBarViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DefaultSearchBarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aTT-8g-UdL" customClass="DefaultSearchBarViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="VZF-3b-rcm">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultToolbarViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/DefaultToolbarViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Default Toolbar-->
         <scene sceneID="LI9-fK-d77">
             <objects>
-                <viewController storyboardIdentifier="DefaultToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="P5B-ej-GR8" customClass="DefaultToolbarViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DefaultToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="P5B-ej-GR8" customClass="DefaultToolbarViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lTJ-Dz-yrG">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/FontPickerViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/FontPickerViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Font Picker-->
         <scene sceneID="gkd-fd-9L5">
             <objects>
-                <viewController storyboardIdentifier="FontPickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="FontPickerViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="FontPickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="FontPickerViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EB5-Ny-mbq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ImagePickerViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ImagePickerViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Image Picker-->
         <scene sceneID="gkd-fd-9L5">
             <objects>
-                <viewController useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="ImagePickerViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="ImagePickerViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EB5-Ny-mbq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ImageViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ImageViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Image View-->
         <scene sceneID="tB4-Qu-dAN">
             <objects>
-                <viewController id="XCI-A9-c2M" customClass="ImageViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="XCI-A9-c2M" customClass="ImageViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <imageView key="view" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="InE-1J-uPb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/Main.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
         <!--UIKitCatalog-->
         <scene sceneID="hcu-07-1H7">
             <objects>
-                <viewController storyboardIdentifier="OutlineViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="voO-Ai-mPL" customClass="OutlineViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="OutlineViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="voO-Ai-mPL" customClass="OutlineViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="716-hQ-1AE">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/MenuButtonViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/MenuButtonViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Menu Buttons-->
         <scene sceneID="q2O-rM-1tM">
             <objects>
-                <tableViewController id="gl0-hM-EWg" customClass="MenuButtonViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="gl0-hM-EWg" customClass="MenuButtonViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="gDs-OX-aHt">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/PickerViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/PickerViewController.storyboard
@@ -12,7 +12,7 @@
         <scene sceneID="gkd-fd-9L5">
             <objects>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TYZ-t7-BMO" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <viewController storyboardIdentifier="PickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="PickerViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PickerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hIc-I2-PiV" customClass="PickerViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EB5-Ny-mbq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/PointerInteractionButtonViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/PointerInteractionButtonViewController.storyboard
@@ -12,7 +12,7 @@
         <!--Pointer Interaction Buttons-->
         <scene sceneID="q2O-rM-1tM">
             <objects>
-                <tableViewController id="gl0-hM-EWg" customClass="PointerInteractionButtonViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="gl0-hM-EWg" customClass="PointerInteractionButtonViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="gDs-OX-aHt">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/ProgressViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/ProgressViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Progress Views-->
         <scene sceneID="lvJ-t8-0eN">
             <objects>
-                <tableViewController id="aY0-FD-8DD" customClass="ProgressViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="aY0-FD-8DD" customClass="ProgressViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="vxe-YC-yBi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/SegmentedControlViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/SegmentedControlViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Segmented Controls-->
         <scene sceneID="0RQ-gw-hMl">
             <objects>
-                <tableViewController id="Eil-ie-nN6" customClass="SegmentedControlViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Eil-ie-nN6" customClass="SegmentedControlViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="fLQ-5f-tUh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/SliderViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/SliderViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Sliders-->
         <scene sceneID="AcL-XD-MBK">
             <objects>
-                <tableViewController id="laz-6N-ZhE" customClass="SliderViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="laz-6N-ZhE" customClass="SliderViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="8xG-xW-Mvc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/StackViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/StackViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Stack Views-->
         <scene sceneID="upC-MR-WJj">
             <objects>
-                <viewController id="K8w-Uq-R9J" customClass="StackViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="K8w-Uq-R9J" customClass="StackViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Hwb-09-b4P">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/StepperViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/StepperViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Steppers-->
         <scene sceneID="xBH-7V-3ks">
             <objects>
-                <tableViewController id="Ob2-pp-aCj" customClass="StepperViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Ob2-pp-aCj" customClass="StepperViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="aQ3-9F-Tmi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/SwitchViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/SwitchViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Switches-->
         <scene sceneID="yZh-jH-dTD">
             <objects>
-                <tableViewController id="zcI-oN-J3j" customClass="SwitchViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="zcI-oN-J3j" customClass="SwitchViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="4ER-nG-feZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/SymbolViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/SymbolViewController.storyboard
@@ -11,7 +11,7 @@
         <!--SF Symbols-->
         <scene sceneID="xBH-7V-3ks">
             <objects>
-                <tableViewController id="Ob2-pp-aCj" customClass="SymbolViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Ob2-pp-aCj" customClass="SymbolViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="aQ3-9F-Tmi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/TextFieldViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/TextFieldViewController.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19142.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DSJ-7r-oCY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DSJ-7r-oCY">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19142.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23504"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +10,7 @@
         <!--Text Fields-->
         <scene sceneID="LZ1-eW-n5K">
             <objects>
-                <tableViewController id="DSJ-7r-oCY" customClass="TextFieldViewController" customModule="UIKitCatalog" sceneMemberID="viewController">
+                <tableViewController id="DSJ-7r-oCY" customClass="TextFieldViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="dyj-uS-k8j">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -66,7 +65,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6wP-A9-fuw" customClass="CustomTextField" customModule="UIKitCatalog" customModuleProvider="target">
+                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6wP-A9-fuw" customClass="CustomTextField" customModule="CatalogUIKit" customModuleProvider="target">
                                             <rect key="frame" x="77.5" y="7" width="220" height="30"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="30" id="9u9-Ih-c3n"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/TextViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/TextViewController.storyboard
@@ -10,7 +10,7 @@
         <!--Text View-->
         <scene sceneID="DT7-pA-8MW">
             <objects>
-                <viewController id="pUP-b0-VMf" customClass="TextViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="pUP-b0-VMf" customClass="TextViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="eAJ-am-dgQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/TintedToolbarViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/TintedToolbarViewController.storyboard
@@ -11,7 +11,7 @@
         <!--Tinted Toolbar-->
         <scene sceneID="Nqj-IZ-Kif">
             <objects>
-                <viewController storyboardIdentifier="TintedToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="FY6-YQ-KUW" customClass="TintedToolbarViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TintedToolbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="FY6-YQ-KUW" customClass="TintedToolbarViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cQQ-vC-cql">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/VisualEffectViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/VisualEffectViewController.storyboard
@@ -13,7 +13,7 @@
         <!--SimpleApp-->
         <scene sceneID="F0r-75-F0c">
             <objects>
-                <viewController storyboardIdentifier="VisualEffectViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Tca-bC-mV6" customClass="VisualEffectViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="VisualEffectViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Tca-bC-mV6" customClass="VisualEffectViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="0ea-tg-uqz">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BenchmarkTests/CatalogUIKit/Base.lproj/WebViewController.storyboard
+++ b/BenchmarkTests/CatalogUIKit/Base.lproj/WebViewController.storyboard
@@ -10,7 +10,7 @@
         <!--Web View-->
         <scene sceneID="U1S-K7-t1c">
             <objects>
-                <viewController id="i9U-A8-mkf" customClass="WebViewController" customModule="UIKitCatalog" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="i9U-A8-mkf" customClass="WebViewController" customModule="CatalogUIKit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cde-Ag-lVB">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
### What and why?

Some storyboards in `CatalogUIKit` were still targeting `UIKitCatalog` for classes, they should all use the `customModuleProvider="target"` attribute to look in the current target instead.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
