### PR TITLE
RUMS-4235 Remove `-allow-internal-distribution` flag to framework build script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ A brief description of implementation details of this PR.
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
 - [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
 - [ ] Add CHANGELOG entry for user facing changes
-- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
+- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Fixed Swift 6.0.2 compatibility issue with `DatadogCrashReporting` framework. See [#2251][]
+
 # 2.24.1 / 31-04-2025
 
 - [FIX] Do not enforce dynamic linking for OpenTelemetryApi in `DatadogTrace`. See [#2244][]
@@ -847,6 +849,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2244]: https://github.com/DataDog/dd-sdk-ios/pull/2244
 [#2200]: https://github.com/DataDog/dd-sdk-ios/pull/2200
 [#2195]: https://github.com/DataDog/dd-sdk-ios/pull/2195
+[#2251]: https://github.com/DataDog/dd-sdk-ios/pull/2251
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/tools/release/build-xcframeworks.sh
+++ b/tools/release/build-xcframeworks.sh
@@ -83,11 +83,7 @@ build_xcframework() {
         xcoptions+=(-archive "$ARCHIVES_TEMP_OUTPUT/$product/tvos-simulator.xcarchive" -framework "$product.framework")
     fi
 
-    # Datadog class conflicts with module name and Swift emits invalid module interface
-    # cf. https://github.com/apple/swift/issues/56573
-    #
-    # Therefore, we cannot provide ABI stability and we have to supply '-allow-internal-distribution'.
-    xcodebuild -create-xcframework -allow-internal-distribution ${xcoptions[@]} -output "$XCFRAMEWORKS_OUTPUT/$product.xcframework" | xcbeautify
+    xcodebuild -create-xcframework ${xcoptions[@]} -output "$XCFRAMEWORKS_OUTPUT/$product.xcframework" | xcbeautify
 
     echo_succ "The '$product.xcframework' was created successfully in '$XCFRAMEWORKS_OUTPUT'"
 }


### PR DESCRIPTION
### What and why?

This PR removes the `-allow-internal-distribution` flag from the XCFramework build script. This flag is likely causing Swift 6 compatibility issues with our pre-built frameworks, specifically with `DatadogCrashReporting`. Customers using Swift 6 are encountering build errors related to ABI compatibility between our frameworks (built with Swift 5.10) and their Swift 6 environment:

> Failed to build module 'DatadogCrashReporting'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 5.10 (swiftlang-5.10.0.13 clang-1500.3.9.4)', while this compiler is 'Apple Swift version 6.1 effective-5.10 (swiftlang-6.1.0.110.21 clang-1700.0.13.3)'). Please select a toolchain which matches the SDK.

This flag was originally added to bypass ABI stability checks due to naming conflicts between the Datadog classes and modules, but those conflicts have been resolved in our v2 architecture. Removing this flag ensures proper ABI stability checks during framework creation, making our binaries compatible with both Swift 5.x and Swift 6.x projects.

### How?

This PR simply removes the `-allow-internal-distribution` flag from the `build-xcframeworks.sh` script. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) [internal]) and run `make api-surface`)
