### PR TITLE
RUM-7746 Use sampled context injection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [IMPROVEMENT] Update the default tracing sampling rate to 100%. See [#2253][] 
+- [IMPROVEMENT] Update the default TraceContextInjection to `.sampled`. See [#2253][] 
+
 # 2.24.1 / 31-04-2025
 
 - [FIX] Do not enforce dynamic linking for OpenTelemetryApi in `DatadogTrace`. See [#2244][]

--- a/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
+++ b/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
@@ -42,7 +42,7 @@ internal struct DebugManualTraceInjectionView: View {
     @State private var spanName = "network request"
     @State private var requestURL = "https://httpbin.org/get"
     @State private var selectedTraceHeaderTypes: Set<TraceHeaderType> = [.datadog, .w3c]
-    @State private var selectedTraceContextInjection: TraceContextInjection = .all
+    @State private var selectedTraceContextInjection: TraceContextInjection = .sampled
     @State private var sampleRate: SampleRate = .maxSampleRate
     @State private var isRequestPending = false
 

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -145,7 +145,7 @@ class HeadBasedSamplingTests: XCTestCase {
         // Given
         traceConfig.sampleRate = localTraceSampling
         traceConfig.urlSessionTracking = .init(
-            firstPartyHostsTracing: .trace(hosts: ["foo.com"], sampleRate: distributedTraceSampling)
+            firstPartyHostsTracing: .trace(hosts: ["foo.com"], sampleRate: distributedTraceSampling, traceControlInjection: .all)
         )
         Trace.enable(with: traceConfig, in: core)
         URLSessionInstrumentation.enable(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)
@@ -233,7 +233,7 @@ class HeadBasedSamplingTests: XCTestCase {
         // Given
         traceConfig.sampleRate = localTraceSampling
         traceConfig.urlSessionTracking = .init(
-            firstPartyHostsTracing: .trace(hosts: ["foo.com"], sampleRate: distributedTraceSampling)
+            firstPartyHostsTracing: .trace(hosts: ["foo.com"], sampleRate: distributedTraceSampling, traceControlInjection: .all)
         )
         Trace.enable(with: traceConfig, in: core)
         URLSessionInstrumentation.enable(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
@@ -89,7 +89,7 @@ public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
         self.init(
             samplingStrategy: .custom(sampleRate: sampleRate),
             injectEncoding: injectEncoding,
-            traceContextInjection: .all
+            traceContextInjection: .sampled
         )
     }
 
@@ -97,11 +97,11 @@ public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
     ///
     /// - Parameter samplingStrategy: The strategy for sampling trace propagation headers.
     /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
-    /// - Parameter traceContextInjection: The trace context injection strategy, with `.all` as the default.
+    /// - Parameter traceContextInjection: The trace context injection strategy, with `.sampled` as the default.
     public init(
         samplingStrategy: TraceSamplingStrategy,
         injectEncoding: InjectEncoding = .single,
-        traceContextInjection: TraceContextInjection = .all
+        traceContextInjection: TraceContextInjection = .sampled
     ) {
         self.samplingStrategy = samplingStrategy
         self.injectEncoding = injectEncoding

--- a/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
@@ -79,11 +79,11 @@ public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
 
     /// Initializes the headers writer.
     ///
-    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 100% as the default.
     /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(
-        sampleRate: Float = 20,
+        sampleRate: Float = .maxSampleRate,
         injectEncoding: InjectEncoding = .single
     ) {
         self.init(

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -50,7 +50,7 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
     /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(sampleRate: Float = 20) {
-        self.init(samplingStrategy: .custom(sampleRate: sampleRate), traceContextInjection: .all)
+        self.init(samplingStrategy: .custom(sampleRate: sampleRate), traceContextInjection: .sampled)
     }
 
     /// Initializes the headers writer.

--- a/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -47,9 +47,9 @@ public class HTTPHeadersWriter: TracePropagationHeadersWriter {
 
     /// Initializes the headers writer.
     ///
-    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 100% as the default.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
-    public convenience init(sampleRate: Float = 20) {
+    public convenience init(sampleRate: Float = .maxSampleRate) {
         self.init(samplingStrategy: .custom(sampleRate: sampleRate), traceContextInjection: .sampled)
     }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -56,7 +56,7 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     /// - Parameter tracestate: The tracestate to be injected.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public convenience init(sampleRate: Float = 20, tracestate: [String: String] = [:]) {
-        self.init(samplingStrategy: .custom(sampleRate: sampleRate), tracestate: tracestate, traceContextInjection: .all)
+        self.init(samplingStrategy: .custom(sampleRate: sampleRate), tracestate: tracestate, traceContextInjection: .sampled)
     }
 
     /// Initializes the headers writer.
@@ -67,7 +67,7 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
     public init(
         samplingStrategy: TraceSamplingStrategy,
         tracestate: [String: String] = [:],
-        traceContextInjection: TraceContextInjection = .all
+        traceContextInjection: TraceContextInjection = .sampled
     ) {
         self.samplingStrategy = samplingStrategy
         self.tracestate = tracestate

--- a/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -52,10 +52,10 @@ public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
 
     /// Initializes the headers writer.
     ///
-    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 100% as the default.
     /// - Parameter tracestate: The tracestate to be injected.
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
-    public convenience init(sampleRate: Float = 20, tracestate: [String: String] = [:]) {
+    public convenience init(sampleRate: Float = .maxSampleRate, tracestate: [String: String] = [:]) {
         self.init(samplingStrategy: .custom(sampleRate: sampleRate), tracestate: tracestate, traceContextInjection: .sampled)
     }
 

--- a/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
@@ -48,7 +48,7 @@ public class DDB3HTTPHeadersWriter: NSObject {
     @objc
     @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(samplingStrategy: .custom(sampleRate:))` instead.")
     public init(
-        sampleRate: Float = 20,
+        sampleRate: Float = .maxSampleRate,
         injectEncoding: DDInjectEncoding = .single
     ) {
         swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(

--- a/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/B3HTTPHeadersWriter+objc.swift
@@ -54,7 +54,7 @@ public class DDB3HTTPHeadersWriter: NSObject {
         swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate),
             injectEncoding: .init(injectEncoding),
-            traceContextInjection: .all
+            traceContextInjection: .sampled
         )
     }
 
@@ -62,7 +62,7 @@ public class DDB3HTTPHeadersWriter: NSObject {
     public init(
         samplingStrategy: DDTraceSamplingStrategy,
         injectEncoding: DDInjectEncoding = .single,
-        traceContextInjection: DDTraceContextInjection = .all
+        traceContextInjection: DDTraceContextInjection = .sampled
     ) {
         swiftB3HTTPHeadersWriter = B3HTTPHeadersWriter(
             samplingStrategy: samplingStrategy.swiftType,

--- a/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -26,7 +26,7 @@ public class DDHTTPHeadersWriter: NSObject {
     public init(sampleRate: Float = 20) {
         swiftHTTPHeadersWriter = HTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate),
-            traceContextInjection: .all
+            traceContextInjection: .sampled
         )
     }
 

--- a/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
+++ b/DatadogObjc/Sources/Tracing/Propagation/W3CHTTPHeadersWriter+objc.swift
@@ -27,7 +27,7 @@ public class DDW3CHTTPHeadersWriter: NSObject {
         swiftW3CHTTPHeadersWriter = W3CHTTPHeadersWriter(
             samplingStrategy: .custom(sampleRate: sampleRate),
             tracestate: [:],
-            traceContextInjection: .all
+            traceContextInjection: .sampled
         )
     }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -352,22 +352,22 @@ extension RUM.Configuration.URLSessionTracking {
         ///
         /// - Parameters:
         ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.
-        ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
+        ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `100`.
         ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
         case trace(
             hosts: Set<String>,
-            sampleRate: Float = 20,
+            sampleRate: Float = .maxSampleRate,
             traceControlInjection: TraceContextInjection = .sampled
         )
 
         /// Trace given hosts with using custom tracing headers.
         ///
         /// - `hostsWithHeaders` - Dictionary of hosts and tracing header types to use. Note: Hosts must not include "http(s)://" prefix.
-        /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
+        /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `100`.
         /// - `traceControlInjection` - The strategy for injecting trace context into requests. Default: `.sampled`.
         case traceWithHeaders(
             hostsWithHeaders: [String: Set<TracingHeaderType>],
-            sampleRate: Float = 20,
+            sampleRate: Float = .maxSampleRate,
             traceControlInjection: TraceContextInjection = .sampled
         )
     }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -353,22 +353,22 @@ extension RUM.Configuration.URLSessionTracking {
         /// - Parameters:
         ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.
         ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
-        ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.all`.
+        ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
         case trace(
             hosts: Set<String>,
             sampleRate: Float = 20,
-            traceControlInjection: TraceContextInjection = .all
+            traceControlInjection: TraceContextInjection = .sampled
         )
 
         /// Trace given hosts with using custom tracing headers.
         ///
         /// - `hostsWithHeaders` - Dictionary of hosts and tracing header types to use. Note: Hosts must not include "http(s)://" prefix.
         /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
-        /// - `traceControlInjection` - The strategy for injecting trace context into requests. Default: `.all`.
+        /// - `traceControlInjection` - The strategy for injecting trace context into requests. Default: `.sampled`.
         case traceWithHeaders(
             hostsWithHeaders: [String: Set<TracingHeaderType>],
             sampleRate: Float = 20,
-            traceControlInjection: TraceContextInjection = .all
+            traceControlInjection: TraceContextInjection = .sampled
         )
     }
 

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -106,22 +106,22 @@ extension Trace {
                 /// - Parameters:
                 ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.
                 ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
-                ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.all`.
+                ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
                 case trace(
                     hosts: Set<String>,
                     sampleRate: Float = 20,
-                    traceControlInjection: TraceContextInjection = .all
+                    traceControlInjection: TraceContextInjection = .sampled
                 )
 
                 /// Trace given hosts with using custom tracing headers.
                 ///
                 /// - `hostsWithHeaders` - Dictionary of hosts and tracing header types to use. Note: Hosts must not include "http(s)://" prefix.
                 /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
-                ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.all`.
+                ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
                 case traceWithHeaders(
                     hostsWithHeaders: [String: Set<TracingHeaderType>],
                     sampleRate: Float = 20,
-                    traceControlInjection: TraceContextInjection = .all
+                    traceControlInjection: TraceContextInjection = .sampled
                 )
             }
 

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -105,22 +105,22 @@ extension Trace {
                 ///
                 /// - Parameters:
                 ///   - hosts: The set of hosts to inject tracing headers. Note: Hosts must not include the "http(s)://" prefix.
-                ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
+                ///   - sampleRate: The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `100`.
                 ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
                 case trace(
                     hosts: Set<String>,
-                    sampleRate: Float = 20,
+                    sampleRate: Float = .maxSampleRate,
                     traceControlInjection: TraceContextInjection = .sampled
                 )
 
                 /// Trace given hosts with using custom tracing headers.
                 ///
                 /// - `hostsWithHeaders` - Dictionary of hosts and tracing header types to use. Note: Hosts must not include "http(s)://" prefix.
-                /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `20`.
+                /// - `sampleRate` - The sampling rate for tracing. Must be a value between `0.0` and `100.0`. Default: `100`.
                 ///   - traceControlInjection: The strategy for injecting trace context into requests. Default: `.sampled`.
                 case traceWithHeaders(
                     hostsWithHeaders: [String: Set<TracingHeaderType>],
-                    sampleRate: Float = 20,
+                    sampleRate: Float = .maxSampleRate,
                     traceControlInjection: TraceContextInjection = .sampled
                 )
             }

--- a/DatadogTrace/Tests/DDNoopTracerTests.swift
+++ b/DatadogTrace/Tests/DDNoopTracerTests.swift
@@ -22,7 +22,7 @@ class DDNoopTracerTests: XCTestCase {
         let context = DDSpanContext.mockAny()
         noop.inject(
             spanContext: context,
-            writer: HTTPHeadersWriter(samplingStrategy: .headBased, traceContextInjection: .all)
+            writer: HTTPHeadersWriter(samplingStrategy: .headBased, traceContextInjection: .sampled)
         )
         _ = noop.extract(reader: HTTPHeadersReader(httpHeaderFields: [:]))
         let root = noop.startRootSpan(operationName: "root operation").setActive()

--- a/DatadogTrace/Tests/TraceTests.swift
+++ b/DatadogTrace/Tests/TraceTests.swift
@@ -140,7 +140,7 @@ class TraceTests: XCTestCase {
             networkInstrumentation.handlers.firstElement(of: TracingURLSessionHandler.self),
             "It should register `TracingURLSessionHandler` to `NetworkInstrumentationFeature`"
         )
-        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, 20)
+        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, 100)
     }
 
     func testWhenEnabledWithURLSessionTrackingAndCustomSampleRate() throws {


### PR DESCRIPTION
### What and why?

- Use the `.sampled` context injection by default
- Use 100% tracing sampling rate by default
