### PR TITLE
feat: Support Deeplinks in Benchmark Runner

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		868DA2F52D71DD47007D20D5 /* LogsHeavyTrafficScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868DA2F42D71DD47007D20D5 /* LogsHeavyTrafficScenario.swift */; };
 		868DA2F72D71DD8A007D20D5 /* LogsHeavyTrafficContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868DA2F62D71DD8A007D20D5 /* LogsHeavyTrafficContentView.swift */; };
 		868DA2F92D71E622007D20D5 /* LogsUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868DA2F82D71E622007D20D5 /* LogsUtils.swift */; };
-		D231DC372C73355800F3F66C /* CatalogUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D231DC312C73355800F3F66C /* CatalogUIKit.framework */; };
-		D231DC382C73355800F3F66C /* CatalogUIKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D231DC312C73355800F3F66C /* CatalogUIKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		86FA742B2D89C49400F69130 /* RUMAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FA742A2D89C49400F69130 /* RUMAutoScenario.swift */; };
 		86FA742D2D89C4B800F69130 /* RUMAutoContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FA742C2D89C4B800F69130 /* RUMAutoContentView.swift */; };
 		86FA742F2D89CBF100F69130 /* CharactersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FA742E2D89CBF100F69130 /* CharactersView.swift */; };
@@ -43,6 +41,8 @@
 		86FBEDD52D8C436D005CFCC4 /* EpisodeDetailHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FBEDD42D8C436D005CFCC4 /* EpisodeDetailHostingController.swift */; };
 		86FBEDDC2D8C491E005CFCC4 /* EpisodeDetailView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 86FBEDDA2D8C491E005CFCC4 /* EpisodeDetailView.storyboard */; };
 		86FBEDDD2D8C491E005CFCC4 /* EpisodeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FBEDDB2D8C491E005CFCC4 /* EpisodeDetailViewController.swift */; };
+		D231DC372C73355800F3F66C /* CatalogUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D231DC312C73355800F3F66C /* CatalogUIKit.framework */; };
+		D231DC382C73355800F3F66C /* CatalogUIKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D231DC312C73355800F3F66C /* CatalogUIKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D231DCAF2C73356E00F3F66C /* ActivityIndicatorViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D231DC412C73356D00F3F66C /* ActivityIndicatorViewController.storyboard */; };
 		D231DCB02C73356E00F3F66C /* ActivityIndicatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D231DC422C73356D00F3F66C /* ActivityIndicatorViewController.swift */; };
 		D231DCB12C73356E00F3F66C /* AlertControllerViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D231DC442C73356D00F3F66C /* AlertControllerViewController.storyboard */; };
@@ -115,6 +115,7 @@
 		D23DD32D2C58D80C00B90C4C /* DatadogBenchmarks in Frameworks */ = {isa = PBXBuildFile; productRef = D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */; };
 		D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */; };
 		D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */; };
+		D26806112D9D84130004C54A /* BenchmarkVitals.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26806102D9D84130004C54A /* BenchmarkVitals.swift */; };
 		D26DD6E72D0C774000D96148 /* DatadogMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26DD6E62D0C774000D96148 /* DatadogMonitor.swift */; };
 		D27606A12C514F37002D2A14 /* SessionReplayScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27606982C514F37002D2A14 /* SessionReplayScenario.swift */; };
 		D27606A32C514F37002D2A14 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D276069B2C514F37002D2A14 /* Scenario.swift */; };
@@ -276,7 +277,6 @@
 		868DA2F42D71DD47007D20D5 /* LogsHeavyTrafficScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsHeavyTrafficScenario.swift; sourceTree = "<group>"; };
 		868DA2F62D71DD8A007D20D5 /* LogsHeavyTrafficContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsHeavyTrafficContentView.swift; sourceTree = "<group>"; };
 		868DA2F82D71E622007D20D5 /* LogsUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsUtils.swift; sourceTree = "<group>"; };
-		D231DC312C73355800F3F66C /* CatalogUIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CatalogUIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		86FA742A2D89C49400F69130 /* RUMAutoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoScenario.swift; sourceTree = "<group>"; };
 		86FA742C2D89C4B800F69130 /* RUMAutoContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoContentView.swift; sourceTree = "<group>"; };
 		86FA742E2D89CBF100F69130 /* CharactersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharactersView.swift; sourceTree = "<group>"; };
@@ -302,6 +302,7 @@
 		86FBEDD42D8C436D005CFCC4 /* EpisodeDetailHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeDetailHostingController.swift; sourceTree = "<group>"; };
 		86FBEDDA2D8C491E005CFCC4 /* EpisodeDetailView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EpisodeDetailView.storyboard; sourceTree = "<group>"; };
 		86FBEDDB2D8C491E005CFCC4 /* EpisodeDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeDetailViewController.swift; sourceTree = "<group>"; };
+		D231DC312C73355800F3F66C /* CatalogUIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CatalogUIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D231DC402C73356D00F3F66C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/ActivityIndicatorViewController.storyboard; sourceTree = "<group>"; };
 		D231DC422C73356D00F3F66C /* ActivityIndicatorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorViewController.swift; sourceTree = "<group>"; };
 		D231DC432C73356D00F3F66C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/AlertControllerViewController.storyboard; sourceTree = "<group>"; };
@@ -374,6 +375,7 @@
 		D23734962D773DD1004CCAED /* BenchmarkMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMeter.swift; sourceTree = "<group>"; };
 		D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticScenario.swift; sourceTree = "<group>"; };
 		D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkProfiler.swift; sourceTree = "<group>"; };
+		D26806102D9D84130004C54A /* BenchmarkVitals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkVitals.swift; sourceTree = "<group>"; };
 		D26DD6E62D0C774000D96148 /* DatadogMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogMonitor.swift; sourceTree = "<group>"; };
 		D27606982C514F37002D2A14 /* SessionReplayScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayScenario.swift; sourceTree = "<group>"; };
 		D276069B2C514F37002D2A14 /* Scenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
@@ -571,82 +573,6 @@
 			path = UI;
 			sourceTree = "<group>";
 		};
-		D231DC322C73355800F3F66C /* CatalogUIKit */ = {
-			isa = PBXGroup;
-			children = (
-				D256FB522C737F5800377260 /* LICENSE */,
-				D231DC412C73356D00F3F66C /* ActivityIndicatorViewController.storyboard */,
-				D231DC422C73356D00F3F66C /* ActivityIndicatorViewController.swift */,
-				D231DC442C73356D00F3F66C /* AlertControllerViewController.storyboard */,
-				D231DC452C73356D00F3F66C /* AlertControllerViewController.swift */,
-				D231DC472C73356D00F3F66C /* Assets.xcassets */,
-				D231DC482C73356D00F3F66C /* BaseTableViewController.swift */,
-				D231DC4A2C73356D00F3F66C /* ButtonViewController.storyboard */,
-				D231DC4B2C73356D00F3F66C /* ButtonViewController.swift */,
-				D231DC4C2C73356D00F3F66C /* ButtonViewController+Configs.swift */,
-				D231DC4D2C73356D00F3F66C /* CaseElement.swift */,
-				D231DC4F2C73356D00F3F66C /* ColorPickerViewController.storyboard */,
-				D231DC502C73356D00F3F66C /* ColorPickerViewController.swift */,
-				D231DC522C73356D00F3F66C /* content.html */,
-				D231DC542C73356D00F3F66C /* Credits.rtf */,
-				D231DC562C73356D00F3F66C /* CustomPageControlViewController.storyboard */,
-				D231DC572C73356D00F3F66C /* CustomPageControlViewController.swift */,
-				D231DC592C73356D00F3F66C /* CustomSearchBarViewController.storyboard */,
-				D231DC5A2C73356D00F3F66C /* CustomSearchBarViewController.swift */,
-				D231DC5C2C73356D00F3F66C /* CustomToolbarViewController.storyboard */,
-				D231DC5D2C73356D00F3F66C /* CustomToolbarViewController.swift */,
-				D231DC5F2C73356D00F3F66C /* DatePickerController.storyboard */,
-				D231DC602C73356D00F3F66C /* DatePickerController.swift */,
-				D231DC622C73356D00F3F66C /* DefaultPageControlViewController.storyboard */,
-				D231DC632C73356D00F3F66C /* DefaultPageControlViewController.swift */,
-				D231DC652C73356D00F3F66C /* DefaultSearchBarViewController.storyboard */,
-				D231DC662C73356D00F3F66C /* DefaultSearchBarViewController.swift */,
-				D231DC682C73356D00F3F66C /* DefaultToolbarViewController.storyboard */,
-				D231DC692C73356D00F3F66C /* DefaultToolbarViewController.swift */,
-				D231DC6B2C73356D00F3F66C /* FontPickerViewController.storyboard */,
-				D231DC6C2C73356D00F3F66C /* FontPickerViewController.swift */,
-				D231DC6E2C73356D00F3F66C /* ImagePickerViewController.storyboard */,
-				D231DC6F2C73356D00F3F66C /* ImagePickerViewController.swift */,
-				D231DC712C73356D00F3F66C /* ImageViewController.storyboard */,
-				D231DC722C73356D00F3F66C /* ImageViewController.swift */,
-				D231DC782C73356D00F3F66C /* Localizable.strings */,
-				D231DC7A2C73356D00F3F66C /* Main.storyboard */,
-				D231DC7C2C73356D00F3F66C /* MenuButtonViewController.storyboard */,
-				D231DC7D2C73356D00F3F66C /* MenuButtonViewController.swift */,
-				D231DC7E2C73356D00F3F66C /* OutlineViewController.swift */,
-				D231DC802C73356D00F3F66C /* PickerViewController.storyboard */,
-				D231DC812C73356D00F3F66C /* PickerViewController.swift */,
-				D231DC832C73356D00F3F66C /* PointerInteractionButtonViewController.storyboard */,
-				D231DC842C73356D00F3F66C /* PointerInteractionButtonViewController.swift */,
-				D231DC862C73356D00F3F66C /* ProgressViewController.storyboard */,
-				D231DC872C73356D00F3F66C /* ProgressViewController.swift */,
-				D231DC8A2C73356D00F3F66C /* SegmentedControlViewController.storyboard */,
-				D231DC8B2C73356D00F3F66C /* SegmentedControlViewController.swift */,
-				D231DC8D2C73356D00F3F66C /* SliderViewController.storyboard */,
-				D231DC8E2C73356D00F3F66C /* SliderViewController.swift */,
-				D231DC902C73356D00F3F66C /* StackViewController.storyboard */,
-				D231DC912C73356D00F3F66C /* StackViewController.swift */,
-				D231DC932C73356D00F3F66C /* StepperViewController.storyboard */,
-				D231DC942C73356D00F3F66C /* StepperViewController.swift */,
-				D231DC962C73356D00F3F66C /* SwitchViewController.storyboard */,
-				D231DC972C73356D00F3F66C /* SwitchViewController.swift */,
-				D231DC992C73356D00F3F66C /* SymbolViewController.storyboard */,
-				D231DC9A2C73356D00F3F66C /* SymbolViewController.swift */,
-				D231DC9C2C73356D00F3F66C /* TextFieldViewController.storyboard */,
-				D231DC9D2C73356D00F3F66C /* TextFieldViewController.swift */,
-				D231DC9F2C73356D00F3F66C /* TextViewController.storyboard */,
-				D231DCA02C73356D00F3F66C /* TextViewController.swift */,
-				D231DCA22C73356D00F3F66C /* TintedToolbarViewController.storyboard */,
-				D231DCA32C73356D00F3F66C /* TintedToolbarViewController.swift */,
-				D231DCA72C73356D00F3F66C /* VisualEffectViewController.storyboard */,
-				D231DCA82C73356D00F3F66C /* VisualEffectViewController.swift */,
-				D231DCAA2C73356D00F3F66C /* WebViewController.storyboard */,
-				D231DCAB2C73356D00F3F66C /* WebViewController.swift */,
-				D231DCF82C7342D500F3F66C /* ModuleBundle.swift */,
-			);
-			path = CatalogUIKit;
-			sourceTree = "<group>";
-		};
 		86FA74242D89C34700F69130 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -802,6 +728,82 @@
 				86FA74382D8AC2C700F69130 /* RickMortyService.swift */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		D231DC322C73355800F3F66C /* CatalogUIKit */ = {
+			isa = PBXGroup;
+			children = (
+				D256FB522C737F5800377260 /* LICENSE */,
+				D231DC412C73356D00F3F66C /* ActivityIndicatorViewController.storyboard */,
+				D231DC422C73356D00F3F66C /* ActivityIndicatorViewController.swift */,
+				D231DC442C73356D00F3F66C /* AlertControllerViewController.storyboard */,
+				D231DC452C73356D00F3F66C /* AlertControllerViewController.swift */,
+				D231DC472C73356D00F3F66C /* Assets.xcassets */,
+				D231DC482C73356D00F3F66C /* BaseTableViewController.swift */,
+				D231DC4A2C73356D00F3F66C /* ButtonViewController.storyboard */,
+				D231DC4B2C73356D00F3F66C /* ButtonViewController.swift */,
+				D231DC4C2C73356D00F3F66C /* ButtonViewController+Configs.swift */,
+				D231DC4D2C73356D00F3F66C /* CaseElement.swift */,
+				D231DC4F2C73356D00F3F66C /* ColorPickerViewController.storyboard */,
+				D231DC502C73356D00F3F66C /* ColorPickerViewController.swift */,
+				D231DC522C73356D00F3F66C /* content.html */,
+				D231DC542C73356D00F3F66C /* Credits.rtf */,
+				D231DC562C73356D00F3F66C /* CustomPageControlViewController.storyboard */,
+				D231DC572C73356D00F3F66C /* CustomPageControlViewController.swift */,
+				D231DC592C73356D00F3F66C /* CustomSearchBarViewController.storyboard */,
+				D231DC5A2C73356D00F3F66C /* CustomSearchBarViewController.swift */,
+				D231DC5C2C73356D00F3F66C /* CustomToolbarViewController.storyboard */,
+				D231DC5D2C73356D00F3F66C /* CustomToolbarViewController.swift */,
+				D231DC5F2C73356D00F3F66C /* DatePickerController.storyboard */,
+				D231DC602C73356D00F3F66C /* DatePickerController.swift */,
+				D231DC622C73356D00F3F66C /* DefaultPageControlViewController.storyboard */,
+				D231DC632C73356D00F3F66C /* DefaultPageControlViewController.swift */,
+				D231DC652C73356D00F3F66C /* DefaultSearchBarViewController.storyboard */,
+				D231DC662C73356D00F3F66C /* DefaultSearchBarViewController.swift */,
+				D231DC682C73356D00F3F66C /* DefaultToolbarViewController.storyboard */,
+				D231DC692C73356D00F3F66C /* DefaultToolbarViewController.swift */,
+				D231DC6B2C73356D00F3F66C /* FontPickerViewController.storyboard */,
+				D231DC6C2C73356D00F3F66C /* FontPickerViewController.swift */,
+				D231DC6E2C73356D00F3F66C /* ImagePickerViewController.storyboard */,
+				D231DC6F2C73356D00F3F66C /* ImagePickerViewController.swift */,
+				D231DC712C73356D00F3F66C /* ImageViewController.storyboard */,
+				D231DC722C73356D00F3F66C /* ImageViewController.swift */,
+				D231DC782C73356D00F3F66C /* Localizable.strings */,
+				D231DC7A2C73356D00F3F66C /* Main.storyboard */,
+				D231DC7C2C73356D00F3F66C /* MenuButtonViewController.storyboard */,
+				D231DC7D2C73356D00F3F66C /* MenuButtonViewController.swift */,
+				D231DC7E2C73356D00F3F66C /* OutlineViewController.swift */,
+				D231DC802C73356D00F3F66C /* PickerViewController.storyboard */,
+				D231DC812C73356D00F3F66C /* PickerViewController.swift */,
+				D231DC832C73356D00F3F66C /* PointerInteractionButtonViewController.storyboard */,
+				D231DC842C73356D00F3F66C /* PointerInteractionButtonViewController.swift */,
+				D231DC862C73356D00F3F66C /* ProgressViewController.storyboard */,
+				D231DC872C73356D00F3F66C /* ProgressViewController.swift */,
+				D231DC8A2C73356D00F3F66C /* SegmentedControlViewController.storyboard */,
+				D231DC8B2C73356D00F3F66C /* SegmentedControlViewController.swift */,
+				D231DC8D2C73356D00F3F66C /* SliderViewController.storyboard */,
+				D231DC8E2C73356D00F3F66C /* SliderViewController.swift */,
+				D231DC902C73356D00F3F66C /* StackViewController.storyboard */,
+				D231DC912C73356D00F3F66C /* StackViewController.swift */,
+				D231DC932C73356D00F3F66C /* StepperViewController.storyboard */,
+				D231DC942C73356D00F3F66C /* StepperViewController.swift */,
+				D231DC962C73356D00F3F66C /* SwitchViewController.storyboard */,
+				D231DC972C73356D00F3F66C /* SwitchViewController.swift */,
+				D231DC992C73356D00F3F66C /* SymbolViewController.storyboard */,
+				D231DC9A2C73356D00F3F66C /* SymbolViewController.swift */,
+				D231DC9C2C73356D00F3F66C /* TextFieldViewController.storyboard */,
+				D231DC9D2C73356D00F3F66C /* TextFieldViewController.swift */,
+				D231DC9F2C73356D00F3F66C /* TextViewController.storyboard */,
+				D231DCA02C73356D00F3F66C /* TextViewController.swift */,
+				D231DCA22C73356D00F3F66C /* TintedToolbarViewController.storyboard */,
+				D231DCA32C73356D00F3F66C /* TintedToolbarViewController.swift */,
+				D231DCA72C73356D00F3F66C /* VisualEffectViewController.storyboard */,
+				D231DCA82C73356D00F3F66C /* VisualEffectViewController.swift */,
+				D231DCAA2C73356D00F3F66C /* WebViewController.storyboard */,
+				D231DCAB2C73356D00F3F66C /* WebViewController.swift */,
+				D231DCF82C7342D500F3F66C /* ModuleBundle.swift */,
+			);
+			path = CatalogUIKit;
 			sourceTree = "<group>";
 		};
 		D256FB522C737F5800377260 /* LICENSE */ = {
@@ -1164,6 +1166,7 @@
 				D276069D2C514F37002D2A14 /* AppConfiguration.swift */,
 				D24E15F22C776956005AE4E8 /* BenchmarkProfiler.swift */,
 				D23734962D773DD1004CCAED /* BenchmarkMeter.swift */,
+				D26806102D9D84130004C54A /* BenchmarkVitals.swift */,
 				D276069C2C514F37002D2A14 /* Scenarios */,
 				D29F755D2C4AA08000288638 /* Info.plist */,
 			);
@@ -1557,6 +1560,7 @@
 				D23734972D773DD8004CCAED /* BenchmarkMeter.swift in Sources */,
 				86252B1B2D818E360098FAEF /* TraceScenario.swift in Sources */,
 				86FBEDD32D8C4348005CFCC4 /* EpisodeListItem.swift in Sources */,
+				D26806112D9D84130004C54A /* BenchmarkVitals.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -83,7 +83,7 @@ public enum Benchmarks {
             )
         )
 
-        let provider = MeterProviderBuilder()
+        return MeterProviderBuilder()
             .with(pushInterval: 10)
             .with(processor: MetricProcessorSdk())
             .with(exporter: metricExporter)
@@ -98,9 +98,6 @@ public enum Benchmarks {
                 "branch": .string(configuration.context.branch),
             ]))
             .build()
-
-        OpenTelemetry.registerMeterProvider(meterProvider: provider)
-        return provider
     }
 
     /// Configure an OpenTelemetry tracer provider.
@@ -121,11 +118,8 @@ public enum Benchmarks {
         let exporter = try! DatadogExporter(config: exporterConfiguration)
         let processor = SimpleSpanProcessor(spanExporter: exporter)
 
-        let provider = TracerProviderBuilder()
+        return TracerProviderBuilder()
             .add(spanProcessor: processor)
             .build()
-
-        OpenTelemetry.registerTracerProvider(tracerProvider: provider)
-        return provider
     }
 }

--- a/BenchmarkTests/README.md
+++ b/BenchmarkTests/README.md
@@ -10,51 +10,6 @@ To open the project with the correct environment, make sure Xcode is closed and 
 make benchmark-tests-open
 ```
 
-> [!TIP]
-> If Xcode is failing to install packages with a message such as **failed to clone**, **requires authentication** or **dependency failed**, it might be due to a Git configuration that forces HTTPS URLs to be rewritten as SSH. In that case, try commenting the following lines in your global Git config (~/.gitconfig).
-
-```bash
-[url "ssh://git@github.com/"]
-    insteadOf = https://github.com/
-```
-
-> Or remove it with the following command:
-
-```bash
-git config --global --unset url."ssh://git@github.com/".insteadOf
-```
-
-## CI
-
-CI continuously builds, signs, and uploads a runner application to Synthetics, which runs predefined tests.
-
-### Build
-
-Before building the application, make sure the `BenchmarkTests/xcconfigs/Benchmark.local.xcconfig` configuration file is present and contains the `Mobile - Integration Org` client token, RUM application ID, and API Key. These values are sensitive and must be securely stored.
-
-```ini
-CLIENT_TOKEN=
-RUM_APPLICATION_ID=
-API_KEY=
-```
-
-### Sign
-
-To sign the runner application, the certificate and provision profile defined in [Synthetics.xcconfig](xcconfigs/Synthetics.xcconfig) and in [exportOptions.plist](exportOptions.plist) needs to be installed on the build machine. The certificate and profile are sensitive files and must be securely stored. Make sure to update both files when updating the certificate and provisioning profile, otherwise signing fails.
-
-> [!NOTE]
-> Certificate & Provisioning Profile are also available through the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi). But we don't have the tooling in place.
-
-### Upload
-
-The application version (build number) is set to the commit SHA of the current job, and the build is uploaded to Synthetics using the [datadog-ci](https://github.com/DataDog/datadog-ci) CLI. This step expects environment variables to authenticate with the `Mobile - Integration Org`:
-
-```bash
-export DATADOG_API_KEY=
-export DATADOG_APP_KEY=
-export S8S_APPLICATION_ID=
-```
-
 ## Development
 
 Each scenario is independent and can be considered as an app within the runner.
@@ -93,8 +48,66 @@ struct LogsScenario: Scenario {
 }
 ```
 
-Add the test to the [`SyntheticScenario`](Runner/Scenarios/SyntheticScenario.swift#L12) object so it can be selected by setting the `BENCHMARK_SCENARIO` environment variable.
+Once the Scenario is created, add its name as enum case of the [`SyntheticScenario`](Runner/Scenarios/SyntheticScenario.swift#L12) object so it can be selected by setting the `BENCHMARK_SCENARIO` environment variable.
+
+### Run a Scenario
+
+There is 2 options to execute a Scenario:
+1. Using Environment Variables in the `Runner.xcscheme` (Edit Scheme from Xcode)
+```xml
+<EnvironmentVariables>
+    <EnvironmentVariable
+        key = "BENCHMARK_RUN"
+        value = "<run>"
+        isEnabled = "YES">
+    </EnvironmentVariable>
+    <EnvironmentVariable
+        key = "BENCHMARK_SCENARIO"
+        value = "<scenario>"
+        isEnabled = "YES">
+    </EnvironmentVariable>
+</EnvironmentVariables>
+```
+2. Opening a Deep Link:
+```bash
+xcrun simctl openurl booted 'bench://start?scenario=<scenario>&run=<run>'
+```
+If you intent to execute multiple Scenario/Run in the same application process, you must stop the previous execution with: 
+```bash
+xcrun simctl openurl booted 'bench://stop'
+```
 
 ### Synthetics Configuration
 
 Please refer to [Confluence page (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3981476482/Benchmarks+iOS)
+
+## CI
+
+CI continuously builds, signs, and uploads a runner application to Synthetics, which runs predefined tests.
+
+### Build
+
+Before building the application, make sure the `BenchmarkTests/xcconfigs/Benchmark.local.xcconfig` configuration file is present and contains the `Mobile - Integration Org` client token, RUM application ID, and API Key. These values are sensitive and must be securely stored.
+
+```ini
+CLIENT_TOKEN=
+RUM_APPLICATION_ID=
+API_KEY=
+```
+
+### Sign
+
+To sign the runner application, the certificate and provision profile defined in [Synthetics.xcconfig](xcconfigs/Synthetics.xcconfig) and in [exportOptions.plist](exportOptions.plist) needs to be installed on the build machine. The certificate and profile are sensitive files and must be securely stored. Make sure to update both files when updating the certificate and provisioning profile, otherwise signing fails.
+
+> [!NOTE]
+> Certificate & Provisioning Profile are also available through the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi). But we don't have the tooling in place.
+
+### Upload
+
+The application version (build number) is set to the commit SHA of the current job, and the build is uploaded to Synthetics using the [datadog-ci](https://github.com/DataDog/datadog-ci) CLI. This step expects environment variables to authenticate with the `Mobile - Integration Org`:
+
+```bash
+export DATADOG_API_KEY=
+export DATADOG_APP_KEY=
+export S8S_APPLICATION_ID=
+```

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -5,51 +5,67 @@
  */
 
 import UIKit
+
 import DatadogInternal
+import DatadogCore
 import DatadogBenchmarks
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+    var applicationInfo: AppInfo! //swiftlint:disable:this implicitly_unwrapped_optional
+    var vitals: Vitals?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        guard let scenario = SyntheticScenario() else {
+        applicationInfo = try! AppInfo() // crash if info are missing or malformed
+
+        window = UIWindow(frame: UIScreen.main.bounds)
+
+        if let scenario = SyntheticScenario() {
+            let run = SyntheticRun()
+            start(scenario: scenario, run: run)
+        } else {
+            window?.rootViewController = UIViewController()
+        }
+
+        window?.makeKeyAndVisible()
+        return true
+    }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return false
         }
 
-        let run = SyntheticRun()
-        let applicationInfo = try! AppInfo() // crash if info are missing or malformed
+        // bench://stop
+        if components.host == "stop" {
+            stop()
+            return true
+        }
 
-        // Collect metrics during all run
-        let meter = Meter(
-            provider: Benchmarks.meterProvider(
-                with: Benchmarks.Configuration(
-                    info: applicationInfo,
-                    scenario: scenario,
-                    run: run
-                )
-            )
-        )
+        // bench://start?scenario=<scenario>&run=<run>
+        if components.host == "start", let scenario = SyntheticScenario(urlComponents: components), let run = SyntheticRun(urlComponents: components) {
+            start(scenario: scenario, run: run)
+            return true
+        }
 
+        return false
+    }
+
+    /// Starts instruments for the given run and scenario.
+    ///
+    /// - Parameters:
+    ///   - scenario: The benchmark scenario.
+    ///   - run: The benchmark run.
+    private func start(
+        scenario: SyntheticScenario,
+        run: SyntheticRun
+    ) {
         switch run {
         case .baseline, .instrumented:
-            meter.observeCPU()
-            meter.observeMemory()
-            meter.observeFPS()
-
+            collectApplicationVitals(scenario: scenario, run: run)
         case .profiling:
-            // Collect traces during profiling run
-            let profiler = Profiler(
-                provider: Benchmarks.tracerProvider(
-                    with: Benchmarks.Configuration(
-                        info: applicationInfo,
-                        scenario: scenario,
-                        run: run
-                    )
-                )
-            )
-
-            DatadogInternal.bench = (profiler, meter)
+            profileSDK(scenario: scenario, run: run)
         case .none:
             break
         }
@@ -60,11 +76,77 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             scenario.instrument(with: applicationInfo)
         }
 
-        window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = scenario.initialViewController
-        window?.makeKeyAndVisible()
+    }
 
-        return true
+    /// Stops all current instruments.
+    ///
+    /// The same process can run multiple scenarios and instruments when receiving a deeplink.
+    /// It is important to stop current instruments before starting a new run.
+    private func stop() {
+        vitals = nil // stop collecting vitals
+        Datadog.stopInstance() // stop runner instrumentation
+        DatadogInternal.bench = (NOPBench(), NOPBench()) // stop profiling the sdk
+        window?.rootViewController = UIViewController()
+    }
+
+    /// Starts collection vitals of the runner application.
+    ///
+    /// - Parameters:
+    ///   - scenario: The benchmark scenario.
+    ///   - run: The benchmark run.
+    private func collectApplicationVitals(
+        scenario: SyntheticScenario,
+        run: SyntheticRun
+    ) {
+        let vitals = Vitals(
+            provider: Benchmarks.meterProvider(
+                with: Benchmarks.Configuration(
+                    info: applicationInfo,
+                    scenario: scenario,
+                    run: run
+                )
+            )
+        )
+
+        vitals.observeCPU()
+        vitals.observeMemory()
+        vitals.observeFPS()
+
+        self.vitals = vitals // Keep vitals in memory
+    }
+
+    /// Starts profiling the SDK while running the application.
+    ///
+    /// - Parameters:
+    ///   - scenario: The benchmark scenario.
+    ///   - run: The benchmark run.
+    private func profileSDK(
+        scenario: SyntheticScenario,
+        run: SyntheticRun
+    ) {
+        // Collect traces during profiling run
+        let profiler = Profiler(
+            provider: Benchmarks.tracerProvider(
+                with: Benchmarks.Configuration(
+                    info: applicationInfo,
+                    scenario: scenario,
+                    run: run
+                )
+            )
+        )
+
+        let meter = Meter(
+            provider: Benchmarks.meterProvider(
+                with: Benchmarks.Configuration(
+                    info: applicationInfo,
+                    scenario: scenario,
+                    run: run
+                )
+            )
+        )
+
+        DatadogInternal.bench = (profiler, meter) // Inject profiler and meter to collect telemetry
     }
 }
 

--- a/BenchmarkTests/Runner/BenchmarkMeter.swift
+++ b/BenchmarkTests/Runner/BenchmarkMeter.swift
@@ -8,57 +8,15 @@ import Foundation
 import DatadogInternal
 import DatadogBenchmarks
 import OpenTelemetryApi
-import OpenTelemetrySdk
 
 internal final class Meter: DatadogInternal.BenchmarkMeter {
     let meter: OpenTelemetryApi.Meter
-
-    let queue = DispatchQueue(label: "com.datadoghq.benchmarks.metrics", target: .global(qos: .utility))
 
     init(provider: MeterProvider) {
         self.meter = provider.get(
             instrumentationName: "benchmarks",
             instrumentationVersion: nil
         )
-    }
-
-    @discardableResult
-    func observeMemory() -> OpenTelemetryApi.DoubleObserverMetric {
-        let memory = Memory(queue: queue)
-        return meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
-            // report the maximum memory footprint that was recorded during push interval
-            if let value = memory.aggregation?.max {
-                metric.observe(value: value, labelset: .empty)
-            }
-
-            memory.reset()
-        }
-    }
-
-    @discardableResult
-    func observeCPU() -> OpenTelemetryApi.DoubleObserverMetric {
-        let cpu = CPU(queue: queue)
-        return meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
-            // report the average cpu usage that was recorded during push interval
-            if let value = cpu.aggregation?.avg {
-                metric.observe(value: value, labelset: .empty)
-            }
-
-            cpu.reset()
-        }
-    }
-
-    @discardableResult
-    func observeFPS() -> OpenTelemetryApi.IntObserverMetric {
-        let fps = FPS()
-        return meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
-            // report the minimum frame rate that was recorded during push interval
-            if let value = fps.aggregation?.min {
-                metric.observe(value: value, labelset: .empty)
-            }
-
-            fps.reset()
-        }
     }
 
     func counter(metric: @autoclosure () -> String) -> DatadogInternal.BenchmarkCounter {

--- a/BenchmarkTests/Runner/BenchmarkProfiler.swift
+++ b/BenchmarkTests/Runner/BenchmarkProfiler.swift
@@ -8,7 +8,6 @@ import Foundation
 import DatadogInternal
 import DatadogBenchmarks
 import OpenTelemetryApi
-import OpenTelemetrySdk
 
 internal final class Profiler: DatadogInternal.BenchmarkProfiler {
     let provider: TracerProvider

--- a/BenchmarkTests/Runner/BenchmarkVitals.swift
+++ b/BenchmarkTests/Runner/BenchmarkVitals.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogBenchmarks
+import OpenTelemetryApi
+
+/// Collect Vital Metrics such CPU, Memory, and FPS.
+///
+/// The metrics are reported via opentelemetry.
+internal final class Vitals {
+    let provider: OpenTelemetryApi.MeterProvider
+
+    private lazy var meter: OpenTelemetryApi.Meter = provider.get(instrumentationName: "vitals", instrumentationVersion: nil)
+
+    let queue = DispatchQueue(label: "com.datadoghq.benchmarks.vitals", target: .global(qos: .utility))
+
+    init(provider: MeterProvider) {
+        self.provider = provider
+    }
+
+    @discardableResult
+    func observeMemory() -> OpenTelemetryApi.DoubleObserverMetric {
+        let memory = Memory(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.memory") { metric in
+            // report the maximum memory footprint that was recorded during push interval
+            if let value = memory.aggregation?.max {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            memory.reset()
+        }
+    }
+
+    @discardableResult
+    func observeCPU() -> OpenTelemetryApi.DoubleObserverMetric {
+        let cpu = CPU(queue: queue)
+        return meter.createDoubleObservableGauge(name: "ios.benchmark.cpu") { metric in
+            // report the average cpu usage that was recorded during push interval
+            if let value = cpu.aggregation?.avg {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            cpu.reset()
+        }
+    }
+
+    @discardableResult
+    func observeFPS() -> OpenTelemetryApi.IntObserverMetric {
+        let fps = FPS()
+        return meter.createIntObservableGauge(name: "ios.benchmark.fps.min") { metric in
+            // report the minimum frame rate that was recorded during push interval
+            if let value = fps.aggregation?.min {
+                metric.observe(value: value, labelset: .empty)
+            }
+
+            fps.reset()
+        }
+    }
+}

--- a/BenchmarkTests/Runner/Info.plist
+++ b/BenchmarkTests/Runner/Info.plist
@@ -2,6 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bench</string>
+			</array>
+		</dict>
+		<dict/>
+	</array>
 	<key>DatadogConfiguration</key>
 	<dict>
 		<key>ApiKey</key>

--- a/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
@@ -11,7 +11,7 @@ import UIKit
 /// variable to instantiate a `Scenario` compliant object.
 internal struct SyntheticScenario: Scenario {
     /// The Synthetics benchmark scenario value.
-    internal enum Name: String {
+    internal enum Name: String, CaseIterable {
         case sessionReplay
         case sessionReplaySwiftUI
         case logsCustom
@@ -33,12 +33,39 @@ internal struct SyntheticScenario: Scenario {
     /// configured
     init?(processInfo: ProcessInfo = .processInfo) {
         guard
-            let rawValue = processInfo.environment["BENCHMARK_SCENARIO"],
+            let rawValue = processInfo.environment["BENCHMARK_SCENARIO"]
+        else {
+            return nil
+        }
+
+        self.init(rawValue: rawValue)
+    }
+
+    /// Creates the scenario by reading the `scenario` value from the
+    /// URL query item.
+    ///
+    /// - Parameter urlComponents: The `URLComponents` to read.
+    init?(urlComponents: URLComponents) {
+        guard
+            let rawValue = urlComponents.queryItem("scenario")
+        else {
+            return nil
+        }
+
+        self.init(rawValue: rawValue)
+    }
+
+    init?(rawValue: String) {
+        guard
             let name = Name(rawValue: rawValue)
         else {
             return nil
         }
 
+        self.init(name: name)
+    }
+
+    init(name: Name) {
         switch name {
         case .sessionReplay:
             _scenario = SessionReplayScenario()
@@ -84,7 +111,7 @@ internal enum SyntheticRun: String {
     case profiling
     case none
 
-    /// Creates the scenario by reading the `BENCHMARK_RUN` value from the
+    /// Creates the run by reading the `BENCHMARK_RUN` value from the
     /// environment variables.
     ///
     /// - Parameter processInfo: The `ProcessInfo` with environment variables
@@ -94,5 +121,25 @@ internal enum SyntheticRun: String {
             .environment["BENCHMARK_RUN"]
             .flatMap(Self.init(rawValue:))
         ?? .none
+    }
+
+    /// Creates the run by reading the `run` value from the
+    /// URL query item.
+    ///
+    /// - Parameter urlComponents: The `URLComponents` to read.
+    init?(urlComponents: URLComponents) {
+        guard
+            let rawValue = urlComponents.queryItem("run")
+        else {
+            return nil
+        }
+
+        self.init(rawValue: rawValue)
+    }
+}
+
+extension URLComponents {
+    func queryItem(_ name: String) -> String? {
+        queryItems?.first(where: { $0.name == name })?.value
     }
 }

--- a/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
+++ b/DatadogInternal/Sources/Benchmarks/BenchmarkProfiler.swift
@@ -136,21 +136,22 @@ extension BenchmarkGauge {
     }
 }
 
-private final class NOPBench: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan, BenchmarkMeter, BenchmarkCounter, BenchmarkGauge {
+public final class NOPBench: BenchmarkProfiler, BenchmarkTracer, BenchmarkSpan, BenchmarkMeter, BenchmarkCounter, BenchmarkGauge {
+    public init() { }
     /// no-op
-    func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer { self }
+    public func tracer(operation: @autoclosure () -> String) -> BenchmarkTracer { self }
     /// no-op
-    func counter(metric: @autoclosure () -> String) -> BenchmarkCounter { self }
+    public func counter(metric: @autoclosure () -> String) -> BenchmarkCounter { self }
     /// no-op
-    func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge { self }
+    public func gauge(metric: @autoclosure () -> String) -> BenchmarkGauge { self }
     /// no-op
-    func observe(metric: @autoclosure () -> String, callback: @escaping (any BenchmarkGauge) -> Void) { }
+    public func observe(metric: @autoclosure () -> String, callback: @escaping (any BenchmarkGauge) -> Void) { }
     /// no-op
-    func add(value: Double, attributes: @autoclosure () -> [String: String]) { }
+    public func add(value: Double, attributes: @autoclosure () -> [String: String]) { }
     /// no-op
-    func record(value: Double, attributes: @autoclosure () -> [String: String]) { }
+    public func record(value: Double, attributes: @autoclosure () -> [String: String]) { }
     /// no-op
-    func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan { self }
+    public func startSpan(named: @autoclosure () -> String) -> BenchmarkSpan { self }
     /// no-op
-    func stop() {}
+    public func stop() {}
 }


### PR DESCRIPTION
### What and why?

The Benchmark Runner expect Environment Arguments to start a Scenario and Run. Synthetics only support setting Environment Arguments for the entire test, it is not yet possible to restart the application with new arguments.
For Benchmarks, it means that we need a test per Scenario and per Run. It doesn't scale well with the addition of the `profiling` run and the increased number of Scenarios.

It would be beneficial to execute all Benchmark Runs of a Scenario in a single Synthetic Test.

### How?

Leverage Deep Link Synthetic Step to switch Benchmark Scenario and Run and be able to execute the `baseline`, `instrumented`, and `profiling` in a single Test.

The Runner application now supports 2 Deep Links:
1. `bench://stop` to stop the current execution.
2. `bench://start?scenario=<scenario>&run=<run>` to start a new Scenario and Run.

In Synthetic, we will be able to define a test such as:
<img width="491" alt="image" src="https://github.com/user-attachments/assets/ce134c56-e198-4aea-afc8-ef0451ed4f75" />

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
