### PR TITLE
RUM-9395 fix: Fatal App Hang Duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [FIX] Fix Fatal App Hang Duplicates. See [#2260][]
+
 # 2.25.0 / 03-04-2025
 
 - [FEATURE] Calculate Hang rate and Hitch rate in RUM. See [#2234][]
@@ -858,6 +862,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2223]: https://github.com/DataDog/dd-sdk-ios/pull/2223
 [#2234]: https://github.com/DataDog/dd-sdk-ios/pull/2234
 [#2236]: https://github.com/DataDog/dd-sdk-ios/pull/2236
+[#2260]: https://github.com/DataDog/dd-sdk-ios/pull/2260
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
@@ -61,6 +61,7 @@ internal final class FatalAppHangsHandler {
     }
 
     func reportFatalAppHangIfFound() {
+        // Report pending app hang
         featureScope.rumDataStore.value(forKey: .fatalAppHangKey) { [weak self] (fatalHang: FatalAppHang?) in
             guard let fatalHang = fatalHang else {
                 DD.logger.debug("No pending App Hang found")
@@ -71,6 +72,9 @@ internal final class FatalAppHangsHandler {
             }
             self?.send(fatalHang: fatalHang)
         }
+
+        // Remove pending app hang
+        featureScope.rumDataStore.removeValue(forKey: .fatalAppHangKey)
     }
 
     private func send(fatalHang: FatalAppHang) {

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -196,6 +196,7 @@ class AppHangsMonitorTests: XCTestCase {
         XCTAssertEqual(featureScope.eventsWritten.count, 2, "It must send both RUM error and RUM view")
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMErrorEvent.self).count, 1)
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1)
+        XCTAssertNil(featureScope.dataStoreMock.value(forKey: RUMDataStore.Key.fatalAppHangKey.rawValue))
     }
 
     func testGivenPendingHangStartedMoreThan4HoursAgo_whenStartedInAnotherProcess_itSendsOnlyRUMError() throws {
@@ -235,6 +236,7 @@ class AppHangsMonitorTests: XCTestCase {
 
         XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must send only RUM error")
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMErrorEvent.self).count, 1)
+        XCTAssertNil(featureScope.dataStoreMock.value(forKey: RUMDataStore.Key.fatalAppHangKey.rawValue))
     }
 
     func testGivenPendingHangStartedWithPendingOrNotGrantedConsent_whenStartedInAnotherProcess_itSendsNoEvent() throws {
@@ -272,6 +274,7 @@ class AppHangsMonitorTests: XCTestCase {
         )
 
         XCTAssertEqual(featureScope.eventsWritten.count, 0, "It must send no event")
+        XCTAssertNil(featureScope.dataStoreMock.value(forKey: RUMDataStore.Key.fatalAppHangKey.rawValue))
     }
 
     // MARK: - Fatal App Hangs - Testing Uploaded Data


### PR DESCRIPTION
### What and why?

After reporting the crash-error at launch, the AppHang report is never removed from the persistent DataStore. Meaning that the same error will be reported at each application launch, until the event expires after 18hrs, or until another report overrides it.

Fix #2158

### How?

Remove the stored App Hang after report at launch.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
