### PR TITLE
GH-2277 Fix access level for `DatadogPrivate` imports

### DIFF
--- a/DatadogCore/Sources/Core/Context/LaunchTimePublisher.swift
+++ b/DatadogCore/Sources/Core/Context/LaunchTimePublisher.swift
@@ -7,9 +7,15 @@
 import Foundation
 import DatadogInternal
 
+// swiftlint:disable duplicate_imports
 #if SPM_BUILD
-import DatadogPrivate
+    #if swift(>=6.0)
+    internal import DatadogPrivate
+    #else
+    @_implementationOnly import DatadogPrivate
+    #endif
 #endif
+// swiftlint:enable duplicate_imports
 
 /// An interface for tracking key timestamps in the app launch sequence, including launch time and activation events.
 internal protocol AppLaunchHandling {

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -527,9 +527,15 @@ extension DatadogCore: Storage {
         }
     }
 }
+// swiftlint:disable duplicate_imports
 #if SPM_BUILD
-import DatadogPrivate
+    #if swift(>=6.0)
+    internal import DatadogPrivate
+    #else
+    @_implementationOnly import DatadogPrivate
+    #endif
 #endif
+// swiftlint:enable duplicate_imports
 
 internal let registerObjcExceptionHandlerOnce: () -> Void = {
     ObjcException.rethrow = __dd_private_ObjcExceptionHandler.rethrow


### PR DESCRIPTION
### What and why?

📦 This PR updates the access-level used when importing the `DatadogPrivate` module in SPM builds.

It addresses [#2267](https://github.com/DataDog/dd-sdk-ios/issues/2267), where using a direct import DatadogPrivate in DatadogCore could lead to the error:

> "Missing required module 'DatadogPrivate'"

This may occur if `DatadogCore` is imported into a custom module within a client application (rather than the app target).

### How?

The fix introduces Swift version–aware access-level imports, following [SE-0409](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md). Specifically:

```swift
#if swift(>=6.0)
internal import DatadogPrivate
#else
@_implementationOnly import DatadogPrivate
#endif
```

This ensures that `DatadogPrivate` remains hidden from SDK consumers, preventing accidental exposure of internal APIs and resolving module visibility issues across various SPM use cases.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
