### PR TITLE
RUM-9521 Move RUM models to DatadogInternal

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -7,15 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		11030D762D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
-		11030D772D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
-		1117AA062D09A39400F86B29 /* RUMAttributesIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */; };
-		1117AA072D09A39400F86B29 /* RUMAttributesIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */; };
 		11030D5F2D959EAD00732D5F /* DatadogLogs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D207317C29A5226A00ECBF94 /* DatadogLogs.framework */; };
 		11030D642D959EC300732D5F /* DatadogLogs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20731B429A5279D00ECBF94 /* DatadogLogs.framework */; };
 		11030D692D959F1700732D5F /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		11030D6D2D95A48B00732D5F /* DatadogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* DatadogCore.framework */; };
 		11030D712D95A51100732D5F /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */; };
+		11030D762D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
+		11030D772D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
 		112877992D708D300082D11B /* VitalRefreshRateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877972D708D300082D11B /* VitalRefreshRateReader.swift */; };
 		1128779A2D708D300082D11B /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877942D708D300082D11B /* FrameInfoProvider.swift */; };
 		1128779B2D708D300082D11B /* RenderLoopObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877952D708D300082D11B /* RenderLoopObserver.swift */; };
@@ -24,8 +22,6 @@
 		1128779E2D708D300082D11B /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877942D708D300082D11B /* FrameInfoProvider.swift */; };
 		1128779F2D708D300082D11B /* RenderLoopObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877952D708D300082D11B /* RenderLoopObserver.swift */; };
 		112877A02D708D300082D11B /* ViewHitchesReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877962D708D300082D11B /* ViewHitchesReader.swift */; };
-		112877A62D72161A0082D11B /* VitalMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877A52D7216150082D11B /* VitalMocks.swift */; };
-		112877A72D72161A0082D11B /* VitalMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877A52D7216150082D11B /* VitalMocks.swift */; };
 		1132B34C2D9E9A30002384F2 /* RUMViewHitchesMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1132B34B2D9E9A03002384F2 /* RUMViewHitchesMetricIntegrationTests.swift */; };
 		1132B34D2D9E9A30002384F2 /* RUMViewHitchesMetricIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1132B34B2D9E9A03002384F2 /* RUMViewHitchesMetricIntegrationTests.swift */; };
 		114CA1592D75C65700262287 /* ViewHitchesReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114CA1582D75C64E00262287 /* ViewHitchesReaderTests.swift */; };
@@ -126,7 +122,6 @@
 		1182FA372DA2F827007FE71A /* ReflectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA022DA2F827007FE71A /* ReflectionMocks.swift */; };
 		1182FA382DA2F827007FE71A /* ResourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA032DA2F827007FE71A /* ResourceMocks.swift */; };
 		1182FA392DA2F827007FE71A /* DatadogCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA192DA2F827007FE71A /* DatadogCoreProxy.swift */; };
-		1182FA3A2DA2F827007FE71A /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9F82DA2F827007FE71A /* RUMDataModelMocks.swift */; };
 		1182FA3B2DA2F827007FE71A /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9CA2DA2F827007FE71A /* RUMEventMatcher.swift */; };
 		1182FA3C2DA2F827007FE71A /* ServerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA1B2DA2F827007FE71A /* ServerMock.swift */; };
 		1182FA3D2DA2F827007FE71A /* JSONObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9C82DA2F827007FE71A /* JSONObjectMatcher.swift */; };
@@ -210,7 +205,6 @@
 		1182FA8B2DA2F827007FE71A /* ReflectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA022DA2F827007FE71A /* ReflectionMocks.swift */; };
 		1182FA8C2DA2F827007FE71A /* ResourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA032DA2F827007FE71A /* ResourceMocks.swift */; };
 		1182FA8D2DA2F827007FE71A /* DatadogCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA192DA2F827007FE71A /* DatadogCoreProxy.swift */; };
-		1182FA8E2DA2F827007FE71A /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9F82DA2F827007FE71A /* RUMDataModelMocks.swift */; };
 		1182FA8F2DA2F827007FE71A /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9CA2DA2F827007FE71A /* RUMEventMatcher.swift */; };
 		1182FA902DA2F827007FE71A /* ServerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182FA1B2DA2F827007FE71A /* ServerMock.swift */; };
 		1182FA912DA2F827007FE71A /* JSONObjectMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9C82DA2F827007FE71A /* JSONObjectMatcher.swift */; };
@@ -1144,7 +1138,6 @@
 		D23F8E5F29DDCD28001CFAE8 /* UIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */; };
 		D23F8E6029DDCD28001CFAE8 /* PerformanceMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */; };
 		D23F8E6129DDCD28001CFAE8 /* RUMConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25FF2EA29CC6D6F0063802D /* RUMConfiguration.swift */; };
-		D23F8E6329DDCD28001CFAE8 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		D23F8E6429DDCD28001CFAE8 /* SwiftUIViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */; };
 		D23F8E6529DDCD28001CFAE8 /* RUMFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25FF2E729CC6B680063802D /* RUMFeature.swift */; };
 		D23F8E6629DDCD28001CFAE8 /* RUMDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */; };
@@ -1288,6 +1281,8 @@
 		D263BCB729DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263BCB329DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift */; };
 		D26416B62A30E84F00BCD9F7 /* CoreRegistryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26416B52A30E84F00BCD9F7 /* CoreRegistryTest.swift */; };
 		D26416B72A30E84F00BCD9F7 /* CoreRegistryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26416B52A30E84F00BCD9F7 /* CoreRegistryTest.swift */; };
+		D266ECF92DBA5B1800CB9B3A /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */; };
+		D266ECFA2DBA5B1800CB9B3A /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */; };
 		D26C49AF2886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C49AE2886DC7B00802B2D /* ApplicationStatePublisherTests.swift */; };
 		D26C49B02886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C49AE2886DC7B00802B2D /* ApplicationStatePublisherTests.swift */; };
 		D26C49BF288982DA00802B2D /* FeatureUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C49BE288982DA00802B2D /* FeatureUpload.swift */; };
@@ -1314,6 +1309,8 @@
 		D28F836929C9E71D00EF8EA2 /* DDSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */; };
 		D28F836B29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */; };
 		D28F836C29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */; };
+		D28FB6962DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */; };
+		D28FB6972DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */; };
 		D28FCC352B5EBAAF00CCC077 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D28FCC342B5EBAAF00CCC077 /* PrivacyInfo.xcprivacy */; };
 		D28FCC362B5FCBD100CCC077 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D28FCC342B5EBAAF00CCC077 /* PrivacyInfo.xcprivacy */; };
 		D29294E0291D5ED100F8EFF9 /* ApplicationVersionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29294DF291D5ECD00F8EFF9 /* ApplicationVersionPublisher.swift */; };
@@ -1371,7 +1368,6 @@
 		D29A9F7829DD85BB005C54A4 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		D29A9F7929DD85BB005C54A4 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25FF2ED29CC73240063802D /* RequestBuilder.swift */; };
 		D29A9F7A29DD85BB005C54A4 /* VitalCPUReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */; };
-		D29A9F7B29DD85BB005C54A4 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		D29A9F7C29DD85BB005C54A4 /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
 		D29A9F7D29DD85BB005C54A4 /* RUMEventsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E81EF25A740140084B751 /* RUMEventsMapper.swift */; };
 		D29A9F7E29DD85BB005C54A4 /* UIViewControllerSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */; };
@@ -2294,7 +2290,6 @@
 		112877952D708D300082D11B /* RenderLoopObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderLoopObserver.swift; sourceTree = "<group>"; };
 		112877962D708D300082D11B /* ViewHitchesReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHitchesReader.swift; sourceTree = "<group>"; };
 		112877972D708D300082D11B /* VitalRefreshRateReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalRefreshRateReader.swift; sourceTree = "<group>"; };
-		112877A52D7216150082D11B /* VitalMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalMocks.swift; sourceTree = "<group>"; };
 		1132B34B2D9E9A03002384F2 /* RUMViewHitchesMetricIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewHitchesMetricIntegrationTests.swift; sourceTree = "<group>"; };
 		114CA1582D75C64E00262287 /* ViewHitchesReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHitchesReaderTests.swift; sourceTree = "<group>"; };
 		114CA15B2D75D6A700262287 /* DisplayLinkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkerTests.swift; sourceTree = "<group>"; };
@@ -2355,7 +2350,6 @@
 		1182F9F32DA2F827007FE71A /* UploadMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMock.swift; sourceTree = "<group>"; };
 		1182F9F42DA2F827007FE71A /* UploadMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMocks.swift; sourceTree = "<group>"; };
 		1182F9F62DA2F827007FE71A /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
-		1182F9F82DA2F827007FE71A /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		1182F9F92DA2F827007FE71A /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		1182F9FA2DA2F827007FE71A /* VitalMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalMocks.swift; sourceTree = "<group>"; };
 		1182F9FC2DA2F827007FE71A /* CoreGraphicsMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphicsMocks.swift; sourceTree = "<group>"; };
@@ -2965,7 +2959,6 @@
 		96F25A802CC7EA4300459567 /* SessionReplayPrivacyOverrides+objc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SessionReplayPrivacyOverrides+objc.swift"; sourceTree = "<group>"; };
 		96F25A812CC7EA4300459567 /* UIView+SessionReplayPrivacyOverrides+objc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+SessionReplayPrivacyOverrides+objc.swift"; sourceTree = "<group>"; };
 		9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Kronos.xcframework; path = ../Carthage/Build/Kronos.xcframework; sourceTree = "<group>"; };
-		9E26E6B824C87693000B3270 /* RUMDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
 		9E2EF44E2694FA14008A7DAE /* VitalInfoSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoSamplerTests.swift; sourceTree = "<group>"; };
 		9E359F4D26CD518D001E25E9 /* LongTaskObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTaskObserver.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
@@ -3160,6 +3153,7 @@
 		D263BCB229DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+ConvenienceTests.swift"; sourceTree = "<group>"; };
 		D263BCB329DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ConvenienceTests.swift"; sourceTree = "<group>"; };
 		D26416B52A30E84F00BCD9F7 /* CoreRegistryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRegistryTest.swift; sourceTree = "<group>"; };
+		D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		D26C49AE2886DC7B00802B2D /* ApplicationStatePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatePublisherTests.swift; sourceTree = "<group>"; };
 		D26C49B52889416300802B2D /* UploadPerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadPerformancePreset.swift; sourceTree = "<group>"; };
 		D26C49BE288982DA00802B2D /* FeatureUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureUpload.swift; sourceTree = "<group>"; };
@@ -3173,6 +3167,7 @@
 		D28ABFD52CECDE6B00623F27 /* URLSessionInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptorTests.swift; sourceTree = "<group>"; };
 		D28F836729C9E71C00EF8EA2 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
 		D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionHandlerTests.swift; sourceTree = "<group>"; };
+		D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
 		D28FCC342B5EBAAF00CCC077 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D29294DF291D5ECD00F8EFF9 /* ApplicationVersionPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationVersionPublisher.swift; sourceTree = "<group>"; };
 		D29294E2291D652900F8EFF9 /* ApplicationVersionPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationVersionPublisherTests.swift; sourceTree = "<group>"; };
@@ -3767,6 +3762,7 @@
 				1182F9F22DA2F827007FE71A /* TelemetryReceiverMock.swift */,
 				1182F9F32DA2F827007FE71A /* UploadMock.swift */,
 				1182F9F42DA2F827007FE71A /* UploadMocks.swift */,
+				D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -3782,7 +3778,6 @@
 		1182F9FB2DA2F827007FE71A /* DatadogRUM */ = {
 			isa = PBXGroup;
 			children = (
-				1182F9F82DA2F827007FE71A /* RUMDataModelMocks.swift */,
 				1182F9F92DA2F827007FE71A /* RUMFeatureMocks.swift */,
 				1182F9FA2DA2F827007FE71A /* VitalMocks.swift */,
 			);
@@ -5513,6 +5508,7 @@
 			isa = PBXGroup;
 			children = (
 				619F5CEA2BF5089B004BFE70 /* GlobalRUMAttributes.swift */,
+				D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -5716,7 +5712,6 @@
 		61E5333224B7A504003D6C4E /* DataModels */ = {
 			isa = PBXGroup;
 			children = (
-				9E26E6B824C87693000B3270 /* RUMDataModels.swift */,
 				618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */,
 			);
 			path = DataModels;
@@ -8887,6 +8882,7 @@
 				D23039F5298D5236001A1FA3 /* AnyEncodable.swift in Sources */,
 				D2303A00298D5236001A1FA3 /* DatadogExtended.swift in Sources */,
 				D23039E6298D5236001A1FA3 /* Sysctl.swift in Sources */,
+				D28FB6962DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */,
 				614A708E2BF754D800D9AF42 /* ImmutableRequest.swift in Sources */,
 				D2160CF429C0EDFC00FAA9A5 /* UploadPerformancePreset.swift in Sources */,
 				D23039E1298D5236001A1FA3 /* AppState.swift in Sources */,
@@ -8977,7 +8973,6 @@
 				1128779A2D708D300082D11B /* FrameInfoProvider.swift in Sources */,
 				1128779B2D708D300082D11B /* RenderLoopObserver.swift in Sources */,
 				1128779C2D708D300082D11B /* ViewHitchesReader.swift in Sources */,
-				D23F8E6329DDCD28001CFAE8 /* RUMDataModels.swift in Sources */,
 				61C713AB2A3B790B00FA735A /* Monitor.swift in Sources */,
 				D23F8E6429DDCD28001CFAE8 /* SwiftUIViewHandler.swift in Sources */,
 				965497002D761E2B006428EE /* RUMView.swift in Sources */,
@@ -9136,6 +9131,7 @@
 			files = (
 				1182FA202DA2F827007FE71A /* AttributesMocks.swift in Sources */,
 				1182FA212DA2F827007FE71A /* DatadogCoreProxy+Utils.swift in Sources */,
+				D266ECFA2DBA5B1800CB9B3A /* RUMDataModelMocks.swift in Sources */,
 				1182FA222DA2F827007FE71A /* ResourceProcessorSpy.swift in Sources */,
 				1182FA232DA2F827007FE71A /* RecorderMocks.swift in Sources */,
 				1182FA242DA2F827007FE71A /* CrashReportingFeatureMocks.swift in Sources */,
@@ -9160,7 +9156,6 @@
 				1182FA372DA2F827007FE71A /* ReflectionMocks.swift in Sources */,
 				1182FA382DA2F827007FE71A /* ResourceMocks.swift in Sources */,
 				1182FA392DA2F827007FE71A /* DatadogCoreProxy.swift in Sources */,
-				1182FA3A2DA2F827007FE71A /* RUMDataModelMocks.swift in Sources */,
 				1182FA3B2DA2F827007FE71A /* RUMEventMatcher.swift in Sources */,
 				1182FA3C2DA2F827007FE71A /* ServerMock.swift in Sources */,
 				1182FA3D2DA2F827007FE71A /* JSONObjectMatcher.swift in Sources */,
@@ -9227,6 +9222,7 @@
 			files = (
 				1182FA742DA2F827007FE71A /* AttributesMocks.swift in Sources */,
 				1182FA752DA2F827007FE71A /* DatadogCoreProxy+Utils.swift in Sources */,
+				D266ECF92DBA5B1800CB9B3A /* RUMDataModelMocks.swift in Sources */,
 				1182FA762DA2F827007FE71A /* ResourceProcessorSpy.swift in Sources */,
 				1182FA772DA2F827007FE71A /* RecorderMocks.swift in Sources */,
 				1182FA782DA2F827007FE71A /* CrashReportingFeatureMocks.swift in Sources */,
@@ -9251,7 +9247,6 @@
 				1182FA8B2DA2F827007FE71A /* ReflectionMocks.swift in Sources */,
 				1182FA8C2DA2F827007FE71A /* ResourceMocks.swift in Sources */,
 				1182FA8D2DA2F827007FE71A /* DatadogCoreProxy.swift in Sources */,
-				1182FA8E2DA2F827007FE71A /* RUMDataModelMocks.swift in Sources */,
 				1182FA8F2DA2F827007FE71A /* RUMEventMatcher.swift in Sources */,
 				1182FA902DA2F827007FE71A /* ServerMock.swift in Sources */,
 				1182FA912DA2F827007FE71A /* JSONObjectMatcher.swift in Sources */,
@@ -9417,7 +9412,6 @@
 				1128779E2D708D300082D11B /* FrameInfoProvider.swift in Sources */,
 				1128779F2D708D300082D11B /* RenderLoopObserver.swift in Sources */,
 				112877A02D708D300082D11B /* ViewHitchesReader.swift in Sources */,
-				D29A9F7B29DD85BB005C54A4 /* RUMDataModels.swift in Sources */,
 				61C713AA2A3B790B00FA735A /* Monitor.swift in Sources */,
 				D29A9F8529DD85BB005C54A4 /* SwiftUIViewHandler.swift in Sources */,
 				965496FF2D761E2B006428EE /* RUMView.swift in Sources */,
@@ -9825,10 +9819,7 @@
 				D2CB6F6827C520D400A62B57 /* SwiftUIExtensionsTests.swift in Sources */,
 				D2CB6F6A27C520D400A62B57 /* DDRUMMonitor+apiTests.m in Sources */,
 				D22743DD29DEB8B5001A7EF9 /* VitalInfoTests.swift in Sources */,
-				D2CB6F7027C520D400A62B57 /* UIKitMocks.swift in Sources */,
-				D2CB6F7327C520D400A62B57 /* CoreTelephonyMocks.swift in Sources */,
 				1132B34C2D9E9A30002384F2 /* RUMViewHitchesMetricIntegrationTests.swift in Sources */,
-				D20605B7287572640047275C /* DatadogContextProviderMock.swift in Sources */,
 				D2CB6F7527C520D400A62B57 /* UIKitExtensionsTests.swift in Sources */,
 				61F930C92BA1C51C005F0EE2 /* Storage+TLVTests.swift in Sources */,
 				61DA8CB928647A500074A606 /* InternalLoggerTests.swift in Sources */,
@@ -9971,6 +9962,7 @@
 				614A708F2BF754D800D9AF42 /* ImmutableRequest.swift in Sources */,
 				D2160CF529C0EDFC00FAA9A5 /* UploadPerformancePreset.swift in Sources */,
 				D2DA236C298D57AA00C6C7E6 /* AppState.swift in Sources */,
+				D28FB6972DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */,
 				D2DE63542A30A7CA00441A54 /* CoreRegistry.swift in Sources */,
 				E2AA55EC2C32C78B002FEF28 /* WatchKitExtensions.swift in Sources */,
 				D2EBEE3629BA161100B15732 /* W3CHTTPHeadersWriter.swift in Sources */,

--- a/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMConfigurationTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+import DatadogInternal
 @testable import DatadogRUM
 @testable import DatadogObjc
 

--- a/DatadogCore/Tests/DatadogObjc/RUM/RUMDataModels+objcTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/RUM/RUMDataModels+objcTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+import DatadogInternal
 @testable import DatadogRUM
 @testable import DatadogCore
 @testable import DatadogObjc

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -4,13 +4,11 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-import DatadogInternal
-
 // This file was generated from JSON Schema. Do not modify it directly.
 
 // swiftlint:disable all
 
-internal protocol RUMDataModel: Codable {}
+public protocol RUMDataModel: Codable {}
 
 /// Schema of all properties of an Action event
 public struct RUMActionEvent: RUMDataModel {

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-import DatadogRUM
+import DatadogInternal
 
 // This file was generated from JSON Schema. Do not modify it directly.
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -14,6 +14,11 @@ import DatadogInternal
 @_exported import protocol DatadogInternal.__URLSessionDelegateProviding
 @_exported import enum DatadogInternal.URLSessionInstrumentation
 @_exported import enum DatadogInternal.TraceContextInjection
+@_exported import struct DatadogInternal.RUMViewEvent
+@_exported import struct DatadogInternal.RUMResourceEvent
+@_exported import struct DatadogInternal.RUMErrorEvent
+@_exported import struct DatadogInternal.RUMActionEvent
+@_exported import struct DatadogInternal.RUMLongTaskEvent
 // swiftlint:enable duplicate_imports
 
 extension RUM {

--- a/DatadogRUM/Sources/RUMContext/RUMContext.swift
+++ b/DatadogRUM/Sources/RUMContext/RUMContext.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 internal struct RUMContext {
     /// The ID of RUM application.

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMocks.swift
@@ -49,7 +49,7 @@ class WatchdogTerminationReporterMock: WatchdogTerminationReporting {
         self.didSend = didSend
     }
 
-    func send(date: Date?, state: DatadogRUM.WatchdogTerminationAppState, viewEvent: DatadogRUM.RUMViewEvent) {
+    func send(date: Date?, state: DatadogRUM.WatchdogTerminationAppState, viewEvent: DatadogInternal.RUMViewEvent) {
         sendParams = SendParams(date: date, state: state, viewEvent: viewEvent)
         didSend.fulfill()
     }
@@ -57,7 +57,7 @@ class WatchdogTerminationReporterMock: WatchdogTerminationReporting {
     struct SendParams {
         let date: Date?
         let state: DatadogRUM.WatchdogTerminationAppState
-        let viewEvent: DatadogRUM.RUMViewEvent
+        let viewEvent: DatadogInternal.RUMViewEvent
     }
 }
 

--- a/DatadogRUM/Tests/RUMEvent/RUMEventBuilderTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMEventBuilderTests.swift
@@ -6,15 +6,14 @@
 
 import XCTest
 import TestUtilities
+import DatadogInternal
 @testable import DatadogRUM
 
 class RUMEventBuilderTests: XCTestCase {
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                viewEventMapper: { viewEvent in
-                    return RUMViewEvent.mockRandom()
-                }
+                viewEventMapper: { _ in.mockRandom() }
             )
         )
         let originalEventModel = RUMViewEvent.mockRandom()
@@ -28,9 +27,7 @@ class RUMEventBuilderTests: XCTestCase {
     func testGivenEventBuilderWithEventMapper_whenEventIsDropped_itBuildsNoEvent() {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                resourceEventMapper: { event in
-                    return nil
-                }
+                resourceEventMapper: { _ in nil }
             )
         )
         let event = builder.build(from: RUMResourceEvent.mockRandom())
@@ -40,9 +37,7 @@ class RUMEventBuilderTests: XCTestCase {
     func testGivenEventBuilderWithNoEventMapper_whenBuildingAnEvent_itBuildsEventWithOriginalModel() throws {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                resourceEventMapper: { event in
-                    return event
-                }
+                resourceEventMapper: { $0 }
             )
         )
         let originalEventModel = RUMResourceEvent.mockRandom()

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -22,7 +22,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
 
         // When
-        viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil, in: sessionID) }
+        viewIDs.forEach { controller.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: $0), instrumentationType: nil, in: sessionID) }
         errorKinds.forEach { controller.track(sdkErrorKind: $0, in: sessionID) }
         controller.track(missedEventType: .action, in: sessionID)
         controller.trackWasStopped(sessionID: sessionID)
@@ -47,7 +47,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Session 1:
-        controller.track(view: .mockRandomWith(sessionID: sessionID1), instrumentationType: nil, in: sessionID1)
+        controller.track(view: .mockRandomWith(sessionID: sessionID1.rawValue), instrumentationType: nil, in: sessionID1)
         controller.track(sdkErrorKind: "error.kind1", in: sessionID1)
         controller.trackWasStopped(sessionID: sessionID1)
         // Session 2:
@@ -79,7 +79,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Track latest session (`sessionID: nil`)
-        controller.track(view: .mockRandomWith(sessionID: sessionID2), instrumentationType: nil, in: nil)
+        controller.track(view: .mockRandomWith(sessionID: sessionID2.rawValue), instrumentationType: nil, in: nil)
         controller.track(sdkErrorKind: "error.kind1", in: nil)
         controller.track(missedEventType: .resource, in: nil)
         controller.trackWasStopped(sessionID: nil)

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -118,7 +118,7 @@ class SessionEndedMetricTests: XCTestCase {
     func testComputingDurationFromSingleView() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID)
-        let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID)
+        let view: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue)
 
         // When
         try metric.track(view: view, instrumentationType: nil)
@@ -132,9 +132,9 @@ class SessionEndedMetricTests: XCTestCase {
     func testComputingDurationFromMultipleViews() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID)
-        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
-        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
-        let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
+        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 10.s2ms, viewTimeSpent: 10.s2ns)
+        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 10.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
+        let view3: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 10.s2ms + 10.s2ms + 20.s2ms, viewTimeSpent: 50.s2ns)
 
         // When
         try metric.track(view: view1, instrumentationType: nil)
@@ -150,8 +150,8 @@ class SessionEndedMetricTests: XCTestCase {
     func testComputingDurationFromOverlappingViews() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID)
-        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 10.s2ms, viewTimeSpent: 10.s2ns)
-        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
+        let view1: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 10.s2ms, viewTimeSpent: 10.s2ns)
+        let view2: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 15.s2ms, viewTimeSpent: 20.s2ns) // starts in the middle of `view1`
 
         // When
         try metric.track(view: view1, instrumentationType: nil)
@@ -166,12 +166,12 @@ class SessionEndedMetricTests: XCTestCase {
     func testDurationIsAlwaysComputedFromTheFirstAndLastView() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID)
-        let firstView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms, viewTimeSpent: 10.s2ns)
-        let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
+        let firstView: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 5.s2ms, viewTimeSpent: 10.s2ns)
+        let lastView: RUMViewEvent = .mockRandomWith(sessionID: sessionID.rawValue, date: 5.s2ms + 10.s2ms, viewTimeSpent: 20.s2ns)
 
         // When
         try metric.track(view: firstView, instrumentationType: nil)
-        try (0..<10).forEach { _ in try metric.track(view: .mockRandomWith(sessionID: sessionID), instrumentationType: nil) } // middle views should not alter the duration
+        try (0..<10).forEach { _ in try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue), instrumentationType: nil) } // middle views should not alter the duration
         try metric.track(view: lastView, instrumentationType: nil)
         let attributes = metric.asMetricAttributes()
 
@@ -248,7 +248,7 @@ class SessionEndedMetricTests: XCTestCase {
         let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
-        try viewIDs.forEach { try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: $0), instrumentationType: nil) }
+        try viewIDs.forEach { try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: $0), instrumentationType: nil) }
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -265,8 +265,8 @@ class SessionEndedMetricTests: XCTestCase {
 
         // When
         try (0..<5).forEach { _ in // repeat few times
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID1), instrumentationType: nil)
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID2), instrumentationType: nil)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: viewID1), instrumentationType: nil)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: viewID2), instrumentationType: nil)
         }
         let attributes = metric.asMetricAttributes()
 
@@ -286,7 +286,7 @@ class SessionEndedMetricTests: XCTestCase {
         // When
         try viewIDs.forEach { viewID in
             let viewURL = backgroundViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.backgroundViewURL : .mockRandom()
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL), instrumentationType: nil)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: viewID, viewURL: viewURL), instrumentationType: nil)
         }
         let attributes = metric.asMetricAttributes()
 
@@ -306,7 +306,7 @@ class SessionEndedMetricTests: XCTestCase {
         // When
         try viewIDs.forEach { viewID in
             let viewURL = appLaunchViewIDs.contains(viewID) ? RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL : .mockRandom()
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: viewID, viewURL: viewURL), instrumentationType: nil)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: viewID, viewURL: viewURL), instrumentationType: nil)
         }
         let attributes = metric.asMetricAttributes()
 
@@ -326,16 +326,16 @@ class SessionEndedMetricTests: XCTestCase {
 
         // When
         try (0..<manualViewsCount).forEach { idx in
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "manual\(idx)"), instrumentationType: .manual)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "manual\(idx)"), instrumentationType: .manual)
         }
         try (0..<swiftuiViewsCount).forEach { idx in
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "swiftui\(idx)"), instrumentationType: .swiftui)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "swiftui\(idx)"), instrumentationType: .swiftui)
         }
         try (0..<uikitViewsCount).forEach { idx in
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "uikit\(idx)"), instrumentationType: .uikit)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "uikit\(idx)"), instrumentationType: .uikit)
         }
         try (0..<unknownViewsCount).forEach { idx in
-            try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "unknown\(idx)"), instrumentationType: nil)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "unknown\(idx)"), instrumentationType: nil)
         }
         let attributes = metric.asMetricAttributes()
 
@@ -355,12 +355,12 @@ class SessionEndedMetricTests: XCTestCase {
     func testWhenReportingViewsCountByInstrumentationType_itIgnoresSuccedingInstrumentationTypesForGivenViewID() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "view-id"), instrumentationType: .manual)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "view-id"), instrumentationType: .manual)
 
         // When
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "view-id"), instrumentationType: nil)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "view-id"), instrumentationType: .swiftui)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "view-id"), instrumentationType: .uikit)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "view-id"), instrumentationType: nil)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "view-id"), instrumentationType: .swiftui)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "view-id"), instrumentationType: .uikit)
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -373,12 +373,12 @@ class SessionEndedMetricTests: XCTestCase {
         let metric = SessionEndedMetric.with(sessionID: sessionID)
 
         // When
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "1", hasReplay: nil), instrumentationType: nil)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "1", hasReplay: false), instrumentationType: nil)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "1", hasReplay: true), instrumentationType: nil) // count
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "2", hasReplay: false), instrumentationType: nil)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "3", hasReplay: true), instrumentationType: nil) // count
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewID: "3", hasReplay: false), instrumentationType: nil) // ignore
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "1", hasReplay: nil), instrumentationType: nil)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "1", hasReplay: false), instrumentationType: nil)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "1", hasReplay: true), instrumentationType: nil) // count
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "2", hasReplay: false), instrumentationType: nil)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "3", hasReplay: true), instrumentationType: nil) // count
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "3", hasReplay: false), instrumentationType: nil) // ignore
         let attributes = metric.asMetricAttributes()
 
         // Then
@@ -532,9 +532,9 @@ class SessionEndedMetricTests: XCTestCase {
     func testEncodedMetricAttributesFollowTheSpec() throws {
         // Given
         let metric = SessionEndedMetric.with(sessionID: sessionID, context: .mockWith(applicationBundleType: .iOSApp))
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .manual)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .swiftui)
-        try metric.track(view: .mockRandomWith(sessionID: sessionID, viewTimeSpent: 10), instrumentationType: .uikit)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewTimeSpent: 10), instrumentationType: .manual)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewTimeSpent: 10), instrumentationType: .swiftui)
+        try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewTimeSpent: 10), instrumentationType: .uikit)
         metric.track(uploadQuality: [UploadQualityMetric.track: "feature"])
 
         // When

--- a/IntegrationTests/IntegrationScenarios/UITestsHelpers.swift
+++ b/IntegrationTests/IntegrationScenarios/UITestsHelpers.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+import DatadogInternal
 import TestUtilities
 import XCTest
 

--- a/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -93,7 +93,6 @@
 		9EC2835A26CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC2835926CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift */; };
 		9EC2835E26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EC2835D26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard */; };
 		9EC2836026CFF59400FACF1C /* RUMMobileVitalsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */; };
-		D218665029967CBC006F5B23 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D218664E29967CBC006F5B23 /* RUMDataModels.swift */; };
 		D22F06CF29DAE5360026CC3C /* KioskSendInterruptedEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22F06CB29DAE5360026CC3C /* KioskSendInterruptedEventsViewController.swift */; };
 		D22F06D029DAE5360026CC3C /* KioskSendEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22F06CC29DAE5360026CC3C /* KioskSendEventsViewController.swift */; };
 		D22F06D129DAE5360026CC3C /* KioskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22F06CD29DAE5360026CC3C /* KioskViewController.swift */; };
@@ -229,8 +228,6 @@
 		9EC2835D26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMMobileVitalsScenario.storyboard; sourceTree = "<group>"; };
 		9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMobileVitalsViewController.swift; sourceTree = "<group>"; };
 		D21866412996796B006F5B23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = IntegrationScenarios/Info.plist; sourceTree = SOURCE_ROOT; };
-		D218664E29967CBC006F5B23 /* RUMDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
-		D218664F29967CBC006F5B23 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
 		D2186652299698E8006F5B23 /* IntegrationScenarios.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationScenarios.debug.xcconfig; sourceTree = "<group>"; };
 		D2186653299699DE006F5B23 /* IntegrationScenarios.integration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationScenarios.integration.xcconfig; sourceTree = "<group>"; };
 		D2186654299699FD006F5B23 /* IntegrationScenarios.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationScenarios.release.xcconfig; sourceTree = "<group>"; };
@@ -508,7 +505,6 @@
 			children = (
 				61441C3B24617013003D8BB8 /* IntegrationTests.swift */,
 				61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */,
-				D218664D29967CBC006F5B23 /* DataModels */,
 				61F3CD9C251106EB00C816E5 /* Scenarios */,
 				D21866412996796B006F5B23 /* Info.plist */,
 			);
@@ -693,16 +689,6 @@
 				9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */,
 			);
 			path = MobileVitals;
-			sourceTree = "<group>";
-		};
-		D218664D29967CBC006F5B23 /* DataModels */ = {
-			isa = PBXGroup;
-			children = (
-				D218664E29967CBC006F5B23 /* RUMDataModels.swift */,
-				D218664F29967CBC006F5B23 /* RUMDataModelsMapping.swift */,
-			);
-			name = DataModels;
-			path = ../../DatadogRUM/Sources/DataModels;
 			sourceTree = "<group>";
 		};
 		D22F06CA29DAE5360026CC3C /* StopSessionScenario */ = {
@@ -945,9 +931,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -962,9 +952,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1001,9 +995,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS-IntegrationScenarios/Pods-Runner iOS-IntegrationScenarios-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1018,9 +1016,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner iOS/Pods-Runner iOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1100,7 +1102,6 @@
 				61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
 				61098D2D27FEE4130021237A /* MessagePortChannel.swift in Sources */,
-				D218665029967CBC006F5B23 /* RUMDataModels.swift in Sources */,
 				9EC2835A26CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				612C13DF2AAB6E940086B5D1 /* SRCommonAsserts.swift in Sources */,

--- a/TestUtilities/Sources/Matchers/RUMSessionMatcher.swift
+++ b/TestUtilities/Sources/Matchers/RUMSessionMatcher.swift
@@ -10,7 +10,7 @@ import Foundation
 /// * The Unit Tests target can see `Datadog` by `@testable import DatadogCore`.
 /// * In Integration Tests target we want to compile `Datadog` in "Release" configuration, so testability is not possible.
 /// This compiler statement gives both targets the visibility of `RUMDataModels.swift` either by import or direct compilation.
-@testable import DatadogRUM
+@testable import DatadogInternal
 #endif
 
 /// An error thrown by the `RUMSessionMatcher` if it spots an inconsistency in tracked RUM Session, e.g. when

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -6,7 +6,20 @@
 
 import Foundation
 
-@testable import DatadogRUM
+import DatadogInternal
+
+/// Creates random RUM event.
+public func randomRUMEvent() -> RUMDataModel {
+    // swiftlint:disable opening_brace
+    return oneOf([
+        { RUMViewEvent.mockRandom() },
+        { RUMActionEvent.mockRandom() },
+        { RUMResourceEvent.mockRandom() },
+        { RUMErrorEvent.mockRandom() },
+        { RUMLongTaskEvent.mockRandom() },
+    ])
+    // swiftlint:enable opening_brace
+}
 
 extension RUMUser: RandomMockable {
     public static func mockRandom() -> RUMUser {
@@ -125,7 +138,7 @@ extension RUMViewEvent: RandomMockable {
 
     /// Produces random `RUMViewEvent` with setting given fields to certain values.
     public static func mockRandomWith(
-        sessionID: RUMUUID = .mockRandom(),
+        sessionID: UUID = .mockRandom(),
         viewID: String = .mockRandom(),
         date: Int64 = .mockRandom(),
         viewIsActive: Bool? = .random(),
@@ -162,7 +175,7 @@ extension RUMViewEvent: RandomMockable {
             service: .mockRandom(),
             session: .init(
                 hasReplay: hasReplay,
-                id: sessionID.toRUMDataFormat,
+                id: sessionID.uuidString.lowercased(),
                 isActive: true,
                 sampledForReplay: nil,
                 type: .user

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -4,9 +4,10 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-import DatadogInternal
 import Foundation
 import UIKit
+import DatadogInternal
+
 @testable import DatadogRUM
 
 extension RUM.Configuration {
@@ -96,19 +97,6 @@ public struct RUMDataModelMock: RUMDataModel, RUMSanitizableEvent {
         self.usr = usr
         self.context = context
     }
-}
-
-/// Creates random RUM event.
-public func randomRUMEvent() -> RUMDataModel {
-    // swiftlint:disable opening_brace
-    return oneOf([
-        { RUMViewEvent.mockRandom() },
-        { RUMActionEvent.mockRandom() },
-        { RUMResourceEvent.mockRandom() },
-        { RUMErrorEvent.mockRandom() },
-        { RUMLongTaskEvent.mockRandom() },
-    ])
-    // swiftlint:enable opening_brace
 }
 
 // MARK: - Component Mocks

--- a/tools/rum-models-generator/Sources/rum-models-generator/GenerateRUMModels.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/GenerateRUMModels.swift
@@ -19,13 +19,11 @@ internal func generateRUMSwiftModels(from schema: URL) throws -> String {
              * Copyright 2019-Present Datadog, Inc.
              */
 
-            import DatadogInternal
-
             // This file was generated from JSON Schema. Do not modify it directly.
 
             // swiftlint:disable all
 
-            internal protocol RUMDataModel: Codable {}
+            public protocol RUMDataModel: Codable {}
 
             """,
         footer: ""
@@ -54,7 +52,7 @@ internal func generateRUMObjcInteropModels(from schema: URL, skip typesToSkip: S
              */
 
             import Foundation
-            import DatadogRUM
+            import DatadogInternal
 
             // This file was generated from JSON Schema. Do not modify it directly.
 

--- a/tools/rum-models-generator/run.py
+++ b/tools/rum-models-generator/run.py
@@ -22,7 +22,7 @@ RUM_SCHEMA_PATH = '/rum-events-format/rum-events-format.json'
 SR_SCHEMA_PATH = '/rum-events-format/session-replay-mobile-format.json'
 
 # Generated file paths (relative to repository root)
-RUM_SWIFT_GENERATED_FILE_PATH = '/DatadogRUM/Sources/DataModels/RUMDataModels.swift'
+RUM_SWIFT_GENERATED_FILE_PATH = '/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift'
 RUM_OBJC_GENERATED_FILE_PATH = '/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift'
 SR_SWIFT_GENERATED_FILE_PATH = '/DatadogSessionReplay/Sources/Models/SRDataModels.swift'
 


### PR DESCRIPTION
### What and why?

Models that are shared between modules must be shared in `DatadogInternal`. That is the case with RUM generated models.
This PR changes the generator destination for RUM schema.

### How?
- Change generator destination to `DatadogInternal` when generating RUM models.
- Update imports accordingly
- Re-export events used in mappers from RUM module.
- Move/Update mocks accordingly

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
