### PR TITLE
RUM-9022 Session consistent trace sampling

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersWriter.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/TracePropagationHeadersWriter.swift
@@ -25,7 +25,14 @@ public enum TraceSamplingStrategy {
         case .headBased:
             return DeterministicSampler(shouldSample: traceContext.isKept, samplingRate: traceContext.sampleRate)
         case .custom(let sampleRate):
-            return DeterministicSampler(baseId: traceContext.traceID.idLo, samplingRate: sampleRate)
+            // for a UUID with value aaaaaaaa-bbbb-Mccc-Nddd-1234567890ab
+            // we use as the base id the last part : 0x1234567890ab
+            let baseId = traceContext.rumSessionId
+             .flatMap { $0.split(separator: "-").last }
+             .flatMap { UInt64($0, radix: 16) }
+            ?? traceContext.traceID.idLo
+
+            return DeterministicSampler(baseId: baseId, samplingRate: sampleRate)
         }
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/W3CHTTPHeadersWriterTests.swift
@@ -106,4 +106,79 @@ class W3CHTTPHeadersWriterTests: XCTestCase {
         XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:0")
         XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
     }
+
+    // The sampling based on session ID should pass at 18% sampling rate and fail at 17%
+    func testWritingSampledTraceContext_withCustomSamplingStrategy_18percent() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: 18),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ],
+            traceContextInjection: .sampled
+        )
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                parentSpanID: 5_678,
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertEqual(headers[W3CHTTPHeaders.traceparent], "00-00000000000004d200000000000004d2-0000000000000929-01")
+        XCTAssertEqual(headers[W3CHTTPHeaders.tracestate], "dd=o:rum;p:0000000000000929;s:1")
+        XCTAssertEqual(headers[W3CHTTPHeaders.baggage], "session.id=abcdef01-2345-6789-abcd-ef0123456789")
+    }
+
+    func testWritingDroppedTraceContext_withCustomSamplingStrategy_17percent() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: 17),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ],
+            traceContextInjection: .sampled
+        )
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertNil(headers[W3CHTTPHeaders.traceparent])
+        XCTAssertNil(headers[W3CHTTPHeaders.tracestate])
+        XCTAssertNil(headers[W3CHTTPHeaders.baggage])
+    }
+
+    func testNotWritingDroppedTraceContext_withCustomSamplingStrategy() {
+        let writer = W3CHTTPHeadersWriter(
+            samplingStrategy: .custom(sampleRate: 0),
+            tracestate: [
+                W3CHTTPHeaders.Constants.origin: W3CHTTPHeaders.Constants.originRUM
+            ],
+            traceContextInjection: .sampled
+        )
+
+        writer.write(
+            traceContext: .mockWith(
+                traceID: .init(idHi: 1_234, idLo: 1_234),
+                spanID: 2_345,
+                parentSpanID: 5_678,
+                isKept: .random(),
+                rumSessionId: "abcdef01-2345-6789-abcd-ef0123456789"
+            )
+        )
+
+        let headers = writer.traceHeaderFields
+        XCTAssertNil(headers[W3CHTTPHeaders.traceparent])
+        XCTAssertNil(headers[W3CHTTPHeaders.tracestate])
+        XCTAssertNil(headers[W3CHTTPHeaders.baggage])
+    }
 }


### PR DESCRIPTION
### What and why?

Uses the session id when available to compute the trace sampling on network traces.