### PR TITLE
RUM-9522 Migrate Crash messages to payload format

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1698,6 +1698,8 @@
 		D2D7483B2DC2306100C61353 /* SpanID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D748392DC2306100C61353 /* SpanID.swift */; };
 		D2D7483C2DC2306100C61353 /* TraceID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D748382DC2306100C61353 /* TraceID.swift */; };
 		D2D7483D2DC2306100C61353 /* SpanID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D748392DC2306100C61353 /* SpanID.swift */; };
+		D2D7483F2DC24F1100C61353 /* Crash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D7483E2DC24F1100C61353 /* Crash.swift */; };
+		D2D748402DC24F1100C61353 /* Crash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D7483E2DC24F1100C61353 /* Crash.swift */; };
 		D2D9A9D92DBFD360005DB31D /* CrashContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A9D82DBFD360005DB31D /* CrashContext.swift */; };
 		D2D9A9DA2DBFD360005DB31D /* CrashContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A9D82DBFD360005DB31D /* CrashContext.swift */; };
 		D2D9A9DC2DBFD507005DB31D /* RUMPayloadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A9DB2DBFD507005DB31D /* RUMPayloadMessages.swift */; };
@@ -3241,6 +3243,7 @@
 		D2D748312DC220B100C61353 /* LogMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMessage.swift; sourceTree = "<group>"; };
 		D2D748382DC2306100C61353 /* TraceID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceID.swift; sourceTree = "<group>"; };
 		D2D748392DC2306100C61353 /* SpanID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanID.swift; sourceTree = "<group>"; };
+		D2D7483E2DC24F1100C61353 /* Crash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crash.swift; sourceTree = "<group>"; };
 		D2D9A9D82DBFD360005DB31D /* CrashContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContext.swift; sourceTree = "<group>"; };
 		D2D9A9DB2DBFD507005DB31D /* RUMPayloadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMPayloadMessages.swift; sourceTree = "<group>"; };
 		D2DA2385298D57AA00C6C7E6 /* DatadogInternal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogInternal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -5243,6 +5246,7 @@
 		6167E6E02B81204B00C3CA2D /* CrashReporting */ = {
 			isa = PBXGroup;
 			children = (
+				D2D7483E2DC24F1100C61353 /* Crash.swift */,
 				D2D9A9D82DBFD360005DB31D /* CrashContext.swift */,
 				6167E6E12B81207200C3CA2D /* DDCrashReport.swift */,
 				6167E6E72B8122E900C3CA2D /* BacktraceReport.swift */,
@@ -8906,6 +8910,7 @@
 				D2160CF429C0EDFC00FAA9A5 /* UploadPerformancePreset.swift in Sources */,
 				D23039E1298D5236001A1FA3 /* AppState.swift in Sources */,
 				D2DE63532A30A7CA00441A54 /* CoreRegistry.swift in Sources */,
+				D2D748402DC24F1100C61353 /* Crash.swift in Sources */,
 				E2AA55EA2C32C76A002FEF28 /* WatchKitExtensions.swift in Sources */,
 				D2EBEE2829BA160F00B15732 /* W3CHTTPHeadersWriter.swift in Sources */,
 				D23039EA298D5236001A1FA3 /* DeviceInfo.swift in Sources */,
@@ -9986,6 +9991,7 @@
 				E2AA55EC2C32C78B002FEF28 /* WatchKitExtensions.swift in Sources */,
 				D2EBEE3629BA161100B15732 /* W3CHTTPHeadersWriter.swift in Sources */,
 				D2DA236D298D57AA00C6C7E6 /* DeviceInfo.swift in Sources */,
+				D2D7483F2DC24F1100C61353 /* Crash.swift in Sources */,
 				D2EBEE3129BA161100B15732 /* B3HTTPHeadersReader.swift in Sources */,
 				96155A3F2D7F013A0029034E /* ReflectionMirror.swift in Sources */,
 				D2DA236E298D57AA00C6C7E6 /* InternalLogger.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -23,9 +23,8 @@ class CrashLogReceiverTests: XCTestCase {
 
         // When
         core.send(
-            message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(
+            message: .payload(
+                Crash(
                     report: DDCrashReport.mockAny(),
                     context: CrashContext.mockWith(lastRUMViewEvent: nil)
                 )
@@ -268,8 +267,8 @@ class CrashLogReceiverTests: XCTestCase {
         // Then
         let log = try XCTUnwrap(core.events(ofType: LogEvent.self).first)
 
-        XCTAssertEqual((log.attributes.userAttributes["mock-string-attribute"] as? AnyCodable)?.value as? String, stringAttribute)
-        XCTAssertEqual((log.attributes.userAttributes["mock-bool-attribute"] as? AnyCodable)?.value as? Bool, boolAttribute)
+        XCTAssertEqual(log.attributes.userAttributes["mock-string-attribute"] as? String, stringAttribute)
+        XCTAssertEqual(log.attributes.userAttributes["mock-bool-attribute"] as? Bool, boolAttribute)
     }
 
     func testWhenSendingCrashWithLogMapper_itSendsModifiedCrash() throws {

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -18,9 +18,8 @@ class CrashReportReceiverTests: XCTestCase {
         let receiver: CrashReportReceiver = .mockWith(featureScope: featureScope)
 
         // When
-        let message: FeatureMessage = .baggage(
-            key: CrashReportReceiver.MessageKeys.crash,
-            value: MessageBusSender.Crash(
+        let message: FeatureMessage = .payload(
+            Crash(
                 report: DDCrashReport.mockAny(),
                 context: CrashContext.mockWith(lastRUMViewEvent: nil)
             )
@@ -38,9 +37,8 @@ class CrashReportReceiverTests: XCTestCase {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // When
-        let message: FeatureMessage = .baggage(
-            key: CrashReportReceiver.MessageKeys.crash,
-            value: MessageBusSender.Crash(
+        let message: FeatureMessage = .payload(
+            Crash(
                 report: DDCrashReport.mockWith(date: Date()),
                 context: CrashContext.mockWith(
                     lastRUMViewEvent: lastRUMViewEvent
@@ -80,9 +78,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -115,9 +112,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -148,9 +144,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -182,9 +177,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -217,9 +211,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -250,9 +243,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -281,9 +273,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -318,9 +309,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -352,9 +342,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -454,9 +443,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -537,9 +525,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -583,9 +570,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -657,9 +643,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -739,9 +724,8 @@ class CrashReportReceiverTests: XCTestCase {
 
         // When
         XCTAssertTrue(
-            receiver.receive(message: .baggage(
-                key: MessageBusSender.MessageKeys.crash,
-                value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
             ), from: NOPDatadogCore())
         )
 
@@ -807,9 +791,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -944,9 +927,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1022,9 +1004,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1091,9 +1072,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1163,9 +1143,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1287,9 +1266,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1365,9 +1343,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 
@@ -1449,9 +1426,8 @@ class CrashReportReceiverTests: XCTestCase {
 
             // When
             XCTAssertTrue(
-                receiver.receive(message: .baggage(
-                    key: MessageBusSender.MessageKeys.crash,
-                    value: MessageBusSender.Crash(report: crashReport, context: crashContext)
+                receiver.receive(message: .payload(
+                    Crash(report: crashReport, context: crashContext)
                 ), from: NOPDatadogCore())
             )
 

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -24,22 +24,6 @@ internal protocol CrashReportSender {
 
 /// An object for sending crash reports on the Core message-bus.
 internal struct MessageBusSender: CrashReportSender {
-    /// Defines keys referencing Crash Report message on the bus.
-    internal enum MessageKeys {
-        /// The key for a crash message.
-        ///
-        /// Use this key when the crash should be reported
-        /// as a RUM and a Logs event.
-        static let crash = "crash"
-    }
-
-    struct Crash: Encodable {
-        /// The crash report.
-        let report: DDCrashReport
-        /// The crash context
-        let context: CrashContext
-    }
-
     /// The core for sending crash report and context.
     ///
     /// It must be a weak reference to avoid retain cycle (the `CrashReportSender` is held by crash reporting
@@ -58,9 +42,8 @@ internal struct MessageBusSender: CrashReportSender {
         }
 
         core.send(
-            message: .baggage(
-                key: MessageKeys.crash,
-                value: Crash(report: report, context: context)
+            message: .payload(
+                Crash(report: report, context: context)
             ),
             else: {
                 DD.logger.warn(

--- a/DatadogInternal/Sources/Models/CrashReporting/BinaryImage.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/BinaryImage.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Binary Image referenced in frames from `DDThread`.
-public struct BinaryImage: Codable, PassthroughAnyCodable {
+public struct BinaryImage: Codable {
     public let libraryName: String
     public let uuid: String
     public let architecture: String

--- a/DatadogInternal/Sources/Models/CrashReporting/Crash.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/Crash.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct Crash {
+    /// The crash report.
+    public let report: DDCrashReport
+    /// The crash context
+    public let context: CrashContext
+
+    /// Creates a Crash to be transmited on the message-bus.
+    ///
+    /// - Parameters:
+    ///   - report: The crash report.
+    ///   - context: The crash context
+    public init(report: DDCrashReport, context: CrashContext) {
+        self.report = report
+        self.context = context
+    }
+}

--- a/DatadogInternal/Sources/Models/CrashReporting/DDCrashReport.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/DDCrashReport.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 /// Crash Report format supported by Datadog SDK.
-public struct DDCrashReport: Codable, PassthroughAnyCodable {
+public struct DDCrashReport {
     /// Meta information about the process.
     /// Ref.: https://developer.apple.com/documentation/xcode/examining-the-fields-in-a-crash-report
-    public struct Meta: Codable, PassthroughAnyCodable {
+    public struct Meta: Encodable {
         /// A client-generated 16-byte UUID of the incident.
         public let incidentIdentifier: String?
         /// The name of the crashed process.

--- a/DatadogInternal/Sources/Models/CrashReporting/DDThread.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/DDThread.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Unsymbolicated stack trace of a running thread.
-public struct DDThread: Codable, PassthroughAnyCodable {
+public struct DDThread: Codable {
     /// The name of the thread, e.g. `"Thread 0"`
     public let name: String
     /// Unsymbolicated stack trace of the crash.

--- a/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
@@ -14,7 +14,7 @@ public enum RUMPayloadMessages {
 
 /// Lightweight representation of current RUM session state, used to compute `RUMOffViewEventsHandlingRule`.
 /// It gets serialized into fatal error context for computing the rule upon app process restart.
-public struct RUMSessionState: Equatable, Codable {
+public struct RUMSessionState: Codable, Equatable {
     /// The session ID. Can be `.nullUUID` if the session was rejected by sampler.
     public let sessionUUID: UUID
     /// If this is the very first session in the app process (`true`) or was re-created upon timeout (`false`).

--- a/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
@@ -108,36 +108,18 @@ public class CrashReportSenderMock: CrashReportSender {
     public func send(launch: DatadogInternal.LaunchReport) {}
 }
 
-public class RUMCrashReceiverMock: FeatureMessageReceiver {
-    public var receivedBaggage: FeatureBaggage?
+public class CrashReceiverMock: FeatureMessageReceiver {
+    public var receivedCrash: Crash?
 
     public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .baggage(let label, let baggage) where label == CrashReportReceiver.MessageKeys.crash:
-            receivedBaggage = baggage
-            return true
-        default:
+        guard case let .payload(crash as Crash) = message else {
             return false
         }
+        receivedCrash = crash
+        return true
     }
 
     public init() {}
-}
-
-public class LogsCrashReceiverMock: FeatureMessageReceiver {
-    public var receivedBaggage: FeatureBaggage?
-
-    public init() {}
-
-    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .baggage(let label, let baggage) where label == LoggingMessageKeys.crash:
-            receivedBaggage = baggage
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 extension CrashContext {


### PR DESCRIPTION
### What and why?

Following #2276 

Migrate Crash messages on the message-bus to the new strongly-typed `.payload`

### How?

- Create a shared `Crash` type.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
