### PR TITLE
Added environment tag to Benchmark configuration

### DIFF
--- a/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Benchmarks.swift
@@ -24,6 +24,7 @@ public enum Benchmarks {
             var applicationIdentifier: String
             var applicationName: String
             var applicationVersion: String
+            var env: String
             var sdkVersion: String
             var deviceModel: String
             var osName: String
@@ -36,6 +37,7 @@ public enum Benchmarks {
                 applicationIdentifier: String,
                 applicationName: String,
                 applicationVersion: String,
+                env: String,
                 sdkVersion: String,
                 deviceModel: String,
                 osName: String,
@@ -47,6 +49,7 @@ public enum Benchmarks {
                 self.applicationIdentifier = applicationIdentifier
                 self.applicationName = applicationName
                 self.applicationVersion = applicationVersion
+                self.env = env
                 self.sdkVersion = sdkVersion
                 self.deviceModel = deviceModel
                 self.osName = osName
@@ -93,6 +96,7 @@ public enum Benchmarks {
                 "os_version": .string(configuration.context.osVersion),
                 "run": .string(configuration.context.run),
                 "scenario": .string(configuration.context.scenario),
+                "env": .string(configuration.context.env),
                 "application_id": .string(configuration.context.applicationIdentifier),
                 "sdk_version": .string(configuration.context.sdkVersion),
                 "branch": .string(configuration.context.branch),

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -166,6 +166,7 @@ extension Benchmarks.Configuration {
                 applicationIdentifier: bundle.bundleIdentifier!,
                 applicationName: bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as! String,
                 applicationVersion: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as! String,
+                env: info.env,
                 sdkVersion: "",
                 deviceModel: try! sysctl.model(),
                 osName: device.systemName,


### PR DESCRIPTION
### What and why?

This PR adds an `env` tag to the Benchmark configuration to differentiate metrics collected by synthetic tests and those collected locally. This allows the continuous benchmarking dashboard to only analyze performance data collected from synthetics.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
