### PR TITLE
RUM-9747 Add strongly-typed additional context to core

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -313,6 +313,10 @@ extension DatadogCore: DatadogCoreProtocol {
         contextProvider.write { $0.baggages[key] = baggage() }
     }
 
+    func set(context: @escaping () -> Any?, forKey key: String) {
+        contextProvider.write { $0.additionalContext[key] = context() }
+    }
+
     func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
         bus.send(message: message, else: fallback)
     }
@@ -380,6 +384,10 @@ internal class CoreFeatureScope<Feature>: @unchecked Sendable, FeatureScope wher
 
     func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
         core?.set(baggage: baggage, forKey: key)
+    }
+
+    func set(context: @escaping () -> Any?, forKey key: String) {
+        core?.set(context: context, forKey: key)
     }
 
     func set(anonymousId: String?) {
@@ -489,6 +497,7 @@ extension DatadogCore: Flushable {
 
         // Reset baggages that need not be persisted across flushes.
         set(baggage: nil, forKey: LaunchReport.baggageKey)
+        set(context: nil, forKey: LaunchReport.baggageKey)
 
         let features = features.values.compactMap { $0 as? Flushable }
 

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -313,8 +313,8 @@ extension DatadogCore: DatadogCoreProtocol {
         contextProvider.write { $0.baggages[key] = baggage() }
     }
 
-    func set(context: @escaping () -> Any?, forKey key: String) {
-        contextProvider.write { $0.additionalContext[key] = context() }
+    func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        contextProvider.write { $0.additionalContext[Context.key] = context() }
     }
 
     func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
@@ -386,8 +386,8 @@ internal class CoreFeatureScope<Feature>: @unchecked Sendable, FeatureScope wher
         core?.set(baggage: baggage, forKey: key)
     }
 
-    func set(context: @escaping () -> Any?, forKey key: String) {
-        core?.set(context: context, forKey: key)
+    func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        core?.set(context: context)
     }
 
     func set(anonymousId: String?) {
@@ -496,8 +496,8 @@ extension DatadogCore: Flushable {
         // follow our design choices around SDK core's threading.
 
         // Reset baggages that need not be persisted across flushes.
-        set(baggage: nil, forKey: LaunchReport.baggageKey)
-        set(context: nil, forKey: LaunchReport.baggageKey)
+        set(baggage: nil, forKey: LaunchReport.key)
+        removeContext(ofType: LaunchReport.self)
 
         let features = features.values.compactMap { $0 as? Flushable }
 

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
@@ -10,7 +10,7 @@ import TestUtilities
 @testable import DatadogCore
 
 class FeatureContextTests: XCTestCase {
-    func testV2FeatureContextSharing() throws {
+    func testFeatureContextSharing() throws {
         // Given
         let core = DatadogCore(
             directory: temporaryCoreDirectory,
@@ -29,14 +29,11 @@ class FeatureContextTests: XCTestCase {
 
         // When
         let attributes = ["key": "value"]
-        core.set(baggage: attributes, forKey: "test")
+        core.set(context: attributes, forKey: "test")
 
         // Then
         let context = core.contextProvider.read()
-        let testBaggage = try XCTUnwrap(context.baggages["test"])
-        try DDAssertDictionariesEqual(
-            testBaggage.decode(type: [String: String].self),
-            attributes
-        )
+        let testContext = try XCTUnwrap(context.additionalContext["test"] as? [String: String])
+        XCTAssertEqual(testContext, attributes)
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/FeatureContextTests.swift
@@ -27,13 +27,17 @@ class FeatureContextTests: XCTestCase {
 
         defer { temporaryCoreDirectory.delete() }
 
+        struct ContextMock: AdditionalContext {
+            static let key: String = "test"
+            let attribute: [String: String]
+        }
+
         // When
         let attributes = ["key": "value"]
-        core.set(context: attributes, forKey: "test")
+        core.set(context: ContextMock(attribute: attributes))
 
         // Then
         let context = core.contextProvider.read()
-        let testContext = try XCTUnwrap(context.additionalContext["test"] as? [String: String])
-        XCTAssertEqual(testContext, attributes)
+        XCTAssertEqual(context.additionalContext(ofType: ContextMock.self)?.attribute, attributes)
     }
 }

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -78,6 +78,6 @@ internal struct MessageBusSender: CrashReportSender {
     /// - Parameters:
     ///   - launch: The launch report.
     func send(launch: DatadogInternal.LaunchReport) {
-        core?.set(baggage: launch, forKey: LaunchReport.baggageKey)
+        core?.set(baggage: launch, forKey: LaunchReport.key)
     }
 }

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -107,7 +107,11 @@ public struct DatadogContext {
     /// `true` if the Low Power Mode is enabled.
     public var isLowPowerModeEnabled = false
 
+    /// Additional context that can set from `core` instance.
+    public var additionalContext: [String: Any] = [:]
+
     /// Type-less context baggages.
+    @available(*, deprecated, renamed: "additionalContext", message: "`FeatureBaggage` is deprecated in favor of strongly typed `additionalContext`.")
     public var baggages: [String: FeatureBaggage] = [:]
 
     // swiftlint:disable function_default_parameter_at_end
@@ -138,6 +142,7 @@ public struct DatadogContext {
         carrierInfo: CarrierInfo? = nil,
         batteryStatus: BatteryStatus? = nil,
         isLowPowerModeEnabled: Bool = false,
+        additionalContext: [String: Any] = [:],
         baggages: [String: FeatureBaggage] = [:]
     ) {
         self.site = site
@@ -166,6 +171,7 @@ public struct DatadogContext {
         self.carrierInfo = carrierInfo
         self.batteryStatus = batteryStatus
         self.isLowPowerModeEnabled = isLowPowerModeEnabled
+        self.additionalContext = additionalContext
         self.baggages = baggages
     }
     // swiftlint:enable function_default_parameter_at_end

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -108,7 +108,7 @@ public struct DatadogContext {
     public var isLowPowerModeEnabled = false
 
     /// Additional context that can set from `core` instance.
-    public var additionalContext: [String: Any] = [:]
+    public var additionalContext: [String: AdditionalContext] = [:]
 
     /// Type-less context baggages.
     @available(*, deprecated, renamed: "additionalContext", message: "`FeatureBaggage` is deprecated in favor of strongly typed `additionalContext`.")
@@ -142,7 +142,7 @@ public struct DatadogContext {
         carrierInfo: CarrierInfo? = nil,
         batteryStatus: BatteryStatus? = nil,
         isLowPowerModeEnabled: Bool = false,
-        additionalContext: [String: Any] = [:],
+        additionalContext: [String: AdditionalContext] = [:],
         baggages: [String: FeatureBaggage] = [:]
     ) {
         self.site = site
@@ -175,4 +175,20 @@ public struct DatadogContext {
         self.baggages = baggages
     }
     // swiftlint:enable function_default_parameter_at_end
+}
+
+/// Defines an additional context value type associated to a key.
+public protocol AdditionalContext {
+    /// The additional context key.
+    static var key: String { get }
+}
+
+extension DatadogContext {
+    /// Gets an additional context value.
+    ///
+    /// - Parameter type: The value type.
+    /// - Returns: The `Context` if found
+    public func additionalContext<Context>(ofType type: Context.Type = Context.self) -> Context? where Context: AdditionalContext {
+        additionalContext[type.key] as? Context
+    }
 }

--- a/DatadogInternal/Sources/MessageBus/FeatureBaggage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureBaggage.swift
@@ -47,6 +47,7 @@ import Foundation
 ///
 /// A Feature Baggage does not ensure thread-safety of values that holds references, make
 /// sure that any value can be accessibe from any thread.
+@available(*, deprecated, message: "FeatureBaggage has performance implications and will be removed.")
 public final class FeatureBaggage {
     /// The raw value contained in the baggage.
     @ReadWriteLock

--- a/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 /// Launch report format supported by Datadog SDK.
-public struct LaunchReport: Codable, PassthroughAnyCodable {
+public struct LaunchReport: AdditionalContext, Codable, PassthroughAnyCodable {
     /// The key used to encode/decode the `LaunchReport` in `DatadogContext.baggages`
-    public static let baggageKey = "launch-report"
+    public static let key = "launch-report"
 
     /// Returns `true` if the previous session crashed.
     public let didCrash: Bool

--- a/DatadogInternal/Tests/DatadogCoreProtocolTests.swift
+++ b/DatadogInternal/Tests/DatadogCoreProtocolTests.swift
@@ -10,17 +10,17 @@ import TestUtilities
 @testable import DatadogInternal
 
 class DatadogCoreProtocolTests: XCTestCase {
-    func testSendMessageExtension() throws {
+    func testSendMessageExtension() {
         // Given
         let receiver = FeatureMessageReceiverMock()
         let core = PassthroughCoreMock(messageReceiver: receiver)
 
         // When
-        core.send(message: .baggage(key: "test", value: "value"))
+        core.send(message: .payload("value"))
 
         // Then
         XCTAssertEqual(
-            try receiver.messages.last?.baggage(forKey: "test"), "value", "DatadogCoreProtocol.send(message:) should forward message"
+            receiver.messages.last?.asPayload as? String, "value", "DatadogCoreProtocol.send(message:) should forward message"
         )
     }
 
@@ -52,5 +52,27 @@ class DatadogCoreProtocolTests: XCTestCase {
 
         core.set(baggage: nil as String?, forKey: "test")
         XCTAssertNil(core.context.baggages["test"], "DatadogCoreProtocol.set(baggage:) should forward baggage" )
+    }
+
+    func testAdditionalContextExtension() throws {
+        // Given
+        let core = PassthroughCoreMock()
+
+        struct MyContext: AdditionalContext, Equatable {
+            static let key = "my-context"
+            let value: String
+        }
+
+        // When
+        core.set(context: MyContext(value: "value"))
+
+        // Then
+        XCTAssertEqual(core.context.additionalContext(ofType: MyContext.self), MyContext(value: "value"))
+
+        // When
+        core.removeContext(ofType: MyContext.self)
+
+        // Then
+        XCTAssertNil(core.context.additionalContext(ofType: MyContext.self))
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -168,7 +168,7 @@ extension WatchdogTerminationMonitor: FeatureMessageReceiver {
 
         if currentState == .stopped {
             do {
-                guard let launchReport = try context.baggages[LaunchReport.baggageKey]?.decode(type: LaunchReport.self) else {
+                guard let launchReport = try context.baggages[LaunchReport.key]?.decode(type: LaunchReport.self) else {
                     return false
                 }
                 self.start(launchReport: launchReport)

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -96,7 +96,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
 
         featureScope.contextMock.version = appVersion
         featureScope.contextMock.device = deviceInfo
-        featureScope.contextMock.baggages[LaunchReport.baggageKey] = .init(LaunchReport(didCrash: didCrash))
+        featureScope.contextMock.baggages[LaunchReport.key] = .init(LaunchReport(didCrash: didCrash))
 
         let appStateManager = WatchdogTerminationAppStateManager(
             featureScope: featureScope,

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
@@ -55,7 +55,7 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         // not supported - use different type of core mock if you need this
     }
 
-    public func set(context: @escaping () -> Any?, forKey key: String) {
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
         // not supported - use different type of core mock if you need this
     }
 

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
@@ -55,6 +55,10 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         // not supported - use different type of core mock if you need this
     }
 
+    public func set(context: @escaping () -> Any?, forKey key: String) {
+        // not supported - use different type of core mock if you need this
+    }
+
     public func send(message: DatadogInternal.FeatureMessage, else fallback: @escaping () -> Void) {
         // not supported - use different type of core mock if you need this
     }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
@@ -48,8 +48,8 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
         contextMock.baggages[key] = baggage()
     }
 
-    public func set(context: @escaping () -> Any?, forKey key: String) {
-        contextMock.additionalContext[key] = context()
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        contextMock.additionalContext[Context.key] = context()
     }
 
     public func set(anonymousId: String?) {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
@@ -48,6 +48,10 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
         contextMock.baggages[key] = baggage()
     }
 
+    public func set(context: @escaping () -> Any?, forKey key: String) {
+        contextMock.additionalContext[key] = context()
+    }
+
     public func set(anonymousId: String?) {
         self.anonymousId = anonymousId
     }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -82,6 +82,10 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
         context.baggages[key] = baggage()
     }
 
+    public func set(context: @escaping () -> Any?, forKey key: String) {
+        self.context.additionalContext[key] = context()
+    }
+
     public func send(message: FeatureMessage, else fallback: () -> Void) {
         if !messageReceiver.receive(message: message, from: self) {
             fallback()

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -82,8 +82,8 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
         context.baggages[key] = baggage()
     }
 
-    public func set(context: @escaping () -> Any?, forKey key: String) {
-        self.context.additionalContext[key] = context()
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        self.context.additionalContext[Context.key] = context()
     }
 
     public func send(message: FeatureMessage, else fallback: () -> Void) {

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -107,6 +107,10 @@ public final class DatadogCoreProxy: DatadogCoreProtocol {
         core.set(baggage: baggage, forKey: key)
     }
 
+    public func set(context: @escaping () -> Any?, forKey key: String) {
+        core.set(context: context, forKey: key)
+    }
+
     public func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
         core.send(message: message, else: fallback)
     }
@@ -162,6 +166,10 @@ private struct FeatureScopeProxy: FeatureScope {
 
     func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
         proxy.set(baggage: baggage, forKey: key)
+    }
+
+    func set(context: @escaping () -> Any?, forKey key: String) {
+        proxy.set(context: context, forKey: key)
     }
 
     func set(anonymousId: String?) {

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -107,8 +107,8 @@ public final class DatadogCoreProxy: DatadogCoreProtocol {
         core.set(baggage: baggage, forKey: key)
     }
 
-    public func set(context: @escaping () -> Any?, forKey key: String) {
-        core.set(context: context, forKey: key)
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        core.set(context: context)
     }
 
     public func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
@@ -168,8 +168,8 @@ private struct FeatureScopeProxy: FeatureScope {
         proxy.set(baggage: baggage, forKey: key)
     }
 
-    func set(context: @escaping () -> Any?, forKey key: String) {
-        proxy.set(context: context, forKey: key)
+    func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        proxy.set(context: context)
     }
 
     func set(anonymousId: String?) {


### PR DESCRIPTION
### What and why?

`FeatureBaggage` comes with perf implications, we are replacing loosely-typed baggages in core context by strongly-typed additional context.

### How?

Similar to `BaggageSharing` (now deprecated), add `AdditionalContextSharing` for sharing additional context from core and feature-scope.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
