### PR TITLE
RUM-9066: Fix global attribute propagation in views

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/RUMAttributesIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMAttributesIntegrationTests.swift
@@ -46,9 +46,8 @@ final class RUMAttributesIntegrationTests: XCTestCase {
             .takeSingle()
 
         let firstView = try XCTUnwrap(session.views.first(where: { $0.name == firstViewName }))
-        firstView.viewEvents.forEach { viewEvent in
-            XCTAssertEqual(viewEvent.numberOfAttributes, 3)
-        }
+        XCTAssertEqual(firstView.viewEvents[0].numberOfAttributes, 3) // startView
+        XCTAssertEqual(firstView.viewEvents[1].numberOfAttributes, 0) // stopView
 
         let secondView = try XCTUnwrap(session.views.first(where: { $0.name == secondViewName }))
         secondView.viewEvents.forEach { viewEvent in
@@ -262,7 +261,7 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "key2"), "value2")
-        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "sameKey"), "globalValue")
+        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "sameKey"), "value1") // view attributes take precedence
     }
 
     func testWhenViewReceivesActions_theViewAttributesAreNotUpdated_withActionAttributes() throws {

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -140,6 +140,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                     error: error,
                     source: .network,
                     httpStatusCode: interception.completion?.httpResponse?.statusCode,
+                    globalAttributes: [:],
                     attributes: userAttributes
                 )
             )

--- a/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/RUMViewsHandler.swift
@@ -174,6 +174,7 @@ internal final class RUMViewsHandler {
                 identity: view.identity,
                 name: view.name,
                 path: view.path,
+                globalAttributes: [:],
                 attributes: view.attributes,
                 instrumentationType: view.instrumentationType
             )
@@ -188,7 +189,7 @@ internal final class RUMViewsHandler {
         subscriber?.process(
             command: RUMStopViewCommand(
                 time: dateProvider.now,
-                attributes: [:],
+                attributes: view.attributes,
                 identity: view.identity
             )
         )

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -247,6 +247,7 @@ extension Monitor: RUMMonitorProtocol {
                 identity: ViewIdentifier(viewController),
                 name: name ?? viewController.canonicalClassName,
                 path: viewController.canonicalClassName,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 instrumentationType: .manual
             )
@@ -257,6 +258,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMStopViewCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 identity: ViewIdentifier(viewController)
             )
@@ -270,6 +272,7 @@ extension Monitor: RUMMonitorProtocol {
                 identity: ViewIdentifier(key),
                 name: name ?? key,
                 path: key,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 instrumentationType: .manual
             )
@@ -280,6 +283,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMStopViewCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 identity: ViewIdentifier(key)
             )
@@ -290,6 +294,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMAddViewLoadingTime(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: [:],
                 overwrite: overwrite
             )
@@ -302,6 +307,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMAddViewTimingCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: [:],
                 timingName: name
             )
@@ -326,6 +332,7 @@ extension Monitor: RUMMonitorProtocol {
                 type: type,
                 stack: stack,
                 source: RUMInternalErrorSource(source),
+                globalAttributes: self.attributes,
                 attributes: attributes
             )
         )
@@ -337,6 +344,7 @@ extension Monitor: RUMMonitorProtocol {
                 time: dateProvider.now,
                 error: error,
                 source: RUMInternalErrorSource(source),
+                globalAttributes: self.attributes,
                 attributes: attributes
             )
         )
@@ -349,6 +357,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStartResourceCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 url: request.url?.absoluteString ?? "unknown_url",
                 httpMethod: RUMMethod(httpMethod: request.httpMethod),
@@ -363,6 +372,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStartResourceCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 url: url.absoluteString,
                 httpMethod: .get,
@@ -377,6 +387,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStartResourceCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 url: urlString,
                 httpMethod: httpMethod,
@@ -391,6 +402,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMAddResourceMetricsCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 metrics: ResourceMetrics(taskMetrics: metrics)
             )
@@ -412,6 +424,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStopResourceCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 kind: resourceKind,
                 httpStatusCode: statusCode,
@@ -425,6 +438,7 @@ extension Monitor: RUMMonitorProtocol {
             command: RUMStopResourceCommand(
                 resourceKey: resourceKey,
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 kind: kind,
                 httpStatusCode: statusCode,
@@ -441,6 +455,7 @@ extension Monitor: RUMMonitorProtocol {
                 error: error,
                 source: .network,
                 httpStatusCode: (response as? HTTPURLResponse)?.statusCode,
+                globalAttributes: self.attributes,
                 attributes: attributes
             )
         )
@@ -455,6 +470,7 @@ extension Monitor: RUMMonitorProtocol {
                 type: type,
                 source: .network,
                 httpStatusCode: (response as? HTTPURLResponse)?.statusCode,
+                globalAttributes: self.attributes,
                 attributes: attributes
             )
         )
@@ -466,6 +482,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMAddUserActionCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 instrumentation: .manual,
                 actionType: type,
@@ -478,6 +495,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMStartUserActionCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 instrumentation: .manual,
                 actionType: type,
@@ -490,6 +508,7 @@ extension Monitor: RUMMonitorProtocol {
         process(
             command: RUMStopUserActionCommand(
                 time: dateProvider.now,
+                globalAttributes: self.attributes,
                 attributes: attributes,
                 actionType: type,
                 name: name
@@ -553,6 +572,7 @@ extension Monitor {
                 type: type,
                 stack: stack,
                 source: source,
+                globalAttributes: self.attributes,
                 attributes: attributes
             )
         )

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -95,9 +95,7 @@ internal class RUMResourceScope: RUMScope {
     // MARK: - RUMScope
 
     func process(command: RUMCommand, context: DatadogContext, writer: Writer) -> Bool {
-        self.attributes = self.attributes
-            .merging(command.globalAttributes, uniquingKeysWith: { $1 })
-            .merging(command.attributes, uniquingKeysWith: { $1 })
+        self.attributes = self.attributes.merging(command.attributes, uniquingKeysWith: { $1 })
 
         switch command {
         case let command as RUMStopResourceCommand where command.resourceKey == resourceKey:
@@ -187,7 +185,7 @@ internal class RUMResourceScope: RUMScope {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: attributes),
+            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
             date: resourceStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -297,7 +295,7 @@ internal class RUMResourceScope: RUMScope {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: attributes),
+            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
             date: command.time.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -141,7 +141,6 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     // MARK: - Sending RUM Events
 
     private func sendActionEvent(completionTime: Date, on command: RUMCommand?, context: DatadogContext, writer: Writer) {
-        attributes.merge(rumCommandAttributes: command?.globalAttributes)
         attributes.merge(rumCommandAttributes: command?.attributes)
 
         var frustrations: [RUMActionEvent.Action.Frustration.FrustrationType]? = nil
@@ -176,7 +175,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: attributes),
+            context: .init(contextInfo: (command?.globalAttributes ?? [:]).merging(attributes) { $1 }),
             date: actionStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -377,7 +377,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies: dependencies,
             name: command.name,
             actionType: command.actionType,
-            attributes: command.globalAttributes.merging(command.attributes, uniquingKeysWith: { $1 }),
+            attributes: command.attributes,
             startTime: command.time,
             serverTimeOffset: serverTimeOffset,
             isContinuous: true,
@@ -395,7 +395,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies: dependencies,
             name: command.name,
             actionType: command.actionType,
-            attributes: command.globalAttributes.merging(command.attributes, uniquingKeysWith: { $1 }),
+            attributes: command.attributes,
             startTime: command.time,
             serverTimeOffset: serverTimeOffset,
             isContinuous: false,
@@ -495,7 +495,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: attributes),
+            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
             date: viewStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -536,8 +536,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         // RUMM-3133 Don't override View attributes with commands that are not view related.
         if command is RUMViewScopePropagatableAttributes {
-            attributes.merge(rumCommandAttributes: command.globalAttributes)
-
             // The local attributes should only be updated by commands related to this 'RUMViewScope'
             switch command {
             case let command as RUMStartViewCommand where identity == command.identity:
@@ -624,7 +622,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: attributes),
+            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
             date: viewStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -49,6 +49,7 @@ public struct DatadogInternalInterface {
             threads: nil,
             binaryImages: binaryImages,
             isStackTraceTruncated: nil,
+            globalAttributes: globalAttributes,
             attributes: attributes
         )
         monitor.process(command: addErrorCommand)

--- a/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Views/RUMViewsHandlerTests.swift
@@ -81,7 +81,7 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(startCommand1.identity == ViewIdentifier(view1))
         XCTAssertEqual(startCommand1.attributes as? [String: String], ["key1": "val1"])
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(view1))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertEqual(stopCommand.attributes as? [String: String], ["key1": "val1"])
         XCTAssertTrue(startCommand2.identity == ViewIdentifier(view2))
         XCTAssertEqual(startCommand2.attributes as? [String: String], ["key2": "val2"])
     }
@@ -212,7 +212,7 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertEqual(startCommand1.attributes as? [String: String], ["key1": "val1"])
         XCTAssertEqual(startCommand1.instrumentationType, .swiftuiAutomatic)
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(view1))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertEqual(stopCommand.attributes as? [String: String], ["key1": "val1"])
         XCTAssertTrue(startCommand2.identity == ViewIdentifier(view2))
         XCTAssertEqual(startCommand2.attributes as? [String: String], ["key2": "val2"])
         XCTAssertEqual(startCommand2.instrumentationType, .swiftuiAutomatic)
@@ -345,7 +345,7 @@ class RUMViewsHandlerTests: XCTestCase {
 
         let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(view))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertEqual(stopCommand.attributes as? [String: String], ["foo": "bar"])
         XCTAssertEqual(stopCommand.time, .mockDecember15th2019At10AMUTC())
 
         let startCommand = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
@@ -507,7 +507,7 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(startCommand1.identity == ViewIdentifier(view1Identity))
         DDAssertDictionariesEqual(startCommand1.attributes, view1Attributes)
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(view1Identity))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertGreaterThan(stopCommand.attributes.count, 0)
         XCTAssertTrue(startCommand2.identity == ViewIdentifier(view2Identity))
         DDAssertDictionariesEqual(startCommand2.attributes, view2Attributes)
     }
@@ -581,7 +581,7 @@ class RUMViewsHandlerTests: XCTestCase {
         XCTAssertTrue(startCommand.identity == ViewIdentifier(viewIdentity))
         DDAssertDictionariesEqual(startCommand.attributes, viewAttributes)
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(viewIdentity))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertGreaterThan(stopCommand.attributes.count, 0)
     }
 
     func testGiven2AppearedView_whenTheFirstDisappears_itDoesNotStopItTwice() throws {
@@ -707,7 +707,7 @@ class RUMViewsHandlerTests: XCTestCase {
         let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
         let startCommand = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
         XCTAssertTrue(stopCommand.identity == ViewIdentifier(viewIdentity))
-        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertGreaterThan(stopCommand.attributes.count, 0)
         XCTAssertEqual(stopCommand.time, .mockDecember15th2019At10AMUTC())
         XCTAssertTrue(startCommand.identity == ViewIdentifier(viewIdentity))
         XCTAssertEqual(startCommand.path, viewPath)

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -129,9 +129,9 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.addAction(type: .custom, name: "custom action")
 
         // Then
-        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
-        XCTAssertEqual(lastView.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
-        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        let actionViewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        XCTAssertEqual(actionViewEvent.view.name, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
+        XCTAssertEqual(actionViewEvent.attribute(forKey: "attribute"), "value") // "ApplicationLaunch" event triggered by RUM action
     }
 
     func testAddingGlobalAttributesAfterSDKInit_thenRemovingAttribute() throws {
@@ -231,7 +231,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         // Then
         let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(lastView.view.name, "View")
-        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        XCTAssertEqual(lastView.attribute(forKey: "attribute"), "value")
     }
 
     func testAddingGlobalAttributesAfterViewIsStarted_thenRemovingAttribute() throws {
@@ -328,7 +328,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView1.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(lastView1.attribute(forKey: "attribute3"), "value3")
 
-        XCTAssertEqual(lastView2.attribute(forKey: "attribute1"), "value1")
+        XCTAssertNil(lastView2.attribute(forKey: "attribute1"))
         XCTAssertEqual(lastView2.attribute(forKey: "attribute2"), "value2")
         XCTAssertEqual(lastView2.attribute(forKey: "attribute3"), "value3")
 
@@ -393,7 +393,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
-        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute"))
+        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute"), "value")
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute"))
     }
 
@@ -416,8 +416,8 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
-        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
-        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"), "value1")
+        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute2"), "value2")
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute2"))
     }
@@ -443,7 +443,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
         XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
-        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
+        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute2"), "value2")
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
         XCTAssertEqual(lastActiveView.attribute(forKey: "attribute2"), "value2")
     }
@@ -471,7 +471,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.view.error.count, 1)
         XCTAssertEqual(lastView.view.action.count, 1)
         XCTAssertEqual(lastView.view.resource.count, 1)
-        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        XCTAssertEqual(lastView.context?.contextInfo["attribute"] as? String, "value") // "ActiveView" event triggered by `stopResource`
         XCTAssertEqual(errorEvent.context?.contextInfo["attribute"] as? String, "value")
         XCTAssertEqual(actionEvent.context?.contextInfo["attribute"] as? String, "value")
         XCTAssertEqual(resourceEvent.context?.contextInfo["attribute"] as? String, "value")
@@ -492,7 +492,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.stopResource(resourceKey: "resource", response: .mockAny())
 
         // Then
-        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last) // "ActiveView" event triggered by RUM resource
         let errorEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
         let actionEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMActionEvent.self).last)
         let resourceEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMResourceEvent.self).last)
@@ -501,7 +501,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.view.action.count, 1)
         XCTAssertEqual(lastView.view.resource.count, 1)
         XCTAssertNil(lastView.attribute(forKey: "attribute1"))
-        XCTAssertNil(lastView.attribute(forKey: "attribute2"))
+        XCTAssertEqual(lastView.context?.contextInfo["attribute2"] as? String, "value2")
         XCTAssertNil(errorEvent.context?.contextInfo["attribute1"])
         XCTAssertEqual(errorEvent.context?.contextInfo["attribute2"] as? String, "value2")
         XCTAssertNil(actionEvent.context?.contextInfo["attribute1"])
@@ -524,7 +524,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         monitor.stopResource(resourceKey: "resource", response: .mockAny())
 
         // Then
-        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let lastView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last) // "ActiveView" event triggered by RUM resource
         let errorEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
         let actionEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMActionEvent.self).last)
         let resourceEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMResourceEvent.self).last)
@@ -532,7 +532,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         XCTAssertEqual(lastView.view.error.count, 1)
         XCTAssertEqual(lastView.view.action.count, 1)
         XCTAssertEqual(lastView.view.resource.count, 1)
-        XCTAssertNil(lastView.attribute(forKey: "attribute"))
+        XCTAssertEqual(lastView.context?.contextInfo["attribute"] as? String, "new-value")
         XCTAssertEqual(errorEvent.context?.contextInfo["attribute"] as? String, "new-value")
         XCTAssertEqual(actionEvent.context?.contextInfo["attribute"] as? String, "new-value")
         XCTAssertEqual(resourceEvent.context?.contextInfo["attribute"] as? String, "new-value")

--- a/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
@@ -29,6 +29,7 @@ class RUMCommandTests: XCTestCase {
             time: .mockAny(),
             error: SwiftError(),
             source: .source,
+            globalAttributes: [:],
             attributes: [:]
         )
 
@@ -40,6 +41,7 @@ class RUMCommandTests: XCTestCase {
             time: .mockAny(),
             error: SwiftEnumeratedError.errorLabel,
             source: .source,
+            globalAttributes: [:],
             attributes: [:]
         )
 
@@ -51,6 +53,7 @@ class RUMCommandTests: XCTestCase {
             time: .mockAny(),
             error: nsError,
             source: .source,
+            globalAttributes: [:],
             attributes: [:]
         )
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -545,6 +545,7 @@ class RUMResourceScopeTests: XCTestCase {
                     error: ErrorMock("network issue explanation"),
                     source: .network,
                     httpStatusCode: 500,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"]
                 ),
                 context: context,
@@ -607,6 +608,7 @@ class RUMResourceScopeTests: XCTestCase {
                     error: ErrorMock("network issue explanation"),
                     source: .network,
                     httpStatusCode: 500,
+                    globalAttributes: [:],
                     attributes: [
                         "foo": "bar",
                         RUM.Attributes.errorFingerprint: "custom-fingerprint"
@@ -674,6 +676,7 @@ class RUMResourceScopeTests: XCTestCase {
                     error: ErrorMock("network issue explanation"),
                     source: .network,
                     httpStatusCode: 500,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"]
                 ),
                 context: context,
@@ -739,6 +742,7 @@ class RUMResourceScopeTests: XCTestCase {
                     error: ErrorMock("network issue explanation"),
                     source: .network,
                     httpStatusCode: 500,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"]
                 ),
                 context: context,
@@ -809,6 +813,7 @@ class RUMResourceScopeTests: XCTestCase {
                     error: ErrorMock("network issue explanation"),
                     source: .network,
                     httpStatusCode: 500,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"]
                 ),
                 context: customContext,

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -198,6 +198,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMStopUserActionCommand(
                     time: currentTime,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"],
                     actionType: .swipe,
                     name: nil
@@ -247,6 +248,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMStopUserActionCommand(
                     time: currentTime,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"],
                     actionType: .swipe,
                     name: nil
@@ -298,6 +300,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMStopUserActionCommand(
                     time: currentTime,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"],
                     actionType: .swipe,
                     name: nil
@@ -683,6 +686,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMStopUserActionCommand(
                     time: currentTime,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"],
                     actionType: .tap,
                     name: nil
@@ -726,6 +730,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMStopUserActionCommand(
                     time: currentTime,
+                    globalAttributes: [:],
                     attributes: ["foo": "bar"],
                     actionType: .tap,
                     name: nil

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -212,6 +212,7 @@ extension RUMStartViewCommand: AnyMockable, RandomMockable {
 
     static func mockWith(
         time: Date = Date(),
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
         attributes: [AttributeKey: AttributeValue] = [:],
         identity: ViewIdentifier = .mockViewIdentifier(),
         name: String = .mockAny(),
@@ -223,6 +224,7 @@ extension RUMStartViewCommand: AnyMockable, RandomMockable {
             identity: identity,
             name: name,
             path: path,
+            globalAttributes: globalAttributes,
             attributes: attributes,
             instrumentationType: instrumentationType
         )
@@ -289,6 +291,7 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
             time: time,
             error: error,
             source: source,
+            globalAttributes: globalAttributes,
             attributes: attributes
         )
     }
@@ -299,6 +302,7 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
         type: String? = .mockAny(),
         source: RUMInternalErrorSource = .source,
         stack: String? = "Foo.swift:10",
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
         attributes: [AttributeKey: AttributeValue] = [:]
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
@@ -307,6 +311,7 @@ extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
             type: type,
             stack: stack,
             source: source,
+            globalAttributes: globalAttributes,
             attributes: attributes
         )
     }
@@ -503,6 +508,7 @@ extension RUMStopResourceWithErrorCommand: AnyMockable, RandomMockable {
         error: Error = ErrorMock(),
         source: RUMInternalErrorSource = .source,
         httpStatusCode: Int? = .mockAny(),
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
         attributes: [AttributeKey: AttributeValue] = [:]
     ) -> RUMStopResourceWithErrorCommand {
         return RUMStopResourceWithErrorCommand(
@@ -511,6 +517,7 @@ extension RUMStopResourceWithErrorCommand: AnyMockable, RandomMockable {
             error: error,
             source: source,
             httpStatusCode: httpStatusCode,
+            globalAttributes: globalAttributes,
             attributes: attributes
         )
     }
@@ -522,6 +529,7 @@ extension RUMStopResourceWithErrorCommand: AnyMockable, RandomMockable {
         type: String? = .mockAny(),
         source: RUMInternalErrorSource = .source,
         httpStatusCode: Int? = .mockAny(),
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
         attributes: [AttributeKey: AttributeValue] = [:]
     ) -> RUMStopResourceWithErrorCommand {
         return RUMStopResourceWithErrorCommand(
@@ -531,6 +539,7 @@ extension RUMStopResourceWithErrorCommand: AnyMockable, RandomMockable {
             type: type,
             source: source,
             httpStatusCode: httpStatusCode,
+            globalAttributes: globalAttributes,
             attributes: attributes
         )
     }


### PR DESCRIPTION
### What and why?

This PR fixes the propagation of global attributes across dependent scopes.
It is part of a broader effort to ensure consistent attribute management across all SDKs (iOS, Android, Browser, etc.).

### How?
This is a task to handle the management of `View` attributes discussed in the  [RFC - internal](https://datadoghq.atlassian.net/wiki/x/QoFRGwE).

To ensure correct propagation of global attributes, they are stored in a single location within the environment (e.g. `Monitor`). Each time an event occurs, the global attributes are propagated via `RUMCommands` to create the event. This approach guarantees that global attributes remain separate from local ones, and that the environment is accurately captured at the moment the event occurs.
For example, this solution ensures that each `View` update has the correct global attributes, even if some attributes were removed earlier in the `View` lifecycle.

**Note:**
This is the first part of 2 (1/2) focused on global attributes. The second part will focus on the View attributes management and will have a proper test coverage to cover all use cases.
 
### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
