### PR TITLE
RUM-9747 Strongly-typed Crash Reporting Additional Context

### DIFF
--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -61,6 +61,6 @@ internal struct MessageBusSender: CrashReportSender {
     /// - Parameters:
     ///   - launch: The launch report.
     func send(launch: DatadogInternal.LaunchReport) {
-        core?.set(baggage: launch, forKey: LaunchReport.key)
+        core?.set(context: launch)
     }
 }

--- a/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/LaunchReport.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Launch report format supported by Datadog SDK.
-public struct LaunchReport: AdditionalContext, Codable, PassthroughAnyCodable {
+public struct LaunchReport: AdditionalContext {
     /// The key used to encode/decode the `LaunchReport` in `DatadogContext.baggages`
     public static let key = "launch-report"
 

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -26,7 +26,6 @@ internal final class WatchdogTerminationMonitor {
         static let failedToReadViewEvent = "Failed to read the view event from the data store"
         static let rumViewEventUpdated = "RUM View event updated"
         static let failedToSendWatchdogTermination = "Failed to send Watchdog Termination event"
-        static let failedToDecodeLaunchReport = "Fails to decode LaunchReport in RUM"
     }
 
     let checker: WatchdogTerminationChecker
@@ -167,15 +166,11 @@ extension WatchdogTerminationMonitor: FeatureMessageReceiver {
         }
 
         if currentState == .stopped {
-            do {
-                guard let launchReport = try context.baggages[LaunchReport.key]?.decode(type: LaunchReport.self) else {
-                    return false
-                }
-                self.start(launchReport: launchReport)
-            } catch {
-                DD.logger.error(ErrorMessages.failedToDecodeLaunchReport, error: error)
-                self.feature.telemetry.error(ErrorMessages.failedToDecodeLaunchReport, error: error)
+            guard let launchReport = context.additionalContext(ofType: LaunchReport.self) else {
+                return false
             }
+
+            self.start(launchReport: launchReport)
         }
 
         // Once the monitor has started, ie watchdog termination check has been done

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -96,7 +96,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
 
         featureScope.contextMock.version = appVersion
         featureScope.contextMock.device = deviceInfo
-        featureScope.contextMock.baggages[LaunchReport.key] = .init(LaunchReport(didCrash: didCrash))
+        featureScope.contextMock.set(additionalContext: LaunchReport(didCrash: didCrash))
 
         let appStateManager = WatchdogTerminationAppStateManager(
             featureScope: featureScope,


### PR DESCRIPTION
### What and why?

Following: #2289

`FeatureBaggage` comes with perf implications, we are replacing loosely-typed baggages in core context by strongly-typed additional context.

### How?

Set `LaunchReport` as additional context instead of feature-baggage.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
