### PR TITLE
RUM-9522 Remove `.baggage` message type from the bus

### DIFF
--- a/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
@@ -20,13 +20,12 @@ class MessageBusTests: XCTestCase {
 
         let receiver = FeatureMessageReceiverMock { message in
             // Then
-            if let value: String = try? message.baggage(forKey: "test") {
-                XCTAssertEqual(value, "value")
+            switch message {
+            case let .payload(payload as String) where payload == "value":
                 expectation.fulfill()
-            } else {
+            default:
                 XCTFail("wrong message case")
             }
-            expectation.fulfill()
         }
 
         let bus = MessageBus()
@@ -36,7 +35,7 @@ class MessageBusTests: XCTestCase {
         bus.connect(receiver, forKey: "receiver 2")
 
         // When
-        bus.send(message: .baggage(key: "test", value: "value"))
+        bus.send(message: .payload("value"))
 
         // Then
         wait(for: [expectation], timeout: 0.5)

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -6,21 +6,8 @@
 
 import Foundation
 
-/// The set of messages that can be transimtted on the Features message bus.
+/// The set of messages that can be transmitted on the Features message bus.
 public enum FeatureMessage {
-    /// A custom message with generic encodable attributes.
-    ///
-    /// A baggage can be used to transmit loosely-typed data structure using `Codable`.
-    /// The encoding/decoding processes will have an impact on performances, opt for a baggage
-    /// only if the data-structure is small.
-    ///
-    /// For large data type, use the `.payload` case with shared type definition.
-    @available(*, deprecated, message: "Use .payload instead")
-    case baggage(
-        key: String,
-        baggage: FeatureBaggage
-    )
-
     /// A custom payload message.
     case payload(Any)
 
@@ -31,45 +18,13 @@ public enum FeatureMessage {
 
     /// A core context message.
     ///
-    /// The core will send updated context throught the bus. Do not send new context values
+    /// The core will send updated context through the bus. Do not send new context values
     /// from a Feature or Integration.
     case context(DatadogContext)
 
-    /// A telemtry message.
+    /// A telemetry message.
     ///
-    /// The core can send telemtry data coming from all Features.
+    /// The core can send t
+    /// elemetry data coming from all Features.
     case telemetry(TelemetryMessage)
-}
-
-extension FeatureMessage {
-    /// Creates a `.baggage` message with the given key and `Encodable` value.
-    ///
-    /// A baggage can be used to transmit loosely-typed data structure using `Codable`.
-    /// The encoding/decoding processes will have an impact on performances, opt for a baggage
-    /// only if the data-structure is small.
-    /// 
-    /// - Parameters:
-    ///   - key: The baggage key.
-    ///   - baggage: The baggage value.
-    /// - Returns: a `.baggage` case.
-    @available(*, deprecated, message: "Use .payload instead")
-    public static func baggage<Value>(key: String, value: Value) -> FeatureMessage where Value: Encodable {
-        .baggage(key: key, baggage: .init(value))
-    }
-
-    /// Returns the baggage if the key matches the message.
-    ///
-    /// - Parameters:
-    ///   - key: The requested baggage key.
-    ///   - type: The expected type of the baggage value.
-    /// - Returns: The decoded baggage value, or nil if the key doesn't match.
-    /// - Throws: A `DecodingError` if decoding fails.
-    @available(*, deprecated, message: "Use .value instead")
-    public func baggage<Value>(forKey key: String, type: Value.Type = Value.self) throws -> Value? where Value: Decodable {
-        guard case let .baggage(messageKey, baggage) = self, messageKey == key else {
-            return nil
-        }
-
-        return try baggage.decode(type: type)
-    }
 }

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -24,7 +24,6 @@ public enum FeatureMessage {
 
     /// A telemetry message.
     ///
-    /// The core can send t
-    /// elemetry data coming from all Features.
+    /// The core can send telemetry data coming from all Features.
     case telemetry(TelemetryMessage)
 }

--- a/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
@@ -37,7 +37,7 @@ class FeatureMessageReceiverTests: XCTestCase {
 
     func testEmptyCombinedReceiver_returnsFalse() throws {
         let receiver = CombinedFeatureMessageReceiver([])
-        XCTAssertFalse(receiver.receive(message: .payload( "test"), from: core))
+        XCTAssertFalse(receiver.receive(message: .payload("test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 

--- a/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
@@ -31,13 +31,13 @@ class FeatureMessageReceiverTests: XCTestCase {
 
     func testNOPReceiver_returnsFalse() throws {
         let receiver = NOPFeatureMessageReceiver()
-        XCTAssertFalse(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertFalse(receiver.receive(message: .payload("test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
     func testEmptyCombinedReceiver_returnsFalse() throws {
         let receiver = CombinedFeatureMessageReceiver([])
-        XCTAssertFalse(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertFalse(receiver.receive(message: .payload( "test"), from: core))
         XCTAssertFalse(receiver.receive(message: .context(.mockRandom()), from: core))
     }
 
@@ -50,7 +50,7 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: expectation)
         )
 
-        XCTAssertTrue(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertTrue(receiver.receive(message: .payload("test"), from: core))
         XCTAssertTrue(receiver.receive(message: .context(.mockRandom()), from: core))
         waitForExpectations(timeout: 0)
     }
@@ -65,7 +65,7 @@ class FeatureMessageReceiverTests: XCTestCase {
             TestReceiver(expectation: noExpectation)
         )
 
-        XCTAssertTrue(receiver.receive(message: .baggage(key: .mockAny(), value: "test"), from: core))
+        XCTAssertTrue(receiver.receive(message: .payload("test"), from: core))
         waitForExpectations(timeout: 0)
     }
 }

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -218,7 +218,7 @@ class WebViewEventReceiverTests: XCTestCase {
         )
 
         // When
-        let otherMessage: FeatureMessage = .baggage(key: "message to other receiver", value: String.mockRandom())
+        let otherMessage: FeatureMessage = .payload(String.mockRandom())
         let result = receiver.receive(message: otherMessage, from: NOPDatadogCore())
 
         // Then

--- a/DatadogSessionReplay/Tests/Feature/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RUMContextReceiverTests.swift
@@ -236,7 +236,7 @@ class RUMContextReceiverTests: XCTestCase {
 
         // When
         XCTAssertFalse(
-            receiver.receive(message: .baggage(key: "key", value: "value"), from: core)
+            receiver.receive(message: .payload("value"), from: core)
         )
 
         // Then

--- a/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
@@ -88,7 +88,7 @@ class WebViewRecordReceiverTests: XCTestCase {
         let receiver = WebViewRecordReceiver(scope: scope)
 
         // When
-        let otherMessage: FeatureMessage = .baggage(key: "message to other receiver", value: String.mockRandom())
+        let otherMessage: FeatureMessage = .payload(String.mockRandom())
         let result = receiver.receive(message: otherMessage, from: NOPDatadogCore())
 
         // Then

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureMessageMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureMessageMocks.swift
@@ -8,19 +8,6 @@ import Foundation
 import DatadogInternal
 
 public extension Array where Element == FeatureMessage {
-    /// Unpacks the first "baggage message" with given key in this array.
-    func firstBaggage(withKey key: String) -> FeatureBaggage? {
-        lazy
-            .compactMap { $0.asBaggage }
-            .first(where: { $0.key == key })?.baggage
-    }
-
-    /// Unpacks the last "baggage message" with given key in this array.
-    func lastBaggage(withKey key: String) -> FeatureBaggage? {
-        compactMap({ $0.asBaggage })
-            .last(where: { $0.key == key })?.baggage
-    }
-
     /// Unpacks the first "payload message" in this array.
     var firstPayload: Any? {
         lazy.compactMap { $0.asPayload }.first
@@ -53,14 +40,6 @@ public extension Array where Element == FeatureMessage {
 }
 
 public extension FeatureMessage {
-    /// Extracts baggage attributes from feature message.
-    var asBaggage: (key: String, baggage: FeatureBaggage)? {
-        guard case let .baggage(key, baggage) = self else {
-            return nil
-        }
-        return (key: key, baggage: baggage)
-    }
-
     /// Extracts payload message.
     var asPayload: Any? {
         guard case let .payload(value) = self else {


### PR DESCRIPTION
### What and why?

Remove `.baggage` message type following migration of:
- #2276
- #2277
- #2278
- #2279

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
