### PR TITLE
RUM-4236 Increase RUM batch ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Increase RUM batch maximum age to 24hrs. See [#2302][]
+
 # 2.27.0 / 06-05-2025
 
 - [FEATURE] Propagate RUM session ID in request headers. See [#2201][]
@@ -872,6 +874,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2236]: https://github.com/DataDog/dd-sdk-ios/pull/2236
 [#2260]: https://github.com/DataDog/dd-sdk-ios/pull/2260
 [#2268]: https://github.com/DataDog/dd-sdk-ios/pull/2268
+[#2302]: https://github.com/DataDog/dd-sdk-ios/pull/2302
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -146,7 +146,7 @@ internal extension PerformancePreset {
             maxDirectorySize: maxDirectorySize,
             maxFileAgeForWrite: override.maxFileAgeForWrite ?? maxFileAgeForWrite,
             minFileAgeForRead: override.minFileAgeForRead ?? minFileAgeForRead,
-            maxFileAgeForRead: maxFileAgeForRead,
+            maxFileAgeForRead: override.maxFileAgeForRead ?? maxFileAgeForRead,
             maxObjectsInFile: maxObjectsInFile,
             maxObjectSize: override.maxObjectSize ?? maxObjectSize,
             initialUploadDelay: override.initialUploadDelay ?? initialUploadDelay,

--- a/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
@@ -159,14 +159,22 @@ class PerformancePresetTests: XCTestCase {
             range: (TimeInterval.mockRandom(min: 1, max: 10)..<TimeInterval.mockRandom(min: 11, max: 100)),
             changeRate: .mockRandom()
         )
+        let maxFileAgeForRead: TimeInterval = .mockRandom(min: 100, max: 1_000)
 
         // When
-        let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom(), batchProcessingLevel: .mockRandom())
+        let preset = PerformancePreset(
+            batchSize: .mockRandom(),
+            uploadFrequency: .mockRandom(),
+            bundleType: .mockRandom(),
+            batchProcessingLevel: .mockRandom()
+        )
+
         let updatedPreset = preset.updated(
             with: PerformancePresetOverride(
                 maxFileSize: maxFileSizeOverride,
                 maxObjectSize: maxObjectSizeOverride,
                 meanFileAge: meanFileAgeOverride,
+                maxFileAgeForRead: maxFileAgeForRead,
                 uploadDelay: uploadDelayOverride
             )
         )
@@ -176,6 +184,7 @@ class PerformancePresetTests: XCTestCase {
         XCTAssertEqual(updatedPreset.maxObjectSize, maxObjectSizeOverride)
         XCTAssertEqual(updatedPreset.maxFileAgeForWrite, meanFileAgeOverride * 0.95, accuracy: 0.01)
         XCTAssertEqual(updatedPreset.minFileAgeForRead, meanFileAgeOverride * 1.05, accuracy: 0.01)
+        XCTAssertEqual(updatedPreset.maxFileAgeForRead, maxFileAgeForRead)
         XCTAssertEqual(updatedPreset.uploaderWindow, meanFileAgeOverride, accuracy: 0.01)
         XCTAssertEqual(updatedPreset.initialUploadDelay, uploadDelayOverride.initial)
         XCTAssertEqual(updatedPreset.minUploadDelay, uploadDelayOverride.range.lowerBound)

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -16,9 +16,6 @@ public protocol DatadogFeature {
     /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
     /// from a bus that is shared between Features registered in a core.
     var messageReceiver: FeatureMessageReceiver { get }
-
-    /// (Optional) `PerformancePresetOverride` allows overriding certain performance presets if needed.
-    var performanceOverride: PerformancePresetOverride? { get }
 }
 
 /// A Datadog Feature with remote data store.
@@ -31,8 +28,11 @@ public protocol DatadogRemoteFeature: DatadogFeature {
     /// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
     /// The request will be transported by `DatadogCore`.
     var requestBuilder: FeatureRequestBuilder { get }
+
+    /// (Optional) `PerformancePresetOverride` allows overriding certain performance presets if needed.
+    var performanceOverride: PerformancePresetOverride? { get }
 }
 
-extension DatadogFeature {
+extension DatadogRemoteFeature {
     public var performanceOverride: PerformancePresetOverride? { nil }
 }

--- a/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
+++ b/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
@@ -27,12 +27,16 @@ public struct PerformancePresetOverride {
     /// It has an arbitrary offset  (~0.5s) over `maxFileAgeForWrite` to ensure that no upload can start for the file being currently written.
     public let minFileAgeForRead: TimeInterval?
 
+    /// Maximum age qualifying given file for upload (in seconds).
+    /// Files older than this are considered obsolete and get deleted without uploading.
+    public let maxFileAgeForRead: TimeInterval?
+
     /// Overrides the initial upload delay (in seconds).
     /// At runtime, the upload interval starts with `initialUploadDelay` and then ranges from `minUploadDelay` to `maxUploadDelay` depending
     /// on delivery success or failure.
     public let initialUploadDelay: TimeInterval?
 
-    /// Overrides the mininum  interval of data upload (in seconds).
+    /// Overrides the minimum  interval of data upload (in seconds).
     public let minUploadDelay: TimeInterval?
 
     /// Overrides the maximum interval of data upload (in seconds).
@@ -43,20 +47,23 @@ public struct PerformancePresetOverride {
     public let uploadDelayChangeRate: Double?
 
     /// Initializes a new `PerformancePresetOverride` instance with the provided overrides.
-    ///
+    /// 
     /// - Parameters:
     ///   - maxFileSize: The maximum allowed file size in bytes, or `nil` to use the default value from `PerformancePreset`.
     ///   - maxObjectSize: The maximum allowed object size in bytes, or `nil` to use the default value from `PerformancePreset`.
     ///   - meanFileAge: The mean age qualifying a file for reuse, or `nil` to use the default value from `PerformancePreset`.
+    ///   - maxFileAgeForRead: Maximum age qualifying given file for upload (in seconds). Files older than this are considered obsolete and get deleted without uploading.
     ///   - uploadDelay: The configuration of time interval for data uploads (initial, minimum, maximum and change rate). Set `nil` to use the default value from `PerformancePreset`.
     public init(
-        maxFileSize: UInt32?,
-        maxObjectSize: UInt32?,
+        maxFileSize: UInt32? = nil,
+        maxObjectSize: UInt32? = nil,
         meanFileAge: TimeInterval? = nil,
+        maxFileAgeForRead: TimeInterval? = nil,
         uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)? = nil
     ) {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
+        self.maxFileAgeForRead = maxFileAgeForRead
 
         if let meanFileAge = meanFileAge {
             // Following constants are the same as in `DatadogCore.PerformancePreset`

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -23,6 +23,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
     let anonymousIdentifierManager: AnonymousIdentifierManaging
 
+    let performanceOverride = PerformancePresetOverride(
+        maxFileAgeForRead: 24.hours // RUM intake can ingest events up to 24hrs old
+    )
+
     init(
         in core: DatadogCoreProtocol,
         configuration: RUM.Configuration

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -89,6 +89,7 @@ class RUMTests: XCTestCase {
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
         let telemetryReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: TelemetryReceiver.self)
         let crashReportReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
+        XCTAssertEqual(rum.performanceOverride.maxFileAgeForRead, 24.hours)
         XCTAssertEqual(monitor.scopes.dependencies.rumApplicationID, applicationID)
         XCTAssertEqual(monitor.scopes.dependencies.sessionSampler.samplingRate, 100)
         XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.sampleRate, 15)


### PR DESCRIPTION
### What and why?

To reduce data loss, we want to extend the “max age” of uploaded RUM batches to 24h.

### How?

Provide Performance Override in RUM to increase the max file age for reading.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
