### PR TITLE
RUM-9068: Align attribute propagation mechanism

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/RUMAttributesIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMAttributesIntegrationTests.swift
@@ -25,6 +25,8 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Global Attributes
+
     func testWhenViewStops_theViewEvents_haveTheCorrectGlobalAttributes() throws {
         // Given
         let initialAttributes: [AttributeKey: AttributeValue] = ["key1": "value1", "key2": "value2", "key3": "value3"]
@@ -130,6 +132,506 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         }
     }
 
+    func testWhenGlobalAttributesAreRemoved_eventsDoNotHaveThem() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName, attributes: ["viewKey": "viewValue"])
+        monitor.addAttribute(forKey: "globalKey", value: "globalValue")
+        monitor.addTiming(name: "addViewTiming")
+        monitor.removeAttribute(forKey: "globalKey")
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 3)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[0].attribute(forKey: "viewKey"), "viewValue")
+
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "globalKey"), "globalValue")
+
+        XCTAssertEqual(customView.viewEvents[2].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "viewKey"), "viewValue")
+    }
+
+    // MARK: - View Attributes
+
+    func testViewAttributesManagementOnUserActions_fromGlobalMonitor() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+
+        monitor.addViewAttribute(forKey: "viewKey", value: "viewValue")
+        monitor.addAction(type: .custom, name: "tap")
+
+        monitor.addViewAttributes(["newViewKey": "newViewValue", "anotherViewKey": "anotherViewValue"])
+        monitor.removeViewAttribute(forKey: "viewKey")
+        monitor.addAction(type: .custom, name: "tap2")
+
+        monitor.removeViewAttributes(forKeys: ["newViewKey", "anotherViewKey"])
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 0)
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[2].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+        XCTAssertEqual(customView.viewEvents[3].numberOfAttributes, 0)
+
+        XCTAssertEqual(customView.actionEvents.count, 2)
+        XCTAssertEqual(customView.actionEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.actionEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.actionEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.actionEvents[1].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.actionEvents[1].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+    }
+
+    func testViewAttributesManagementOnResources_fromGlobalMonitor() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+
+        monitor.addViewAttribute(forKey: "viewKey", value: "viewValue")
+        monitor.startResource(resourceKey: "resourceKey", url: .mockAny())
+        monitor.stopResource(resourceKey: "resourceKey", kind: .fetch)
+
+        monitor.addViewAttributes(["newViewKey": "newViewValue", "anotherViewKey": "anotherViewValue"])
+        monitor.removeViewAttribute(forKey: "viewKey")
+        monitor.startResource(resourceKey: "resourceKey", url: .mockAny())
+        monitor.stopResource(resourceKey: "resourceKey", kind: .fetch)
+
+        monitor.removeViewAttributes(forKeys: ["newViewKey", "anotherViewKey"])
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 0)
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[2].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+        XCTAssertEqual(customView.viewEvents[3].numberOfAttributes, 0)
+
+        XCTAssertEqual(customView.resourceEvents.count, 2)
+        XCTAssertEqual(customView.resourceEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.resourceEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.resourceEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.resourceEvents[1].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.resourceEvents[1].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+    }
+
+    func testViewAttributesManagementOnErrors_fromGlobalMonitor() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+
+        monitor.addViewAttribute(forKey: "viewKey", value: "viewValue")
+        monitor.addError(error: ErrorMock(), source: .custom)
+
+        monitor.addViewAttributes(["newViewKey": "newViewValue", "anotherViewKey": "anotherViewValue"])
+        monitor.removeViewAttribute(forKey: "viewKey")
+        monitor.addError(message: .mockAny(), type: nil, stack: nil, source: .custom, file: nil, line: nil)
+
+        monitor.removeViewAttributes(forKeys: ["newViewKey", "anotherViewKey"])
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 0)
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[2].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+        XCTAssertEqual(customView.viewEvents[3].numberOfAttributes, 0)
+
+        XCTAssertEqual(customView.errorEvents.count, 2)
+        XCTAssertEqual(customView.errorEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.errorEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.errorEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.errorEvents[1].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.errorEvents[1].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+    }
+
+    func testViewAttributesManagementOnLong_fromGlobalMonitor() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName)
+
+        monitor.addViewAttribute(forKey: "viewKey", value: "viewValue")
+        monitor._internal?.addLongTask(at: Date(), duration: 1.0)
+
+        monitor.addViewAttributes(["newViewKey": "newViewValue", "anotherViewKey": "anotherViewValue"])
+        monitor.removeViewAttribute(forKey: "viewKey")
+        monitor._internal?.addLongTask(at: Date(), duration: 1.0)
+
+        monitor.removeViewAttributes(forKeys: ["newViewKey", "anotherViewKey"])
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 0)
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[2].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.viewEvents[2].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+        XCTAssertEqual(customView.viewEvents[3].numberOfAttributes, 0)
+
+        XCTAssertEqual(customView.longTaskEvents.count, 2)
+        XCTAssertEqual(customView.longTaskEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.longTaskEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.longTaskEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.longTaskEvents[1].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(customView.longTaskEvents[1].attribute(forKey: "anotherViewKey"), "anotherViewValue")
+    }
+
+    func testGlobalAndViewAttributes_propagatingToChildScopes() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName, attributes: ["viewKey": "viewValue"])
+        monitor.addAttribute(forKey: "globalKey", value: "globalValue")
+        monitor.addAction(type: .custom, name: "tap", attributes: ["actionKey": "actionValue"])
+        monitor.addViewAttribute(forKey: "newViewKey", value: "newViewValue")
+
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["resourceKey": "resourceValue"]
+        )
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["resourceKey": "resourceValue"]
+        )
+
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[1].numberOfAttributes, 2)
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(customView.viewEvents[1].attribute(forKey: "globalKey"), "globalValue")
+        customView.viewEvents.dropFirst().dropFirst().forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, 3)
+            XCTAssertEqual(viewEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(viewEvent.attribute(forKey: "newViewKey"), "newViewValue")
+            XCTAssertEqual(viewEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+
+        customView.actionEvents.forEach { actionEvent in
+            XCTAssertEqual(actionEvent.numberOfAttributes, 3)
+            XCTAssertEqual(actionEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(actionEvent.attribute(forKey: "actionKey"), "actionValue")
+            XCTAssertEqual(actionEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+
+        customView.resourceEvents.forEach { resourceEvent in
+            XCTAssertEqual(resourceEvent.numberOfAttributes, 4)
+            XCTAssertEqual(resourceEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(resourceEvent.attribute(forKey: "newViewKey"), "newViewValue")
+            XCTAssertEqual(resourceEvent.attribute(forKey: "resourceKey"), "resourceValue")
+            XCTAssertEqual(resourceEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+    }
+
+    func testViewAttributes_arePropagatedToChildScopes() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "MyView"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName, attributes: ["viewKey": "viewValue"])
+        monitor.addAttribute(forKey: "globalKey", value: "globalValue")
+        monitor.addAction(type: .custom, name: "tap", attributes: ["actionKey": "actionValue"])
+
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["resourceKey": "resourceValue"]
+        )
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["resourceKey": "resourceValue"]
+        )
+
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+        XCTAssertEqual(customView.viewEvents[0].numberOfAttributes, 1)
+        XCTAssertEqual(customView.viewEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        customView.viewEvents.dropFirst().forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, 2)
+            XCTAssertEqual(viewEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(viewEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+
+        customView.actionEvents.forEach { actionEvent in
+            XCTAssertEqual(actionEvent.numberOfAttributes, 3)
+            XCTAssertEqual(actionEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(actionEvent.attribute(forKey: "actionKey"), "actionValue")
+            XCTAssertEqual(actionEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+
+        customView.resourceEvents.forEach { resourceEvent in
+            XCTAssertEqual(resourceEvent.numberOfAttributes, 3)
+            XCTAssertEqual(resourceEvent.attribute(forKey: "viewKey"), "viewValue")
+            XCTAssertEqual(resourceEvent.attribute(forKey: "resourceKey"), "resourceValue")
+            XCTAssertEqual(resourceEvent.attribute(forKey: "globalKey"), "globalValue")
+        }
+    }
+
+    // MARK: - Precedences
+
+    func testViewAttributes_havePrecedenceOverGlobalAttributes() throws {
+        // Given
+        let initialAttributes: [AttributeKey: AttributeValue] = ["sameKey": "value1", "key2": "value2"]
+        let viewName = "MyView"
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.addAttribute(forKey: "sameKey", value: "globalValue")
+        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
+        monitor.stopView(key: "key", attributes: initialAttributes)
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let applicationView = try XCTUnwrap(session.views.first(where: { $0.isApplicationLaunchView() }))
+        let firstViewEvent = applicationView.viewEvents.first
+        let lastViewEvent = applicationView.viewEvents.last
+        XCTAssertEqual(firstViewEvent?.numberOfAttributes, 0)
+        XCTAssertEqual(lastViewEvent?.numberOfAttributes, 1)
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+
+        customView.viewEvents.forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, initialAttributes.count)
+
+            initialAttributes.forEach {
+                XCTAssertEqual(viewEvent.attribute(forKey: $0.key), $0.value as? String)
+            }
+        }
+    }
+
+    func testLocalAttributesHavePrecendence_overViewAttributes_overGlobalAttributes() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "viewName"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.addAttributes(["key": "globalValue"])
+        monitor.startView(key: "key", name: viewName, attributes: ["key": "viewValue"])
+        monitor.addAction(type: .custom, name: "tap", attributes: ["key": "actionValue"])
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["key": "resourceValue"]
+        )
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["key": "resourceValue"]
+        )
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 3)
+        customView.viewEvents.forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, 1)
+            XCTAssertEqual(viewEvent.attribute(forKey: "key"), "viewValue")
+        }
+
+        customView.actionEvents.forEach { actionEvent in
+            XCTAssertEqual(actionEvent.numberOfAttributes, 1)
+            XCTAssertEqual(actionEvent.attribute(forKey: "key"), "actionValue")
+        }
+
+        customView.resourceEvents.forEach { resourceEvent in
+            XCTAssertEqual(resourceEvent.numberOfAttributes, 1)
+            XCTAssertEqual(resourceEvent.attribute(forKey: "key"), "resourceValue")
+        }
+    }
+
+    func testTimingAttributes_inheritViewAttributes_overGlobalAttributes() throws {
+        // Given
+        RUM.enable(with: rumConfig, in: core)
+        let viewName = "viewName"
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName, attributes: ["key": "viewValue"])
+        monitor.addAttributes(["key": "globalValue"])
+        monitor.addTiming(name: "addViewTiming")
+        monitor.addAction(type: .custom, name: "tap", attributes: ["key": "actionValue"])
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["key": "resourceValue"]
+        )
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["key": "resourceValue"]
+        )
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(customView.viewEvents.count, 4)
+
+        customView.viewEvents.dropFirst().forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, 1)
+            XCTAssertEqual(viewEvent.attribute(forKey: "key"), "viewValue")
+        }
+
+        customView.actionEvents.forEach { actionEvent in
+            XCTAssertEqual(actionEvent.numberOfAttributes, 1)
+            XCTAssertEqual(actionEvent.attribute(forKey: "key"), "actionValue")
+        }
+
+        customView.resourceEvents.forEach { resourceEvent in
+            XCTAssertEqual(resourceEvent.numberOfAttributes, 1)
+            XCTAssertEqual(resourceEvent.attribute(forKey: "key"), "resourceValue")
+        }
+    }
+
+    func testViewAttributes_haveGlobalAttributesOverWritingViewAttributes_whenNoViewAttributesArePassed() throws {
+        // Given
+        let initialAttributes: [AttributeKey: AttributeValue] = ["sameKey": "value1", "key2": "value2"]
+        let viewName = "MyView"
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.addAttribute(forKey: "sameKey", value: "globalValue")
+        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        let applicationView = try XCTUnwrap(session.views.first(where: { $0.isApplicationLaunchView() }))
+        let firstViewEvent = applicationView.viewEvents.first
+        let lastViewEvent = applicationView.viewEvents.last
+        XCTAssertEqual(firstViewEvent?.numberOfAttributes, 0)
+        XCTAssertEqual(lastViewEvent?.numberOfAttributes, 1)
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+
+        let firstCustomViewEvent = customView.viewEvents.first
+        let lastCustomViewEvent = customView.viewEvents.last
+
+        XCTAssertEqual(firstCustomViewEvent?.numberOfAttributes, initialAttributes.count)
+        initialAttributes.forEach {
+            XCTAssertEqual(firstCustomViewEvent?.attribute(forKey: $0.key), $0.value as? String)
+        }
+
+        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "key2"), "value2")
+        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "sameKey"), "value1") // view attributes take precedence
+    }
+
+    // MARK: - Session
+
     func testWhenSessionEnds_theViewAttributesAreNotUpdated_withNewCommands() throws {
         // Given
         let initialAttributes: [AttributeKey: AttributeValue] = ["key1": "value1", "key2": "value2"]
@@ -191,77 +693,117 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         XCTAssertEqual(stopViewEvent.attribute(forKey: "anotherAdditionalKey"), "anotherAdditionalValue")
     }
 
-    func testViewAttributes_havePrecedenceOverGlobalAttributes() throws {
+    // View attributes are not added or overwritten after a view has “stopped”, even if that view is still active because of Resource or Action events.
+    // Changes to global attributes also do not affect “stopped” views, but should be transferred to other active events when they are stopped.
+    func testWhenAttributesChange_onStoppedViews_withActiveResources() throws {
         // Given
-        let initialAttributes: [AttributeKey: AttributeValue] = ["sameKey": "value1", "key2": "value2"]
-        let viewName = "MyView"
+        let view1 = "MyView1"
+        let view2 = "MyView2"
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
 
         // When
-        monitor.addAttribute(forKey: "sameKey", value: "globalValue")
-        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
-        monitor.stopView(key: "key", attributes: initialAttributes)
+        monitor.addAttribute(forKey: "globalKey", value: "globalValue")
+        monitor.startView(key: view1, name: view1, attributes: ["viewKey": "viewValue"])
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["resourceKey": "resourceValue"]
+        )
+
+        monitor.addViewAttribute(forKey: "newViewKey", value: "newViewValue")
+        monitor.startView(key: view2, name: view2, attributes: ["view2Key": "view2Value"])
+
+        monitor.addAttribute(forKey: "newGlobalKey", value: "newGlobalValue")
+        monitor.addViewAttribute(forKey: "newView2Key", value: "newView2Value")
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["resourceKey": "resourceValue"]
+        )
 
         // Then
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
-        let applicationView = try XCTUnwrap(session.views.first(where: { $0.isApplicationLaunchView() }))
-        let firstViewEvent = applicationView.viewEvents.first
-        let lastViewEvent = applicationView.viewEvents.last
-        XCTAssertEqual(firstViewEvent?.numberOfAttributes, 0)
-        XCTAssertEqual(lastViewEvent?.numberOfAttributes, 1)
+        let firstView = try XCTUnwrap(session.views.first(where: { $0.name == view1 }))
+        let secondView = try XCTUnwrap(session.views.first(where: { $0.name == view2 }))
 
-        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        XCTAssertEqual(firstView.viewEvents.count, 3)
+        XCTAssertEqual(firstView.resourceEvents.count, 1)
+        XCTAssertEqual(secondView.viewEvents.count, 1)
 
-        customView.viewEvents.forEach { viewEvent in
-            XCTAssertEqual(viewEvent.numberOfAttributes, initialAttributes.count)
+        // start view event
+        XCTAssertEqual(firstView.viewEvents[0].numberOfAttributes, 2)
+        XCTAssertEqual(firstView.viewEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(firstView.viewEvents[0].attribute(forKey: "globalKey"), "globalValue")
 
-            initialAttributes.forEach {
-                XCTAssertEqual(viewEvent.attribute(forKey: $0.key), $0.value as? String)
-            }
-        }
+        // stop view event
+        XCTAssertEqual(firstView.viewEvents[1].numberOfAttributes, 3)
+        XCTAssertEqual(firstView.viewEvents[1].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(firstView.viewEvents[1].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(firstView.viewEvents[1].attribute(forKey: "globalKey"), "globalValue")
+
+        // resource view event
+        XCTAssertEqual(firstView.viewEvents[2].numberOfAttributes, 3)
+        XCTAssertEqual(firstView.viewEvents[2].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(firstView.viewEvents[2].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(firstView.viewEvents[2].attribute(forKey: "globalKey"), "globalValue")
+
+        // start view2 event
+        XCTAssertEqual(secondView.viewEvents[0].numberOfAttributes, 2)
+        XCTAssertEqual(secondView.viewEvents[0].attribute(forKey: "view2Key"), "view2Value")
+        XCTAssertEqual(secondView.viewEvents[0].attribute(forKey: "globalKey"), "globalValue")
+
+        // resource event
+        XCTAssertEqual(firstView.resourceEvents[0].numberOfAttributes, 5)
+        XCTAssertEqual(firstView.resourceEvents[0].attribute(forKey: "resourceKey"), "resourceValue")
+        XCTAssertEqual(firstView.resourceEvents[0].attribute(forKey: "viewKey"), "viewValue")
+        XCTAssertEqual(firstView.resourceEvents[0].attribute(forKey: "newViewKey"), "newViewValue")
+        XCTAssertEqual(firstView.resourceEvents[0].attribute(forKey: "globalKey"), "globalValue")
+        XCTAssertEqual(firstView.resourceEvents[0].attribute(forKey: "newGlobalKey"), "newGlobalValue")
     }
 
-    func testViewAttributes_haveGlobalAttributesOverWritingViewAttributes_whenNoViewAttributesArePassed() throws {
+    // MARK: - User Actions
+
+    func testGlobalAttributes_areAddedToActionEvents() throws {
         // Given
-        let initialAttributes: [AttributeKey: AttributeValue] = ["sameKey": "value1", "key2": "value2"]
-        let viewName = "MyView"
         RUM.enable(with: rumConfig, in: core)
 
         let monitor = RUMMonitor.shared(in: core)
 
         // When
-        monitor.addAttribute(forKey: "sameKey", value: "globalValue")
-        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
-        monitor.stopView(key: "key")
+        monitor.addAttribute(forKey: "sameKey", value: "value1")
+        monitor.addAction(type: .custom, name: "drag")
+        monitor.addAction(type: .swipe, name: "swipe up")
+        monitor.addAttribute(forKey: "key2", value: "value2")
+        monitor.stopAction(type: .swipe, name: "swipe up", attributes: ["sameKey": "value3"] )
 
         // Then
         let session = try RUMSessionMatcher
             .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
             .takeSingle()
 
+        // It should have the `ApplicationLaunchView` and `MyView` views
+        XCTAssertEqual(session.views.count, 1)
+
         let applicationView = try XCTUnwrap(session.views.first(where: { $0.isApplicationLaunchView() }))
-        let firstViewEvent = applicationView.viewEvents.first
-        let lastViewEvent = applicationView.viewEvents.last
-        XCTAssertEqual(firstViewEvent?.numberOfAttributes, 0)
-        XCTAssertEqual(lastViewEvent?.numberOfAttributes, 1)
+        XCTAssertEqual(applicationView.actionEvents.count, 3)
 
-        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+        let firstActionEvent = applicationView.actionEvents[1]
+        XCTAssertEqual(firstActionEvent.numberOfAttributes, 1)
+        XCTAssertEqual(firstActionEvent.attribute(forKey: "sameKey"), "value1")
 
-        let firstCustomViewEvent = customView.viewEvents.first
-        let lastCustomViewEvent = customView.viewEvents.last
-
-        XCTAssertEqual(firstCustomViewEvent?.numberOfAttributes, initialAttributes.count)
-        initialAttributes.forEach {
-            XCTAssertEqual(firstCustomViewEvent?.attribute(forKey: $0.key), $0.value as? String)
-        }
-
-        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "key2"), "value2")
-        XCTAssertEqual(lastCustomViewEvent?.attribute(forKey: "sameKey"), "value1") // view attributes take precedence
+        let lastActionEvent = applicationView.actionEvents[2]
+        XCTAssertEqual(lastActionEvent.numberOfAttributes, 2)
+        XCTAssertEqual(lastActionEvent.attribute(forKey: "sameKey"), "value3")
+        XCTAssertEqual(lastActionEvent.attribute(forKey: "key2"), "value2")
     }
 
     func testWhenViewReceivesActions_theViewAttributesAreNotUpdated_withActionAttributes() throws {
@@ -302,85 +844,7 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         }
     }
 
-    func testWhenViewReceivesResources_theViewAttributesAreNotUpdated_withResourceAttributes() throws {
-        // Given
-        let initialAttributes: [AttributeKey: AttributeValue] = ["key1": "value1", "key2": "value2"]
-        let viewName = "MyView"
-        RUM.enable(with: rumConfig, in: core)
-
-        let monitor = RUMMonitor.shared(in: core)
-
-        // When
-        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
-        monitor.startResource(
-            resourceKey: "resourceKey",
-            httpMethod: .get,
-            urlString: .mockAny(),
-            attributes: ["additionalKey": "additionalValue"]
-        )
-
-        monitor.stopResource(
-            resourceKey: "resourceKey",
-            statusCode: 200,
-            kind: .fetch,
-            size: nil,
-            attributes: ["resourceAdditionalKey": "resourceAdditionalValue"]
-        )
-
-        monitor.stopView(key: "key")
-
-        // Then
-        let session = try RUMSessionMatcher
-            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
-            .takeSingle()
-
-        // It should have the `ApplicationLaunchView` and `MyView` views
-        XCTAssertEqual(session.views.count, 2)
-
-        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
-
-        customView.viewEvents.forEach { viewEvent in
-            XCTAssertEqual(viewEvent.numberOfAttributes, initialAttributes.count)
-
-            initialAttributes.forEach {
-                XCTAssertEqual(viewEvent.attribute(forKey: $0.key), $0.value as? String)
-            }
-        }
-    }
-
-    func testGlobalAttributes_areAddedToActionEvents() throws {
-        // Given
-        RUM.enable(with: rumConfig, in: core)
-
-        let monitor = RUMMonitor.shared(in: core)
-
-        // When
-        monitor.addAttribute(forKey: "sameKey", value: "value1")
-        monitor.addAction(type: .custom, name: "drag")
-        monitor.addAction(type: .swipe, name: "swipe up")
-        monitor.addAttribute(forKey: "key2", value: "value2")
-        monitor.stopAction(type: .swipe, name: "swipe up", attributes: ["sameKey": "value3"] )
-
-        // Then
-        let session = try RUMSessionMatcher
-            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
-            .takeSingle()
-
-        // It should have the `ApplicationLaunchView` and `MyView` views
-        XCTAssertEqual(session.views.count, 1)
-
-        let applicationView = try XCTUnwrap(session.views.first(where: { $0.isApplicationLaunchView() }))
-        XCTAssertEqual(applicationView.actionEvents.count, 3)
-
-        let firstActionEvent = applicationView.actionEvents[1]
-        XCTAssertEqual(firstActionEvent.numberOfAttributes, 1)
-        XCTAssertEqual(firstActionEvent.attribute(forKey: "sameKey"), "value1")
-
-        let lastActionEvent = applicationView.actionEvents[2]
-        XCTAssertEqual(lastActionEvent.numberOfAttributes, 2)
-        XCTAssertEqual(lastActionEvent.attribute(forKey: "sameKey"), "value3")
-        XCTAssertEqual(lastActionEvent.attribute(forKey: "key2"), "value2")
-    }
+    // MARK: - Resources
 
     func testGlobalAttributes_areAddedToResourceEvents() throws {
         // Given
@@ -443,6 +907,54 @@ final class RUMAttributesIntegrationTests: XCTestCase {
         XCTAssertEqual(lastResourceEvent.attribute(forKey: "key3"), "value3")
     }
 
+    func testWhenViewReceivesResources_theViewAttributesAreNotUpdated_withResourceAttributes() throws {
+        // Given
+        let initialAttributes: [AttributeKey: AttributeValue] = ["key1": "value1", "key2": "value2"]
+        let viewName = "MyView"
+        RUM.enable(with: rumConfig, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key", name: viewName, attributes: initialAttributes)
+        monitor.startResource(
+            resourceKey: "resourceKey",
+            httpMethod: .get,
+            urlString: .mockAny(),
+            attributes: ["additionalKey": "additionalValue"]
+        )
+
+        monitor.stopResource(
+            resourceKey: "resourceKey",
+            statusCode: 200,
+            kind: .fetch,
+            size: nil,
+            attributes: ["resourceAdditionalKey": "resourceAdditionalValue"]
+        )
+
+        monitor.stopView(key: "key")
+
+        // Then
+        let session = try RUMSessionMatcher
+            .groupMatchersBySessions(try core.waitAndReturnRUMEventMatchers())
+            .takeSingle()
+
+        // It should have the `ApplicationLaunchView` and `MyView` views
+        XCTAssertEqual(session.views.count, 2)
+
+        let customView = try XCTUnwrap(session.views.first(where: { $0.name == viewName }))
+
+        customView.viewEvents.forEach { viewEvent in
+            XCTAssertEqual(viewEvent.numberOfAttributes, initialAttributes.count)
+
+            initialAttributes.forEach {
+                XCTAssertEqual(viewEvent.attribute(forKey: $0.key), $0.value as? String)
+            }
+        }
+    }
+
+    // MARK: - Error tracking
+
     func testGlobalAttributes_areAddedToErrorEvents() throws {
         // Given
         RUM.enable(with: rumConfig, in: core)
@@ -498,6 +1010,12 @@ private extension RUMResourceEvent {
 }
 
 private extension RUMErrorEvent {
+    var numberOfAttributes: Int { context?.contextInfo.count ?? 0 }
+
+    func attribute<T: Equatable>(forKey key: String) -> T? { (context?.contextInfo[key] as? AnyCodable)?.value as? T }
+}
+
+private extension RUMLongTaskEvent {
     var numberOfAttributes: Int { context?.contextInfo.count ?? 0 }
 
     func attribute<T: Equatable>(forKey key: String) -> T? { (context?.contextInfo[key] as? AnyCodable)?.value as? T }

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -238,69 +238,6 @@ extension Monitor: RUMMonitorProtocol {
         process(command: RUMStopSessionCommand(time: dateProvider.now))
     }
 
-    // MARK: - views
-
-    func startView(viewController: UIViewController, name: String?, attributes: [AttributeKey: AttributeValue]) {
-        process(
-            command: RUMStartViewCommand(
-                time: dateProvider.now,
-                identity: ViewIdentifier(viewController),
-                name: name ?? viewController.canonicalClassName,
-                path: viewController.canonicalClassName,
-                globalAttributes: self.attributes,
-                attributes: attributes,
-                instrumentationType: .manual
-            )
-        )
-    }
-
-    func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) {
-        process(
-            command: RUMStopViewCommand(
-                time: dateProvider.now,
-                globalAttributes: self.attributes,
-                attributes: attributes,
-                identity: ViewIdentifier(viewController)
-            )
-        )
-    }
-
-    func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) {
-        process(
-            command: RUMStartViewCommand(
-                time: dateProvider.now,
-                identity: ViewIdentifier(key),
-                name: name ?? key,
-                path: key,
-                globalAttributes: self.attributes,
-                attributes: attributes,
-                instrumentationType: .manual
-            )
-        )
-    }
-
-    func stopView(key: String, attributes: [AttributeKey: AttributeValue]) {
-        process(
-            command: RUMStopViewCommand(
-                time: dateProvider.now,
-                globalAttributes: self.attributes,
-                attributes: attributes,
-                identity: ViewIdentifier(key)
-            )
-        )
-    }
-
-    func addViewLoadingTime(overwrite: Bool) {
-        process(
-            command: RUMAddViewLoadingTime(
-                time: dateProvider.now,
-                globalAttributes: self.attributes,
-                attributes: [:],
-                overwrite: overwrite
-            )
-        )
-    }
-
     // MARK: - custom timings
 
     func addTiming(name: String) {
@@ -546,6 +483,108 @@ extension Monitor: RUMMonitorProtocol {
         get {
             debugging != nil
         }
+    }
+}
+
+// MARK: - View
+
+/// Declares `Monitor` conformance to public `RUMMonitorViewProtocol`.
+extension Monitor: RUMMonitorViewProtocol {
+    func addViewAttribute(forKey key: AttributeKey, value: AttributeValue) {
+        process(
+            command: RUMAddViewAttributesCommand(
+                time: dateProvider.now,
+                attributes: [key: value]
+            )
+        )
+    }
+
+    func addViewAttributes(_ attributes: [AttributeKey: AttributeValue]) {
+        process(
+            command: RUMAddViewAttributesCommand(
+                time: dateProvider.now,
+                attributes: attributes
+            )
+        )
+    }
+
+    func removeViewAttribute(forKey key: AttributeKey) {
+        process(
+            command: RUMRemoveViewAttributesCommand(
+                time: dateProvider.now,
+                keysToRemove: [key]
+            )
+        )
+    }
+
+    func removeViewAttributes(forKeys keys: [AttributeKey]) {
+        process(
+            command: RUMRemoveViewAttributesCommand(
+                time: dateProvider.now,
+                keysToRemove: keys
+            )
+        )
+    }
+
+    func startView(viewController: UIViewController, name: String?, attributes: [AttributeKey: AttributeValue]) {
+        process(
+            command: RUMStartViewCommand(
+                time: dateProvider.now,
+                identity: ViewIdentifier(viewController),
+                name: name ?? viewController.canonicalClassName,
+                path: viewController.canonicalClassName,
+                globalAttributes: self.attributes,
+                attributes: attributes,
+                instrumentationType: .manual
+            )
+        )
+    }
+
+    func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) {
+        process(
+            command: RUMStopViewCommand(
+                time: dateProvider.now,
+                globalAttributes: self.attributes,
+                attributes: attributes,
+                identity: ViewIdentifier(viewController)
+            )
+        )
+    }
+
+    func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) {
+        process(
+            command: RUMStartViewCommand(
+                time: dateProvider.now,
+                identity: ViewIdentifier(key),
+                name: name ?? key,
+                path: key,
+                globalAttributes: self.attributes,
+                attributes: attributes,
+                instrumentationType: .manual
+            )
+        )
+    }
+
+    func stopView(key: String, attributes: [AttributeKey: AttributeValue]) {
+        process(
+            command: RUMStopViewCommand(
+                time: dateProvider.now,
+                globalAttributes: self.attributes,
+                attributes: attributes,
+                identity: ViewIdentifier(key)
+            )
+        )
+    }
+
+    func addViewLoadingTime(overwrite: Bool) {
+        process(
+            command: RUMAddViewLoadingTime(
+                time: dateProvider.now,
+                globalAttributes: self.attributes,
+                attributes: [:],
+                overwrite: overwrite
+            )
+        )
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -57,7 +57,29 @@ internal struct RUMStopSessionCommand: RUMCommand {
 
 // MARK: - RUM View related commands
 
-internal struct RUMStartViewCommand: RUMCommand, RUMViewScopePropagatableAttributes {
+internal struct RUMAddViewAttributesCommand: RUMCommand {
+    var time: Date
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
+    var attributes: [AttributeKey: AttributeValue]
+    var canStartBackgroundView = false
+    var isUserInteraction = false
+    var missedEventType: SessionEndedMetric.MissedEventType? = nil
+
+    var areInternalAttributes = false
+}
+
+internal struct RUMRemoveViewAttributesCommand: RUMCommand {
+    var time: Date
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
+    var attributes: [AttributeKey: AttributeValue] = [:]
+    var canStartBackgroundView = false
+    var isUserInteraction = false
+    var missedEventType: SessionEndedMetric.MissedEventType? = nil
+
+    var keysToRemove: [AttributeKey]
+}
+
+internal struct RUMStartViewCommand: RUMCommand {
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]
@@ -96,7 +118,7 @@ internal struct RUMStartViewCommand: RUMCommand, RUMViewScopePropagatableAttribu
     }
 }
 
-internal struct RUMStopViewCommand: RUMCommand, RUMViewScopePropagatableAttributes {
+internal struct RUMStopViewCommand: RUMCommand {
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]
@@ -283,7 +305,7 @@ internal struct RUMAddCurrentViewMemoryWarningCommand: RUMErrorCommand {
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
 }
 
-internal struct RUMAddViewLoadingTime: RUMCommand, RUMViewScopePropagatableAttributes {
+internal struct RUMAddViewLoadingTime: RUMCommand {
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue]
     var attributes: [AttributeKey: AttributeValue]
@@ -294,7 +316,7 @@ internal struct RUMAddViewLoadingTime: RUMCommand, RUMViewScopePropagatableAttri
     let overwrite: Bool
 }
 
-internal struct RUMAddViewTimingCommand: RUMCommand, RUMViewScopePropagatableAttributes {
+internal struct RUMAddViewTimingCommand: RUMCommand {
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue]
     var attributes: [AttributeKey: AttributeValue]
@@ -459,7 +481,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     var globalAttributes: [AttributeKey: AttributeValue]
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
-    let isUserInteraction = true // a user action definitely is a User Interacgion
+    let isUserInteraction = true // a user action definitely is a User Interaction
     /// The type of instrumentation used to create this command.
     let instrumentation: InstrumentationType
 
@@ -474,7 +496,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     var globalAttributes: [AttributeKey: AttributeValue]
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
-    let isUserInteraction = true // a user action definitely is a User Interacgion
+    let isUserInteraction = true // a user action definitely is a User Interaction
 
     let actionType: RUMActionType
     let name: String?
@@ -487,7 +509,7 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
-    let isUserInteraction = true // a user action definitely is a User Interacgion
+    let isUserInteraction = true // a user action definitely is a User Interaction
     /// The type of instrumentation used to create this command.
     let instrumentation: InstrumentationType
 
@@ -552,16 +574,4 @@ internal struct RUMUpdatePerformanceMetric: RUMCommand {
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]
     let missedEventType: SessionEndedMetric.MissedEventType? = nil
-}
-
-internal struct RUMSetInternalViewAttributeCommand: RUMCommand {
-    let canStartBackgroundView = false
-    let isUserInteraction = false
-    var time: Date
-    var globalAttributes: [AttributeKey: AttributeValue] = [:]
-    var attributes: [AttributeKey: AttributeValue] = [:]
-    let missedEventType: SessionEndedMetric.MissedEventType? = nil
-
-    let key: AttributeKey
-    let value: AttributeValue
 }

--- a/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMScope.swift
@@ -37,13 +37,3 @@ extension Array where Element: RUMScope {
         }
     }
 }
-
-extension Dictionary where Key == AttributeKey, Value == AttributeValue {
-    /// Merges given `rumCommandAttributes` to current dictionary, by overwriting values.
-    mutating func merge(rumCommandAttributes: [AttributeKey: AttributeValue]?) {
-        guard let additionalAttributes = rumCommandAttributes else {
-            return
-        }
-        merge(additionalAttributes) { _, new in new }
-    }
-}

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     // MARK: - Child Scopes
 
-    // Whether the applciation is already active. Set to true
+    // Whether the application is already active. Set to true
     // when the first session starts.
     private(set) var applicationActive = false
 
@@ -125,7 +125,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             }
         })
 
-        // Sanity telemety, only end up with one active session
+        // Sanity telemetry, only end up with one active session
         let activeSessions = sessionScopes.filter { $0.isActive }
         if activeSessions.count > 1 {
             dependencies.telemetry.error("An application has \(activeSessions.count) active sessions")

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -98,6 +98,10 @@ internal class RUMResourceScope: RUMScope {
         self.attributes = self.attributes.merging(command.attributes, uniquingKeysWith: { $1 })
 
         switch command {
+        case let command as RUMAddViewAttributesCommand:
+            attributes.merge(command.attributes) { $1 }
+        case let command as RUMRemoveViewAttributesCommand:
+            command.keysToRemove.forEach { attributes.removeValue(forKey: $0) }
         case let command as RUMStopResourceCommand where command.resourceKey == resourceKey:
             sendResourceEvent(on: command, context: context, writer: writer)
             return false

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -187,15 +187,21 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         context.activeViewName = viewName
         return context
     }
+}
 
-    // MARK: - RUMScope
+// MARK: - RUMCommands Processing
 
+extension RUMViewScope {
     func process(command: RUMCommand, context: DatadogContext, writer: Writer) -> Bool {
         // Tells if the View did change and an update event should be send.
         needsViewUpdate = false
 
         // Propagate to User Action scope
-        userActionScope = userActionScope?.scope(byPropagating: command, context: context, writer: writer)
+        userActionScope = userActionScope?.scope(
+            byPropagating: command.with(viewAttributes: attributes, isActiveView: isActiveView),
+            context: context,
+            writer: writer
+        )
 
         let hasSentNoViewUpdatesYet = version == 0
         if isInitialView, hasSentNoViewUpdatesYet {
@@ -222,12 +228,23 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             needsViewUpdate = true
 
         // View commands
+        case let command as RUMAddViewAttributesCommand where isActiveView:
+            if command.areInternalAttributes {
+                internalAttributes.merge(command.attributes) { $1 }
+            } else {
+                attributes.merge(command.attributes) { $1 }
+                resourceScopes.forEach { _ = $1.scope(byPropagating: command, context: context, writer: writer) }
+            }
+        case let command as RUMRemoveViewAttributesCommand where isActiveView:
+            command.keysToRemove.forEach { attributes.removeValue(forKey: $0) }
+            resourceScopes.forEach { _ = $1.scope(byPropagating: command, context: context, writer: writer) }
         case let command as RUMStartViewCommand where identity == command.identity:
             if didReceiveStartCommand {
                 // This is the case of duplicated "start" command. We know that the Session scope has created another instance of
                 // the `RUMViewScope` for tracking this View, so we mark this one as inactive.
                 isActiveView = false
             }
+            attributes.merge(command.attributes) { $1 }
             didReceiveStartCommand = true
             needsViewUpdate = true
         case let command as RUMStartViewCommand where identity != command.identity && isActiveView:
@@ -236,18 +253,18 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             // deactivated. This is achieved by setting `isActiveView` to `false` and sending one more view update.
             isActiveView = false
             needsViewUpdate = true
-        case let command as RUMSetInternalViewAttributeCommand where isActiveView:
-            internalAttributes[command.key] = command.value
-            // Purposefully don't perform a view update. Most (all?) internal view attributes
-            // aren't important enough to expect them to be uploaded automatically. They can
-            // get sent with the next view update.
-
+            // View attributes are updated with the last snapshot of the global attributes
+            attributes = command.globalAttributes.merging(self.attributes) { $1 }
         case let command as RUMStopViewCommand where identity == command.identity:
             isActiveView = false
             needsViewUpdate = true
+            // View attributes are updated with the last snapshot of the global attributes
+            attributes = command.globalAttributes.merging(self.attributes) { $1 }.merging(command.attributes) { $1 }
         case let command as RUMAddViewLoadingTime where isActiveView:
+            attributes.merge(command.attributes) { $1 }
             addViewLoadingTime(on: command)
         case let command as RUMAddViewTimingCommand where isActiveView:
+            attributes.merge(command.attributes) { $1 }
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true
 
@@ -297,7 +314,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         // Propagate to Resource scopes
         if let resourceCommand = command as? RUMResourceCommand {
             resourceScopes[resourceCommand.resourceKey] = resourceScopes[resourceCommand.resourceKey]?.scope(
-                byPropagating: resourceCommand,
+                byPropagating: resourceCommand.with(viewAttributes: attributes, isActiveView: isActiveView),
                 context: context,
                 writer: writer
             )
@@ -325,8 +342,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         return !shouldComplete
     }
-
-    // MARK: - RUMCommands Processing
 
     private func addViewLoadingTime(on command: RUMAddViewLoadingTime) {
         if viewLoadingTime == nil {
@@ -377,7 +392,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies: dependencies,
             name: command.name,
             actionType: command.actionType,
-            attributes: command.attributes,
+            attributes: attributes.merging(command.attributes) { $1 },
             startTime: command.time,
             serverTimeOffset: serverTimeOffset,
             isContinuous: true,
@@ -395,7 +410,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dependencies: dependencies,
             name: command.name,
             actionType: command.actionType,
-            attributes: command.attributes,
+            attributes: attributes.merging(command.attributes) { $1 },
             startTime: command.time,
             serverTimeOffset: serverTimeOffset,
             isContinuous: false,
@@ -423,7 +438,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             command: RUMStopUserActionCommand(
                 time: command.time,
                 globalAttributes: command.globalAttributes,
-                attributes: command.attributes,
+                attributes: attributes.merging(command.attributes) { $1 },
                 actionType: .custom,
                 name: nil
             ),
@@ -445,13 +460,15 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private func sendApplicationStartAction(on command: RUMApplicationStartCommand, context: DatadogContext, writer: Writer) {
         actionsCount += 1
 
-        var attributes = self.attributes
+        var commandAttributes = command.globalAttributes
+            .merging(attributes) { $1 }
+
         var loadingTime: Int64?
 
         if context.launchTime.isActivePrewarm {
             // Set `active_pre_warm` attribute to true in case
             // of pre-warmed app.
-            attributes[Constants.activePrewarm] = true
+            commandAttributes[Constants.activePrewarm] = true
         } else if let launchTime = context.launchTime.launchTime {
             // Report Application Launch Time only if not pre-warmed
             loadingTime = launchTime.toInt64Nanoseconds
@@ -495,7 +512,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
+            context: .init(contextInfo: commandAttributes),
             date: viewStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -534,20 +551,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             hasReplay = hasReplay || hasContextReplay
         }
 
-        // RUMM-3133 Don't override View attributes with commands that are not view related.
-        if command is RUMViewScopePropagatableAttributes {
-            // The local attributes should only be updated by commands related to this 'RUMViewScope'
-            switch command {
-            case let command as RUMStartViewCommand where identity == command.identity:
-                attributes.merge(rumCommandAttributes: command.attributes)
-            case let command as RUMStopViewCommand where identity == command.identity:
-                attributes.merge(rumCommandAttributes: command.attributes)
-            case let command as RUMAddViewLoadingTime:
-                attributes.merge(rumCommandAttributes: command.attributes)
-            case let command as RUMAddViewTimingCommand:
-                attributes.merge(rumCommandAttributes: command.attributes)
-            default: break
-            }
+        let attributes: [AttributeKey: AttributeValue]
+        if isActiveView {
+            attributes = command.globalAttributes.merging(self.attributes) { $1 }
+        } else {
+            attributes = self.attributes
         }
 
         let isCrash = (command as? RUMErrorCommand).map { $0.isCrash ?? false } ?? false
@@ -622,7 +630,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: command.globalAttributes.merging(attributes) { $1 }),
+            context: .init(contextInfo: attributes),
             date: viewStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -732,7 +740,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         errorsCount += 1
         totalAppHangDuration += (command as? RUMAddCurrentViewAppHangCommand)?.hangDuration ?? 0
 
-        var commandAttributes = command.globalAttributes.merging(command.attributes) { $1 }
+        var commandAttributes = command.globalAttributes
+            .merging(attributes) { $1 }
+            .merging(command.attributes) { $1 }
         let errorFingerprint: String? = commandAttributes.removeValue(forKey: RUM.Attributes.errorFingerprint)?.dd.decode()
         let timeSinceAppStart = command.time.timeIntervalSince(context.launchTime.launchDate).toInt64Milliseconds
 
@@ -824,6 +834,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let taskDurationInNs = command.duration.toInt64Nanoseconds
         let isFrozenFrame = taskDurationInNs > Constants.frozenFrameThresholdInNs
 
+        let commandAttributes = command.globalAttributes
+            .merging(attributes) { $1 }
+            .merging(command.attributes) { $1 }
+
         let longTaskEvent = RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -843,7 +857,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: command.globalAttributes.merging(command.attributes) { $1 }),
+            context: .init(contextInfo: commandAttributes),
             date: (command.time - command.duration).addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: .init(context: context, telemetry: dependencies.telemetry),
             display: nil,
@@ -944,15 +958,23 @@ private extension VitalInfo {
     }
 }
 
-/// A protocol for `RUMCommand`s that can propagate their attributes to the `RUMViewScope``.
-internal protocol RUMViewScopePropagatableAttributes where Self: RUMCommand {
-}
-
 private extension Result {
     var value: Success? {
         switch self {
         case .success(let success): return success
         case .failure: return nil
         }
+    }
+}
+
+private extension RUMCommand {
+    func with(viewAttributes: [AttributeKey: AttributeValue], isActiveView: Bool) -> RUMCommand {
+        guard isActiveView else {
+            return self
+        }
+
+        var command = self
+        command.attributes = viewAttributes.merging(command.attributes) { $1 }
+        return command
     }
 }

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -12,7 +12,7 @@ import DatadogInternal
 
 /// Convenience extension for defining `RUMMonitorProtocol` methods with default parameter values.
 ///
-/// ⚠️ Be extra caucious when adding new methods here. Each method overloads (shadows) its original
+/// ⚠️ Be extra cautious when adding new methods here. Each method overloads (shadows) its original
 /// definition in extended protocol, which makes the Swift compiler no longer require it on the type conforming
 /// to `RUMMonitorProtocol`. If that conformance is not provided, it will cause an infinite recursive call and crash.
 ///

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -105,10 +105,10 @@ public struct DatadogInternalInterface {
         key: AttributeKey,
         value: AttributeValue
     ) {
-        let attributeCommand = RUMSetInternalViewAttributeCommand(
+        let attributeCommand = RUMAddViewAttributesCommand(
             time: time,
-            key: key,
-            value: value
+            attributes: [key: value],
+            areInternalAttributes: true
         )
         monitor.process(command: attributeCommand)
     }

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -35,7 +35,7 @@ public enum RUMErrorSource {
 }
 
 /// Public interface of RUM monitor for manual interaction with RUM feature.
-public protocol RUMMonitorProtocol: AnyObject {
+public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     // MARK: - attributes
 
     /// Adds a custom attribute to the next RUM events.
@@ -75,56 +75,6 @@ public protocol RUMMonitorProtocol: AnyObject {
     /// A new session will start in response to a call to `startView` or `addAction`.
     /// If the session is started because of a call to `addAction`, the last known view is restarted in the new session.
     func stopSession()
-
-    // MARK: - views
-
-    /// Starts RUM view.
-    /// - Parameters:
-    ///   - viewController: the instance of `UIViewController` representing this view.
-    ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
-    ///   - attributes: custom attributes to attach to this view.
-    func startView(
-        viewController: UIViewController,
-        name: String?,
-        attributes: [AttributeKey: AttributeValue]
-    )
-
-    /// Stops RUM view.
-    /// - Parameters:
-    ///   - viewController: the instance of `UIViewController` representing this view.
-    ///   - attributes: custom attributes to attach to this view.
-    func stopView(
-        viewController: UIViewController,
-        attributes: [AttributeKey: AttributeValue]
-    )
-
-    /// Starts RUM view.
-    /// - Parameters:
-    ///   - key: a `String` value identifying this view. It must match the `key` passed later to `stopView(key:attributes:)`.
-    ///   - name: the name of the view. If not provided, the `key` name will be used.
-    ///   - attributes: custom attributes to attach to this  view.
-    func startView(
-        key: String,
-        name: String?,
-        attributes: [AttributeKey: AttributeValue]
-    )
-
-    /// Stops RUM view.
-    /// - Parameters:
-    ///   - key: a `String` value identifying this view. It must match the `key` passed earlier to `startView(key:name:attributes:)`.
-    ///   - attributes: custom attributes to attach to this view.
-    func stopView(
-        key: String,
-        attributes: [AttributeKey: AttributeValue]
-    )
-
-    /// Adds view loading time to current RUM view based on the time elapsed since the view was started.
-    /// This method should be called only once per view.
-    /// If the view is not started, this method does nothing.
-    /// If the view is not active, this method does nothing.
-    /// - Parameter overwrite: if true, overwrites the previosuly calculated view loading time.
-    @_spi(Experimental)
-    func addViewLoadingTime(overwrite: Bool)
 
     // MARK: - custom timings
 
@@ -335,7 +285,83 @@ public protocol RUMMonitorProtocol: AnyObject {
     var debug: Bool { set get }
 }
 
-extension RUMMonitorProtocol {
+// MARK: - View Interface
+
+/// Public interface of RUM monitor for manual interaction with the active RUM View.
+public protocol RUMMonitorViewProtocol: AnyObject {
+    /// Adds a custom attribute to the active RUM View. It will be propagated to all future RUM events associated with the active View.
+    /// - Parameters:
+    ///   - key: key for this view attribute. See `AttributeKey`  documentation for more information.
+    ///   - value: any value that conforms to `Encodable`. See `AttributeValue` documentation
+    ///   for information about nested encoding containers limitation.
+    func addViewAttribute(forKey key: AttributeKey, value: AttributeValue)
+
+    /// Adds multiple attributes to the active RUM View. They will be propagated to all future RUM events associated with the active View.
+    /// - Parameter attributes: dictionary with view attributes. Each attribute is defined by a key `AttributeKey` and a value that conforms to `Encodable`.
+    func addViewAttributes(_ attributes: [AttributeKey: AttributeValue])
+
+    /// Removes an attribute from the active RUM View.
+    /// Future RUM events associated with the active View won't have this attribute.
+    /// Events created prior to this call will not lose this attribute.
+    /// - Parameter key: key for the view attribute that will be removed.
+    func removeViewAttribute(forKey key: AttributeKey)
+
+    /// Removes multiple attributes from the active RUM View.
+    /// Future RUM events associated with the active View won't have these attributes.
+    /// Events created prior to this call will not lose these attributes.
+    /// - Parameter keys: array of attribute keys that will be removed.
+    func removeViewAttributes(forKeys keys: [AttributeKey])
+
+    /// Starts RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `UIViewController` representing this view.
+    ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
+    ///   - attributes: custom attributes to attach to this view.
+    func startView(
+        viewController: UIViewController,
+        name: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Stops RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `UIViewController` representing this view.
+    ///   - attributes: custom attributes to attach to this view.
+    func stopView(
+        viewController: UIViewController,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Starts RUM view.
+    /// - Parameters:
+    ///   - key: a `String` value identifying this view. It must match the `key` passed later to `stopView(key:attributes:)`.
+    ///   - name: the name of the view. If not provided, the `key` name will be used.
+    ///   - attributes: custom attributes to attach to this  view.
+    func startView(
+        key: String,
+        name: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Stops RUM view.
+    /// - Parameters:
+    ///   - key: a `String` value identifying this view. It must match the `key` passed earlier to `startView(key:name:attributes:)`.
+    ///   - attributes: custom attributes to attach to this view.
+    func stopView(
+        key: String,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Adds view loading time to current RUM view based on the time elapsed since the view was started.
+    /// This method should be called only once per view.
+    /// If the view is not started, this method does nothing.
+    /// If the view is not active, this method does nothing.
+    /// - Parameter overwrite: if true, overwrites the previously calculated view loading time.
+    @_spi(Experimental)
+    func addViewLoadingTime(overwrite: Bool)
+}
+
+extension RUMMonitorViewProtocol {
     /// It cannot be declared '@_spi' without a default implementation in a protocol extension
     func addViewLoadingTime(overwrite: Bool) {
         // no-op
@@ -360,11 +386,6 @@ internal class NOPMonitor: RUMMonitorProtocol {
     func removeAttribute(forKey key: AttributeKey) { warn() }
     func removeAttributes(forKeys keys: [AttributeKey]) {warn() }
     func stopSession() { warn() }
-    func startView(viewController: UIViewController, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
-    func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) { warn() }
-    func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
-    func stopView(key: String, attributes: [AttributeKey: AttributeValue]) { warn() }
-    func addViewLoadingTime(overwrite: Bool) { warn() }
     func addTiming(name: String) { warn() }
     func addError(message: String, type: String?, stack: String?, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?) { warn() }
     func addError(error: Error, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]) { warn() }
@@ -387,4 +408,18 @@ internal class NOPMonitor: RUMMonitorProtocol {
             return false
         }
     }
+}
+
+extension NOPMonitor: RUMMonitorViewProtocol {
+    func addViewAttribute(forKey key: AttributeKey, value: AttributeValue) { warn() }
+    func addViewAttributes(_ attributes: [AttributeKey: AttributeValue]) { warn() }
+    func removeViewAttribute(forKey key: AttributeKey) { warn() }
+    func removeViewAttributes(forKeys keys: [AttributeKey]) { warn() }
+
+    func startView(viewController: UIViewController, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func stopView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func stopView(key: String, attributes: [AttributeKey: AttributeValue]) { warn() }
+
+    func addViewLoadingTime(overwrite: Bool) { warn() }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -393,7 +393,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
-        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute"), "value")
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute"))
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute"))
     }
 
@@ -416,8 +416,8 @@ class Monitor_GlobalAttributesTests: XCTestCase {
         let lastActiveView = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "ActiveView" }))
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
-        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"), "value1")
-        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute2"), "value2")
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute2"))
     }
@@ -443,7 +443,7 @@ class Monitor_GlobalAttributesTests: XCTestCase {
 
         XCTAssertEqual(lastInactiveView.view.resource.count, 1)
         XCTAssertNil(lastInactiveView.attribute(forKey: "attribute1"))
-        XCTAssertEqual(lastInactiveView.attribute(forKey: "attribute2"), "value2")
+        XCTAssertNil(lastInactiveView.attribute(forKey: "attribute2"))
         XCTAssertNil(lastActiveView.attribute(forKey: "attribute1"))
         XCTAssertEqual(lastActiveView.attribute(forKey: "attribute2"), "value2")
     }

--- a/DatadogRUM/Tests/RUMMonitor/RUMScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMScopeTests.swift
@@ -55,10 +55,7 @@ class RUMScopeTests: XCTestCase {
         var attributes: [AttributeKey: AttributeValue] = ["foo": "bar", "fizz": "buzz"]
         let additionalAttributes: [AttributeKey: AttributeValue] = ["foo": "bar 2", "baz": "qux"]
 
-        attributes.merge(rumCommandAttributes: additionalAttributes)
+        attributes.merge(additionalAttributes) { $1 }
         XCTAssertEqual(attributes as? [String: String], ["foo": "bar 2", "fizz": "buzz", "baz": "qux"], "`bar` should be overwritten")
-
-        attributes.merge(rumCommandAttributes: nil)
-        XCTAssertEqual(attributes as? [String: String], ["foo": "bar 2", "fizz": "buzz", "baz": "qux"])
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -815,6 +815,603 @@ class RUMViewScopeTests: XCTestCase {
         resourceEvents.forEach { XCTAssertEqual($0.dd.session?.sessionPrecondition, randomPrecondition) }
     }
 
+    // MARK: - View Attributes
+
+    func testWhenViewAttributesAreSet_nextEventsHaveThem() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    attributes: ["viewKey": "viewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["viewKey": "viewValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewAttributesCommand.mockWith(
+                    attributes: ["newViewKey": "newViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    attributes: ["anotherKey": "anotherValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue", "newViewKey": "newViewValue", "anotherKey": "anotherValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["viewKey": "viewValue", "newViewKey": "newViewValue", "anotherKey": "anotherValue"])
+    }
+
+    func testWhenViewAttributesAreRemoved_eventsDoNotIncludeThem() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    attributes: ["viewKey": "viewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["viewKey": "viewValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMRemoveViewAttributesCommand.mockWith(
+                    keysToRemove: ["viewKey"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, [:])
+        DDAssertDictionariesEqual(event.context!.contextInfo, [:])
+    }
+
+    func testWhenInternalViewAttributesAreSet_eventsAreNotAffected() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    attributes: ["viewKey": "viewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewAttributesCommand.mockWith(
+                    attributes: ["internalKey": "internalValue"],
+                    areInternalAttributes: true
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(scope.internalAttributes, ["internalKey": "internalValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["viewKey": "viewValue"])
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    attributes: ["viewKey": "newViewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "newViewValue"])
+        DDAssertDictionariesEqual(scope.internalAttributes, ["internalKey": "internalValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["viewKey": "newViewValue"])
+    }
+
+    // Attributes on views are immediately propagated to their child events after they are added.
+    func testWhenViewAttributesAreSet_childEventsHaveThem() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: [:],
+                    attributes: ["viewKey": "viewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["viewKey": "viewValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddUserActionCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["localKey": "localValue"],
+                    actionType: .custom
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        let actionEvent = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).last)
+        XCTAssertNil(scope.userActionScope, "It should not count custom action as pending")
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["viewKey": "viewValue", "globalKey": "globalValue"])
+        DDAssertDictionariesEqual(actionEvent.context!.contextInfo, ["viewKey": "viewValue", "globalKey": "globalValue", "localKey": "localValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewAttributesCommand.mockWith(
+                    attributes: ["newViewKey": "newViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand.mockAny(),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["resourceKey": "resourceValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        let resourceEvent = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue", "newViewKey": "newViewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["viewKey": "viewValue", "newViewKey": "newViewValue", "globalKey": "globalValue"])
+        DDAssertDictionariesEqual(
+            resourceEvent.context!.contextInfo,
+            [
+                "resourceKey": "resourceValue",
+                "viewKey": "viewValue",
+                "newViewKey": "newViewValue",
+                "globalKey": "globalValue"
+            ]
+        )
+    }
+
+    // Attributes are overwritten in events as they become more specific, so the precedence order is “Local, View, Global”.
+    func testWhenViewAttributesCollide_thePrecedenceIsRespected() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "viewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["key": "viewValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddUserActionCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "localValue"],
+                    actionType: .custom
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        let actionEvent = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["key": "viewValue"])
+        DDAssertDictionariesEqual(actionEvent.context!.contextInfo, ["key": "localValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand.mockAny(),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "resourceValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        viewEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        let resourceEvent = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(viewEvent.context!.contextInfo, ["key": "viewValue"])
+        DDAssertDictionariesEqual(resourceEvent.context!.contextInfo, ["key": "resourceValue"])
+    }
+
+    // View attributes are not added or overwritten after a view has “stopped”, even if that view is still active because of Resource or Action events.
+    // Changes to global attributes also do not affect “stopped” views, but should be transferred to other active events when they are stopped.
+    func testWhenViewAttributesChangeOnStoppedViewWithActiveResources() throws {
+        let view1 = "view1"
+        let view2 = "view2"
+        let firstViewScope: RUMViewScope = .mockWith(parent: parent, identity: ViewIdentifier(view1), name: view1)
+
+        // When
+        XCTAssertTrue(
+            firstViewScope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["viewKey": "viewValue"],
+                    identity: ViewIdentifier(view1),
+                    name: "view1"
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var view1Event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(firstViewScope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(view1Event.context!.contextInfo, ["viewKey": "viewValue", "globalKey": "globalValue"])
+
+        // When
+        XCTAssertTrue(
+            firstViewScope.process(
+                command: RUMStartResourceCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["resourceKey": "resourceValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        XCTAssertTrue(
+            firstViewScope.process(
+                command: RUMAddViewAttributesCommand.mockWith(
+                    attributes: ["newViewKey": "newViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        let startView2Command = RUMStartViewCommand.mockWith(
+            globalAttributes: ["globalKey": "globalValue"],
+            attributes: ["view2Key": "view2Value"],
+            identity: ViewIdentifier(view2),
+            name: view2
+        )
+        XCTAssertTrue(firstViewScope.process(command: startView2Command, context: context, writer: writer))
+        let secondViewScope: RUMViewScope = .mockWith(parent: parent, identity: ViewIdentifier(view2), name: view2)
+        XCTAssertTrue(secondViewScope.process(command: startView2Command, context: context, writer: writer))
+
+        // Then
+        view1Event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last(where: { $0.view.name == "view1" }))
+        let view2Event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last(where: { $0.view.name == "view2" }))
+        // First view scope is inactive with the final snapshot of attributes
+        DDAssertDictionariesEqual(firstViewScope.attributes, ["viewKey": "viewValue", "newViewKey": "newViewValue", "globalKey": "globalValue"])
+        DDAssertDictionariesEqual(secondViewScope.attributes, ["view2Key": "view2Value"])
+        DDAssertDictionariesEqual(view1Event.context!.contextInfo, ["viewKey": "viewValue", "newViewKey": "newViewValue", "globalKey": "globalValue"])
+        DDAssertDictionariesEqual(view2Event.context!.contextInfo, ["view2Key": "view2Value", "globalKey": "globalValue"])
+
+        // When
+        XCTAssertTrue(
+            secondViewScope.process(
+                command: RUMAddViewAttributesCommand.mockWith(
+                    attributes: ["newView2Key": "newView2Value"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        XCTAssertFalse(
+            firstViewScope.process(
+                command: RUMStopResourceCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue", "newGlobalKey": "newGlobalValue"],
+                    attributes: [:]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        view1Event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        let resourceEvent = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).last)
+        // First view scope is inactive with the final snapshot of attributes
+        DDAssertDictionariesEqual(firstViewScope.attributes, ["viewKey": "viewValue", "newViewKey": "newViewValue", "globalKey": "globalValue"])
+        DDAssertDictionariesEqual(secondViewScope.attributes, ["view2Key": "view2Value", "newView2Key": "newView2Value"])
+        DDAssertDictionariesEqual(
+            view1Event.context!.contextInfo,
+            [
+                "viewKey": "viewValue",
+                "newViewKey": "newViewValue",
+                "globalKey": "globalValue"
+            ]
+        )
+        DDAssertDictionariesEqual(
+            resourceEvent.context!.contextInfo,
+            [
+                "resourceKey": "resourceValue",
+                "viewKey": "viewValue",
+                "newViewKey": "newViewValue",
+                "globalKey": "globalValue",
+                "newGlobalKey": "newGlobalValue",
+            ]
+        )
+    }
+
+    // MARK: - Global Attributes
+
+    func testWhenGlobalAttributesAreUpdated_eventsHaveTheUpdate() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["viewKey": "viewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["globalKey": "globalValue", "viewKey": "viewValue"])
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    globalAttributes: ["globalKey": "newGlobalValue"],
+                    attributes: ["viewKey": "newViewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        // View scope is stopped with the final snapshot of attributes
+        DDAssertDictionariesEqual(scope.attributes, ["viewKey": "newViewValue", "globalKey": "newGlobalValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["globalKey": "newGlobalValue", "viewKey": "newViewValue"])
+    }
+
+    func testViewAttributesTakePrecedenceOverGlobalAttributes() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "viewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "viewValue"])
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    globalAttributes: ["key": "newGlobalValue"],
+                    attributes: ["key": "newViewValue"],
+                    identity: .mockViewIdentifier()
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "newViewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "newViewValue"])
+    }
+
+    func testCommandAttributesTakePrecendenceOverViewAttributesAndGlobalAttributes() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "viewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "viewValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddLongTaskCommand.mockWith(
+                    globalAttributes: ["key": "globalValue"],
+                    attributes: ["key": "localValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        let longTaskEvent = try XCTUnwrap(writer.events(ofType: RUMLongTaskEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(longTaskEvent.context!.contextInfo, ["key": "localValue"])
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    globalAttributes: ["key": "newGlobalValue"],
+                    attributes: ["key": "newViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "newViewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "newViewValue"])
+    }
+
+    // Removing global attributes is immediately reflected in attributes sent on View Update events and on child events.
+    func testWhenRemovingGlobalAttributes_eventsDoNotIncludeThem() throws {
+        let scope: RUMViewScope = .mockWith(parent: parent)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(
+                    globalAttributes: ["globalKey": "globalValue"],
+                    attributes: ["key": "viewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        var event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "viewValue", "globalKey": "globalValue"])
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewTimingCommand.mockWith(
+                    globalAttributes: [:],
+                    attributes: ["anotherViewKey": "anotherViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "viewValue", "anotherViewKey": "anotherViewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "viewValue", "anotherViewKey": "anotherViewValue"])
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(
+                    globalAttributes: [:],
+                    attributes: ["key": "newViewValue"]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+        // Then
+        event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
+        DDAssertDictionariesEqual(scope.attributes, ["key": "newViewValue", "anotherViewKey": "anotherViewValue"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["key": "newViewValue", "anotherViewKey": "anotherViewValue"])
+    }
+
     // MARK: - Resources Tracking
 
     func testItManagesResourceScopesLifecycle() throws {
@@ -1500,7 +2097,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertTrue(error.error.isCrash == false)
         XCTAssertNil(error.error.resource)
         XCTAssertNil(error.action)
-        XCTAssertEqual(error.context?.contextInfo as? [String: String], [:])
+        XCTAssertEqual(error.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(error.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
         XCTAssertEqual(error.source, .ios)
         XCTAssertEqual(error.service, "test-service")
@@ -1663,7 +2260,7 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let error = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).last)
-        DDAssertDictionariesEqual(error.context!.contextInfo, ["other_attribute": "overwritten", "foo": "bar"])
+        DDAssertDictionariesEqual(error.context!.contextInfo, ["test_attribute": "abc", "other_attribute": "overwritten", "foo": "bar"])
 
         XCTAssertEqual(scope.attributes["test_attribute"] as? String, "abc")
         XCTAssertEqual(scope.attributes["other_attribute"] as? String, "my attribute")
@@ -2341,7 +2938,7 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let event = try XCTUnwrap(writer.events(ofType: RUMLongTaskEvent.self).last)
-        DDAssertDictionariesEqual(event.context!.contextInfo, ["foo": "bar", "test_attribute": "overwritten"])
+        DDAssertDictionariesEqual(event.context!.contextInfo, ["foo": "bar", "test_attribute": "overwritten", "other_attribute": "my attribute"])
         DDAssertDictionariesEqual(scope.attributes, ["test_attribute": "abc", "other_attribute": "my attribute"])
     }
 
@@ -3142,10 +3739,10 @@ class RUMViewScopeTests: XCTestCase {
         let mockKey: String = .mockRandom()
         let mockValue: String = .mockRandom()
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: mockKey,
-                value: mockValue
+                attributes: [mockKey: mockValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
@@ -3176,10 +3773,10 @@ class RUMViewScopeTests: XCTestCase {
         let mockKey: String = .mockRandom()
         let mockValue: String = .mockRandom()
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: mockKey,
-                value: mockValue
+                attributes: [mockKey: mockValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
@@ -3188,10 +3785,10 @@ class RUMViewScopeTests: XCTestCase {
         // When
         let updatedValue: String = .mockRandom()
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: mockKey,
-                value: updatedValue
+                attributes: [mockKey: updatedValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
@@ -3231,10 +3828,10 @@ class RUMViewScopeTests: XCTestCase {
         let mockKey: String = .mockRandom()
         let mockValue: String = .mockRandom()
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: mockKey,
-                value: mockValue
+                attributes: [mockKey: mockValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
@@ -3266,10 +3863,10 @@ class RUMViewScopeTests: XCTestCase {
         )
         let fbcValue = Int64.mockRandom(min: 0)
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: CrossPlatformAttributes.flutterFirstBuildComplete,
-                value: fbcValue
+                attributes: [CrossPlatformAttributes.flutterFirstBuildComplete: fbcValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
@@ -3291,7 +3888,7 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     // Custom INV Values
-    func testGivenCustomINVValuess_itSetsTheValueOnTheViewEvent() throws {
+    func testGivenCustomINVValues_itSetsTheValueOnTheViewEvent() throws {
         // Given
         let viewStartDate = Date()
         let viewID: RUMUUID = .mockRandom()
@@ -3309,22 +3906,21 @@ class RUMViewScopeTests: XCTestCase {
             serverTimeOffset: .mockRandom(),
             interactionToNextViewMetric: nil
         )
+
+        // When
         let invValue = Int64.mockRandom(min: 0, max: 100_000_000)
         _ = scope.process(
-            command: RUMSetInternalViewAttributeCommand(
+            command: RUMAddViewAttributesCommand(
                 time: .mockAny(),
-                key: CrossPlatformAttributes.customINVValue,
-                value: invValue
+                attributes: [CrossPlatformAttributes.customINVValue: invValue],
+                areInternalAttributes: true
             ),
             context: context,
             writer: writer
         )
 
-        // When
-        // Though this property would be unlikely to be set during StartView, processing
-        // the StartViewCommand will give us a view update, which is what we want.
         _ = scope.process(
-            command: RUMStartViewCommand.mockWith(identity: .mockViewIdentifier()),
+            command: RUMStopViewCommand.mockAny(),
             context: context,
             writer: writer
         )

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -197,6 +197,60 @@ extension RUMCommand {
     }
 }
 
+extension RUMAddViewAttributesCommand: AnyMockable, RandomMockable {
+    public static func mockAny() -> RUMAddViewAttributesCommand { mockWith() }
+
+    public static func mockRandom() -> RUMAddViewAttributesCommand {
+        .mockWith(
+            time: .mockRandomInThePast(),
+            globalAttributes: mockRandomAttributes(),
+            attributes: mockRandomAttributes(),
+            areInternalAttributes: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        time: Date = Date(),
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
+        attributes: [AttributeKey: AttributeValue] = [:],
+        areInternalAttributes: Bool = .mockAny()
+    ) -> RUMAddViewAttributesCommand {
+        RUMAddViewAttributesCommand(
+            time: time,
+            globalAttributes: globalAttributes,
+            attributes: attributes,
+            areInternalAttributes: areInternalAttributes
+        )
+    }
+}
+
+extension RUMRemoveViewAttributesCommand: AnyMockable, RandomMockable {
+    public static func mockAny() -> RUMRemoveViewAttributesCommand { mockWith() }
+
+    public static func mockRandom() -> RUMRemoveViewAttributesCommand {
+        .mockWith(
+            time: .mockRandomInThePast(),
+            globalAttributes: mockRandomAttributes(),
+            attributes: mockRandomAttributes(),
+            keysToRemove: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        time: Date = Date(),
+        globalAttributes: [AttributeKey: AttributeValue] = [:],
+        attributes: [AttributeKey: AttributeValue] = [:],
+        keysToRemove: [AttributeKey] = []
+    ) -> RUMRemoveViewAttributesCommand {
+        RUMRemoveViewAttributesCommand(
+            time: time,
+            globalAttributes: globalAttributes,
+            attributes: attributes,
+            keysToRemove: keysToRemove
+        )
+    }
+}
+
 extension RUMStartViewCommand: AnyMockable, RandomMockable {
     public static func mockAny() -> RUMStartViewCommand { mockWith() }
 


### PR DESCRIPTION
### What and why?

This PR aligns the propagation of custom attributes across dependent scopes.
It is part of a broader effort to ensure consistent attribute management across all SDKs (iOS, Android, Browser, etc.).

### How?
This is a task to handle the management of `View` attributes discussed in the  [RFC - internal](https://datadoghq.atlassian.net/wiki/x/QoFRGwE).

It introduces a new public interface to add View attributes:
```swift
public protocol RUMMonitorViewProtocol: AnyObject {
    func addViewAttribute(forKey key: AttributeKey, value: AttributeValue)
    func addViewAttributes(_ attributes: [AttributeKey: AttributeValue])

    func removeViewAttribute(forKey key: AttributeKey)
    func removeViewAttributes(forKeys keys: [AttributeKey])
}
```

These attributes will be attached to the current active View that will store them during its lifecycle. Additionally, these view attributes will be automatically propagated downward to the child events. 

In case of name collisions, attribute precedence is as follows:
Event level attributes overwrite View level attributes, which in turn overwrite global attributes.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)