### PR TITLE
RUM-9496: Deprecate `DatadogObjc.podspec`

### DIFF
--- a/DatadogObjc.podspec
+++ b/DatadogObjc.podspec
@@ -2,6 +2,10 @@ Pod::Spec.new do |s|
   s.name         = "DatadogObjc"
   s.version      = "2.28.0"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
+  s.description  = <<-DESC
+                   The DatadogObjc pod is deprecated and will no longer be maintained.
+                   Starting with version 3.0.0, Objective-C interfaces are available directly in their respective feature modules.
+                   DESC
 
   s.homepage     = "https://www.datadoghq.com"
   s.social_media_url   = "https://twitter.com/datadoghq"
@@ -13,6 +17,8 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com",
     "Maciej Burda" => "maciej.burda@datadoghq.com"
   }
+
+  s.deprecated = true
 
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
### What and why?

 This PR deprecates the `DatadogObjc` pod.
 Starting with version [3.0.0](https://github.com/DataDog/dd-sdk-ios/tree/feature/v3), Objective-C interfaces are only available directly in their respective modules.

### How?

`DatadogObjc.podspec` is marked deprecated.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
