### PR TITLE
Release `2.28.1`

### DIFF
--- a/DatadogAlamofireExtension.podspec
+++ b/DatadogAlamofireExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogAlamofireExtension"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   s.description  = <<-DESC
                    The DatadogAlamofireExtension pod is deprecated and will no longer be maintained.

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCore"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogCore/Sources/Versioning.swift
+++ b/DatadogCore/Sources/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "2.28.0"
+internal let __sdkVersion = "2.28.1"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCrashReporting"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogInternal"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog Internal Package. This module is not for public use."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogLogs"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog Logs Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogObjc.podspec
+++ b/DatadogObjc.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogObjc"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -6,8 +6,9 @@
 
 import Foundation
 import UIKit
-import DatadogInternal
 import DatadogRUM
+
+import struct DatadogInternal.AnyEncodable
 
 internal struct UIKitRUMViewsPredicateBridge: UIKitRUMViewsPredicate {
     let objcPredicate: DDUIKitRUMViewsPredicate

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogRUM"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog Real User Monitoring Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -8,6 +8,10 @@ import UIKit
 import Foundation
 import DatadogInternal
 
+// swiftlint:disable duplicate_imports
+@_exported import enum DatadogInternal.RUMMethod
+// swiftlint:enable duplicate_imports
+
 /// The type of RUM resource.
 public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
 

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSessionReplay"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Official Datadog Session Replay SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogTrace"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog Trace Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogWebViewTracking"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog WebView Tracking Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TestUtilities"
-  s.version      = "2.28.0"
+  s.version      = "2.28.1"
   s.summary      = "Datadog Testing Utilities. This module is for internal testing and should not be published."
 
   s.homepage     = "https://www.datadoghq.com"


### PR DESCRIPTION
### What and why?

Hotfix `2.28.1`: Fix breaking changes where `RUMMethod` is no longer exposed by RUM module

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
