### PR TITLE
FFM-43309 PLCrashReporter can now be configured to use mach or BSD

### DIFF
--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -21,8 +21,8 @@ import DatadogInternal
 public final class CrashReporting {
     /// Initializes the Datadog Crash Reporter using the default
     /// `PLCrashReporter` plugin.
-    public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default) {
-        enable(with: PLCrashReporterPlugin(), in: core)
+    public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default, useMachExceptions: Bool = false) {
+        enable(with: PLCrashReporterPlugin(useMachExceptions: useMachExceptions), in: core)
     }
 
     /// Initializes the Datadog Crash Reporter with a custom Crash Reporting Plugin.

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterPlugin.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterPlugin.swift
@@ -19,6 +19,11 @@ internal class PLCrashReporterPlugin: NSObject, CrashReportingPlugin {
         self.init { try PLCrashReporterIntegration() }
     }
 
+    // Overrides PLCrashReporterConfig to use the "mach" signal handler type instead of "BSD". Defaults to false
+    convenience init(useMachExceptions: Bool = false) {
+        self.init { try PLCrashReporterIntegration(useMachExceptions: useMachExceptions) }
+    }
+    
     internal init(thirdPartyCrashReporterFactory: () throws -> ThirdPartyCrashReporter) {
         PLCrashReporterPlugin.enableOnce(using: thirdPartyCrashReporterFactory)
     }


### PR DESCRIPTION
### What and why?

This PR adds a `useMachExceptions` parameter to the initializer for `PLCrashReporterPlugin` which allows us to configure which signal handler to use. The default is still BSD.

### How?

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
