### PR TITLE
Add workflow: Changelog update to Confluence

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -1,6 +1,6 @@
 name: Publish Changelog to Confluence
 on:
-    pull_request:
+    push:
         branches:
             - develop
         paths:

--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -1,0 +1,31 @@
+name: Publish Changelog to Confluence
+on:
+    pull_request:
+        branches:
+            - develop
+        paths:
+            - 'CHANGELOG.md'
+permissions:
+    contents: read
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+
+            - name: Prepare Only Changelog
+              run: |
+                  mkdir -p publish_folder
+                  cp CHANGELOG.md publish_folder/dd-ios-sdk-changelog.md
+                  echo "Publishing only CHANGELOG.md"
+
+            - name: Publish Markdown to Confluence
+              uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5
+              with:
+                  confluenceBaseUrl: ${{ secrets.CONFLUENCE_BASE_URL }}
+                  confluenceParentId: ${{ secrets.CONFLUENCE_PARENT_ID }}
+                  atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
+                  atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+                  contentRoot: '.'
+                  folderToPublish: 'publish_folder'


### PR DESCRIPTION
### What and why?

A short description of what changes this PR introduces and why.
- Adds a workflow changelog-to-confluence.yaml to import the Changelog release notes to confluence.
- The release notes are disperced by products which makes difficult to find the release notes information.

[TEEP-967](https://datadoghq.atlassian.net/browse/TEEP-967)

### How?

A brief description of implementation details of this PR.
- Adds an workflow to publish the Changelog.md file to confluence.

### Before merging
- Configure Github secrets on the repo.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integra
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)


[TEEP-967]: https://datadoghq.atlassian.net/browse/TEEP-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ