### PR TITLE
RUM-9335 Fix missing app ID in Session Ended metric

### DIFF
--- a/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
+++ b/DatadogInternal/Sources/SDKMetrics/SDKMetricFields.swift
@@ -17,4 +17,9 @@ public enum SDKMetricFields {
     /// When attached to metric attributes, the value of this key (session ID) will be used to replace
     /// the ID of session that the metric was collected in. The key itself is dropped before the metric is sent.
     public static let sessionIDOverrideKey = "session_id_override"
+    /// Key referencing the application ID (`String`) that the metric should be sent with. It expects `String` value.
+    ///
+    /// When attached to metric attributes, the value of this key (application ID) will be used to replace
+    /// the ID of application that the metric was collected in. The key itself is dropped before the metric is sent.
+    public static let applicationIDOverrideKey = "application_id_override"
 }

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -43,8 +43,11 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
         let featureScope = core.scope(for: RUMFeature.self)
         let sessionEndedMetric = SessionEndedMetricController(
-            telemetry: core.telemetry,
-            sampleRate: configuration.debugSDK ? 100 : configuration.sessionEndedSampleRate
+            dependencies: .init(
+                telemetry: core.telemetry,
+                applicationID: configuration.applicationID,
+                sampleRate: configuration.debugSDK ? 100 : configuration.sessionEndedSampleRate
+            )
         )
         let tnsPredicateType = configuration.networkSettledResourcePredicate.metricPredicateType
         let invPredicateType = configuration.nextViewActionPredicate?.metricPredicateType ?? .disabled

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -259,6 +259,10 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
             let sessionIDOverride: String? = attributes.removeValue(forKey: SDKMetricFields.sessionIDOverrideKey)?.dd.decode()
             let sessionID = sessionIDOverride ?? rum?.sessionID
 
+            // Override applicationID using standard `SDKMetricFields`, otherwise use current RUM application ID:
+            let applicationIDOverride: String? = attributes.removeValue(forKey: SDKMetricFields.applicationIDOverrideKey)?.dd.decode()
+            let applicationID = applicationIDOverride ?? rum?.applicationID
+
             // Calculates the composition of sample rates. The metric can have up to 3 layers of sampling.
             var effectiveSampleRate = metric.sampleRate.composed(with: self.sampler.samplingRate)
             if let headSampleRate = attributes.removeValue(forKey: SDKMetricFields.headSampleRate) as? SampleRate {
@@ -268,7 +272,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
             let event = TelemetryDebugEvent(
                 dd: .init(),
                 action: rum?.userActionID.map { .init(id: $0) },
-                application: rum.map { .init(id: $0.applicationID) },
+                application: applicationID.map { .init(id: $0) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
                 effectiveSampleRate: Double(effectiveSampleRate),
                 experimentalFeatures: nil,

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -39,8 +39,11 @@ internal class SessionEndedMetric {
         static let rseKey = "rse"
     }
 
-   /// An ID of the session being tracked through this metric object.
+    /// An ID of the session being tracked through this metric object.
     let sessionID: RUMUUID
+
+    /// An ID of the session being tracked through this metric object.
+    let applicationID: String
 
     /// The type of OS component where the session was tracked.
     private let bundleType: BundleType
@@ -121,16 +124,19 @@ internal class SessionEndedMetric {
     /// Initializer.
     /// - Parameters:
     ///   - sessionID: An ID of the session that is being tracked with this metric.
+    ///   - applicationID: The RUM application ID for this session.
     ///   - precondition: The precondition that led to starting this session.
     ///   - context: The SDK context at the moment of starting this session.
     ///   - tracksBackgroundEvents: If background events tracking is enabled for this session.
     init(
         sessionID: RUMUUID,
+        applicationID: String,
         precondition: RUMSessionPrecondition?,
         context: DatadogContext,
         tracksBackgroundEvents: Bool
     ) {
         self.sessionID = sessionID
+        self.applicationID = applicationID
         self.bundleType = context.applicationBundleType
         self.precondition = precondition
         self.tracksBackgroundEvents = tracksBackgroundEvents
@@ -413,6 +419,7 @@ internal class SessionEndedMetric {
         return [
             SDKMetricFields.typeKey: Constants.typeValue,
             SDKMetricFields.sessionIDOverrideKey: sessionID.toRUMDataFormat,
+            SDKMetricFields.applicationIDOverrideKey: applicationID,
             Constants.rseKey: Attributes(
                 processType: {
                     switch bundleType {

--- a/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryInterceptorTests.swift
@@ -16,7 +16,7 @@ class TelemetryInterceptorTests: XCTestCase {
         let sessionID: RUMUUID = .mockRandom()
 
         // Given
-        let metricController = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let metricController = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 100))
         let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
 
         // When
@@ -36,7 +36,7 @@ class TelemetryInterceptorTests: XCTestCase {
         let sessionID: RUMUUID = .mockRandom()
 
         // Given
-        let metricController = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let metricController = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 100))
         let interceptor = TelemetryInterceptor(sessionEndedMetric: metricController)
 
         // When

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -456,21 +456,23 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(os.build, deviceMock.osBuildNumber)
     }
 
-    func testSendTelemetryMetricWithRUMContextAndSessionIDOverride() {
+    func testSendTelemetryMetricWithRUMContextAndOverrides() {
         // Given
         let rumContext: RUMCoreContext = .mockRandom()
         featureScope.contextMock.set(additionalContext: rumContext)
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
         let sessionIDOverride = "session-id-override"
+        let applicationIDOverride = "application-id-override"
 
         // When
         var attributes = mockRandomAttributes()
         attributes[SDKMetricFields.sessionIDOverrideKey] = sessionIDOverride
+        attributes[SDKMetricFields.applicationIDOverrideKey] = applicationIDOverride
         TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: attributes, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
-        XCTAssertEqual(event?.application?.id, rumContext.applicationID)
+        XCTAssertEqual(event?.application?.id, applicationIDOverride)
         XCTAssertEqual(event?.session?.id, sessionIDOverride)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
         XCTAssertEqual(event?.action?.id, rumContext.userActionID)

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -92,7 +92,7 @@ class RUMTests: XCTestCase {
         XCTAssertEqual(rum.performanceOverride.maxFileAgeForRead, 24.hours)
         XCTAssertEqual(monitor.scopes.dependencies.rumApplicationID, applicationID)
         XCTAssertEqual(monitor.scopes.dependencies.sessionSampler.samplingRate, 100)
-        XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.sampleRate, 15)
+        XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.dependencies.sampleRate, 15)
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 20)
         XCTAssertEqual(crashReportReceiver?.sessionSampler.samplingRate, 100)
     }

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricControllerTests.swift
@@ -18,7 +18,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let errorKinds: [String] = .mockRandom(count: 5)
 
         // Given
-        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 4.2)
+        let controller = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 4.2))
         controller.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
 
         // When
@@ -43,7 +43,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let sessionID2: RUMUUID = .mockRandom()
 
         // When
-        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let controller = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 100))
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Session 1:
@@ -75,7 +75,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
         let sessionID2: RUMUUID = .mockRandom()
 
         // When
-        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let controller = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 100))
         controller.startMetric(sessionID: sessionID1, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         controller.startMetric(sessionID: sessionID2, precondition: .mockRandom(), context: .mockRandom(), tracksBackgroundEvents: .mockRandom())
         // Track latest session (`sessionID: nil`)
@@ -98,7 +98,7 @@ class SessionEndedMetricControllerTests: XCTestCase {
 
     func testTrackingSessionEndedMetricIsThreadSafe() {
         let sessionIDs: [RUMUUID] = .mockRandom(count: 10)
-        let controller = SessionEndedMetricController(telemetry: telemetry, sampleRate: 100)
+        let controller = SessionEndedMetricController(dependencies: .init(telemetry: telemetry, applicationID: .mockRandom(), sampleRate: 100))
 
         // swiftlint:disable opening_brace
         callConcurrently(

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -58,6 +58,20 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertEqual(attributes[SDKMetricFields.sessionIDOverrideKey] as? String, sessionID.toRUMDataFormat)
     }
 
+    // MARK: - Application ID
+
+    func testReportingApplicationID() throws {
+        // Given
+        let expectedApplicationID = "test-app-id"
+        let metric = SessionEndedMetric.with(sessionID: sessionID, applicationID: expectedApplicationID)
+
+        // When
+        let attributes = metric.asMetricAttributes()
+
+        // Then
+        XCTAssertEqual(attributes[SDKMetricFields.applicationIDOverrideKey] as? String, expectedApplicationID)
+    }
+
     // MARK: - Process Type
 
     func testReportingAppProcessType() throws {
@@ -678,11 +692,12 @@ private extension Int {
 private extension SessionEndedMetric {
     static func with(
         sessionID: RUMUUID,
+        applicationID: String = .mockRandom(),
         precondition: RUMSessionPrecondition? = .mockRandom(),
         context: DatadogContext = .mockRandom(),
         tracksBackgroundEvents: Bool = .mockRandom()
     ) -> SessionEndedMetric {
-        SessionEndedMetric(sessionID: sessionID, precondition: precondition, context: context, tracksBackgroundEvents: tracksBackgroundEvents)
+        SessionEndedMetric(sessionID: sessionID, applicationID: applicationID, precondition: precondition, context: context, tracksBackgroundEvents: tracksBackgroundEvents)
     }
 
     func asMetricAttributes() -> [String: Encodable] {

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -785,7 +785,7 @@ extension RUMScopeDependencies {
         onSessionStart: @escaping RUM.SessionListener = mockNoOpSessionListener(),
         viewCache: ViewCache = ViewCache(dateProvider: SystemDateProvider()),
         fatalErrorContext: FatalErrorContextNotifying = FatalErrorContextNotifierMock(),
-        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(telemetry: NOPTelemetry(), sampleRate: 0),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(dependencies: .init(telemetry: NOPTelemetry(), applicationID: .mockAny(), sampleRate: 0)),
         viewEndedMetricFactory: @escaping () -> ViewEndedController = {
             ViewEndedController(telemetry: NOPTelemetry(), sampleRate: 0)
         },


### PR DESCRIPTION
### What and why?

This PR fixes the missing application ID in RUM Session Ended telemetry. This can happen when stopping a session manually with `RUMMonitor`.

### How?

For consistency, application ID follows the same override pattern as session ID, using `application_id_override` which gets transformed to `application.id` by the `TelemetryReceiver`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
