### PR TITLE
RUM-9997 Adjust "ApplicationLaunch" view for tvOS scene-based apps

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -555,11 +555,6 @@
 		6119DDCC2DD24A9600DA80F9 /* RUMSessionStopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC42DD24A9600DA80F9 /* RUMSessionStopTests.swift */; };
 		6119DDCD2DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift */; };
 		6119DDCE2DD24A9600DA80F9 /* RUMSessionTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC52DD24A9600DA80F9 /* RUMSessionTestsBase.swift */; };
-		6119DDCF2DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC72DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift */; };
-		6119DDD02DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC62DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift */; };
-		6119DDD12DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC22DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift */; };
-		6119DDD22DD24A9600DA80F9 /* RUMSessionStopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC42DD24A9600DA80F9 /* RUMSessionStopTests.swift */; };
-		6119DDD32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDC32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift */; };
 		6119DDDA2DD24AB700DA80F9 /* AppRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDD42DD24AB700DA80F9 /* AppRun.swift */; };
 		6119DDDB2DD24AB700DA80F9 /* AppRunStep+Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDD62DD24AB700DA80F9 /* AppRunStep+Fixtures.swift */; };
 		6119DDDC2DD24AB700DA80F9 /* AppRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6119DDD52DD24AB700DA80F9 /* AppRunner.swift */; };
@@ -638,6 +633,9 @@
 		615192CE2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */; };
 		615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */; };
 		615192D12BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */; };
+		61536ABE2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */; };
+		61536ABF2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */; };
+		61536AC02DF21A0500B06D7D /* LaunchReasonResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */; };
 		6156A9072BF75A7C00DF66C3 /* ImmutableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156A9062BF75A7C00DF66C3 /* ImmutableRequestTests.swift */; };
 		6156A9082BF75A7C00DF66C3 /* ImmutableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156A9062BF75A7C00DF66C3 /* ImmutableRequestTests.swift */; };
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
@@ -749,6 +747,9 @@
 		619CE75F2A458CE1005588CB /* TraceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */; };
 		619CE7612A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
 		619CE7622A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
+		619F1A242DEE493F003954BD /* LaunchReasonResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */; };
+		619F1A252DEE493F003954BD /* LaunchReasonResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */; };
+		619F1A282DEF0B3F003954BD /* LaunchReasonResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */; };
 		61A2CC212A443D330000FF25 /* DDRUMConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */; };
 		61A2CC222A443D330000FF25 /* DDRUMConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */; };
 		61A2CC242A44454D0000FF25 /* DDRUMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC232A44454D0000FF25 /* DDRUMTests.swift */; };
@@ -2723,6 +2724,7 @@
 		615192CC2BD6948B0005A782 /* HTTPHeadersWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersWriterTests.swift; sourceTree = "<group>"; };
 		615192CF2BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogTracer+InjectAndExtract.swift"; sourceTree = "<group>"; };
 		6152C84224BE2165006A1679 /* MockServerAddress.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockServerAddress.local.xcconfig; sourceTree = "<group>"; };
+		61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionTrackingTests.swift; sourceTree = "<group>"; };
 		615519252461BCE7002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519262461BCE7002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
 		61569894256D0E9A00C6AADA /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -2829,6 +2831,8 @@
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
 		619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceConfigurationTests.swift; sourceTree = "<group>"; };
 		619CE7602A458D66005588CB /* TraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTests.swift; sourceTree = "<group>"; };
+		619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReasonResolver.swift; sourceTree = "<group>"; };
+		619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReasonResolverTests.swift; sourceTree = "<group>"; };
 		61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMConfigurationTests.swift; sourceTree = "<group>"; };
 		61A2CC232A44454D0000FF25 /* DDRUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMTests.swift; sourceTree = "<group>"; };
 		61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceConfiguration.swift; sourceTree = "<group>"; };
@@ -5119,6 +5123,7 @@
 				61C1510C25AC8C1B00362D4B /* ViewIdentifierTests.swift */,
 				61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */,
 				D253EE982B98B3690010B589 /* ViewCacheTests.swift */,
+				619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5179,6 +5184,7 @@
 		61494B7827F3522C0082BBCC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */,
 				61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */,
 				61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */,
 				D253EE952B988CA90010B589 /* ViewCache.swift */,
@@ -5797,6 +5803,7 @@
 				6119DDC62DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift */,
 				6119DDC42DD24A9600DA80F9 /* RUMSessionStopTests.swift */,
 				6119DDC72DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift */,
+				61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */,
 				A757AE8F2D3815AC00C772FA /* AnonymousIdentifierTests.swift */,
 				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
 				1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */,
@@ -8310,6 +8317,7 @@
 				6119DDDE2DD24AB700DA80F9 /* AppRun.swift in Sources */,
 				6119DDDF2DD24AB700DA80F9 /* AppRunStep+Fixtures.swift in Sources */,
 				6119DDE02DD24AB700DA80F9 /* AppRunner.swift in Sources */,
+				61536ABE2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift in Sources */,
 				118248682D908CF400E3D16F /* WatchdogTerminationsMonitoringTests.swift in Sources */,
 				6119DDEE2DD4E94300DA80F9 /* AppRunStep.swift in Sources */,
 				118248692D908CF400E3D16F /* AppHangsMonitoringTests.swift in Sources */,
@@ -8345,16 +8353,12 @@
 				6119DDDA2DD24AB700DA80F9 /* AppRun.swift in Sources */,
 				6119DDDB2DD24AB700DA80F9 /* AppRunStep+Fixtures.swift in Sources */,
 				6119DDDC2DD24AB700DA80F9 /* AppRunner.swift in Sources */,
+				61536ABF2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift in Sources */,
 				1182492D2D9096B400E3D16F /* WebEventIntegrationTests.swift in Sources */,
 				6119DDED2DD4E94300DA80F9 /* AppRunStep.swift in Sources */,
 				1182492E2D9096B400E3D16F /* WebRecordIntegrationTests.swift in Sources */,
 				1182492F2D9096B400E3D16F /* WatchdogTerminationsMonitoringTests.swift in Sources */,
 				6119DDCE2DD24A9600DA80F9 /* RUMSessionTestsBase.swift in Sources */,
-				6119DDCF2DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift in Sources */,
-				6119DDD02DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift in Sources */,
-				6119DDD12DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift in Sources */,
-				6119DDD22DD24A9600DA80F9 /* RUMSessionStopTests.swift in Sources */,
-				6119DDD32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift in Sources */,
 				118249302D9096B400E3D16F /* NetworkInstrumentationIntegrationTests.swift in Sources */,
 				118249312D9096B400E3D16F /* GeneratingBacktraceTests.swift in Sources */,
 				118249322D9096B400E3D16F /* RUMSessionEndedMetricIntegrationTests.swift in Sources */,
@@ -9091,6 +9095,7 @@
 				D23F8E6B29DDCD28001CFAE8 /* RUMMonitor.swift in Sources */,
 				D23F8E6C29DDCD28001CFAE8 /* RUMContextProvider.swift in Sources */,
 				61DA6F6D2BB57E32009537E5 /* FatalErrorBuilder.swift in Sources */,
+				619F1A242DEE493F003954BD /* LaunchReasonResolver.swift in Sources */,
 				D23F8E6D29DDCD28001CFAE8 /* ViewIdentifier.swift in Sources */,
 				49D8C0B82AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D23F8E6E29DDCD28001CFAE8 /* RUMViewsHandler.swift in Sources */,
@@ -9171,6 +9176,7 @@
 				D23F8EA629DDCD38001CFAE8 /* RUMDeviceInfoTests.swift in Sources */,
 				D23F8EA829DDCD38001CFAE8 /* RUMResourceScopeTests.swift in Sources */,
 				3CFF4FA52C0E0FE9006F191D /* WatchdogTerminationCheckerTests.swift in Sources */,
+				619F1A282DEF0B3F003954BD /* LaunchReasonResolverTests.swift in Sources */,
 				D23F8EAC29DDCD38001CFAE8 /* RUMDataModelsMappingTests.swift in Sources */,
 				D23F8EAD29DDCD38001CFAE8 /* RUMEventBuilderTests.swift in Sources */,
 				61CE2E602BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift in Sources */,
@@ -9531,6 +9537,7 @@
 				D29A9F6329DD85BB005C54A4 /* RUMMonitor.swift in Sources */,
 				D29A9F7029DD85BB005C54A4 /* RUMContextProvider.swift in Sources */,
 				61DA6F6C2BB57E32009537E5 /* FatalErrorBuilder.swift in Sources */,
+				619F1A252DEE493F003954BD /* LaunchReasonResolver.swift in Sources */,
 				D29A9F6029DD85BB005C54A4 /* ViewIdentifier.swift in Sources */,
 				49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				D29A9F7629DD85BB005C54A4 /* RUMViewsHandler.swift in Sources */,
@@ -9641,6 +9648,7 @@
 				6105C4FA2CEBD72600C4C5EE /* TNSMetricTests.swift in Sources */,
 				D29A9FB729DDB483005C54A4 /* ViewIdentifierTests.swift in Sources */,
 				D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */,
+				61536AC02DF21A0500B06D7D /* LaunchReasonResolverTests.swift in Sources */,
 				D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				D29A9FA229DDB483005C54A4 /* RUMEventSanitizerTests.swift in Sources */,
 				3CEC57732C16FD0B0042B5F2 /* WatchdogTerminationMocks.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
@@ -17,6 +17,12 @@ extension AppRunStep {
         })
     }
 
+    static func advanceTime(by duration: TimeInterval) -> AppRunStep {
+        return AppRunStep({ app in
+            app.advanceTime(by: duration)
+        })
+    }
+
     static func appBecomesActive(after dt: TimeInterval) -> AppRunStep {
         return AppRunStep({ app in
             app.advanceTime(by: dt)
@@ -114,6 +120,20 @@ extension AppRunStep {
             app.rum._internal?.addLongTask(at: app.currentTime, duration: duration1)
             app.advanceTime(by: dt2)
             app.rum._internal?.addLongTask(at: app.currentTime, duration: duration2)
+        })
+    }
+
+    static func startResource(after dt: TimeInterval, key: String, url: URL) -> AppRunStep {
+        return AppRunStep({ app in
+            app.advanceTime(by: dt)
+            app.rum.startResource(resourceKey: key, url: url)
+        })
+    }
+
+    static func stopResource(after dt: TimeInterval, key: String) -> AppRunStep {
+        return AppRunStep({ app in
+            app.advanceTime(by: dt)
+            app.rum.stopResource(resourceKey: key, response: .mockAny())
         })
     }
 }

--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
@@ -29,8 +29,14 @@ internal class AppRunner {
         ///
         /// Sets `TASK_FOREGROUND_APPLICATION` as the task policy role — confirmed through local testing.
         static func userLaunchInSceneDelegateBasedApp(processLaunchDate: Date) -> ProcessLaunchType {
+            #if os(iOS)
+            let taskPolicyRole = Int(TASK_FOREGROUND_APPLICATION.rawValue)
+            #else
+            let taskPolicyRole = __dd_private_TASK_POLICY_UNAVAILABLE
+            #endif
+
             return .init(
-                taskPolicyRole: Int(TASK_FOREGROUND_APPLICATION.rawValue),
+                taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
                 initialAppState: .background,
@@ -43,8 +49,14 @@ internal class AppRunner {
         ///
         /// Sets `TASK_FOREGROUND_APPLICATION` as the task policy role — confirmed through local testing.
         static func userLaunchInAppDelegateBasedApp(processLaunchDate: Date) -> ProcessLaunchType {
+            #if os(iOS)
+            let taskPolicyRole = Int(TASK_FOREGROUND_APPLICATION.rawValue)
+            #else
+            let taskPolicyRole = __dd_private_TASK_POLICY_UNAVAILABLE
+            #endif
+
             return .init(
-                taskPolicyRole: Int(TASK_FOREGROUND_APPLICATION.rawValue),
+                taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
                 initialAppState: .inactive,
@@ -57,6 +69,7 @@ internal class AppRunner {
         /// Sets `TASK_DARWINBG_APPLICATION` as the task policy role, though this has not been confirmed
         /// in prewarming scenarios. This uncertainty is acceptable, as the `"ActivePrewarm"` flag in
         /// `ProcessInfo.environment` takes precedence when classifying prewarming.
+        @available(tvOS, unavailable)
         static func osPrewarm(processLaunchDate: Date) -> ProcessLaunchType {
             return .init(
                 taskPolicyRole: Int(TASK_DARWINBG_APPLICATION.rawValue),
@@ -73,8 +86,14 @@ internal class AppRunner {
         /// confirmed for background launch scenarios. This is acceptable, as the SDK determines
         /// background launch based on a heuristic: "not user launch AND not prewarming" — which is reliably detectable.
         static func backgroundLaunch(processLaunchDate: Date) -> ProcessLaunchType {
+            #if os(iOS)
+            let taskPolicyRole = Int(TASK_NONUI_APPLICATION.rawValue)
+            #else
+            let taskPolicyRole = __dd_private_TASK_POLICY_UNAVAILABLE
+            #endif
+
             return .init(
-                taskPolicyRole: Int(TASK_NONUI_APPLICATION.rawValue),
+                taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
                 initialAppState: .background,

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTestsBase.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTestsBase.swift
@@ -120,6 +120,7 @@ class RUMSessionTestsBase: XCTestCase {
     /// ```
     /// [BG:(no view)]
     /// ```
+    @available(tvOS, unavailable)
     func prewarmedSession(rumSetup: AppRunner.RUMSetup? = nil) -> AppRun {
         return .given(.appLaunch(type: .osPrewarm(processLaunchDate: processLaunchDate)))
             .and(.enableRUM(after: timeToSDKInit, rumSetup: rumSetup))
@@ -129,6 +130,7 @@ class RUMSessionTestsBase: XCTestCase {
     /// ```
     /// [BG:Background]
     /// ```
+    @available(tvOS, unavailable)
     func prewarmedSessionWithResource(
         resourceStartAfter: TimeInterval,
         resourceDuration: TimeInterval,

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
@@ -152,7 +152,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
 
         // Await tvOS launch window duration:
         run = run
-            .and(.init { $0.advanceTime(by: AppLaunchWindow.Constants.launchWindowThreshold) })
+            .and(.init { $0.advanceTime(by: LaunchReasonResolver.Constants.launchWindowThreshold) })
 
         // Track more background events:
         run = run
@@ -170,13 +170,13 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         XCTAssertNil(session.applicationStartAction)
         XCTAssertNil(session.applicationStartupTime)
         DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
-        DDAssertEqual(session.duration, 5 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
+        DDAssertEqual(session.duration, 5 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
         XCTAssertEqual(session.views.count, 1)
 
         let view = session.views[0]
         XCTAssertEqual(view.name, backgroundViewName)
-        DDAssertEqual(view.duration, 5 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
+        DDAssertEqual(view.duration, 5 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
         XCTAssertEqual(view.actionEvents.count, 4)
         XCTAssertEqual(view.resourceEvents.count, 2)
         XCTAssertEqual(view.longTaskEvents.count, 4)
@@ -246,7 +246,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         var run = run
             .when(.trackResource(after: dt, duration: dt))
             .and(.trackTwoActions(after1: dt, after2: dt))
-            .and(.init { $0.advanceTime(by: AppLaunchWindow.Constants.launchWindowThreshold) })
+            .and(.init { $0.advanceTime(by: LaunchReasonResolver.Constants.launchWindowThreshold) })
             .and(.trackResource(after: dt, duration: dt))
 
         // Suspend for long time
@@ -270,13 +270,13 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         XCTAssertNil(session.applicationStartAction)
         XCTAssertNil(session.applicationStartupTime)
         DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
-        DDAssertEqual(session.duration, 3 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
+        DDAssertEqual(session.duration, 3 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
         XCTAssertEqual(session.views.count, 1)
 
         let view = session.views[0]
         XCTAssertEqual(view.name, backgroundViewName)
-        DDAssertEqual(view.duration, 3 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
+        DDAssertEqual(view.duration, 3 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
         XCTAssertEqual(view.actionEvents.count, 2)
         XCTAssertEqual(view.resourceEvents.count, 2)
         XCTAssertEqual(view.longTaskEvents.count, 0)
@@ -288,7 +288,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
     ) {
         XCTAssertNil(session.applicationStartAction)
         XCTAssertNil(session.applicationStartupTime)
-        DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + 6 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2.hours, accuracy: accuracy)
+        DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + 6 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 2.hours, accuracy: accuracy)
         DDAssertEqual(session.duration, 4 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
         XCTAssertEqual(session.views.count, 1)

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
@@ -1,0 +1,365 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+@testable import DatadogCore
+@testable import DatadogRUM
+
+class RUMSessionTrackingTests: RUMSessionTestsBase {
+    private func enableRUM(_ launchType: AppRunner.ProcessLaunchType, rumSetup: AppRunner.RUMSetup? = nil) -> AppRun {
+        return .given(.appLaunch(type: launchType))
+            .and(.enableRUM(after: timeToSDKInit, rumSetup: rumSetup))
+    }
+
+    private let dt: TimeInterval = 1
+
+    // MARK: - User Launch → track user session
+
+    /// User launch in `UISceneDelegate`-based app.
+    private var userLaunchWithSceneDelegate: AppRunner.ProcessLaunchType { .userLaunchInSceneDelegateBasedApp(processLaunchDate: processLaunchDate) }
+    /// User launch in `UIApplicationDelegate`-based app.
+    private var userLaunchWithAppDelegate: AppRunner.ProcessLaunchType { .userLaunchInAppDelegateBasedApp(processLaunchDate: processLaunchDate) }
+
+    private func simulateUserSession(in run: AppRun) -> AppRun {
+        // Track app launch events within "ApplicationLaunch" view:
+        var run = run
+            .when(.trackTwoActions(after1: dt, after2: dt))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+
+        // Move to foreground, start "FirstView" and track events:
+        run = run
+            .and(.appBecomesActive(after: timeToAppBecomeActive))
+            .and(.startAutomaticView(after: 0, viewController: createMockView(viewControllerClassName: "FirstView")))
+            .and(.trackResource(after: dt, duration: dt))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+
+        // Switch to "SecondView" and track events::
+        run = run
+            .and(.startAutomaticView(after: 0, viewController: createMockView(viewControllerClassName: "SecondView")))
+            .and(.trackTwoActions(after1: dt, after2: dt))
+            .and(.startResource(after: dt, key: "foreground-resource", url: .mockAny()))
+
+        // Move to background, and track events:
+        run = run
+            .and(.appEntersBackground(after: dt))
+            .and(.stopResource(after: dt, key: "foreground-resource"))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+            .and(.startResource(after: dt, key: "background-resource", url: .mockAny()))
+
+        // Move to back foreground ("SecondView"), and track events:
+        run = run
+            .and(.appBecomesActive(after: dt))
+            .and(.stopResource(after: dt, key: "background-resource"))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+            .and(.trackTwoActions(after1: dt, after2: dt))
+
+        return run
+    }
+
+    private func assertUserSession(
+        session: RUMSessionMatcher,
+        expectBackgroundView: Bool
+    ) {
+        XCTAssertNotNil(session.applicationStartAction)
+        DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+        DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
+        DDAssertEqual(session.duration, timeToSDKInit + 4 * dt + timeToAppBecomeActive + 18 * dt, accuracy: accuracy)
+        XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
+
+        var views = session.views
+        var nextView = views.removeFirst()
+        XCTAssertEqual(nextView.name, applicationLaunchViewName)
+        DDAssertEqual(nextView.duration, timeToSDKInit + 4 * dt + timeToAppBecomeActive, accuracy: accuracy)
+        XCTAssertEqual(nextView.actionEvents.count, 3)
+        XCTAssertEqual(nextView.resourceEvents.count, 0)
+        XCTAssertEqual(nextView.longTaskEvents.count, 2)
+
+        nextView = views.removeFirst()
+        XCTAssertEqual(nextView.name, "FirstView")
+        DDAssertEqual(nextView.duration, 4 * dt, accuracy: accuracy)
+        XCTAssertEqual(nextView.actionEvents.count, 0)
+        XCTAssertEqual(nextView.resourceEvents.count, 1)
+        XCTAssertEqual(nextView.longTaskEvents.count, 2)
+
+        nextView = views.removeFirst()
+        XCTAssertEqual(nextView.name, "SecondView")
+        DDAssertEqual(nextView.duration, 5 * dt, accuracy: accuracy)
+        XCTAssertEqual(nextView.actionEvents.count, 2)
+        XCTAssertEqual(nextView.resourceEvents.count, 1)
+        XCTAssertEqual(nextView.longTaskEvents.count, 0)
+
+        if expectBackgroundView {
+            nextView = views.removeFirst()
+            XCTAssertEqual(nextView.name, backgroundViewName)
+            DDAssertEqual(nextView.duration, 2 * dt, accuracy: accuracy)
+            XCTAssertEqual(nextView.actionEvents.count, 0)
+            XCTAssertEqual(nextView.resourceEvents.count, 1)
+            XCTAssertEqual(nextView.longTaskEvents.count, 0)
+        }
+
+        nextView = views.removeFirst()
+        XCTAssertEqual(nextView.name, "SecondView")
+        DDAssertEqual(nextView.duration, 5 * dt, accuracy: accuracy)
+        XCTAssertEqual(nextView.actionEvents.count, 2)
+        XCTAssertEqual(nextView.resourceEvents.count, 0)
+        XCTAssertEqual(nextView.longTaskEvents.count, 2)
+
+        XCTAssertTrue(views.isEmpty)
+    }
+
+    func testGivenUserLaunch_whenTrackingUserSession() throws {
+        // Given
+        // - BET disabled
+        let givens = [
+            enableRUM(userLaunchWithSceneDelegate) { $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate() },
+            enableRUM(userLaunchWithAppDelegate) { $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate() },
+            enableRUM(userLaunchWithSceneDelegate) {
+                $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate()
+                $0.trackBackgroundEvents = true
+            },
+            enableRUM(userLaunchWithAppDelegate) {
+                $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate()
+                $0.trackBackgroundEvents = true
+            },
+        ]
+
+        for given in givens {
+            // When
+            let when = simulateUserSession(in: given)
+
+            // Then
+            let session = try when.then().takeSingle()
+            assertUserSession(
+                session: session,
+                expectBackgroundView: given == givens[2] || given == givens[3]
+            )
+        }
+    }
+
+    // MARK: - Prewarming & Background Launch → track background session
+
+    private func simulateBackgroundSession(in run: AppRun) -> AppRun {
+        // Track background events:
+        var run = run
+            .when(.trackResource(after: dt, duration: dt))
+            .and(.trackTwoActions(after1: dt, after2: dt))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+
+        // Await tvOS launch window duration:
+        run = run
+            .and(.init { $0.advanceTime(by: AppLaunchWindow.Constants.launchWindowThreshold) })
+
+        // Track more background events:
+        run = run
+            .and(.trackResource(after: dt, duration: dt))
+            .and(.trackTwoActions(after1: dt, after2: dt))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+
+        return run
+    }
+
+    private func assertBackgroundSession(
+        session: RUMSessionMatcher,
+        expectedSessionPrecondition: RUMSessionPrecondition
+    ) {
+        XCTAssertNil(session.applicationStartAction)
+        XCTAssertNil(session.applicationStartupTime)
+        DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
+        DDAssertEqual(session.duration, 5 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
+        XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
+        XCTAssertEqual(session.views.count, 1)
+
+        let view = session.views[0]
+        XCTAssertEqual(view.name, backgroundViewName)
+        DDAssertEqual(view.duration, 5 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
+        XCTAssertEqual(view.actionEvents.count, 4)
+        XCTAssertEqual(view.resourceEvents.count, 2)
+        XCTAssertEqual(view.longTaskEvents.count, 4)
+    }
+
+    @available(tvOS, unavailable)
+    private var osPrewarmLaunch: AppRunner.ProcessLaunchType { .osPrewarm(processLaunchDate: processLaunchDate) }
+
+    @available(tvOS, unavailable)
+    func testGivenPrewarmedLaunch_whenTrackingBackgroundSession() throws {
+        // Given
+        // - BET disabled
+        let given = enableRUM(osPrewarmLaunch)
+
+        // When
+        let when = simulateBackgroundSession(in: given)
+
+        // Then
+        let sessions = try when.then()
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    @available(tvOS, unavailable)
+    func testGivenPrewarmedLaunch_andBETEnabled_whenTrackingBackgroundSession() throws {
+        // Given
+        // - BET enabled
+        let given = enableRUM(osPrewarmLaunch) { $0.trackBackgroundEvents = true }
+
+        let when = simulateBackgroundSession(in: given)
+
+        let session = try when.then().takeSingle()
+        assertBackgroundSession(session: session, expectedSessionPrecondition: .prewarm)
+    }
+
+    private var backgroundLaunch: AppRunner.ProcessLaunchType { .backgroundLaunch(processLaunchDate: processLaunchDate) }
+
+    func testGivenBackgroundLaunch_whenTrackingBackgroundSession() throws {
+        // Given
+        // - BET disabled
+        let given = enableRUM(backgroundLaunch)
+
+        // When
+        let when = simulateBackgroundSession(in: given)
+
+        // Then
+        let sessions = try when.then()
+        XCTAssertTrue(sessions.isEmpty)
+    }
+
+    func testGivenBackgroundLaunch_andBETEnabled_whenTrackingBackgroundSession() throws {
+        // Given
+        // - BET enabled
+        let given = enableRUM(backgroundLaunch) { $0.trackBackgroundEvents = true }
+
+        // When
+        let when = simulateBackgroundSession(in: given)
+
+        // Then
+        let session = try when.then().takeSingle()
+        assertBackgroundSession(session: session, expectedSessionPrecondition: .backgroundLaunch)
+    }
+
+    // MARK: - Prewarming & Background Launch → suspend → resume by user session
+
+    private func simulateSuspendedBackgroundSessionResumedByUser(in run: AppRun) -> AppRun {
+        // Track background events:
+        var run = run
+            .when(.trackResource(after: dt, duration: dt))
+            .and(.trackTwoActions(after1: dt, after2: dt))
+            .and(.init { $0.advanceTime(by: AppLaunchWindow.Constants.launchWindowThreshold) })
+            .and(.trackResource(after: dt, duration: dt))
+
+        // Suspend for long time
+        run = run
+            .and(.advanceTime(by: 2.hours))
+
+        // Move to foreground, start "FirstView" and track events:
+        run = run
+            .and(.appBecomesActive(after: 0))
+            .and(.startAutomaticView(after: 0, viewController: createMockView(viewControllerClassName: "FirstView")))
+            .and(.trackResource(after: dt, duration: dt))
+            .and(.trackTwoLongTasks(after1: dt, after2: dt))
+
+        return run
+    }
+
+    private func assertSuspendedBackgroundSession(
+        session: RUMSessionMatcher,
+        expectedSessionPrecondition: RUMSessionPrecondition
+    ) {
+        XCTAssertNil(session.applicationStartAction)
+        XCTAssertNil(session.applicationStartupTime)
+        DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
+        DDAssertEqual(session.duration, 3 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
+        XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
+        XCTAssertEqual(session.views.count, 1)
+
+        let view = session.views[0]
+        XCTAssertEqual(view.name, backgroundViewName)
+        DDAssertEqual(view.duration, 3 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
+        XCTAssertEqual(view.actionEvents.count, 2)
+        XCTAssertEqual(view.resourceEvents.count, 2)
+        XCTAssertEqual(view.longTaskEvents.count, 0)
+    }
+
+    private func assertResumedUserSession(
+        session: RUMSessionMatcher,
+        expectedSessionPrecondition: RUMSessionPrecondition
+    ) {
+        XCTAssertNil(session.applicationStartAction)
+        XCTAssertNil(session.applicationStartupTime)
+        DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + 6 * dt + AppLaunchWindow.Constants.launchWindowThreshold + 2.hours, accuracy: accuracy)
+        DDAssertEqual(session.duration, 4 * dt, accuracy: accuracy)
+        XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
+        XCTAssertEqual(session.views.count, 1)
+
+        let view = session.views[0]
+        XCTAssertEqual(view.name, "FirstView")
+        DDAssertEqual(view.duration, 4 * dt, accuracy: accuracy)
+        XCTAssertEqual(view.actionEvents.count, 0)
+        XCTAssertEqual(view.resourceEvents.count, 1)
+        XCTAssertEqual(view.longTaskEvents.count, 2)
+    }
+
+    @available(tvOS, unavailable)
+    func testGivenPrewarmedLaunch_andSuspendedBackgroundSession_whenItGetsResumedByUserSession() throws {
+        // Given
+        // - BET disabled
+        let given = enableRUM(osPrewarmLaunch) { $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate() }
+
+        // When
+        let when = simulateSuspendedBackgroundSessionResumedByUser(in: given)
+
+        // Then
+        let userSession = try when.then().takeSingle()
+        assertResumedUserSession(session: userSession, expectedSessionPrecondition: .inactivityTimeout)
+    }
+
+    @available(tvOS, unavailable)
+    func testGivenPrewarmedLaunch_andBETEnabled_andSuspendedBackgroundSession_whenItGetsResumedByUserSession() throws {
+        // Given
+        // - BET enabled
+        let given = enableRUM(osPrewarmLaunch) {
+            $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate()
+            $0.trackBackgroundEvents = true
+        }
+
+        // When
+        let when = simulateSuspendedBackgroundSessionResumedByUser(in: given)
+
+        // Then
+        let (backgroundSession, userSession) = try when.then().takeTwo()
+        assertSuspendedBackgroundSession(session: backgroundSession, expectedSessionPrecondition: .prewarm)
+        assertResumedUserSession(session: userSession, expectedSessionPrecondition: .inactivityTimeout)
+    }
+
+    func testGivenBackgroundLaunch_andSuspendedBackgroundSession_whenItGetsResumedByUserSession() throws {
+        // Given
+        // - BET disabled
+        let given = enableRUM(backgroundLaunch) { $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate() }
+
+        // When
+        let when = simulateSuspendedBackgroundSessionResumedByUser(in: given)
+
+        // Then
+        let userSession = try when.then().takeSingle()
+        assertResumedUserSession(session: userSession, expectedSessionPrecondition: .inactivityTimeout)
+    }
+
+    func testGivenBackgroundLaunch_andBETEnabled_andSuspendedBackgroundSession_whenItGetsResumedByUserSession() throws {
+        // Given
+        // - BET enabled
+        let given = enableRUM(backgroundLaunch) {
+            $0.uiKitViewsPredicate = DefaultUIKitRUMViewsPredicate()
+            $0.trackBackgroundEvents = true
+        }
+
+        // When
+        let when = simulateSuspendedBackgroundSessionResumedByUser(in: given)
+
+        // Then
+        let (backgroundSession, userSession) = try when.then().takeTwo()
+        assertSuspendedBackgroundSession(session: backgroundSession, expectedSessionPrecondition: .backgroundLaunch)
+        assertResumedUserSession(session: userSession, expectedSessionPrecondition: .inactivityTimeout)
+    }
+}

--- a/DatadogInternal/Sources/Context/LaunchInfo.swift
+++ b/DatadogInternal/Sources/Context/LaunchInfo.swift
@@ -22,7 +22,11 @@ public enum LaunchReason: Codable {
 /// Info about app launch.
 public struct LaunchInfo: Codable, Equatable, PassthroughAnyCodable {
     /// The reason for app startup.
-    public let launchReason: LaunchReason
+    ///
+    /// While this property is typically set at SDK initialization, some products (e.g., RUM) may choose to resolve it lazily
+    /// using custom heuristics. This is necessary on platforms like tvOS, where the actual launch reason cannot be determined
+    /// immediately at launch time and must be inferred during a short observation window.
+    public var launchReason: LaunchReason
 
     /// The date when the application process was started.
     public let processLaunchDate: Date

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/LaunchReasonResolver.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/LaunchReasonResolver.swift
@@ -1,0 +1,120 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// A helper that resolves the app launch reason (`LaunchReason`) for tvOS apps, using a timed window and
+/// observed lifecycle events. This is needed because tvOS does not expose kernel-level signals (like `task_role`)
+/// that are available on iOS to detect whether an app was launched by the user or in the background.
+///
+/// It buffers RUM commands along with their corresponding `DatadogContext` and `Writer`. Once the launch reason is resolved
+/// (either by receiving a `willEnterForeground` event or exceeding the launch window threshold),
+/// it replays all buffered items in FIFO order. The original commands and writers are preserved, but the
+/// `launchReason` field in each context is updated with the resolved value before forwarding.
+internal final class LaunchReasonResolver {
+    private let window: AppLaunchWindow
+
+    init(launchWindowThreshold: TimeInterval) {
+        self.window = AppLaunchWindow(launchWindowThreshold: launchWindowThreshold)
+    }
+
+    /// Buffers the given command and forwards it once the launch reason is resolved.
+    /// If resolution occurs as a result of this command, all previously buffered commands are forwarded in order,
+    /// with their `DatadogContext.launchInfo.launchReason` updated to match the resolved reason.
+    /// If the context already contains a known `launchReason`, the command is forwarded immediately without modification.
+    func forwardWithLaunchReason(
+        command: RUMCommand,
+        context: DatadogContext,
+        writer: Writer,
+        forwardingBlock: ([(command: RUMCommand, context: DatadogContext, writer: Writer)]) -> Void
+    ) {
+        guard context.launchInfo.launchReason == .uncertain else {
+            // Unexpected pre-set reason, forward as-is.
+            forwardingBlock([(command, context, writer)])
+            return
+        }
+
+        if window.resolvedReason != .uncertain {
+            // Launch reason already resolved, inject and forward immediately.
+            let resolvedCommand = (command, context.replacing(launchReason: window.resolvedReason), writer)
+            forwardingBlock([resolvedCommand])
+        } else {
+            // Buffer command and check if this one resolved the launch reason.
+            window.buffer(command: command, context: context, writer: writer)
+
+            if window.resolvedReason != .uncertain {
+                let resolvedCommands = window
+                    .flushBuffer()
+                    .map { oldCommand, oldContext, oldWriter in (oldCommand, oldContext.replacing(launchReason: window.resolvedReason), oldWriter) }
+                forwardingBlock(resolvedCommands)
+            }
+        }
+    }
+}
+
+private extension DatadogContext {
+    func replacing(launchReason newLaunchReason: LaunchReason) -> DatadogContext {
+        var new = self
+        new.launchInfo.launchReason = newLaunchReason
+        return new
+    }
+}
+
+internal final class AppLaunchWindow {
+    internal enum Constants {
+        /// Default time to wait before classifying as background launch.
+        static let launchWindowThreshold: TimeInterval = 10.0
+    }
+
+    /// Time to wait before classifying as background launch.
+    private let threshold: TimeInterval
+
+    /// Commands buffered during launch window (with original context and writer).
+    private var buffer: [(command: RUMCommand, context: DatadogContext, writer: Writer)] = []
+
+    /// Launch reason, resolved once conditions are met.
+    private(set) var resolvedReason: LaunchReason = .uncertain
+
+    init(launchWindowThreshold: TimeInterval) {
+        self.threshold = launchWindowThreshold
+    }
+
+    /// Buffers the command if launch reason is not yet resolved.
+    /// Once resolved, this becomes a no-op.
+    func buffer(command: RUMCommand, context: DatadogContext, writer: Writer) {
+        guard resolvedReason == .uncertain else {
+            return
+        }
+
+        buffer.append((command, context, writer))
+
+        // Resolve immediately if app did not start in background.
+        if context.applicationStateHistory.initialState != .background {
+            resolvedReason = .userLaunch
+            return
+        }
+
+        // Resolve as background if command exceeds launch window.
+        let elapsed = command.time.timeIntervalSince(context.launchInfo.processLaunchDate)
+        if elapsed >= threshold {
+            resolvedReason = .backgroundLaunch
+            return
+        }
+
+        // Resolve as user launch if lifecycle indicates foreground entry.
+        if let lifecycleCommand = command as? RUMHandleAppLifecycleEventCommand,
+           lifecycleCommand.event == .willEnterForeground {
+            resolvedReason = .userLaunch
+        }
+    }
+
+    /// Returns and clears all buffered commands in FIFO order.
+    func flushBuffer() -> [(RUMCommand, DatadogContext, Writer)] {
+        defer { buffer.removeAll() }
+        return buffer
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/LaunchReasonResolverTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/LaunchReasonResolverTests.swift
@@ -3,313 +3,130 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019-Present Datadog, Inc.
  */
-
 import XCTest
 import TestUtilities
 import DatadogInternal
 @testable import DatadogRUM
 
 class LaunchReasonResolverTests: XCTestCase {
-    private let processLaunchDate = Date()
-    private let threshold = AppLaunchWindow.Constants.launchWindowThreshold
-    private lazy var resolver: LaunchReasonResolver = { LaunchReasonResolver(launchWindowThreshold: threshold) }()
+    private let threshold = LaunchReasonResolver.Constants.launchWindowThreshold
+    private lazy var resolver = LaunchReasonResolver(launchWindowThreshold: threshold)
     private let writer = FileWriterMock()
+
+    private var baseLaunchInfo: LaunchInfo {
+        .mockWith(launchReason: .uncertain, processLaunchDate: Date())
+    }
 
     // MARK: - Helper
 
-    /// Sends an array of commands through the resolver, then verifies that each forwarded context has the same `launchReason`.
-    /// Returns the resolved reason.
-    private func resolveAndValidate(context: DatadogContext, commands: [RUMCommand], file: StaticString = #file, line: UInt = #line) throws -> LaunchReason {
-        var forwarded: [(command: RUMCommand, context: DatadogContext, writer: Writer)] = []
+    /// Sends each command through the resolver, collects the contexts when `onReady` is called,
+    /// and asserts that the launch reason is the same for all. Returns that reason.
+    private func resolveAndValidate(
+        context: DatadogContext,
+        commands: [RUMCommand],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> LaunchReason {
+        var received: [(RUMCommand, DatadogContext)] = []
 
         for command in commands {
-            resolver.forwardWithLaunchReason(command: command, context: context, writer: writer) { items in
-                forwarded.append(contentsOf: items)
+            resolver.deferUntilLaunchReasonResolved(command: command,context: context, writer: writer) { cmd, ctx, _ in
+                received.append((cmd, ctx))
             }
         }
 
-        XCTAssertEqual(forwarded.count, commands.count, "Should forward all commands", file: file, line: line)
-
-        let launchReason = try XCTUnwrap(forwarded.first?.context.launchInfo.launchReason)
-
-        for (index, item) in forwarded.enumerated() {
-            DDAssertReflectionEqual(item.command, commands[index], "Forwarded command should match original at index \(index)", file: file, line: line)
-            XCTAssertEqual(item.context.launchInfo.launchReason, launchReason, "Launch reason should be consistent", file: file, line: line)
+        XCTAssertEqual(received.count, commands.count, "Should forward all commands", file: file, line: line)
+        let reason = try XCTUnwrap(received.first?.1.launchInfo.launchReason, file: file, line: line)
+        for (index, (cmd, ctx)) in received.enumerated() {
+            DDAssertReflectionEqual(cmd, commands[index], "Forwarded command[\(index)] must match original", file: file, line: line)
+            XCTAssertEqual(ctx.launchInfo.launchReason, reason, "All contexts must share the same launchReason", file: file, line: line)
         }
-
-        return launchReason
+        return reason
     }
 
     // MARK: - User Launch
 
-    func testUserLaunch_injectsUserLaunchForAllCommandsBeforeAndAfterResolution() throws {
-        // Given
+    func testUserLaunch_resolvesUserLaunchForSceneDelegateFlow() throws {
         let context: DatadogContext = .mockWith(
-            launchInfo: .mockWith(
-                launchReason: .uncertain,
-                processLaunchDate: processLaunchDate
-            ),
-            applicationStateHistory: .mockWith(
-                initialState: .background, // like in UISceneDelegate
-                date: processLaunchDate
-            )
-        )
-        let commands: [RUMCommand] = [
-            RUMCommandMock(time: processLaunchDate + 0.2 * threshold),
-            RUMCommandMock(time: processLaunchDate + 0.5 * threshold),
-            RUMHandleAppLifecycleEventCommand(
-                time: processLaunchDate + 0.8 * threshold,
-                event: .willEnterForeground
-            ),
-            RUMCommandMock(time: processLaunchDate + 1.2 * threshold)
-        ]
-
-        // When
-        let reason = try resolveAndValidate(context: context, commands: commands)
-
-        // Then
-        XCTAssertEqual(reason, .userLaunch, "Resolved reason should be userLaunch")
-    }
-
-    func testUserLaunch_initialStateInactive_resolvesImmediately() throws {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: .mockWith(
-                launchReason: .uncertain,
-                processLaunchDate: processLaunchDate
-            ),
-            applicationStateHistory: .mockWith(
-                initialState: .inactive, // like in UIApplicationDelegate
-                date: processLaunchDate
-            )
-        )
-        let commands: [RUMCommand] = [
-            RUMCommandMock(time: processLaunchDate),
-            RUMCommandMock(time: processLaunchDate + 0.5 * threshold)
-        ]
-
-        // When
-        let reason = try resolveAndValidate(context: context, commands: commands)
-
-        // Then
-        XCTAssertEqual(reason, .userLaunch, "Resolved reason should be userLaunch for inactive start")
-    }
-
-    // MARK: - Background Launch Path
-
-    func testBackgroundLaunch_injectsBackgroundLaunchForAllCommandsBeforeAndAfterThreshold() throws {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: .mockWith(
-                launchReason: .uncertain,
-                processLaunchDate: processLaunchDate
-            ),
+            launchInfo: baseLaunchInfo,
             applicationStateHistory: .mockWith(
                 initialState: .background,
-                date: processLaunchDate
+                date: baseLaunchInfo.processLaunchDate
             )
         )
         let commands: [RUMCommand] = [
-            RUMCommandMock(time: processLaunchDate + 0.3 * threshold),
-            RUMCommandMock(time: processLaunchDate + 0.6 * threshold),
-            RUMCommandMock(time: processLaunchDate + threshold),
-            RUMCommandMock(time: processLaunchDate + 1.5 * threshold)
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.2 * threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.5 * threshold),
+            RUMHandleAppLifecycleEventCommand(
+                time: baseLaunchInfo.processLaunchDate + 0.8 * threshold,
+                event: .willEnterForeground
+            ),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 1.2 * threshold)
         ]
 
-        // When
         let reason = try resolveAndValidate(context: context, commands: commands)
+        XCTAssertEqual(reason, .userLaunch, "Should resolve to userLaunch after willEnterForeground")
+    }
 
-        // Then
-        XCTAssertEqual(reason, .backgroundLaunch, "Resolved reason should be backgroundLaunch")
+    func testUserLaunch_resolvesImmediately_whenInitialStateInactiveOrActive() throws {
+        let context: DatadogContext = .mockWith(
+            launchInfo: baseLaunchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: [.inactive, .active].randomElement()!,
+                date: baseLaunchInfo.processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.5 * threshold)
+        ]
+
+        let reason = try resolveAndValidate(context: context, commands: commands)
+        XCTAssertEqual(reason, .userLaunch, "Should resolve to userLaunch immediately when initialState is inactive or active")
+    }
+
+    // MARK: - Background Launch
+
+    func testBackgroundLaunch_resolvesAfterThreshold() throws {
+        let context: DatadogContext = .mockWith(
+            launchInfo: baseLaunchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: baseLaunchInfo.processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.3 * threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.6 * threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 1.5 * threshold)
+        ]
+
+        let reason = try resolveAndValidate(context: context, commands: commands)
+        XCTAssertEqual(reason, .backgroundLaunch, "Should resolve to backgroundLaunch after threshold")
     }
 
     // MARK: - Pre-set Launch Reason
 
-    func testWhenLaunchReasonAlreadySet_forwardsAllCommandsWithoutChange() throws {
-        // Given
-        let prewarmLaunchInfo: LaunchInfo = .mockWith(
+    func testPrewarmingContext_forwardsAllCommandsUnchanged() throws {
+        let prewarmInfo: LaunchInfo = .mockWith(
             launchReason: .prewarming,
-            processLaunchDate: processLaunchDate
+            processLaunchDate: baseLaunchInfo.processLaunchDate
         )
         let context: DatadogContext = .mockWith(
-            launchInfo: prewarmLaunchInfo,
+            launchInfo: prewarmInfo,
             applicationStateHistory: .mockWith(
                 initialState: .background,
-                date: processLaunchDate
+                date: baseLaunchInfo.processLaunchDate
             )
         )
         let commands: [RUMCommand] = [
-            RUMCommandMock(time: processLaunchDate + 0.1 * threshold),
-            RUMCommandMock(time: processLaunchDate + 0.5 * threshold),
-            RUMCommandMock(time: processLaunchDate + threshold)
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.1 * threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + 0.5 * threshold),
+            RUMCommandMock(time: baseLaunchInfo.processLaunchDate + threshold)
         ]
 
-        // When
         let reason = try resolveAndValidate(context: context, commands: commands)
-
-        // Then
-        XCTAssertEqual(reason, .prewarming, "Resolved reason should remain prewarming")
-    }
-}
-
-class AppLaunchWindowTests: XCTestCase {
-    private let launchInfo: LaunchInfo = .mockWith(launchReason: .uncertain, processLaunchDate: Date())
-    private let threshold = AppLaunchWindow.Constants.launchWindowThreshold
-    private lazy var window: AppLaunchWindow = { AppLaunchWindow(launchWindowThreshold: threshold) }()
-    private let writer = FileWriterMock()
-
-    // MARK: - User Launch Resolution
-
-    func testResolvesUserLaunchImmediately_whenInitialStateIsNotBackground() {
-        for foregroundState in [AppState.inactive, AppState.active] {
-            // Given
-            let window = AppLaunchWindow(launchWindowThreshold: threshold)
-            let context: DatadogContext = .mockWith(
-                launchInfo: launchInfo,
-                applicationStateHistory: .mockWith(
-                    initialState: foregroundState,
-                    date: launchInfo.processLaunchDate
-                )
-            )
-
-            // When
-            let command = RUMCommandMock(time: launchInfo.processLaunchDate)
-            window.buffer(command: command, context: context, writer: writer)
-
-            // Then
-            XCTAssertEqual(window.resolvedReason, .userLaunch, "Initial state \(foregroundState) should resolve to userLaunch")
-            DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the user command")
-        }
-    }
-
-    func testResolvesUserLaunch_whenWillEnterForegroundInsideWindow() {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .background,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let commands: [RUMCommand] = [
-            RUMCommandMock(time: launchInfo.processLaunchDate + 0.2 * threshold),
-            RUMCommandMock(time: launchInfo.processLaunchDate + 0.5 * threshold)
-        ]
-        for cmd in commands {
-            window.buffer(command: cmd, context: context, writer: writer)
-            XCTAssertEqual(window.resolvedReason, .uncertain, "Within window, reason remains uncertain")
-        }
-
-        // When
-        let lifecycleCommand = RUMHandleAppLifecycleEventCommand(
-            time: launchInfo.processLaunchDate + 0.8 * threshold,
-            event: .willEnterForeground
-        )
-        window.buffer(command: lifecycleCommand, context: context, writer: writer)
-
-        // Then
-        XCTAssertEqual(window.resolvedReason, .userLaunch, "willEnterForeground should resolve to userLaunch")
-        let expected = (commands + [lifecycleCommand]).map { cmd in (cmd, context, writer) }
-        DDAssertReflectionEqual(window.flushBuffer(), expected, "Buffer should include all commands and lifecycle")
-    }
-
-    // MARK: - Background Launch Resolution
-
-    func testResolvesBackgroundLaunch_whenFirstCommandOutsideWindow() {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .background,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let command = RUMCommandMock(time: launchInfo.processLaunchDate + threshold)
-
-        // When
-        window.buffer(command: command, context: context, writer: writer)
-
-        // Then
-        XCTAssertEqual(window.resolvedReason, .backgroundLaunch, "First command at threshold → backgroundLaunch")
-        DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the threshold command")
-    }
-
-    func testResolvesBackgroundLaunch_whenExceedingThresholdAfterBuffering() {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .background,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let earlyCommand = RUMCommandMock(time: launchInfo.processLaunchDate + 0.3 * threshold)
-        window.buffer(command: earlyCommand, context: context, writer: writer)
-        XCTAssertEqual(window.resolvedReason, .uncertain, "Within window, reason remains uncertain")
-
-        // When
-        let thresholdCommand = RUMCommandMock(time: launchInfo.processLaunchDate + threshold)
-        window.buffer(command: thresholdCommand, context: context, writer: writer)
-
-        // Then
-        XCTAssertEqual(window.resolvedReason, .backgroundLaunch, "Threshold command should resolve to backgroundLaunch")
-        let expected = [(earlyCommand, context, writer), (thresholdCommand, context, writer)]
-        DDAssertReflectionEqual(window.flushBuffer(), expected, "Buffer should contain early and threshold commands")
-    }
-
-    // MARK: - Uncertain State
-
-    func testRemainsUncertain_ifNoLifecycleEventAndBelowThreshold() {
-        // Given
-        let context: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .background,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let command = RUMCommandMock(time: launchInfo.processLaunchDate + 0.5 * threshold)
-
-        // When
-        window.buffer(command: command, context: context, writer: writer)
-
-        // Then
-        XCTAssertEqual(window.resolvedReason, .uncertain, "First command inside window should keep reason uncertain")
-        DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the single command")
-    }
-
-    // MARK: - Once Resolved, No Further Buffering
-
-    func testNoFurtherBuffering_afterResolution() {
-        // Given a resolved userLaunch
-        let contextForeground: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .inactive,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let firstCommand = RUMCommandMock(time: launchInfo.processLaunchDate)
-        window.buffer(command: firstCommand, context: contextForeground, writer: writer)
-        XCTAssertEqual(window.resolvedReason, .userLaunch, "Non-background initial state resolves to userLaunch")
-        DDAssertReflectionEqual(window.flushBuffer(), [(firstCommand, contextForeground, writer)], "Buffer should contain the first command")
-
-        // When (subsequent commands after resolution)
-        let subsequentContext: DatadogContext = .mockWith(
-            launchInfo: launchInfo,
-            applicationStateHistory: .mockWith(
-                initialState: .inactive,
-                date: launchInfo.processLaunchDate
-            )
-        )
-        let furtherCommands: [RUMCommand] = [
-            RUMCommandMock(time: launchInfo.processLaunchDate + 1),
-            RUMCommandMock(time: launchInfo.processLaunchDate + 2)
-        ]
-        for cmd in furtherCommands {
-            window.buffer(command: cmd, context: subsequentContext, writer: writer)
-            XCTAssertEqual(window.resolvedReason, .userLaunch, "Once resolved, reason stays userLaunch")
-            XCTAssertTrue(window.flushBuffer().isEmpty, "After resolution, buffer should be empty")
-        }
+        XCTAssertEqual(reason, .prewarming, "Should leave launchReason as prewarming for prewarm context")
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/LaunchReasonResolverTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/LaunchReasonResolverTests.swift
@@ -1,0 +1,315 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class LaunchReasonResolverTests: XCTestCase {
+    private let processLaunchDate = Date()
+    private let threshold = AppLaunchWindow.Constants.launchWindowThreshold
+    private lazy var resolver: LaunchReasonResolver = { LaunchReasonResolver(launchWindowThreshold: threshold) }()
+    private let writer = FileWriterMock()
+
+    // MARK: - Helper
+
+    /// Sends an array of commands through the resolver, then verifies that each forwarded context has the same `launchReason`.
+    /// Returns the resolved reason.
+    private func resolveAndValidate(context: DatadogContext, commands: [RUMCommand], file: StaticString = #file, line: UInt = #line) throws -> LaunchReason {
+        var forwarded: [(command: RUMCommand, context: DatadogContext, writer: Writer)] = []
+
+        for command in commands {
+            resolver.forwardWithLaunchReason(command: command, context: context, writer: writer) { items in
+                forwarded.append(contentsOf: items)
+            }
+        }
+
+        XCTAssertEqual(forwarded.count, commands.count, "Should forward all commands", file: file, line: line)
+
+        let launchReason = try XCTUnwrap(forwarded.first?.context.launchInfo.launchReason)
+
+        for (index, item) in forwarded.enumerated() {
+            DDAssertReflectionEqual(item.command, commands[index], "Forwarded command should match original at index \(index)", file: file, line: line)
+            XCTAssertEqual(item.context.launchInfo.launchReason, launchReason, "Launch reason should be consistent", file: file, line: line)
+        }
+
+        return launchReason
+    }
+
+    // MARK: - User Launch
+
+    func testUserLaunch_injectsUserLaunchForAllCommandsBeforeAndAfterResolution() throws {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .uncertain,
+                processLaunchDate: processLaunchDate
+            ),
+            applicationStateHistory: .mockWith(
+                initialState: .background, // like in UISceneDelegate
+                date: processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: processLaunchDate + 0.2 * threshold),
+            RUMCommandMock(time: processLaunchDate + 0.5 * threshold),
+            RUMHandleAppLifecycleEventCommand(
+                time: processLaunchDate + 0.8 * threshold,
+                event: .willEnterForeground
+            ),
+            RUMCommandMock(time: processLaunchDate + 1.2 * threshold)
+        ]
+
+        // When
+        let reason = try resolveAndValidate(context: context, commands: commands)
+
+        // Then
+        XCTAssertEqual(reason, .userLaunch, "Resolved reason should be userLaunch")
+    }
+
+    func testUserLaunch_initialStateInactive_resolvesImmediately() throws {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .uncertain,
+                processLaunchDate: processLaunchDate
+            ),
+            applicationStateHistory: .mockWith(
+                initialState: .inactive, // like in UIApplicationDelegate
+                date: processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: processLaunchDate),
+            RUMCommandMock(time: processLaunchDate + 0.5 * threshold)
+        ]
+
+        // When
+        let reason = try resolveAndValidate(context: context, commands: commands)
+
+        // Then
+        XCTAssertEqual(reason, .userLaunch, "Resolved reason should be userLaunch for inactive start")
+    }
+
+    // MARK: - Background Launch Path
+
+    func testBackgroundLaunch_injectsBackgroundLaunchForAllCommandsBeforeAndAfterThreshold() throws {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .uncertain,
+                processLaunchDate: processLaunchDate
+            ),
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: processLaunchDate + 0.3 * threshold),
+            RUMCommandMock(time: processLaunchDate + 0.6 * threshold),
+            RUMCommandMock(time: processLaunchDate + threshold),
+            RUMCommandMock(time: processLaunchDate + 1.5 * threshold)
+        ]
+
+        // When
+        let reason = try resolveAndValidate(context: context, commands: commands)
+
+        // Then
+        XCTAssertEqual(reason, .backgroundLaunch, "Resolved reason should be backgroundLaunch")
+    }
+
+    // MARK: - Pre-set Launch Reason
+
+    func testWhenLaunchReasonAlreadySet_forwardsAllCommandsWithoutChange() throws {
+        // Given
+        let prewarmLaunchInfo: LaunchInfo = .mockWith(
+            launchReason: .prewarming,
+            processLaunchDate: processLaunchDate
+        )
+        let context: DatadogContext = .mockWith(
+            launchInfo: prewarmLaunchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: processLaunchDate + 0.1 * threshold),
+            RUMCommandMock(time: processLaunchDate + 0.5 * threshold),
+            RUMCommandMock(time: processLaunchDate + threshold)
+        ]
+
+        // When
+        let reason = try resolveAndValidate(context: context, commands: commands)
+
+        // Then
+        XCTAssertEqual(reason, .prewarming, "Resolved reason should remain prewarming")
+    }
+}
+
+class AppLaunchWindowTests: XCTestCase {
+    private let launchInfo: LaunchInfo = .mockWith(launchReason: .uncertain, processLaunchDate: Date())
+    private let threshold = AppLaunchWindow.Constants.launchWindowThreshold
+    private lazy var window: AppLaunchWindow = { AppLaunchWindow(launchWindowThreshold: threshold) }()
+    private let writer = FileWriterMock()
+
+    // MARK: - User Launch Resolution
+
+    func testResolvesUserLaunchImmediately_whenInitialStateIsNotBackground() {
+        for foregroundState in [AppState.inactive, AppState.active] {
+            // Given
+            let window = AppLaunchWindow(launchWindowThreshold: threshold)
+            let context: DatadogContext = .mockWith(
+                launchInfo: launchInfo,
+                applicationStateHistory: .mockWith(
+                    initialState: foregroundState,
+                    date: launchInfo.processLaunchDate
+                )
+            )
+
+            // When
+            let command = RUMCommandMock(time: launchInfo.processLaunchDate)
+            window.buffer(command: command, context: context, writer: writer)
+
+            // Then
+            XCTAssertEqual(window.resolvedReason, .userLaunch, "Initial state \(foregroundState) should resolve to userLaunch")
+            DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the user command")
+        }
+    }
+
+    func testResolvesUserLaunch_whenWillEnterForegroundInsideWindow() {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let commands: [RUMCommand] = [
+            RUMCommandMock(time: launchInfo.processLaunchDate + 0.2 * threshold),
+            RUMCommandMock(time: launchInfo.processLaunchDate + 0.5 * threshold)
+        ]
+        for cmd in commands {
+            window.buffer(command: cmd, context: context, writer: writer)
+            XCTAssertEqual(window.resolvedReason, .uncertain, "Within window, reason remains uncertain")
+        }
+
+        // When
+        let lifecycleCommand = RUMHandleAppLifecycleEventCommand(
+            time: launchInfo.processLaunchDate + 0.8 * threshold,
+            event: .willEnterForeground
+        )
+        window.buffer(command: lifecycleCommand, context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(window.resolvedReason, .userLaunch, "willEnterForeground should resolve to userLaunch")
+        let expected = (commands + [lifecycleCommand]).map { cmd in (cmd, context, writer) }
+        DDAssertReflectionEqual(window.flushBuffer(), expected, "Buffer should include all commands and lifecycle")
+    }
+
+    // MARK: - Background Launch Resolution
+
+    func testResolvesBackgroundLaunch_whenFirstCommandOutsideWindow() {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let command = RUMCommandMock(time: launchInfo.processLaunchDate + threshold)
+
+        // When
+        window.buffer(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(window.resolvedReason, .backgroundLaunch, "First command at threshold → backgroundLaunch")
+        DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the threshold command")
+    }
+
+    func testResolvesBackgroundLaunch_whenExceedingThresholdAfterBuffering() {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let earlyCommand = RUMCommandMock(time: launchInfo.processLaunchDate + 0.3 * threshold)
+        window.buffer(command: earlyCommand, context: context, writer: writer)
+        XCTAssertEqual(window.resolvedReason, .uncertain, "Within window, reason remains uncertain")
+
+        // When
+        let thresholdCommand = RUMCommandMock(time: launchInfo.processLaunchDate + threshold)
+        window.buffer(command: thresholdCommand, context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(window.resolvedReason, .backgroundLaunch, "Threshold command should resolve to backgroundLaunch")
+        let expected = [(earlyCommand, context, writer), (thresholdCommand, context, writer)]
+        DDAssertReflectionEqual(window.flushBuffer(), expected, "Buffer should contain early and threshold commands")
+    }
+
+    // MARK: - Uncertain State
+
+    func testRemainsUncertain_ifNoLifecycleEventAndBelowThreshold() {
+        // Given
+        let context: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let command = RUMCommandMock(time: launchInfo.processLaunchDate + 0.5 * threshold)
+
+        // When
+        window.buffer(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(window.resolvedReason, .uncertain, "First command inside window should keep reason uncertain")
+        DDAssertReflectionEqual(window.flushBuffer(), [(command, context, writer)], "Buffer should contain the single command")
+    }
+
+    // MARK: - Once Resolved, No Further Buffering
+
+    func testNoFurtherBuffering_afterResolution() {
+        // Given a resolved userLaunch
+        let contextForeground: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .inactive,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let firstCommand = RUMCommandMock(time: launchInfo.processLaunchDate)
+        window.buffer(command: firstCommand, context: contextForeground, writer: writer)
+        XCTAssertEqual(window.resolvedReason, .userLaunch, "Non-background initial state resolves to userLaunch")
+        DDAssertReflectionEqual(window.flushBuffer(), [(firstCommand, contextForeground, writer)], "Buffer should contain the first command")
+
+        // When (subsequent commands after resolution)
+        let subsequentContext: DatadogContext = .mockWith(
+            launchInfo: launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .inactive,
+                date: launchInfo.processLaunchDate
+            )
+        )
+        let furtherCommands: [RUMCommand] = [
+            RUMCommandMock(time: launchInfo.processLaunchDate + 1),
+            RUMCommandMock(time: launchInfo.processLaunchDate + 2)
+        ]
+        for cmd in furtherCommands {
+            window.buffer(command: cmd, context: subsequentContext, writer: writer)
+            XCTAssertEqual(window.resolvedReason, .userLaunch, "Once resolved, reason stays userLaunch")
+            XCTAssertTrue(window.flushBuffer().isEmpty, "After resolution, buffer should be empty")
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adjusts the timing of the "ApplicationLaunch" view for tvOS apps using `UISceneDelegate`. It ensures that user-initiated launches are correctly detected and that the view start aligns with the actual process start time.

This is a counterpart to https://github.com/DataDog/dd-sdk-ios/pull/2321. Unlike iOS, tvOS does not support the `task_role` API, so we cannot determine the launch reason at SDK init. Instead, we apply a **launch window heuristic** that defers `LaunchReason` resolution until enough information can be inferred from app state and lifecycle events.

### How?

The implementation follows the [RFC (internal)](https://datadoghq.atlassian.net/wiki/x/eQHZMAE). It introduces two main components that work together to resolve the launch reason and defer processing of early RUM commands: `AppLaunchWindow` and `LaunchReasonResolver`.

#### 🆕 `AppLaunchWindow`

Buffers RUM commands along with their associated `DatadogContext` and `Writer` while the `LaunchReason` is `.uncertain`.

It resolves to:
- `.userLaunch` if the app starts in `INACTIVE` or `ACTIVE`, or
- `.userLaunch` if a `willEnterForeground` event is received within a 10s threshold, or
- `.backgroundLaunch` if the threshold is exceeded without a foreground transition.

Once resolved, all buffered items are returned via `flushBuffer()` in FIFO order.

#### 🆕 `LaunchReasonResolver`

Uses `AppLaunchWindow` internally to buffer and defer forwarding of commands. Once the `launchReason` is resolved, it:
- Updates the `launchReason` inside each buffered command’s context,
- Forwards all commands to RUM in original order.

<img width="1111" alt="Screenshot 2025-06-06 at 08 27 34" src="https://github.com/user-attachments/assets/3d295bf5-c139-416b-bf11-cd3d5528b9a5" />

`LaunchReasonResolver` is integrated in `RUMApplicationScope`. The `process(command:context:writer:)` method now:
- Always routes through the resolver on **tvOS** and **watchOS**.
- Falls back to it on **iOS** only if `launchReason == .uncertain`, with a one-time debug telemetry log.

#### 🧪 Tests

Both `AppLaunchWindow` and `LaunchReasonResolver` are fully covered with unit tests.

A new integration suite, `RUMSessionTrackingTests`, was added to cover end-to-end session lifecycle scenarios, including:
- User launch + multiple views tracking in foreground + short background interruption.
- Background launch + events tracking remains in background.
- Background launch + app suspended + then moves to foreground where views tracking continues.

This test suite runs on both iOS and tvOS to ensure consistent session tracking behavior for both immediate (iOS) and deferred (tvOS) launch resolution.

#### 🧪 Tests – Alternative Considered

I initially considered reusing the test coverage from https://github.com/DataDog/dd-sdk-ios/pull/2299 to validate deferred `launchReason` resolution on tvOS. While the behaviors should be the same, iOS resolves immediately, whereas tvOS relies on timing - making the existing suite not directly reusable due to short timings used there (under tvOS launch window threshold).

Some scenarios (e.g., short background launches or prewarming) don’t apply to tvOS or fall outside the launch window, and adapting them would require event timing tweaks, more events to be simulated and doing extensive `#if os(tvOS)` branching.

Instead, I chose to:
- Keep the existing test suite focused on iOS,
- Add a new, platform-agnostic `RUMSessionTrackingTests` suite that validates both iOS and tvOS behavior cleanly.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
