### PR TITLE
RUM 8421 Add ObjC APIs for SwiftUI Auto-Tracking

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -867,6 +867,12 @@
 		96155A3E2D7F01250029034E /* CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D382D6E2490004BB999 /* CustomDump.swift */; };
 		96155A3F2D7F013A0029034E /* ReflectionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D392D6E2490004BB999 /* ReflectionMirror.swift */; };
 		96155A402D7F014D0029034E /* Reflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D3A2D6E2490004BB999 /* Reflector.swift */; };
+		962223552DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223542DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift */; };
+		962223562DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223542DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift */; };
+		962223592DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */; };
+		9622235A2DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */; };
+		9622235B2DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */; };
+		9622235C2DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */; };
 		962900242D8351AB008DFE39 /* TopLevelReflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962900232D8351A7008DFE39 /* TopLevelReflector.swift */; };
 		962900252D8351AB008DFE39 /* TopLevelReflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962900232D8351A7008DFE39 /* TopLevelReflector.swift */; };
 		9629FFDE2D81C317008DFE39 /* SwiftUIViewPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9629FFDD2D81C315008DFE39 /* SwiftUIViewPath.swift */; };
@@ -2957,6 +2963,9 @@
 		960B26BF2D0360EE00D7196F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		960B26C22D075BD200D7196F /* DisplayListReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayListReflectionTests.swift; sourceTree = "<group>"; };
 		96155A282D79A4DF0029034E /* SwiftUIViewNameExtractorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewNameExtractorIntegrationTests.swift; sourceTree = "<group>"; };
+		962223542DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUIRUMPredicate+objc.swift"; sourceTree = "<group>"; };
+		962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSwiftUIRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
+		962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSwiftUIRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		962900232D8351A7008DFE39 /* TopLevelReflector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLevelReflector.swift; sourceTree = "<group>"; };
 		9629FFDD2D81C315008DFE39 /* SwiftUIViewPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewPath.swift; sourceTree = "<group>"; };
 		9629FFE02D81C345008DFE39 /* SwiftUIControllerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIControllerType.swift; sourceTree = "<group>"; };
@@ -4558,6 +4567,7 @@
 			isa = PBXGroup;
 			children = (
 				9E55407B25812D1C00F6E3AD /* RUM+objc.swift */,
+				962223542DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift */,
 				6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */,
 			);
 			path = RUM;
@@ -4788,6 +4798,8 @@
 				614798952A459AA80095CB02 /* DDTraceTests.swift */,
 				615A4A8824A34FD700233986 /* DDTracerTests.swift */,
 				616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */,
+				962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */,
+				962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */,
 				61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */,
 				61A2CC232A44454D0000FF25 /* DDRUMTests.swift */,
 				A7DA18022AB0C8A700F76337 /* DDUIKitRUMViewsPredicateTests.swift */,
@@ -8455,6 +8467,8 @@
 				6136CB4A2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
 				266BFA5E2D6F4E31003041A5 /* AccountInfoPublisherTests.swift in Sources */,
 				D26C49AF2886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */,
+				9622235B2DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */,
+				9622235C2DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift in Sources */,
 				6147989C2A459E2B0095CB02 /* DDTrace+apiTests.m in Sources */,
 				D22743EB29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */,
 				61DA8CB2286215DE0074A606 /* CryptographyTests.swift in Sources */,
@@ -8579,6 +8593,7 @@
 				616AAA6D2BDA674C00AB9DAD /* TraceSamplingStrategy+objc.swift in Sources */,
 				611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */,
 				9E55407C25812D1C00F6E3AD /* RUM+objc.swift in Sources */,
+				962223552DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift in Sources */,
 				615A4A8D24A356A000233986 /* OTSpanContext+objc.swift in Sources */,
 				F6E106542C75E0D000716DC6 /* LogsDataModels+objc.swift in Sources */,
 				61133C112423983800786299 /* DatadogConfiguration+objc.swift in Sources */,
@@ -9880,6 +9895,8 @@
 				A79B0F65292BD074008742B3 /* DDB3HTTPHeadersWriter+apiTests.m in Sources */,
 				D2CB6F4327C520D400A62B57 /* DDLogsTests.swift in Sources */,
 				D2CB6F4527C520D400A62B57 /* TracerTests.swift in Sources */,
+				962223592DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */,
+				9622235A2DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift in Sources */,
 				D22743EC29DEC9E6001A7EF9 /* Casting+RUM.swift in Sources */,
 				D2CB6F4D27C520D400A62B57 /* DataUploadStatusTests.swift in Sources */,
 				D2CB6F4F27C520D400A62B57 /* RetryingTests.swift in Sources */,
@@ -9947,6 +9964,7 @@
 				3CA852652BF2148400B52CBA /* TraceContextInjection+objc.swift in Sources */,
 				D2CB6FA327C5217A00A62B57 /* OTSpan+objc.swift in Sources */,
 				D2CB6FA427C5217A00A62B57 /* DDURLSessionDelegate+objc.swift in Sources */,
+				962223562DFC1C0E00D58EEC /* SwiftUIRUMPredicate+objc.swift in Sources */,
 				D2CB6FA527C5217A00A62B57 /* RUM+objc.swift in Sources */,
 				D2CB6FA627C5217A00A62B57 /* OTSpanContext+objc.swift in Sources */,
 				D2CB6FA827C5217A00A62B57 /* DatadogConfiguration+objc.swift in Sources */,

--- a/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDRUMMonitorTests.swift
@@ -95,6 +95,44 @@ class DDRUMUserActionTypeTests: XCTestCase {
     }
 }
 
+class SwiftUIRUMViewsPredicateBridgeTests: XCTestCase {
+    func testItForwardsCallToObjcPredicate() {
+        class MockPredicate: DDSwiftUIRUMViewsPredicate {
+            var didCallRUMView = false
+            func rumView(for extractedViewName: String) -> DDRUMView? {
+                didCallRUMView = true
+                return nil
+            }
+        }
+
+        let objcPredicate = MockPredicate()
+
+        let predicateBridge = SwiftUIRUMViewsPredicateBridge(objcPredicate: objcPredicate)
+        _ = predicateBridge.rumView(for: "TestView")
+
+        XCTAssertTrue(objcPredicate.didCallRUMView)
+    }
+}
+
+class SwiftUIRUMActionsPredicateBridgeTests: XCTestCase {
+    func testItForwardsCallToObjcPredicate() {
+        class MockPredicate: DDSwiftUIRUMActionsPredicate {
+            var didCallRUMAction = false
+            func rumAction(with componentName: String) -> DDRUMAction? {
+                didCallRUMAction = true
+                return nil
+            }
+        }
+
+        let objcPredicate = MockPredicate()
+
+        let predicateBridge = SwiftUIRUMActionsPredicateBridge(objcPredicate: objcPredicate)
+        _ = predicateBridge.rumAction(with: "Button")
+
+        XCTAssertTrue(objcPredicate.didCallRUMAction)
+    }
+}
+
 class DDRUMErrorSourceTests: XCTestCase {
     func testMappingToSwiftRUMErrorSource() {
         XCTAssertEqual(DDRUMErrorSource.source.swiftType, .source)

--- a/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMActionsPredicateTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMActionsPredicateTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogObjc
+import TestUtilities
+@testable import DatadogRUM
+
+class DDSwiftUIRUMActionsPredicateTests: XCTestCase {
+    func testGivenDefaultPredicate_whenAskingForComponentName_itReturnsAction() {
+        // Given
+        let predicate = DDDefaultSwiftUIRUMActionsPredicate()
+
+        // When
+        let rumAction = predicate.rumAction(with: "Button")
+
+        // Then
+        XCTAssertEqual(rumAction?.name, "Button")
+        XCTAssertTrue(rumAction!.attributes.isEmpty)
+    }
+
+    func testGivenPredicateWithLegacyEnabled_onAnyiOSVersion_itReturnsAction() {
+        // Given
+        let predicate = DDDefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
+
+        // When
+        let rumAction = predicate.rumAction(with: "SwiftUI_Action")
+
+        // Then
+        XCTAssertEqual(rumAction?.name, "SwiftUI_Action")
+        XCTAssertTrue(rumAction!.attributes.isEmpty)
+    }
+
+    func testGivenPredicateWithLegacyDisabled_oniOS17_itReturnsNoAction() {
+        // Given
+        let predicate = DDDefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: false)
+
+        // When
+        let rumAction = predicate.rumAction(with: "SwiftUI_Action")
+
+        // Then
+        if #available(iOS 18.0, *) {
+            XCTAssertEqual(rumAction?.name, "SwiftUI_Action")
+            XCTAssertTrue(rumAction!.attributes.isEmpty)
+        } else {
+            XCTAssertNil(rumAction, "On iOS 17 and below with legacy disabled, should return `nil`")
+        }
+    }
+}

--- a/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMViewsPredicateTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMViewsPredicateTests.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogObjc
+import TestUtilities
+@testable import DatadogRUM
+
+class DDSwiftUIRUMViewsPredicateTests: XCTestCase {
+    func testGivenDefaultPredicate_whenAskingForExtractedViewName_itReturnsView() {
+        // Given
+        let predicate = DDDefaultSwiftUIRUMViewsPredicate()
+
+        // When
+        let rumView = predicate.rumView(for: "SwiftUIView")
+
+        // Then
+        XCTAssertEqual(rumView?.name, "SwiftUIView")
+        XCTAssertTrue(rumView!.attributes.isEmpty)
+    }
+}

--- a/DatadogObjc/Sources/RUM/RUM+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUM+objc.swift
@@ -358,6 +358,16 @@ public class DDRUMConfiguration: NSObject {
         get { (swiftConfig.uiKitActionsPredicate as? UIKitRUMActionsPredicateBridge)?.objcPredicate as? DDUIKitRUMActionsPredicate  }
     }
 
+    @objc public var swiftUIViewsPredicate: DDSwiftUIRUMViewsPredicate? {
+        set { swiftConfig.swiftUIViewsPredicate = newValue.map { SwiftUIRUMViewsPredicateBridge(objcPredicate: $0) } }
+        get { (swiftConfig.swiftUIViewsPredicate as? SwiftUIRUMViewsPredicateBridge)?.objcPredicate }
+    }
+
+    @objc public var swiftUIActionsPredicate: DDSwiftUIRUMActionsPredicate? {
+        set { swiftConfig.swiftUIActionsPredicate = newValue.map { SwiftUIRUMActionsPredicateBridge(objcPredicate: $0) } }
+        get { (swiftConfig.swiftUIActionsPredicate as? SwiftUIRUMActionsPredicateBridge)?.objcPredicate }
+    }
+
     @objc
     public func setURLSessionTracking(_ tracking: DDRUMURLSessionTracking) {
         swiftConfig.urlSessionTracking = tracking.swiftConfig

--- a/DatadogObjc/Sources/RUM/SwiftUIRUMPredicate+objc.swift
+++ b/DatadogObjc/Sources/RUM/SwiftUIRUMPredicate+objc.swift
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogRUM
+import DatadogInternal
+
+// MARK: - SwiftUI Views Predicate Bridge
+
+internal struct SwiftUIRUMViewsPredicateBridge: SwiftUIRUMViewsPredicate {
+    let objcPredicate: DDSwiftUIRUMViewsPredicate
+
+    func rumView(for extractedViewName: String) -> RUMView? {
+        return objcPredicate.rumView(for: extractedViewName)?.swiftView
+    }
+}
+
+@objc
+public protocol DDSwiftUIRUMViewsPredicate: AnyObject {
+    /// The predicate deciding if the RUM View should be tracked or dropped for given SwiftUI view name.
+    /// - Parameter extractedViewName: The name of the SwiftUI view detected by the SDK.
+    /// - Returns: RUM View parameters if the view should be tracked, `nil` otherwise.
+    func rumView(for extractedViewName: String) -> DDRUMView?
+}
+
+@objc
+public class DDDefaultSwiftUIRUMViewsPredicate: NSObject, DDSwiftUIRUMViewsPredicate {
+    private let swiftPredicate = DefaultSwiftUIRUMViewsPredicate()
+
+    public func rumView(for extractedViewName: String) -> DDRUMView? {
+        return swiftPredicate.rumView(for: extractedViewName).map {
+            DDRUMView(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+}
+
+// MARK: - SwiftUI Actions Predicate Bridge
+
+internal struct SwiftUIRUMActionsPredicateBridge: SwiftUIRUMActionsPredicate {
+    let objcPredicate: DDSwiftUIRUMActionsPredicate
+
+    func rumAction(with componentName: String) -> RUMAction? {
+        return objcPredicate.rumAction(with: componentName)?.swiftAction
+    }
+}
+
+@objc
+public protocol DDSwiftUIRUMActionsPredicate: AnyObject {
+    /// The predicate deciding if the RUM Action should be tracked or dropped.
+    /// - Parameter componentName: The name of the SwiftUI component that received the action
+    /// - Returns: RUM Action if it should be tracked, `nil` otherwise.
+    func rumAction(with componentName: String) -> DDRUMAction?
+}
+
+@objc
+public class DDDefaultSwiftUIRUMActionsPredicate: NSObject, DDSwiftUIRUMActionsPredicate {
+    private let swiftPredicate: DefaultSwiftUIRUMActionsPredicate
+
+    public init(isLegacyDetectionEnabled: Bool) {
+        swiftPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: isLegacyDetectionEnabled)
+        super.init()
+    }
+
+    override public convenience init() {
+        self.init(isLegacyDetectionEnabled: true)
+    }
+
+    public func rumAction(with componentName: String) -> DDRUMAction? {
+        return swiftPredicate.rumAction(with: componentName).map {
+            DDRUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

This PR adds the ObjC APIs for SwiftUI Auto-instrumentation. See previous work in #2315 and #2237.

### How?

- Added `swiftUIViewsPredicate` and `swiftUIActionsPredicate` parameters to ObjC RUM configuration
- Created Swift bridges for both 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)