### PR TITLE
Update changelog-to-confluence: Update secret names

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -23,9 +23,9 @@ jobs:
             - name: Publish Markdown to Confluence
               uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5
               with:
-                  confluenceBaseUrl: ${{ secrets.CONFLUENCE_BASE_URL }}
+                  confluenceBaseUrl: ${{ secrets.DATADOG_CONFLUENCE_BASE_URL }}
                   confluenceParentId: ${{ secrets.CONFLUENCE_PARENT_ID }}
-                  atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
-                  atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+                  atlassianUserName: ${{ secrets.CONFLUENCE_ROBOT_RUM_EMAIL }}
+                  atlassianApiToken: ${{ secrets.CONFLUENCE_ROBOT_RUM_API_KEY }}
                   contentRoot: '.'
-                  folderToPublish: 'publish_folder' 
+                  folderToPublish: 'publish_folder'


### PR DESCRIPTION
### What and why?

- Updated secrets names on the workflow
- Reason: Better mantainability as this is common to multiple SDK's.

### How?

- Updated the secrets on the workflow

---

### Actions to Take

- Remove previous secrets from the project
  - `CONFLUENCE_BASE_URL`
  - `ATLASSIAN_USERNAME`
  - `ATLASSIAN_API_TOKEN`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
