### PR TITLE
RUM-9540: Introduce new category for network errors

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -412,6 +412,8 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     let errorSource: RUMInternalErrorSource
     /// The platform type of the error (iOS, React Native, ...)
     let errorSourceType: RUMErrorEvent.Error.SourceType
+    /// If error is related with the network connection.
+    let isNetworkError: Bool
     /// Error stacktrace.
     let stack: String?
     /// HTTP status code of the Ressource error.
@@ -433,6 +435,7 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
         self.errorMessage = message
         self.errorType = type
         self.errorSource = source
+        self.isNetworkError = false
         self.globalAttributes = globalAttributes
         self.attributes = attributes
         self.httpStatusCode = httpStatusCode
@@ -461,6 +464,8 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
         let dderror = DDError(error: error)
         self.errorMessage = dderror.message
         self.errorType = dderror.type
+        let nsError = error as NSError
+        self.isNetworkError = nsError.domain == NSURLErrorDomain
         // The stack will give the networking error (`NSError`) description in most cases:
         self.stack = dderror.stack
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -303,7 +303,7 @@ internal class RUMResourceScope: RUMScope {
             display: nil,
             error: .init(
                 binaryImages: nil,
-                category: .exception, // resource errors are categorised as "Exception"
+                category: command.isNetworkError ? .network : .exception,
                 csp: nil,
                 fingerprint: errorFingerprint,
                 handling: nil,

--- a/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
@@ -120,4 +120,17 @@ class RUMCommandTests: XCTestCase {
         XCTAssertEqual(defaultCommand1.errorSourceType, .ios)
         XCTAssertEqual(defaultCommand2.errorSourceType, .ios)
     }
+
+    func testResourceWithErrorCommand_forDifferentErrorCategories() {
+        let command1: RUMStopResourceWithErrorCommand = .mockWithErrorObject(error: ErrorMock(), source: .network)
+
+        XCTAssertEqual(command1.isNetworkError, false)
+        XCTAssertEqual(command1.errorSource, .network)
+
+        let networkError = NSError(domain: NSURLErrorDomain, code: -1_001, userInfo: [:])
+        let command2: RUMStopResourceWithErrorCommand = .mockWithErrorObject(error: networkError, source: .network)
+
+        XCTAssertEqual(command2.isNetworkError, true)
+        XCTAssertEqual(command2.errorSource, .network)
+    }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -568,7 +568,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.error.stack, "network issue explanation")
         XCTAssertEqual(event.error.category, .exception)
         XCTAssertEqual(event.error.resource?.method, .post)
-        XCTAssertEqual(event.error.type, "ErrorMock")
         XCTAssertNil(event.error.resource?.provider)
         XCTAssertEqual(event.error.resource?.statusCode, 500)
         XCTAssertEqual(event.error.resource?.url, "https://foo.com/resource/1")
@@ -582,6 +581,53 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
+    }
+
+    func testGivenStartedResource_whenResourceFailsWithNetworkError_itSendsErrorEvent() throws {
+        let currentTime: Date = .mockDecember15th2019At10AMUTC()
+
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            startTime: currentTime,
+            url: "https://foo.com/resource/1",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: currentTime,
+                    error: NSError(
+                        domain: NSURLErrorDomain,
+                        code: -1_001,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "The request timed out."
+                        ]
+                    ),
+                    source: .network,
+                    httpStatusCode: nil,
+                    globalAttributes: [:],
+                    attributes: [:]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.error.type, "NSURLErrorDomain - -1001")
+        XCTAssertEqual(event.error.message, "The request timed out.")
+        XCTAssertEqual(event.error.source, .network)
+        XCTAssertEqual(event.error.stack, "Error Domain=NSURLErrorDomain Code=-1001 \"The request timed out.\" UserInfo={NSLocalizedDescription=The request timed out.}")
+        XCTAssertEqual(event.error.category, .network)
+        XCTAssertEqual(event.error.resource?.method, .post)
+        XCTAssertEqual(event.error.resource?.url, "https://foo.com/resource/1")
     }
 
     func testGivenStartedResource_whenResourceLoadingEndsWithErrorAndFingerprintAttribute_itSendsErrorEvent() throws {
@@ -635,7 +681,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.error.stack, "network issue explanation")
         XCTAssertEqual(event.error.category, .exception)
         XCTAssertEqual(event.error.resource?.method, .post)
-        XCTAssertEqual(event.error.type, "ErrorMock")
         XCTAssertNil(event.error.resource?.provider)
         XCTAssertEqual(event.error.resource?.statusCode, 500)
         XCTAssertEqual(event.error.resource?.url, "https://foo.com/resource/1")
@@ -699,7 +744,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.error.stack, "network issue explanation")
         XCTAssertEqual(event.error.category, .exception)
         XCTAssertEqual(event.error.resource?.method, .post)
-        XCTAssertEqual(event.error.type, "ErrorMock")
         XCTAssertNil(event.error.resource?.provider)
         XCTAssertEqual(event.error.resource?.statusCode, 500)
         XCTAssertEqual(event.error.resource?.url, "https://foo.com/resource/1")
@@ -765,7 +809,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.error.stack, "network issue explanation")
         XCTAssertEqual(event.error.category, .exception)
         XCTAssertEqual(event.error.resource?.method, .post)
-        XCTAssertEqual(event.error.type, "ErrorMock")
         XCTAssertNil(event.error.resource?.provider)
         XCTAssertEqual(event.error.resource?.statusCode, 500)
         XCTAssertEqual(event.error.resource?.url, "https://foo.com/resource/1")


### PR DESCRIPTION
### What and why?

This PR adds a new category, `Network`, to the [@error.category](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/error-schema.json#L104).
This new error category aims to tag network errors triggered by no connections, connections cancelled, request timeouts and whatnot.

### How?

This new category was primarily [defined](https://github.com/DataDog/rum-events-format/pull/281) in the error schema. 
The iOS SDK applies it under the `RUMResource` scope by verifying the information stored by the `RUMStopResourceWithError` command.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
