### PR TITLE
RUM-10225: Add GitHub app secrets to Vault

### DIFF
--- a/tools/secrets/config.sh
+++ b/tools/secrets/config.sh
@@ -27,6 +27,9 @@ DD_IOS_SECRET__E2E_S8S_APPLICATION_ID="e2e.s8s.app.id"
 DD_IOS_SECRET__BENCHMARK_PROVISIONING_PROFILE_BASE64="benchmark.provisioning.profile.base64"
 DD_IOS_SECRET__BENCHMARK_XCCONFIG_BASE64="benchmark.xcconfig.base64"
 DD_IOS_SECRET__BENCHMARK_S8S_APPLICATION_ID="benchmark.s8s.app.id"
+DD_IOS_SECRET__GITHUB_APP_CLIENT_ID="gh.app.client.id"
+DD_IOS_SECRET__GITHUB_APP_INSTALLATION_ID="gh.app.installation.id"
+DD_IOS_SECRET__GITHUB_APP_PRIVATE_KEY="gh.app.private.key"
 
 idx=0
 declare -A DD_IOS_SECRETS
@@ -46,3 +49,6 @@ DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__E2E_S8S_APPLICATION_ID | Synthetics 
 DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__BENCHMARK_PROVISIONING_PROFILE_BASE64 | Base64-encoded provisioning profile file for signing Benchmark app"
 DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__BENCHMARK_XCCONFIG_BASE64 | Base64-encoded xcconfig file for Benchmark app"
 DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__BENCHMARK_S8S_APPLICATION_ID | Synthetics app ID for Benchmark tests"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__GITHUB_APP_CLIENT_ID | GitHub App (https://github.com/apps/dd-mobile-sdk-ci) client id"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__GITHUB_APP_INSTALLATION_ID | GitHub App (https://github.com/apps/dd-mobile-sdk-ci) installation id"
+DD_IOS_SECRETS[$((idx++))]="$DD_IOS_SECRET__GITHUB_APP_PRIVATE_KEY | GitHub App (https://github.com/apps/dd-mobile-sdk-ci) private key"


### PR DESCRIPTION
### What and why?

Adding secrets that are necessary to obtain GitHub installation token that will be used instead of classical PAT. See [this](https://github.com/DataDog/dd-sdk-android/pull/2726) Android PR for details.

I'll actually upload the secrets when the PR is approved. Just in case I made a mistake.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
