### PR TITLE
Fix SwiftUI Auto-tracking ObjC APIs

### DIFF
--- a/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMActionsPredicateTests.swift
+++ b/DatadogCore/Tests/DatadogObjc/DDSwiftUIRUMActionsPredicateTests.swift
@@ -10,18 +10,6 @@ import TestUtilities
 @testable import DatadogRUM
 
 class DDSwiftUIRUMActionsPredicateTests: XCTestCase {
-    func testGivenDefaultPredicate_whenAskingForComponentName_itReturnsAction() {
-        // Given
-        let predicate = DDDefaultSwiftUIRUMActionsPredicate()
-
-        // When
-        let rumAction = predicate.rumAction(with: "Button")
-
-        // Then
-        XCTAssertEqual(rumAction?.name, "Button")
-        XCTAssertTrue(rumAction!.attributes.isEmpty)
-    }
-
     func testGivenPredicateWithLegacyEnabled_onAnyiOSVersion_itReturnsAction() {
         // Given
         let predicate = DDDefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)

--- a/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/DatadogObjc/ObjcAPITests/DDRUM+apiTests.m
@@ -73,6 +73,16 @@
     config.uiKitActionsPredicate = actionsPredicate;
     XCTAssertIdentical(config.uiKitActionsPredicate, actionsPredicate);
 
+    XCTAssertNil(config.swiftUIViewsPredicate);
+    DDDefaultSwiftUIRUMViewsPredicate *swiftUIViewsPredicate = [DDDefaultSwiftUIRUMViewsPredicate new];
+    config.swiftUIViewsPredicate = swiftUIViewsPredicate;
+    XCTAssertIdentical(config.swiftUIViewsPredicate, swiftUIViewsPredicate);
+
+    XCTAssertNil(config.swiftUIActionsPredicate);
+    DDDefaultSwiftUIRUMActionsPredicate *swiftUIActionsPredicate = [[DDDefaultSwiftUIRUMActionsPredicate alloc] initWithIsLegacyDetectionEnabled:YES];
+    config.swiftUIActionsPredicate = swiftUIActionsPredicate;
+    XCTAssertIdentical(config.swiftUIActionsPredicate, swiftUIActionsPredicate);
+
     DDRUMURLSessionTracking *urlSessionTracking = [DDRUMURLSessionTracking new];
     DDRUMFirstPartyHostsTracing *tracing;
     tracing = [[DDRUMFirstPartyHostsTracing alloc] initWithHosts:[NSSet new] sampleRate:20];

--- a/DatadogObjc/Sources/RUM/SwiftUIRUMPredicate+objc.swift
+++ b/DatadogObjc/Sources/RUM/SwiftUIRUMPredicate+objc.swift
@@ -59,13 +59,10 @@ public protocol DDSwiftUIRUMActionsPredicate: AnyObject {
 public class DDDefaultSwiftUIRUMActionsPredicate: NSObject, DDSwiftUIRUMActionsPredicate {
     private let swiftPredicate: DefaultSwiftUIRUMActionsPredicate
 
+    @objc(initWithIsLegacyDetectionEnabled:)
     public init(isLegacyDetectionEnabled: Bool) {
         swiftPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: isLegacyDetectionEnabled)
         super.init()
-    }
-
-    override public convenience init() {
-        self.init(isLegacyDetectionEnabled: true)
     }
 
     public func rumAction(with componentName: String) -> DDRUMAction? {


### PR DESCRIPTION
### What and why?

For SwiftUI Auto action tracking, the Swift API's default predicate ([DefaultSwiftUIRUMActionsPredicate](https://github.com/DataDog/dd-sdk-ios/blob/968bf9586048d2d81aae3fd096bd2fcc0cb9ce8b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIRUMActionsPredicate.swift#L20)) requires explicitly passing the `isLegacyDetectionEnabled` parameter to control whether action detection should be enabled on iOS 17 and below. However, the recently introduced Objective-C APIs (in #2337) provided a default value of `true` through a convenience initializer, creating an inconsistency between Swift and ObjC interfaces. This PR aligns both APIs to ensure consistent behavior and explicit control over legacy detection.

### How?

- Removed the convenience init that defaulted `isLegacyDetectionEnabled` to `true` in the ObjcC API
- Added `@objc(initWithIsLegacyDetectionEnabled:)` attribute to properly expose the required initializer to Objective-C
- Updated test in `DDRUM+apiTests`
- Removed one redundant test 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
