### PR TITLE
Added ability to block uploads on networks with "Low Data Mode" enabled

### DIFF
--- a/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift
@@ -10,6 +10,7 @@ import DatadogInternal
 /// Tells if data upload can be performed based on given system conditions.
 internal struct DataUploadConditions {
     enum Blocker {
+        case allowsConstrainedNetworkAccessFalse
         case battery(level: Int, state: BatteryStatus.State)
         case lowPowerModeOn
         case networkReachability(description: String)
@@ -22,9 +23,13 @@ internal struct DataUploadConditions {
 
     /// Battery level above which data upload can be performed.
     let minBatteryLevel: Float
+    
+    /// Blocks uploads on networks with "Low Data Mode" enabled when set to `false`. Defaults to `true`.
+    let allowsConstrainedNetworkAccess: Bool
 
-    init(minBatteryLevel: Float = Constants.minBatteryLevel) {
+    init(minBatteryLevel: Float = Constants.minBatteryLevel, allowsConstrainedNetworkAccess: Bool = true) {
         self.minBatteryLevel = minBatteryLevel
+        self.allowsConstrainedNetworkAccess = allowsConstrainedNetworkAccess
     }
 
     func blockersForUpload(with context: DatadogContext) -> [Blocker] {
@@ -37,6 +42,9 @@ internal struct DataUploadConditions {
         let networkIsReachable = reachability == .yes || reachability == .maybe
         if !networkIsReachable {
             blockers = [.networkReachability(description: reachability.rawValue)]
+        }
+        if let isConstrained = context.networkConnectionInfo?.isConstrained, isConstrained, !allowsConstrainedNetworkAccess {
+            return [.allowsConstrainedNetworkAccessFalse]
         }
         #endif
 

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -244,6 +244,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
             failure: "blocker",
             blockers: blockers.map {
                 switch $0 {
+                case .allowsConstrainedNetworkAccessFalse: return "allows_constrained_network_access_false"
                 case .battery: return "low_battery"
                 case .lowPowerModeOn: return "lpm"
                 case .networkReachability: return "offline"
@@ -291,6 +292,8 @@ internal class DataUploadWorker: DataUploadWorkerType {
 extension DataUploadConditions.Blocker: CustomStringConvertible {
     var description: String {
         switch self {
+        case .allowsConstrainedNetworkAccessFalse:
+            return "🛜 Network is in Low Data Mode and uploads are disabled for constrained networks"
         case let .battery(level: level, state: state):
             return "🔋 Battery state is: \(state) (\(level)%)"
         case .lowPowerModeOn:

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -58,7 +58,7 @@ internal struct FeatureUpload {
                 fileReader: fileReader,
                 dataUploader: dataUploader,
                 contextProvider: contextProvider,
-                uploadConditions: DataUploadConditions(),
+                uploadConditions: DataUploadConditions(allowsConstrainedNetworkAccess: performance.constrainedNetworkAccessEnabled),
                 delay: DataUploadDelay(performance: performance),
                 featureName: featureName,
                 telemetry: telemetry,

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -135,49 +135,57 @@ public enum Datadog {
         ///
         /// `false` by default.
         public var backgroundTasksEnabled: Bool
+        
+        /// Allows uploads on networks with "Low Data Mode" enabled.
+        /// When set to `false`, uploads are deferred until the device is connected to an unconstrained network.
+        ///
+        /// Defaults to `true`.
+        public var constrainedNetworkAccessEnabled: Bool
 
         /// Creates a Datadog SDK Configuration object.
         ///
         /// - Parameters:
-        ///   - clientToken:                Either the RUM client token (which supports RUM, Logging and APM) or regular client token,
-        ///                                 only for Logging and APM.
+        ///   - clientToken:                            Either the RUM client token (which supports RUM, Logging and APM) or regular client token,
+        ///                                             only for Logging and APM.
         ///
-        ///   - env:                        The environment name which will be sent to Datadog. This can be used
-        ///                                 To filter events on different environments (e.g. "staging" or "production").
+        ///   - env:                                    The environment name which will be sent to Datadog. This can be used
+        ///                                             To filter events on different environments (e.g. "staging" or "production").
         ///
-        ///   - site:                       Datadog site endpoint, default value is `.us1`.
+        ///   - site:                                   Datadog site endpoint, default value is `.us1`.
         ///
-        ///   - service:                    The service name associated with data send to Datadog.
-        ///                                 Default value is set to application bundle identifier.
+        ///   - service:                                The service name associated with data send to Datadog.
+        ///                                             Default value is set to application bundle identifier.
         ///
-        ///   - bundle:                     The bundle object that contains the current executable.
+        ///   - bundle:                                 The bundle object that contains the current executable.
         ///
-        ///   - batchSize:                  The preferred size of batched data uploaded to Datadog servers.
-        ///                                 This value impacts the size and number of requests performed by the SDK.
-        ///                                 `.medium` by default.
+        ///   - batchSize:                              The preferred size of batched data uploaded to Datadog servers.
+        ///                                             This value impacts the size and number of requests performed by the SDK.
+        ///                                             `.medium` by default.
         ///
-        ///   - uploadFrequency:            The preferred frequency of uploading data to Datadog servers.
-        ///                                 This value impacts the frequency of performing network requests by the SDK.
-        ///                                 `.average` by default.
+        ///   - uploadFrequency:                        The preferred frequency of uploading data to Datadog servers.
+        ///                                             This value impacts the frequency of performing network requests by the SDK.
+        ///                                             `.average` by default.
         ///
-        ///   - proxyConfiguration:         A proxy configuration attributes.
-        ///                                 This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
+        ///   - proxyConfiguration:                     A proxy configuration attributes.
+        ///                                             This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
         ///
-        ///   - encryption:                 Data encryption to use for on-disk data persistency by providing an object
-        ///                                 complying with `DataEncryption` protocol.
+        ///   - encryption:                             Data encryption to use for on-disk data persistency by providing an object
+        ///                                             complying with `DataEncryption` protocol.
         ///
-        ///   - serverDateProvider:         A custom NTP synchronization interface.
-        ///                                 By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
-        ///                                 https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
-        ///                                 implementation will result in desynchronization of the SDK instance and the Datadog servers.
-        ///                                 This can lead to significant time shift in RUM sessions or distributed traces.
-        ///   - backgroundTasksEnabled:     A flag that determines if `UIApplication` methods
-        ///                                 `beginBackgroundTask(expirationHandler:)` and `endBackgroundTask:`
-        ///                                 are used to perform background uploads.
-        ///                                 It may extend the amount of time the app is operating in background by 30 seconds.
-        ///                                 Tasks are normally stopped when there's nothing to upload or when encountering
-        ///                                 any upload blocker such us no internet connection or low battery.
-        ///                                 By default it's set to `false`.
+        ///   - serverDateProvider:                     A custom NTP synchronization interface.
+        ///                                             By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
+        ///                                             https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
+        ///                                             implementation will result in desynchronization of the SDK instance and the Datadog servers.
+        ///                                             This can lead to significant time shift in RUM sessions or distributed traces.
+        ///   - backgroundTasksEnabled:                 A flag that determines if `UIApplication` methods
+        ///                                             `beginBackgroundTask(expirationHandler:)` and `endBackgroundTask:`
+        ///                                             are used to perform background uploads.
+        ///                                             It may extend the amount of time the app is operating in background by 30 seconds.
+        ///                                             Tasks are normally stopped when there's nothing to upload or when encountering
+        ///                                             any upload blocker such us no internet connection or low battery.
+        ///                                             By default it's set to `false`.
+        ///   - constrainedNetworkAccessEnabled:        A flag that determines if uploads should be enabled on networks with "Low Data Mode" enabled.
+        ///                                             By default it's set to `true`.
         public init(
             clientToken: String,
             env: String,
@@ -190,7 +198,8 @@ public enum Datadog {
             encryption: DataEncryption? = nil,
             serverDateProvider: ServerDateProvider? = nil,
             batchProcessingLevel: BatchProcessingLevel = .medium,
-            backgroundTasksEnabled: Bool = false
+            backgroundTasksEnabled: Bool = false,
+            constrainedNetworkAccessEnabled: Bool = true
         ) {
             self.clientToken = clientToken
             self.env = env
@@ -204,6 +213,7 @@ public enum Datadog {
             self.serverDateProvider = serverDateProvider ?? DatadogNTPDateProvider()
             self.batchProcessingLevel = batchProcessingLevel
             self.backgroundTasksEnabled = backgroundTasksEnabled
+            self.constrainedNetworkAccessEnabled = constrainedNetworkAccessEnabled
         }
 
         // MARK: - Internal
@@ -596,7 +606,8 @@ extension DatadogCore {
             batchSize: debug ? .small : configuration.batchSize,
             uploadFrequency: debug ? .frequent : configuration.uploadFrequency,
             bundleType: bundleType,
-            batchProcessingLevel: configuration.batchProcessingLevel
+            batchProcessingLevel: configuration.batchProcessingLevel,
+            constrainedNetworkAccessEnabled: configuration.constrainedNetworkAccessEnabled
         )
         let isRunFromExtension = bundleType == .iOSAppExtension
 

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -66,6 +66,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
     let maxBatchesPerUpload: Int
+    let constrainedNetworkAccessEnabled: Bool
 }
 
 internal extension PerformancePreset {
@@ -73,7 +74,8 @@ internal extension PerformancePreset {
         batchSize: Datadog.Configuration.BatchSize,
         uploadFrequency: Datadog.Configuration.UploadFrequency,
         bundleType: BundleType,
-        batchProcessingLevel: Datadog.Configuration.BatchProcessingLevel
+        batchProcessingLevel: Datadog.Configuration.BatchProcessingLevel,
+        constrainedNetworkAccessEnabled: Bool = true
     ) {
         let meanFileAgeInSeconds: TimeInterval = {
             switch (bundleType, batchSize) {
@@ -116,7 +118,8 @@ internal extension PerformancePreset {
             meanFileAge: meanFileAgeInSeconds,
             minUploadDelay: minUploadDelayInSeconds,
             uploadDelayFactors: uploadDelayFactors,
-            maxBatchesPerUpload: batchProcessingLevel.maxBatchesPerUpload
+            maxBatchesPerUpload: batchProcessingLevel.maxBatchesPerUpload,
+            constrainedNetworkAccessEnabled: constrainedNetworkAccessEnabled
         )
     }
 
@@ -124,7 +127,8 @@ internal extension PerformancePreset {
         meanFileAge: TimeInterval,
         minUploadDelay: TimeInterval,
         uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double),
-        maxBatchesPerUpload: Int
+        maxBatchesPerUpload: Int,
+        constrainedNetworkAccessEnabled: Bool
     ) {
         self.maxFileSize = 4.MB.asUInt32()
         self.maxDirectorySize = 512.MB.asUInt32()
@@ -138,6 +142,7 @@ internal extension PerformancePreset {
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate
         self.maxBatchesPerUpload = maxBatchesPerUpload
+        self.constrainedNetworkAccessEnabled = constrainedNetworkAccessEnabled
     }
 
     func updated(with override: PerformancePresetOverride) -> PerformancePreset {
@@ -153,7 +158,8 @@ internal extension PerformancePreset {
             minUploadDelay: override.minUploadDelay ?? minUploadDelay,
             maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
             uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate,
-            maxBatchesPerUpload: maxBatchesPerUpload
+            maxBatchesPerUpload: maxBatchesPerUpload,
+            constrainedNetworkAccessEnabled: override.constrainedNetworkAccessEnabled ?? constrainedNetworkAccessEnabled
         )
     }
 }

--- a/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
+++ b/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
@@ -45,6 +45,9 @@ public struct PerformancePresetOverride {
     /// Overrides the current interval is change on successful upload. Should be less or equal `1.0`.
     /// E.g: if rate is `0.1` then `delay` will be changed by `delay * 0.1`.
     public let uploadDelayChangeRate: Double?
+    
+    /// Overrides the current upload behavior when connected to a network with "Low Data Mode" enabled.
+    public let constrainedNetworkAccessEnabled: Bool?
 
     /// Initializes a new `PerformancePresetOverride` instance with the provided overrides.
     /// 
@@ -54,12 +57,14 @@ public struct PerformancePresetOverride {
     ///   - meanFileAge: The mean age qualifying a file for reuse, or `nil` to use the default value from `PerformancePreset`.
     ///   - maxFileAgeForRead: Maximum age qualifying given file for upload (in seconds). Files older than this are considered obsolete and get deleted without uploading.
     ///   - uploadDelay: The configuration of time interval for data uploads (initial, minimum, maximum and change rate). Set `nil` to use the default value from `PerformancePreset`.
+    ///   - constrainedNetworkUploadsEnabled: Allows uploads on networks with "Low Data Mode" enabled.
     public init(
         maxFileSize: UInt32? = nil,
         maxObjectSize: UInt32? = nil,
         meanFileAge: TimeInterval? = nil,
         maxFileAgeForRead: TimeInterval? = nil,
-        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)? = nil
+        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)? = nil,
+        constrainedNetworkAccessEnabled: Bool? = nil
     ) {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
@@ -85,5 +90,7 @@ public struct PerformancePresetOverride {
             self.maxUploadDelay = nil
             self.uploadDelayChangeRate = nil
         }
+        
+        self.constrainedNetworkAccessEnabled = constrainedNetworkAccessEnabled
     }
 }

--- a/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
+++ b/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
@@ -20,4 +20,6 @@ public protocol UploadPerformancePreset {
     var uploadDelayChangeRate: Double { get }
     /// Number of batches to process during one upload cycle.
     var maxBatchesPerUpload: Int { get }
+    /// Enable uploads on networks with "Low Data Mode" enabled. Default is `true`.
+    var constrainedNetworkAccessEnabled: Bool { get }
 }

--- a/TestUtilities/Sources/Mocks/DatadogCore/CoreMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogCore/CoreMocks.swift
@@ -201,7 +201,8 @@ extension PerformancePreset: AnyMockable, RandomMockable {
             minUploadDelay: upload.minUploadDelay,
             maxUploadDelay: upload.maxUploadDelay,
             uploadDelayChangeRate: upload.uploadDelayChangeRate,
-            maxBatchesPerUpload: upload.maxBatchesPerUpload
+            maxBatchesPerUpload: upload.maxBatchesPerUpload,
+            constrainedNetworkAccessEnabled: upload.constrainedNetworkAccessEnabled
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/UploadMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/UploadMocks.swift
@@ -13,19 +13,22 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
     public var maxUploadDelay: TimeInterval
     public var uploadDelayChangeRate: Double
     public var maxBatchesPerUpload: Int
+    public var constrainedNetworkAccessEnabled: Bool
 
     public init(
         initialUploadDelay: TimeInterval,
         minUploadDelay: TimeInterval,
         maxUploadDelay: TimeInterval,
         uploadDelayChangeRate: Double,
-        maxBatchesPerUpload: Int = 1
+        maxBatchesPerUpload: Int = 1,
+        constrainedNetworkAccessEnabled: Bool = true
     ) {
         self.initialUploadDelay = initialUploadDelay
         self.minUploadDelay = minUploadDelay
         self.maxUploadDelay = maxUploadDelay
         self.uploadDelayChangeRate = uploadDelayChangeRate
         self.maxBatchesPerUpload = maxBatchesPerUpload
+        self.constrainedNetworkAccessEnabled = constrainedNetworkAccessEnabled
     }
 
     public static let noOp = UploadPerformanceMock(
@@ -33,7 +36,8 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         minUploadDelay: .distantFuture,
         maxUploadDelay: .distantFuture,
         uploadDelayChangeRate: 0,
-        maxBatchesPerUpload: 0
+        maxBatchesPerUpload: 0,
+        constrainedNetworkAccessEnabled: true
     )
 
     /// Optimized for performing very fast uploads in unit tests.
@@ -42,7 +46,8 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         minUploadDelay: 0.05,
         maxUploadDelay: 0.05,
         uploadDelayChangeRate: 0,
-        maxBatchesPerUpload: 10
+        maxBatchesPerUpload: 10,
+        constrainedNetworkAccessEnabled: true
     )
 
     /// Optimized for performing very fast first upload and then changing to unrealistically long intervals.
@@ -51,7 +56,8 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
         minUploadDelay: 60,
         maxUploadDelay: 60,
         uploadDelayChangeRate: 60 / 0.05,
-        maxBatchesPerUpload: 10
+        maxBatchesPerUpload: 10,
+        constrainedNetworkAccessEnabled: true
     )
 }
 
@@ -62,6 +68,7 @@ extension UploadPerformanceMock {
         maxUploadDelay = other.maxUploadDelay
         uploadDelayChangeRate = other.uploadDelayChangeRate
         maxBatchesPerUpload = other.maxBatchesPerUpload
+        constrainedNetworkAccessEnabled = other.constrainedNetworkAccessEnabled
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR allows us to configure the SDK to block uploads when connected to a network with "Low Data Mode" enabled. 

Why?
A large number of our users rely on satellite internet with plans that charge based on data consumption. There are also scenarios where the connection has limited bandwidth and we only want to allow critical services to make network requests. 

### How?

This PR adds a `constrainedNetworkAccessEnabled` parameter that can be passed to `Datadog.init()`. This name was chosen to based on URLSession's [allowsConstrainedNetworkAccess](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/allowsconstrainednetworkaccess) property which specifies if "Low Data Mode" is enabled. The property defaults to `true` to maintain the current behavior and will disable uploads when set to `false`.

The SDK is already tracking whether or not the network is constrained in [NWPathMonitorPublisher](https://github.com/DataDog/dd-sdk-ios/blob/968bf9586048d2d81aae3fd096bd2fcc0cb9ce8b/DatadogCore/Sources/Core/Context/NetworkConnectionInfoPublisher.swift#L20) with the `isConstrained` property, and has a mechanism for blocking uploads with [DataUploadConditions.blockersForUpload()](https://github.com/DataDog/dd-sdk-ios/blob/968bf9586048d2d81aae3fd096bd2fcc0cb9ce8b/DatadogCore/Sources/Core/Upload/DataUploadConditions.swift#L30). This PR updates `blockersForUpload()` to block uploads if `isConstrained` is `true` and the `allowsConstrainedNetworkAccess` parameter is `false`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
