### PR TITLE
Merge `release/2.29.0` to `develop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
-- Support for AP2 Datacenter added. You can configure it setting `DatadogSite.ap2` on `Datadog.Configuration.site`.
+# 2.29.0 / 18-06-2025
+
+- [FEATURE] Add SwiftUI auto-tracking for views and actions. See [#2237][] [#2315][]
+- [FEATURE] Add support for AP2 Datacenter. You can configure it setting `DatadogSite.ap2` on `Datadog.Configuration.site`. See [#2343][]
+- [FEATURE] Add account information configuration. The account information propagates to Logs, RUM, Traces, Crash and Error Reporting. See [#2225][]
 
 # 2.28.1 / 29-05-2025
 
@@ -31,7 +35,6 @@
 # 2.24.1 / 31-03-2025
 
 - [FIX] Do not enforce dynamic linking for OpenTelemetryApi in `DatadogTrace`. See [#2244][]
-- [FEATURE] Adds account information configuration. The account information propagates to Logs, RUM, Traces, Crash and Error Reporting. See [#2225][]
 
 # 2.24.0 / 06-03-2025
 
@@ -877,16 +880,21 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2200]: https://github.com/DataDog/dd-sdk-ios/pull/2200
 [#2201]: https://github.com/DataDog/dd-sdk-ios/pull/2201
 [#2195]: https://github.com/DataDog/dd-sdk-ios/pull/2195
-[#2251]: https://github.com/DataDog/dd-sdk-ios/pull/2251
-[#2240]: https://github.com/DataDog/dd-sdk-ios/pull/2240
 [#2223]: https://github.com/DataDog/dd-sdk-ios/pull/2223
+[#2225]: https://github.com/DataDog/dd-sdk-ios/pull/2225
 [#2234]: https://github.com/DataDog/dd-sdk-ios/pull/2234
 [#2236]: https://github.com/DataDog/dd-sdk-ios/pull/2236
+[#2237]: https://github.com/DataDog/dd-sdk-ios/pull/2237
+[#2240]: https://github.com/DataDog/dd-sdk-ios/pull/2240
+[#2251]: https://github.com/DataDog/dd-sdk-ios/pull/2251
 [#2260]: https://github.com/DataDog/dd-sdk-ios/pull/2260
 [#2268]: https://github.com/DataDog/dd-sdk-ios/pull/2268
 [#2302]: https://github.com/DataDog/dd-sdk-ios/pull/2302
 [#2304]: https://github.com/DataDog/dd-sdk-ios/pull/2304
+[#2315]: https://github.com/DataDog/dd-sdk-ios/pull/2315
 [#2316]: https://github.com/DataDog/dd-sdk-ios/pull/2316
+[#2343]: https://github.com/DataDog/dd-sdk-ios/pull/2343
+
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogAlamofireExtension.podspec
+++ b/DatadogAlamofireExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogAlamofireExtension"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   s.description  = <<-DESC
                    The DatadogAlamofireExtension pod is deprecated and will no longer be maintained.

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCore"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogCore/Sources/Versioning.swift
+++ b/DatadogCore/Sources/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "2.28.1"
+internal let __sdkVersion = "2.29.0"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCrashReporting"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogInternal"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog Internal Package. This module is not for public use."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogLogs"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog Logs Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogObjc.podspec
+++ b/DatadogObjc.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogObjc"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogRUM"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog Real User Monitoring Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSessionReplay"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Official Datadog Session Replay SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogTrace"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog Trace Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogWebViewTracking"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog WebView Tracking Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TestUtilities"
-  s.version      = "2.28.1"
+  s.version      = "2.29.0"
   s.summary      = "Datadog Testing Utilities. This module is for internal testing and should not be published."
 
   s.homepage     = "https://www.datadoghq.com"


### PR DESCRIPTION
### What and why?

It merges `release/2.29.0` to `develop` and is the counterpart of: 
- #2346

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)