### PR TITLE
RUM-9988 Expand Action Tracking to other UI components

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/LegacySwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/LegacySwiftUIComponentDetector.swift
@@ -40,12 +40,7 @@ internal final class LegacySwiftUIComponentDetector: SwiftUIComponentDetector {
             }
         }
 
-        // Special detection for SwiftUI Toogle
-        return SwiftUIComponentHelpers.extractSwiftUIToggleAction(
-            from: touch,
-            predicate: predicate,
-            dateProvider: dateProvider
-        )
+        return nil
     }
 }
 

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
@@ -48,13 +48,6 @@ internal final class ModernSwiftUIComponentDetector: SwiftUIComponentDetector {
             ) {
                 return command
             }
-
-            // Special detection for SwiftUI Toogle
-            return SwiftUIComponentHelpers.extractSwiftUIToggleAction(
-                from: touch,
-                predicate: predicate,
-                dateProvider: dateProvider
-            )
         }
 
         return nil

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIComponentDetector.swift
@@ -11,7 +11,6 @@ import DatadogInternal
 internal enum SwiftUIComponentNames {
     static let button = "SwiftUI_Button"
     static let navigationLink = "SwiftUI_NavigationLink"
-    static let toggle = "SwiftUI_Toggle"
     static let unidentified = "SwiftUI_Unidentified_Element"
 }
 
@@ -89,43 +88,6 @@ internal class SwiftUIComponentHelpers {
         }
 
         return defaultName
-    }
-
-    /// Extracts a SwiftUI Toggle action from a touch if applicable
-    /// - Parameters:
-    ///   - touch: The `UITouch` to analyze
-    ///   - predicate: The predicate to use for determining if an action should be created
-    ///   - dateProvider: Provider for current time
-    /// - Returns: A RUM action command if a toggle was detected, `nil` otherwise
-    static func extractSwiftUIToggleAction(
-        from touch: UITouch,
-        predicate: SwiftUIRUMActionsPredicate?,
-        dateProvider: DateProvider
-    ) -> RUMAddUserActionCommand? {
-        guard let predicate = predicate,
-              let view = touch.view else {
-            return nil
-        }
-
-        #if !os(tvOS)
-        let uiSwitch = view.findInParentHierarchy { parent in
-            // Note: we might want to extend to `UIControl` in the future.
-            return parent is UISwitch
-        }
-
-        if uiSwitch != nil,
-           let rumAction = predicate.rumAction(with: SwiftUIComponentNames.toggle) {
-            return RUMAddUserActionCommand(
-                time: dateProvider.now,
-                attributes: rumAction.attributes,
-                instrumentation: .swiftuiAutomatic,
-                actionType: .tap,
-                name: rumAction.name
-            )
-        }
-        #endif
-
-        return nil
     }
 }
 

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
@@ -106,6 +106,7 @@ internal final class UITouchCommandFactory: UIEventCommandFactory {
             let bestParent = view.findInParentHierarchy { parent in
                 return parent is UITableViewCell
                 || parent is UICollectionViewCell
+                || parent is UIControl
             }
             return bestParent // best parent or `nil`
         }

--- a/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
@@ -116,40 +116,6 @@ class SwiftUIComponentDetectorTests: XCTestCase {
         XCTAssertNil(command)
     }
 
-#if !os(tvOS)
-    @available(iOS 18.0, tvOS 18.0, *)
-    func testModernDetector_DetectsToggle() {
-        // Given
-        let detector = ModernSwiftUIComponentDetector()
-
-        // Create a view hierarchy simulating a toggle
-        let switchView = UIView()
-        let parentView = UIView()
-        let grandparentView = UISwitch()
-        parentView.addSubview(switchView)
-        grandparentView.addSubview(parentView)
-
-        let mockTouch = MockUITouch(
-            phase: .ended,
-            view: switchView
-        )
-
-        // When
-        let command = detector.createActionCommand(
-            from: mockTouch,
-            predicate: defaultPredicate,
-            dateProvider: dateProvider
-        )
-
-        // Then
-        XCTAssertNotNil(command)
-        XCTAssertEqual(command?.name, "SwiftUI_Toggle")
-        XCTAssertEqual(command?.actionType, .tap)
-        XCTAssertEqual(command?.instrumentation, .swiftuiAutomatic)
-        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
-    }
-#endif
-
     @available(iOS 18.0, tvOS 18.0, *)
     func testModernDetector_IgnoresNonSwiftUIViews() {
         // Given
@@ -343,40 +309,6 @@ class SwiftUIComponentDetectorTests: XCTestCase {
         XCTAssertEqual(command?.instrumentation, .swiftuiAutomatic)
         XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
     }
-
-#if !os(tvOS)
-    func testLegacyDetector_DetectsToggle() {
-        // Given
-        let detector = LegacySwiftUIComponentDetector()
-        let defaultPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
-
-        // Create a view hierarchy simulating a toggle
-        let switchView = UIView()
-        let parentView = UIView()
-        let grandparentView = UISwitch()
-        parentView.addSubview(switchView)
-        grandparentView.addSubview(parentView)
-
-        let mockTouch = MockUITouch(
-            phase: .ended,
-            view: switchView
-        )
-
-        // When
-        let command = detector.createActionCommand(
-            from: mockTouch,
-            predicate: defaultPredicate,
-            dateProvider: dateProvider
-        )
-
-        // Then
-        XCTAssertNotNil(command)
-        XCTAssertEqual(command?.name, "SwiftUI_Toggle")
-        XCTAssertEqual(command?.actionType, .tap)
-        XCTAssertEqual(command?.instrumentation, .swiftuiAutomatic)
-        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
-    }
-#endif
 
     func testLegacyDetector_IgnoresContainerViews() {
         // Given
@@ -676,25 +608,6 @@ private class MockGestureRecognizer: UIGestureRecognizer {
     override var name: String? {
         get { return mockName }
         set { mockName = newValue }
-    }
-}
-
-private class MockToggleView: UIView {
-    var overrideIsSafeForPrivacy: Bool?
-    var mockTypeDescription: String?
-    var overrideIsSwiftUIView: Bool?
-
-    override var typeDescription: String {
-        return mockTypeDescription ?? "ToggleView"
-    }
-
-    // Override extension properties
-    @objc override var isSafeForPrivacy: Bool {
-        return overrideIsSafeForPrivacy ?? true
-    }
-
-    @objc override var isSwiftUIView: Bool {
-        return false
     }
 }
 

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
@@ -215,7 +215,7 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
         if #available(iOS 18.0, tvOS 18.0, visionOS 18.0, *) {
             XCTAssertEqual(mainView.actionEvents[0].action.target?.name, SwiftUIComponentNames.button)
             XCTAssertEqual(mainView.actionEvents[1].action.target?.name, SwiftUIComponentNames.navigationLink)
-            XCTAssertEqual(mainView.actionEvents[2].action.target?.name, "SwiftUI_Toggle")
+            XCTAssertEqual(mainView.actionEvents[2].action.target?.name, "UISwitch")
             XCTAssertEqual(mainView.actionEvents[3].action.target?.name, "UISlider(slider)")
             XCTAssertEqual(mainView.actionEvents[4].action.target?.name, "UIStepper(stepper)")
             XCTAssertEqual(mainView.actionEvents[5].action.target?.name, "UISegmentedControl")
@@ -225,7 +225,7 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
         } else {
             XCTAssertEqual(mainView.actionEvents[0].action.target?.name, SwiftUIComponentNames.unidentified)
             XCTAssertEqual(mainView.actionEvents[1].action.target?.name, SwiftUIComponentNames.unidentified)
-            XCTAssertEqual(mainView.actionEvents[2].action.target?.name, "SwiftUI_Toggle")
+            XCTAssertEqual(mainView.actionEvents[2].action.target?.name, "UISwitch")
             XCTAssertEqual(mainView.actionEvents[3].action.target?.name, "UISlider(slider)")
             XCTAssertEqual(mainView.actionEvents[4].action.target?.name, "UIStepper(stepper)")
             XCTAssertEqual(mainView.actionEvents[5].action.target?.name, "UISegmentedControl")


### PR DESCRIPTION
### What and why?

This PR improves SwiftUI automatic action tracking coverage by making the detection logic more generic and comprehensive. Previously, the SDK had limited detection for certain SwiftUI components (mainly `Button`, `NavigationLink`, `Link`) and relied on specific class name checks.

### How?

- Extended `bestActionTarget` to search for `UIControl` in the parent hierarchy, not just at the tapped view level
- Removed the special `SwiftUI_Toggle` detection logic (now tracked as `UISwitch`)

The generic parent hierarchy search now covers more SwiftUI and UIKit components naturally.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
