### PR TITLE
RUM-10225 Set gitlab cache for carthage dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,11 @@ default:
       when: delayed
       start_in: 40 minutes
 
+.carthage-cache: &carthage-cache
+  key: "carthage-cache-$CI_COMMIT_REF_SLUG"
+  paths:
+    - Carthage/Build
+
 ENV check:
   stage: pre
   rules: 
@@ -86,6 +91,30 @@ ENV check:
   script:
     - ./tools/runner-setup.sh --datadog-ci
     - make env-check
+
+# ┌──────────────┐
+# │ Local Cache: │
+# └──────────────┘
+
+Dependency Cache:
+  stage: pre
+  rules:
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
+  cache:
+    - <<: *carthage-cache
+      policy: push
+  script:
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - make clean dependencies
+
+Clear Cache:
+  stage: post
+  cache:
+    - <<: *carthage-cache
+      policy: pull-push
+  script:
+    - make clean-carthage
 
 # ┌──────────────────────────┐
 # │ SDK changes integration: │
@@ -106,6 +135,9 @@ Unit Tests (iOS):
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
+  cache:
+    - <<: *carthage-cache
+      policy: pull
   variables:
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 16 Pro"
@@ -119,6 +151,9 @@ Unit Tests (tvOS):
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
+  cache:
+    - <<: *carthage-cache
+      policy: pull
   variables:
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
@@ -132,6 +167,9 @@ UI Tests:
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
+  cache:
+    - <<: *carthage-cache
+      policy: pull
   variables:
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 16 Pro"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,11 +78,6 @@ default:
       when: delayed
       start_in: 40 minutes
 
-.carthage-cache: &carthage-cache
-  key: "carthage-cache-$CI_COMMIT_REF_SLUG"
-  paths:
-    - Carthage/Build
-
 ENV check:
   stage: pre
   rules: 
@@ -96,25 +91,20 @@ ENV check:
 # │ Local Cache: │
 # └──────────────┘
 
-Dependency Cache:
+Build Dependencies:
   stage: pre
   rules:
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  cache:
-    - <<: *carthage-cache
-      policy: push
+  artifacts:
+    paths:
+      - Carthage/Build
+    expire_in: 4 hours
+    when: on_success
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - echo "Building dependencies..."
     - make clean dependencies
-
-Clear Cache:
-  stage: post
-  cache:
-    - <<: *carthage-cache
-      policy: pull-push
-  script:
-    - make clean-carthage
 
 # ┌──────────────────────────┐
 # │ SDK changes integration: │
@@ -135,9 +125,8 @@ Unit Tests (iOS):
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  cache:
-    - <<: *carthage-cache
-      policy: pull
+  dependencies:
+    - "Build Dependencies"
   variables:
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 16 Pro"
@@ -151,9 +140,8 @@ Unit Tests (tvOS):
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  cache:
-    - <<: *carthage-cache
-      policy: pull
+  dependencies:
+    - "Build Dependencies"
   variables:
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
@@ -167,9 +155,8 @@ UI Tests:
   rules: 
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
-  cache:
-    - <<: *carthage-cache
-      policy: pull
+  dependencies:
+    - "Build Dependencies"
   variables:
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 16 Pro"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-all: env-check repo-setup templates
-.PHONY: env-check repo-setup clean templates \
+all: env-check repo-setup dependencies templates
+.PHONY: env-check repo-setup dependencies clean templates \
 		lint license-check \
 		test test-ios test-ios-all test-tvos test-tvos-all \
 		ui-test ui-test-all ui-test-podinstall \
@@ -30,9 +30,17 @@ repo-setup:
 	@$(ECHO_TITLE) "make repo-setup ENV='$(ENV)'"
 	./tools/repo-setup/repo-setup.sh --env "$(ENV)"
 
+dependencies:
+	@$(ECHO_TITLE) "make dependencies"
+	./tools/repo-setup/carthage-bootstrap.sh
+
 clean:
 	@$(ECHO_TITLE) "make clean"
-	./tools/clean.sh
+	./tools/clean.sh --derived-data --pods --xcconfigs
+
+clean-carthage:
+	@$(ECHO_TITLE) "make clean-carthage"
+	./tools/clean.sh --carthage
 
 lint:
 	@$(ECHO_TITLE) "make lint"

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -5,6 +5,13 @@
 
 set -e
 source ./tools/utils/echo-color.sh
+source ./tools/utils/argparse.sh
+
+set_description "Cleans up the local environment."
+define_arg "derived-data" "false" "Clean Xcode derived data." "store_true"
+define_arg "pods" "false" "Clean Pods." "store_true"
+define_arg "xcconfigs" "false" "Clean local xcconfigs." "store_true"
+define_arg "carthage" "false" "Clean Carthage cache." "store_true"
 
 clean_dir() {
     local dir="$1"
@@ -16,13 +23,29 @@ clean_dir() {
     fi
 }
 
-clean_dir ~/Library/Developer/Xcode/DerivedData
-clean_dir ~/Library/Caches/org.carthage.CarthageKit/dependencies/
-clean_dir ~/Library/org.swift.swiftpm
-clean_dir ./Carthage/Build
-clean_dir ./Carthage/Checkouts
-clean_dir ./IntegrationTests/Pods
+check_for_help "$@"
+parse_args "$@"
 
-echo_warn "Cleaning local xcconfigs"
-rm -vf ./xcconfigs/Base.ci.local.xcconfig
-rm -vf ./xcconfigs/Base.dev.local.xcconfig
+if [[ "$derived-data" == "true" ]]; then
+    echo_subtitle "Cleaning Xcode derived data"
+    clean_dir ~/Library/Developer/Xcode/DerivedData
+    clean_dir ~/Library/org.swift.swiftpm
+fi
+
+if [[ "$pods" == "true" ]]; then
+    echo_subtitle "Cleaning Pods"
+    clean_dir ./IntegrationTests/Pods
+fi
+
+if [[ "$xcconfigs" == "true" ]]; then
+    echo_subtitle "Cleaning local xcconfigs"
+    rm -vf ./xcconfigs/Base.ci.local.xcconfig
+    rm -vf ./xcconfigs/Base.dev.local.xcconfig
+fi
+
+if [[ "$carthage" == "true" ]]; then
+    echo_subtitle "Cleaning Carthage cache"
+    clean_dir ~/Library/Caches/org.carthage.CarthageKit/dependencies/
+    clean_dir ./Carthage/Build
+    clean_dir ./Carthage/Checkouts
+fi

--- a/tools/repo-setup/carthage-bootstrap.sh
+++ b/tools/repo-setup/carthage-bootstrap.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+set -eo pipefail
+
+source ./tools/utils/echo-color.sh
+
+./tools/carthage-shim.sh bootstrap --platform iOS,tvOS --use-xcframeworks
+
+echo_succ "Using OpenTelemetryApi version: $(cat ./Carthage/Build/.OpenTelemetryApi.version | grep 'commitish' | awk -F'"' '{print $4}')"
+echo_succ "Using PLCrashReporter version: $(cat ./Carthage/Build/.plcrashreporter.version | grep 'commitish' | awk -F'"' '{print $4}')"

--- a/tools/repo-setup/repo-setup.sh
+++ b/tools/repo-setup/repo-setup.sh
@@ -34,7 +34,3 @@ if [[ "$env" == "$ENV_DEV" ]]; then
 fi
 
 bundle install
-./tools/carthage-shim.sh bootstrap --platform iOS,tvOS --use-xcframeworks
-
-echo_succ "Using OpenTelemetryApi version: $(cat ./Carthage/Build/.OpenTelemetryApi.version | grep 'commitish' | awk -F'"' '{print $4}')"
-echo_succ "Using PLCrashReporter version: $(cat ./Carthage/Build/.plcrashreporter.version | grep 'commitish' | awk -F'"' '{print $4}')"


### PR DESCRIPTION
### What and why?

Optimize build by caching the dependencies. This will reduce call to `carthage bootstrap`. The goal is also to reduce call to `dd-octo-sts` for requesting GH token.

### How?

~~Use [Gitlab CI Cache](https://docs.gitlab.com/ci/caching/#cache) for caching Carthage dependencies across jobs.~~
Use [Gitlab CI Artifacts](https://docs.gitlab.com/ci/jobs/job_artifacts/) for caching Carthage dependencies across jobs.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
