### PR TITLE
Refactor renderer extraction in `UIHostingViewRecorder` and add support for iOS 26

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -86,9 +86,7 @@ internal func createDefaultNodeRecorders(featureFlags: SessionReplay.Configurati
         UIActivityIndicatorRecorder(identifier: UUID()),
     ]
 
-    if #available(iOS 18.1, tvOS 18.1, *) {
-        recorders.append(iOS18HostingViewRecorder(identifier: UUID()))
-    } else if #available(iOS 13, tvOS 13, *) {
+    if #available(iOS 13, tvOS 13, *) {
         recorders.append(UIHostingViewRecorder(identifier: UUID()))
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -261,13 +261,7 @@ private func render<V>(
     with attributes: ViewAttributes = .mockAny(),
     in context: ViewTreeRecordingContext = .mockAny()
 ) throws -> [SRWireframe] where V: SwiftUI.View {
-    let recorder: UIHostingViewRecorder
-    if #available(iOS 18.1, tvOS 18.1, *) {
-        recorder = iOS18HostingViewRecorder(identifier: UUID())
-    } else {
-        recorder = UIHostingViewRecorder(identifier: UUID())
-    }
-
+    let recorder = UIHostingViewRecorder(identifier: UUID())
     let window = UIWindow(frame: CGRect(origin: .zero, size: size))
     let host = UIHostingController(rootView: view)
     window.rootViewController = host


### PR DESCRIPTION
### What and why?

The location of the `renderer` instance has changed in iOS 26. Session Replay depends on the `renderer` to record SwiftUI snapshots. This _partially fixes_ some issues found when capturing snapshots in iOS 26.

### How?

Instead of adding another subclass, I refactored the renderer extraction to take a key path as an input. This key path is based on the available iOS version:

- For iOS >= 26, `_base.viewGraph.renderer`
- For iOS >= 18.1, `_base.renderer`
- For iOS < 18.1, `renderer`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
