### PR TITLE
RUM-10225 Create carthage sts policy

### DIFF
--- a/.github/chainguard/self.carthage.sts.yaml
+++ b/.github/chainguard/self.carthage.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:(branch|tag):ref:.*"
+
+claim_pattern:
+  project_path: "DataDog/dd-sdk-ios"
+  ref_type: 
+    - branch
+    - tag
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-sdk-ios//.gitlab-ci.yml@*"
+
+permissions:
+  metadata: read

--- a/.github/chainguard/self.carthage.sts.yaml
+++ b/.github/chainguard/self.carthage.sts.yaml
@@ -1,12 +1,8 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:(branch|tag):ref:.*"
-
 claim_pattern:
   project_path: "DataDog/dd-sdk-ios"
-  ref_type: 
-    - branch
-    - tag
+  ref_type: "(branch|tag)"
   ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-sdk-ios//.gitlab-ci.yml@*"
 
 permissions:


### PR DESCRIPTION
### What and why?

Add policy for [dd-ocot-sts (internal)](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts) to generate an token and increase rate limit when using `carthage`.

This policy must be present on the main branch before updating the CI configuration.

### How?

The OIDC trust policy:
- allow both `branch` and `tag` pipelines to get a GitHub tokens
- ensure only our official `.gitlab-ci.yml` can request tokens
- allow reading metadata only as we only need a low permission token

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
