### PR TITLE
RUM-10225 Create release sts policy

### DIFF
--- a/.github/chainguard/self.release.sts.yaml
+++ b/.github/chainguard/self.release.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:tag:ref:refs/tags/*"
+subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:tag:ref:refs/tags/.*"
 
 claim_pattern:
   project_path: "DataDog/dd-sdk-ios"

--- a/.github/chainguard/self.release.sts.yaml
+++ b/.github/chainguard/self.release.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:tag:ref:refs/tags/*"
+
+claim_pattern:
+  project_path: "DataDog/dd-sdk-ios"
+  ref_type: "tag"
+  ref_protected: "true"
+  pipeline_source: "push"
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-sdk-ios//.gitlab-ci.yml@refs/heads/master"
+
+permissions:
+  contents: write


### PR DESCRIPTION
### What and why?

Add policy for [dd-ocot-sts (internal)](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts) to generate an fined-grained, short-lived GH token to publish artefacts to GH release..

This policy must be present on the main branch before updating the CI configuration.

### How?

The OIDC trust policy:
- allow `tag` pipelines to get a GitHub tokens
- ensure only our official `.gitlab-ci.yml` can request tokens
- allow writing to contents to enable uploading to GH release.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
