### PR TITLE
RUM-10225 Use dd-octo-sts for carthage bootstrap

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,10 @@ default:
       when: delayed
       start_in: 40 minutes
 
+.dd-octo-sts-id-token: &dd-octo-sts-id-token
+  DDOCTOSTS_ID_TOKEN:
+    aud: dd-octo-sts
+
 ENV check:
   stage: pre
   rules: 
@@ -101,9 +105,10 @@ Build Dependencies:
       - Carthage/Build
     expire_in: 4 hours
     when: on_success
+  id_tokens:
+    <<: *dd-octo-sts-id-token
   script:
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
-    - echo "Building dependencies..."
     - make clean dependencies
 
 # ┌──────────────────────────┐

--- a/tools/carthage-shim.sh
+++ b/tools/carthage-shim.sh
@@ -15,7 +15,9 @@ source "${REPO_ROOT:-.}/tools/secrets/get-secret.sh"
 # a higher rate limit."
 # Ref.: https://github.com/Carthage/Carthage/pull/605
 if [ "$CI" = "true" ]; then
-    export GITHUB_ACCESS_TOKEN=$(get_secret $DD_IOS_SECRET__CARTHAGE_GH_TOKEN)
+    export GITHUB_ACCESS_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/dd-sdk-ios --policy self.carthage)
+    # Set up trap to always revoke token on script exit (success, failure, or interruption)
+    trap 'dd-octo-sts --disable-tracing revoke --token $GITHUB_ACCESS_TOKEN' EXIT
 fi
 
 carthage "$@"

--- a/tools/env-check.sh
+++ b/tools/env-check.sh
@@ -88,6 +88,11 @@ if [ "$CI" = "true" ]; then
     echo_succ "datadog-ci:"
     check_if_installed datadog-ci
     datadog-ci version
+    
+    echo ""
+    echo_succ "dd-octo-sts:"
+    check_if_installed dd-octo-sts
+    dd-octo-sts version
 
     # Check if all secrets are available:
     ./tools/secrets/check-secrets.sh


### PR DESCRIPTION
### What and why?

Remove use of Github PAT for running `carthage`.

### How?

Use `dd-octo-sts` to acquire a fine-grained, short-lived access-token

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
