### PR TITLE
RUM-10486: Add `accountInfo` property to `DDLogEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add SwiftUI support for Session Replay privacy overrides. See [#2333][]
+- [IMPROVEMENT] Add `accountInfo` property to `DDLogEvent`. See [#2360][]
 
 # 2.29.0 / 18-06-2025
 
@@ -896,6 +897,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2315]: https://github.com/DataDog/dd-sdk-ios/pull/2315
 [#2316]: https://github.com/DataDog/dd-sdk-ios/pull/2316
 [#2343]: https://github.com/DataDog/dd-sdk-ios/pull/2343
+[#2360]: https://github.com/DataDog/dd-sdk-ios/pull/2360
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogObjc/Sources/Logs/LogsDataModels+objc.swift
+++ b/DatadogObjc/Sources/Logs/LogsDataModels+objc.swift
@@ -85,6 +85,10 @@ public class DDLogEvent: NSObject {
         .init(root: self)
     }
 
+    @objc public var accountInfo: DDLogEventAccountInfo {
+        .init(root: self)
+    }
+
     @objc public var networkConnectionInfo: DDLogEventNetworkConnectionInfo? {
         if swiftModel.networkConnectionInfo != nil {
             .init(root: self)
@@ -184,6 +188,30 @@ public class DDLogEventUserInfo: NSObject {
         set { root.swiftModel.userInfo.extraInfo = newValue.dd.swiftAttributes }
         get { root.swiftModel.userInfo.extraInfo.dd.objCAttributes }
     }
+}
+
+@objc
+public class DDLogEventAccountInfo: NSObject {
+    internal let root: DDLogEvent
+
+    internal init(root: DDLogEvent) {
+        self.root = root
+    }
+
+    // swiftlint:disable force_unwrapping
+    @objc public var id: String {
+        root.swiftModel.accountInfo!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.accountInfo!.name
+    }
+
+    @objc public var extraInfo: [String: Any] {
+        set { root.swiftModel.accountInfo!.extraInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.accountInfo!.extraInfo.dd.objCAttributes }
+    }
+    // swiftlint:enable force_unwrapping
 }
 
 @objc

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -49,6 +49,7 @@ public class DDSite: NSObject
     public static func us5() -> DDSite
     public static func eu1() -> DDSite
     public static func ap1() -> DDSite
+    public static func ap2() -> DDSite
     public static func us1_fed() -> DDSite
 public enum DDBatchSize: Int
     case small
@@ -161,6 +162,7 @@ public class DDLogEvent: NSObject
     @objc public var dd: DDLogEventDd
     @objc public var os: DDLogEventOperatingSystem
     @objc public var userInfo: DDLogEventUserInfo
+    @objc public var accountInfo: DDLogEventAccountInfo
     @objc public var networkConnectionInfo: DDLogEventNetworkConnectionInfo?
     @objc public var mobileCarrierInfo: DDLogEventCarrierInfo?
     @objc public var attributes: DDLogEventAttributes
@@ -179,6 +181,10 @@ public class DDLogEventUserInfo: NSObject
     @objc public var id: String?
     @objc public var name: String?
     @objc public var email: String?
+    @objc public var extraInfo: [String: Any]
+public class DDLogEventAccountInfo: NSObject
+    @objc public var id: String
+    @objc public var name: String?
     @objc public var extraInfo: [String: Any]
 public class DDLogEventError: NSObject
     @objc public var kind: String?
@@ -341,6 +347,8 @@ public class DDRUMConfiguration: NSObject
     @objc public var telemetrySampleRate: Float
     @objc public var uiKitViewsPredicate: DDUIKitRUMViewsPredicate?
     @objc public var uiKitActionsPredicate: DDUIKitRUMActionsPredicate?
+    @objc public var swiftUIViewsPredicate: DDSwiftUIRUMViewsPredicate?
+    @objc public var swiftUIActionsPredicate: DDSwiftUIRUMActionsPredicate?
     public func setURLSessionTracking(_ tracking: DDRUMURLSessionTracking)
     @objc public var trackFrustrations: Bool
     @objc public var trackBackgroundEvents: Bool
@@ -414,6 +422,7 @@ public class DDRUMActionEventDD: NSObject
     @objc public var browserSdkVersion: String?
     @objc public var configuration: DDRUMActionEventDDConfiguration?
     @objc public var formatVersion: NSNumber
+    @objc public var sdkName: String?
     @objc public var session: DDRUMActionEventDDSession?
 public class DDRUMActionEventDDAction: NSObject
     @objc public var nameSource: DDRUMActionEventDDActionNameSource
@@ -630,6 +639,7 @@ public class DDRUMErrorEventDD: NSObject
     @objc public var browserSdkVersion: String?
     @objc public var configuration: DDRUMErrorEventDDConfiguration?
     @objc public var formatVersion: NSNumber
+    @objc public var sdkName: String?
     @objc public var session: DDRUMErrorEventDDSession?
 public class DDRUMErrorEventDDConfiguration: NSObject
     @objc public var sessionReplaySampleRate: NSNumber?
@@ -925,6 +935,7 @@ public class DDRUMLongTaskEventDD: NSObject
     @objc public var configuration: DDRUMLongTaskEventDDConfiguration?
     @objc public var discarded: NSNumber?
     @objc public var formatVersion: NSNumber
+    @objc public var sdkName: String?
     @objc public var session: DDRUMLongTaskEventDDSession?
 public class DDRUMLongTaskEventDDConfiguration: NSObject
     @objc public var sessionReplaySampleRate: NSNumber?
@@ -1125,6 +1136,7 @@ public class DDRUMResourceEventDD: NSObject
     @objc public var discarded: NSNumber?
     @objc public var formatVersion: NSNumber
     @objc public var rulePsr: NSNumber?
+    @objc public var sdkName: String?
     @objc public var session: DDRUMResourceEventDDSession?
     @objc public var spanId: String?
     @objc public var traceId: String?
@@ -1399,6 +1411,7 @@ public class DDRUMViewEventDD: NSObject
     @objc public var formatVersion: NSNumber
     @objc public var pageStates: [DDRUMViewEventDDPageStates]?
     @objc public var replayStats: DDRUMViewEventDDReplayStats?
+    @objc public var sdkName: String?
     @objc public var session: DDRUMViewEventDDSession?
 public class DDRUMViewEventDDCLS: NSObject
     @objc public var devicePixelRatio: NSNumber?
@@ -1718,6 +1731,7 @@ public class DDRUMVitalEventDD: NSObject
     @objc public var browserSdkVersion: String?
     @objc public var configuration: DDRUMVitalEventDDConfiguration?
     @objc public var formatVersion: NSNumber
+    @objc public var sdkName: String?
     @objc public var session: DDRUMVitalEventDDSession?
     @objc public var vital: DDRUMVitalEventDDVital?
 public class DDRUMVitalEventDDConfiguration: NSObject
@@ -2015,6 +2029,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var invTimeThresholdMs: NSNumber?
     @objc public var isMainProcess: NSNumber?
     @objc public var mobileVitalsUpdatePeriod: NSNumber?
+    @objc public var numberOfDisplays: NSNumber?
     @objc public var plugins: [DDTelemetryConfigurationEventTelemetryConfigurationPlugins]?
     @objc public var premiumSampleRate: NSNumber?
     @objc public var reactNativeVersion: String?
@@ -2029,6 +2044,8 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var startRecordingImmediately: NSNumber?
     @objc public var startSessionReplayRecordingManually: NSNumber?
     @objc public var storeContextsAcrossPages: NSNumber?
+    @objc public var swiftuiActionTrackingEnabled: NSNumber?
+    @objc public var swiftuiViewTrackingEnabled: NSNumber?
     @objc public var telemetryConfigurationSampleRate: NSNumber?
     @objc public var telemetrySampleRate: NSNumber?
     @objc public var telemetryUsageSampleRate: NSNumber?
@@ -2041,6 +2058,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var tracerApiVersion: String?
     @objc public var trackAnonymousUser: NSNumber?
     @objc public var trackBackgroundEvents: NSNumber?
+    @objc public var trackBfcacheViews: NSNumber?
     @objc public var trackCrossPlatformLongTasks: NSNumber?
     @objc public var trackErrors: NSNumber?
     @objc public var trackFeatureFlagsForEvents: [Int]?
@@ -2060,6 +2078,7 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject
     @objc public var unityVersion: String?
     @objc public var useAllowedTracingOrigins: NSNumber?
     @objc public var useAllowedTracingUrls: NSNumber?
+    @objc public var useAllowedTrackingOrigins: NSNumber?
     @objc public var useBeforeSend: NSNumber?
     @objc public var useCrossSiteSessionCookie: NSNumber?
     @objc public var useExcludedActivityUrls: NSNumber?
@@ -2122,6 +2141,15 @@ public class DDTelemetryConfigurationEventTelemetryRUMTelemetryOperatingSystem: 
     @objc public var version: String?
 public class DDTelemetryConfigurationEventView: NSObject
     @objc public var id: String
+public protocol DDSwiftUIRUMViewsPredicate: AnyObject
+    func rumView(for extractedViewName: String) -> DDRUMView?
+public class DDDefaultSwiftUIRUMViewsPredicate: NSObject, DDSwiftUIRUMViewsPredicate
+    public func rumView(for extractedViewName: String) -> DDRUMView?
+public protocol DDSwiftUIRUMActionsPredicate: AnyObject
+    func rumAction(with componentName: String) -> DDRUMAction?
+public class DDDefaultSwiftUIRUMActionsPredicate: NSObject, DDSwiftUIRUMActionsPredicate
+    public init(isLegacyDetectionEnabled: Bool)
+    public func rumAction(with componentName: String) -> DDRUMAction?
 public enum DDInjectEncoding: Int
     case multiple = 0
     case single = 1


### PR DESCRIPTION
### What and why?

Account info property was missing in the ObjC API for Logs, this PR fixes that.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
