### PR TITLE
RUM-10492: Refactor `DisplayList.ViewInfo` and `DisplayList.Content.Value` for iOS 26 support

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
@@ -21,6 +21,13 @@ extension SwiftUI.Color._Resolved: Reflection {
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
+extension ColorView: Reflection {
+    init(from reflector: Reflector) throws {
+        color = try reflector.descendant("color", "base")
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
 extension ResolvedPaint: Reflection {
     init(from reflector: Reflector) throws {
         paint = reflector.descendantIfPresent("paint")

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color.swift
@@ -20,6 +20,11 @@ extension SwiftUI.Color {
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
+internal struct ColorView {
+    let color: SwiftUI.Color._Resolved
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
 internal struct ResolvedPaint {
     let paint: SwiftUI.Color._Resolved?
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -156,7 +156,11 @@ extension DisplayList.Content.Value: Reflection {
             self = .unknown
 
         case let (.enum("color"), color):
-            self = try .color(reflector.reflect(color))
+            if #available(iOS 26, tvOS 26, *) {
+                self = try .color(reflector.reflect(type: ColorView.self, color).color)
+            } else {
+                self = try .color(reflector.reflect(color))
+            }
 
         default:
             self = .unknown


### PR DESCRIPTION
### What and why?

iOS 26 introduces some structural changes in the `DisplayList` type we rely on for SwiftUI Session Replay:

- `ViewInfo.view` and `ViewInfo.container` can either be a `UIView` or a `CALayer` (the same as the `ViewInfo.layer` in this case)
- The payload for the `DisplayList.Content.Value.color` case is a `ColorView` instead of a `SwiftUI.Color._Resolved`.

We need to address these differences to improve SwiftUI Session Replay on iOS 26.

### How?

- Make the `ViewInfo.view` property reflection optional, falling back to a `CALayer` for `ViewInfo.container`
- Add an internal `ColorView` type with a `color` property, matching the structure for the payload on iOS 26.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
