### PR TITLE
RUM-10190: Sample traces according to `session.id`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		11030D712D95A51100732D5F /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */; };
 		11030D762D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
 		11030D772D96EC5C00732D5F /* ViewHitchesMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */; };
+		110B0ECB2DF0ABC6008ABA19 /* DeterministicSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110B0ECA2DF0ABBE008ABA19 /* DeterministicSampler.swift */; };
+		110B0ECC2DF0ABC6008ABA19 /* DeterministicSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110B0ECA2DF0ABBE008ABA19 /* DeterministicSampler.swift */; };
 		112877992D708D300082D11B /* VitalRefreshRateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877972D708D300082D11B /* VitalRefreshRateReader.swift */; };
 		1128779A2D708D300082D11B /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877942D708D300082D11B /* FrameInfoProvider.swift */; };
 		1128779B2D708D300082D11B /* RenderLoopObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112877952D708D300082D11B /* RenderLoopObserver.swift */; };
@@ -30,6 +32,8 @@
 		114CA15D2D75D6AB00262287 /* DisplayLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114CA15B2D75D6A700262287 /* DisplayLinkerTests.swift */; };
 		114FFDE82E0031BA00330C91 /* SwiftUIRUMViewsPredicate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FFDE72E0031BA00330C91 /* SwiftUIRUMViewsPredicate+objc.swift */; };
 		114FFDE92E0031BA00330C91 /* SwiftUIRUMViewsPredicate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FFDE72E0031BA00330C91 /* SwiftUIRUMViewsPredicate+objc.swift */; };
+		115F480B2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
+		115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
 		116F84062CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
 		116F84072CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
 		117E52222D91A61A00A8E930 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; };
@@ -2265,6 +2269,7 @@
 
 /* Begin PBXFileReference section */
 		11030D752D96EC5300732D5F /* ViewHitchesMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHitchesMetric.swift; sourceTree = "<group>"; };
+		110B0ECA2DF0ABBE008ABA19 /* DeterministicSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSampler.swift; sourceTree = "<group>"; };
 		1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAttributesIntegrationTests.swift; sourceTree = "<group>"; };
 		112877942D708D300082D11B /* FrameInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameInfoProvider.swift; sourceTree = "<group>"; };
 		112877952D708D300082D11B /* RenderLoopObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderLoopObserver.swift; sourceTree = "<group>"; };
@@ -2274,6 +2279,7 @@
 		114CA1582D75C64E00262287 /* ViewHitchesReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHitchesReaderTests.swift; sourceTree = "<group>"; };
 		114CA15B2D75D6A700262287 /* DisplayLinkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkerTests.swift; sourceTree = "<group>"; };
 		114FFDE72E0031BA00330C91 /* SwiftUIRUMViewsPredicate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUIRUMViewsPredicate+objc.swift"; sourceTree = "<group>"; };
+		115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
 		116F84052CFDD06700705755 /* SampleRateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRateTests.swift; sourceTree = "<group>"; };
 		118246772D90416A00E3D16F /* DirectoriesStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoriesStub.swift; sourceTree = "<group>"; };
 		118248612D908BEF00E3D16F /* DatadogIntegrationTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogIntegrationTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6531,6 +6537,7 @@
 		D2A783D329A53049003B03BB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				110B0ECA2DF0ABBE008ABA19 /* DeterministicSampler.swift */,
 				960A0D382D6E2490004BB999 /* CustomDump.swift */,
 				960A0D392D6E2490004BB999 /* ReflectionMirror.swift */,
 				960A0D3A2D6E2490004BB999 /* Reflector.swift */,
@@ -6548,6 +6555,7 @@
 		D2A783D629A530B4003B03BB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */,
 				D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */,
 				116F84052CFDD06700705755 /* SampleRateTests.swift */,
 				613C6B912768FF3100870CBF /* SamplerTests.swift */,
@@ -8805,6 +8813,7 @@
 				D23039F4298D5236001A1FA3 /* AnyCodable.swift in Sources */,
 				D29A9F9529DDB1DB005C54A4 /* UIKitExtensions.swift in Sources */,
 				6167E6E82B8122E900C3CA2D /* BacktraceReport.swift in Sources */,
+				110B0ECB2DF0ABC6008ABA19 /* DeterministicSampler.swift in Sources */,
 				960A0D3B2D6E2490004BB999 /* Reflector.swift in Sources */,
 				960A0D3C2D6E2490004BB999 /* CustomDump.swift in Sources */,
 				960A0D3D2D6E2490004BB999 /* ReflectionMirror.swift in Sources */,
@@ -9924,6 +9933,7 @@
 				D2DA2361298D57AA00C6C7E6 /* AnyCodable.swift in Sources */,
 				D29A9F9629DDB1DB005C54A4 /* UIKitExtensions.swift in Sources */,
 				6167E6E92B8122E900C3CA2D /* BacktraceReport.swift in Sources */,
+				110B0ECC2DF0ABC6008ABA19 /* DeterministicSampler.swift in Sources */,
 				D2BEEDB62B3360830065F3AC /* URLSessionSwizzler.swift in Sources */,
 				D2EBEE2F29BA161100B15732 /* W3CHTTPHeaders.swift in Sources */,
 				6167E6F72B81E94C00C3CA2D /* DDThread.swift in Sources */,
@@ -10048,6 +10058,7 @@
 				D20731CD29A52E8700ECBF94 /* SamplerTests.swift in Sources */,
 				D2EBEE3E29BA163E00B15732 /* W3CHTTPHeadersReaderTests.swift in Sources */,
 				D2160CE929C0E00200FAA9A5 /* MethodSwizzlerTests.swift in Sources */,
+				115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */,
 				D2160CDC29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
 				615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */,
 				6156A9072BF75A7C00DF66C3 /* ImmutableRequestTests.swift in Sources */,
@@ -10075,6 +10086,7 @@
 				61F3E3672BC595F600C7881E /* HTTPHeadersReaderTests.swift in Sources */,
 				D2EBEE4029BA163F00B15732 /* B3HTTPHeadersWriterTests.swift in Sources */,
 				D21AE6BD29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */,
+				115F480B2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */,
 				D2DA23B1298D59DC00C6C7E6 /* AnyEncodableTests.swift in Sources */,
 				3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB529DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -48,7 +48,7 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
         )
     }
 
-        override func tearDownWithError() throws {
+    override func tearDownWithError() throws {
         try core.flushAndTearDown()
         core = nil
     }

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -36,7 +36,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: receiver,
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init([
                 "www.example.com": [.datadog]
             ]),

--- a/DatadogInternal/Sources/Utils/DeterministicSampler.swift
+++ b/DatadogInternal/Sources/Utils/DeterministicSampler.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+/// Deterministic sampler that makes consistent sampling decisions for a given `seed`.
+///
+/// This sampler uses Knuth hashing to compute a uniform hash of the `seed`, allowing
+/// deterministic sampling based on a sampling rate `samplingRate`.
+///
+/// Conforms to the `Sampling` protocol.
+public struct DeterministicSampler: Sampling {
+    enum Constants {
+        /// Good number for Knuth hashing (large, prime, fit in 64 bit long)
+        internal static let samplerHasher: UInt64 = 1_111_111_111_111_111_111
+        internal static let maxID: UInt64 = 0xFFFFFFFFFFFFFFFF
+    }
+
+    /// Value between `0.0` and `100.0`, where `0.0` means NO event will be sent and `100.0` means ALL events will be sent.
+    public let samplingRate: SampleRate
+    /// Persisted sampling decision.
+    private let shouldSample: Bool
+
+    /// Initializes a new instance of `DeterministicSampler`.
+    ///
+    /// - Parameters:
+    ///   - seed: A 64-bit unsigned integer used as the base input for Knuth hashing.
+    ///   - samplingRate: A percentage value between `0.0` and `100.0`.
+    ///     - `0.0` disables sampling entirely (no data is sampled).
+    ///     - `100.0` enables full sampling (all data is sampled).
+    public init(seed: UInt64, samplingRate: SampleRate) {
+        // We use overflow multiplication to create a "randomized" hash based on the `seed`
+        let hash = seed &* Constants.samplerHasher
+        let threshold = Float(Constants.maxID) * samplingRate.percentageProportion
+        self.samplingRate = samplingRate
+        self.shouldSample = Float(hash) < threshold
+    }
+
+    /// Based on the `seed` and sampling rate, it returns consistent value decisions.
+    /// - Returns: `true` if data should be "sampled".
+    public func sample() -> Bool { shouldSample }
+}

--- a/DatadogInternal/Sources/Utils/Sampler.swift
+++ b/DatadogInternal/Sources/Utils/Sampler.swift
@@ -12,6 +12,8 @@ public typealias SampleRate = Float
 
 /// Protocol for determining sampling decisions.
 public protocol Sampling {
+    /// Value between `0.0` and `100.0`, where `0.0` means NO event will be sent and `100.0` means ALL events will be sent.
+    var samplingRate: SampleRate { get }
     /// Determines whether sampling should be performed.
     ///
     /// - Returns: A boolean value indicating whether sampling should occur.

--- a/DatadogInternal/Tests/Utils/DeterministicSamplerTests.swift
+++ b/DatadogInternal/Tests/Utils/DeterministicSamplerTests.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogInternal
+
+ final class DeterministicSamplerTests: XCTestCase {
+     func testWithHardcodedTraceId_itReturnsExpectedDecision() {
+         XCTAssertEqual(DeterministicSampler(seed: 4_815_162_342, samplingRate: 55.9).sample(), false)
+         XCTAssertEqual(DeterministicSampler(seed: 4_815_162_342, samplingRate: 56.0).sample(), true)
+
+         XCTAssertEqual(DeterministicSampler(seed: 1_415_926_535_897_932_384, samplingRate: 90.5).sample(), false)
+         XCTAssertEqual(DeterministicSampler(seed: 1_415_926_535_897_932_384, samplingRate: 90.6).sample(), true)
+
+         XCTAssertEqual(DeterministicSampler(seed: 718_281_828_459_045_235, samplingRate: 7.4).sample(), false)
+         XCTAssertEqual(DeterministicSampler(seed: 718_281_828_459_045_235, samplingRate: 7.5).sample(), true)
+
+         XCTAssertEqual(DeterministicSampler(seed: 41_421_356_237_309_504, samplingRate: 32.1).sample(), false)
+         XCTAssertEqual(DeterministicSampler(seed: 41_421_356_237_309_504, samplingRate: 32.2).sample(), true)
+
+         XCTAssertEqual(DeterministicSampler(seed: 6_180_339_887_498_948_482, samplingRate: 68.2).sample(), false)
+         XCTAssertEqual(DeterministicSampler(seed: 6_180_339_887_498_948_482, samplingRate: 68.3).sample(), true)
+     }
+ }

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -88,7 +88,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
     }
 
     func startRootSpan(operationName: String, tags: [String: Encodable]? = nil, startTime: Date? = nil) -> OTSpan {
-        return startSpan(
+        startSpan(
             spanContext: createSpanContext(parentSpanContext: nil, using: localTraceSampler),
             operationName: operationName,
             tags: tags,
@@ -122,8 +122,8 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
 
     // MARK: - Internal
 
-    internal func createSpanContext(parentSpanContext: DDSpanContext?, using sampler: Sampler) -> DDSpanContext {
-        return DDSpanContext(
+    internal func createSpanContext(parentSpanContext: DDSpanContext?, using sampler: Sampling) -> DDSpanContext {
+        DDSpanContext(
             traceID: parentSpanContext?.traceID ?? traceIDGenerator.generate(),
             spanID: spanIDGenerator.generate(),
             parentSpanID: parentSpanContext?.spanID,

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -10,10 +10,10 @@ import DatadogInternal
 internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
     /// Integration with Core Context.
     let contextReceiver: ContextMessageReceiver
-    /// Distributed trace sampler. Used for spans created through network instrumentation.
-    let distributedTraceSampler: Sampler
     /// First party hosts defined by the user.
     let firstPartyHosts: FirstPartyHosts
+    /// Value between `0.0` and `100.0`, where `0.0` means NO trace will be sent and `100.0` means ALL trace and spans will be sent.
+    let samplingRate: SampleRate
     /// Trace context injection configuration to determine whether the trace context should be injected or not.
     let traceContextInjection: TraceContextInjection
 
@@ -22,35 +22,33 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
     init(
         tracer: DatadogTracer,
         contextReceiver: ContextMessageReceiver,
-        distributedTraceSampler: Sampler,
+        samplingRate: SampleRate,
         firstPartyHosts: FirstPartyHosts,
         traceContextInjection: TraceContextInjection
     ) {
         self.tracer = tracer
         self.contextReceiver = contextReceiver
-        self.distributedTraceSampler = distributedTraceSampler
+        self.samplingRate = samplingRate
         self.firstPartyHosts = firstPartyHosts
         self.traceContextInjection = traceContextInjection
     }
 
-    func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?) {
+    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?) {
         guard let tracer = tracer else {
             return (request, nil)
         }
 
-        // Use the current active span as parent if the propagation
-        // headers support it.
+        // Use the current active span as parent if the propagation headers support it.
         let parentSpanContext = tracer.activeSpan?.context as? DDSpanContext
-        let spanContext = tracer.createSpanContext(
-            parentSpanContext: parentSpanContext,
-            using: distributedTraceSampler
-        )
+        let traceID = parentSpanContext?.traceID ?? tracer.traceIDGenerator.generate()
+        let sampler = sampler(sessionID: contextReceiver.context.rumContext?.sessionID, traceID: traceID.idLo)
+
         let injectedSpanContext = TraceContext(
-            traceID: spanContext.traceID,
-            spanID: spanContext.spanID,
-            parentSpanID: spanContext.parentSpanID,
-            sampleRate: spanContext.sampleRate,
-            isKept: spanContext.isKept,
+            traceID: traceID,
+            spanID: tracer.spanIDGenerator.generate(),
+            parentSpanID: parentSpanContext?.spanID,
+            sampleRate: parentSpanContext?.sampleRate ?? samplingRate,
+            isKept: parentSpanContext?.isKept ?? sampler.sample(),
             rumSessionId: contextReceiver.context.rumContext?.sessionID
         )
 
@@ -124,7 +122,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
                 operationName: "urlsession.request",
                 startTime: resourceMetrics.fetch.start
             )
-        } else if distributedTraceSampler.sample() {
+        } else if Sampler(samplingRate: samplingRate).sample() {
             // Span context may not be injected on iOS13+ if `URLSession.dataTask(...)` for `URL`
             // was used to create the session task.
             span = tracer.startSpan(
@@ -175,6 +173,22 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         }
 
         span.finish(at: resourceMetrics.fetch.end)
+    }
+
+    private func sampler(sessionID: String?, traceID: UInt64?) -> Sampling {
+        if let sessionID,
+           // for a UUID with value aaaaaaaa-bbbb-Mccc-Nddd-1234567890ab
+           // we use as the base id the last part : 0x1234567890ab
+            let seed = sessionID
+            .split(separator: "-")
+            .last
+            .flatMap({ UInt64($0, radix: 16) }) {
+            return DeterministicSampler(seed: seed, samplingRate: samplingRate)
+        } else if let traceID {
+            return DeterministicSampler(seed: traceID, samplingRate: samplingRate)
+        }
+
+        return Sampler(samplingRate: samplingRate)
     }
 }
 

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -45,17 +45,17 @@ public enum Trace {
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:
         if let firstPartyHostsTracing = configuration.urlSessionTracking?.firstPartyHostsTracing {
-            let distributedTraceSampler: Sampler
             let firstPartyHosts: FirstPartyHosts
             let traceContextInjection: TraceContextInjection
+            let tracingSampleRate: SampleRate
 
             switch firstPartyHostsTracing {
             case let .trace(hosts, sampleRate, injection):
-                distributedTraceSampler = Sampler(samplingRate: configuration.debugSDK ? 100 : sampleRate)
+                tracingSampleRate = sampleRate
                 firstPartyHosts = FirstPartyHosts(hosts)
                 traceContextInjection = injection
             case let .traceWithHeaders(hostsWithHeaders, sampleRate, injection):
-                distributedTraceSampler = Sampler(samplingRate: configuration.debugSDK ? 100 : sampleRate)
+                tracingSampleRate = sampleRate
                 firstPartyHosts = FirstPartyHosts(hostsWithHeaders)
                 traceContextInjection = injection
             }
@@ -63,7 +63,7 @@ public enum Trace {
             let urlSessionHandler = TracingURLSessionHandler(
                 tracer: trace.tracer,
                 contextReceiver: trace.contextReceiver,
-                distributedTraceSampler: distributedTraceSampler,
+                samplingRate: configuration.debugSDK ? 100 : tracingSampleRate,
                 firstPartyHosts: firstPartyHosts,
                 traceContextInjection: traceContextInjection
             )

--- a/DatadogTrace/Tests/TraceTests.swift
+++ b/DatadogTrace/Tests/TraceTests.swift
@@ -140,7 +140,7 @@ class TraceTests: XCTestCase {
             networkInstrumentation.handlers.firstElement(of: TracingURLSessionHandler.self),
             "It should register `TracingURLSessionHandler` to `NetworkInstrumentationFeature`"
         )
-        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, 100)
+        XCTAssertEqual(tracingHandler.samplingRate, 100)
     }
 
     func testWhenEnabledWithURLSessionTrackingAndCustomSampleRate() throws {
@@ -169,7 +169,7 @@ class TraceTests: XCTestCase {
             networkInstrumentation.handlers.firstElement(of: TracingURLSessionHandler.self),
             "It should register `TracingURLSessionHandler` to `NetworkInstrumentationFeature`"
         )
-        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, random, accuracy: 0.001)
+        XCTAssertEqual(tracingHandler.samplingRate, random, accuracy: 0.001)
     }
 
     func testWhenEnabledWithBundleWithRUM() throws {
@@ -246,7 +246,7 @@ class TraceTests: XCTestCase {
         let networkInstrumentation = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
         let tracingHandler = try XCTUnwrap(networkInstrumentation.handlers.firstElement(of: TracingURLSessionHandler.self))
         XCTAssertEqual(tracer.localTraceSampler.samplingRate, 100)
-        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, 100)
+        XCTAssertEqual(tracingHandler.samplingRate, 100)
     }
 
     func testWhenEnabledWithNoDebugSDKArgument() throws {
@@ -269,6 +269,6 @@ class TraceTests: XCTestCase {
         let networkInstrumentation = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
         let tracingHandler = try XCTUnwrap(networkInstrumentation.handlers.firstElement(of: TracingURLSessionHandler.self))
         XCTAssertEqual(tracer.localTraceSampler.samplingRate, random)
-        XCTAssertEqual(tracingHandler.distributedTraceSampler.samplingRate, random)
+        XCTAssertEqual(tracingHandler.samplingRate, random)
     }
 }

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -31,7 +31,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: receiver,
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init([
                 "www.example.com": [.datadog]
             ]),
@@ -49,7 +49,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: ContextMessageReceiver(),
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
             traceContextInjection: .all
         )
@@ -96,7 +96,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: ContextMessageReceiver(),
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
             traceContextInjection: .all
         )
@@ -151,7 +151,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: ContextMessageReceiver(),
-            distributedTraceSampler: .mockRejectAll(),
+            samplingRate: 0,
             firstPartyHosts: .init(),
             traceContextInjection: .sampled
         )
@@ -191,7 +191,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let handler = TracingURLSessionHandler(
             tracer: tracer,
             contextReceiver: ContextMessageReceiver(),
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
             traceContextInjection: .all
         )
@@ -420,7 +420,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let handler = TracingURLSessionHandler(
             tracer: .mockWith(core: core),
             contextReceiver: receiver,
-            distributedTraceSampler: .mockKeepAll(),
+            samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
             traceContextInjection: .all
         )


### PR DESCRIPTION
### What and why?

This PR ensures that trace sampling is deterministic based on the `session.id` when the RUM feature is enabled.
This guarantees a consistent sampling decision for each session, which is important for features like RUM that rely on [head-based instrumentation](https://github.com/DataDog/dd-sdk-ios/blob/053b4d6b978ae9dba658b8e44a9212d36d1f5a7b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift#L168-L193) strategies.

### How?

A `DeterministicSampler` is introduced in the `TracingURLSessionHandler` to make trace sampling consistent per `session.id`. The `session.id` is extracted from the `RUMContext`, which implies that the RUM feature is enabled.
If RUM is not active, the sampling falls back to using the `traceID`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
