### PR TITLE
chore: Restore `setUserInfo()` deprecation

### DIFF
--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -84,6 +84,23 @@ public enum Datadog {
         )
     }
 
+    @available(*, deprecated, message: "UserInfo id property is now mandatory.")
+    public static func setUserInfo(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:],
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
+        let core = core as? DatadogCore
+        core?.setUserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
+    }
+
     /// Add custom attributes to the current user information
     ///
     /// This extra info will be added to already existing extra info that is added


### PR DESCRIPTION
### What and why?

📦 Restores the deprecated `setUserInfo()` API, which was removed in https://github.com/DataDog/dd-sdk-ios/pull/2361 without providing an alternative. This brings it back temporarily until a new API is introduced as part of `RUM-9263`.

### How?

Reintroduces the previously deprecated `setUserInfo()` method to avoid breaking changes, pending the implementation of the new replacement API.


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
