### PR TITLE
RUM-10225 Use dd-octo-sts for Mobile App PR 

### DIFF
--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -274,11 +274,12 @@ if [ "$datadog_app" = "true" ]; then
     update_dependant_sdk_version "$CLONE_PATH/Targets/Platform/DatadogObservability/DogfoodingConfig.swift"
 
     echo_info "▸ Exporting 'GITHUB_TOKEN' for CI"
-    export GITHUB_TOKEN=$(get_secret $DD_IOS_SECRET__GH_CLI_TOKEN)
+    export GITHUB_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/datadog-ios --policy dd-sdk-ios.gitlab.pr)
     verify_gh_auth
 
     # Push & create PR:
     commit_repo $CLONE_PATH
     push_repo $CLONE_PATH
     create_pr $CLONE_PATH $CHANGELOG $DEFAULT_BRANCH
+    dd-octo-sts --disable-tracing revoke
 fi


### PR DESCRIPTION
### What and why?

Remove use of Github PAT for dogfooding Mobile App.

### How?

Use `dd-octo-sts` to acquire a fine-grained, short-lived access-token.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
