### PR TITLE
RUM-10225 Use dd-octo-sts to publish release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -369,6 +369,8 @@ Publish GH Asset:
   stage: release-publish
   rules: 
     - !reference [.release-pipeline-job, rules]
+  id_tokens:
+    <<: *dd-octo-sts-id-token
   before_script:
     - *export_MAKE_release_params
   script:

--- a/tools/release/publish-github.sh
+++ b/tools/release/publish-github.sh
@@ -28,10 +28,7 @@ parse_args "$@"
 GH_ASSET_PATH="$artifacts_path/Datadog.xcframework.zip"
 REPO_NAME="DataDog/dd-sdk-ios"
 
-authenticate() {
-    echo_subtitle "Authenticate 'gh' CLI"
-    echo_info "Exporting 'GITHUB_TOKEN' for CI"
-    export GITHUB_TOKEN=$(get_secret $DD_IOS_SECRET__GH_CLI_TOKEN)
+verify_gh_auth() {
     echo_info "▸ gh auth status"
     gh auth status
     if [[ $? -ne 0 ]]; then
@@ -59,5 +56,7 @@ echo_info "Publishing '$GH_ASSET_PATH' to '$tag' release in '$REPO_NAME'"
 echo_info "▸ Using DRY_RUN = $DRY_RUN"
 echo_info "▸ Using OVERWRITE_EXISTING = $OVERWRITE_EXISTING"
 
-authenticate
+export GITHUB_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/dd-sdk-ios --policy self.release)
+verify_gh_auth
 upload
+dd-octo-sts --disable-tracing revoke


### PR DESCRIPTION
### What and why?

Remove use of Github PAT for uploading release artifacts.

### How?

Use `dd-octo-sts` to acquire a fine-grained, short-lived access-token.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
