### PR TITLE
RUM-9263 Keep anonymous id when clearing User Info

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -174,7 +174,7 @@ internal final class DatadogCore {
     /// you need to stop the view first by using `RUMMonitor.stopView(viewController:attributes:)`
     ///
     func clearUserInfo() {
-        userInfoPublisher.current = .empty
+        userInfoPublisher.current = UserInfo(anonymousId: userInfoPublisher.current.anonymousId)
     }
 
     /// Sets current account information.

--- a/DatadogCore/Tests/Datadog/DatadogTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogTests.swift
@@ -223,7 +223,9 @@ class DatadogTests: XCTestCase {
             email: "foo@bar.com",
             extraInfo: ["abc": 123]
         )
+        core?.set(anonymousId: "anonymous-id")
 
+        XCTAssertEqual(core?.userInfoPublisher.current.anonymousId, "anonymous-id")
         XCTAssertEqual(core?.userInfoPublisher.current.id, "foo")
         XCTAssertEqual(core?.userInfoPublisher.current.name, "bar")
         XCTAssertEqual(core?.userInfoPublisher.current.email, "foo@bar.com")
@@ -231,6 +233,7 @@ class DatadogTests: XCTestCase {
 
         Datadog.clearUserInfo()
 
+        XCTAssertEqual(core?.userInfoPublisher.current.anonymousId, "anonymous-id")
         XCTAssertNil(core?.userInfoPublisher.current.id)
         XCTAssertNil(core?.userInfoPublisher.current.email)
         XCTAssertNil(core?.userInfoPublisher.current.name)


### PR DESCRIPTION
### What and why?

Follow up to https://github.com/DataDog/dd-sdk-ios/pull/2369

After implementing on Android and cross consulting with Browser SDK team, it appeared that `clearUserInfo()` should keep generated `anonymousId` if present.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
