### PR TITLE
RUM-9068: Fix propagation of global attributes on expired user actions

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -106,7 +106,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
     func process(command: RUMCommand, context: DatadogContext, writer: Writer) -> Bool {
         if let expirationTime = possibleExpirationTime(currentTime: command.time), allResourcesCompletedLoading() {
-            sendActionEvent(completionTime: expirationTime, on: nil, context: context, writer: writer)
+            // Stop user action due to timeout
+            sendActionEvent(completionTime: expirationTime, on: command, context: context, writer: writer)
             return false
         }
 
@@ -140,9 +141,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
     // MARK: - Sending RUM Events
 
-    private func sendActionEvent(completionTime: Date, on command: RUMCommand?, context: DatadogContext, writer: Writer) {
-        if let commandAttributes = command?.attributes {
-            attributes.merge(commandAttributes) { $1 }
+    private func sendActionEvent(completionTime: Date, on command: RUMCommand, context: DatadogContext, writer: Writer) {
+        if command is RUMUserActionCommand {
+            attributes.merge(command.attributes) { $1 }
         }
 
         var frustrations: [RUMActionEvent.Action.Frustration.FrustrationType]? = nil
@@ -178,7 +179,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             container: nil,
-            context: .init(contextInfo: (command?.globalAttributes ?? [:]).merging(parent.attributes) { $1 }.merging(attributes) { $1 }),
+            context: .init(contextInfo: command.globalAttributes.merging(parent.attributes) { $1 }.merging(attributes) { $1 }),
             date: actionStartTime.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
             device: context.device.normalizedDevice,
             display: nil,


### PR DESCRIPTION
### What and why?

This PR fixes an issue where global attributes were not properly propagated for expired user actions.

### How?

Global attributes are propagated via `RUMCommand` to capture a snapshot of the global environment at the exact moment an event occurs.
However, user actions that time out should also reflect the global environment at their expiration point. To address this, a `RUMStopUserActionCommand` is now propagated to properly close the expired user action with the appropriate snapshot of the global attributes.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
