### PR TITLE
RUM-7219 Add jitter to initial uploads

### DIFF
--- a/DatadogCore/Sources/Core/Upload/DataUploadDelay.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadDelay.swift
@@ -14,11 +14,13 @@ internal class DataUploadDelay {
     private let changeRate: Double
 
     private(set) var current: TimeInterval
+    let maxJitter: TimeInterval
 
     init(performance: UploadPerformancePreset) {
         self.minDelay = performance.minUploadDelay
         self.maxDelay = performance.maxUploadDelay
         self.changeRate = performance.uploadDelayChangeRate
+        self.maxJitter = performance.maxUploadJitter
         self.current = performance.initialUploadDelay
     }
 

--- a/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
+++ b/DatadogCore/Sources/Core/Upload/DataUploadWorker.swift
@@ -89,8 +89,9 @@ internal class DataUploadWorker: DataUploadWorkerType {
         }
         self.readWork = readWorkItem
 
-        // Start sending batches immediately after initialization:
-        queue.async(execute: readWorkItem)
+        // Start sending batches with jitter to avoid concurrent execution during app launch:
+        let jitter: TimeInterval = .random(in: 0...delay.maxJitter)
+        queue.asyncAfter(deadline: .now() + jitter, execute: readWorkItem)
     }
 
     private func scheduleNextCycle() {

--- a/DatadogCore/Sources/PerformancePreset.swift
+++ b/DatadogCore/Sources/PerformancePreset.swift
@@ -66,6 +66,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
     let maxBatchesPerUpload: Int
+    let maxUploadJitter: TimeInterval
 }
 
 internal extension PerformancePreset {
@@ -138,6 +139,7 @@ internal extension PerformancePreset {
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate
         self.maxBatchesPerUpload = maxBatchesPerUpload
+        self.maxUploadJitter = 1.0 // 1 second max jitter to avoid concurrent execution
     }
 
     func updated(with override: PerformancePresetOverride) -> PerformancePreset {
@@ -153,7 +155,8 @@ internal extension PerformancePreset {
             minUploadDelay: override.minUploadDelay ?? minUploadDelay,
             maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
             uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate,
-            maxBatchesPerUpload: maxBatchesPerUpload
+            maxBatchesPerUpload: maxBatchesPerUpload,
+            maxUploadJitter: maxUploadJitter
         )
     }
 }

--- a/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
+++ b/DatadogInternal/Sources/Upload/UploadPerformancePreset.swift
@@ -20,4 +20,7 @@ public protocol UploadPerformancePreset {
     var uploadDelayChangeRate: Double { get }
     /// Number of batches to process during one upload cycle.
     var maxBatchesPerUpload: Int { get }
+    /// Maximum jitter (in seconds) applied to upload delays to avoid concurrent execution.
+    /// Actual jitter will be randomly selected from 0...maxUploadJitter range.
+    var maxUploadJitter: TimeInterval { get }
 }

--- a/TestUtilities/Sources/Mocks/DatadogCore/CoreMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogCore/CoreMocks.swift
@@ -201,7 +201,8 @@ extension PerformancePreset: AnyMockable, RandomMockable {
             minUploadDelay: upload.minUploadDelay,
             maxUploadDelay: upload.maxUploadDelay,
             uploadDelayChangeRate: upload.uploadDelayChangeRate,
-            maxBatchesPerUpload: upload.maxBatchesPerUpload
+            maxBatchesPerUpload: upload.maxBatchesPerUpload,
+            maxUploadJitter: upload.maxUploadJitter
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/UploadMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/UploadMocks.swift
@@ -13,19 +13,22 @@ public struct UploadPerformanceMock: UploadPerformancePreset {
     public var maxUploadDelay: TimeInterval
     public var uploadDelayChangeRate: Double
     public var maxBatchesPerUpload: Int
+    public var maxUploadJitter: TimeInterval
 
     public init(
         initialUploadDelay: TimeInterval,
         minUploadDelay: TimeInterval,
         maxUploadDelay: TimeInterval,
         uploadDelayChangeRate: Double,
-        maxBatchesPerUpload: Int = 1
+        maxBatchesPerUpload: Int = 1,
+        maxUploadJitter: TimeInterval = 0.0
     ) {
         self.initialUploadDelay = initialUploadDelay
         self.minUploadDelay = minUploadDelay
         self.maxUploadDelay = maxUploadDelay
         self.uploadDelayChangeRate = uploadDelayChangeRate
         self.maxBatchesPerUpload = maxBatchesPerUpload
+        self.maxUploadJitter = maxUploadJitter
     }
 
     public static let noOp = UploadPerformanceMock(
@@ -62,6 +65,7 @@ extension UploadPerformanceMock {
         maxUploadDelay = other.maxUploadDelay
         uploadDelayChangeRate = other.uploadDelayChangeRate
         maxBatchesPerUpload = other.maxBatchesPerUpload
+        maxUploadJitter = other.maxUploadJitter
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR fixes a sporadic crash in the Datadog iOS SDK where all `DataUploadWorker` instances created during app launch execute IO operations concurrently, causing race conditions and memory management crashes with `_swift_release_dealloc` in `DataUploadWorker.swift`.

#### Problem

Multiple features register simultaneously during `AppDelegate.application didFinishLaunchingWithOptions`, creating multiple `DataUploadWorker` instances that all start uploading immediately, leading to:
  - Concurrent file system access in `DataReader.readFiles()`
  - Swift memory management race conditions
  - `SIGSEGV` crashes with `SEGV_ACCERR`

  <details>
  <summary>Example crash stacktrace</summary>

Exception Type:  SIGSEGV
Exception Codes: SEGV_ACCERR
Triggered by Thread:  8

Thread 0 name:
Thread 0:
0   libsystem_kernel.dylib              0x000000020b70b9e0 _kernelrpc_mach_vm_map_trap + 8
1   libsystem_malloc.dylib              0x00000001dd218fcc mvm_allocate_pages + 324
2   libsystem_malloc.dylib              0x00000001dd2164b8 large_malloc + 788
3   libsystem_malloc.dylib              0x00000001dd217a14 szone_malloc_should_clear + 220
4   libsystem_malloc.dylib              0x00000001dd216890 _malloc_zone_malloc + 156
5   CoreText                            0x00000001d0a1ef9c TFont::InitShapingGlyphs() const + 340
6   CoreText                            0x00000001d0a2ce08 TASCIIDataCache::InitProps() + 176
7   CoreText                            0x00000001d0a84c44 TASCIIEncoder::Encode(bool) + 228
8   CoreText                            0x00000001d09e8444 TGlyphEncoder::EncodeChars(CFRange, TAttributes const&, TGlyphEncoder::Fallbacks) + 1564
9   CoreText                            0x00000001d09e5650 TTypesetterAttrString::Initialize(__CFAttributedString const*) + 428
10  CoreText                            0x00000001d09fee7c TTypesetterAttrString::TTypesetterAttrString(__CFAttributedString const*, __CFDictionary const*) + 132
11  CoreText                            0x00000001d09f2334 CTLineCreateWithAttributedString + 132
12  UIFoundation                        0x00000001d92b8638 -[UIFont readableWidth] + 252
13  UIKitCore                           0x00000001d16335fc __UIViewReadableWidthForFont + 60
14  UIKitCore                           0x00000001d16b764c __36-[_UISheetLayoutInfo _preferredSize]_block_invoke + 52
15  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
16  libdispatch.dylib                   0x00000001d64a7828 _dispatch_once_callout + 32
17  UIKitCore                           0x00000001d137db60 -[_UISheetLayoutInfo _preferredSize] + 456
18  UIKitCore                           0x00000001d137d5b4 -[_UISheetLayoutInfo _stackAlignmentFrame] + 112
19  UIKitCore                           0x00000001d12bfe78 -[_UISheetLayoutInfo _transform] + 148
20  UIKitCore                           0x00000001d12bfabc -[_UISheetLayoutInfo _shouldPresentedViewControllerControlStatusBarAppearance] + 176
21  UIKitCore                           0x00000001d12bf9dc -[UISheetPresentationController _updateShouldPresentedViewControllerControlStatusBarAppearance] + 40
22  UIKitCore                           0x00000001d12beea8 -[UISheetPresentationController _containerViewLayoutSubviews] + 1308
23  UIKit                               0x0000000253762a64 -[UISheetPresentationControllerAccessibility _containerViewLayoutSubviews] + 52
24  UIKitCore                           0x00000001d12be978 -[UITransitionView layoutSubviews] + 72
25  UIKitCore                           0x00000001d11b2cec -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 1980
26  QuartzCore                          0x00000001d068f4e8 CA::Layer::layout_if_needed(CA::Transaction*) + 500
27  UIKitCore                           0x00000001d1280ae8 -[UIView(Hierarchy) layoutBelowIfNeeded] + 292
28  UIKitCore                           0x00000001d142b7dc -[UISheetPresentationController presentationTransitionWillBegin] + 1064
29  UIKitCore                           0x00000001d142b0d8 __80-[UIPresentationController _initViewHierarchyForPresentationSuperview:inWindow:]_block_invoke + 2008
30  UIKitCore                           0x00000001d190fba8 __56-[UIPresentationController runTransitionForCurrentState]_block_invoke_3 + 300
31  UIKitCore                           0x00000001d14d7364 +[UIPresentationController _scheduleTransition:] + 80
32  UIKitCore                           0x00000001d14d6a70 -[UIPresentationController runTransitionForCurrentState] + 1300
33  UIKitCore                           0x00000001d190e558 -[UIPresentationController _presentWithAnimationController:inWindow:interactionController:target:didFinish:] + 568
34  UIKitCore                           0x00000001d13b5a54 -[UIWindow addRootViewControllerViewIfPossible] + 312
35  UIKitCore                           0x00000001d13b5898 -[UIWindow _updateLayerOrderingAndSetLayerHidden:actionBlock:] + 216
36  UIKitCore                           0x00000001d13b513c -[UIWindow _setHidden:forced:] + 256
37  UIKit                               0x00000002538096e4 -[UIWindowAccessibility _orderFrontWithoutMakingKey] + 92
38  UIKitCore                           0x00000001d1508d94 -[UIWindow _mainQueue_makeKeyAndVisible] + 40
39  UIKitCore                           0x00000001d2045db4 -[UIWindowScene _performDeferredInitialWindowUpdateForConnection] + 208
40  UIKitCore                           0x00000001d1326c7c +[UIScene _sceneForFBSScene:create:withSession:connectionOptions:] + 1192
41  UIKitCore                           0x00000001d13bd444 -[UIApplication _connectUISceneFromFBSScene:transitionContext:] + 888
42  UIKitCore                           0x00000001d13bcf1c -[UIApplication workspace:didCreateScene:withTransitionContext:completion:] + 372
43  UIKitCore                           0x00000001d13bcd3c -[UIApplicationSceneClientAgent scene:didInitializeWithEvent:completion:] + 288
44  FrontBoardServices                  0x00000001e4995d48 -[FBSScene _callOutQueue_agent_didCreateWithTransitionContext:completion:] + 344
45  FrontBoardServices                  0x00000001e49d5104 __92-[FBSWorkspaceScenesClient createSceneWithIdentity:parameters:transitionContext:completion:]_block_invoke.78 + 120
46  FrontBoardServices                  0x00000001e4999ae4 -[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 168
47  FrontBoardServices                  0x00000001e49d4d3c __92-[FBSWorkspaceScenesClient createSceneWithIdentity:parameters:transitionContext:completion:]_block_invoke + 360
48  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
49  libdispatch.dylib                   0x00000001d64a9a5c _dispatch_block_invoke_direct + 264
50  FrontBoardServices                  0x00000001e49a3f2c __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 52
51  FrontBoardServices                  0x00000001e49a3ac8 -[FBSSerialQueue _targetQueue_performNextIfPossible] + 220
52  FrontBoardServices                  0x00000001e49a62a8 -[FBSSerialQueue _performNextFromRunLoopSource] + 28
53  CoreFoundation                      0x00000001cf0f622c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
54  CoreFoundation                      0x00000001cf102614 __CFRunLoopDoSource0 + 176
55  CoreFoundation                      0x00000001cf08657c __CFRunLoopDoSources0 + 340
56  CoreFoundation                      0x00000001cf09beb8 __CFRunLoopRun + 836
57  CoreFoundation                      0x00000001cf0a11e4 CFRunLoopRunSpecific + 612
58  GraphicsServices                    0x0000000207ec1368 GSEventRunModal + 164
59  UIKitCore                           0x00000001d1550d88 -[UIApplication _run] + 888
60  UIKitCore                           0x00000001d15509ec UIApplicationMain + 340
61  Shopist                             0x00000001000e0754 main + 64 (AppDelegate.swift:47)
62  ???                                 0x00000001ed3c5948 0x0 + 8275122504

Thread 1 name:
Thread 1:
0   libsystem_kernel.dylib              0x000000020b70c0a0 kevent_id + 8
1   libdispatch.dylib                   0x00000001d64c9940 _dispatch_event_loop_wait_for_ownership + 444
2   libdispatch.dylib                   0x00000001d64b5844 __DISPATCH_WAIT_FOR_QUEUE__ + 340
3   libdispatch.dylib                   0x00000001d64b540c _dispatch_sync_f_slow + 144
4   libswiftDispatch.dylib              0x00000001d7669040 implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 180
5   libswiftDispatch.dylib              0x00000001d7668060 partial apply for implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 56
6   libswiftDispatch.dylib              0x00000001d7668d50 OS_dispatch_queue._syncHelper<A>(fn: (()), execute: (), rescue: (Error)) + 396
7   libswiftDispatch.dylib              0x00000001d766810c OS_dispatch_queue.sync<A>(execute: ()) + 164
8   Shopist                             0x00000001003008f8 DataReader.readFiles(limit: Int) + 0 (DataReader.swift:21)
9   Shopist                             0x00000001003008f8 protocol witness for Reader.readFiles(limit: Int) in conformance DataReader + 72 (<compiler-generated>:20)
10  Shopist                             0x00000001003079a8 closure #1 () in DataUploadWorker.init(queue: OS_dispatch_queue, fileReader: Reader, dataUploader: DataUploaderType, contextProvider: DatadogContextProvider, uploadConditions: DataUploadConditions, delay: DataUploadDelay, featureName: String, telemetry: Telemetry, maxBatchesPerUpload: Int, backgroundTaskCoordinator: BackgroundTaskCoordinator?) + 628 (DataUploadWorker.swift:76)
11  Shopist                             0x0000000100307424 thunk for @escaping @callee_guaranteed () -> () + 28
12  libdispatch.dylib                   0x00000001d64b5114 _dispatch_block_async_invoke2 + 148
13  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
14  libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
15  libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
16  libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
17  libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
18  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 2 name:
Thread 2:
0   libsystem_kernel.dylib              0x000000020b70c0a0 kevent_id + 8
1   libdispatch.dylib                   0x00000001d64c9940 _dispatch_event_loop_wait_for_ownership + 444
2   libdispatch.dylib                   0x00000001d64b5844 __DISPATCH_WAIT_FOR_QUEUE__ + 340
3   libdispatch.dylib                   0x00000001d64b540c _dispatch_sync_f_slow + 144
4   libswiftDispatch.dylib              0x00000001d7669040 implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 180
5   libswiftDispatch.dylib              0x00000001d7668060 partial apply for implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 56
6   libswiftDispatch.dylib              0x00000001d7668d50 OS_dispatch_queue._syncHelper<A>(fn: (()), execute: (), rescue: (Error)) + 396
7   libswiftDispatch.dylib              0x00000001d766810c OS_dispatch_queue.sync<A>(execute: ()) + 164
8   Shopist                             0x00000001003008f8 DataReader.readFiles(limit: Int) + 0 (DataReader.swift:21)
9   Shopist                             0x00000001003008f8 protocol witness for Reader.readFiles(limit: Int) in conformance DataReader + 72 (<compiler-generated>:20)
10  Shopist                             0x00000001003079a8 closure #1 () in DataUploadWorker.init(queue: OS_dispatch_queue, fileReader: Reader, dataUploader: DataUploaderType, contextProvider: DatadogContextProvider, uploadConditions: DataUploadConditions, delay: DataUploadDelay, featureName: String, telemetry: Telemetry, maxBatchesPerUpload: Int, backgroundTaskCoordinator: BackgroundTaskCoordinator?) + 628 (DataUploadWorker.swift:76)
11  Shopist                             0x0000000100307424 thunk for @escaping @callee_guaranteed () -> () + 28
12  libdispatch.dylib                   0x00000001d64b5114 _dispatch_block_async_invoke2 + 148
13  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
14  libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
15  libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
16  libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
17  libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
18  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 3 name:
Thread 3:
0   CoreFoundation                      0x00000001cf029e2c isEqualToString + 376
1   AccessibilityUtilities              0x00000001d85319ac -[AXCodeLoader _accessibilityCodeItemMatchingName:type:path:] + 516
2   AccessibilityUtilities              0x00000001d8531c54 -[AXCodeLoader _associateAccessibilityCodeItemWithLoadedCodeItem:] + 300
3   AccessibilityUtilities              0x00000001d852fa44 __36-[AXCodeLoader _addTrackedCodeItem:]_block_invoke + 252
4   libdispatch.dylib                   0x00000001d64a44b4 _dispatch_call_block_and_release + 32
5   libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
6   libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
7   libdispatch.dylib                   0x00000001d64ae1e0 _dispatch_lane_invoke + 384
8   libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
9   libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
10  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 4 name:
Thread 4:
0   libsystem_kernel.dylib              0x000000020b70bb48 mach_msg2_trap + 8
1   libsystem_kernel.dylib              0x000000020b71e248 mach_msg_overwrite + 388
2   libsystem_kernel.dylib              0x000000020b70c08c mach_msg + 24
3   CoreFoundation                      0x00000001cf09ae00 __CFRunLoopServiceMachPort + 160
4   CoreFoundation                      0x00000001cf09c044 __CFRunLoopRun + 1232
5   CoreFoundation                      0x00000001cf0a11e4 CFRunLoopRunSpecific + 612
6   Foundation                          0x00000001c94b1818 -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 212
7   Foundation                          0x00000001c94b1700 -[NSRunLoop(NSRunLoop) runUntilDate:] + 64
8   UIKitCore                           0x00000001d168588c -[UIEventFetcher threadMain] + 436
9   Foundation                          0x00000001c94cace8 __NSThread__start__ + 716
10  libsystem_pthread.dylib             0x000000021b9496cc _pthread_start + 148
11  libsystem_pthread.dylib             0x000000021b948ba4 thread_start + 8

Thread 5 name:
Thread 5:
0   libsystem_kernel.dylib              0x000000020b70c680 __ulock_wait + 8
1   libdispatch.dylib                   0x00000001d64a6780 _dispatch_thread_event_wait_slow + 56
2   libdispatch.dylib                   0x00000001d64b5860 __DISPATCH_WAIT_FOR_QUEUE__ + 368
3   libdispatch.dylib                   0x00000001d64b540c _dispatch_sync_f_slow + 144
4   AXCoreUtilities                     0x00000001d9fbe848 AXPerformBlockSynchronouslyOnMainThread + 108
5   AccessibilityUtilities              0x00000001d8549f20 ___AXSharedDisplayManager_block_invoke_2 + 40
6   libdispatch.dylib                   0x00000001d64a44b4 _dispatch_call_block_and_release + 32
7   libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
8   libdispatch.dylib                   0x00000001d64a90c8 _dispatch_queue_override_invoke + 788
9   libdispatch.dylib                   0x00000001d64b7a6c _dispatch_root_queue_drain + 396
10  libdispatch.dylib                   0x00000001d64b8284 _dispatch_worker_thread2 + 164
11  libsystem_pthread.dylib             0x000000021b948dbc _pthread_wqthread + 228
12  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 6 name:
Thread 6:
0   libsystem_kernel.dylib              0x000000020b70c1f0 __getattrlist + 8
1   Foundation                          0x00000001c94b25f4 -[NSString(NSPathUtilities) _stringByResolvingSymlinksInPathUsingCache:] + 128
2   Foundation                          0x00000001c94cecf4 -[NSFileManager setAttributes:ofItemAtPath:error:] + 724
3   Foundation                          0x00000001c94ce90c -[NSFileManager createDirectoryAtPath:withIntermediateDirectories:attributes:error:] + 344
4   Shopist                             0x00000001002f7054 Directory.createSubdirectory(path: String) + 204 (Directory.swift:90)
5   Shopist                             0x00000001002f6c98 Directory.init(withSubdirectoryPath: String) + 0 (Directory.swift:28)
6   Shopist                             0x00000001002f6c98 Directory.deleteAllFiles() + 416 (Directory.swift:159)
7   Shopist                             0x00000001002f5c58 closure #1 @Sendable () in FeatureStorage.clearUnauthorizedData() + 60 (FeatureStorage.swift:85)
8   Shopist                             0x00000001002dd554 thunk for @escaping @callee_guaranteed @Sendable () -> () + 28
9   libdispatch.dylib                   0x00000001d64a44b4 _dispatch_call_block_and_release + 32
10  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
11  libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
12  libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
13  libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
14  libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
15  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 7 name:
Thread 7:
0   libsystem_kernel.dylib              0x000000020b70c0a0 kevent_id + 8
1   libdispatch.dylib                   0x00000001d64c9940 _dispatch_event_loop_wait_for_ownership + 444
2   libdispatch.dylib                   0x00000001d64b5844 __DISPATCH_WAIT_FOR_QUEUE__ + 340
3   libdispatch.dylib                   0x00000001d64b540c _dispatch_sync_f_slow + 144
4   libswiftDispatch.dylib              0x00000001d7669040 implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 180
5   libswiftDispatch.dylib              0x00000001d7668060 partial apply for implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 56
6   libswiftDispatch.dylib              0x00000001d7668d50 OS_dispatch_queue._syncHelper<A>(fn: (()), execute: (), rescue: (Error)) + 396
7   libswiftDispatch.dylib              0x00000001d766810c OS_dispatch_queue.sync<A>(execute: ()) + 164
8   Shopist                             0x00000001003008f8 DataReader.readFiles(limit: Int) + 0 (DataReader.swift:21)
9   Shopist                             0x00000001003008f8 protocol witness for Reader.readFiles(limit: Int) in conformance DataReader + 72 (<compiler-generated>:20)
10  Shopist                             0x00000001003079a8 closure #1 () in DataUploadWorker.init(queue: OS_dispatch_queue, fileReader: Reader, dataUploader: DataUploaderType, contextProvider: DatadogContextProvider, uploadConditions: DataUploadConditions, delay: DataUploadDelay, featureName: String, telemetry: Telemetry, maxBatchesPerUpload: Int, backgroundTaskCoordinator: BackgroundTaskCoordinator?) + 628 (DataUploadWorker.swift:76)
11  Shopist                             0x0000000100307424 thunk for @escaping @callee_guaranteed () -> () + 28
12  libdispatch.dylib                   0x00000001d64b5114 _dispatch_block_async_invoke2 + 148
13  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
14  libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
15  libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
16  libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
17  libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
18  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 8 name:
Thread 8 Crashed:
0   libswiftCore.dylib                  0x00000001c92af1bc _swift_release_dealloc + 32
1   Shopist                             0x00000001003078e4 closure #1 () in DataUploadWorker.init(queue: OS_dispatch_queue, fileReader: Reader, dataUploader: DataUploaderType, contextProvider: DatadogContextProvider, uploadConditions: DataUploadConditions, delay: DataUploadDelay, featureName: String, telemetry: Telemetry, maxBatchesPerUpload: Int, backgroundTaskCoordinator: BackgroundTaskCoordinator?) + 432 (DataUploadWorker.swift:84)
2   Shopist                             0x0000000100307424 thunk for @escaping @callee_guaranteed () -> () + 28
3   libdispatch.dylib                   0x00000001d64b5114 _dispatch_block_async_invoke2 + 148
4   libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
5   libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
6   libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
7   libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
8   libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
9   libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

Thread 9 name:
Thread 9:
0   libsystem_kernel.dylib              0x000000020b70c0a0 kevent_id + 8
1   libdispatch.dylib                   0x00000001d64c9940 _dispatch_event_loop_wait_for_ownership + 444
2   libdispatch.dylib                   0x00000001d64b5844 __DISPATCH_WAIT_FOR_QUEUE__ + 340
3   libdispatch.dylib                   0x00000001d64b540c _dispatch_sync_f_slow + 144
4   libswiftDispatch.dylib              0x00000001d7669040 implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 180
5   libswiftDispatch.dylib              0x00000001d7668060 partial apply for implicit closure #2 (()) in implicit closure #1 (OS_dispatch_queue) in OS_dispatch_queue.sync<A>(execute: ()) + 56
6   libswiftDispatch.dylib              0x00000001d7668d50 OS_dispatch_queue._syncHelper<A>(fn: (()), execute: (), rescue: (Error)) + 396
7   libswiftDispatch.dylib              0x00000001d766810c OS_dispatch_queue.sync<A>(execute: ()) + 164
8   Shopist                             0x00000001003008f8 DataReader.readFiles(limit: Int) + 0 (DataReader.swift:21)
9   Shopist                             0x00000001003008f8 protocol witness for Reader.readFiles(limit: Int) in conformance DataReader + 72 (<compiler-generated>:20)
10  Shopist                             0x00000001003079a8 closure #1 () in DataUploadWorker.init(queue: OS_dispatch_queue, fileReader: Reader, dataUploader: DataUploaderType, contextProvider: DatadogContextProvider, uploadConditions: DataUploadConditions, delay: DataUploadDelay, featureName: String, telemetry: Telemetry, maxBatchesPerUpload: Int, backgroundTaskCoordinator: BackgroundTaskCoordinator?) + 628 (DataUploadWorker.swift:76)
11  Shopist                             0x0000000100307424 thunk for @escaping @callee_guaranteed () -> () + 28
12  libdispatch.dylib                   0x00000001d64b5114 _dispatch_block_async_invoke2 + 148
13  libdispatch.dylib                   0x00000001d64a5fdc _dispatch_client_callout + 20
14  libdispatch.dylib                   0x00000001d64ad694 _dispatch_lane_serial_drain + 672
15  libdispatch.dylib                   0x00000001d64ae214 _dispatch_lane_invoke + 436
16  libdispatch.dylib                   0x00000001d64b8e10 _dispatch_workloop_worker_thread + 652
17  libsystem_pthread.dylib             0x000000021b948df8 _pthread_wqthread + 288
18  libsystem_pthread.dylib             0x000000021b948b98 start_wqthread + 8

  Multiple concurrent threads (1, 2, 7, 8, 9) all executing DataUploadWorker code simultaneously
  </details>

#### Solution

Add configurable upload jitter to stagger worker initialization and prevent concurrent execution during app launch.

### How?

  1. **Added `maxUploadJitter` property** to `UploadPerformancePreset` protocol and implementation `PerformancePreset`: Sets 1.0 second max jitter for production use

  2. **Updated `DataUploadDelay`** to expose jitter configuration from performance preset

  3. **Modified `DataUploadWorker` initialization** to apply random jitter (0 to `maxUploadJitter`) to initial upload scheduling:
 ```swift
 let jitter: TimeInterval = .random(in: 0...delay.maxJitter)
 queue.asyncAfter(deadline: .now() + jitter, execute: readWorkItem)
```

#### Impact:

Workers now start with 0-1 second random delays, eliminating concurrent execution while maintaining responsiveness. The jitter is configurable through performance presets and only affects the initial upload cycle.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
