### PR TITLE
Fix support for Toolbar items in Session Replay on iOS 26

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
@@ -84,6 +84,7 @@ internal struct DisplayList {
             case platformView
             case color(Color._Resolved)
             case image(GraphicsImage)
+            case toolbarItem(String)
             case unknown
         }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -174,6 +174,17 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
 
         case .platformView:
             return nil // Should be recorder by UIKit recorder
+        case let .toolbarItem(text):
+            return context.builder.createTextWireframe(
+                id: id,
+                frame: context.convert(frame: item.frame),
+                clip: context.clip,
+                text: textObfuscator.mask(text: text),
+                textAlignment: .init(systemTextAlignment: .center),
+                textColor: SystemColors.label,
+                font: .systemFont(ofSize: 17),
+                fontScalingEnabled: fontScalingEnabled
+            )
         case .unknown:
             return context.builder.createPlaceholderWireframe(
                 id: id,

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
@@ -58,7 +58,7 @@ class DisplayListReflectionTests: XCTestCase {
     func testDisplayList_withShapeContent() throws {
         let color = Color._Resolved.mockRandom()
         let path: SwiftUI.Path = [
-            SwiftUI.Path { $0.move(to: .zero); $0.addLine(to: CGPoint(x: 10, y: 10)) },
+            SwiftUI.Path { $0.move(to: CGPoint.zero); $0.addLine(to: CGPoint(x: 10, y: 10)) },
             SwiftUI.Path(),
             SwiftUI.Path { $0.addRect(CGRect(x: 0, y: 0, width: 50, height: 50)) }
         ].randomElement()!

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
@@ -164,5 +164,38 @@ class DisplayListReflectionTests: XCTestCase {
             XCTFail("DisplayList should contain a content value.")
         }
     }
+
+    // MARK: Drawing Content (iOS 26+ Toolbar Items)
+    func testDisplayList_withDrawingContent_itHandlesToolbarItemsOniOS26() throws {
+        guard #available(iOS 26, tvOS 26, *) else {
+            return
+        }
+
+        // Given
+        let toolbarContent = DisplayList.Content(
+            seed: .init(value: .mockRandom()),
+            value: .toolbarItem("Save & Continue")
+        )
+        let toolbarDisplayList = DisplayList(items: [
+            DisplayList.Item(
+                identity: .init(value: .mockRandom()),
+                frame: .mockRandom(),
+                value: .content(toolbarContent)
+            )
+        ])
+
+        // When
+        let toolbarReflector = Reflector(subject: toolbarDisplayList, telemetry: NOPTelemetry())
+        let toolbarReflectedList = try DisplayList(from: toolbarReflector)
+
+        // Then
+        XCTAssertEqual(toolbarReflectedList.items.count, 1)
+        if case let .content(content) = toolbarReflectedList.items[0].value,
+           case let .toolbarItem(extractedText) = content.value {
+            XCTAssertEqual(extractedText, "Save & Continue 📱")
+        } else {
+            XCTFail("Toolbar items should extract text correctly")
+        }
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
@@ -52,5 +52,44 @@ class SwiftUIWireframesBuilderTests: XCTestCase {
         let wireframe = try XCTUnwrap(wireframes.last?.placeholderWireframe)
         XCTAssertEqual(wireframe.label, "Unsupported SwiftUI component")
     }
+
+    func testDisplayListWithToolbarItem_itCreatesTextWireframeOniOS26() throws {
+        guard #available(iOS 26, tvOS 26, *) else {
+            return
+        }
+
+        // Given
+        let renderer = DisplayList.ViewUpdater(
+            viewCache: DisplayList.ViewUpdater.ViewCache(map: [:]),
+            lastList: DisplayList.Lazy(
+                DisplayList(items: [
+                    DisplayList.Item(
+                        identity: DisplayList.Identity(value: .mockRandom()),
+                        frame: CGRect(x: 0, y: 0, width: 100, height: 44),
+                        value: .content(DisplayList.Content(
+                            seed: DisplayList.Seed(value: .mockRandom()),
+                            value: .toolbarItem("Cancel")
+                        ))
+                    )
+                ])
+            )
+        )
+
+        // When
+        let builder = SwiftUIWireframesBuilder(
+            wireframeID: .mockRandom(),
+            renderer: renderer,
+            textObfuscator: TextObfuscatorMock(),
+            fontScalingEnabled: true,
+            imagePrivacyLevel: .maskNone,
+            attributes: .mockRandom()
+        )
+
+        // Then
+        let wireframes = builder.buildWireframes(with: WireframesBuilder())
+        XCTAssertEqual(wireframes.count, 2)
+        let textWireframe = try XCTUnwrap(wireframes.last?.textWireframe)
+        XCTAssertEqual(textWireframe.text, "Cancel")
+    }
 }
 #endif


### PR DESCRIPTION
### What and why?

In iOS 26, Toolbar items are now rendered as drawings and since in session replay we do not support drawings, this caused them to give `unsupported swiftui component` error in the replay.

### How?

As a temporary solution, we extract the text from these toolbar item drawings and display them as text wireframes to ensure users can see the button labels in session replay instead of having no content.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
