### PR TITLE
[SwiftUI instru] Fix misleading doc comment

### DIFF
--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -91,8 +91,8 @@ extension RUM {
 
         /// The predicate for automatically tracking SwiftUI views as RUM views.
         ///
-        /// RUM will query this predicate for each SwiftUI view detected in the app. The SDK uses reflection to extract
-        /// view names from the SwiftUI view hierarchy, then passes those names to this predicate to determine which
+        /// RUM will query this predicate for each SwiftUI view detected through hosting controllers. The SDK extracts
+        /// view names from the SwiftUI view hierarchy within those controllers, then passes those names to this predicate to determine which
         /// views should be tracked. The predicate implementation should return RUM view parameters if the given view
         /// should be tracked, or `nil` to ignore it.
         ///

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -72,7 +72,7 @@ extension RUM {
         ///
         /// Note: Automatic RUM views tracking involves swizzling the `UIViewController` lifecycle methods.
         ///
-        /// Default: `nil` - which means automatic RUM view tracking is not enabled by default.
+        /// Default: `nil` - which means automatic RUM view tracking for UIKit is not enabled by default.
         public var uiKitViewsPredicate: UIKitRUMViewsPredicate?
 
         /// The predicate for automatically tracking `UITouch` events as RUM actions.
@@ -86,19 +86,21 @@ extension RUM {
         ///
         /// Note: Automatic RUM action tracking involves swizzling the `UIApplication.sendEvent(_:)` method.
         ///
-        /// Default: `nil` - which means automatic RUM action tracking is not enabled by default.
+        /// Default: `nil` - which means automatic RUM action tracking for UIKit is not enabled by default.
         public var uiKitActionsPredicate: UIKitRUMActionsPredicate?
 
-        /// The predicate for automatically tracking `UIViewControllers` as RUM views.
+        /// The predicate for automatically tracking SwiftUI views as RUM views.
         ///
-        /// RUM will query this predicate for each `UIViewController` presented in the app. The predicate implementation
-        /// should return RUM view parameters if the given controller should start a view, or `nil` to ignore it.
+        /// RUM will query this predicate for each SwiftUI view detected in the app. The SDK uses reflection to extract
+        /// view names from the SwiftUI view hierarchy, then passes those names to this predicate to determine which
+        /// views should be tracked. The predicate implementation should return RUM view parameters if the given view
+        /// should be tracked, or `nil` to ignore it.
         ///
         /// You can use `DefaultSwiftUIRUMViewsPredicate` or create your own predicate by implementing `SwiftUIRUMViewsPredicate`.
         ///
-        /// Note: Automatic RUM views tracking involves swizzling the `UIViewController` lifecycle methods.
+        /// Note: Automatic SwiftUI view tracking involves swizzling the `UIViewController` lifecycle methods of hosting controllers.
         ///
-        /// Default: `nil` - which means automatic RUM view tracking is not enabled by default.
+        /// Default: `nil` - which means automatic RUM view tracking for SwiftUI is not enabled by default.
         @available(*, message: "This API is experimental and may change in future releases")
         public var swiftUIViewsPredicate: SwiftUIRUMViewsPredicate?
 
@@ -113,7 +115,7 @@ extension RUM {
         ///
         /// Note: Automatic RUM action tracking involves swizzling the `UIApplication.sendEvent(_:)` method.
         ///
-        /// Default: `nil` - which means automatic RUM action tracking is not enabled by default.
+        /// Default: `nil` - which means automatic RUM action tracking for SwiftUI is not enabled by default.
 
         @available(*, message: "This API is experimental and may change in future releases")
         @available(*, message: "This API has different behavior on iOS 18 vs iOS 17 and below - component detection is more precise on iOS 18+")


### PR DESCRIPTION
### What and why?

As suggested in [this comment](https://github.com/DataDog/dd-sdk-ios/pull/2237#discussion_r2176723264), documentation about SwiftUI view tracking is misleading.

### How?

Updating comment.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
