### PR TITLE
RUM-10723 Add 1ns view filtering to RUMViewEventsFilter

### DIFF
--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -67,10 +67,13 @@ internal extension RUMViewEvent {
     struct Metadata: Codable {
         let id: String
         let documentVersion: Int64
+        /// Duration of the view in nanoseconds.
+        let duration: Int64?
 
         private enum CodingKeys: String, CodingKey {
             case id = "id"
             case documentVersion = "document_version"
+            case duration = "duration"
         }
     }
 
@@ -81,7 +84,11 @@ internal extension RUMViewEvent {
     /// Creates `Metadata` from the given `RUMViewEvent`.
     /// - Returns: The `Metadata` for the given `RUMViewEvent`.
     func metadata() -> Metadata {
-        return Metadata(id: view.id, documentVersion: dd.documentVersion)
+        return Metadata(
+            id: view.id,
+            documentVersion: dd.documentVersion,
+            duration: view.timeSpent
+        )
     }
 }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -205,7 +205,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
         )
         self.requestBuilder = RequestBuilder(
             customIntakeURL: configuration.customEndpoint,
-            eventsFilter: RUMViewEventsFilter(),
+            eventsFilter: RUMViewEventsFilter(telemetry: core.telemetry),
             telemetry: core.telemetry
         )
         var messageReceivers: [FeatureMessageReceiver] = [

--- a/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
+++ b/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
@@ -8,45 +8,80 @@ import Foundation
 import DatadogInternal
 
 internal struct RUMViewEventsFilter {
-    let decoder: JSONDecoder
+    /// Duration threshold for filtering out 1ns views that represent failed eventual consistency scenarios
+    private static let oneNanosecondDuration: Int64 = 1
 
-    init(decoder: JSONDecoder = JSONDecoder()) {
+    let decoder: JSONDecoder
+    let telemetry: Telemetry
+
+    init(telemetry: Telemetry, decoder: JSONDecoder = JSONDecoder()) {
+        self.telemetry = telemetry
         self.decoder = decoder
     }
 
+    private enum FilterResult {
+        case keep
+        case skipRedundant
+        case skipOneNs
+    }
+
+    /// Filters RUM view events to improve data quality and optimize payload size by removing:
+    /// - Redundant view events (duplicate view IDs)
+    /// - 1ns view events that represent failed eventual consistency scenarios
     func filter(events: [Event]) -> [Event] {
         var seen = Set<String>()
-        var skipped: [String: [Int64]] = [:]
+        var redundantEventsCount = 0
+        var oneNsEventsCount = 0
 
         // reversed is O(1) and no copy because it is view on the original array
         let filtered: [Event] = events.reversed().compactMap { event in
-            guard let metadata = event.metadata else {
-                // If there is no metadata, we can't filter it.
-                return event
-            }
-
-            guard let viewMetadata = try? decoder.decode(RUMViewEvent.Metadata.self, from: metadata) else {
-                // If we can't decode the metadata, we can't filter it.
-                return event
-            }
-
-            guard seen.contains(viewMetadata.id) == false else {
-                // If we've already seen this view, we can skip this
-                if skipped[viewMetadata.id] == nil {
-                    skipped[viewMetadata.id] = []
+            do {
+                let result = try filterEvent(event, seen: &seen)
+                switch result {
+                case .keep:
+                    return event
+                case .skipRedundant:
+                    redundantEventsCount += 1
+                    return nil
+                case .skipOneNs:
+                    oneNsEventsCount += 1
+                    return nil
                 }
-                skipped[viewMetadata.id]?.append(viewMetadata.documentVersion)
-                return nil
+            } catch {
+                telemetry.error("Failed to decode RUM view event metadata", error: error)
+                return event
             }
-
-            seen.insert(viewMetadata.id)
-            return event
         }
 
-        for (id, versions) in skipped {
-            DD.logger.debug("Skipping RUMViewEvent with id: \(id) and versions: \(versions.reversed().map(String.init).joined(separator: ", "))")
+        if redundantEventsCount > 0 || oneNsEventsCount > 0 {
+            DD.logger.debug("RUMViewEventsFilter: skipped \(redundantEventsCount) redundant view updates, \(oneNsEventsCount) 1ns views")
         }
 
         return filtered.reversed()
+    }
+
+    private func filterEvent(_ event: Event, seen: inout Set<String>) throws -> FilterResult {
+        guard let metadata = event.metadata else {
+            // If there is no metadata, we can't filter it.
+            return .keep
+        }
+
+        let viewMetadata = try decoder.decode(RUMViewEvent.Metadata.self, from: metadata)
+
+        if let duration = viewMetadata.duration, duration == RUMViewEventsFilter.oneNanosecondDuration {
+            // Filter out 1ns views to prevent low-quality 1ns sessions.
+            // Views start with a 1ns "placeholder" duration that gets updated as events arrive.
+            // When eventual consistency fails (e.g., app crashes immediately or has sparse instrumentation),
+            // views keep their 1ns duration, which can create problematic 1ns sessions.
+            return .skipOneNs
+        }
+
+        guard seen.contains(viewMetadata.id) == false else {
+            // If we've already seen an update for this view, we can skip the next one.
+            return .skipRedundant
+        }
+
+        seen.insert(viewMetadata.id)
+        return .keep
     }
 }

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -20,7 +20,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
 
@@ -35,7 +35,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
 
@@ -60,7 +60,7 @@ class RequestBuilderTests: XCTestCase {
         let randomURL: URL = .mockRandom()
         let builder = RequestBuilder(
             customIntakeURL: randomURL,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
 
@@ -93,7 +93,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
         let context: DatadogContext = .mockWith(
@@ -119,7 +119,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
         let context: DatadogContext = .mockWith(variant: randomVariant)
@@ -148,7 +148,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
         let context: DatadogContext = .mockWith(
@@ -189,7 +189,7 @@ class RequestBuilderTests: XCTestCase {
         // Given
         let builder = RequestBuilder(
             customIntakeURL: nil,
-            eventsFilter: .init(),
+            eventsFilter: .init(telemetry: TelemetryMock()),
             telemetry: NOPTelemetry()
         )
 

--- a/DatadogRUM/Tests/RUMViewEventsFilterTests.swift
+++ b/DatadogRUM/Tests/RUMViewEventsFilterTests.swift
@@ -10,7 +10,18 @@ import DatadogInternal
 @testable import DatadogRUM
 
 final class RUMViewEventsFilterTests: XCTestCase {
-    let sut = RUMViewEventsFilter()
+    private var telemetry: TelemetryMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var sut: RUMViewEventsFilter! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        telemetry = TelemetryMock()
+        sut = RUMViewEventsFilter(telemetry: telemetry)
+    }
+
+    override func tearDown() {
+        telemetry = nil
+        sut = nil
+    }
 
     // MARK: - Base cases
 
@@ -25,10 +36,10 @@ final class RUMViewEventsFilterTests: XCTestCase {
 
     func testFilterWhenNoMetadata() throws {
         let events = [
-            try Event(data: "A.1", metadata: nil),
-            try Event(data: "A.2", metadata: nil),
-            try Event(data: "A.3", metadata: nil),
-            try Event(data: "A.4", metadata: nil)
+            try Event(data: "A.1", viewMetadata: nil),
+            try Event(data: "A.2", viewMetadata: nil),
+            try Event(data: "A.3", viewMetadata: nil),
+            try Event(data: "A.4", viewMetadata: nil)
         ]
 
         let actual = sut.filter(events: events)
@@ -38,22 +49,22 @@ final class RUMViewEventsFilterTests: XCTestCase {
 
     func testFilterWhenMixedMissingMetadata() throws {
         let events = [
-            try Event(data: "A.1", metadata: nil),
-            try Event(data: "A.2", metadata: nil),
-            try Event(data: "B.1", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1)),
-            try Event(data: "B.2", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2)),
-            try Event(data: "C.1", metadata: nil),
-            try Event(data: "B.3", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3)),
-            try Event(data: "A.3", metadata: nil)
+            try Event(data: "A.1", viewMetadata: nil),
+            try Event(data: "A.2", viewMetadata: nil),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: nil)),
+            try Event(data: "B.2", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2, duration: nil)),
+            try Event(data: "C.1", viewMetadata: nil),
+            try Event(data: "B.3", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3, duration: nil)),
+            try Event(data: "A.3", viewMetadata: nil)
         ]
 
         let actual = sut.filter(events: events)
         let expected = [
-            try Event(data: "A.1", metadata: nil),
-            try Event(data: "A.2", metadata: nil),
-            try Event(data: "C.1", metadata: nil),
-            try Event(data: "B.3", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3)),
-            try Event(data: "A.3", metadata: nil)
+            try Event(data: "A.1", viewMetadata: nil),
+            try Event(data: "A.2", viewMetadata: nil),
+            try Event(data: "C.1", viewMetadata: nil),
+            try Event(data: "B.3", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3, duration: nil)),
+            try Event(data: "A.3", viewMetadata: nil)
         ]
 
         XCTAssertEqual(actual, expected)
@@ -63,15 +74,15 @@ final class RUMViewEventsFilterTests: XCTestCase {
 
     func testFilterWhenSameEvent() throws {
          let events = [
-            try Event(data: "A.1", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1)),
-            try Event(data: "A.2", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 2)),
-            try Event(data: "A.3", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 3)),
-            try Event(data: "A.4", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 4))
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: nil)),
+            try Event(data: "A.2", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 2, duration: nil)),
+            try Event(data: "A.3", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 3, duration: nil)),
+            try Event(data: "A.4", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 4, duration: nil))
          ]
 
         let actual = sut.filter(events: events)
         let expected = [
-            try Event(data: "A.4", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 4))
+            try Event(data: "A.4", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 4, duration: nil))
         ]
 
         XCTAssertEqual(actual, expected)
@@ -79,15 +90,15 @@ final class RUMViewEventsFilterTests: XCTestCase {
 
     func testFilterWhenMixedEvents() throws {
           let events = [
-            try Event(data: "B.1", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1)),
-            try Event(data: "A.5", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 5)),
-            try Event(data: "B.2", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2)),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: nil)),
+            try Event(data: "A.5", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 5, duration: nil)),
+            try Event(data: "B.2", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2, duration: nil)),
           ]
 
         let actual = sut.filter(events: events)
         let expected = [
-            try Event(data: "A.5", metadata: RUMViewEvent.Metadata(id: "A", documentVersion: 5)),
-            try Event(data: "B.2", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2)),
+            try Event(data: "A.5", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 5, duration: nil)),
+            try Event(data: "B.2", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2, duration: nil)),
         ]
 
         XCTAssertEqual(actual, expected)
@@ -95,22 +106,111 @@ final class RUMViewEventsFilterTests: XCTestCase {
 
     func testFilterWhenSingleEvent() throws {
         let events = [
-            try Event(data: "B.3", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3)),
+            try Event(data: "B.3", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3, duration: nil)),
         ]
 
         let actual = sut.filter(events: events)
         let expected = [
-            try Event(data: "B.3", metadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3)),
+            try Event(data: "B.3", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 3, duration: nil)),
         ]
 
         XCTAssertEqual(actual, expected)
     }
+
+    // MARK: - 1ns duration filtering
+
+    func testFilterWhenOneNsDuration() throws {
+        let events = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: 1)),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: 100)),
+            try Event(data: "C.1", viewMetadata: RUMViewEvent.Metadata(id: "C", documentVersion: 1, duration: 1))
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: 100))
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testFilterWhenMixedOneNsAndRedundant() throws {
+        let events = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: 1)),
+            try Event(data: "A.2", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 2, duration: 100)),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: 1)),
+            try Event(data: "B.2", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2, duration: 200))
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            try Event(data: "A.2", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 2, duration: 100)),
+            try Event(data: "B.2", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 2, duration: 200))
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testFilterWhenOneNsDurationWithNilDuration() throws {
+        let events = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: nil)),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: 1)),
+            try Event(data: "C.1", viewMetadata: RUMViewEvent.Metadata(id: "C", documentVersion: 1, duration: 2))
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: nil)),
+            try Event(data: "C.1", viewMetadata: RUMViewEvent.Metadata(id: "C", documentVersion: 1, duration: 2))
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    // MARK: - Error handling and telemetry
+
+    func testFilterWhenInvalidMetadata() throws {
+        let invalidMetadata = "invalid json".utf8Data
+        let events = [
+            Event(data: "A.1".utf8Data, metadata: invalidMetadata),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: nil))
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            Event(data: "A.1".utf8Data, metadata: invalidMetadata),
+            try Event(data: "B.1", viewMetadata: RUMViewEvent.Metadata(id: "B", documentVersion: 1, duration: nil))
+        ]
+
+        XCTAssertEqual(actual, expected)
+        XCTAssertEqual(telemetry.messages.count, 1)
+        XCTAssertTrue(telemetry.messages.firstError()?.message.contains("Failed to decode RUM view event metadata") == true)
+    }
+
+    func testFilterWhenMixedValidAndInvalidMetadata() throws {
+        let invalidMetadata = "invalid json".utf8Data
+        let events = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: nil)),
+            Event(data: "B.1".utf8Data, metadata: invalidMetadata),
+            try Event(data: "C.1", viewMetadata: RUMViewEvent.Metadata(id: "C", documentVersion: 1, duration: 1)),
+            Event(data: "D.1".utf8Data, metadata: invalidMetadata)
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            try Event(data: "A.1", viewMetadata: RUMViewEvent.Metadata(id: "A", documentVersion: 1, duration: nil)),
+            Event(data: "B.1".utf8Data, metadata: invalidMetadata),
+            Event(data: "D.1".utf8Data, metadata: invalidMetadata)
+        ]
+
+        XCTAssertEqual(actual, expected)
+        XCTAssertEqual(telemetry.messages.compactMap({ $0.asError }).count, 2)
+    }
 }
 
 extension Event {
-    init(data: String, metadata: RUMViewEvent.Metadata?) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        self.init(data: data.utf8Data, metadata: try encoder.encode(metadata))
+    init(data: String, viewMetadata: RUMViewEvent.Metadata?) throws {
+        let encoder: JSONEncoder = .dd.default()
+        self.init(data: data.utf8Data, metadata: try encoder.encode(viewMetadata))
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR enhances session integrity by filtering out view events with minimal (placeholder) duration. This situation occurs when views receive no follow-up events after being started with a 1ns placeholder duration, representing a failed attempt to reach eventual consistency (where `view.time_spent` should be updated by subsequent events).

### How?

This work leverages the "event metadata" available in the Core interface, which gets written to batches alongside each event. We already use this metadata in RUM to filter redundant view updates from payloads.

The metadata for views is now extended with a `duration` field (optional for backwards compatibility):
```diff
struct Metadata: Codable {
    let id: String
    let documentVersion: Int64
+    /// Duration of the view in nanoseconds.
+    let duration: Int64?
}
```
Based on the `duration` check, views with 1ns `time_spent` are filtered out from the payload in `RUMViewEventsFilter` (used in `RUM.RequestBuilder`).

#### 💭 Alternative considered

I considered change in `RUMViewScope` to not write view updates if their duration is unsatisfactory.

The rationale for rejecting this approach:
- **Scope and complexity:** Implementing this would require significant changes across the codebase and test suite. Many tests assume that `startView()` immediately writes an initial event (with a 1ns duration), which aligns with our eventual consistency model—view durations are later updated as follow-up events arrive. This solution would force updates to dozens of tests that don’t simulate those subsequent events.
- **Design philosophy:** Since 1ns durations are not expected under normal circumstances (due to eventual consistency), filtering them using generic and centralized logic is a cleaner and more maintainable solution.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
