### PR TITLE
RUM-8727 Automatically close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: 'Automatically close stale issues'
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity and has the `awaiting-response` label.
+            
+            It will be closed if no further activity occurs within 3 days.
+        
+          # The label that will be added to the issues when automatically marked as stale
+          stale-issue-label: 'stale'
+          # The label that will be added to the issues when automatically marked as stale
+          close-issue-label: 'automatically-closed'
+          # Only target issues with 'awaiting-response' label
+          only-labels: 'awaiting-response'
+          # Mark issues as stale after 14 days
+          days-before-issue-stale: 14
+          # Close issues after 3 days of being marked stale
+          days-before-issue-close: 3
+          # Automatically remove the stale label when the issues or the pull requests are updated
+          remove-stale-when-updated: true
+          # Run the stale workflow as dry-run.
+          # No GitHub API calls that can alter the issues and pull requests will happen.
+          # Useful to debug or when you want to configure the stale workflow safely. 
+          debug-only: true


### PR DESCRIPTION
### What and why?

This PR adds a GitHub Actions workflow to **automatically manage stale issues** that are waiting for responses. The goal is to keep the issue tracker clean by automatically closing issues with the `awaiting-response` label that have been inactive for 17 days (14 days to mark as stale with a message + 3 days to close). This helps maintain repository hygiene and ensures issues don't remain open indefinitely when waiting for user responses.

### How?

- Added `.github/workflows/stale.yml` using the [Stale Github Action](https://github.com/actions/stale)
- Targets only issues with the `awaiting-response` label
- Adds `stale` label when marking issues as stale and `automatically-closed` label when closing
- Automatically removes stale label when issues are updated

### Debugging
As a first step, the workflow:
- can only be triggered **manually**
- includes `debug-only: true` in the configuration for initial testing; this flag allows to safely observe what the workflow would do, **without affecting any issues**

A follow-up PR will:
- set `debug-only` to `false`
- schedule the action to run daily

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
