### PR TITLE
RUM-8727 Switch Stale Github Action to prod config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,10 @@
 name: 'Automatically close stale issues'
 
 on:
-  workflow_dispatch: # Allows manual triggering
+  schedule:
+    # Runs every day at 8:00 AM CET
+    - cron: '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -18,7 +21,7 @@ jobs:
           # The label that will be added to the issues when automatically marked as stale
           stale-issue-label: 'stale'
           # The label that will be added to the issues when automatically marked as stale
-          close-issue-label: 'automatically-closed'
+          close-issue-label: 'automatically closed'
           # Only target issues with 'awaiting-response' label
           only-labels: 'awaiting-response'
           # Mark issues as stale after 14 days
@@ -30,4 +33,4 @@ jobs:
           # Run the stale workflow as dry-run.
           # No GitHub API calls that can alter the issues and pull requests will happen.
           # Useful to debug or when you want to configure the stale workflow safely. 
-          debug-only: true
+          debug-only: false


### PR DESCRIPTION
### What and why?

This PR updates the stale issues workflow introduced in #2392 to enable production use. The workflow will now automatically mark issues with the `awaiting response` label as stale after 14 days of inactivity and close them 3 days later if there is no further activity.

### How?

- Set `debug-only: false` to allow the workflow to perform real actions (label, comment, close issues)
- Added the daily cron schedule to run the workflow automatically at 8:00 AM CET
- Corrected the targeted label from `awaiting-response` to `awaiting response` (the label was temporarily changed in the GitHub UI for testing and has since been reverted)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
