### PR TITLE
RUM-10438 Improve backtrace collection and error messages

### DIFF
--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -44,11 +44,21 @@ internal extension PLCrashReporterConfig {
 
 internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     private let crashReporter: PLCrashReporter
+    private let backtraceReporter: PLCrashReporter
     private let builder = DDCrashReportBuilder()
 
     init() throws {
-        self.crashReporter = try PLCrashReporter(configuration: .ddConfiguration())
+        let configuration: PLCrashReporterConfig = try .ddConfiguration()
+        self.crashReporter = PLCrashReporter(configuration: configuration)
         try crashReporter.enableAndReturnError()
+
+        // Secondary instance for collecting Live Report for backtraces to prevent
+        // race condition while accessing customData: PLCrashReporter's customData
+        // is not thread-safe and is actually not needed for backtraces.
+        //
+        // This secondary instance doesn't need to and should not be enabled as it
+        // will conflict with the primary one.
+        self.backtraceReporter = PLCrashReporter(configuration: configuration)
     }
 
     func hasPendingCrashReport() -> Bool {
@@ -71,7 +81,7 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     }
 
     func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport {
-        let liveReportData = crashReporter.generateLiveReport(withThread: threadID)
+        let liveReportData = try backtraceReporter.generateLiveReport(withThread: threadID, exception: nil)
         let liveReport = try PLCrashReport(data: liveReportData)
 
         // This is quite opportunistic - we map PLCR's live report through existing `DDCrashReport` builder to

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -40,6 +40,14 @@ internal extension PLCrashReporterConfig {
             maxReportBytes: maxReportBytes
         )
     }
+
+    static var liveReportConfiguration = PLCrashReporterConfig(
+        signalHandlerType: .BSD, // no effect on Live Report
+        symbolicationStrategy: [],
+        shouldRegisterUncaughtExceptionHandler: false, // no effect on Live Report
+        basePath: nil, // Live Report uses /tmp folder always
+        maxReportBytes: Constants.maxReportBytes
+    )
 }
 
 internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
@@ -48,8 +56,7 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     private let builder = DDCrashReportBuilder()
 
     init() throws {
-        let configuration: PLCrashReporterConfig = try .ddConfiguration()
-        self.crashReporter = PLCrashReporter(configuration: configuration)
+        self.crashReporter = try PLCrashReporter(configuration: .ddConfiguration())
         try crashReporter.enableAndReturnError()
 
         // Secondary instance for collecting Live Report for backtraces to prevent
@@ -58,7 +65,7 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
         //
         // This secondary instance doesn't need to and should not be enabled as it
         // will conflict with the primary one.
-        self.backtraceReporter = PLCrashReporter(configuration: configuration)
+        self.backtraceReporter = PLCrashReporter(configuration: .liveReportConfiguration)
     }
 
     func hasPendingCrashReport() -> Bool {

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
@@ -14,9 +14,9 @@ internal final class AppHangsMonitor {
         /// The standardized `error.type` for RUM errors describing an app hang.
         static let appHangErrorType = "AppHang"
         /// The standardized `error.stack` when backtrace generation was not available.
-        static let appHangStackNotAvailableErrorMessage = "Stack trace was not generated because `DatadogCrashReporting` had not been enabled."
+        static let appHangStackNotAvailableErrorMessage = "Stack trace was not collected because `DatadogCrashReporting` had not been enabled."
         /// The standardized `error.stack` when backtrace generation failed due to an internal error.
-        static let appHangStackGenerationFailedErrorMessage = "Failed to generate stack trace. This is a known issue and we work on it."
+        static let appHangStackGenerationFailedErrorMessage = "Failed to collect the stack trace."
     }
 
     /// Watchdog thread that monitors the main queue for App Hangs.


### PR DESCRIPTION
### What and why?

We are seeing telemetry errors implying that `PLCrashReporter` [fails to decode the protobuf encoded stacktrace](https://github.com/microsoft/plcrashreporter/blob/master/Source/PLCrashReport.m#L333) while generating App Hang backtraces.

App Hang is based on `PLCrashReporter`'s 'Live Report' to collect backtraces, Live Report feature will write a report on-disk like during a crash using protobuf serialization and then read the file to decode it. We are reaching the decoding point of failure, meaning that data was corrupted.

While we are not able to reproduce this issue, we have identified a thread-safety issue: Our Crash Context is [injected in the Live Report](https://github.com/microsoft/plcrashreporter/blob/master/Source/PLCrashReporter.m#L751-L754) for encoding but the `customData` property is [nonatomic](https://github.com/microsoft/plcrashreporter/blob/master/Source/PLCrashReporter.h#L127). Context propagation and App Hang occurs on different threads leading to a race condition on `customData`.

### How?

Introduces a secondary `PLCrashReporter` instance for backtrace collection. This secondary instance will only be used for Live Report and will not include the crash-context.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
