### PR TITLE
RUM-10572: Fix timestamp discrepancies in web-view session replay recordings

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -393,6 +393,8 @@
 		49D8C0BD2AC5F2BB0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
+		5BFDD7A92E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */; };
+		5BFDD7AA2E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */; };
 		61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */; };
 		61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */; };
 		61054E612A6EE10A00AAA894 /* SRCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E082A6EE10A00AAA894 /* SRCompression.swift */; };
@@ -2483,6 +2485,7 @@
 		49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUM+Internal.swift"; sourceTree = "<group>"; };
 		49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logs+Internal.swift"; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
+		5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWebViewContext.swift; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
 		61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundEventsViewController.swift; sourceTree = "<group>"; };
 		61054E082A6EE10A00AAA894 /* SRCompression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRCompression.swift; sourceTree = "<group>"; };
@@ -5577,6 +5580,7 @@
 		619F5CEB2BF5089B004BFE70 /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */,
 				D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */,
 				D2D9A9DB2DBFD507005DB31D /* RUMPayloadMessages.swift */,
 				D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */,
@@ -9041,6 +9045,7 @@
 				D23039E5298D5236001A1FA3 /* DateProvider.swift in Sources */,
 				861FD6892DF3366400F59823 /* LocaleInfo.swift in Sources */,
 				D23039E0298D5235001A1FA3 /* DatadogCoreProtocol.swift in Sources */,
+				5BFDD7A92E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */,
 				D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */,
 				D2C179E12DD2388800556F68 /* SpanCoreContext.swift in Sources */,
 				B3E46CAE2D91B40000BABF66 /* NetworkContext.swift in Sources */,
@@ -10152,6 +10157,7 @@
 				D2DA237C298D57AA00C6C7E6 /* DatadogCoreProtocol.swift in Sources */,
 				861FD6882DF3366400F59823 /* LocaleInfo.swift in Sources */,
 				D2DA237D298D57AA00C6C7E6 /* DataCompression.swift in Sources */,
+				5BFDD7AA2E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */,
 				D2C9A26A2C0F3F5A007526F5 /* SessionReplayConfiguration.swift in Sources */,
 				D2C179E22DD2388800556F68 /* SpanCoreContext.swift in Sources */,
 				B3E46CAF2D91B40000BABF66 /* NetworkContext.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/SessionReplay/WebRecordIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/SessionReplay/WebRecordIntegrationTests.swift
@@ -64,6 +64,19 @@ class WebRecordIntegrationTests: XCTestCase {
             $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
         }, in: core)
 
+        let rumBody = """
+        {
+            "eventType": "rum",
+                "event": {
+                    "date": \(1_635_932_927_012),
+                    "type": "view",
+                    "application": { "id": "\(randomApplicationID)" },
+                    "session": { "id": "\(randomUUID.toRUMDataFormat)" },
+                    "view": { "id": "\(randomBrowserViewID.uuidString.lowercased())" }
+            }
+        }
+        """
+
         let body = """
         {
             "eventType": "record",
@@ -77,6 +90,9 @@ class WebRecordIntegrationTests: XCTestCase {
 
         // When
         RUMMonitor.shared(in: core).startView(key: "web-view")
+        controller.send(body: rumBody, from: webView)
+        controller.flush()
+        _ = core.waitAndReturnEventsData(ofFeature: RUMFeature.name) // Wait for context propagation
         controller.send(body: body, from: webView)
         controller.flush()
 
@@ -116,6 +132,19 @@ class WebRecordIntegrationTests: XCTestCase {
             $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
         }, in: core)
 
+        let rumBody = """
+        {
+            "eventType": "rum",
+                "event": {
+                    "date": \(1_635_932_927_012),
+                    "type": "view",
+                    "application": { "id": "\(randomApplicationID)" },
+                    "session": { "id": "\(randomUUID.toRUMDataFormat)" },
+                    "view": { "id": "\(randomBrowserViewID.uuidString.lowercased())" }
+            }
+        }
+        """
+
         let body = """
         {
             "eventType": "record",
@@ -129,6 +158,9 @@ class WebRecordIntegrationTests: XCTestCase {
 
         // When
         RUMMonitor.shared(in: core).startView(key: "web-view")
+        controller.send(body: rumBody, from: webView)
+        controller.flush()
+        _ = core.waitAndReturnEventsData(ofFeature: RUMFeature.name) // Wait for context propagation
         controller.send(body: body, from: webView)
         controller.flush()
 

--- a/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
@@ -20,8 +20,6 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
     public let userActionID: String?
     /// Current view related server time offset
     public let viewServerTimeOffset: TimeInterval?
-    /// Latest web view server time offsets
-    private var webViewServerTimeOffsets: [String: TimeInterval]
 
     /// Creates a RUM context.
     ///
@@ -36,22 +34,12 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
         sessionID: String,
         viewID: String? = nil,
         userActionID: String? = nil,
-        viewServerTimeOffset: TimeInterval? = nil,
-        webViewServerTimeOffsets: [String: TimeInterval] = [:]
+        viewServerTimeOffset: TimeInterval? = nil
     ) {
         self.applicationID = applicationID
         self.sessionID = sessionID
         self.viewID = viewID
         self.userActionID = userActionID
         self.viewServerTimeOffset = viewServerTimeOffset
-        self.webViewServerTimeOffsets = webViewServerTimeOffsets
-    }
-
-    public func serverTimeOffset(forWebView id: String) -> TimeInterval? {
-        webViewServerTimeOffsets[id]
-    }
-
-    public mutating func setServerTimeOffset(_ offset: TimeInterval, forWebView id: String) {
-        webViewServerTimeOffsets[id] = offset
     }
 }

--- a/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
@@ -20,6 +20,8 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
     public let userActionID: String?
     /// Current view related server time offset
     public let viewServerTimeOffset: TimeInterval?
+    /// Latest web view server time offsets
+    private var webViewServerTimeOffsets: [String: TimeInterval] = [:]
 
     /// Creates a RUM context.
     ///
@@ -41,5 +43,13 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
         self.viewID = viewID
         self.userActionID = userActionID
         self.viewServerTimeOffset = viewServerTimeOffset
+    }
+
+    public func serverTimeOffset(forWebView id: String) -> TimeInterval? {
+        webViewServerTimeOffsets[id]
+    }
+
+    public mutating func setServerTimeOffset(_ offset: TimeInterval, forWebView id: String) {
+        webViewServerTimeOffsets[id] = offset
     }
 }

--- a/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift
@@ -21,7 +21,7 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
     /// Current view related server time offset
     public let viewServerTimeOffset: TimeInterval?
     /// Latest web view server time offsets
-    private var webViewServerTimeOffsets: [String: TimeInterval] = [:]
+    private var webViewServerTimeOffsets: [String: TimeInterval]
 
     /// Creates a RUM context.
     ///
@@ -36,13 +36,15 @@ public struct RUMCoreContext: AdditionalContext, Equatable {
         sessionID: String,
         viewID: String? = nil,
         userActionID: String? = nil,
-        viewServerTimeOffset: TimeInterval? = nil
+        viewServerTimeOffset: TimeInterval? = nil,
+        webViewServerTimeOffsets: [String: TimeInterval] = [:]
     ) {
         self.applicationID = applicationID
         self.sessionID = sessionID
         self.viewID = viewID
         self.userActionID = userActionID
         self.viewServerTimeOffset = viewServerTimeOffset
+        self.webViewServerTimeOffsets = webViewServerTimeOffsets
     }
 
     public func serverTimeOffset(forWebView id: String) -> TimeInterval? {

--- a/DatadogInternal/Sources/Models/RUM/RUMWebViewContext.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMWebViewContext.swift
@@ -6,19 +6,27 @@
 
 import Foundation
 
+/// RUM web-view specific context.
 public struct RUMWebViewContext: AdditionalContext {
-    public static let key = "rum_webview"
+    /// The key used to identify this context in the core's additional context dictionary.
+    public static let key = "rum_web_view"
 
     private var serverTimeOffsets: [String: TimeInterval]
 
+    /// Creates a new WebView context.
+    ///
+    /// - Parameter serverTimeOffsets: Pre-existing server time offsets to initialize with.
+    ///   Defaults to an empty dictionary for new contexts.
     public init(serverTimeOffsets: [String: TimeInterval] = [:]) {
         self.serverTimeOffsets = serverTimeOffsets
     }
 
+    /// Retrieves the cached server time offset for a specific view event.
     public func serverTimeOffset(forView id: String) -> TimeInterval? {
         serverTimeOffsets[id]
     }
 
+    /// Caches a server time offset for a specific view event.
     public mutating func setServerTimeOffset(_ offset: TimeInterval, forView id: String) {
         serverTimeOffsets[id] = offset
     }

--- a/DatadogInternal/Sources/Models/RUM/RUMWebViewContext.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMWebViewContext.swift
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct RUMWebViewContext: AdditionalContext {
+    public static let key = "rum_webview"
+
+    private var serverTimeOffsets: [String: TimeInterval]
+
+    public init(serverTimeOffsets: [String: TimeInterval] = [:]) {
+        self.serverTimeOffsets = serverTimeOffsets
+    }
+
+    public func serverTimeOffset(forView id: String) -> TimeInterval? {
+        serverTimeOffsets[id]
+    }
+
+    public mutating func setServerTimeOffset(_ offset: TimeInterval, forView id: String) {
+        serverTimeOffsets[id] = offset
+    }
+}

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -68,10 +68,11 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
         )
 
         featureScope.eventWriteContext { context, writer in
-            guard var rum = context.additionalContext(ofType: RUMCoreContext.self) else {
+            guard let rum = context.additionalContext(ofType: RUMCoreContext.self) else {
                 return // Drop event if RUM is not enabled or RUM session is not sampled
             }
 
+            var webViewContext = context.additionalContext(ofType: RUMWebViewContext.self) ?? .init()
             var event = event
 
             if let date = event["date"] as? Int,
@@ -79,13 +80,13 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                let id = view["id"] as? String {
                 let offsetMilliseconds: Int64
 
-                if let offset = rum.serverTimeOffset(forWebView: id) {
+                if let offset = webViewContext.serverTimeOffset(forView: id) {
                     offsetMilliseconds = offset.toInt64Milliseconds
                 } else {
                     let offset = context.serverTimeOffset
-                    rum.setServerTimeOffset(offset, forWebView: id)
-                    self.featureScope.set(context: rum)
+                    webViewContext.setServerTimeOffset(offset, forView: id)
 
+                    self.featureScope.set(context: webViewContext)
                     offsetMilliseconds = offset.toInt64Milliseconds
                 }
 

--- a/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
+++ b/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
@@ -35,7 +35,7 @@ internal struct WebViewRecordReceiver: FeatureMessageReceiver {
 
             var event = event
 
-            if let timestamp = event["timestamp"] as? Int, let offset = rumContext.viewServerTimeOffset {
+            if let timestamp = event["timestamp"] as? Int, let offset = rumContext.serverTimeOffset(forWebView: view.id) {
                 event["timestamp"] = Int64(timestamp) + offset.toInt64Milliseconds
             }
 

--- a/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
+++ b/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
@@ -35,7 +35,9 @@ internal struct WebViewRecordReceiver: FeatureMessageReceiver {
 
             var event = event
 
-            if let timestamp = event["timestamp"] as? Int, let offset = rumContext.serverTimeOffset(forWebView: view.id) {
+            if let timestamp = event["timestamp"] as? Int,
+               let webViewContext = context.additionalContext(ofType: RUMWebViewContext.self),
+               let offset = webViewContext.serverTimeOffset(forView: view.id) {
                 event["timestamp"] = Int64(timestamp) + offset.toInt64Milliseconds
             }
 

--- a/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
@@ -17,14 +17,15 @@ class WebViewRecordReceiverTests: XCTestCase {
         let browserViewID: String = .mockRandom()
         let serverTimeOffset: TimeInterval = .mockRandom(min: -10, max: 10).rounded()
 
-        let rumContext: RUMCoreContext = .mockWith(
-            webViewServerTimeOffsets: [browserViewID: serverTimeOffset]
+        let rumContext: RUMCoreContext = .mockAny()
+        let webViewContext: RUMWebViewContext = .mockWith(
+            serverTimeOffsets: [browserViewID: serverTimeOffset]
         )
 
         let scope = FeatureScopeMock(
             context: .mockWith(
                 source: "react-native",
-                additionalContext: [rumContext]
+                additionalContext: [rumContext, webViewContext]
             )
         )
 

--- a/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
@@ -14,10 +14,11 @@ import TestUtilities
 
 class WebViewRecordReceiverTests: XCTestCase {
     func testGivenRUMContextAvailable_whenReceivingWebRecord_itCreatesSegment() throws {
+        let browserViewID: String = .mockRandom()
         let serverTimeOffset: TimeInterval = .mockRandom(min: -10, max: 10).rounded()
 
         let rumContext: RUMCoreContext = .mockWith(
-            serverTimeOffset: serverTimeOffset
+            webViewServerTimeOffsets: [browserViewID: serverTimeOffset]
         )
 
         let scope = FeatureScopeMock(
@@ -37,8 +38,6 @@ class WebViewRecordReceiverTests: XCTestCase {
             "timestamp": 100_000,
             "type": 2
         ].merging(random, uniquingKeysWith: { old, _ in old })
-
-        let browserViewID: String = .mockRandom()
 
         // When
 

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1448,13 +1448,15 @@ extension RUMCoreContext: RandomMockable {
         applicationID: String = .mockAny(),
         sessionID: String = .mockAny(),
         viewID: String? = .mockAny(),
-        serverTimeOffset: TimeInterval = .mockAny()
+        serverTimeOffset: TimeInterval = .mockAny(),
+        webViewServerTimeOffsets: [String: TimeInterval] = .mockAny()
     ) -> Self {
         .init(
             applicationID: applicationID,
             sessionID: sessionID,
             viewID: viewID,
-            viewServerTimeOffset: serverTimeOffset
+            viewServerTimeOffset: serverTimeOffset,
+            webViewServerTimeOffsets: webViewServerTimeOffsets
         )
     }
 
@@ -1464,7 +1466,8 @@ extension RUMCoreContext: RandomMockable {
             sessionID: .mockRandom(),
             viewID: .mockRandom(),
             userActionID: .mockRandom(),
-            viewServerTimeOffset: .mockRandom()
+            viewServerTimeOffset: .mockRandom(),
+            webViewServerTimeOffsets: .mockRandom()
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1448,15 +1448,13 @@ extension RUMCoreContext: RandomMockable {
         applicationID: String = .mockAny(),
         sessionID: String = .mockAny(),
         viewID: String? = .mockAny(),
-        serverTimeOffset: TimeInterval = .mockAny(),
-        webViewServerTimeOffsets: [String: TimeInterval] = .mockAny()
+        serverTimeOffset: TimeInterval = .mockAny()
     ) -> Self {
         .init(
             applicationID: applicationID,
             sessionID: sessionID,
             viewID: viewID,
-            viewServerTimeOffset: serverTimeOffset,
-            webViewServerTimeOffsets: webViewServerTimeOffsets
+            viewServerTimeOffset: serverTimeOffset
         )
     }
 
@@ -1466,9 +1464,24 @@ extension RUMCoreContext: RandomMockable {
             sessionID: .mockRandom(),
             viewID: .mockRandom(),
             userActionID: .mockRandom(),
-            viewServerTimeOffset: .mockRandom(),
-            webViewServerTimeOffsets: .mockRandom()
+            viewServerTimeOffset: .mockRandom()
         )
+    }
+}
+
+extension RUMWebViewContext: RandomMockable {
+    public static func mockAny() -> Self {
+        .mockWith()
+    }
+
+    public static func mockWith(
+        serverTimeOffsets: [String: TimeInterval] = [:]
+    ) -> Self {
+        .init(serverTimeOffsets: serverTimeOffsets)
+    }
+
+    public static func mockRandom() -> Self {
+        .init(serverTimeOffsets: .mockRandom())
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR fixes a timing discrepancy that occurs between web-view RUM events and Session Replay records when NTP synchronization updates the server time offset after a web-view RUM view is created.

#### The Problem
  - `WebViewEventReceiver` caches `context.serverTimeOffset` when the first web-view event arrives
  - `WebViewRecordReceiver` uses `rumContext.viewServerTimeOffset` which is frozen at native RUM view creation time
  - If an NTP sync occurs between these two timing points, the receivers would apply different offsets to events from the same web-view, creating timing gaps between RUM events and Session Replay records

### How?

Both receivers now use the same cached offset per web-view ID, ensuring consistent timestamps across RUM events and Session Replay records for the same web-view.

- `WebViewEventReceiver` caches offsets in `RUMWebViewContext`
- `WebViewRecordReceiver` uses cached web-view server time offsets.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
