### PR TITLE
RUM-1151: Update objc interface with RUM `addViewLoadingTime`

### DIFF
--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -255,6 +255,7 @@ class DDRUMMonitorTests: XCTestCase {
         objcRUMMonitor.startView(viewController: mockView, name: "FirstView", attributes: ["event-attribute1": "foo1"])
         objcRUMMonitor.stopView(viewController: mockView, attributes: ["event-attribute2": "foo2"])
         objcRUMMonitor.startView(key: "view2", name: "SecondView", attributes: ["event-attribute1": "bar1"])
+        objcRUMMonitor.addViewLoadingTime(overwrite: true)
         objcRUMMonitor.stopView(key: "view2", attributes: ["event-attribute2": "bar2"])
 
         let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
@@ -262,12 +263,13 @@ class DDRUMMonitorTests: XCTestCase {
         let viewEvents = rumEventMatchers.filterRUMEvents(ofType: RUMViewEvent.self) { event in
             return event.view.name != RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName
         }
-        XCTAssertEqual(viewEvents.count, 4)
+        XCTAssertEqual(viewEvents.count, 5)
 
         let event1: RUMViewEvent = try viewEvents[0].model()
         let event2: RUMViewEvent = try viewEvents[1].model()
         let event3: RUMViewEvent = try viewEvents[2].model()
         let event4: RUMViewEvent = try viewEvents[3].model()
+        let event5: RUMViewEvent = try viewEvents[4].model()
         XCTAssertEqual(event1.view.name, "FirstView")
         XCTAssertEqual(event1.view.url, "FirstViewController")
         XCTAssertEqual(event2.view.name, "FirstView")
@@ -276,10 +278,13 @@ class DDRUMMonitorTests: XCTestCase {
         XCTAssertEqual(event3.view.url, "view2")
         XCTAssertEqual(event4.view.name, "SecondView")
         XCTAssertEqual(event4.view.url, "view2")
+        XCTAssertNotNil(event4.view.loadingTime)
+        XCTAssertEqual(event5.view.name, "SecondView")
+        XCTAssertEqual(event5.view.url, "view2")
         XCTAssertEqual(try viewEvents[1].attribute(forKeyPath: "context.event-attribute1"), "foo1")
         XCTAssertEqual(try viewEvents[1].attribute(forKeyPath: "context.event-attribute2"), "foo2")
-        XCTAssertEqual(try viewEvents[3].attribute(forKeyPath: "context.event-attribute1"), "bar1")
-        XCTAssertEqual(try viewEvents[3].attribute(forKeyPath: "context.event-attribute2"), "bar2")
+        XCTAssertEqual(try viewEvents[4].attribute(forKeyPath: "context.event-attribute1"), "bar1")
+        XCTAssertEqual(try viewEvents[4].attribute(forKeyPath: "context.event-attribute2"), "bar2")
     }
 
     func testSendingViewEventsWithTiming() throws {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -60,6 +60,7 @@
     [monitor stopViewWithViewController:anyVC attributes:@{}];
     [monitor startViewWithKey:@"" name:nil attributes:@{}];
     [monitor stopViewWithKey:@"" attributes:@{}];
+    [monitor addViewLoadingTimeWithOverwrite:YES];
     [monitor addErrorWithMessage:@"" stack:nil source:DDRUMErrorSourceCustom attributes:@{}];
     [monitor addErrorWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:-100 userInfo:nil]
                         source:DDRUMErrorSourceNetwork attributes:@{}];

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -536,6 +536,11 @@ public class objc_RUMMonitor: NSObject {
         swiftRUMMonitor.stopView(key: key, attributes: attributes.dd.swiftAttributes)
     }
 
+    @available(*, message: "This API is experimental and may change in future releases")
+    public func addViewLoadingTime(overwrite: Bool) {
+        swiftRUMMonitor.addViewLoadingTime(overwrite: overwrite)
+    }
+
     public func addTiming(name: String) {
         swiftRUMMonitor.addTiming(name: name)
     }


### PR DESCRIPTION
### What and why?

The Objective-C RUM interface was missing support for the experimental API to report view loading times.
This PR adds the missing interface to ensure it is publicly available in both Swift and Objective-C.

### How?

It adds the following method to `DDRUMMonitor`:
```swift
public func addViewLoadingTime(overwrite: Bool)
```
This enables Objective-C calls to record view loading times.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
