### PR TITLE
RUM-10501: Improve TNS calculation

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -108,6 +108,7 @@ internal class RUMResourceScope: RUMScope {
             return false
         case let command as RUMAddResourceMetricsCommand where command.resourceKey == resourceKey:
             resourceMetrics = command.metrics
+            networkSettledMetric.updateResource(with: command.metrics, resourceID: resourceUUID, resourceURL: resourceURL)
         default:
             break
         }
@@ -268,7 +269,11 @@ internal class RUMResourceScope: RUMScope {
         if let event = dependencies.eventBuilder.build(from: resourceEvent) {
             writer.write(value: event)
             onResourceEvent(true)
-            networkSettledMetric.trackResourceEnd(at: command.time, resourceID: resourceUUID, resourceDuration: resourceDuration)
+            networkSettledMetric.trackResourceEnd(
+                at: resourceMetrics?.fetch.end ?? command.time,
+                resourceID: resourceUUID,
+                resourceDuration: resourceDuration
+            )
         } else {
             onResourceEvent(false)
             networkSettledMetric.trackResourceDropped(resourceID: resourceUUID)
@@ -352,7 +357,11 @@ internal class RUMResourceScope: RUMScope {
         if let event = dependencies.eventBuilder.build(from: errorEvent) {
             writer.write(value: event)
             onErrorEvent(true)
-            networkSettledMetric.trackResourceEnd(at: command.time, resourceID: resourceUUID, resourceDuration: nil)
+            networkSettledMetric.trackResourceEnd(
+                at: resourceMetrics?.fetch.end ?? command.time,
+                resourceID: resourceUUID,
+                resourceDuration: nil
+            )
         } else {
             onErrorEvent(false)
             networkSettledMetric.trackResourceDropped(resourceID: resourceUUID)

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1347,6 +1347,10 @@ public class TNSMetricMock: TNSMetricTracking {
         resourceStartDates[resourceID] = startDate
     }
 
+    public func updateResource(with metrics: ResourceMetrics, resourceID: RUMUUID, resourceURL: String) {
+        resourceStartDates[resourceID] = metrics.fetch.start
+    }
+
     public func trackResourceEnd(at endDate: Date, resourceID: RUMUUID, resourceDuration: TimeInterval?) {
         resourceEndDates[resourceID] = (endDate, resourceDuration)
     }


### PR DESCRIPTION
### What and why?

The TNS (Time to Network Settled) measurement can be inaccurate when the instrumentation also captures `URLSessionTaskMetrics`. This is particularly common in hybrid mobile applications.

### How?

- TNS is primarily computed using the network call metrics wrapped in the `ResourceMetrics`, especially the `fetch` phase’s start and end timestamps.
- Additionally, TNS is still computed even if the view experienced an inactive app state during loading.
This state, where the app is in the foreground but not receiving user input (e.g., during an incoming phone call, Notification Center pulled down, etc.), should not delay or invalidate the completion of the view’s initial network calls.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
