### PR TITLE
RUM-5993 Refactor dynamic property handling for additionalProperties

### DIFF
--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -6492,8 +6492,8 @@ public class objc_RUMViewEventView: NSObject {
         root.swiftModel.view.cumulativeLayoutShiftTime as NSNumber?
     }
 
-    public var customTimings: [String: NSNumber]? {
-        root.swiftModel.view.customTimings as [String: NSNumber]?
+    public var customTimings: objc_RUMViewEventViewCustomTimings? {
+        root.swiftModel.view.customTimings != nil ? objc_RUMViewEventViewCustomTimings(root: root) : nil
     }
 
     public var domComplete: NSNumber? {
@@ -6794,6 +6794,22 @@ public class objc_RUMViewEventViewCrash: NSObject {
 
     public var count: NSNumber {
         root.swiftModel.view.crash!.count as NSNumber
+    }
+}
+
+@objc(DDRUMViewEventViewCustomTimings)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewEventViewCustomTimings: NSObject {
+    internal let root: objc_RUMViewEvent
+
+    internal init(root: objc_RUMViewEvent) {
+        self.root = root
+    }
+
+    public var customTimingsInfo: [String: NSNumber] {
+        set { root.swiftModel.view.customTimings!.customTimingsInfo = newValue.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value } }
+        get { root.swiftModel.view.customTimings!.customTimingsInfo as [String: NSNumber] }
     }
 }
 
@@ -8165,8 +8181,8 @@ public class objc_RUMVitalEventVital: NSObject {
         root.swiftModel.vital.name
     }
 
-    public var parentId: String? {
-        root.swiftModel.vital.parentId
+    public var operationKey: String? {
+        root.swiftModel.vital.operationKey
     }
 
     public var stepType: objc_RUMVitalEventVitalStepType {
@@ -8241,19 +8257,19 @@ public enum objc_RUMVitalEventVitalVitalType: Int {
     internal init(swift: RUMVitalEvent.Vital.VitalType) {
         switch swift {
         case .duration: self = .duration
-        case .step: self = .step
+        case .operationStep: self = .operationStep
         }
     }
 
     internal var toSwift: RUMVitalEvent.Vital.VitalType {
         switch self {
         case .duration: return .duration
-        case .step: return .step
+        case .operationStep: return .operationStep
         }
     }
 
     case duration
-    case step
+    case operationStep
 }
 
 @objc(DDTelemetryErrorEvent)
@@ -9679,4 +9695,4 @@ public class objc_TelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/fd61fb5b16ccd0cbf24e59050ebe4d42c4bd593e
+// Generated from https://github.com/DataDog/rum-events-format/tree/364afe383024cfbdc0a57253c1961cf938b19cf0

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -671,9 +671,9 @@ extension RUMViewScope {
                 cumulativeLayoutShift: nil,
                 cumulativeLayoutShiftTargetSelector: nil,
                 cumulativeLayoutShiftTime: nil,
-                customTimings: customTimings.reduce(into: [:]) { acc, element in
+                customTimings: .init(customTimingsInfo: customTimings.reduce(into: [:]) { acc, element in
                     acc[sanitizeCustomTimingName(customTiming: element.key)] = element.value
-                },
+                }),
                 domComplete: nil,
                 domContentLoaded: nil,
                 domInteractive: nil,

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+GlobalAttributesTests.swift
@@ -552,8 +552,8 @@ class Monitor_GlobalAttributesTests: XCTestCase {
 
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self).filter { $0.view.name == "ActiveView" }
-        let viewAfterFirstTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.count == 1 }))
-        let viewAfterSecondTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.count == 2 }))
+        let viewAfterFirstTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.customTimingsInfo.count == 1 }))
+        let viewAfterSecondTiming = try XCTUnwrap(viewEvents.last(where: { $0.view.customTimings?.customTimingsInfo.count == 2 }))
 
         XCTAssertEqual(viewAfterFirstTiming.attribute(forKey: "attribute1"), "value1")
         XCTAssertEqual(viewAfterFirstTiming.attribute(forKey: "attribute2"), "value2")

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -3097,13 +3097,13 @@ class RUMViewScopeTests: XCTestCase {
         let events = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self))
 
         XCTAssertEqual(events.count, 3, "There should be 3 View updates sent")
-        XCTAssertEqual(events[0].view.customTimings, [:])
+        XCTAssertEqual(events[0].view.customTimings?.customTimingsInfo, [:])
         XCTAssertEqual(
-            events[1].view.customTimings,
+            events[1].view.customTimings?.customTimingsInfo,
             ["timing-after-500000000ns": 500_000_000]
         )
         XCTAssertEqual(
-            events[2].view.customTimings,
+            events[2].view.customTimings?.customTimingsInfo,
             ["timing-after-500000000ns": 500_000_000, "timing-after-1000000000ns": 1_000_000_000]
         )
     }
@@ -3151,7 +3151,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Then
         let lastEvent = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
-        XCTAssertEqual(lastEvent.view.customTimings, [:])
+        XCTAssertEqual(lastEvent.view.customTimings?.customTimingsInfo, [:])
     }
 
     func testGivenActiveView_whenCustomTimingIsRegistered_itSanitizesCustomTiming() throws {
@@ -3200,9 +3200,9 @@ class RUMViewScopeTests: XCTestCase {
         let events = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self))
 
         XCTAssertEqual(events.count, 2, "There should be 2 View updates sent")
-        XCTAssertEqual(events[0].view.customTimings, [:])
+        XCTAssertEqual(events[0].view.customTimings?.customTimingsInfo, [:])
         XCTAssertEqual(
-            events[1].view.customTimings,
+            events[1].view.customTimings?.customTimingsInfo,
             [sanitizedTimingName: 500_000_000]
         )
         XCTAssertEqual(

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -2113,4 +2113,4 @@ public enum SRRecord: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/fd61fb5b16ccd0cbf24e59050ebe4d42c4bd593e
+// Generated from https://github.com/DataDog/rum-events-format/tree/364afe383024cfbdc0a57253c1961cf938b19cf0

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -210,6 +210,12 @@ extension RUMViewEvent.View.SlowFrames: RandomMockable {
     }
 }
 
+extension RUMViewEvent.View.CustomTimings: AnyMockable {
+    public static func mockAny() -> RUMViewEvent.View.CustomTimings {
+        return .init(customTimingsInfo: .mockAny())
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     public static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
@@ -530,7 +530,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
             let keyCast = try objcToSwiftCast(for: swiftDictionary.key) ?? ""
             let valueCast = try objcToSwiftCast(for: swiftDictionary.value)
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftDictionary` with values of type: \(type(of: swiftDictionary.value))"))
-            return ".reduce(into: [:]) { $0[$1.0\(keyCast)] = $1.1\(valueCast)"
+            return ".reduce(into: [:]) { $0[$1.0\(keyCast)] = $1.1\(valueCast) }"
         case is SwiftPrimitive<String>:
             return nil // `String` <> `NSString` interoperability doesn't require casting
         default:

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Generate/Transformers/JSONToSwiftTypeTransformerTests.swift
@@ -301,9 +301,24 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertyWithAdditionalIntProperties",
                     comment: "Description of a property with nested additional Int properties.",
-                    type: SwiftDictionary(value: SwiftPrimitive<Int>()),
+                    type: SwiftStruct(
+                        name: "propertyWithAdditionalIntProperties",
+                        comment: "Description of a property with nested additional Int properties.",
+                        properties: [
+                            SwiftStruct.Property(
+                                name: "propertyWithAdditionalIntPropertiesInfo",
+                                comment: nil,
+                                type: SwiftDictionary(value: SwiftPrimitive<Int>()),
+                                isOptional: false,
+                                mutability: .mutable,
+                                defaultValue: nil,
+                                codingKey: .dynamic
+                            )
+                        ],
+                        conformance: []
+                    ),
                     isOptional: true,
-                    mutability: .immutable,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalIntProperties")
                 )
@@ -529,11 +544,24 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertyWithAdditionalProperties",
                     comment: "Description of a property with nested additional properties.",
-                    type: SwiftDictionary(
-                        value: SwiftPrimitive<Int>()
+                    type: SwiftStruct(
+                        name: "propertyWithAdditionalProperties",
+                        comment: "Description of a property with nested additional properties.",
+                        properties: [
+                            SwiftStruct.Property(
+                                name: "propertyWithAdditionalPropertiesInfo",
+                                comment: nil,
+                                type: SwiftDictionary(value: SwiftPrimitive<Int>()),
+                                isOptional: false,
+                                mutability: .mutable,
+                                defaultValue: nil,
+                                codingKey: .dynamic
+                            )
+                        ],
+                        conformance: []
                     ),
                     isOptional: false,
-                    mutability: .immutable,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalProperties")
                 )

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
@@ -1477,12 +1477,12 @@ final class ObjcInteropPrinterTests: XCTestCase {
             }
 
             public var mutableInt64s: [String: NSNumber] {
-                set { root.swiftModel.mutableInt64s = newValue.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value }
+                set { root.swiftModel.mutableInt64s = newValue.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value } }
                 get { root.swiftModel.mutableInt64s as [String: NSNumber] }
             }
 
             public var optionalMutableInt64s: [String: NSNumber]? {
-                set { root.swiftModel.optionalMutableInt64s = newValue?.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value }
+                set { root.swiftModel.optionalMutableInt64s = newValue?.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value } }
                 get { root.swiftModel.optionalMutableInt64s as [String: NSNumber]? }
             }
         }

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
@@ -356,22 +356,18 @@ final class SwiftPrinterTests: XCTestCase {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
                 try context.forEach {
-                    let key = DynamicCodingKey($0)
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
                 }
             }
 
             public init(from decoder: Decoder) throws {
-                // Decode other properties into [String: Codable] dictionary:
+                // Decode other properties into [String: AnyCodable] dictionary:
                 let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
-                let dynamicKeys = dynamicContainer.allKeys
-                var dictionary: [String: Codable] = [:]
+                self.context = [:]
 
-                try dynamicKeys.forEach { codingKey in
-                    dictionary[codingKey.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: codingKey)
+                try dynamicContainer.allKeys.forEach {
+                    self.context[$0.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: $0)
                 }
-
-                self.context = dictionary
             }
         }
 
@@ -474,8 +470,7 @@ final class SwiftPrinterTests: XCTestCase {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
                 try context.forEach {
-                    let key = DynamicCodingKey($0)
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
                 }
             }
 
@@ -485,17 +480,14 @@ final class SwiftPrinterTests: XCTestCase {
                 self.property1 = try staticContainer.decode(Int.self, forKey: .property1)
                 self.property2 = try staticContainer.decodeIfPresent(Bool.self, forKey: .property2)
 
-                // Decode other properties into [String: Codable] dictionary:
+                // Decode other properties into [String: AnyCodable] dictionary:
                 let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+                self.context = [:]
+
                 let allStaticKeys = Set(staticContainer.allKeys.map { $0.stringValue })
-                let dynamicKeys = dynamicContainer.allKeys.filter { !allStaticKeys.contains($0.stringValue) }
-                var dictionary: [String: Codable] = [:]
-
-                try dynamicKeys.forEach { codingKey in
-                    dictionary[codingKey.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: codingKey)
+                try dynamicContainer.allKeys.filter { !allStaticKeys.contains($0.stringValue) }.forEach {
+                    self.context[$0.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: $0)
                 }
-
-                self.context = dictionary
             }
         }
 
@@ -722,22 +714,18 @@ final class SwiftPrinterTests: XCTestCase {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
                 try context.forEach {
-                    let key = DynamicCodingKey($0)
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
                 }
             }
 
             public init(from decoder: Decoder) throws {
-                // Decode other properties into [String: Codable] dictionary:
+                // Decode other properties into [String: AnyCodable] dictionary:
                 let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
-                let dynamicKeys = dynamicContainer.allKeys
-                var dictionary: [String: Codable] = [:]
+                self.context = [:]
 
-                try dynamicKeys.forEach { codingKey in
-                    dictionary[codingKey.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: codingKey)
+                try dynamicContainer.allKeys.forEach {
+                    self.context[$0.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: $0)
                 }
-
-                self.context = dictionary
             }
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR changes generated RUM model which is `public` and exposed via the event mappers.
> This breaking change should be considered for v3.

### What and why?

There is a discrepancy in the model generation between iOS and Android. If we have the following [definition](https://github.com/DataDog/rum-events-format/blob/master/schemas/rum/view-schema.json#L177-L186):

```json
"custom_timings": {
  "type": "object",
  "description": "User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $",
  "additionalProperties": {
    "type": "integer",
    "minimum": 0,
    "readOnly": true
  },
  "readOnly": true
}
```

In that case iOS generator prefers to omit dedicated type creation and simply does public let [`customTimings: [String: Int64]?`](https://github.com/DataDog/dd-sdk-ios/blob/d840edcd4ba3ef3493c0b04241e01e2f52547f53/DatadogRUM/Sources/DataModels/RUMDataModels.swift#L2345C9-L2345C51)). On Android, they create a dedicated class:

```kotlin
public data class CustomTimings(
    public val additionalProperties: MutableMap<String, Long> = mutableMapOf(),
)
```

The downside of such inlining is that if a property is added to the object definition, in case of iOS model approach it won’t be backward compatible change (because now we need a dedicated model).

**We need to align and allow background compatible schema evolution.**

### How?

Dynamic properties with `additionalProperties` are now always represented as nested structs with internal dictionaries, regardless of the value type. This change updates the code generation logic, Swift and ObjC interop, and related tests to ensure consistent handling and encoding/decoding of dynamic properties, including for non-'any' types. Also updates generated models to match the latest RUM events schema.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
