### PR TITLE
Fix release sts policy

### DIFF
--- a/.github/chainguard/self.release.sts.yaml
+++ b/.github/chainguard/self.release.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:tag:ref:refs/tags/.*"
+subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:tag:ref:.*"
 
 claim_pattern:
   project_path: "DataDog/dd-sdk-ios"


### PR DESCRIPTION
### What and why?

Fix STS policy to publish the `xcframework` in GH release asset.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
