### PR TITLE
RUM-5176 [CP] Allow reporting critical log in sync

### DIFF
--- a/DatadogLogs/Sources/ConsoleLogger.swift
+++ b/DatadogLogs/Sources/ConsoleLogger.swift
@@ -89,15 +89,32 @@ internal final class ConsoleLogger: LoggerProtocol {
 }
 
 extension ConsoleLogger: InternalLoggerProtocol {
-    func log(level: LogLevel, message: String, errorKind: String?, errorMessage: String?, stackTrace: String?, attributes: [String: Encodable]?) {
+    func log(
+        level: LogLevel,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        stackTrace: String?,
+        attributes: [String: Encodable]?
+    ) {
         var errorString: String? = nil
         if errorKind != nil || errorMessage != nil || stackTrace != nil {
-            // Cross platform frameworks don't necessarilly send all values for errors. Send empty strings
+            // Cross platform frameworks don't necessarily send all values for errors. Send empty strings
             // for any values that are empty.
             let ddError = DDError(type: errorKind ?? "", message: errorMessage ?? "", stack: stackTrace ?? "")
             errorString = buildErrorString(error: ddError)
         }
 
         internalLog(level: level, message: message, errorString: errorString)
+    }
+
+    func critical(
+        message: String,
+        error: Error?,
+        attributes: [String: Encodable]?,
+        completionHandler: @escaping CompletionHandler
+    ) {
+        self.critical(message, error: error, attributes: attributes)
+        completionHandler()
     }
 }

--- a/DatadogLogs/Sources/LoggerProtocol+Internal.swift
+++ b/DatadogLogs/Sources/LoggerProtocol+Internal.swift
@@ -11,10 +11,10 @@ import DatadogInternal
 public protocol InternalLoggerProtocol {
     /// General purpose logging method.
     /// Sends a log with certain `level`, `message`, `errorKind`,  `errorMessage`,  `stackTrace` and `attributes`.
-    ///
+    /// 
     /// This method is meant for non-native or cross platform frameworks (such as React Native or Flutter) to send error information
     /// to Datadog. Although it can be used directly, it is recommended to use other methods declared on `Logger`.
-    ///
+    /// 
     /// - Parameters:
     ///   - level: the log level
     ///   - message: the message to be logged
@@ -22,7 +22,7 @@ public protocol InternalLoggerProtocol {
     ///   - errorMessage: the message attached to the error
     ///   - stackTrace: a string representation of the error's stack trace
     ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
-    /// the same key already exist in this logger, it will be overridden (only for this message).
+    ///                 the same key already exist in this logger, it will be overridden (only for this message).
     func log(
         level: LogLevel,
         message: String,
@@ -30,6 +30,24 @@ public protocol InternalLoggerProtocol {
         errorMessage: String?,
         stackTrace: String?,
         attributes: [String: Encodable]?
+    )
+
+    /// Logs a critical entry then call completion.
+    ///
+    /// This method is meant for non-native or cross platform frameworks (such as KMP) to send error information
+    /// synchronously.
+    ///
+    /// - Parameters:
+    ///   - error: the `Error` object. It will be used to infer error details.
+    ///   - message: the message to be logged
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    ///                 the same key already exist in this logger, it will be overridden (only for this message).
+    ///   - completionHandler: A completion closure called when reporting the log is completed.
+    func critical(
+        message: String,
+        error: Error?,
+        attributes: [String: Encodable]?,
+        completionHandler: @escaping CompletionHandler
     )
 }
 
@@ -42,6 +60,13 @@ private struct NOPInternalLogger: InternalLoggerProtocol {
         stackTrace: String?,
         attributes: [String: Encodable]?
     ) { }
+
+    func critical(
+        message: String,
+        error: Error?,
+        attributes: [String: Encodable]?,
+        completionHandler: @escaping CompletionHandler
+    ) { completionHandler() }
 }
 
 /// Extends `LoggerProtocol` with additional methods designed for Datadog cross-platform SDKs.

--- a/DatadogLogs/Sources/LoggerProtocol.swift
+++ b/DatadogLogs/Sources/LoggerProtocol.swift
@@ -227,7 +227,8 @@ extension CombinedLogger: InternalLoggerProtocol {
         errorKind: String?,
         errorMessage: String?,
         stackTrace: String?,
-        attributes: [String: Encodable]?) {
+        attributes: [String: Encodable]?
+    ) {
         combinedLoggers.forEach {
             $0._internal.log(
                 level: level,
@@ -237,6 +238,34 @@ extension CombinedLogger: InternalLoggerProtocol {
                 stackTrace: stackTrace,
                 attributes: attributes
             )
+        }
+    }
+
+    func critical(
+        message: String,
+        error: Error?,
+        attributes: [String: Encodable]?,
+        completionHandler: @escaping CompletionHandler
+    ) {
+        let group = DispatchGroup()
+
+        combinedLoggers.forEach {
+            group.enter()
+
+            $0._internal.critical(
+                message: message,
+                error: error,
+                attributes: attributes,
+                completionHandler: { group.leave() }
+            )
+        }
+
+        // Sync on a global queue for simplicity.
+        // In practice, users of the internal logger are cross-platform
+        // SDKs which don't use console logger and therefor don't use
+        // the combined-logger.
+        group.notify(queue: .global()) {
+            completionHandler()
         }
     }
 }

--- a/DatadogLogs/Tests/ConsoleLoggerTests.swift
+++ b/DatadogLogs/Tests/ConsoleLoggerTests.swift
@@ -128,4 +128,43 @@ class ConsoleLoggerTests: XCTestCase {
         XCTAssertEqual(mock.printedMessages.first, expectedMessage)
         XCTAssertEqual(mock.printedMessages.count, 1)
     }
+
+    func testItPrintsCritical_andCallCompletion() {
+        let completionExpectation = expectation(description: "Error processing completion")
+
+        // Given
+        let logger = ConsoleLogger(
+            configuration: .init(
+                timeZone: .UTC,
+                format: .short
+            ),
+            dateProvider: RelativeDateProvider(
+                using: .mockDecember15th2019At10AMUTC()
+            ),
+            printFunction: mock.print
+        )
+
+        let message = String.mockRandom()
+
+        logger._internal.critical(
+            message: message,
+            error: NSError.mockAny(),
+            attributes: nil,
+            completionHandler: completionExpectation.fulfill
+        )
+
+        // Then
+        let expectedMessage = """
+            10:00:00.000 [CRITICAL] \(message)
+
+            Error details:
+            → type: abc - 0
+            → message: Error Domain=abc Code=0 "(null)"
+            → stack: Error Domain=abc Code=0 "(null)"
+            """
+
+        wait(for: [completionExpectation], timeout: 0)
+        XCTAssertEqual(mock.printedMessages.first, expectedMessage)
+        XCTAssertEqual(mock.printedMessages.count, 1)
+    }
 }

--- a/DatadogLogs/Tests/LoggerTests.swift
+++ b/DatadogLogs/Tests/LoggerTests.swift
@@ -148,6 +148,26 @@ class LoggerTests: XCTestCase {
         XCTAssertTrue(logger is NOPLogger)
     }
 
+    func testWhenCriticalLoggedFromInternal_itCallCompletionOnce() throws {
+        let completionExpectation = expectation(description: "Error processing completion")
+        completionExpectation.assertForOverFulfill = true
+
+        // Given
+        let logger = Logger.create(with: Logger.Configuration(consoleLogFormat: .short), in: core)
+
+        // When
+        logger._internal.critical(
+            message: "test",
+            error: nil,
+            attributes: nil,
+            completionHandler: completionExpectation.fulfill
+        )
+
+        // Then
+        wait(for: [completionExpectation], timeout: 0)
+        XCTAssertTrue(logger is CombinedLogger)
+    }
+
     func testConfiguration_withDebug_itDisableSampling() throws {
         //Given
         var config = Logger.Configuration(remoteSampleRate: 50)

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -161,6 +161,53 @@ class RemoteLoggerTests: XCTestCase {
         XCTAssertEqual(errorMessage.attributes[Logs.Attributes.errorFingerprint] as? String, mockFingerprint)
     }
 
+    func testWhenCriticalLoggedFromInternal_itCallCompletion() throws {
+        let completionExpectation = expectation(description: "Error processing completion")
+
+        // Given
+        let stubBacktrace: BacktraceReport = .mockRandom()
+
+        let logger = RemoteLogger(
+            featureScope: featureScope,
+            globalAttributes: .mockAny(),
+            configuration: .mockAny(),
+            dateProvider: RelativeDateProvider(),
+            rumContextIntegration: false,
+            activeSpanIntegration: false,
+            backtraceReporter: BacktraceReporterMock(backtrace: stubBacktrace)
+        )
+
+        // When
+        let message = String.mockRandom()
+        logger._internal.critical(
+            message: message,
+            error: ErrorMock(),
+            attributes: [CrossPlatformAttributes.includeBinaryImages: true],
+            completionHandler: completionExpectation.fulfill
+        )
+
+        // Then
+        wait(for: [completionExpectation], timeout: 0)
+        let logs = featureScope.eventsWritten(ofType: LogEvent.self)
+        XCTAssertEqual(logs.count, 1)
+
+        let log = try XCTUnwrap(logs.first)
+        XCTAssertEqual(log.message, message)
+        XCTAssertNil(log.attributes.userAttributes[CrossPlatformAttributes.includeBinaryImages])
+        XCTAssertNotNil(log.error?.binaryImages)
+        XCTAssertEqual(log.error?.binaryImages?.count, stubBacktrace.binaryImages.count)
+        for i in 0..<stubBacktrace.binaryImages.count {
+            let logBacktrace = log.error!.binaryImages![i]
+            let errorBacktrace = stubBacktrace.binaryImages[i]
+            XCTAssertEqual(logBacktrace.name, errorBacktrace.libraryName)
+            XCTAssertEqual(logBacktrace.uuid, errorBacktrace.uuid)
+            XCTAssertEqual(logBacktrace.arch, errorBacktrace.architecture)
+            XCTAssertEqual(logBacktrace.isSystem, errorBacktrace.isSystemLibrary)
+            XCTAssertEqual(logBacktrace.loadAddress, errorBacktrace.loadAddress)
+            XCTAssertEqual(logBacktrace.maxAddress, errorBacktrace.maxAddress)
+        }
+    }
+
     // MARK: - Attributes
 
     func testWhenAddingAndRemovingLoggerAttributes_itSendsLogsWithCurrentAttributes() throws {


### PR DESCRIPTION
### What and why?

Logs counter-part of #2180

Cross-platform SDKs can report fatal errors before the native process crashes. However, Logs execute processing and write asynchronously, and the crash can suspend these executions, leading to the loss of the cross-platform error information.

We should let cross-platform SDKs to report error in sync, blocking the caller-thread.

### How?

The change involve changes at different layers:

#### Logs Module

Add method to `InternalLoggerProtocol` for logging a critical entry with a `completionHandler`. The `RemoteLogger` and `ConsoleLogger` call the completion handler after writing the log.

```swift
/// Internal Logger for Cross-Platform access.
public protocol InternalLoggerProtocol {
    /// Logs a critical entry then call completion.
    ///
    /// This method is meant for non-native or cross platform frameworks (such as KMP) to send error information
    /// synchronously.
    ///
    /// - Parameters:
    ///   - error: the `Error` object. It will be used to infer error details.
    ///   - message: the message to be logged
    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
    ///                 the same key already exist in this logger, it will be overridden (only for this message).
    ///   - completionHandler: A completion closure called when reporting the log is completed.
    func critical(
        message: String,
        error: Error?,
        attributes: [String: Encodable]?,
        completionHandler: @escaping CompletionHandler
    )
}
```

#### Objc Module

The `DDLogger` now expose a `_internal_sync_critical` to report an error in sync. This method will wait for the underlying completion handler to be called before returning.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
