### PR TITLE
RUM-9494: Fix the propagation of `device` and `os` on spans

### DIFF
--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -79,14 +79,14 @@ class TracerTests: XCTestCase {
               "type": "custom",
               "meta.tracer.version": "1.2.3",
               "meta.version": "1.0.0",
-              "device": {
+              "meta.device": {
                 "architecture": "arm64",
                 "brand": "Apple",
                 "model": "iPhone10,1",
                 "name": "iPhone",
                 "type": "mobile"
               },
-              "os": {
+              "meta.os": {
                 "build": "13D20",
                 "name": "iOS",
                 "version": "15.4.1",

--- a/DatadogTrace/Sources/Span/SpanEventEncoder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventEncoder.swift
@@ -127,8 +127,8 @@ internal struct SpanEventEncoder {
         case startTime = "start"
         case duration
         case isError = "error"
-        case device = "device"
-        case os = "os"
+        case device = "meta.device" // Should be under `meta` to comply with the span schema
+        case os = "meta.os" // Should be under `meta` to comply with the span schema
 
         // MARK: - Metrics
 


### PR DESCRIPTION
### What and why?

This PR fixes an issue with the ingestion of custom spans.
Previously, the `device` and `os` information was published without the correct schema alignment, which prevented these spans from being ingested properly.

### How?

The `device` and `os` fields are now prefixed with the `meta` namespace to comply with the expected span schema.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
