### PR TITLE
Fix visionOS availability checks

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 import DatadogInternal
 
-@available(iOS 18.0, tvOS 18.0, visionOS 18.0, *)
+@available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
 internal final class ModernSwiftUIComponentDetector: SwiftUIComponentDetector {
     /// Storage for pending touches that began but haven't ended yet
     private var pendingSwiftUIActions = [ObjectIdentifier: PendingAction]()

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIComponentDetector.swift
@@ -54,7 +54,7 @@ internal enum SwiftUIComponentFactory {
     /// Factory that creates the appropriate SwiftUI detector based on platform and version.
     /// Modern detection is only available on iOS 18+ and tvOS 18+.
     static func createDetector() -> SwiftUIComponentDetector {
-        if #available(iOS 18.0, tvOS 18.0, visionOS 18.0, *) {
+        if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             return ModernSwiftUIComponentDetector()
         }
         return LegacySwiftUIComponentDetector()

--- a/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
@@ -553,7 +553,7 @@ class SwiftUIComponentDetectorTests: XCTestCase {
         // Test will always use the correct detector based on iOS version
         let detector = SwiftUIComponentFactory.createDetector()
 
-        if #available(iOS 18.0, tvOS 18.0, visionOS 18.0, *) {
+        if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             XCTAssertTrue(detector is ModernSwiftUIComponentDetector)
         } else {
             XCTAssertTrue(detector is LegacySwiftUIComponentDetector)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
@@ -212,7 +212,7 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
 
         let mainView = session.views[1]
         XCTAssertEqual(mainView.name, "Runner.SwiftUIAutoInstrumentationActionView")
-        if #available(iOS 18.0, tvOS 18.0, visionOS 18.0, *) {
+        if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             XCTAssertEqual(mainView.actionEvents[0].action.target?.name, SwiftUIComponentNames.button)
             XCTAssertEqual(mainView.actionEvents[1].action.target?.name, SwiftUIComponentNames.navigationLink)
             XCTAssertEqual(mainView.actionEvents[2].action.target?.name, "UISwitch")


### PR DESCRIPTION
### What and why?

We were mistakenly using `visionOS 18.0` instead of `visionOS 2.0` in availability checks.

### How?

Replace `visionOS 18.0` with `visionOS 2.0`