### PR TITLE
RUM-9495: Fix e2e test upload

### DIFF
--- a/E2ETests/Runner/Scenarios/SessionReplayWebView/SessionReplayWebViewScenario.swift
+++ b/E2ETests/Runner/Scenarios/SessionReplayWebView/SessionReplayWebViewScenario.swift
@@ -29,7 +29,9 @@ struct SessionReplayWebViewScenario: Scenario {
         SessionReplay.enable(
             with: SessionReplay.Configuration(
                 replaySampleRate: 100,
-                defaultPrivacyLevel: .allow
+                textAndInputPrivacyLevel: .maskSensitiveInputs,
+                imagePrivacyLevel: .maskNone,
+                touchPrivacyLevel: .show,
             )
         )
 


### PR DESCRIPTION
### What and why?

It fixes a compilation error related with the `SessionReplay.Configuration` that is preventing the `e2e test upload` to run.

### How?

It updates the `SessionReplay.Configuration` by using the latest interface.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
