### PR TITLE
chore: Fix SPI docs build and add CI check for SPI compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,6 +277,16 @@ SPM Build (Swift 5.9):
     - make spm-build-macos
     - make spm-build-watchos
 
+SPI Docs Build:
+  stage: lint
+  rules: 
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
+  script:
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --iOS
+    - make clean repo-setup ENV=ci
+    - make spi-docs-build
+
 # ┌──────────────────────┐
 # │ E2E Test app upload: │
 # └──────────────────────┘

--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,11 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: ["DatadogInternal", "DatadogCore", "DatadogLogs", "DatadogTrace", "DatadogRUM", "DatadogSessionReplay", "DatadogCrashReporting", "DatadogWebViewTracking"]
+      documentation_targets: 
+        - DatadogCore iOS
+        - DatadogLogs iOS
+        - DatadogTrace iOS
+        - DatadogRUM iOS
+        - DatadogSessionReplay iOS
+        - DatadogCrashReporting iOS
+        - DatadogWebViewTracking iOS

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ all: env-check repo-setup dependencies templates
 		e2e-upload \
 		benchmark-build benchmark-upload \
 		models-generate rum-models-generate sr-models-generate models-verify rum-models-verify sr-models-verify \
+		api-surface spi-docs-build \
 		dogfood-shopist dogfood-datadog-app \
 		release-build release-validate release-publish-github \
 		release-publish-podspec release-publish-internal-podspecs release-publish-dependent-podspecs \
@@ -341,6 +342,11 @@ api-surface:
 			--library-name DatadogSessionReplay \
 			> ../../api-surface-objc && \
 			cd -
+
+# Builds API documentation using the same process as Swift Package Index.
+spi-docs-build:
+	@$(ECHO_TITLE) "make spi-docs-build"
+	./tools/doc-build.sh --spi-path .spi.yml
 
 # Creates dogfooding PR in shopist-ios
 dogfood-shopist:

--- a/tools/doc-build.sh
+++ b/tools/doc-build.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env zsh
+
+# Usage:
+# $ ./tools/doc-build.sh -h
+# This script runs xcodebuild docbuild for targets listed in a .spi.yml file to ensure SDK compatibility with https://swiftpackageindex.com/ documentation builds.
+
+# Options:
+#  --spi-path: Path to the .spi.yml file
+
+set -eo pipefail
+source ./tools/utils/echo-color.sh
+source ./tools/utils/argparse.sh
+
+set_description "This script runs xcodebuild docbuild for targets listed in a .spi.yml file to ensure SDK compatibility with https://swiftpackageindex.com/ documentation builds."
+define_arg "spi-path" "" "Path to the .spi.yml file" "string" "false"
+
+check_for_help "$@"
+parse_args "$@"
+
+# Extract platform (first one)
+platform=$(sed -n '/platform:/s/.*platform: *//p' "$spi_path" | head -n 1)
+
+if [[ -z "$platform" ]]; then
+  echo_err "Error: platform not found in $spi_path"
+  exit 1
+fi
+
+# Extract documentation_targets block (YAML list):
+# - Find line with 'documentation_targets:'
+# - From that line, grab all lines that start with '  - ' (two spaces + dash)
+# - Trim leading spaces and dash
+
+targets_list=()
+inside_targets=0
+while IFS= read -r line; do
+  if [[ $inside_targets -eq 0 && "$line" =~ documentation_targets: ]]; then
+    inside_targets=1
+    continue
+  fi
+
+  if [[ $inside_targets -eq 1 ]]; then
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*)$ ]]; then
+      target="${line#*- }"
+      targets_list+=("$target")
+    else
+      # End of list (non-list line or empty)
+      break
+    fi
+  fi
+done < "$spi_path"
+
+if [[ ${#targets_list[@]} -eq 0 ]]; then
+  echo_err "Error: documentation_targets not found or empty in $spi_path"
+  exit 1
+fi
+
+for target in "${targets_list[@]}"; do
+  echo_subtitle "Building docs for target: '$target' on platform: '$platform'"
+  xcodebuild \
+    -skipMacroValidation \
+    -skipPackagePluginValidation \
+    docbuild \
+    -scheme "$target" \
+    -destination "generic/platform=$platform" | xcbeautify
+done


### PR DESCRIPTION
### What and why?

📦 This PR fixes [SPI documentation](https://swiftpackageindex.com/DataDog/dd-sdk-ios/develop/documentation) build failures by correcting target names in `.spi.yml` and adds a CI job to ensure ongoing compatibility with SPI doc builds.

### How?

Updates `.spi.yml` target names and introduces a script that runs SPI’s exact `xcodebuild docbuild` commands for each target, integrated into CI `lint` phase to catch regressions early.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
