### PR TITLE
RUM-11242: [Session Replay] Capture SwiftUI shapes as SVG image resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [IMPROVEMENT] Remove fatal errors from Logs. See [#2359][]
 - [IMPROVEMENT] Introduce new category for network errors. See [#2341][]
 - [IMPROVEMENT] Add opt-out API to disable tracking memory warnings as RUM Errors. See [#2355][]
+- [IMPROVEMENT] Improve SwiftUI system image and SF symbol capture in Session Replay through shape SVG recording, image maskColor support, and drawing rasterization. See [#2432][] [#2428][] [#2391][]
 
 # 2.30.0 / 28-07-2025
 

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -442,10 +442,14 @@
 		49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		5B0A9B8B2E3BB98E00A8131C /* GraphicsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */; };
 		5B0A9B8D2E3BBB4500A8131C /* GraphicsFilter+Reflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */; };
+		5B9B20C52E460A0600C95B6C /* ShapeResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
 		5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E42E41FD5C005485E6 /* Drawing.swift */; };
 		5B9CB9E72E420ACB005485E6 /* ImageRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E62E420AC4005485E6 /* ImageRendererTests.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
+		5BF7B51F2E44F7D300E0B772 /* ShapeResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF7B51E2E44F7CE00E0B772 /* ShapeResource.swift */; };
+		5BF7B5212E45032600E0B772 /* CGPath+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF7B5202E45031C00E0B772 /* CGPath+SessionReplay.swift */; };
+		5BF7B5232E45045600E0B772 /* CGPath+SessionReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF7B5222E45045600E0B772 /* CGPath+SessionReplayTests.swift */; };
 		5BFDD7A92E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */; };
 		5BFDD7AA2E28FDD3009A2CEE /* RUMWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */; };
 		5BFE7B7B2E3CFCDE00B8FAA8 /* ImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFE7B7A2E3CFCDA00B8FAA8 /* ImageRenderer.swift */; };
@@ -2438,10 +2442,14 @@
 		49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logs+Internal.swift"; sourceTree = "<group>"; };
 		5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicsFilter.swift; sourceTree = "<group>"; };
 		5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphicsFilter+Reflection.swift"; sourceTree = "<group>"; };
+		5B9B20C42E4609FC00C95B6C /* ShapeResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
 		5B9CB9E42E41FD5C005485E6 /* Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drawing.swift; sourceTree = "<group>"; };
 		5B9CB9E62E420AC4005485E6 /* ImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRendererTests.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
+		5BF7B51E2E44F7CE00E0B772 /* ShapeResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResource.swift; sourceTree = "<group>"; };
+		5BF7B5202E45031C00E0B772 /* CGPath+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPath+SessionReplay.swift"; sourceTree = "<group>"; };
+		5BF7B5222E45045600E0B772 /* CGPath+SessionReplayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGPath+SessionReplayTests.swift"; sourceTree = "<group>"; };
 		5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWebViewContext.swift; sourceTree = "<group>"; };
 		5BFE7B7A2E3CFCDA00B8FAA8 /* ImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderer.swift; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
@@ -4088,6 +4096,7 @@
 			children = (
 				61054E142A6EE10A00AAA894 /* UIImage+SessionReplay.swift */,
 				962D72BE2CF7538800F86EF0 /* CGImage+SessionReplay.swift */,
+				5BF7B5202E45031C00E0B772 /* CGPath+SessionReplay.swift */,
 				D22442C42CA301DA002E71E4 /* UIColor+SessionReplay.swift */,
 				61054E152A6EE10A00AAA894 /* UIView+SessionReplay.swift */,
 				61054E162A6EE10A00AAA894 /* CFType+Safety.swift */,
@@ -4380,6 +4389,7 @@
 			children = (
 				61054F5D2A6EE1BA00AAA894 /* UIView+SessionReplayTests.swift */,
 				61054F5F2A6EE1BA00AAA894 /* CGRect+SessionReplayTests.swift */,
+				5BF7B5222E45045600E0B772 /* CGPath+SessionReplayTests.swift */,
 			);
 			path = Utilties;
 			sourceTree = "<group>";
@@ -5867,6 +5877,7 @@
 		960B26BA2D03541900D7196F /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				5B9B20C42E4609FC00C95B6C /* ShapeResourceTests.swift */,
 				5B9CB9E62E420AC4005485E6 /* ImageRendererTests.swift */,
 				D21331C02D132F0600E4A6A1 /* SwiftUIWireframesBuilderTests.swift */,
 				962D72C42CF7806300F86EF0 /* GraphicsImageReflectionTests.swift */,
@@ -6128,10 +6139,8 @@
 				E2AA55E62C32C6D9002FEF28 /* ApplicationNotifications.swift */,
 				D23039B3298D5235001A1FA3 /* AppState.swift */,
 				D23039B5298D5235001A1FA3 /* BatteryStatus.swift */,
-				6174D6122BFDF16C00EC7469 /* BundleType.swift */,
 				D23039B6298D5235001A1FA3 /* CarrierInfo.swift */,
 				D23039BA298D5235001A1FA3 /* DatadogContext.swift */,
-				D2F8235229915E12003C7E99 /* DatadogSite.swift */,
 				D23039B7298D5235001A1FA3 /* DateProvider.swift */,
 				D23039BC298D5235001A1FA3 /* DeviceInfo.swift */,
 				D23039BE298D5235001A1FA3 /* LaunchTime.swift */,
@@ -6140,7 +6149,6 @@
 				D23039B8298D5235001A1FA3 /* Sysctl.swift */,
 				D23039BB298D5235001A1FA3 /* TrackingConsent.swift */,
 				D23039B4298D5235001A1FA3 /* UserInfo.swift */,
-				8648D07A2E01ABB0002F226B /* BrightnessStatus.swift */,
 				D2F8235229915E12003C7E99 /* DatadogSite.swift */,
 				6174D6122BFDF16C00EC7469 /* BundleType.swift */,
 				8648D07A2E01ABB0002F226B /* BrightnessLevel.swift */,
@@ -6559,6 +6567,7 @@
 				962D72BB2CF6436600F86EF0 /* GraphicsImage+Reflection.swift */,
 				5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */,
 				5BFE7B7A2E3CFCDA00B8FAA8 /* ImageRenderer.swift */,
+				5BF7B51E2E44F7CE00E0B772 /* ShapeResource.swift */,
 				D2AD1CBE2CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift */,
 				D2AD1CBF2CE4AE6600106C74 /* Text.swift */,
 				D2AD1CC02CE4AE6600106C74 /* Text+Reflection.swift */,
@@ -8480,6 +8489,7 @@
 				61054E972A6EE10A00AAA894 /* Diff.swift in Sources */,
 				61054E6E2A6EE10A00AAA894 /* RecordingCoordinator.swift in Sources */,
 				61054E9F2A6EE10B00AAA894 /* Errors.swift in Sources */,
+				5BF7B51F2E44F7D300E0B772 /* ShapeResource.swift in Sources */,
 				D29A470D2D2ED49F0092BC79 /* Xoshiro.swift in Sources */,
 				61054E642A6EE10A00AAA894 /* SessionReplay.swift in Sources */,
 				61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */,
@@ -8514,6 +8524,7 @@
 				D22442C52CA301DA002E71E4 /* UIColor+SessionReplay.swift in Sources */,
 				61054E8E2A6EE10A00AAA894 /* SRContextPublisher.swift in Sources */,
 				61054E732A6EE10A00AAA894 /* WindowTouchSnapshotProducer.swift in Sources */,
+				5BF7B5212E45032600E0B772 /* CGPath+SessionReplay.swift in Sources */,
 				96F25A822CC7EA4400459567 /* SessionReplayPrivacyOverrides+objc.swift in Sources */,
 				A70ADCD22B583B1300321BC9 /* UIImageResource.swift in Sources */,
 				61054E792A6EE10A00AAA894 /* UITextViewRecorder.swift in Sources */,
@@ -8531,6 +8542,7 @@
 				960B26C32D075BD200D7196F /* DisplayListReflectionTests.swift in Sources */,
 				61054FD42A6EE1BA00AAA894 /* SegmentRequestBuilderTests.swift in Sources */,
 				61054FB52A6EE1BA00AAA894 /* UISliderRecorderTests.swift in Sources */,
+				5B9B20C52E460A0600C95B6C /* ShapeResourceTests.swift in Sources */,
 				61054FB22A6EE1BA00AAA894 /* UILabelRecorderTests.swift in Sources */,
 				D2C5D52D2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift in Sources */,
 				61054FBA2A6EE1BA00AAA894 /* UIImageViewRecorderTests.swift in Sources */,
@@ -8560,6 +8572,7 @@
 				61054FBD2A6EE1BA00AAA894 /* UIViewRecorderTests.swift in Sources */,
 				61054F952A6EE1BA00AAA894 /* SessionReplayConfigurationTests.swift in Sources */,
 				61054FAC2A6EE1BA00AAA894 /* CGRect+SessionReplayTests.swift in Sources */,
+				5BF7B5232E45045600E0B772 /* CGPath+SessionReplayTests.swift in Sources */,
 				D218B0482D072CF300E3F82C /* SessionReplayTelemetryTests.swift in Sources */,
 				D21331C12D132F0600E4A6A1 /* SwiftUIWireframesBuilderTests.swift in Sources */,
 				61054FA42A6EE1BA00AAA894 /* DiffTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		5B0A9B8B2E3BB98E00A8131C /* GraphicsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */; };
 		5B0A9B8D2E3BBB4500A8131C /* GraphicsFilter+Reflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */; };
+		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
 		5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E42E41FD5C005485E6 /* Drawing.swift */; };
@@ -2442,6 +2443,7 @@
 		49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logs+Internal.swift"; sourceTree = "<group>"; };
 		5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicsFilter.swift; sourceTree = "<group>"; };
 		5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphicsFilter+Reflection.swift"; sourceTree = "<group>"; };
+		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
 		5B9CB9E42E41FD5C005485E6 /* Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drawing.swift; sourceTree = "<group>"; };
@@ -4008,6 +4010,14 @@
 			path = WatchdogTerminations;
 			sourceTree = "<group>";
 		};
+		5B3AF8A82E4B3A7F009E5375 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
 			isa = PBXGroup;
 			children = (
@@ -4041,18 +4051,19 @@
 		61054E022A6EE0DB00AAA894 /* DatadogSessionReplayTests */ = {
 			isa = PBXGroup;
 			children = (
+				61054F882A6EE1BA00AAA894 /* Feature */,
+				61054F922A6EE1BA00AAA894 /* Helpers */,
+				5B3AF8A82E4B3A7F009E5375 /* Models */,
+				61054F4E2A6EE1BA00AAA894 /* Processor */,
+				61054F592A6EE1BA00AAA894 /* Recorder */,
 				960B26C12D03611400D7196F /* Resources */,
+				61054F3E2A6EE1B900AAA894 /* Utilities */,
+				61054F492A6EE1BA00AAA894 /* Writer */,
 				96E863712C9C547B0023BF78 /* SessionReplayOverrideTests.swift */,
 				61054F482A6EE1B900AAA894 /* SessionReplayTests.swift */,
 				61054F3D2A6EE1B900AAA894 /* SessionReplayConfigurationTests.swift */,
 				D2A434AD2A8E426C0028E329 /* DDSessionReplayTests.swift */,
 				96E863752C9C7E800023BF78 /* DDSessionReplayOverridesTests.swift */,
-				61054F882A6EE1BA00AAA894 /* Feature */,
-				61054F922A6EE1BA00AAA894 /* Helpers */,
-				61054F4E2A6EE1BA00AAA894 /* Processor */,
-				61054F592A6EE1BA00AAA894 /* Recorder */,
-				61054F3E2A6EE1B900AAA894 /* Utilities */,
-				61054F492A6EE1BA00AAA894 /* Writer */,
 			);
 			name = DatadogSessionReplayTests;
 			path = ../DatadogSessionReplay/Tests;
@@ -8544,6 +8555,7 @@
 				61054FB52A6EE1BA00AAA894 /* UISliderRecorderTests.swift in Sources */,
 				5B9B20C52E460A0600C95B6C /* ShapeResourceTests.swift in Sources */,
 				61054FB22A6EE1BA00AAA894 /* UILabelRecorderTests.swift in Sources */,
+				5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */,
 				D2C5D52D2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift in Sources */,
 				61054FBA2A6EE1BA00AAA894 /* UIImageViewRecorderTests.swift in Sources */,
 				61054FC02A6EE1BA00AAA894 /* UITextViewRecorderTests.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BA0067B2E49F6A3000148DB /* UIImage+SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA0067A2E49F698000148DB /* UIImage+SVG.swift */; };
+		5BA0067D2E49F8BF000148DB /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA0067C2E49F8B3000148DB /* UIColor+Hex.swift */; };
 		5BB746152E02ABB900B568F1 /* SwiftUIFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB746142E02ABB500B568F1 /* SwiftUIFixture.swift */; };
 		5BB746182E02B4CD00B568F1 /* SwiftUIViewWithPrivacyOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB746172E02B4CD00B568F1 /* SwiftUIViewWithPrivacyOverrides.swift */; };
 		614396642A5E8C0600197326 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614396632A5E8C0600197326 /* Environment.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5BA0067A2E49F698000148DB /* UIImage+SVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SVG.swift"; sourceTree = "<group>"; };
+		5BA0067C2E49F8B3000148DB /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
 		5BB746142E02ABB500B568F1 /* SwiftUIFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIFixture.swift; sourceTree = "<group>"; };
 		5BB746172E02B4CD00B568F1 /* SwiftUIViewWithPrivacyOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewWithPrivacyOverrides.swift; sourceTree = "<group>"; };
 		614396632A5E8C0600197326 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Environment.swift; path = SRHost/Environment.swift; sourceTree = "<group>"; };
@@ -101,6 +105,8 @@
 		619C49B529955106006B66A6 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5BA0067C2E49F8B3000148DB /* UIColor+Hex.swift */,
+				5BA0067A2E49F698000148DB /* UIImage+SVG.swift */,
 				5BB746142E02ABB500B568F1 /* SwiftUIFixture.swift */,
 				619C49B329952E12006B66A6 /* SnapshotTestCase.swift */,
 				96363B2B2CD26AF3006FEC9D /* PrivacyOverrides.swift */,
@@ -304,8 +310,10 @@
 			files = (
 				619C49BB299639BC006B66A6 /* ImageRendering.swift in Sources */,
 				614396652A5E8C0600197326 /* Environment.swift in Sources */,
+				5BA0067B2E49F6A3000148DB /* UIImage+SVG.swift in Sources */,
 				61B3BC652993BEAF0032C78A /* SRSnapshotTests.swift in Sources */,
 				96363B2C2CD26AF3006FEC9D /* PrivacyOverrides.swift in Sources */,
+				5BA0067D2E49F8BF000148DB /* UIColor+Hex.swift in Sources */,
 				61BB975F2A5D675400AFFF86 /* ImageComposition.swift in Sources */,
 				5BB746182E02B4CD00B568F1 /* SwiftUIViewWithPrivacyOverrides.swift in Sources */,
 				619C49B72995512A006B66A6 /* ImageComparison.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -59,11 +59,15 @@ private extension SRWireframe {
         case .textWireframe(let text):
             return text.toFrame()
         case .imageWireframe(value: let image):
-            return image.toFrame(
-                imageData: resources
-                    .first { $0.calculateIdentifier() == image.resourceId }?
-                    .calculateData()
-            )
+            let resource = resources.first {
+                $0.calculateIdentifier() == image.resourceId
+            }
+            switch resource?.mimeType {
+            case .some("image/svg+xml"):
+                return image.toFrame(svgData: resource?.calculateData())
+            default:
+                return image.toFrame(imageData: resource?.calculateData())
+            }
         case .placeholderWireframe(value: let placeholder):
             return placeholder.toFrame()
         case .webviewWireframe(value: let webview):
@@ -113,6 +117,19 @@ private extension SRImageWireframe {
             style: shapeStyle,
             clip: clip,
             content: .init(imageData: imageData)
+        )
+    }
+
+    func toFrame(svgData: Data?) -> BlueprintFrame {
+        BlueprintFrame(
+            x: x,
+            y: y,
+            width: width,
+            height: height,
+            border: border,
+            style: shapeStyle,
+            clip: clip,
+            content: .init(svgData: svgData)
         )
     }
 }
@@ -267,23 +284,10 @@ extension BlueprintFrame.Content {
         let contentType: BlueprintFrame.Content.ContentType = .image(image: image)
         self.init(contentType: contentType)
     }
-}
 
-private extension UIColor {
-    convenience init(hexString: String) {
-        precondition(hexString.count == 9, "Invalid `hexString` - expected 9 characters, got '\(hexString)'")
-        precondition(hexString.hasPrefix("#"), "Invalid `hexString` - expected # prefix, got '\(hexString)'")
-
-        guard let hex8 = UInt64(hexString.dropFirst(), radix: 16) else {
-            preconditionFailure("Invalid `hexString`` - expected hexadecimal value, got '\(hexString)'")
-        }
-
-        let mask: UInt64 = 0x00000000FF
-        self.init(
-            red: CGFloat((hex8 >> 24) & mask) / CGFloat(255),
-            green: CGFloat((hex8 >> 16) & mask) / CGFloat(255),
-            blue: CGFloat((hex8 >> 8) & mask) / CGFloat(255),
-            alpha: CGFloat(hex8 & mask) / CGFloat(255)
-        )
+    init(svgData: Data?) {
+        let image = svgData.flatMap { UIImage(svgData: $0, scale: UIScreen.main.scale) } ?? UIImage()
+        let contentType: BlueprintFrame.Content.ContentType = .image(image: image)
+        self.init(contentType: contentType)
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIColor+Hex.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIColor+Hex.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+extension UIColor {
+    convenience init(hexString: String) {
+        precondition(hexString.count == 9, "Invalid `hexString` - expected 9 characters, got '\(hexString)'")
+        precondition(hexString.hasPrefix("#"), "Invalid `hexString` - expected # prefix, got '\(hexString)'")
+
+        guard let hex8 = UInt64(hexString.dropFirst(), radix: 16) else {
+            preconditionFailure("Invalid `hexString`` - expected hexadecimal value, got '\(hexString)'")
+        }
+
+        let mask: UInt64 = 0x00000000FF
+        self.init(
+            red: CGFloat((hex8 >> 24) & mask) / CGFloat(255),
+            green: CGFloat((hex8 >> 16) & mask) / CGFloat(255),
+            blue: CGFloat((hex8 >> 8) & mask) / CGFloat(255),
+            alpha: CGFloat(hex8 & mask) / CGFloat(255)
+        )
+    }
+}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIImage+SVG.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIImage+SVG.swift
@@ -1,0 +1,154 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+// NB: This extension is tailored to our specific use case, SVG
+//     containing a single shape with a fill color.
+//     For other use cases or full SVG support we should consider a
+//     3rd party dependency.
+
+extension UIImage {
+    convenience init?(svgData: Data, scale: CGFloat) {
+        guard let document = SVGShapeDocument(svgData: svgData) else { return nil }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = scale
+        format.opaque = false
+
+        let renderer = UIGraphicsImageRenderer(size: document.size, format: format)
+        let image = renderer.image { _ in
+            let path = UIBezierPath(cgPath: document.path)
+            path.usesEvenOddFillRule = document.isEOFilled
+
+            document.fillColor.setFill()
+            path.fill()
+        }
+
+        self.init(cgImage: image.cgImage!, scale: image.scale, orientation: .up)
+    }
+}
+
+private struct SVGShapeDocument {
+    private final class ParserDelegate: NSObject, XMLParserDelegate {
+        var svgAttributes: [String: String] = [:]
+        var pathAttributes: [String: String] = [:]
+
+        private var didParseSVG = false
+        private var didParsePath = false
+
+        func parser(
+            _ parser: XMLParser,
+            didStartElement elementName: String,
+            namespaceURI: String?,
+            qualifiedName qName: String?,
+            attributes attributeDict: [String: String] = [:]
+        ) {
+            switch elementName.lowercased() {
+            case "svg":
+                guard !didParseSVG else { return }
+                svgAttributes = attributeDict
+                didParseSVG = true
+            case "path":
+                guard !didParsePath else { return }
+                pathAttributes = attributeDict
+                didParsePath = true
+            default:
+                break
+            }
+        }
+    }
+
+    let size: CGSize
+    let path: CGPath
+    let fillColor: UIColor
+    let isEOFilled: Bool
+
+    init?(svgData: Data) {
+        let delegate = ParserDelegate()
+
+        let parser = XMLParser(data: svgData)
+        parser.delegate = delegate
+        parser.shouldResolveExternalEntities = false
+
+        guard parser.parse() else { return nil }
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale(identifier: "en_US_POSIX")
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.allowsFloats = true
+
+        guard
+            let width = delegate.svgAttributes["width"].flatMap(numberFormatter.number(from:))?.doubleValue,
+            let height = delegate.svgAttributes["height"].flatMap(numberFormatter.number(from:))?.doubleValue,
+            let path = delegate.pathAttributes["d"].flatMap(CGPath.parse(_:)),
+            let fillColor = delegate.pathAttributes["fill"]
+        else {
+            return nil
+        }
+
+        self.size = CGSize(width: width, height: height)
+        self.path = path
+        self.fillColor = UIColor(hexString: fillColor)
+        self.isEOFilled = delegate.pathAttributes["fill-rule"]?.lowercased() == "evenodd"
+    }
+}
+
+extension CGPath {
+    fileprivate static func parse(_ d: String) -> CGPath? {
+        let scanner = Scanner(string: d)
+        scanner.charactersToBeSkipped = CharacterSet(charactersIn: " ,\n\t\r")
+        scanner.locale = Locale(identifier: "en_US_POSIX")
+
+        let path = CGMutablePath()
+        var hasSubpath = false
+
+        func nextCommand() -> Character? {
+            while !scanner.isAtEnd {
+                let character = scanner.string[scanner.currentIndex]
+                if ("A"..."Z").contains(character) || ("a"..."z").contains(character) {
+                    scanner.currentIndex = scanner.string.index(after: scanner.currentIndex)
+                    return character
+                }
+                scanner.currentIndex = scanner.string.index(after: scanner.currentIndex)
+            }
+            return nil
+        }
+
+        func scan() -> CGFloat? {
+            scanner.scanDouble().map(CGFloat.init(_:))
+        }
+
+        while let command = nextCommand() {
+            // Absolute M/L/Q/C only
+            switch command {
+            case "M":
+                guard let x = scan(), let y = scan() else { return nil }
+                path.move(to: CGPoint(x: x, y: y)); hasSubpath = true
+            case "L":
+                guard let x = scan(), let y = scan() else { return nil }
+                path.addLine(to: CGPoint(x: x, y: y))
+            case "Q":
+                guard let cx = scan(), let cy = scan(),
+                      let x = scan(), let y = scan() else { return nil }
+                path.addQuadCurve(to: CGPoint(x: x, y: y), control: CGPoint(x: cx, y: cy))
+            case "C":
+                guard let c1x = scan(), let c1y = scan(),
+                      let c2x = scan(), let c2y = scan(),
+                      let x = scan(), let y = scan() else { return nil }
+                path.addCurve(to: CGPoint(x: x, y: y),
+                              control1: CGPoint(x: c1x, y: c1y),
+                              control2: CGPoint(x: c2x, y: c2y))
+            case "Z", "z":
+                if hasSubpath { path.closeSubpath(); hasSubpath = false }
+            default:
+                return nil // unsupported command
+            }
+        }
+
+        return path
+    }
+}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIImage+SVG.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/UIImage+SVG.swift
@@ -13,7 +13,9 @@ import UIKit
 
 extension UIImage {
     convenience init?(svgData: Data, scale: CGFloat) {
-        guard let document = SVGShapeDocument(svgData: svgData) else { return nil }
+        guard let document = SVGShapeDocument(svgData: svgData) else {
+            return nil
+        }
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = scale
@@ -49,11 +51,15 @@ private struct SVGShapeDocument {
         ) {
             switch elementName.lowercased() {
             case "svg":
-                guard !didParseSVG else { return }
+                guard !didParseSVG else {
+                    return
+                }
                 svgAttributes = attributeDict
                 didParseSVG = true
             case "path":
-                guard !didParsePath else { return }
+                guard !didParsePath else {
+                    return
+                }
                 pathAttributes = attributeDict
                 didParsePath = true
             default:
@@ -74,7 +80,9 @@ private struct SVGShapeDocument {
         parser.delegate = delegate
         parser.shouldResolveExternalEntities = false
 
-        guard parser.parse() else { return nil }
+        guard parser.parse() else {
+            return nil
+        }
 
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -126,24 +134,40 @@ extension CGPath {
             // Absolute M/L/Q/C only
             switch command {
             case "M":
-                guard let x = scan(), let y = scan() else { return nil }
+                guard let x = scan(), let y = scan() else {
+                    return nil
+                }
                 path.move(to: CGPoint(x: x, y: y)); hasSubpath = true
             case "L":
-                guard let x = scan(), let y = scan() else { return nil }
+                guard let x = scan(), let y = scan() else {
+                    return nil
+                }
                 path.addLine(to: CGPoint(x: x, y: y))
             case "Q":
-                guard let cx = scan(), let cy = scan(),
-                      let x = scan(), let y = scan() else { return nil }
+                guard
+                    let cx = scan(), let cy = scan(),
+                    let x = scan(), let y = scan()
+                else {
+                    return nil
+                }
                 path.addQuadCurve(to: CGPoint(x: x, y: y), control: CGPoint(x: cx, y: cy))
             case "C":
-                guard let c1x = scan(), let c1y = scan(),
-                      let c2x = scan(), let c2y = scan(),
-                      let x = scan(), let y = scan() else { return nil }
-                path.addCurve(to: CGPoint(x: x, y: y),
-                              control1: CGPoint(x: c1x, y: c1y),
-                              control2: CGPoint(x: c2x, y: c2y))
+                guard
+                    let c1x = scan(), let c1y = scan(),
+                    let c2x = scan(), let c2y = scan(),
+                    let x = scan(), let y = scan()
+                else {
+                    return nil
+                }
+                path.addCurve(
+                    to: CGPoint(x: x, y: y),
+                    control1: CGPoint(x: c1x, y: c1y),
+                    control2: CGPoint(x: c2x, y: c2y)
+                )
             case "Z", "z":
-                if hasSubpath { path.closeSubpath(); hasSubpath = false }
+                if hasSubpath {
+                    path.closeSubpath(); hasSubpath = false
+                }
             default:
                 return nil // unsupported command
             }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskAll_images-maskAll-privacy.png.json
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskAll_images-maskAll-privacy.png.json
@@ -1,1 +1,1 @@
-{"hash":"156469e534277f6ccefa46890a3f726e1ceffa6b"}
+{"hash":"0b40c4d557fe2c3f570a157f742312ca482cd77c"}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskNonBundledOnly_images-maskAllInputs-privacy.png.json
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskNonBundledOnly_images-maskAllInputs-privacy.png.json
@@ -1,1 +1,1 @@
-{"hash":"ff1f39105d8fbfa171c9f9d2e009ae663200c96e"}
+{"hash":"645faece7294912c95b8f65bd84e692d194bf88f"}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskNone_images-maskSensitiveInputs-privacy.png.json
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUI()-maskNone_images-maskSensitiveInputs-privacy.png.json
@@ -1,1 +1,1 @@
-{"hash":"b457cde706442ac13f09f810ecbc075b016f386b"}
+{"hash":"0f9b5e8305cc51a161bfd00a890667cba1dd52d0"}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUIWithPrivacyOverrides()-maskNone_images-maskSensitiveInputs-privacy.png.json
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/_snapshots_/pointers/testSwiftUIWithPrivacyOverrides()-maskNone_images-maskSensitiveInputs-privacy.png.json
@@ -1,1 +1,1 @@
-{"hash":"ee32a8059f8eae6ad27501102df8f7f6456adc43"}
+{"hash":"2d162d77211218934dc0c5ad5ce0be810c520d9d"}

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -75,7 +75,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
                 name: "image",
                 filename: $0.identifier,
                 data: $0.data,
-                mimeType: $0.mimeType ?? "image/png"
+                mimeType: $0.mimeType
             )
         }
         if let context = resources.first?.context {

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -75,7 +75,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
                 name: "image",
                 filename: $0.identifier,
                 data: $0.data,
-                mimeType: "image/png"
+                mimeType: $0.mimeType ?? "image/png"
             )
         }
         if let context = resources.first?.context {

--- a/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
+++ b/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
@@ -23,15 +23,18 @@ internal struct EnrichedResource: Codable, Equatable {
     }
     internal var identifier: String
     internal var data: Data
+    internal var mimeType: String?
     internal var context: Context
 
     internal init(
         identifier: String,
         data: Data,
+        mimeType: String?,
         context: Context
     ) {
         self.identifier = identifier
         self.data = data
+        self.mimeType = mimeType
         self.context = context
     }
 }

--- a/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
+++ b/DatadogSessionReplay/Sources/Models/EnrichedResource.swift
@@ -23,19 +23,31 @@ internal struct EnrichedResource: Codable, Equatable {
     }
     internal var identifier: String
     internal var data: Data
-    internal var mimeType: String?
+    internal var mimeType: String
     internal var context: Context
 
     internal init(
         identifier: String,
         data: Data,
-        mimeType: String?,
+        mimeType: String,
         context: Context
     ) {
         self.identifier = identifier
         self.data = data
         self.mimeType = mimeType
         self.context = context
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.data = try container.decode(Data.self, forKey: .data)
+        self.context = try container.decode(EnrichedResource.Context.self, forKey: .context)
+
+        // Maintain backward compatibility:
+        //   Before introducing `mimeType` all resources where PNG images
+        self.mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? "image/png"
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/Builders/WireframesBuilder.swift
@@ -93,7 +93,6 @@ extension SessionReplayWireframesBuilder {
         resource: SessionReplayResource,
         frame: CGRect,
         clip: CGRect,
-        mimeType: String = "png",
         borderColor: CGColor? = nil,
         borderWidth: CGFloat? = nil,
         backgroundColor: CGColor? = nil,
@@ -110,7 +109,7 @@ extension SessionReplayWireframesBuilder {
             height: Int64(withNoOverflow: frame.height),
             id: id,
             isEmpty: false, // field deprecated - we should use placeholder wireframe instead
-            mimeType: mimeType,
+            mimeType: resource.mimeType,
             resourceId: resource.calculateIdentifier(),
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
             width: Int64(withNoOverflow: frame.width),

--- a/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/ResourcesProcessor.swift
@@ -35,6 +35,7 @@ internal class ResourceProcessor: ResourceProcessing {
                     return !isProcessed ? EnrichedResource(
                         identifier: identifier,
                         data: $0.calculateData(),
+                        mimeType: $0.mimeType,
                         context: context
                     ) : nil
                 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CGPath+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CGPath+SessionReplay.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import CoreGraphics
+import DatadogInternal
+import Foundation
+
+#if $RetroactiveAttribute
+extension CGPath: @retroactive DatadogExtended {}
+#else
+extension CGPath: DatadogExtended {}
+#endif
+
+extension DatadogExtension where ExtendedType: CGPath {
+    var svgString: String {
+        var d = ""
+        type.applyWithBlock { pointer in
+            let element = pointer.pointee
+            let points = element.points
+
+            switch element.type {
+            case .moveToPoint:
+                d += "M \(points[0].dd.svgString) "
+            case .addLineToPoint:
+                d += "L \(points[0].dd.svgString) "
+            case .addQuadCurveToPoint:
+                d += "Q \(points[0].dd.svgString) \(points[1].dd.svgString) "
+            case .addCurveToPoint:
+                d += "C \(points[0].dd.svgString) \(points[1].dd.svgString) \(points[2].dd.svgString) "
+            case .closeSubpath:
+                d += "Z "
+            @unknown default:
+                break
+            }
+        }
+        return d.trimmingCharacters(in: .whitespaces)
+    }
+}
+
+#if $RetroactiveAttribute
+extension CGPoint: @retroactive DatadogExtended {}
+#else
+extension CGPoint: DatadogExtended {}
+#endif
+
+extension DatadogExtension where ExtendedType == CGPoint {
+    fileprivate var svgString: String {
+        String(format: "%.3f %.3f", type.x, type.y)
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CGPath+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CGPath+SessionReplay.swift
@@ -49,8 +49,20 @@ extension CGPoint: DatadogExtended {}
 #endif
 
 extension DatadogExtension where ExtendedType == CGPoint {
-    fileprivate var svgString: String {
-        String(format: "%.3f %.3f", type.x, type.y)
+    internal var svgString: String {
+        "\(type.x.dd.svgString) \(type.y.dd.svgString)"
+    }
+}
+
+#if $RetroactiveAttribute
+extension CGFloat: @retroactive DatadogExtended {}
+#else
+extension CGFloat: DatadogExtended {}
+#endif
+
+extension DatadogExtension where ExtendedType == CGFloat {
+    internal var svgString: String {
+        String(format: "%.3f", locale: .init(identifier: "en_US_POSIX"), type)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CGRect+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CGRect+SessionReplay.swift
@@ -8,7 +8,11 @@
 import UIKit
 import DatadogInternal
 
+#if $RetroactiveAttribute
+extension CGRect: @retroactive DatadogExtended {}
+#else
 extension CGRect: DatadogExtended {}
+#endif
 
 internal extension DatadogExtension where ExtendedType == CGRect {
     func contentFrame(

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CGSize+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CGSize+SessionReplay.swift
@@ -8,7 +8,11 @@
 import UIKit
 import DatadogInternal
 
+#if $RetroactiveAttribute
+extension CGSize: @retroactive DatadogExtended {}
+#else
 extension CGSize: DatadogExtended {}
+#endif
 
 internal extension DatadogExtension where ExtendedType == CGSize {
     var aspectRatio: CGFloat {

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -13,7 +13,11 @@ import CommonCrypto
 private let bitsPerComponent = 8
 private var identifierKey: UInt8 = 0
 
+#if $RetroactiveAttribute
+extension UIImage: @retroactive DatadogExtended {}
+#else
 extension UIImage: DatadogExtended {}
+#endif
 
 extension DatadogExtension where ExtendedType: UIImage {
     var identifier: String {

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIView+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIView+SessionReplay.swift
@@ -8,7 +8,11 @@
 import UIKit
 import DatadogInternal
 
+#if $RetroactiveAttribute
+extension UIView: @retroactive DatadogExtended { }
+#else
 extension UIView: DatadogExtended { }
+#endif
 
 /// Sensitive text content types as defined in Session Replay.
 private let UITextContentSensitiveTypes: Set<UITextContentType> = [

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
@@ -38,7 +38,11 @@ extension ColorView: Reflection {
 @available(iOS 13.0, tvOS 13.0, *)
 extension ResolvedPaint: Reflection {
     init(from reflector: Reflector) throws {
-        paint = reflector.descendantIfPresent("paint")
+        if #available(iOS 26, tvOS 26, *) {
+            paint = reflector.descendantIfPresent(type: ColorView.self, "paint")?.color.base
+        } else {
+            paint = reflector.descendantIfPresent("paint")
+        }
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import SwiftUI
+
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+@available(iOS 13.0, tvOS 13.0, *)
+internal struct ShapeResource {
+    let svgString: String
+
+    init(path: SwiftUI.Path, color: ResolvedPaint, fillStyle: SwiftUI.FillStyle, size: CGSize) {
+        let pathData = path.cgPath.dd.svgString
+        let fillColor = color.paint.map(\.uiColor.dd.hexString) ?? "#000000FF"
+        let fillRule = fillStyle.isEOFilled ? "evenodd" : "nonzero"
+
+        self.svgString = """
+          <svg width="\(String(format: "%.3f", size.width))" height="\(String(format: "%.3f", size.height))" xmlns="http://www.w3.org/2000/svg">
+            <path d="\(pathData)" fill="\(fillColor)" fill-rule="\(fillRule)"/>
+          </svg>
+          """
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ShapeResource: Resource {
+    var mimeType: String {
+        "image/svg+xml"
+    }
+
+    func calculateIdentifier() -> String {
+        #if canImport(CryptoKit)
+            let data = Data(svgString.utf8)
+            let hash = Insecure.MD5.hash(data: data)
+            return hash.map { String(format: "%02hhx", $0) }.joined()
+        #else
+            // Should never execute since CryptoKit is available iOS 13
+            fatalError("CryptoKit not available")
+        #endif
+    }
+
+    func calculateData() -> Data {
+        Data(svgString.utf8)
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import CryptoKit
 #endif
 
-@available(iOS 13.0, tvOS 13.0, *)
+@available(iOS 13.0, *)
 internal struct ShapeResource {
     let svgString: String
 
@@ -22,14 +22,14 @@ internal struct ShapeResource {
         let fillRule = fillStyle.isEOFilled ? "evenodd" : "nonzero"
 
         self.svgString = """
-          <svg width="\(String(format: "%.3f", size.width))" height="\(String(format: "%.3f", size.height))" xmlns="http://www.w3.org/2000/svg">
+          <svg width="\(size.width.dd.svgString)" height="\(size.height.dd.svgString)" xmlns="http://www.w3.org/2000/svg">
             <path d="\(pathData)" fill="\(fillColor)" fill-rule="\(fillRule)"/>
           </svg>
           """
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
+@available(iOS 13.0, *)
 extension ShapeResource: Resource {
     var mimeType: String {
         "image/svg+xml"

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -101,20 +101,27 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
         let id: Int64 = .positiveRandom(using: &generator)
 
         switch content.value {
-        case let .shape(_, paint, _):
-            return paint.paint.map { paint in
-                context.builder.createShapeWireframe(
+        case let .shape(path, color, fillStyle):
+            // We treat shapes as bundled images
+            if case .maskAll = self.imagePrivacyLevel {
+                return context.builder.createPlaceholderWireframe(
                     id: id,
                     frame: context.convert(frame: item.frame),
                     clip: context.clip,
-                    backgroundColor: CGColor(
-                        red: CGFloat(paint.linearRed),
-                        green: CGFloat(paint.linearGreen),
-                        blue: CGFloat(paint.linearBlue),
-                        alpha: CGFloat(paint.opacity)
-                    ),
-                    cornerRadius: viewInfo?.cornerRadius,
-                    opacity: CGFloat(paint.opacity)
+                    label: "Image"
+                )
+            } else {
+                let shapeResource = ShapeResource(
+                    path: path,
+                    color: color,
+                    fillStyle: fillStyle,
+                    size: item.frame.size
+                )
+                return context.builder.createImageWireframe(
+                    id: id,
+                    resource: shapeResource,
+                    frame: context.convert(frame: item.frame),
+                    clip: context.clip
                 )
             }
         case let .text(view, _):

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResource.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResource.swift
@@ -19,8 +19,12 @@ internal struct UIImageResource {
 }
 
 extension UIImageResource: Resource {
+    var mimeType: String {
+        "image/png"
+    }
+
     func calculateIdentifier() -> String {
-        tintColor.map { image.dd.identifier + $0 .dd.identifier } ?? image.dd.identifier
+        tintColor.map { image.dd.identifier + $0.dd.identifier } ?? image.dd.identifier
     }
 
     func calculateData() -> Data {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -56,6 +56,8 @@ internal typealias Node = SessionReplayNode
 // An individual resource in `ViewTreeSnapshot`. It is used to describe binary representation of heavy resources such as images.
 @_spi(Internal)
 public protocol SessionReplayResource {
+    var mimeType: String { get }
+
     /// Calculates the unique identifier of the resource.
     /// This function is not thread safe and needs to be synchronized by the caller.
     func calculateIdentifier() -> String

--- a/DatadogSessionReplay/Sources/Utilities/Colors.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Colors.swift
@@ -21,32 +21,6 @@ internal func hexString(from color: CGColor) -> String? {
         return nil
     }
 
-    let uiColor = UIColor(cgColor: color) // TODO: RUMM-2250 Check if there's a way without converting to `UIColor`
-
-    var r: CGFloat = 0
-    var g: CGFloat = 0
-    var b: CGFloat = 0
-    var a: CGFloat = 1
-
-    guard uiColor.getRed(&r, green: &g, blue: &b, alpha: &a) else {
-        return nil
-    }
-
-    let ri = Int16(withNoOverflow: round(r * 255))
-    let gi = Int16(withNoOverflow: round(g * 255))
-    let bi = Int16(withNoOverflow: round(b * 255))
-    let ai = Int16(withNoOverflow: round(a * 255))
-
-    var rstr = String(ri, radix: 16, uppercase: true)
-    var gstr = String(gi, radix: 16, uppercase: true)
-    var bstr = String(bi, radix: 16, uppercase: true)
-    var astr = String(ai, radix: 16, uppercase: true)
-
-    rstr = ri < 16 ? "0\(rstr)" : rstr
-    gstr = gi < 16 ? "0\(gstr)" : gstr
-    bstr = bi < 16 ? "0\(bstr)" : bstr
-    astr = ai < 16 ? "0\(astr)" : astr
-
-    return "#\(rstr)\(gstr)\(bstr)\(astr)"
+    return UIColor(cgColor: color).dd.hexString
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -143,7 +143,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         for i in 0..<resources.count {
             XCTAssertNotNil(multipartSpy.formFiles[i].filename)
             XCTAssertGreaterThan(multipartSpy.formFiles[i].data.count, 0)
-            XCTAssertEqual(multipartSpy.formFiles[i].mimeType, "image/png")
+            XCTAssertEqual(multipartSpy.formFiles[i].mimeType, resources[i].mimeType)
         }
 
         XCTAssertEqual(multipartSpy.formFiles.last?.filename, "blob")

--- a/DatadogSessionReplay/Tests/Models/EnrichedResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Models/EnrichedResourceTests.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import XCTest
+@testable import DatadogSessionReplay
+
+final class EnrichedResourceTests: XCTestCase {
+    func testDecodingWithMimeType() throws {
+        let json = """
+        {
+            "identifier": "test-resource-123",
+            "data": "aGVsbG8gd29ybGQ=",
+            "mimeType": "image/svg+xml",
+            "context": {
+                "type": "resource",
+                "application": {
+                    "id": "test-app-123"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let resource = try JSONDecoder().decode(EnrichedResource.self, from: json)
+
+        XCTAssertEqual(resource.identifier, "test-resource-123")
+        XCTAssertEqual(resource.data, Data(base64Encoded: "aGVsbG8gd29ybGQ=")!)
+        XCTAssertEqual(resource.mimeType, "image/svg+xml")
+        XCTAssertEqual(resource.context.type, "resource")
+        XCTAssertEqual(resource.context.application.id, "test-app-123")
+    }
+
+    func testDecodingWithoutMimeTypeUsesDefaultPNG() throws {
+        let json = """
+        {
+            "identifier": "legacy-resource-456",
+            "data": "aW1hZ2VieXRlcw==",
+            "context": {
+                "type": "resource",
+                "application": {
+                    "id": "test-app-123"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let resource = try JSONDecoder().decode(EnrichedResource.self, from: json)
+
+        XCTAssertEqual(resource.identifier, "legacy-resource-456")
+        XCTAssertEqual(resource.data, Data(base64Encoded: "aW1hZ2VieXRlcw==")!)
+        XCTAssertEqual(resource.mimeType, "image/png", "Should default to PNG for backward compatibility")
+        XCTAssertEqual(resource.context.type, "resource")
+        XCTAssertEqual(resource.context.application.id, "test-app-123")
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ResourceProcessorTests.swift
@@ -41,11 +41,13 @@ class ResourceProcessorTests: XCTestCase {
                 EnrichedResource(
                     identifier: resource1.calculateIdentifier(),
                     data: resource1.calculateData(),
+                    mimeType: resource1.mimeType,
                     context: context
                 ),
                 EnrichedResource(
                     identifier: resource2.calculateIdentifier(),
                     data: resource2.calculateData(),
+                    mimeType: resource2.mimeType,
                     context: context
                 ),
             ]
@@ -85,11 +87,13 @@ class ResourceProcessorTests: XCTestCase {
                 EnrichedResource(
                     identifier: resource1.calculateIdentifier(),
                     data: resource1.calculateData(),
+                    mimeType: resource1.mimeType,
                     context: context
                 ),
                 EnrichedResource(
                     identifier: resource2.calculateIdentifier(),
                     data: resource2.calculateData(),
+                    mimeType: resource2.mimeType,
                     context: context
                 ),
             ]

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/CGPath+SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/CGPath+SessionReplayTests.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import XCTest
+import CoreGraphics
+@testable import DatadogSessionReplay
+
+final class CGPathSessionReplayTests: XCTestCase {
+    func testEmptyPath() {
+        let path = CGMutablePath()
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "")
+    }
+
+    func testMoveToPoint() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 10.5, y: 20.25))
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M 10.500 20.250")
+    }
+
+    func testLineToPoint() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 100, y: 50))
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M 0.000 0.000 L 100.000 50.000")
+    }
+
+    func testQuadCurveToPoint() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addQuadCurve(to: CGPoint(x: 100, y: 100), control: CGPoint(x: 50, y: 0))
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M 0.000 0.000 Q 50.000 0.000 100.000 100.000")
+    }
+
+    func testCubicCurveToPoint() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addCurve(to: CGPoint(x: 100, y: 100), control1: CGPoint(x: 25, y: 0), control2: CGPoint(x: 75, y: 100))
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M 0.000 0.000 C 25.000 0.000 75.000 100.000 100.000 100.000")
+    }
+
+    func testCloseSubpath() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 100, y: 0))
+        path.addLine(to: CGPoint(x: 100, y: 100))
+        path.closeSubpath()
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M 0.000 0.000 L 100.000 0.000 L 100.000 100.000 Z")
+    }
+
+    func testMultipleSubpaths() {
+        let path = CGMutablePath()
+
+        // First subpath - triangle
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 30, y: 0))
+        path.addLine(to: CGPoint(x: 15, y: 25))
+        path.closeSubpath()
+
+        // Second subpath - circle approximation
+        path.move(to: CGPoint(x: 50, y: 50))
+        path.addQuadCurve(to: CGPoint(x: 100, y: 50), control: CGPoint(x: 75, y: 25))
+        path.addQuadCurve(to: CGPoint(x: 50, y: 50), control: CGPoint(x: 75, y: 75))
+
+        let svgString = path.dd.svgString
+
+        let expected = "M 0.000 0.000 L 30.000 0.000 L 15.000 25.000 Z M 50.000 50.000 Q 75.000 25.000 100.000 50.000 Q 75.000 75.000 50.000 50.000"
+        XCTAssertEqual(svgString, expected)
+    }
+
+    func testCoordinatePrecision() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: 1.23456, y: 7.89123))
+        path.addLine(to: CGPoint(x: 45.6789, y: 12.3456))
+
+        let svgString = path.dd.svgString
+
+        // Should round to 3 decimal places
+        XCTAssertEqual(svgString, "M 1.235 7.891 L 45.679 12.346")
+    }
+
+    func testNegativeCoordinates() {
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: -10.5, y: -20.75))
+        path.addLine(to: CGPoint(x: -50, y: 30))
+
+        let svgString = path.dd.svgString
+
+        XCTAssertEqual(svgString, "M -10.500 -20.750 L -50.000 30.000")
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceTests.swift
@@ -1,0 +1,93 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+
+import XCTest
+import SwiftUI
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+final class ShapeResourceTests: XCTestCase {
+    private enum Fixtures {
+        static let shapeResource = ShapeResource(
+            path: .init {
+                $0.addRect(.init(x: 0, y: 0, width: 50, height: 50))
+            },
+            color: .mockAny(),
+            fillStyle: .init(),
+            size: .init(width: 50, height: 50)
+        )
+        static let shapeResourceWithEvenOddFillRule = ShapeResource(
+            path: .init {
+                $0.move(to: .zero)
+                $0.addLine(to: CGPoint(x: 50, y: 50))
+            },
+            color: .mockAny(),
+            fillStyle: .init(eoFill: true),
+            size: .init(width: 50, height: 50)
+        )
+    }
+
+    func testSVGString() {
+        XCTAssertEqual(
+            Fixtures.shapeResource.svgString,
+            """
+            <svg width=\"50.000\" height=\"50.000\" xmlns=\"http://www.w3.org/2000/svg\">
+              <path d=\"M 0.000 0.000 L 50.000 0.000 L 50.000 50.000 L 0.000 50.000 Z\" \
+            fill=\"#00000000\" fill-rule=\"nonzero\"/>
+            </svg>
+            """
+        )
+    }
+
+    func testSVGStringEvenOddFillRule() {
+        XCTAssertEqual(
+            Fixtures.shapeResourceWithEvenOddFillRule.svgString,
+            """
+            <svg width="50.000" height="50.000" xmlns="http://www.w3.org/2000/svg">
+              <path d="M 0.000 0.000 L 50.000 50.000" fill="#00000000" fill-rule="evenodd"/>
+            </svg>
+            """
+        )
+    }
+
+    func testMimeType() {
+        XCTAssertEqual(Fixtures.shapeResource.mimeType, "image/svg+xml")
+    }
+
+    func testCalculateIdentifier() {
+        let identifier = Fixtures.shapeResource.calculateIdentifier()
+
+        XCTAssertEqual(identifier.count, 32)
+        XCTAssertTrue(identifier.allSatisfy { $0.isHexDigit })
+
+        XCTAssertEqual(
+            Fixtures.shapeResource.calculateIdentifier(),
+            Fixtures.shapeResource.calculateIdentifier()
+        )
+        XCTAssertNotEqual(
+            Fixtures.shapeResource.calculateIdentifier(),
+            Fixtures.shapeResourceWithEvenOddFillRule.calculateIdentifier()
+        )
+    }
+
+    func testCalculateData() {
+        let data = Fixtures.shapeResource.calculateData()
+        let svgString = String(data: data, encoding: .utf8)
+
+        XCTAssertNotNil(svgString)
+        XCTAssertEqual(svgString, Fixtures.shapeResource.svgString)
+    }
+}
+
+extension Character {
+    fileprivate var isHexDigit: Bool {
+        return isASCII && (isNumber || ("a"..."f").contains(lowercased().first!))
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -94,12 +94,11 @@ class UIHostingViewRecorderTests: XCTestCase {
 
         let wireframes = try render(MockView())
         XCTAssertEqual(wireframes.count, 1)
-        let wireframe = try XCTUnwrap(wireframes.first?.shapeWireframe)
+        let wireframe = try XCTUnwrap(wireframes.first?.imageWireframe)
         XCTAssertEqual(wireframe.x, 100, accuracy: 5)
         XCTAssertEqual(wireframe.y, 130, accuracy: 5)
         XCTAssertEqual(wireframe.width, 100, accuracy: 5)
         XCTAssertEqual(wireframe.height, 100, accuracy: 5)
-        XCTAssertEqual(wireframe.shapeStyle?.backgroundColor, "#1022A00FF")
     }
 
     // MARK: Image
@@ -141,7 +140,7 @@ class UIHostingViewRecorderTests: XCTestCase {
         }
     }
 
-    func testImage_withUnsupportedType_itDoesNotRecordImage() throws {
+    func testImage_withShape_itDoesRecordSVGImage() throws {
         struct MockView: View {
             var body: some View {
                 Image(systemName: "star.fill")
@@ -160,7 +159,7 @@ class UIHostingViewRecorderTests: XCTestCase {
         )
 
         XCTAssertEqual(wireframes.count, 1)
-        let wireframe = try XCTUnwrap(wireframes.first?.shapeWireframe)
+        let wireframe = try XCTUnwrap(wireframes.first?.imageWireframe)
         XCTAssertEqual(wireframe.x, 125, accuracy: 5)
         XCTAssertEqual(wireframe.y, 155, accuracy: 5)
         XCTAssertEqual(wireframe.width, 50, accuracy: 5)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -25,7 +25,7 @@ private struct MockSemantics: NodeSemantics {
             Node(viewAttributes: .mockAny(), wireframesBuilder: MockWireframesBuilder(nodeName: $0))
         }
         self.resources = resourcesIdentifiers.map {
-            MockResource(identifier: $0, data: .mockRandom())
+            MockResource(identifier: $0, data: .mockRandom(), mimeType: .mockRandom())
         }
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
@@ -290,10 +290,12 @@ extension Node: AnyMockable, RandomMockable {
 public struct MockResource: Resource, AnyMockable, RandomMockable {
     public var identifier: String
     public var data: Data
+    public let mimeType: String
 
-    public init(identifier: String, data: Data) {
+    public init(identifier: String, data: Data, mimeType: String) {
         self.identifier = identifier
         self.data = data
+        self.mimeType = mimeType
     }
 
     public func calculateIdentifier() -> String {
@@ -305,11 +307,11 @@ public struct MockResource: Resource, AnyMockable, RandomMockable {
     }
 
     public static func mockAny() -> MockResource {
-        return MockResource(identifier: .mockAny(), data: .mockAny())
+        return MockResource(identifier: .mockAny(), data: .mockAny(), mimeType: .mockAny())
     }
 
     public static func mockRandom() -> MockResource {
-        return MockResource(identifier: . mockRandom(), data: .mockRandom())
+        return MockResource(identifier: . mockRandom(), data: .mockRandom(), mimeType: .mockRandom())
     }
 }
 

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/ResourceMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/ResourceMocks.swift
@@ -21,7 +21,7 @@ extension EnrichedResource: RandomMockable, AnyMockable {
     public static func mockWith(
         identifier: String = .mockAny(),
         data: Data = .mockAny(),
-        mimeType: String? = .mockAny(),
+        mimeType: String = .mockAny(),
         context: Context = .mockAny()
     ) -> EnrichedResource {
         return .init(

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/ResourceMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/ResourceMocks.swift
@@ -13,6 +13,7 @@ extension EnrichedResource: RandomMockable, AnyMockable {
         return .init(
             identifier: .mockAny(),
             data: .mockAny(),
+            mimeType: .mockAny(),
             context: .mockAny()
         )
     }
@@ -20,11 +21,13 @@ extension EnrichedResource: RandomMockable, AnyMockable {
     public static func mockWith(
         identifier: String = .mockAny(),
         data: Data = .mockAny(),
+        mimeType: String? = .mockAny(),
         context: Context = .mockAny()
     ) -> EnrichedResource {
         return .init(
             identifier: identifier,
             data: data,
+            mimeType: mimeType,
             context: context
         )
     }
@@ -33,6 +36,7 @@ extension EnrichedResource: RandomMockable, AnyMockable {
         return .init(
             identifier: .mockRandom(),
             data: .mockRandom(),
+            mimeType: .mockRandom(),
             context: .mockRandom()
         )
     }


### PR DESCRIPTION
### What and why?

This PR implements SVG-based recording for SwiftUI shapes in Session Replay, enabling accurate vector shape reproduction in replays instead of fallback placeholder wireframes.

Together with #2428 and #2391, this PR improves SwiftUI system image and SF Symbol capture by addressing all three internal representations we know of: shapes, images with tints, and drawings.

### How?

Core SVG Generation:
  - Added `CGPath+SessionReplay.swift` to convert Core Graphics paths to SVG path data
  - Implemented `ShapeResource.swift` as a complete SVG resource with MD5-based stable identifiers
  - Modified `SwiftUIWireframesBuilder.swift` to create image wireframes with SVG resources instead of shape wireframes

iOS Version Compatibility:
  - Fixed `ResolvedPaint` reflection for iOS 26+ while maintaining backward compatibility

Snapshot Test Infrastructure:
  - Created custom `UIImage+SVG.swift` for lightweight SVG parsing and rendering (tailored for single-shape SVGs with fill colors)
  - Refreshed snapshot test pointers to accommodate new SVG-based rendering

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
