### PR TITLE
Close stale issues with reason `completed`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,6 +33,8 @@ jobs:
           days-before-issue-close: 3
           # Automatically remove the stale label when the issues or the pull requests are updated
           remove-stale-when-updated: true
+          # Specify the reason used when closing issues: `completed` or `not_planned`
+          close-issue-reason: completed
           # Run the stale workflow as dry-run.
           # No GitHub API calls that can alter the issues and pull requests will happen.
           # Useful to debug or when you want to configure the stale workflow safely. 


### PR DESCRIPTION
### What and why?

Changing the [reason](https://github.com/actions/stale?tab=readme-ov-file#close-issue-reason) why a stale issue is closed to `completed` instead of `not_planned`. 

<img width="936" height="286" alt="Screenshot 2025-08-18 at 10 16 25" src="https://github.com/user-attachments/assets/bfe9e8d5-b646-4a3a-ab38-392c11ed3137" />


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
