### PR TITLE
RUM-11048 Profile aggregation and serialization

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1176,9 +1176,17 @@
 		D233E7E42E4A2AFE00E7CFDE /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */; };
 		D233E7E52E4A2AFE00E7CFDE /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */; };
 		D233E7EE2E4B588000E7CFDE /* profile.pb-c.c in Sources */ = {isa = PBXBuildFile; fileRef = D233E7EB2E4B588000E7CFDE /* profile.pb-c.c */; };
+		D233E7EF2E4B588000E7CFDE /* profile_pprof_packer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E92E4B588000E7CFDE /* profile_pprof_packer.cpp */; };
+		D233E7F02E4B588000E7CFDE /* profile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E72E4B588000E7CFDE /* profile.cpp */; };
 		D233E7F12E4B588000E7CFDE /* protobuf-c.c in Sources */ = {isa = PBXBuildFile; fileRef = D233E7ED2E4B588000E7CFDE /* protobuf-c.c */; };
 		D233E7F62E4B588000E7CFDE /* profile.pb-c.c in Sources */ = {isa = PBXBuildFile; fileRef = D233E7EB2E4B588000E7CFDE /* profile.pb-c.c */; };
+		D233E7F72E4B588000E7CFDE /* profile_pprof_packer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E92E4B588000E7CFDE /* profile_pprof_packer.cpp */; };
+		D233E7F82E4B588000E7CFDE /* profile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E7E72E4B588000E7CFDE /* profile.cpp */; };
 		D233E7F92E4B588000E7CFDE /* protobuf-c.c in Sources */ = {isa = PBXBuildFile; fileRef = D233E7ED2E4B588000E7CFDE /* protobuf-c.c */; };
+		D233E7FF2E4B588B00E7CFDE /* dd_pprof.h in Headers */ = {isa = PBXBuildFile; fileRef = D233E7FE2E4B588B00E7CFDE /* dd_pprof.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D233E8002E4B588B00E7CFDE /* dd_pprof.h in Headers */ = {isa = PBXBuildFile; fileRef = D233E7FE2E4B588B00E7CFDE /* dd_pprof.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D233E8022E4B653F00E7CFDE /* dd_pprof.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E8012E4B653F00E7CFDE /* dd_pprof.cpp */; };
+		D233E8032E4B653F00E7CFDE /* dd_pprof.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D233E8012E4B653F00E7CFDE /* dd_pprof.cpp */; };
 		D234613128B7713000055D4C /* FeatureContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234613028B7712F00055D4C /* FeatureContextTests.swift */; };
 		D234613228B7713000055D4C /* FeatureContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234613028B7712F00055D4C /* FeatureContextTests.swift */; };
 		D23F8E5229DDCD28001CFAE8 /* UIViewControllerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA2251118FB00C816E5 /* UIViewControllerHandler.swift */; };
@@ -1846,12 +1854,20 @@
 		D2E6E8FC2D8039BB00FF1398 /* BenchmarkURLSessionTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E6E8FA2D8039B200FF1398 /* BenchmarkURLSessionTaskDelegate.swift */; };
 		D2E8A8E72DCBBA5100CF7C63 /* RUMCoreContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */; };
 		D2E8A8E82DCBBA5100CF7C63 /* RUMCoreContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */; };
-		D2E9371A2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */; };
-		D2E9371B2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */; };
-		D2E9372B2E53325200FECA76 /* profile.pb-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372A2E53325200FECA76 /* profile.pb-c.h */; };
-		D2E9372C2E53325200FECA76 /* profile.pb-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372A2E53325200FECA76 /* profile.pb-c.h */; };
-		D2E9372E2E53325900FECA76 /* protobuf-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372D2E53325900FECA76 /* protobuf-c.h */; };
-		D2E9372F2E53325900FECA76 /* protobuf-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372D2E53325900FECA76 /* protobuf-c.h */; };
+		D2E9371A2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E9371B2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E937252E53324100FECA76 /* profile.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937242E53324100FECA76 /* profile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E937262E53324100FECA76 /* profile.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937242E53324100FECA76 /* profile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E937282E53324A00FECA76 /* profile_pprof_packer.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937272E53324A00FECA76 /* profile_pprof_packer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E937292E53324A00FECA76 /* profile_pprof_packer.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E937272E53324A00FECA76 /* profile_pprof_packer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E9372B2E53325200FECA76 /* profile.pb-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372A2E53325200FECA76 /* profile.pb-c.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E9372C2E53325200FECA76 /* profile.pb-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372A2E53325200FECA76 /* profile.pb-c.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E9372E2E53325900FECA76 /* protobuf-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372D2E53325900FECA76 /* protobuf-c.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E9372F2E53325900FECA76 /* protobuf-c.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E9372D2E53325900FECA76 /* protobuf-c.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D2E937312E53368E00FECA76 /* ProfileCxxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E937302E53368E00FECA76 /* ProfileCxxTests.swift */; };
+		D2E937322E53368E00FECA76 /* ProfileCxxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E937302E53368E00FECA76 /* ProfileCxxTests.swift */; };
+		D2E937342E535B6400FECA76 /* ProfileMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E937332E535B6400FECA76 /* ProfileMocks.swift */; };
+		D2E937352E535B6400FECA76 /* ProfileMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E937332E535B6400FECA76 /* ProfileMocks.swift */; };
 		D2EA0F462C0E1AE300CB20F8 /* SessionReplayConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */; };
 		D2EBEE1F29BA160F00B15732 /* HTTPHeadersReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */; };
 		D2EBEE2029BA160F00B15732 /* TracePropagationHeadersWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */; };
@@ -3268,8 +3284,12 @@
 		D233E7DD2E4A109100E7CFDE /* ProfilingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingTest.swift; sourceTree = "<group>"; };
 		D233E7E02E4A10E100E7CFDE /* MockProfiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProfiler.swift; sourceTree = "<group>"; };
 		D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
+		D233E7E72E4B588000E7CFDE /* profile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = profile.cpp; sourceTree = "<group>"; };
+		D233E7E92E4B588000E7CFDE /* profile_pprof_packer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = profile_pprof_packer.cpp; sourceTree = "<group>"; };
 		D233E7EB2E4B588000E7CFDE /* profile.pb-c.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "profile.pb-c.c"; sourceTree = "<group>"; };
 		D233E7ED2E4B588000E7CFDE /* protobuf-c.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "protobuf-c.c"; sourceTree = "<group>"; };
+		D233E7FE2E4B588B00E7CFDE /* dd_pprof.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dd_pprof.h; sourceTree = "<group>"; };
+		D233E8012E4B653F00E7CFDE /* dd_pprof.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dd_pprof.cpp; sourceTree = "<group>"; };
 		D234613028B7712F00055D4C /* FeatureContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureContextTests.swift; sourceTree = "<group>"; };
 		D2355B262E4E05CE000DDF5F /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		D236BE2729520FED00676E67 /* CrashReportReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportReceiver.swift; sourceTree = "<group>"; };
@@ -3431,8 +3451,12 @@
 		D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCoreContext.swift; sourceTree = "<group>"; };
 		D2E8D59728C7AB90007E5DE1 /* ContextMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mach_sampling_profiler.h; sourceTree = "<group>"; };
+		D2E937242E53324100FECA76 /* profile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = profile.h; sourceTree = "<group>"; };
+		D2E937272E53324A00FECA76 /* profile_pprof_packer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = profile_pprof_packer.h; sourceTree = "<group>"; };
 		D2E9372A2E53325200FECA76 /* profile.pb-c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "profile.pb-c.h"; sourceTree = "<group>"; };
 		D2E9372D2E53325900FECA76 /* protobuf-c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "protobuf-c.h"; sourceTree = "<group>"; };
+		D2E937302E53368E00FECA76 /* ProfileCxxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCxxTests.swift; sourceTree = "<group>"; };
+		D2E937332E535B6400FECA76 /* ProfileMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileMocks.swift; sourceTree = "<group>"; };
 		D2EA0F452C0E1AE200CB20F8 /* SessionReplayConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayConfiguration.swift; sourceTree = "<group>"; };
 		D2EBEDCF29B8A02100B15732 /* TracePropagationHeadersWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracePropagationHeadersWriter.swift; sourceTree = "<group>"; };
 		D2EBEDD229B8A58E00B15732 /* TracePropagationHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracePropagationHeadersReader.swift; sourceTree = "<group>"; };
@@ -6321,6 +6345,9 @@
 				D2355B262E4E05CE000DDF5F /* module.modulemap */,
 				D229FF592E3BA298009CCD62 /* mach_profiler.h */,
 				D2E937192E4E25E800FECA76 /* mach_sampling_profiler.h */,
+				D233E7FE2E4B588B00E7CFDE /* dd_pprof.h */,
+				D2E937242E53324100FECA76 /* profile.h */,
+				D2E937272E53324A00FECA76 /* profile_pprof_packer.h */,
 				D2E9372A2E53325200FECA76 /* profile.pb-c.h */,
 				D2E9372D2E53325900FECA76 /* protobuf-c.h */,
 			);
@@ -6332,7 +6359,10 @@
 			children = (
 				D229FF5A2E3BA298009CCD62 /* include */,
 				D2D0E1F12E3CE59700BA4113 /* mach_profiler.cpp */,
+				D233E8012E4B653F00E7CFDE /* dd_pprof.cpp */,
 				D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */,
+				D233E7E72E4B588000E7CFDE /* profile.cpp */,
+				D233E7E92E4B588000E7CFDE /* profile_pprof_packer.cpp */,
 				D233E7EB2E4B588000E7CFDE /* profile.pb-c.c */,
 				D233E7ED2E4B588000E7CFDE /* protobuf-c.c */,
 			);
@@ -6869,6 +6899,8 @@
 				D233E7DD2E4A109100E7CFDE /* ProfilingTest.swift */,
 				D233E7E02E4A10E100E7CFDE /* MockProfiler.swift */,
 				D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */,
+				D2E937302E53368E00FECA76 /* ProfileCxxTests.swift */,
+				D2E937332E535B6400FECA76 /* ProfileMocks.swift */,
 			);
 			name = DatadogProfilingTests;
 			path = ../DatadogProfiling/Tests;
@@ -7097,10 +7129,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D233E7FF2E4B588B00E7CFDE /* dd_pprof.h in Headers */,
+				D2E937292E53324A00FECA76 /* profile_pprof_packer.h in Headers */,
+				D2E937252E53324100FECA76 /* profile.h in Headers */,
 				D2E9372E2E53325900FECA76 /* protobuf-c.h in Headers */,
 				D2E9372C2E53325200FECA76 /* profile.pb-c.h in Headers */,
-				D229FFAC2E3BCAAE009CCD62 /* mach_profiler.h in Headers */,
 				D2E9371B2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */,
+				D229FFAC2E3BCAAE009CCD62 /* mach_profiler.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7108,10 +7143,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2E937282E53324A00FECA76 /* profile_pprof_packer.h in Headers */,
+				D2E937262E53324100FECA76 /* profile.h in Headers */,
 				D2E9372F2E53325900FECA76 /* protobuf-c.h in Headers */,
 				D2E9372B2E53325200FECA76 /* profile.pb-c.h in Headers */,
-				D229FFA92E3BCA9B009CCD62 /* mach_profiler.h in Headers */,
 				D2E9371A2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */,
+				D229FFA92E3BCA9B009CCD62 /* mach_profiler.h in Headers */,
+				D233E8002E4B588B00E7CFDE /* dd_pprof.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9273,9 +9311,12 @@
 				D233E7CB2E46264600E7CFDE /* ProfilerFeature.swift in Sources */,
 				D233E7C72E4625D400E7CFDE /* RequestBuilder.swift in Sources */,
 				D233E7C82E4625D400E7CFDE /* ProfileEvent.swift in Sources */,
+				D233E8032E4B653F00E7CFDE /* dd_pprof.cpp in Sources */,
 				D233E7C92E4625D400E7CFDE /* DatadogProfiling.swift in Sources */,
 				D2D0E1F32E3CE59700BA4113 /* mach_profiler.cpp in Sources */,
 				D233E7F62E4B588000E7CFDE /* profile.pb-c.c in Sources */,
+				D233E7F72E4B588000E7CFDE /* profile_pprof_packer.cpp in Sources */,
+				D233E7F82E4B588000E7CFDE /* profile.cpp in Sources */,
 				D233E7F92E4B588000E7CFDE /* protobuf-c.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9290,9 +9331,12 @@
 				D233E7CC2E46264600E7CFDE /* ProfilerFeature.swift in Sources */,
 				D233E7C42E4625D400E7CFDE /* RequestBuilder.swift in Sources */,
 				D233E7C52E4625D400E7CFDE /* ProfileEvent.swift in Sources */,
+				D233E8022E4B653F00E7CFDE /* dd_pprof.cpp in Sources */,
 				D233E7C62E4625D400E7CFDE /* DatadogProfiling.swift in Sources */,
 				D2D0E1F22E3CE59700BA4113 /* mach_profiler.cpp in Sources */,
 				D233E7EE2E4B588000E7CFDE /* profile.pb-c.c in Sources */,
+				D233E7EF2E4B588000E7CFDE /* profile_pprof_packer.cpp in Sources */,
+				D233E7F02E4B588000E7CFDE /* profile.cpp in Sources */,
 				D233E7F12E4B588000E7CFDE /* protobuf-c.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10148,6 +10192,8 @@
 				D233E7E22E4A10E100E7CFDE /* MockProfiler.swift in Sources */,
 				D2D0E20E2E3CFA6500BA4113 /* CCallbackContext.swift in Sources */,
 				D2D0E2082E3CEF1200BA4113 /* MachProfilerCAPITests.swift in Sources */,
+				D2E937352E535B6400FECA76 /* ProfileMocks.swift in Sources */,
+				D2E937322E53368E00FECA76 /* ProfileCxxTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10162,6 +10208,8 @@
 				D233E7E12E4A10E100E7CFDE /* MockProfiler.swift in Sources */,
 				D2D0E20F2E3CFA6500BA4113 /* CCallbackContext.swift in Sources */,
 				D2D0E2052E3CEF1200BA4113 /* MachProfilerCAPITests.swift in Sources */,
+				D2E937342E535B6400FECA76 /* ProfileMocks.swift in Sources */,
+				D2E937312E53368E00FECA76 /* ProfileCxxTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11162,7 +11210,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11194,7 +11241,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11226,7 +11272,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11258,7 +11303,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -11284,7 +11328,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -11309,7 +11352,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -11366,7 +11408,6 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -11427,7 +11468,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -11610,7 +11650,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11643,7 +11682,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11675,7 +11713,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -11707,7 +11744,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -11734,7 +11770,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -11760,7 +11795,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -12043,7 +12077,6 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -12146,7 +12179,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12180,7 +12212,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12214,7 +12245,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12248,7 +12278,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -12268,7 +12297,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -12288,7 +12316,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -12309,7 +12336,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12339,7 +12365,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12369,7 +12394,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12400,7 +12424,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12433,7 +12456,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12466,7 +12488,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12499,7 +12520,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12535,7 +12555,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12571,7 +12590,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12606,7 +12624,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12639,7 +12656,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12671,7 +12687,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12703,7 +12718,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12735,7 +12749,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12767,7 +12780,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12799,7 +12811,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -12818,7 +12829,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -12837,7 +12847,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -12918,7 +12927,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12954,7 +12962,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -12990,7 +12997,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13026,7 +13032,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13062,7 +13067,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13098,7 +13102,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13134,7 +13137,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13166,7 +13168,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13198,7 +13199,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13230,7 +13230,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13249,7 +13248,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13268,7 +13266,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13288,7 +13285,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13320,7 +13316,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13352,7 +13347,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13384,7 +13378,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13403,7 +13396,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13422,7 +13414,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13442,7 +13433,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -13460,7 +13450,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -13478,7 +13467,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -13497,7 +13485,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13529,7 +13516,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13561,7 +13547,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -13593,7 +13578,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13612,7 +13596,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13631,7 +13614,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -13650,14 +13632,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogProfilingTests;
@@ -13665,6 +13647,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach";
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -13674,14 +13657,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogProfilingTests;
@@ -13696,14 +13679,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogProfilingTests;
@@ -13718,13 +13701,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
@@ -13734,8 +13716,10 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach";
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};
 			name = Debug;
 		};
@@ -13743,13 +13727,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
@@ -13759,6 +13742,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach";
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};
 			name = Release;
 		};
@@ -13766,13 +13750,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JKFCB4CN7C;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = c17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
@@ -13782,6 +13765,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach";
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};
 			name = Integration;
 		};
@@ -14168,7 +14152,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -14202,7 +14185,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -14235,7 +14217,6 @@
 			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -14268,7 +14249,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -14294,7 +14274,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -14319,7 +14298,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -14345,7 +14323,6 @@
 			baseConfigurationReference = 61378BA72555329E00F28837 /* DatadogTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -14372,7 +14349,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -14398,7 +14374,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1770,6 +1770,8 @@
 		D2D0E2112E3D0B4400BA4113 /* TestUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D257958B298ABB83008A1BE5 /* TestUtilities.framework */; platformFilters = (tvos, ); };
 		D2D0E2192E40E34A00BA4113 /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
 		D2D0E21A2E40E34A00BA4113 /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
+		D2D179E22E684DC0004C4D13 /* MachProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D179E12E684DC0004C4D13 /* MachProfilerTests.swift */; };
+		D2D179E32E684DC0004C4D13 /* MachProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D179E12E684DC0004C4D13 /* MachProfilerTests.swift */; };
 		D2D30E5B2A40BF540020C553 /* Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D30E5A2A40BF540020C553 /* Logs.swift */; };
 		D2D30E5C2A40BF540020C553 /* Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D30E5A2A40BF540020C553 /* Logs.swift */; };
 		D2D30E602A40CD310020C553 /* LogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D30E5D2A40CD2C0020C553 /* LogsTests.swift */; };
@@ -3424,6 +3426,7 @@
 		D2D0E2022E3CEF1200BA4113 /* MachSamplingProfilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachSamplingProfilerTests.swift; sourceTree = "<group>"; };
 		D2D0E20D2E3CFA6500BA4113 /* CCallbackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CCallbackContext.swift; sourceTree = "<group>"; };
 		D2D0E2182E40E34A00BA4113 /* MockThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockThread.swift; sourceTree = "<group>"; };
+		D2D179E12E684DC0004C4D13 /* MachProfilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachProfilerTests.swift; sourceTree = "<group>"; };
 		D2D30E5A2A40BF540020C553 /* Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logs.swift; sourceTree = "<group>"; };
 		D2D30E5D2A40CD2C0020C553 /* LogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsTests.swift; sourceTree = "<group>"; };
 		D2D3199929E98D970004F169 /* DefaultJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultJSONEncoder.swift; sourceTree = "<group>"; };
@@ -6892,14 +6895,15 @@
 		D2C9F2522E3B8A88008397FD /* DatadogProfilingTests */ = {
 			isa = PBXGroup;
 			children = (
-				D2D0E2182E40E34A00BA4113 /* MockThread.swift */,
 				D2D0E20D2E3CFA6500BA4113 /* CCallbackContext.swift */,
 				D2D0E2012E3CEF1200BA4113 /* MachProfilerCAPITests.swift */,
 				D2D0E2022E3CEF1200BA4113 /* MachSamplingProfilerTests.swift */,
 				D233E7DD2E4A109100E7CFDE /* ProfilingTest.swift */,
-				D233E7E02E4A10E100E7CFDE /* MockProfiler.swift */,
+				D2D179E12E684DC0004C4D13 /* MachProfilerTests.swift */,
 				D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */,
 				D2E937302E53368E00FECA76 /* ProfileCxxTests.swift */,
+				D2D0E2182E40E34A00BA4113 /* MockThread.swift */,
+				D233E7E02E4A10E100E7CFDE /* MockProfiler.swift */,
 				D2E937332E535B6400FECA76 /* ProfileMocks.swift */,
 			);
 			name = DatadogProfilingTests;
@@ -10186,6 +10190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D233E7E42E4A2AFE00E7CFDE /* RequestBuilderTests.swift in Sources */,
+				D2D179E32E684DC0004C4D13 /* MachProfilerTests.swift in Sources */,
 				D233E7DE2E4A109100E7CFDE /* ProfilingTest.swift in Sources */,
 				D2D0E2192E40E34A00BA4113 /* MockThread.swift in Sources */,
 				D2D0E2072E3CEF1200BA4113 /* MachSamplingProfilerTests.swift in Sources */,
@@ -10202,6 +10207,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D233E7E52E4A2AFE00E7CFDE /* RequestBuilderTests.swift in Sources */,
+				D2D179E22E684DC0004C4D13 /* MachProfilerTests.swift in Sources */,
 				D233E7DF2E4A109100E7CFDE /* ProfilingTest.swift in Sources */,
 				D2D0E21A2E40E34A00BA4113 /* MockThread.swift in Sources */,
 				D2D0E2042E3CEF1200BA4113 /* MachSamplingProfilerTests.swift in Sources */,

--- a/DatadogProfiling/Mach/dd_pprof.cpp
+++ b/DatadogProfiling/Mach/dd_pprof.cpp
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#include "dd_pprof.h"
+#include "profile.h"
+#include "profile_pprof_packer.h"
+
+// C interface implementation
+extern "C" {
+
+dd_pprof_t* dd_pprof_create(uint64_t sampling_interval_ns) {
+    try {
+        auto* profiler = new dd::profiler::profile(sampling_interval_ns);
+        return reinterpret_cast<dd_pprof_t*>(profiler);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void dd_pprof_destroy(dd_pprof_t* profile) {
+    if (profile) {
+        delete reinterpret_cast<dd::profiler::profile*>(profile);
+    }
+}
+
+void dd_pprof_add_samples(dd_pprof_t* profile, const stack_trace_t* traces, size_t count) {
+    if (profile && traces && count > 0) {
+        reinterpret_cast<dd::profiler::profile*>(profile)->add_samples(traces, count);
+    }
+}
+
+size_t dd_pprof_serialize(dd_pprof_t* profile, uint8_t** data) {
+    if (!profile || !data) return 0;
+    return dd::profiler::profile_pprof_pack(*reinterpret_cast<dd::profiler::profile*>(profile), data);
+}
+
+void dd_pprof_free_serialized_data(uint8_t* data) {
+    if (data) free(data);
+}
+
+void dd_pprof_callback(const stack_trace_t* traces, size_t count, void* ctx) {
+    dd_pprof_t* profile = static_cast<dd_pprof_t*>(ctx);
+    if (profile && traces && count > 0) {
+        dd_pprof_add_samples(profile, traces, count);
+    }
+}
+
+} // extern "C"

--- a/DatadogProfiling/Mach/dd_pprof.cpp
+++ b/DatadogProfiling/Mach/dd_pprof.cpp
@@ -48,4 +48,16 @@ void dd_pprof_callback(const stack_trace_t* traces, size_t count, void* ctx) {
     }
 }
 
+double dd_pprof_get_start_timestamp_s(dd_pprof_t* profile) {
+    if (!profile) return 0.0;
+    int64_t timestamp = reinterpret_cast<dd::profiler::profile*>(profile)->start_timestamp();
+    return static_cast<double>(timestamp) / 1e9; // to seconds
+}
+
+double dd_pprof_get_end_timestamp_s(dd_pprof_t* profile) {
+    if (!profile) return 0.0;
+    int64_t timestamp = reinterpret_cast<dd::profiler::profile*>(profile)->end_timestamp();
+    return static_cast<double>(timestamp) / 1e9; // to seconds
+}
+
 } // extern "C"

--- a/DatadogProfiling/Mach/include/dd_pprof.h
+++ b/DatadogProfiling/Mach/include/dd_pprof.h
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#ifndef DD_PROFILER_DD_PPROF_H_
+#define DD_PROFILER_DD_PPROF_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "mach_profiler.h"
+
+#ifdef __cplusplus
+namespace dd::profiler {
+
+class profile;
+
+} // namespace dd:profiler
+
+extern "C" {
+#endif
+
+/**
+ * Opaque handle to a profile instance
+ */
+#ifdef __cplusplus
+typedef dd::profiler::profile dd_pprof_t;
+#else
+typedef struct profile dd_pprof_t;
+#endif
+
+/**
+ * Create a new pprof profile aggregator
+ * 
+ * @param sampling_interval_ns The sampling interval in nanoseconds
+ * @return Pointer to the created profile, or NULL on failure
+ */
+dd_pprof_t* dd_pprof_create(uint64_t sampling_interval_ns);
+
+/**
+ * Destroy a pprof profile aggregator and free all associated memory
+ *
+ * @param profile Pointer to the profile to destroy
+ */
+void dd_pprof_destroy(dd_pprof_t* profile);
+
+/**
+ * Add stack traces to the profile
+ *
+ * @param profile Pointer to the profile
+ * @param traces Array of stack traces to add
+ * @param count Number of traces in the array
+ */
+void dd_pprof_add_samples(dd_pprof_t* profile, const stack_trace_t* traces, size_t count);
+
+/**
+ * Serialize the profile to protobuf format
+ *
+ * @param profile Pointer to the profile
+ * @param data Output parameter for the serialized data (caller must free with dd_pprof_free_serialized_data)
+ * @return Size of the serialized data in bytes, or 0 on failure
+ */
+size_t dd_pprof_serialize(dd_pprof_t* profile, uint8_t** data);
+
+/**
+ * Free memory allocated by dd_pprof_serialize
+ *
+ * @param data Pointer to the data to free
+ */
+void dd_pprof_free_serialized_data(uint8_t* data);
+
+/**
+ * Callback function that forwards stack traces to a dd_pprof_t instance.
+ * 
+ * Use this with profiler_create() by passing your dd_pprof_t instance as the ctx parameter.
+ * 
+ * Example:
+ *   dd_pprof_t* profile = dd_pprof_create(1000000);
+ *   profiler_t* profiler = profiler_create(&config, dd_pprof_callback, profile);
+ */
+void dd_pprof_callback(const stack_trace_t* traces, size_t count, void* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DD_PROFILER_DD_PPROF_H_

--- a/DatadogProfiling/Mach/include/dd_pprof.h
+++ b/DatadogProfiling/Mach/include/dd_pprof.h
@@ -81,6 +81,22 @@ void dd_pprof_free_serialized_data(uint8_t* data);
  */
 void dd_pprof_callback(const stack_trace_t* traces, size_t count, void* ctx);
 
+/**
+ * Get profile start timestamp in seconds since Unix epoch
+ *
+ * @param profile Pointer to the profile
+ * @return Start timestamp in seconds since Unix epoch, or 0.0 if no samples
+ */
+double dd_pprof_get_start_timestamp_s(dd_pprof_t* profile);
+
+/**
+ * Get profile end timestamp in seconds since Unix epoch
+ *
+ * @param profile Pointer to the profile
+ * @return End timestamp in seconds since Unix epoch, or 0.0 if no samples
+ */
+double dd_pprof_get_end_timestamp_s(dd_pprof_t* profile);
+
 #ifdef __cplusplus
 }
 #endif

--- a/DatadogProfiling/Mach/include/mach_profiler.h
+++ b/DatadogProfiling/Mach/include/mach_profiler.h
@@ -13,6 +13,7 @@
 #include <pthread/qos.h>
 
 #ifdef __cplusplus
+
 namespace dd::profiler {
 // Forward declaration
     class mach_sampling_profiler;
@@ -25,7 +26,7 @@ extern "C" {
  * Structure representing a binary image loaded in memory.
  */
 typedef struct binary_image {
-    uint64_t load_address;  ///< Base address where the image is loaded
+    uint64_t load_address; ///< Base address where the image is loaded
     uuid_t uuid;           ///< UUID of the binary
     const char* filename;  ///< Filename of the binary
 } binary_image_t;

--- a/DatadogProfiling/Mach/include/mach_profiler.h
+++ b/DatadogProfiling/Mach/include/mach_profiler.h
@@ -26,9 +26,12 @@ extern "C" {
  * Structure representing a binary image loaded in memory.
  */
 typedef struct binary_image {
-    uint64_t load_address; ///< Base address where the image is loaded
-    uuid_t uuid;           ///< UUID of the binary
-    const char* filename;  ///< Filename of the binary
+    /** Base address where the image is loaded */
+    uint64_t load_address;
+    /** UUID of the binary */
+    uuid_t uuid;
+    /** Filename of the binary */
+    const char* filename;
 } binary_image_t;
 
 /**
@@ -47,6 +50,8 @@ typedef struct stack_frame {
 typedef struct stack_trace {
     /** Thread ID */
     mach_port_t tid;
+    /** Thread name  */
+    const char* thread_name;
     /** Timestamp in nanoseconds since system boot */
     uint64_t timestamp;
     /** Actual sampling interval in nanoseconds for this sample */

--- a/DatadogProfiling/Mach/include/module.modulemap
+++ b/DatadogProfiling/Mach/include/module.modulemap
@@ -1,6 +1,15 @@
 module DatadogMachProfiler {
   header "mach_profiler.h"
+  header "dd_pprof.h"
   export *
+
+  explicit module Cxx {
+      requires cplusplus
+      header "mach_sampling_profiler.h"
+      header "profile.h"
+      header "profile_pprof_packer.h"
+      export *
+  }
 
   explicit module Pprof {
       header "profile.pb-c.h"

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -191,6 +191,12 @@ public:
     /** @brief Get cached string ID for "tid" */
     uint32_t tid_str_id() const { return _tid_str_id; }
 
+    /** @brief Get profile start timestamp (mach_absolute_time) */
+    int64_t start_timestamp() const { return mach_time_to_epoch_ns(_start_timestamp); };
+
+    /** @brief Get profile end timestamp (mach_absolute_time) */
+    int64_t end_timestamp() const { return mach_time_to_epoch_ns(_end_timestamp); };
+
 private:
     /** @brief Deduplicated string table (index 0 is always empty string) */
     std::vector<std::string> _strings;
@@ -224,6 +230,12 @@ private:
     
     /** @brief Time reference data for mach_absolute_time to epoch conversion */
     mach_timeref_t _timeref;
+
+    /** @brief Profile start timestamp (mach_absolute_time, 0 if no samples) */
+    uint64_t _start_timestamp;
+    
+    /** @brief Profile end timestamp (mach_absolute_time, 0 if no samples) */
+    uint64_t _end_timestamp;
     
     /** @brief Hash table for string deduplication: string -> string_id */
     std::unordered_map<std::string, uint32_t> _string_lookup;

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -176,20 +176,11 @@ public:
     /** @brief Get profile sampling interval in nanoseconds */
     uint64_t sampling_interval_ns() const { return _sampling_interval_ns; }
     
-    /** @brief Get cached string ID for empty string */
-    uint32_t empty_str_id() const { return _empty_str_id; }
-    
     /** @brief Get cached string ID for "wall-time" */
     uint32_t wall_time_str_id() const { return _wall_time_str_id; }
     
     /** @brief Get cached string ID for "nanoseconds" */
     uint32_t nanoseconds_str_id() const { return _nanoseconds_str_id; }
-    
-    /** @brief Get cached string ID for "end_timestamp_ns" */
-    uint32_t end_timestamp_ns_str_id() const { return _end_timestamp_ns_str_id; }
-    
-    /** @brief Get cached string ID for "tid" */
-    uint32_t tid_str_id() const { return _tid_str_id; }
 
     /** @brief Get profile start timestamp (mach_absolute_time) */
     int64_t start_timestamp() const { return mach_time_to_epoch_ns(_start_timestamp); };
@@ -226,8 +217,11 @@ private:
     uint32_t _end_timestamp_ns_str_id;
     
     /** @brief Cached string ID for "tid" */
-    uint32_t _tid_str_id;
+    uint32_t _thread_id_str_id;
     
+    /** @brief Cached string ID for "thread name" */
+    uint32_t _thread_name_str_id;
+
     /** @brief Time reference data for mach_absolute_time to epoch conversion */
     mach_timeref_t _timeref;
 

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -1,0 +1,229 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+/**
+ * @file profile.h
+ * @brief Core profiling data structures and aggregation engine
+ * 
+ * This module provides efficient data structures for collecting, deduplicating,
+ * and aggregating profiling samples. The design optimizes for:
+ * 
+ * - Memory efficiency through string/mapping/location deduplication
+ * - Fast sample ingestion with O(1) lookups for existing entities
+ * - Clean separation from serialization concerns
+ * 
+ * The profile class serves as the main aggregation engine that processes
+ * raw stack traces and converts them into a deduplicated, efficient format
+ * suitable for serialization to pprof format.
+ */
+
+#ifndef DD_PROFILER_PROFILE_H_
+#define DD_PROFILER_PROFILE_H_
+
+#include "mach_profiler.h"
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <cstdint>
+
+namespace dd::profiler {
+
+/**
+ * @brief Convert binary UUID to formatted string representation
+ * @param uuid 16-byte UUID array
+ * @return Formatted UUID string in standard hyphenated format
+ */
+std::string uuid_string(const uuid_t uuid);
+
+/**
+ * @brief Represents a deduplicated binary mapping in the profile
+ * 
+ * Maps a contiguous region of memory to a binary file. Each mapping
+ * corresponds to a loaded binary (executable, library, etc.) and contains
+ * the information needed to symbolicate addresses within that region.
+ * 
+ * All strings are deduplicated and stored as IDs referencing the profile's
+ * string table for memory efficiency.
+ */
+struct mapping_t {
+    uint64_t memory_start;
+    uint32_t filename_id;
+    uint32_t build_id;
+};
+
+/**
+ * @brief Represents a deduplicated code location in the profile
+ * 
+ * A location corresponds to a specific instruction address within a binary
+ * mapping. Locations are deduplicated across samples to minimize memory usage
+ * and enable efficient aggregation of samples from the same code location.
+ * 
+ * @note The address is an offset within the mapping, not an absolute memory address
+ */
+struct location_t {
+    uint32_t mapping_id;
+    uint64_t address;
+};
+
+/**
+ * @brief Key-value metadata attached to profiling samples
+ * 
+ * Labels provide additional context for samples, such as timestamps,
+ * thread IDs, or custom application metadata. They support both string
+ * and numeric values with optional units.
+ * 
+ * String values are deduplicated and stored as IDs referencing the
+ * profile's string table for memory efficiency.
+ */
+struct label_t {
+    uint32_t key_id;
+    uint32_t str_id;
+    int64_t num;
+    uint32_t num_unit_id;
+};
+
+/**
+ * @brief Individual profiling sample with stack trace and metadata
+ * 
+ * Represents a single profiling sample containing:
+ * - Stack trace as a sequence of location IDs (leaf-to-root order)
+ * - Associated labels (e.g., timestamps, thread info)
+ * - Sample values (e.g., CPU time, wall time, memory allocation)
+ * - Timestamp when the sample was collected
+ * 
+ * Samples are not aggregated at this level - aggregation happens during
+ * serialization if needed.
+ */
+struct sample_t {
+    std::vector<uint32_t> location_ids;
+    std::vector<label_t> labels;
+    std::vector<int64_t> values;
+    uint64_t timestamp;
+};
+
+/**
+ * @brief Efficient profiling data aggregator with automatic deduplication
+ * 
+ * The profile class is the core engine for processing profiling data. It provides:
+ * 
+ * **Key Features:**
+ * - String deduplication with O(1) lookup via hash table
+ * - Binary mapping deduplication by memory address
+ * - Code location deduplication by instruction address  
+ * - Fast sample ingestion from stack traces
+ * - Memory-efficient storage optimized for large datasets
+ * 
+ * **Thread Safety:**
+ * - Not thread-safe by design for performance
+ * - Callers must ensure external synchronization if needed
+ * 
+ * **Usage Pattern:**
+ * 1. Create profile with sampling interval
+ * 2. Call add_samples() with stack traces
+ * 3. Use external serializer (e.g., profile_pprof_pack) for output
+ * 
+ * The class maintains internal deduplication tables and exposes the
+ * deduplicated data through public member variables for serialization.
+ */
+class profile {
+public:
+    /**
+     * @brief Construct a new profile aggregator
+     * @param sampling_interval_ns Sampling interval in nanoseconds
+     */
+    explicit profile(uint64_t sampling_interval_ns);
+    ~profile() = default;
+    
+    profile(const profile&) = delete;
+    profile& operator=(const profile&) = delete;
+    
+    /**
+     * @brief Process multiple stack traces into deduplicated samples
+     * @param traces Array of stack traces to process
+     * @param count Number of traces in the array
+     */
+    void add_samples(const stack_trace_t* traces, size_t count);
+
+    /** @brief Get read-only access to deduplicated string table */
+    const std::vector<std::string>& strings() const { return _strings; }
+    
+    /** @brief Get read-only access to deduplicated binary mappings */
+    const std::vector<mapping_t>& mappings() const { return _mappings; }
+    
+    /** @brief Get read-only access to deduplicated code locations */
+    const std::vector<location_t>& locations() const { return _locations; }
+    
+    /** @brief Get read-only access to collected samples */
+    const std::vector<sample_t>& samples() const { return _samples; }
+    
+    /** @brief Get profile sampling interval in nanoseconds */
+    uint64_t sampling_interval_ns() const { return _sampling_interval_ns; }
+    
+    /** @brief Get cached string ID for empty string */
+    uint32_t empty_str_id() const { return _empty_str_id; }
+    
+    /** @brief Get cached string ID for "wall-time" */
+    uint32_t wall_time_str_id() const { return _wall_time_str_id; }
+    
+    /** @brief Get cached string ID for "nanoseconds" */
+    uint32_t nanoseconds_str_id() const { return _nanoseconds_str_id; }
+    
+    /** @brief Get cached string ID for "end_timestamp_ns" */
+    uint32_t end_timestamp_ns_str_id() const { return _end_timestamp_ns_str_id; }
+    
+    /** @brief Get cached string ID for "tid" */
+    uint32_t tid_str_id() const { return _tid_str_id; }
+
+private:
+    /** @brief Deduplicated string table (index 0 is always empty string) */
+    std::vector<std::string> _strings;
+    
+    /** @brief Deduplicated binary mappings (1-based IDs) */
+    std::vector<mapping_t> _mappings;
+    
+    /** @brief Deduplicated code locations (1-based IDs) */
+    std::vector<location_t> _locations;
+    
+    /** @brief All collected samples */
+    std::vector<sample_t> _samples;
+    
+    /** @brief Profile sampling interval in nanoseconds */
+    uint64_t _sampling_interval_ns;
+    
+    /** @brief Cached string ID for empty string */
+    uint32_t _empty_str_id;
+    
+    /** @brief Cached string ID for "wall-time" */
+    uint32_t _wall_time_str_id;
+    
+    /** @brief Cached string ID for "nanoseconds" */
+    uint32_t _nanoseconds_str_id;
+    
+    /** @brief Cached string ID for "end_timestamp_ns" */
+    uint32_t _end_timestamp_ns_str_id;
+    
+    /** @brief Cached string ID for "tid" */
+    uint32_t _tid_str_id;
+    
+    /** @brief Hash table for string deduplication: string -> string_id */
+    std::unordered_map<std::string, uint32_t> _string_lookup;
+    
+    /** @brief Hash table for mapping deduplication: memory_start -> mapping_id */
+    std::unordered_map<uint64_t, uint32_t> _mapping_lookup;
+    
+    /** @brief Hash table for location deduplication: instruction_addr -> location_id */
+    std::unordered_map<uint64_t, uint32_t> _location_lookup;
+    
+    // Helper methods
+    uint32_t intern_string(const std::string& str);
+    uint32_t intern_frame(const stack_frame_t& frame);
+    uint32_t intern_binary(const binary_image_t& image);
+    uint32_t intern_location(const location_t& location);
+};
+
+} // namespace dd::profiler
+
+#endif // DD_PROFILER_PROFILE_H_

--- a/DatadogProfiling/Mach/include/profile_pprof_packer.h
+++ b/DatadogProfiling/Mach/include/profile_pprof_packer.h
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#ifndef DD_PROFILER_PROFILE_PACKER_H_
+#define DD_PROFILER_PROFILE_PACKER_H_
+
+#include <cstdint>
+#include <cstddef>
+
+namespace dd::profiler {
+
+class profile;
+
+/**
+ * Pack profile data into pprof protobuf binary format
+ *
+ * Converts internal profile data structures to the standardized pprof
+ * protobuf format for serialization and consumption by profiling tools.
+ *
+ * @param prof The profile data to pack
+ * @param data Output buffer pointer - allocated buffer containing serialized data
+ * @return Size of serialized data in bytes, or 0 on failure
+ * 
+ * @note The caller is responsible for freeing the returned buffer with free()
+ * @note This function is thread-safe and does not modify the input profile
+ */
+size_t profile_pprof_pack(const profile& prof, uint8_t** data);
+
+} // namespace dd::profiler
+
+#endif // DD_PROFILER_PROFILE_PACKER_H_

--- a/DatadogProfiling/Mach/profile.cpp
+++ b/DatadogProfiling/Mach/profile.cpp
@@ -1,0 +1,218 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+/**
+ * @file profile.cpp
+ * @brief Implementation of profiling data aggregation and deduplication
+ * 
+ * This module implements the core profiling engine that efficiently processes
+ * raw stack traces into deduplicated, aggregated profile data.
+ * 
+ * **Key Implementation Details:**
+ * - String interning with hash table lookup for O(1) deduplication
+ * - Binary mapping deduplication by load address
+ * - Location deduplication by instruction address
+ * - UUID formatting for binary identification
+ * - System binary detection for filtering
+ * 
+ * The implementation prioritizes performance for high-throughput profiling
+ * workloads while maintaining memory efficiency through aggressive deduplication.
+ */
+
+#include "profile.h"
+
+namespace dd::profiler {
+
+/**
+ * @brief Convert binary UUID to formatted string representation
+ * 
+ * Converts a 16-byte UUID array into the standard hyphenated string format
+ * (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX) for use as build identifiers.
+ * 
+ * @param uuid 16-byte UUID array
+ * @return Formatted UUID string
+ */
+std::string uuid_string(const uuid_t uuid) {
+    char uuid_str[37];  // 36 chars + null terminator
+    snprintf(uuid_str, sizeof(uuid_str),
+             "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+             uuid[0], uuid[1], uuid[2], uuid[3],
+             uuid[4], uuid[5], uuid[6], uuid[7],
+             uuid[8], uuid[9], uuid[10], uuid[11],
+             uuid[12], uuid[13], uuid[14], uuid[15]);
+    return std::string(uuid_str);
+}
+
+/**
+ * @brief Constructs a new profile aggregator
+ * 
+ * Initializes the profile with the specified sampling interval and
+ * pre-interns commonly used strings for performance optimization.
+ * 
+ * @param sampling_interval_ns Sampling interval in nanoseconds
+ */
+profile::profile(uint64_t sampling_interval_ns) 
+    : _sampling_interval_ns(sampling_interval_ns) {
+    
+    // Ensure empty string is always at index 0
+    _strings.push_back("");
+    _string_lookup[""] = 0;
+    
+    // Pre-intern common strings for performance
+    _empty_str_id = intern_string("");
+    _wall_time_str_id = intern_string("wall-time");
+    _nanoseconds_str_id = intern_string("nanoseconds");
+    _end_timestamp_ns_str_id = intern_string("end_timestamp_ns");
+    _tid_str_id = intern_string("tid");
+}
+
+/**
+ * @brief Process multiple stack traces into deduplicated samples
+ * 
+ * Converts raw stack traces into profile samples with automatic deduplication
+ * of strings, mappings, and locations. Each trace is processed independently
+ * and added to the profile's sample collection.
+ * 
+ * @param traces Array of stack traces to process
+ * @param count Number of traces in the array
+ * 
+ * **Processing Steps:**
+ * 1. Convert stack frames to deduplicated location IDs
+ * 2. Create timestamp labels for each sample
+ * 3. Store sample values (sampling intervals)
+ * 4. Add completed samples to the profile
+ */
+void profile::add_samples(const stack_trace_t* traces, size_t count) {
+    if (!traces) return;
+    
+    for (int i = 0; i < count; ++i) {
+        const auto& trace = traces[i];
+        
+        // Build location IDs from stack frames
+        std::vector<uint32_t> location_ids;
+        location_ids.reserve(trace.frame_count);
+        for (uint32_t j = 0; j < trace.frame_count; ++j) {
+            const auto& frame = trace.frames[j];
+            uint32_t location_id = intern_frame(frame);
+            location_ids.push_back(location_id);
+        }
+        
+        // Create labels with timestamp and tid
+        std::vector<label_t> labels;
+        labels.reserve(2);
+        
+        // Add timestamp label
+        label_t timestamp_label;
+        timestamp_label.key_id = _end_timestamp_ns_str_id;
+        timestamp_label.str_id = 0;
+        timestamp_label.num = static_cast<int64_t>(trace.timestamp);
+        timestamp_label.num_unit_id = _nanoseconds_str_id;
+        labels.push_back(timestamp_label);
+        
+        // Add thread ID label
+        label_t thread_label;
+        thread_label.key_id = _tid_str_id;
+        thread_label.str_id = 0;
+        thread_label.num = static_cast<int64_t>(trace.tid);
+        thread_label.num_unit_id = 0; // No unit for thread ID
+        labels.push_back(thread_label);
+        
+        // Create sample
+        sample_t sample;
+        sample.location_ids = std::move(location_ids);
+        sample.labels = std::move(labels);
+        sample.values = {static_cast<int64_t>(trace.sampling_interval_nanos)};
+        sample.timestamp = trace.timestamp;
+        
+        _samples.push_back(std::move(sample));
+    }
+}
+
+/**
+ * @brief Deduplicate and intern a string in the string table
+ * 
+ * Adds the string to the profile's string table if not already present,
+ * or returns the existing ID if the string has been seen before.
+ * 
+ * @param str String to intern
+ * @return 0-based index of the string in the string table
+ * @note This is the core deduplication mechanism for all string data
+ */
+uint32_t profile::intern_string(const std::string& str) {
+    auto it = _string_lookup.find(str);
+    if (it != _string_lookup.end()) return it->second;
+    
+    uint32_t id = static_cast<uint32_t>(_strings.size());
+    _strings.push_back(str);
+    _string_lookup[str] = id;
+    return id;
+}
+
+/**
+ * @brief Convert a stack frame to a deduplicated location ID
+ * 
+ * Processes a single stack frame by first ensuring its binary mapping
+ * is registered, then creating a location entry that references the
+ * mapping and contains the instruction address.
+ * 
+ * @param frame Stack frame containing binary info and instruction pointer
+ * @return Location ID (1-based) for the frame's instruction address
+ */
+uint32_t profile::intern_frame(const stack_frame_t& frame) {
+    uint32_t mapping_id = intern_binary(frame.image);
+    location_t location;
+    location.mapping_id = mapping_id;
+    location.address = frame.instruction_ptr;
+    return intern_location(location);
+}
+
+/**
+ * @brief Deduplicate and intern a binary mapping
+ * 
+ * Creates a mapping entry for the binary if not already present,
+ * extracting the filename basename and converting UUID to string format.
+ * 
+ * @param image Binary image information from the runtime
+ * @return 1-based mapping ID, or existing ID if mapping already exists
+ * @note Uses load address as the primary key for deduplication
+ */
+uint32_t profile::intern_binary(const binary_image_t& image) {    
+    auto it = _mapping_lookup.find(image.load_address);
+    if (it != _mapping_lookup.end()) return it->second;
+
+    std::string build_id = uuid_string(image.uuid);
+    
+    mapping_t mapping;
+    mapping.memory_start = image.load_address;
+    mapping.filename_id = image.filename ? intern_string(image.filename): 0;
+    mapping.build_id = intern_string(build_id);
+    
+    uint32_t id = static_cast<uint32_t>(_mappings.size() + 1);
+    _mappings.push_back(mapping);
+    _mapping_lookup[image.load_address] = id;
+    return id;
+}
+
+/**
+ * @brief Deduplicate and intern a code location
+ * 
+ * Adds the location to the profile's location table if not already present.
+ * Locations are deduplicated by instruction address for memory efficiency.
+ * 
+ * @param location Location data containing mapping ID and address
+ * @return 1-based location ID, or existing ID if location already exists
+ */
+uint32_t profile::intern_location(const location_t& location) {
+    auto it = _location_lookup.find(location.address);
+    if (it != _location_lookup.end()) return it->second;
+    
+    uint32_t id = static_cast<uint32_t>(_locations.size() + 1);
+    _locations.push_back(location);
+    _location_lookup[location.address] = id;
+    return id;
+}
+
+} // namespace dd::profiler

--- a/DatadogProfiling/Mach/profile_pprof_packer.cpp
+++ b/DatadogProfiling/Mach/profile_pprof_packer.cpp
@@ -1,0 +1,304 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+/**
+ * @file profile_packer.cpp
+ * @brief Converts internal profile data structures to protobuf format for serialization
+ * 
+ * This module implements the conversion from Datadog's internal profiling data structures
+ * to the standardized pprof protobuf format. The pprof format is a Google-defined format
+ * for representing profiling data that can be consumed by various profiling tools.
+ * 
+ * Key responsibilities:
+ * - Convert internal string tables, functions, mappings, locations, and samples to protobuf
+ * - Handle memory allocation consistently through a custom allocator
+ * - Serialize the final protobuf structure to binary format
+ * 
+ * The implementation follows the pprof specification and ensures all data is properly
+ * deduplicated and referenced by ID rather than duplicated content.
+ */
+
+#include "profile_pprof_packer.h"
+#include "profile.h"
+#include "profile.pb-c.h"
+
+/**
+ * @brief Custom allocator functions for protobuf-c memory management
+ * 
+ * These functions provide a consistent allocation interface that wraps
+ * standard malloc/free. Using a custom allocator ensures all protobuf
+ * memory can be tracked and cleaned up properly.
+ */
+
+/** @brief Allocation function wrapper around malloc */
+static void* sys_malloc(void* allocator_data, size_t size) {
+    (void)allocator_data;
+    return malloc(size);
+}
+
+/** @brief Deallocation function wrapper around free */
+static void sys_free(void* allocator_data, void* ptr) {
+    (void)allocator_data;
+    free(ptr);
+}
+
+/** @brief Global allocator instance used for all protobuf allocations */
+static ProtobufCAllocator profile_allocator = {
+    sys_malloc,
+    sys_free,
+    nullptr  // allocator_data
+};
+
+/** @brief Allocate memory using the protobuf allocator */
+static inline void* pb_alloc(ProtobufCAllocator* allocator, size_t size) {
+    return allocator->alloc(allocator->allocator_data, size);
+}
+
+namespace dd::profiler {
+
+/**
+ * @brief Helper function forward declarations
+ * 
+ * These functions handle the conversion of specific data types from the internal
+ * profile representation to protobuf structures. Each function is responsible
+ * for allocating and populating the corresponding protobuf message type.
+ */
+
+/** @brief Convert string table to protobuf format with proper memory allocation */
+void perftools__profiles__profile__add_strings(const std::vector<std::string>& strings, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/** @brief Set sample type definitions (e.g., "cpu"/"nanoseconds", "wall"/"nanoseconds") */
+void perftools__profiles__profile__set_sample_type(int64_t type, int64_t unit, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/** @brief Set period type and value for sampling interval */
+void perftools__profiles__profile__set_period(int64_t type, int64_t unit, int64_t period, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/** @brief Convert memory mapping information to protobuf format */
+void perftools__profiles__profile__add_mappings(const std::vector<mapping_t>& mappings, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/** @brief Convert code location information to protobuf format */
+void perftools__profiles__profile__add_locations(const std::vector<location_t>& locations, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/** @brief Convert sample data to protobuf format */
+void perftools__profiles__profile__add_samples(const std::vector<sample_t>& samples, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+
+/**
+ * @brief Pack profile data into pprof protobuf binary format
+ * 
+ * This is the main entry point for converting profile data to the
+ * standardized pprof binary format. The function:
+ * 
+ * 1. Creates a protobuf Profile message structure
+ * 2. Converts all internal data (strings, functions, mappings, etc.) to protobuf format
+ * 3. Serializes the protobuf message to binary data
+ * 4. Returns ownership of the allocated buffer to the caller
+ * 
+ * @param prof The profile data to pack
+ * @param data Output parameter - pointer to allocated buffer containing serialized data
+ * @return Size of the serialized data in bytes, or 0 on failure
+ * 
+ * @note The caller is responsible for freeing the returned buffer with free()
+ * @note All protobuf memory is allocated using the custom allocator and cleaned up automatically
+ */
+size_t profile_pprof_pack(const profile& prof, uint8_t** data) {
+    if (!data) return 0;
+    
+    // Allocate and initialize the main protobuf profile structure
+    auto* pprof = static_cast<Perftools__Profiles__Profile*>(
+        pb_alloc(&profile_allocator, sizeof(Perftools__Profiles__Profile))
+    );
+    perftools__profiles__profile__init(pprof);
+    
+    // Convert each component of the profile to protobuf format
+    perftools__profiles__profile__add_strings(prof.strings(), pprof, &profile_allocator);
+    perftools__profiles__profile__set_sample_type(prof.wall_time_str_id(), prof.nanoseconds_str_id(), pprof, &profile_allocator);
+    perftools__profiles__profile__set_period(prof.wall_time_str_id(), prof.nanoseconds_str_id(), prof.sampling_interval_ns(), pprof, &profile_allocator);
+    perftools__profiles__profile__add_mappings(prof.mappings(), pprof, &profile_allocator);
+    perftools__profiles__profile__add_locations(prof.locations(), pprof, &profile_allocator);
+    perftools__profiles__profile__add_samples(prof.samples(), pprof, &profile_allocator);
+    
+    // Calculate required buffer size and serialize to binary format
+    size_t packed_size = perftools__profiles__profile__get_packed_size(pprof);
+    
+    if (packed_size == 0) {
+        perftools__profiles__profile__free_unpacked(pprof, &profile_allocator);
+        return 0;
+    }
+    
+    uint8_t* buffer = static_cast<uint8_t*>(malloc(packed_size));
+    if (!buffer) {
+        perftools__profiles__profile__free_unpacked(pprof, &profile_allocator);
+        return 0;
+    }
+    
+    size_t actual_size = pprof_pb_message_pack(
+        reinterpret_cast<const ProtobufCMessage*>(pprof),
+        buffer
+    );
+    
+    // Clean up protobuf structures (buffer is transferred to caller)
+    perftools__profiles__profile__free_unpacked(pprof, &profile_allocator);
+    
+    if (actual_size == 0) {
+        free(buffer);
+        return 0;
+    }
+    
+    *data = buffer;
+    return actual_size;
+}
+
+/**
+ * @brief Convert string table to protobuf format
+ * 
+ * Copies all strings from the internal string table to protobuf format.
+ * Each string is allocated using the protobuf allocator to ensure
+ * consistent memory management.
+ */
+void perftools__profiles__profile__add_strings(const std::vector<std::string>& strings, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    pprof->n_string_table = strings.size();
+    if (strings.empty()) return;
+    
+    pprof->string_table = static_cast<char**>(pb_alloc(allocator, strings.size() * sizeof(char*)));
+    
+    for (size_t i = 0; i < strings.size(); ++i) {
+        size_t str_len = strings[i].length() + 1;  // +1 for null terminator
+        pprof->string_table[i] = static_cast<char*>(pb_alloc(allocator, str_len));
+        memcpy(pprof->string_table[i], strings[i].c_str(), str_len);
+    }
+}
+
+void perftools__profiles__profile__set_sample_type(int64_t type, int64_t unit, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    // Create wall-time sample types
+    pprof->n_sample_type = 1;
+    pprof->sample_type = static_cast<Perftools__Profiles__ValueType**>(
+        pb_alloc(allocator, pprof->n_sample_type * sizeof(Perftools__Profiles__ValueType*))
+    );
+    
+    auto* sample_type_0 = static_cast<Perftools__Profiles__ValueType*>(
+        pb_alloc(allocator, sizeof(Perftools__Profiles__ValueType))
+    );
+    perftools__profiles__value_type__init(sample_type_0);
+    sample_type_0->type = type;
+    sample_type_0->unit = unit;
+    pprof->sample_type[0] = sample_type_0;
+}
+
+void perftools__profiles__profile__set_period(int64_t type, int64_t unit, int64_t period, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    // Create a separate ValueType for period_type
+    auto* period_type = static_cast<Perftools__Profiles__ValueType*>(
+        pb_alloc(allocator, sizeof(Perftools__Profiles__ValueType))
+    );
+    perftools__profiles__value_type__init(period_type);
+    period_type->type = type;
+    period_type->unit = unit;
+    pprof->period_type = period_type;
+    
+    // Set the period value
+    pprof->period = period;
+}
+
+void perftools__profiles__profile__add_mappings(const std::vector<mapping_t>& mappings, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    pprof->n_mapping = mappings.size();
+    if (mappings.empty()) return;
+    
+    pprof->mapping = static_cast<Perftools__Profiles__Mapping**>(
+        pb_alloc(allocator, mappings.size() * sizeof(Perftools__Profiles__Mapping*))
+    );
+    
+    for (size_t i = 0; i < mappings.size(); ++i) {
+        auto* mapping = static_cast<Perftools__Profiles__Mapping*>(
+            pb_alloc(allocator, sizeof(Perftools__Profiles__Mapping))
+        );
+        perftools__profiles__mapping__init(mapping);
+        mapping->id = static_cast<uint64_t>(i + 1);
+        mapping->memory_start = mappings[i].memory_start;
+        mapping->filename = mappings[i].filename_id;
+        mapping->build_id = mappings[i].build_id;
+        pprof->mapping[i] = mapping;
+    }
+}
+
+void perftools__profiles__profile__add_locations(const std::vector<location_t>& locations, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    pprof->n_location = locations.size();
+    if (locations.empty()) return;
+    
+    pprof->location = static_cast<Perftools__Profiles__Location**>(
+        pb_alloc(allocator, locations.size() * sizeof(Perftools__Profiles__Location*))
+    );
+    
+    for (size_t i = 0; i < locations.size(); ++i) {
+        auto* location = static_cast<Perftools__Profiles__Location*>(
+            pb_alloc(allocator, sizeof(Perftools__Profiles__Location))
+        );
+        perftools__profiles__location__init(location);
+        location->id = static_cast<uint64_t>(i + 1);
+        location->mapping_id = locations[i].mapping_id;
+        location->address = locations[i].address;
+        
+        // No line information - leave n_line = 0 and line = NULL
+        
+        pprof->location[i] = location;
+    }
+}
+
+void perftools__profiles__profile__add_samples(const std::vector<sample_t>& samples, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    pprof->n_sample = samples.size();
+    if (pprof->n_sample == 0) return;
+    
+    pprof->sample = static_cast<Perftools__Profiles__Sample**>(
+        pb_alloc(allocator, pprof->n_sample * sizeof(Perftools__Profiles__Sample*))
+    );
+    
+    for (size_t sample_idx = 0; sample_idx < samples.size(); ++sample_idx) {
+        const auto& src_sample = samples[sample_idx];
+        auto* sample = static_cast<Perftools__Profiles__Sample*>(
+            pb_alloc(allocator, sizeof(Perftools__Profiles__Sample))
+        );
+        perftools__profiles__sample__init(sample);
+        
+        // Set location IDs
+        sample->n_location_id = src_sample.location_ids.size();
+        sample->location_id = static_cast<uint64_t*>(
+            pb_alloc(allocator, src_sample.location_ids.size() * sizeof(uint64_t))
+        );
+        for (size_t i = 0; i < src_sample.location_ids.size(); ++i) {
+            sample->location_id[i] = src_sample.location_ids[i];
+        }
+        
+        // Set values
+        sample->n_value = src_sample.values.size();
+        sample->value = static_cast<int64_t*>(
+            pb_alloc(allocator, src_sample.values.size() * sizeof(int64_t))
+        );
+        for (size_t i = 0; i < src_sample.values.size(); ++i) {
+            sample->value[i] = src_sample.values[i];
+        }
+        
+        // Set labels
+        sample->n_label = src_sample.labels.size();
+        if (sample->n_label > 0) {
+            sample->label = static_cast<Perftools__Profiles__Label**>(
+                pb_alloc(allocator, sample->n_label * sizeof(Perftools__Profiles__Label*))
+            );
+            for (size_t i = 0; i < src_sample.labels.size(); ++i) {
+                auto* label = static_cast<Perftools__Profiles__Label*>(
+                    pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
+                );
+                perftools__profiles__label__init(label);
+                label->key = src_sample.labels[i].key_id;
+                label->str = src_sample.labels[i].str_id;
+                label->num = src_sample.labels[i].num;
+                label->num_unit = src_sample.labels[i].num_unit_id;
+                sample->label[i] = label;
+            }
+        }
+        
+        pprof->sample[sample_idx] = sample;
+    }
+}
+
+} // namespace dd::profiler

--- a/DatadogProfiling/Sources/DatadogProfiling.swift
+++ b/DatadogProfiling/Sources/DatadogProfiling.swift
@@ -59,7 +59,7 @@ public enum Profiling {
     ///   - core: The Datadog core instance to use. Defaults to the default core.
     public static func start(currentThreadOnly: Bool = false, in core: DatadogCoreProtocol = CoreRegistry.default) {
         core.get(feature: ProfilerFeature.self)?
-            .profiler.start()
+            .profiler.start(currentThreadOnly: currentThreadOnly)
     }
 
     /// Stops the current profiling session and uploads the captured data.

--- a/DatadogProfiling/Sources/Profiler.swift
+++ b/DatadogProfiling/Sources/Profiler.swift
@@ -19,7 +19,7 @@ internal struct Profile {
 /// Protocol defining the interface for profilers that can capture performance data.
 internal protocol Profiler {
     /// Starts the profiling session.
-    func start()
+    func start(currentThreadOnly: Bool)
     /// Stops the profiling session and returns the captured profile data.
     /// - Returns: A `Profile` containing the session data, or `nil` if no data was captured.
     /// - Throws: An error if the profiling session could not be stopped properly.

--- a/DatadogProfiling/Tests/MachProfilerTests.swift
+++ b/DatadogProfiling/Tests/MachProfilerTests.swift
@@ -1,0 +1,199 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+
+// swiftlint:disable duplicate_imports
+import DatadogMachProfiler.Cxx
+import DatadogMachProfiler.Pprof
+// swiftlint:enable duplicate_imports
+
+@testable import DatadogProfiling
+
+final class MachProfilerTests: XCTestCase {
+    // MARK: - Core Functionality Tests
+
+    func testSamplingFrequencyConversion_with100Hz_converts10msInterval() {
+        // Given
+        let frequency: Double = 200
+
+        // When
+        let profiler = MachProfiler(samplingFrequencyHz: frequency)
+
+        // Then
+        XCTAssertEqual(profiler.samplingIntervalNs, 5_000_000)
+    }
+
+    func testStart_beforeStop_ignoresSubsequentStarts() throws {
+        // Given
+        let startDate: Date = .mockRandom()
+        let dateProvider = RelativeDateProvider(
+            startingFrom: startDate,
+            advancingBySeconds: 0.01
+        )
+        let profiler = MachProfiler(
+            samplingFrequencyHz: 100,
+            dateProvider: dateProvider
+        )
+
+        let mockThread = MockThread {
+            profiler.start(currentThreadOnly: true)
+            profiler.start(currentThreadOnly: false) // Should be ignored
+        }
+
+        // When
+        mockThread.start()
+        mockThread.waitForWorkCompletion()
+
+        // Then
+        let profile = try XCTUnwrap(profiler.stop())
+        XCTAssertNotNil(profile)
+        XCTAssertEqual(profile.start, startDate)
+        XCTAssertGreaterThan(profile.end, startDate)
+    }
+
+    func testStop_withoutStart_returnsNil() throws {
+        // Given
+        let profiler = MachProfiler()
+
+        // When
+        let profile = try profiler.stop()
+
+        // Then
+        XCTAssertNil(profile)
+    }
+
+    func testStop_afterStart_returnsValidProfile() throws {
+        // Given
+        let startDate: Date = .mockRandom()
+        let dateProvider = RelativeDateProvider(
+            startingFrom: startDate,
+            advancingBySeconds: 0.02
+        )
+        let profiler = MachProfiler(
+            samplingFrequencyHz: 100,
+            dateProvider: dateProvider
+        )
+
+        let mockThread = MockThread {
+            profiler.start(currentThreadOnly: true)
+        }
+
+        mockThread.start()
+        mockThread.waitForWorkCompletion()
+
+        // When
+        let profile = try XCTUnwrap(profiler.stop())
+
+        // Then
+        XCTAssertEqual(profile.start, startDate)
+        XCTAssertEqual(profile.end, startDate.addingTimeInterval(0.02))
+        XCTAssertGreaterThan(profile.pprof.count, 0)
+    }
+
+    func testStop_calledTwice_returnsNilOnSecond() throws {
+        // Given
+        let profiler = MachProfiler()
+
+        let mockThread = MockThread {
+            profiler.start(currentThreadOnly: true)
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        mockThread.start()
+        mockThread.waitForWorkCompletion()
+
+        // When
+        let firstProfile = try profiler.stop()
+        let secondProfile = try profiler.stop()
+
+        // Then
+        XCTAssertNotNil(firstProfile)
+        XCTAssertNil(secondProfile)
+    }
+
+    func testProfileData_isValidPprof() throws {
+        // Given
+        let profiler = MachProfiler()
+
+        let mockThread = MockThread {
+            profiler.start(currentThreadOnly: true)
+
+            // Generate some activity
+            var sum = 0
+            for i in 0..<1_000 {
+                sum += i * i
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        mockThread.start()
+        mockThread.waitForWorkCompletion()
+
+        // When
+        let profile = try XCTUnwrap(profiler.stop())
+
+        // Then
+        XCTAssertGreaterThan(profile.pprof.count, 0)
+
+        // Validate pprof format
+        profile.pprof.withUnsafeBytes { bytes in
+            let unpackedProfile = perftools__profiles__profile__unpack(
+                nil,
+                profile.pprof.count,
+                bytes.bindMemory(to: UInt8.self).baseAddress
+            )
+            defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+            XCTAssertNotNil(unpackedProfile)
+            if let unwrapped = unpackedProfile {
+                XCTAssertGreaterThan(unwrapped.pointee.n_string_table, 0)
+                XCTAssertGreaterThan(unwrapped.pointee.n_location, 0)
+            }
+        }
+    }
+
+    // MARK: - Memory Management Tests
+
+    func testDeinit_withActiveProfiler_cleansUpCorrectly() {
+        // Given
+        var profiler: MachProfiler? = MachProfiler()
+
+        let mockThread = MockThread {
+            profiler?.start(currentThreadOnly: true)
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+
+        // When
+        mockThread.start()
+        mockThread.waitForWorkCompletion()
+        profiler = nil
+
+        // Then
+        // Should not crash when deallocated while active
+    }
+
+    func testMultipleStartStopCycles_doesNotLeak() throws {
+        // Given
+        let profiler = MachProfiler()
+
+        // When
+        for _ in 0..<5 {
+            let mockThread = MockThread {
+                profiler.start(currentThreadOnly: true)
+                Thread.sleep(forTimeInterval: 0.005)
+            }
+
+            mockThread.start()
+            mockThread.waitForWorkCompletion()
+            _ = try profiler.stop()
+        }
+
+        // Then
+        // Test passes if no crashes or memory issues
+    }
+}

--- a/DatadogProfiling/Tests/MachSamplingProfilerTests.swift
+++ b/DatadogProfiling/Tests/MachSamplingProfilerTests.swift
@@ -287,6 +287,7 @@ final class MachSamplingProfilerTests: XCTestCase {
 
         struct CallbackContext {
             var tids: Set<mach_port_t> = []
+            var names: Set<String> = []
             var count: Int = 0
         }
 
@@ -299,7 +300,10 @@ final class MachSamplingProfilerTests: XCTestCase {
 
             CCallbackContext<CallbackContext>.withContextPointer(ctx) { context in
                 context.count += count
-                (0..<count).forEach { context.tids.insert(traces[$0].tid) }
+                (0..<count).forEach {
+                    context.tids.insert(traces[$0].tid)
+                    context.names.insert(String(cString: traces[$0].thread_name))
+                }
             }
         }
 

--- a/DatadogProfiling/Tests/MockProfiler.swift
+++ b/DatadogProfiling/Tests/MockProfiler.swift
@@ -32,7 +32,7 @@ internal struct MockProfiler: Profiler {
 
     /// Starts the mock profiling session.
     /// This is a no-op implementation for testing purposes.
-    func start() {
+    func start(currentThreadOnly: Bool) {
         // no-op
     }
 

--- a/DatadogProfiling/Tests/MockThread.swift
+++ b/DatadogProfiling/Tests/MockThread.swift
@@ -51,7 +51,7 @@ final class MockThread: Thread {
 
 /// Helper class to manage multiple profiled threads for testing
 final class MockThreadGroup {
-    private var threads: [MockThread] = []
+    private(set) var threads: [MockThread] = []
 
     /// Add a thread to the group
     /// - Parameter thread: The thread to add

--- a/DatadogProfiling/Tests/ProfileCxxTests.swift
+++ b/DatadogProfiling/Tests/ProfileCxxTests.swift
@@ -1,0 +1,328 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+
+// swiftlint:disable duplicate_imports
+import DatadogMachProfiler.Cxx
+import DatadogMachProfiler.Pprof
+// swiftlint:enable duplicate_imports
+
+final class ProfileCxxTests: XCTestCase {
+    // MARK: - Profile Creation and Basic Operations
+
+    func testProfileCreation_withValidInterval_createsProfile() {
+        // Given
+        let samplingInterval: UInt64 = 10_000_000 // 10ms
+
+        // When
+        let profile = dd_pprof_create(samplingInterval)
+        defer { dd_pprof_destroy(profile) }
+
+        // Then
+        XCTAssertNotNil(profile, "Profile should be created successfully")
+    }
+
+    func testProfileDestroy_withValidProfile_doesNotCrash() {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        XCTAssertNotNil(profile)
+
+        // When/Then - Should not crash
+        dd_pprof_destroy(profile)
+    }
+
+    func testProfileDestroy_withNilProfile_doesNotCrash() {
+        // When/Then - Should not crash
+        dd_pprof_destroy(nil)
+    }
+
+    // MARK: - Stack Trace Aggregation Tests
+
+    func testProfileAggregation_withIdenticalTraces_aggregatesCorrectly() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        let addresses: [UInt64] = [0x100001000, 0x100002000, 0x100003000]
+
+        // When
+        // - Add the same stack trace multiple times
+        for _ in 0..<5 {
+            let stackTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+            stackTrace.pointee = .mockWith(tid: 1, addresses: addresses)
+            dd_pprof_add_samples(profile, stackTrace, 1)
+            dd_free(stackTrace)
+        }
+
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        // Then
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+        XCTAssertNotNil(data, "Serialized data should not be nil")
+
+        // - Validate the profile contains aggregated samples
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_sample, 0, "Profile should contain samples")
+        XCTAssertLessThanOrEqual(unpackedProfile.pointee.n_sample, 5, "Should not exceed number of input traces")
+
+        // - Verify sample structure regardless of aggregation behavior
+        let totalSampleValue = try (0..<5).reduce(0) { sum, i in
+            let sample = try XCTUnwrap(unpackedProfile.pointee.sample[i])
+            XCTAssertEqual(sample.pointee.n_value, 1, "Sample should have one value")
+            XCTAssertEqual(sample.pointee.n_location_id, 3, "Sample should reference 3 locations")
+            XCTAssertEqual(sample.pointee.value[0], 10_000_000, "Sample value should be 10ms interval")
+            return sum + Int(sample.pointee.value[0])
+        }
+
+        // - Total sample values should represent cumulative time intervals (5 samples * 10ms each)
+        XCTAssertEqual(totalSampleValue, 50_000_000, "Total sample values should equal 5 * 10ms = 50ms")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_location, 0, "Profile should have location data")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_string_table, 0, "Profile should have string table")
+    }
+
+    func testProfileAggregation_withDifferentThreads_separatesSamples() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        let addresses: [UInt64] = [0x100001000, 0x100002000, 0x100003000]
+
+        // When
+        // - Add same stack from different threads
+        let thread1Trace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        thread1Trace.pointee = .mockWith(tid: 1, addresses: addresses)
+        let thread2Trace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        thread2Trace.pointee = .mockWith(tid: 2, addresses: addresses)
+        defer {
+            dd_free(thread1Trace)
+            dd_free(thread2Trace)
+        }
+
+        dd_pprof_add_samples(profile, thread1Trace, 1)
+        dd_pprof_add_samples(profile, thread2Trace, 1)
+
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        // Then
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        // - Validate the profile separates samples by thread
+        XCTAssertEqual(unpackedProfile.pointee.n_sample, 2, "Different threads should create separate samples")
+
+        // - Verify both samples have correct values and structure
+        for i in 0..<2 {
+            let sample = try XCTUnwrap(unpackedProfile.pointee.sample[i])
+            XCTAssertEqual(sample.pointee.n_value, 1, "Sample should have one value")
+            XCTAssertEqual(sample.pointee.value[0], 10_000_000, "Each sample should have 10ms interval")
+            XCTAssertEqual(sample.pointee.n_location_id, 3, "Sample should reference 3 locations")
+        }
+    }
+
+    func testProfileAggregation_withDifferentStacks_createsMultipleSamples() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        let stack1: [UInt64] = [0x100001000, 0x100002000, 0x100003000]
+        let stack2: [UInt64] = [0x100004000, 0x100005000, 0x100006000]
+        let stack3: [UInt64] = [0x100007000, 0x100008000, 0x100009000]
+
+        // When
+        let trace1 = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        trace1.pointee = .mockWith(tid: 1, addresses: stack1)
+        let trace2 = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        trace2.pointee = .mockWith(tid: 1, addresses: stack2)
+        let trace3 = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        trace3.pointee = .mockWith(tid: 1, addresses: stack3)
+        defer {
+            dd_free(trace1)
+            dd_free(trace2)
+            dd_free(trace3)
+        }
+
+        dd_pprof_add_samples(profile, trace1, 1)
+        dd_pprof_add_samples(profile, trace2, 1)
+        dd_pprof_add_samples(profile, trace3, 1)
+
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        // Then
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        // - Should have 3 separate samples (3 different stacks)
+        XCTAssertEqual(unpackedProfile.pointee.n_sample, 3, "Different stacks should create separate samples")
+
+        // - Verify each sample has correct structure 
+        for i in 0..<3 {
+            let sample = try XCTUnwrap(unpackedProfile.pointee.sample[i])
+            XCTAssertEqual(sample.pointee.n_value, 1, "Sample should have one value")
+            XCTAssertEqual(sample.pointee.value[0], 10_000_000, "Each sample should have 10ms interval")
+            XCTAssertEqual(sample.pointee.n_location_id, 3, "Sample should reference 3 locations")
+        }
+    }
+
+    // MARK: - Memory Management Tests
+
+    func testProfileMemoryManagement_withManyStacks_doesNotLeak() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        // When - Add many different stacks
+        for i in 0..<1_000 {
+            let addresses: [UInt64] = [
+                UInt64(0x100000000 + i * 0x1000),
+                UInt64(0x200000000 + i * 0x1000),
+                UInt64(0x300000000 + i * 0x1000)
+            ]
+            let stackTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+            stackTrace.pointee = .mockWith(tid: UInt32(i % 10), addresses: addresses)
+            dd_pprof_add_samples(profile, stackTrace, 1)
+            dd_free(stackTrace)
+        }
+
+        // Then - Should be able to serialize without issues
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+
+        // Validate the profile contains the expected number of samples and data integrity
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        // With 1000 different stacks, we should have exactly 1000 samples (each unique)
+        XCTAssertEqual(unpackedProfile.pointee.n_sample, 1_000, "Should have created 1000 unique samples")
+
+        // Verify we have locations and string table data
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_location, 0, "Should have location data")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_string_table, 0, "Should have string table")
+
+        // Spot check a few samples to ensure they have valid structure
+        for i in 0..<min(10, Int(unpackedProfile.pointee.n_sample)) {
+            let sample = try XCTUnwrap(unpackedProfile.pointee.sample[i])
+            XCTAssertEqual(sample.pointee.n_value, 1, "Sample should have one value")
+            XCTAssertEqual(sample.pointee.value[0], 10_000_000, "Each sample should have 10ms interval")
+            XCTAssertEqual(sample.pointee.n_location_id, 3, "Sample should reference 3 locations")
+        }
+    }
+
+    // MARK: - Serialization Tests
+
+    func testProfileSerialization_withEmptyProfile_producesValidPprof() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        // When
+        // - Serialize empty profile
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        // Then
+        XCTAssertGreaterThan(size, 0, "Empty profile should still produce some data")
+        XCTAssertNotNil(data, "Serialized data should not be nil")
+        // - Validate basic profile structure
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        perftools__profiles__profile__free_unpacked(unpackedProfile, nil)
+    }
+
+    func testProfileSerialization_withNilProfile_returnsZero() {
+        // When
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(nil, &data)
+
+        // Then
+        XCTAssertEqual(size, 0, "Nil profile should return zero size")
+        XCTAssertNil(data, "Data should be nil for nil profile")
+    }
+
+    // MARK: - Edge Cases
+
+    func testProfileAggregation_withZeroAddresses_returnsEmptyData() {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        let emptyTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        emptyTrace.pointee = .mockWith(tid: 1, addresses: [])
+        defer { dd_free(emptyTrace) }
+
+        // When
+        dd_pprof_add_samples(profile, emptyTrace, 1)
+
+        // Then
+        // - Should not crash
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        XCTAssertGreaterThanOrEqual(size, 0, "Should handle empty traces gracefully")
+    }
+
+    func testProfileAggregation_withMaxStackDepth_createValidProfile() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        // Create a deep stack (128 frames - typical max)
+        let addresses = (0..<128).map { UInt64(0x100000000 + $0 * 0x1000) }
+        let deepTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        deepTrace.pointee = .mockWith(tid: 1, addresses: addresses)
+        defer { dd_free(deepTrace) }
+
+        // When
+        dd_pprof_add_samples(profile, deepTrace, 1)
+
+        // Then
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        XCTAssertGreaterThan(size, 0, "Should handle deep stacks")
+        // Validate basic profile structure
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        // Validate profile contains expected data
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_string_table, 0, "Should have string table")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_sample, 0, "Should have samples")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_location, 0, "Should have locations")
+        XCTAssertGreaterThan(unpackedProfile.pointee.n_mapping, 0, "Should have mappings")
+        XCTAssertEqual(unpackedProfile.pointee.n_sample_type, 1, "Should have one sample type")
+    }
+}
+///  Deallocates a stack_trace_t and its subsequent frames
+func dd_free(_ trace: UnsafeMutablePointer<stack_trace_t>) {
+    // Deallocate frames if they exist
+    if let frames = trace.pointee.frames {
+        frames.deallocate()
+    }
+    trace.deallocate()
+}

--- a/DatadogProfiling/Tests/ProfileMocks.swift
+++ b/DatadogProfiling/Tests/ProfileMocks.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import TestUtilities
+import DatadogMachProfiler.Cxx
+
+extension binary_image_t {
+    static func mockAny() -> binary_image_t {
+        return mockWith()
+    }
+
+    static func mockWith(
+        loadAddress: UInt64 = 0x100000000,
+        uuid: UUID = UUID(uuidString: "01234567-89AB-CDEF-0123-456789ABCDEF")!,
+        filename: StaticString = "TestBinary"
+    ) -> binary_image_t {
+        return binary_image_t(
+            load_address: loadAddress,
+            uuid: uuid.uuid,
+            filename: UnsafeRawPointer(filename.utf8Start).assumingMemoryBound(to: CChar.self)
+        )
+    }
+}
+
+extension stack_trace_t {
+    static func mockWith(
+        tid: UInt32,
+        addresses: [UInt64],
+        timestamp: UInt64? = nil,
+        samplingIntervalNanos: UInt64 = 10_000_000,
+        binaryImage: binary_image_t = .mockAny()
+    ) -> stack_trace_t {
+        let frameCount = UInt32(addresses.count)
+        let frames: UnsafeMutablePointer<stack_frame_t>?
+
+        if frameCount > 0 {
+            frames = UnsafeMutablePointer<stack_frame_t>.allocate(capacity: Int(frameCount))
+            for (index, address) in addresses.enumerated() {
+                frames![index] = stack_frame_t(
+                    instruction_ptr: address,
+                    image: binaryImage
+                )
+            }
+        } else {
+            frames = nil
+        }
+
+        return stack_trace_t(
+            tid: tid,
+            timestamp: timestamp ?? UInt64(Date().timeIntervalSince1970 * 1_000_000_000),
+            sampling_interval_nanos: samplingIntervalNanos,
+            frames: frames,
+            frame_count: frameCount
+        )
+    }
+}

--- a/DatadogProfiling/Tests/ProfileMocks.swift
+++ b/DatadogProfiling/Tests/ProfileMocks.swift
@@ -30,6 +30,7 @@ extension stack_trace_t {
     static func mockWith(
         tid: UInt32,
         addresses: [UInt64],
+        threadName: StaticString = "TestThread",
         timestamp: UInt64? = nil,
         samplingIntervalNanos: UInt64 = 10_000_000,
         binaryImage: binary_image_t = .mockAny()
@@ -51,6 +52,7 @@ extension stack_trace_t {
 
         return stack_trace_t(
             tid: tid,
+            thread_name: UnsafeRawPointer(threadName.utf8Start).assumingMemoryBound(to: CChar.self),
             timestamp: timestamp ?? UInt64(Date().timeIntervalSince1970 * 1_000_000_000),
             sampling_interval_nanos: samplingIntervalNanos,
             frames: frames,

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ sr-models-verify:
 
 # Generate profiling protobuf-c files from pprof proto
 protoc-pprof:
-	@$(ECHO_TITLE) "make profiling-protoc"
+	@$(ECHO_TITLE) "protoc-pprof"
 	./tools/protoc-pprof.sh --proto-path DatadogProfiling/Protos/profile.proto --output-dir DatadogProfiling/Mach
 
 # Pushes current SR snapshots to snapshots repo

--- a/tools/protoc-pprof.sh
+++ b/tools/protoc-pprof.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 # Usage:
-# $ ./tools/pprof-protoc.sh --proto-path DatadogProfiling/Protos/profile.proto --output-dir DatadogProfiling/Mach
+# $ ./tools/protoc-pprof.sh --proto-path DatadogProfiling/Protos/profile.proto --output-dir DatadogProfiling/Mach
 
 set -e
 source ./tools/utils/echo-color.sh


### PR DESCRIPTION
### What and why?

This PR implements pprof data aggregation and serialization for Profiling. It adds the engine to collect, deduplicate, and serialize profiling samples into the standard pprof protobuf format, enabling ingestion from Profiling intake.

### How?

#### Key Components:
- Adds `profile` C++ class for sample aggregation with deduplication of strings, mappings, and locations
- Implements `profile_pprof_packer` to convert internal data structures to protobuf format
- Creates C API wrapper (`dd_pprof`) for Swift integration
- Updates `MachProfiler` to use the new aggregation system and generate pprof data

#### Testing:

Uses Cxx interoperability feature introduced in Swift 5.9 for testing aggregation and serialization.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)