### PR TITLE
Fix `DDLogEvent.accountInfo` initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [BUGFIX] Fix `DDLogEvent.accountInfo` property initialization in case of missing account info. See [#2442][]
+- [FIX] Fix `DDLogEvent.accountInfo` property initialization in case of missing account info. See [#2442][]
 - [IMPROVEMENT] Update the default tracing sampling rate to 100%. See [#2253][] 
 - [IMPROVEMENT] Update the default TraceContextInjection to `.sampled`. See [#2253][]
 - [IMPROVEMENT] Enforce head-based sampling on Trace by default. See [#2288][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [BUGFIX] Fix `DDLogEvent.accountInfo` property initialization in case of missing account info. See [#2442][]
 - [IMPROVEMENT] Update the default tracing sampling rate to 100%. See [#2253][] 
 - [IMPROVEMENT] Update the default TraceContextInjection to `.sampled`. See [#2253][]
 - [IMPROVEMENT] Enforce head-based sampling on Trace by default. See [#2288][]
@@ -945,6 +946,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2370]: https://github.com/DataDog/dd-sdk-ios/pull/2370
 [#2395]: https://github.com/DataDog/dd-sdk-ios/pull/2395
 [#2405]: https://github.com/DataDog/dd-sdk-ios/pull/2405
+[#2442]: https://github.com/DataDog/dd-sdk-ios/pull/2442
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogLogs/Sources/LogsDataModels+objc.swift
+++ b/DatadogLogs/Sources/LogsDataModels+objc.swift
@@ -90,8 +90,12 @@ public class objc_LogEvent: NSObject {
         .init(root: self)
     }
 
-    public var accountInfo: objc_LogEventAccountInfo {
-        .init(root: self)
+    public var accountInfo: objc_LogEventAccountInfo? {
+        if swiftModel.accountInfo != nil {
+            .init(root: self)
+        } else {
+            nil
+        }
     }
 
     public var networkConnectionInfo: objc_LogEventNetworkConnectionInfo? {

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -145,7 +145,7 @@ public class objc_LogEvent: NSObject
     public var device: objc_LogEventDevice
     public var os: objc_LogEventOperatingSystem
     public var userInfo: objc_LogEventUserInfo
-    public var accountInfo: objc_LogEventAccountInfo
+    public var accountInfo: objc_LogEventAccountInfo?
     public var networkConnectionInfo: objc_LogEventNetworkConnectionInfo?
     public var mobileCarrierInfo: objc_LogEventCarrierInfo?
     public var attributes: objc_LogEventAttributes
@@ -1590,7 +1590,7 @@ public class objc_RUMViewEventView: NSObject
     public var cumulativeLayoutShift: NSNumber?
     public var cumulativeLayoutShiftTargetSelector: String?
     public var cumulativeLayoutShiftTime: NSNumber?
-    public var customTimings: [String: NSNumber]?
+    public var customTimings: objc_RUMViewEventViewCustomTimings?
     public var domComplete: NSNumber?
     public var domContentLoaded: NSNumber?
     public var domInteractive: NSNumber?
@@ -1660,6 +1660,8 @@ public class objc_RUMViewEventViewAction: NSObject
     public var count: NSNumber
 public class objc_RUMViewEventViewCrash: NSObject
     public var count: NSNumber
+public class objc_RUMViewEventViewCustomTimings: NSObject
+    public var customTimingsInfo: [String: NSNumber]
 public class objc_RUMViewEventViewError: NSObject
     public var count: NSNumber
 public class objc_RUMViewEventViewFlutterBuildTime: NSObject
@@ -1919,7 +1921,7 @@ public class objc_RUMVitalEventVital: NSObject
     public var failureReason: objc_RUMVitalEventVitalFailureReason
     public var id: String
     public var name: String?
-    public var parentId: String?
+    public var operationKey: String?
     public var stepType: objc_RUMVitalEventVitalStepType
     public var type: objc_RUMVitalEventVitalVitalType
 public enum objc_RUMVitalEventVitalFailureReason: Int
@@ -1935,7 +1937,7 @@ public enum objc_RUMVitalEventVitalStepType: Int
     case end
 public enum objc_RUMVitalEventVitalVitalType: Int
     case duration
-    case step
+    case operationStep
 public class objc_TelemetryErrorEvent: NSObject
     public internal(set) var swiftModel: TelemetryErrorEvent
     public init(swiftModel: TelemetryErrorEvent)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1121,7 +1121,7 @@ public class SessionReplayWireframesBuilder
     public struct FontOverride
         public init(size: CGFloat?)
     public func createShapeWireframe(id: WireframeID,frame: CGRect,clip: CGRect,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
-    public func createImageWireframe(id: WireframeID,resource: SessionReplayResource,frame: CGRect,clip: CGRect,mimeType: String = "png",borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
+    public func createImageWireframe(id: WireframeID,resource: SessionReplayResource,frame: CGRect,clip: CGRect,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
     public func createTextWireframe(id: WireframeID,frame: CGRect,clip: CGRect,text: String,textFrame: CGRect? = nil,textAlignment: SRTextPosition.Alignment? = nil,textColor: CGColor? = nil,font: UIFont? = nil,fontOverride: FontOverride? = nil,fontScalingEnabled: Bool = false,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
     public func createPlaceholderWireframe(id: Int64,frame: CGRect,clip: CGRect,label: String) -> SRWireframe
     public func visibleWebViewWireframe(id: Int,frame: CGRect,clip: CGRect,borderColor: CGColor? = nil,borderWidth: CGFloat? = nil,backgroundColor: CGColor? = nil,cornerRadius: CGFloat? = nil,opacity: CGFloat? = nil) -> SRWireframe
@@ -1163,6 +1163,7 @@ public struct SessionReplayNode
     public let wireframesBuilder: SessionReplayNodeWireframesBuilder
     public init(viewAttributes: SessionReplayViewAttributes, wireframesBuilder: SessionReplayNodeWireframesBuilder)
 public protocol SessionReplayResource
+    var mimeType: String
     func calculateIdentifier() -> String
     func calculateData() -> Data
 public struct SessionReplayViewAttributes: Equatable


### PR DESCRIPTION
### What and why?

`LogEvent.accountInfo` property is nullable, so making `DDLogEvent.accountInfo` nullable as well.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
