### PR TITLE
mariedm/rum 11185 usage telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -963,6 +963,8 @@
 		96E414142C2AF56F005A6119 /* UIProgressViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */; };
 		96E414162C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */; };
 		96E863722C9C547B0023BF78 /* SessionReplayOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E863712C9C547B0023BF78 /* SessionReplayOverrideTests.swift */; };
+		96EF73062E42028C0001EEF0 /* FeatureOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EF73052E42028C0001EEF0 /* FeatureOperationTests.swift */; };
+		96EF73072E42028C0001EEF0 /* FeatureOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EF73052E42028C0001EEF0 /* FeatureOperationTests.swift */; };
 		96F25A822CC7EA4400459567 /* SessionReplayPrivacyOverrides+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F25A802CC7EA4300459567 /* SessionReplayPrivacyOverrides+objc.swift */; };
 		96F25A832CC7EA4400459567 /* UIView+SessionReplayPrivacyOverrides+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F25A812CC7EA4300459567 /* UIView+SessionReplayPrivacyOverrides+objc.swift */; };
 		96F69D6C2CBE94A800A6178B /* DatadogCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B78EA296D7B63009C6B92 /* DatadogCoreTests.swift */; };
@@ -2970,6 +2972,7 @@
 		96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorderTests.swift; sourceTree = "<group>"; };
 		96E863712C9C547B0023BF78 /* SessionReplayOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayOverrideTests.swift; sourceTree = "<group>"; };
 		96E863752C9C7E800023BF78 /* DDSessionReplayOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSessionReplayOverridesTests.swift; sourceTree = "<group>"; };
+		96EF73052E42028C0001EEF0 /* FeatureOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureOperationTests.swift; sourceTree = "<group>"; };
 		96F25A802CC7EA4300459567 /* SessionReplayPrivacyOverrides+objc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SessionReplayPrivacyOverrides+objc.swift"; sourceTree = "<group>"; };
 		96F25A812CC7EA4300459567 /* UIView+SessionReplayPrivacyOverrides+objc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+SessionReplayPrivacyOverrides+objc.swift"; sourceTree = "<group>"; };
 		96F70D442DD793C400D3736B /* RUMAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAction.swift; sourceTree = "<group>"; };
@@ -5411,6 +5414,7 @@
 				618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */,
 				6176C1712ABDBA2E00131A70 /* MonitorTests.swift */,
 				61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */,
+				96EF73052E42028C0001EEF0 /* FeatureOperationTests.swift */,
 			);
 			path = RUMMonitor;
 			sourceTree = "<group>";
@@ -9049,6 +9053,7 @@
 				D23F8EB229DDCD38001CFAE8 /* ValuePublisherTests.swift in Sources */,
 				6174D61B2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				9654971E2D774060006428EE /* SwiftUIViewNameExtractorTests.swift in Sources */,
+				96EF73062E42028C0001EEF0 /* FeatureOperationTests.swift in Sources */,
 				61181CDD2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BD2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
@@ -9517,6 +9522,7 @@
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
 				6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				9654971D2D774060006428EE /* SwiftUIViewNameExtractorTests.swift in Sources */,
+				96EF73072E42028C0001EEF0 /* FeatureOperationTests.swift in Sources */,
 				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BC2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,

--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -96,6 +96,14 @@ class DDRUMUserActionTypeTests: XCTestCase {
     }
 }
 
+class DDRUMFeatureOperationFailureReasonTests: XCTestCase {
+    func testMappingToSwiftRUMFeatureOperationFailureReason() {
+        XCTAssertEqual(objc_RUMFeatureOperationFailureReason.error.swiftType, .error)
+        XCTAssertEqual(objc_RUMFeatureOperationFailureReason.abandoned.swiftType, .abandoned)
+        XCTAssertEqual(objc_RUMFeatureOperationFailureReason.other.swiftType, .other)
+    }
+}
+
 class SwiftUIRUMViewsPredicateBridgeTests: XCTestCase {
     func testItForwardsCallToObjcPredicate() {
         class MockPredicate: objc_SwiftUIRUMViewsPredicate {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -49,6 +49,10 @@
     DDRUMMethodTrace; DDRUMMethodOptions;
 }
 
+- (void)testDDRUMFeatureOperationFailureReasonAPI {
+    DDRUMFeatureOperationFailureReasonError; DDRUMFeatureOperationFailureReasonAbandoned; DDRUMFeatureOperationFailureReasonOther;
+}
+
 - (void)testDDRUMMonitorAPI {
     UIViewController *anyVC = [UIViewController new];
 
@@ -81,6 +85,9 @@
     [monitor addAttributes:@{@"string": @"value", @"integer": @1, @"boolean": @true}];
     [monitor removeAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
+    [monitor startFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
+    [monitor succeedFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
+    [monitor failFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" reason:DDRUMFeatureOperationFailureReasonError attributes:@{}];
 
     [monitor setDebug:YES];
     [monitor setDebug:NO];

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -114,8 +114,10 @@ public struct UsageTelemetry: SampledTelemetry {
         case setAccount
         /// addFeatureFlagEvaluation API
         case addFeatureFlagEvaluation
-        /// addFeatureFlagEvaluation API
+        /// addViewLoadingTime API
         case addViewLoadingTime(ViewLoadingTime)
+        /// addOperationStepVital API
+        case addOperationStepVital(TelemetryUsageEvent.Telemetry.Usage.TelemetryCommonFeaturesUsage.AddOperationStepVital)
 
         /// Describes the properties of `addViewLoadingTime` usage telemetry.
         public struct ViewLoadingTime {

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -9120,6 +9120,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
         get { root.swiftModel.telemetry.configuration.reactVersion }
     }
 
+    public var remoteConfigurationId: String? {
+        set { root.swiftModel.telemetry.configuration.remoteConfigurationId = newValue }
+        get { root.swiftModel.telemetry.configuration.remoteConfigurationId }
+    }
+
     public var replaySampleRate: NSNumber? {
         root.swiftModel.telemetry.configuration.replaySampleRate as NSNumber?
     }
@@ -9695,4 +9700,4 @@ public class objc_TelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/364afe383024cfbdc0a57253c1961cf938b19cf0
+// Generated from https://github.com/DataDog/rum-events-format/tree/df49bc14c81031af64b4eeb6994e4310a9b26f8b

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -350,6 +350,14 @@ private extension TelemetryUsageEvent.Telemetry.Usage {
                     )
                 )
             )
+        case .addOperationStepVital(let addOperationStepVital):
+            self = .telemetryCommonFeaturesUsage(
+                value: .addOperationStepVital(
+                    value: .init(
+                        actionType: addOperationStepVital.actionType
+                    )
+                )
+            )
         }
     }
 }

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -290,6 +290,22 @@ public enum objc_VitalsFrequency: Int {
     }
 }
 
+@objc(DDRUMFeatureOperationFailureReason)
+@_spi(objc)
+public enum objc_RUMFeatureOperationFailureReason: Int {
+    case error
+    case abandoned
+    case other
+
+    internal var swiftType: RUMFeatureOperationFailureReason {
+        switch self {
+        case .error: return .error
+        case .abandoned: return .abandoned
+        case .other: return .other
+        }
+    }
+}
+
 @objc(DDRUMFirstPartyHostsTracing)
 @objcMembers
 @_spi(objc)
@@ -683,6 +699,36 @@ public class objc_RUMMonitor: NSObject {
 
     public func addFeatureFlagEvaluation(name: String, value: Any) {
         swiftRUMMonitor.addFeatureFlagEvaluation(name: name, value: AnyEncodable(value))
+    }
+
+    public func startFeatureOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.startFeatureOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+    }
+
+    public func succeedFeatureOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+    }
+
+    public func failFeatureOperation(
+        name: String,
+        operationKey: String?,
+        reason: objc_RUMFeatureOperationFailureReason,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.failFeatureOperation(
+            name: name,
+            operationKey: operationKey,
+            reason: reason.swiftType,
+            attributes: attributes.dd.swiftAttributes
+        )
     }
 
     public var debug: Bool {

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -468,7 +468,6 @@ extension Monitor: RUMMonitorProtocol {
 
     // MARK: - Feature Operations
 
-    // swiftlint:disable function_default_parameter_at_end
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was started")
         process(
@@ -484,8 +483,7 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
-    // swiftlint:disable function_default_parameter_at_end
-    func succeedFeatureOperation(name: String, operationKey: String? = nil, attributes: [AttributeKey: AttributeValue]) {
+    func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was successfully ended")
         process(
             command: RUMOperationStepVitalCommand(
@@ -500,8 +498,7 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
-    // swiftlint:disable function_default_parameter_at_end
-    func failFeatureOperation(name: String, operationKey: String? = nil, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
+    func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was unsuccessfully ended with the following failure reason: \(reason.rawValue)")
         process(
             command: RUMOperationStepVitalCommand(

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -109,6 +109,7 @@ internal class Monitor: RUMCommandSubscriber {
 
     private let fatalErrorContext: FatalErrorContextNotifying
     private let rumUUIDGenerator: RUMUUIDGenerator
+    private let telemetry: Telemetry
 
     init(
         dependencies: RUMScopeDependencies,
@@ -119,6 +120,7 @@ internal class Monitor: RUMCommandSubscriber {
         self.dateProvider = dateProvider
         self.fatalErrorContext = dependencies.fatalErrorContext
         self.rumUUIDGenerator = dependencies.rumUUIDGenerator
+        self.telemetry = dependencies.telemetry
     }
 
     func process(command: RUMCommand) {
@@ -470,6 +472,9 @@ extension Monitor: RUMMonitorProtocol {
 
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was started")
+
+        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
+
         process(
             command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
@@ -485,6 +490,9 @@ extension Monitor: RUMMonitorProtocol {
 
     func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was successfully ended")
+
+        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .succeed)))))
+
         process(
             command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
@@ -500,6 +508,9 @@ extension Monitor: RUMMonitorProtocol {
 
     func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was unsuccessfully ended with the following failure reason: \(reason.rawValue)")
+
+        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .fail)))))
+
         process(
             command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
@@ -631,6 +642,7 @@ extension Monitor: RUMMonitorViewProtocol {
         )
     }
 
+    // check other methods and DD debug or telemetry 
     func addViewLoadingTime(overwrite: Bool) {
         process(
             command: RUMAddViewLoadingTime(

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -472,10 +472,12 @@ extension Monitor: RUMMonitorProtocol {
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was started")
         process(
-            command: RUMStartStepVitalCommand(
+            command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
                 name: name,
                 operationKey: operationKey,
+                stepType: .start,
+                failureReason: nil,
                 time: dateProvider.now,
                 attributes: attributes
             )
@@ -486,10 +488,12 @@ extension Monitor: RUMMonitorProtocol {
     func succeedFeatureOperation(name: String, operationKey: String? = nil, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was successfully ended")
         process(
-            command: RUMEndSuccessfullyStepVitalCommand(
+            command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
                 name: name,
                 operationKey: operationKey,
+                stepType: .end,
+                failureReason: nil,
                 time: dateProvider.now,
                 attributes: attributes
             )
@@ -500,10 +504,11 @@ extension Monitor: RUMMonitorProtocol {
     func failFeatureOperation(name: String, operationKey: String? = nil, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was unsuccessfully ended with the following failure reason: \(reason.rawValue)")
         process(
-            command: RUMEndWithFailureStepVitalCommand(
+            command: RUMOperationStepVitalCommand(
                 vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
                 name: name,
                 operationKey: operationKey,
+                stepType: .end,
                 failureReason: reason,
                 time: dateProvider.now,
                 attributes: attributes

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -108,6 +108,7 @@ internal class Monitor: RUMCommandSubscriber {
     private var attributes: [AttributeKey: AttributeValue] = [:]
 
     private let fatalErrorContext: FatalErrorContextNotifying
+    private let rumUUIDGenerator: RUMUUIDGenerator
 
     init(
         dependencies: RUMScopeDependencies,
@@ -117,6 +118,7 @@ internal class Monitor: RUMCommandSubscriber {
         self.scopes = RUMApplicationScope(dependencies: dependencies)
         self.dateProvider = dateProvider
         self.fatalErrorContext = dependencies.fatalErrorContext
+        self.rumUUIDGenerator = dependencies.rumUUIDGenerator
     }
 
     func process(command: RUMCommand) {
@@ -462,6 +464,58 @@ extension Monitor: RUMMonitorProtocol {
                 value: value
             )
         )
+    }
+
+    // MARK: - Feature Operations
+
+    // swiftlint:disable function_default_parameter_at_end
+    func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+        DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was started")
+        process(
+            command: RUMStartStepVitalCommand(
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
+                operationKey: operationKey,
+                time: dateProvider.now,
+                attributes: attributes
+            )
+        )
+    }
+
+    // swiftlint:disable function_default_parameter_at_end
+    func succeedFeatureOperation(name: String, operationKey: String? = nil, attributes: [AttributeKey: AttributeValue]) {
+        DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was successfully ended")
+        process(
+            command: RUMEndSuccessfullyStepVitalCommand(
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
+                operationKey: operationKey,
+                time: dateProvider.now,
+                attributes: attributes
+            )
+        )
+    }
+
+    // swiftlint:disable function_default_parameter_at_end
+    func failFeatureOperation(name: String, operationKey: String? = nil, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
+        DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) was unsuccessfully ended with the following failure reason: \(reason.rawValue)")
+        process(
+            command: RUMEndWithFailureStepVitalCommand(
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
+                operationKey: operationKey,
+                failureReason: reason,
+                time: dateProvider.now,
+                attributes: attributes
+            )
+        )
+    }
+
+    private func instanceSuffix(_ operationKey: String?) -> String {
+        guard let operationKey = operationKey else {
+            return ""
+        }
+        return " (instance `\(operationKey)`)"
     }
 
     // MARK: - debugging

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -580,3 +580,60 @@ internal struct RUMUpdatePerformanceMetric: RUMCommand {
     var attributes: [AttributeKey: AttributeValue]
     let missedEventType: SessionEndedMetric.MissedEventType? = nil
 }
+
+// MARK: - Feature Operation Steps (Vital) commands
+/// Vital is the model used under the hood to track Feature Operations in RUM. Each step in a Feature Operation is sent as a Vital.
+internal protocol RUMFeatureOperationStepVitalCommand: RUMCommand {
+    /// The vital ID for this operation step
+    var vitalId: String { get }
+    /// The name of the feature operation (e.g., "login_flow")
+    var name: String { get }
+    /// The key of the operation for this operation step (when running several instances of the same operation)
+    var operationKey: String? { get }
+    /// The step type (start, end, retry, etc.)
+    var stepType: RUMVitalEvent.Vital.StepType { get }
+    /// The reason for failure, if applicable
+    var failureReason: RUMVitalEvent.Vital.FailureReason? { get }
+}
+
+internal struct RUMStartStepVitalCommand: RUMFeatureOperationStepVitalCommand {
+    let vitalId: String
+    let name: String
+    let operationKey: String?
+    let stepType: RUMVitalEvent.Vital.StepType = .start
+    let failureReason: RUMVitalEvent.Vital.FailureReason? = nil
+    var time: Date
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
+    var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false
+    let isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
+}
+
+internal struct RUMEndSuccessfullyStepVitalCommand: RUMFeatureOperationStepVitalCommand {
+    let vitalId: String
+    let name: String
+    let operationKey: String?
+    let stepType: RUMVitalEvent.Vital.StepType = .end
+    let failureReason: RUMVitalEvent.Vital.FailureReason? = nil
+    var time: Date
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
+    var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false
+    let isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
+}
+
+internal struct RUMEndWithFailureStepVitalCommand: RUMFeatureOperationStepVitalCommand {
+    let vitalId: String
+    let name: String
+    let operationKey: String?
+    let stepType: RUMVitalEvent.Vital.StepType = .end
+    let failureReason: RUMVitalEvent.Vital.FailureReason?
+    var time: Date
+    var globalAttributes: [AttributeKey: AttributeValue] = [:]
+    var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false
+    let isUserInteraction = false
+    let missedEventType: SessionEndedMetric.MissedEventType? = nil
+}

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -583,53 +583,18 @@ internal struct RUMUpdatePerformanceMetric: RUMCommand {
 
 // MARK: - Feature Operation Steps (Vital) commands
 /// Vital is the model used under the hood to track Feature Operations in RUM. Each step in a Feature Operation is sent as a Vital.
-internal protocol RUMFeatureOperationStepVitalCommand: RUMCommand {
+internal struct RUMOperationStepVitalCommand: RUMCommand {
     /// The vital ID for this operation step
-    var vitalId: String { get }
-    /// The name of the feature operation (e.g., "login_flow")
-    var name: String { get }
+    var vitalId: String
+    /// The name of the operation (e.g., `login_flow`)
+    var name: String
     /// The key of the operation for this operation step (when running several instances of the same operation)
-    var operationKey: String? { get }
+    var operationKey: String?
     /// The step type (start, end, retry, etc.)
-    var stepType: RUMVitalEvent.Vital.StepType { get }
+    var stepType: RUMVitalEvent.Vital.StepType
     /// The reason for failure, if applicable
-    var failureReason: RUMVitalEvent.Vital.FailureReason? { get }
-}
-
-internal struct RUMStartStepVitalCommand: RUMFeatureOperationStepVitalCommand {
-    let vitalId: String
-    let name: String
-    let operationKey: String?
-    let stepType: RUMVitalEvent.Vital.StepType = .start
-    let failureReason: RUMVitalEvent.Vital.FailureReason? = nil
-    var time: Date
-    var globalAttributes: [AttributeKey: AttributeValue] = [:]
-    var attributes: [AttributeKey: AttributeValue]
-    let canStartBackgroundView = false
-    let isUserInteraction = false
-    let missedEventType: SessionEndedMetric.MissedEventType? = nil
-}
-
-internal struct RUMEndSuccessfullyStepVitalCommand: RUMFeatureOperationStepVitalCommand {
-    let vitalId: String
-    let name: String
-    let operationKey: String?
-    let stepType: RUMVitalEvent.Vital.StepType = .end
-    let failureReason: RUMVitalEvent.Vital.FailureReason? = nil
-    var time: Date
-    var globalAttributes: [AttributeKey: AttributeValue] = [:]
-    var attributes: [AttributeKey: AttributeValue]
-    let canStartBackgroundView = false
-    let isUserInteraction = false
-    let missedEventType: SessionEndedMetric.MissedEventType? = nil
-}
-
-internal struct RUMEndWithFailureStepVitalCommand: RUMFeatureOperationStepVitalCommand {
-    let vitalId: String
-    let name: String
-    let operationKey: String?
-    let stepType: RUMVitalEvent.Vital.StepType = .end
-    let failureReason: RUMVitalEvent.Vital.FailureReason?
+    var failureReason: RUMVitalEvent.Vital.FailureReason?
+    // Common properties
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -215,7 +215,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             } else if let startViewCommand = command as? RUMStartViewCommand {
                 // Start view scope explicitly on receiving "start view" command
                 startView(on: startViewCommand, context: context)
-            } else if let operationStepVitalCommand = command as? RUMFeatureOperationStepVitalCommand {
+            } else if let operationStepVitalCommand = command as? RUMOperationStepVitalCommand {
                 sendFeatureOperationStepVitalEvent(on: operationStepVitalCommand, context: context, writer: writer)
             } else if !hasActiveView {
                 handleOffViewCommand(command: command, context: context)
@@ -386,14 +386,14 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
     // MARK: - Feature Operation Step Vital Event Processing
 
-    private func sendFeatureOperationStepVitalEvent(on command: RUMFeatureOperationStepVitalCommand, context: DatadogContext, writer: Writer) {
+    private func sendFeatureOperationStepVitalEvent(on command: RUMOperationStepVitalCommand, context: DatadogContext, writer: Writer) {
         let vital = RUMVitalEvent.Vital(
             vitalDescription: nil,
             duration: nil,
             failureReason: command.failureReason,
             id: command.vitalId,
             name: command.name,
-            operationKey: command.operationKey, // Maps to parentId in RUM model
+            operationKey: command.operationKey,
             stepType: command.stepType,
             type: .operationStep
         )

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -215,6 +215,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             } else if let startViewCommand = command as? RUMStartViewCommand {
                 // Start view scope explicitly on receiving "start view" command
                 startView(on: startViewCommand, context: context)
+            } else if let operationStepVitalCommand = command as? RUMFeatureOperationStepVitalCommand {
+                sendFeatureOperationStepVitalEvent(on: operationStepVitalCommand, context: context, writer: writer)
             } else if !hasActiveView {
                 handleOffViewCommand(command: command, context: context)
             }
@@ -380,5 +382,39 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private func hasExpired(currentTime: Date) -> Bool {
         let sessionDuration = currentTime.timeIntervalSince(sessionStartTime)
         return sessionDuration >= Constants.sessionMaxDuration
+    }
+
+    // MARK: - Feature Operation Step Vital Event Processing
+
+    private func sendFeatureOperationStepVitalEvent(on command: RUMFeatureOperationStepVitalCommand, context: DatadogContext, writer: Writer) {
+        let vital = RUMVitalEvent.Vital(
+            vitalDescription: nil,
+            duration: nil,
+            failureReason: command.failureReason,
+            id: command.vitalId,
+            name: command.name,
+            operationKey: command.operationKey, // Maps to parentId in RUM model
+            stepType: command.stepType,
+            type: .operationStep
+        )
+
+        let vitalEvent = RUMVitalEvent(
+            dd: .init(),
+            application: .init(id: parent.context.rumApplicationID),
+            context: .init(contextInfo: command.globalAttributes.merging(command.attributes) { $1 }),
+            date: command.time.timeIntervalSince1970.toInt64Milliseconds,
+            session: .init(
+                hasReplay: context.hasReplay,
+                id: self.context.sessionID.toRUMDataFormat,
+                type: dependencies.sessionType
+            ),
+            view: .init(
+                id: parent.context.activeViewID.orNull.toRUMDataFormat,
+                url: parent.context.activeViewPath ?? ""
+            ),
+            vital: vital
+        )
+
+        writer.write(value: vitalEvent)
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -309,7 +309,7 @@ extension RUMViewScope {
             updatePerformanceMetric(on: command)
 
         // Feature Operation commands
-        case let command as RUMOperationStepVitalCommand where isActiveView:
+        case _ as RUMOperationStepVitalCommand where isActiveView:
             needsViewUpdate = true
 
         default:

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -308,6 +308,10 @@ extension RUMViewScope {
         case let command as RUMUpdatePerformanceMetric where isActiveView:
             updatePerformanceMetric(on: command)
 
+        // Feature Operation commands
+        case let command as RUMFeatureOperationStepVitalCommand where isActiveView:
+            needsViewUpdate = true
+
         default:
             break
         }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -309,7 +309,7 @@ extension RUMViewScope {
             updatePerformanceMetric(on: command)
 
         // Feature Operation commands
-        case let command as RUMFeatureOperationStepVitalCommand where isActiveView:
+        case let command as RUMOperationStepVitalCommand where isActiveView:
             needsViewUpdate = true
 
         default:

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -305,7 +305,7 @@ public extension RUMMonitorProtocol {
 
     /// Starts a Feature Operation.
     /// - Parameters:
-    ///   - name: the name of the Feature Operation (e.g., "login_flow")
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this Operation
     func startFeatureOperation(
@@ -318,7 +318,7 @@ public extension RUMMonitorProtocol {
 
     /// Completes a Feature Operation successfully.
     /// - Parameters:
-    ///   - name: the name of the Feature Operation
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this Operation
     func succeedFeatureOperation(
@@ -331,7 +331,7 @@ public extension RUMMonitorProtocol {
 
     /// Fails a Feature Operation with a specific reason.
     /// - Parameters:
-    ///   - name: the name of the Feature Operation
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - reason: the reason for the failure
     ///   - attributes: custom attributes to attach to this Operation

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -300,6 +300,49 @@ public extension RUMMonitorProtocol {
     ) {
         stopAction(type: type, name: name, attributes: attributes)
     }
+
+    // MARK: - Feature Operations
+
+    /// Starts a Feature Operation.
+    /// - Parameters:
+    ///   - name: the name of the Feature Operation (e.g., "login_flow")
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this Operation
+    func startFeatureOperation(
+        name: String,
+        operationKey: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        startFeatureOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    /// Completes a Feature Operation successfully.
+    /// - Parameters:
+    ///   - name: the name of the Feature Operation
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this Operation
+    func succeedFeatureOperation(
+        name: String,
+        operationKey: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    /// Fails a Feature Operation with a specific reason.
+    /// - Parameters:
+    ///   - name: the name of the Feature Operation
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - reason: the reason for the failure
+    ///   - attributes: custom attributes to attach to this Operation
+    func failFeatureOperation(
+        name: String,
+        operationKey: String? = nil,
+        reason: RUMFeatureOperationFailureReason,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        failFeatureOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
+    }
 }
 
 // swiftlint:enable function_default_parameter_at_end

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -307,7 +307,7 @@ public extension RUMMonitorProtocol {
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
-    ///   - attributes: custom attributes to attach to this Operation
+    ///   - attributes: custom attributes to attach to this operation
     func startFeatureOperation(
         name: String,
         operationKey: String? = nil,
@@ -319,8 +319,8 @@ public extension RUMMonitorProtocol {
     /// Completes a Feature Operation successfully.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
-    ///   - attributes: custom attributes to attach to this Operation
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - attributes: custom attributes to attach to this operation
     func succeedFeatureOperation(
         name: String,
         operationKey: String? = nil,
@@ -329,12 +329,12 @@ public extension RUMMonitorProtocol {
         succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes)
     }
 
-    /// Fails a Feature Operation with a specific reason.
+    /// Fails a Feature Operation.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
     ///   - reason: the reason for the failure
-    ///   - attributes: custom attributes to attach to this Operation
+    ///   - attributes: custom attributes to attach to this operation
     func failFeatureOperation(
         name: String,
         operationKey: String? = nil,

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -287,7 +287,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
-    ///   - attributes: custom attributes to attach to this Feature
+    ///   - attributes: custom attributes to attach to this operation
     func startFeatureOperation(
         name: String,
         operationKey: String?,
@@ -297,20 +297,20 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     /// Completes a Feature successfully.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
-    ///   - attributes: custom attributes to attach to this completion
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - attributes: custom attributes to attach to this operation
     func succeedFeatureOperation(
         name: String,
         operationKey: String?,
         attributes: [AttributeKey: AttributeValue]
     )
 
-    /// Fails a Feature with a specific reason.
+    /// Fails a Feature Operation.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
     ///   - reason: the reason for the failure
-    ///   - attributes: custom attributes to attach to this failure
+    ///   - attributes: custom attributes to attach to this operation
     func failFeatureOperation(
         name: String,
         operationKey: String?,

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -285,7 +285,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
 
     /// Starts a Feature Operation
     /// - Parameters:
-    ///   - name: the name of the Feature (e.g., "login_flow")
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this Feature
     func startFeatureOperation(
@@ -296,7 +296,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
 
     /// Completes a Feature successfully.
     /// - Parameters:
-    ///   - name: the name of the Feature
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this completion
     func succeedFeatureOperation(
@@ -307,7 +307,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
 
     /// Fails a Feature with a specific reason.
     /// - Parameters:
-    ///   - name: the name of the Feature
+    ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - reason: the reason for the failure
     ///   - attributes: custom attributes to attach to this failure

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -15,6 +15,9 @@ import DatadogInternal
 /// The type of RUM resource.
 public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
 
+/// The type of RUM feature operation failure reason.
+public typealias RUMFeatureOperationFailureReason = RUMVitalEvent.Vital.FailureReason
+
 /// The type of a RUM action.
 public enum RUMActionType {
     case tap
@@ -278,6 +281,43 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
         value: Encodable
     )
 
+    // MARK: - features
+
+    /// Starts a Feature Operation
+    /// - Parameters:
+    ///   - name: the name of the Feature (e.g., "login_flow")
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this Feature
+    func startFeatureOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Completes a Feature successfully.
+    /// - Parameters:
+    ///   - name: the name of the Feature
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this completion
+    func succeedFeatureOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Fails a Feature with a specific reason.
+    /// - Parameters:
+    ///   - name: the name of the Feature
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - reason: the reason for the failure
+    ///   - attributes: custom attributes to attach to this failure
+    func failFeatureOperation(
+        name: String,
+        operationKey: String?,
+        reason: RUMFeatureOperationFailureReason,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
     // MARK: - debugging
 
     /// Debug utility to inspect the active RUM view. Use it only when debugging.
@@ -405,6 +445,9 @@ internal class NOPMonitor: RUMMonitorProtocol {
     func startAction(type: RUMActionType, name: String, attributes: [AttributeKey: AttributeValue]) { warn() }
     func stopAction(type: RUMActionType, name: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func addFeatureFlagEvaluation(name: String, value: Encodable) { warn() }
+    func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) { warn() }
     var debug: Bool {
         set { warn() }
         get {

--- a/DatadogRUM/Tests/RUMMonitor/FeatureOperationTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/FeatureOperationTests.swift
@@ -1,0 +1,219 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+@testable import TestUtilities
+
+class FeatureOperationTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+    private let dateProvider = DateProviderMock()
+    private let writer = FileWriterMock()
+    private let opName = "test_feature"
+    private let operationKey = "operation_123"
+    private let opAttributes: [AttributeKey: AttributeValue] = ["key": "value"]
+
+    private lazy var monitor = Monitor(
+        dependencies: .mockWith(featureScope: featureScope),
+        dateProvider: dateProvider
+    )
+
+    // MARK: - startFeatureOperation Tests
+
+    func testStartFeatureOperation_ProcessesStartCommand() {
+        // When
+        monitor.startFeatureOperation(name: opName)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertNil(vitalEvent?.vital.operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .start)
+        XCTAssertNil(vitalEvent?.vital.failureReason)
+    }
+
+    func testStartFeatureOperation_WithOperationKey_ProcessesStartCommand() {
+        // When
+        let operationKey: String? = .mockRandom()
+        monitor.startFeatureOperation(name: opName, operationKey: operationKey, attributes: opAttributes)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertEqual(vitalEvent?.vital.operationKey, operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .start)
+        XCTAssertNil(vitalEvent?.vital.failureReason)
+        XCTAssertEqual(vitalEvent?.context?.contextInfo["key"] as? String, "value")
+    }
+
+    func testStartFeatureOperation_GeneratesUniqueVitalId() {
+        // When
+        monitor.startFeatureOperation(name: opName, operationKey: nil, attributes: [:])
+        monitor.startFeatureOperation(name: opName, operationKey: nil, attributes: [:])
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 2)
+
+        let vitalEvent1 = vitalEvents[0]
+        let vitalEvent2 = vitalEvents[1]
+
+        XCTAssertNotNil(vitalEvent1.vital.id)
+        XCTAssertNotNil(vitalEvent2.vital.id)
+        XCTAssertNotEqual(vitalEvent1.vital.id, vitalEvent2.vital.id)
+    }
+
+    // MARK: - succeedFeatureOperation Tests
+
+    func testSucceedFeatureOperation_ProcessesEndCommand() {
+        // When
+        monitor.succeedFeatureOperation(name: opName)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertNil(vitalEvent?.vital.operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .end)
+        XCTAssertNil(vitalEvent?.vital.failureReason)
+    }
+
+    func testSucceedFeatureOperation_WithOperationKey_ProcessesEndCommand() {
+        // When
+        monitor.succeedFeatureOperation(name: opName, operationKey: operationKey, attributes: opAttributes)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertEqual(vitalEvent?.vital.operationKey, operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .end)
+        XCTAssertNil(vitalEvent?.vital.failureReason)
+        XCTAssertEqual(vitalEvent?.context?.contextInfo["key"] as? String, "value")
+    }
+
+    // MARK: - failFeatureOperation Tests
+
+    func testFailFeatureOperation_ProcessesFailureCommand() {
+        // Given
+        let reason: RUMFeatureOperationFailureReason = .mockRandom()
+
+        // When
+        monitor.failFeatureOperation(name: opName, reason: reason)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertNil(vitalEvent?.vital.operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .end)
+        XCTAssertEqual(vitalEvent?.vital.failureReason, reason)
+    }
+
+    func testFailFeatureOperation_WithOperationKey_ProcessesFailureCommand() {
+        // Given
+        let reason: RUMFeatureOperationFailureReason = .mockRandom()
+
+        // When
+        monitor.failFeatureOperation(name: opName, operationKey: operationKey, reason: reason, attributes: opAttributes)
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
+
+        let vitalEvent = vitalEvents.first
+        XCTAssertNotNil(vitalEvent)
+        XCTAssertEqual(vitalEvent?.vital.name, opName)
+        XCTAssertEqual(vitalEvent?.vital.operationKey, operationKey)
+        XCTAssertEqual(vitalEvent?.vital.type, .operationStep)
+        XCTAssertEqual(vitalEvent?.vital.stepType, .end)
+        XCTAssertEqual(vitalEvent?.vital.failureReason, reason)
+        XCTAssertEqual(vitalEvent?.context?.contextInfo["key"] as? String, "value")
+    }
+
+    // MARK: - Feature Operation Lifecycle Tests
+
+    func testFeatureOperationLifecycle_CompleteFlow() {
+        // Given
+        let opName: String = .mockRandom()
+        let operationKey: String? = .mockRandom()
+
+        // When - complete feature lifecycle
+        monitor.startFeatureOperation(name: opName, operationKey: operationKey, attributes: ["start": "value"])
+        monitor.succeedFeatureOperation(name: opName, operationKey: operationKey, attributes: ["success": "value"])
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 2)
+
+        let startEvent = vitalEvents[0]
+        let endEvent = vitalEvents[1]
+
+        XCTAssertEqual(startEvent.vital.name, opName)
+        XCTAssertEqual(endEvent.vital.name, opName)
+        XCTAssertEqual(startEvent.vital.operationKey, operationKey)
+        XCTAssertEqual(endEvent.vital.operationKey, operationKey)
+        XCTAssertEqual(startEvent.vital.type, .operationStep)
+        XCTAssertEqual(endEvent.vital.type, .operationStep)
+        XCTAssertEqual(startEvent.vital.stepType, .start)
+        XCTAssertEqual(endEvent.vital.stepType, .end)
+        XCTAssertEqual(startEvent.context?.contextInfo["start"] as? String, "value")
+        XCTAssertEqual(endEvent.context?.contextInfo["success"] as? String, "value")
+    }
+
+    func testFeatureOperationLifecycle_WithFailure() {
+        // Given
+        let opName: String = .mockRandom()
+        let operationKey: String? = .mockRandom()
+        let opFailureError: RUMFeatureOperationFailureReason = .mockRandom()
+
+        // When - feature lifecycle with failure
+        monitor.startFeatureOperation(name: opName, operationKey: operationKey, attributes: ["start": "value"])
+        monitor.failFeatureOperation(name: opName, operationKey: operationKey, reason: opFailureError, attributes: ["failure": "value"])
+
+        // Then
+        let vitalEvents = featureScope.eventsWritten(ofType: RUMVitalEvent.self)
+        XCTAssertEqual(vitalEvents.count, 2)
+
+        let startEvent = vitalEvents[0]
+        let failureEvent = vitalEvents[1]
+
+        XCTAssertEqual(startEvent.vital.name, opName)
+        XCTAssertEqual(failureEvent.vital.name, opName)
+        XCTAssertEqual(startEvent.vital.operationKey, operationKey)
+        XCTAssertEqual(failureEvent.vital.operationKey, operationKey)
+        XCTAssertEqual(startEvent.vital.type, .operationStep)
+        XCTAssertEqual(failureEvent.vital.type, .operationStep)
+        XCTAssertEqual(startEvent.vital.stepType, .start)
+        XCTAssertEqual(failureEvent.vital.stepType, .end)
+        XCTAssertEqual(failureEvent.vital.failureReason, opFailureError)
+        XCTAssertEqual(startEvent.context?.contextInfo["start"] as? String, "value")
+        XCTAssertEqual(failureEvent.context?.contextInfo["failure"] as? String, "value")
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
@@ -39,5 +39,8 @@ class RUMMonitorProtocol_ConvenienceTests: XCTestCase {
         monitor.addAction(type: .click, name: .mockAny())
         monitor.startAction(type: .click, name: .mockAny())
         monitor.stopAction(type: .click)
+        monitor.startFeatureOperation(name: .mockAny())
+        monitor.succeedFeatureOperation(name: .mockAny())
+        monitor.failFeatureOperation(name: .mockAny(), reason: .mockAny())
     }
 }

--- a/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
@@ -41,11 +41,15 @@ class NOPMonitorTests: XCTestCase {
         noop.startAction(type: .click, name: .mockAny())
         noop.stopAction(type: .click)
         noop.addFeatureFlagEvaluation(name: .mockAny(), value: String.mockAny())
+        noop.startFeatureOperation(name: .mockAny())
+        noop.succeedFeatureOperation(name: .mockAny())
+        noop.failFeatureOperation(name: .mockAny(), reason: .mockAny())
+
         noop.debug = .mockRandom()
         _ = noop.debug
 
         // Then
-        XCTAssertEqual(dd.logger.criticalLogs.count, 24)
+        XCTAssertEqual(dd.logger.criticalLogs.count, 27)
         let actualMessages = dd.logger.criticalLogs.map { $0.message }
         let expectedMessages = [
             "addAttribute(forKey:value:)",
@@ -70,6 +74,9 @@ class NOPMonitorTests: XCTestCase {
             "startAction(type:name:attributes:)",
             "stopAction(type:name:attributes:)",
             "addFeatureFlagEvaluation(name:value:)",
+            "startFeatureOperation(name:operationKey:attributes:)",
+            "succeedFeatureOperation(name:operationKey:attributes:)",
+            "failFeatureOperation(name:operationKey:reason:attributes:)",
             "debug",
             "debug",
         ].map { method in

--- a/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
@@ -59,7 +59,7 @@ extension ViewHitchesMock: AnyMockable, RandomMockable {
     }
 }
 
-extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable, @retroactive CaseIterable {
+extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable, CaseIterable {
     public static var allCases: [RUMFeatureOperationFailureReason]
         = [.error, .abandoned, .other]
 

--- a/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
@@ -59,8 +59,8 @@ extension ViewHitchesMock: AnyMockable, RandomMockable {
     }
 }
 
-extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable {
-    private static var allCases: [RUMFeatureOperationFailureReason]
+extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable, CaseIterable {
+    public static var allCases: [RUMFeatureOperationFailureReason]
         = [.error, .abandoned, .other]
 
     public static func mockAny() -> Self {

--- a/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
@@ -59,7 +59,7 @@ extension ViewHitchesMock: AnyMockable, RandomMockable {
     }
 }
 
-extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable, CaseIterable {
+extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable, @retroactive CaseIterable {
     public static var allCases: [RUMFeatureOperationFailureReason]
         = [.error, .abandoned, .other]
 

--- a/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
@@ -58,3 +58,16 @@ extension ViewHitchesMock: AnyMockable, RandomMockable {
         ViewHitchesMock(hitchesDataModel: (Array(repeating: (.mockAny(), .mockAny()), count: .mockAny()), .mockAny())) as! Self
     }
 }
+
+extension RUMFeatureOperationFailureReason: AnyMockable, RandomMockable {
+    private static var allCases: [RUMFeatureOperationFailureReason]
+        = [.error, .abandoned, .other]
+
+    public static func mockAny() -> Self {
+        return .error
+    }
+
+    public static func mockRandom() -> Self {
+        return RUMFeatureOperationFailureReason.allCases.randomElement()!
+    }
+}


### PR DESCRIPTION
- **RUM-11032 Add Feature Operations steps commands + public APIs**
- **RUM-11032 Refactor to use single command + add CaseIterable conforme to mock + edit doc**
- **RUM-11032 - Fix method signatures + remove lint exception**
- **RUM-11032 Remove retroactive attribute**
- **RUM-11232 Add ObjC APis**
- **RUM-11185 Add API Usage Telemetry**

### What and why?

A short description of what changes this PR introduces and why.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
