### PR TITLE
Change prompt from secrets to vars

### DIFF
--- a/.github/workflows/issue_notification.yml
+++ b/.github/workflows/issue_notification.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_TOKEN: ${{ secrets.OPENAI_TOKEN }}
-          OPENAI_SYSTEM_PROMPT: ${{ secrets.OPENAI_SYSTEM_PROMPT }}
+          OPENAI_SYSTEM_PROMPT: ${{ vars.OPENAI_SYSTEM_PROMPT }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
### What and why?

Workflow failed with the following error: `Error: OPENAI_SYSTEM_PROMPT environment variable must be set`.

### How?

Switch from an environment `secret` to a `variable`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
