### PR TITLE
Merge `release/3.0.0` to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 3.0.0 / 02-09-2025
+
+Release `3.0` introduces breaking changes. Follow the [Migration Guide](MIGRATION.md) to upgrade from `2.x` versions.
+
 - [FIX] Fix `DDLogEvent.accountInfo` property initialization in case of missing account info. See [#2442][]
 - [IMPROVEMENT] Update Session Replay batch maximum age to 5hrs. See[#2455][]
 - [IMPROVEMENT] Update the default tracing sampling rate to 100%. See [#2253][] 

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCore"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogCore/Sources/Versioning.swift
+++ b/DatadogCore/Sources/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "2.30.0"
+internal let __sdkVersion = "3.0.0"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCrashReporting"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogInternal"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog Internal Package. This module is not for public use."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogLogs"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog Logs Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogRUM"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog Real User Monitoring Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSessionReplay"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Official Datadog Session Replay SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogTrace"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog Trace Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogWebViewTracking"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog WebView Tracking Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TestUtilities"
-  s.version      = "2.30.0"
+  s.version      = "3.0.0"
   s.summary      = "Datadog Testing Utilities. This module is for internal testing and should not be published."
 
   s.homepage     = "https://www.datadoghq.com"


### PR DESCRIPTION
### What and why?

It merges `release/3.0.0` to `develop` and is the counterpart of: 
- #2458

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)