### PR TITLE
RUM-10654: Fix SwiftUI large title navigation bar in iOS 26 Session Replay recordings

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -36,10 +36,25 @@ internal struct UINavigationBarRecorder: NodeRecorder {
 
     private func inferOccupiedFrame(of navigationBar: UINavigationBar, in context: ViewTreeRecordingContext) -> CGRect {
         var occupiedFrame = navigationBar.frame
+        var largeTitleFrame: CGRect?
+
         for subview in navigationBar.subviews {
             let subviewFrame = subview.convert(subview.bounds, to: context.coordinateSpace)
+
+            if subview.isNavigationBarLargeTitleView {
+                largeTitleFrame = subviewFrame
+            }
+
             occupiedFrame = occupiedFrame.union(subviewFrame)
         }
+
+        if #available(iOS 26, *), navigationBar.isSwiftUINavigationBar, let largeTitleFrame {
+            // For SwiftUI navigation bars, exclude the large title view from `occupiedFrame`
+            // to prevent occluding the large title that's rendered as a sibling view
+            let height = max(0, min(largeTitleFrame.height, occupiedFrame.height))
+            occupiedFrame = occupiedFrame.inset(by: .init(top: 0, left: 0, bottom: height, right: 0))
+        }
+
         return occupiedFrame
     }
 
@@ -88,4 +103,26 @@ internal struct UINavigationBarWireframesBuilder: NodeWireframesBuilder {
         ]
     }
 }
+
+extension UIView {
+    private enum Constants {
+        static let UIKitNavigationBarClass: AnyClass? = NSClassFromString("SwiftUI.UIKitNavigationBar")
+        static let NavigationBarLargeTitleView: AnyClass? = NSClassFromString("UIKit.NavigationBarLargeTitleView")
+    }
+
+    fileprivate var isSwiftUINavigationBar: Bool {
+        guard let cls = Constants.UIKitNavigationBarClass else {
+            return false
+        }
+        return type(of: self).isSubclass(of: cls)
+    }
+
+    fileprivate var isNavigationBarLargeTitleView: Bool {
+        guard let cls = Constants.NavigationBarLargeTitleView else {
+            return false
+        }
+        return type(of: self).isSubclass(of: cls)
+    }
+}
+
 #endif


### PR DESCRIPTION
### What and why?

Fix SwiftUI navigation bar large title occlusion in iOS 26 Session Replay recordings.

In iOS 26, SwiftUI renders large navigation titles outside the navigation bar as sibling views. When Session Replay calculates the navigation bar's occupied frame by merging all subview frames, the resulting opaque background wireframe occludes the large title captured in the separate sibling view tree, making large titles invisible in recordings.

### How?

- Added detection for SwiftUI navigation bars
- Added detection for large title views
- Modified `inferOccupiedFrame()` in `UINavigationBarRecorder` to exclude large title view area from occupied frame calculation for SwiftUI navigation bars on iOS 26+