### PR TITLE
chore: Remove unused `objc_SessionReplayConfigurationPrivacyLevel`

### DIFF
--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -161,36 +161,6 @@ public final class objc_SessionReplayConfiguration: NSObject {
     }
 }
 
-/// Available privacy levels for content masking.
-@objc(DDSessionReplayConfigurationPrivacyLevel)
-@_spi(objc)
-public enum objc_SessionReplayConfigurationPrivacyLevel: Int {
-    /// Record all content.
-    case allow
-
-    /// Mask all content.
-    case mask
-
-    /// Mask input elements, but record all other content.
-    case maskUserInput
-
-    internal var _swift: SessionReplayPrivacyLevel {
-        switch self {
-        case .allow: return .allow
-        case .mask: return .mask
-        case .maskUserInput: return .maskUserInput
-        }
-    }
-
-    internal init(_ swift: SessionReplayPrivacyLevel) {
-        switch swift {
-        case .allow: self = .allow
-        case .mask: self = .mask
-        case .maskUserInput: self = .maskUserInput
-        }
-    }
-}
-
 /// Available privacy levels for text and input masking.
 @objc(DDTextAndInputPrivacyLevel)
 @_spi(objc)

--- a/DatadogSessionReplay/Tests/DDSessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/DDSessionReplayTests.swift
@@ -121,16 +121,6 @@ class DDSessionReplayTests: XCTestCase {
         XCTAssertEqual(config._swift.startRecordingImmediately, startRecordingImmediately)
     }
 
-    func testPrivacyLevelsInterop() {
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel.allow._swift, .allow)
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel.mask._swift, .mask)
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel.maskUserInput._swift, .maskUserInput)
-
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel(.allow), .allow)
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel(.mask), .mask)
-        XCTAssertEqual(objc_SessionReplayConfigurationPrivacyLevel(.maskUserInput), .maskUserInput)
-    }
-
     func testTextAndInputPrivacyLevelsInterop() {
         XCTAssertEqual(objc_TextAndInputPrivacyLevel.maskAll._swift, .maskAll)
         XCTAssertEqual(objc_TextAndInputPrivacyLevel.maskAllInputs._swift, .maskAllInputs)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -2345,6 +2345,8 @@ public class objc_RUMMonitor: NSObject
     public func removeAttributes(forKeys keys: [String])
     public func addFeatureFlagEvaluation(name: String, value: Any)
     public var debug: Bool
+[?] extension objc_RUMMonitor
+    public func _internal_sync_addError(_ error: Error,source: objc_RUMErrorSource,attributes: [String: Any])
 
 
 # ----------------------------------
@@ -2381,10 +2383,6 @@ public final class objc_SessionReplayConfiguration: NSObject
     @objc public var featureFlags: [String: Bool]
     public required init(replaySampleRate: Float,textAndInputPrivacyLevel: objc_TextAndInputPrivacyLevel,imagePrivacyLevel: objc_ImagePrivacyLevel,touchPrivacyLevel: objc_TouchPrivacyLevel,featureFlags: [String: Bool]?)
     public convenience init(replaySampleRate: Float,textAndInputPrivacyLevel: objc_TextAndInputPrivacyLevel,imagePrivacyLevel: objc_ImagePrivacyLevel,touchPrivacyLevel: objc_TouchPrivacyLevel)
-public enum objc_SessionReplayConfigurationPrivacyLevel: Int
-    case allow
-    case mask
-    case maskUserInput
 public enum objc_TextAndInputPrivacyLevel: Int
     case maskSensitiveInputs
     case maskAllInputs

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -511,6 +511,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject
     func stopAction(type: RUMActionType,name: String?,attributes: [AttributeKey: AttributeValue])
     func addFeatureFlagEvaluation(name: String,value: Encodable)
     var debug: Bool
+    func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue],completionHandler: @escaping CompletionHandler)
 public protocol RUMMonitorViewProtocol: AnyObject
     func addViewAttribute(forKey key: AttributeKey, value: AttributeValue)
     func addViewAttributes(_ attributes: [AttributeKey: AttributeValue])


### PR DESCRIPTION
### What and why?

This PR removes the unused `objc_SessionReplayConfigurationPrivacyLevel`. 
It was the Objective-C counterpart of `SessionReplayPrivacyLevel`, which is used for fine-grained masking conversions between the Browser SDK and the `DatadogWebViewTracking`. Since only one structure is required for this purpose, the Objective-C version is no longer needed. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
