### PR TITLE
Add missing `versionMajor` property to the `DDLogEventOperatingSystem` definition in Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Add missing `versionMajor` property to the `DDLogEventOperatingSystem` definition in Objective-C. See [#2463][]
+
 # 3.0.0 / 02-09-2025
 
 Release `3.0` introduces breaking changes. Follow the [Migration Guide](MIGRATION.md) to upgrade from `2.x` versions.
@@ -953,6 +955,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2405]: https://github.com/DataDog/dd-sdk-ios/pull/2405
 [#2442]: https://github.com/DataDog/dd-sdk-ios/pull/2442
 [#2455]: https://github.com/DataDog/dd-sdk-ios/pull/2455
+[#2463]: https://github.com/DataDog/dd-sdk-ios/pull/2463
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogLogs/Sources/LogsDataModels+objc.swift
+++ b/DatadogLogs/Sources/LogsDataModels+objc.swift
@@ -329,6 +329,10 @@ public class objc_LogEventOperatingSystem: NSObject {
     public var build: String? {
         root.swiftModel.os.build
     }
+
+    public var versionMajor: String {
+        root.swiftModel.os.versionMajor
+    }
 }
 
 @objc(DDLogEventDd)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -127,6 +127,8 @@ public final class objc_Logger: NSObject
     public func add(tag: String)
     public func remove(tag: String)
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
+[?] extension objc_Logger
+    public func _internal_sync_critical(message: String,error: Error?,attributes: [String: Any])
 public class objc_LogEvent: NSObject
     public var date: Date
     public var status: objc_LogEventStatus
@@ -187,6 +189,7 @@ public class objc_LogEventOperatingSystem: NSObject
     public var name: String
     public var version: String
     public var build: String?
+    public var versionMajor: String
 public class objc_LogEventDd: NSObject
     public var device: objc_LogEventDevice
 public class objc_LogEventDevice: NSObject

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -132,6 +132,7 @@ public struct Logger
     public static func create(with configuration: Configuration = .init(),in core: DatadogCoreProtocol = CoreRegistry.default) -> LoggerProtocol
 public protocol InternalLoggerProtocol
     func log(level: LogLevel,message: String,errorKind: String?,errorMessage: String?,stackTrace: String?,attributes: [String: Encodable]?)
+    func critical(message: String,error: Error?,attributes: [String: Encodable]?,completionHandler: @escaping CompletionHandler)
 [?] extension LoggerProtocol
     public var _internal: InternalLoggerProtocol
 public enum LogLevel: Int, Codable


### PR DESCRIPTION
### What and why?

This PR adds a missing property which exists in the Swift model, but not in Objective-C.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
