### PR TITLE
Feature Operations - set `canStartBackgroundView` to `true`

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -720,7 +720,7 @@ internal struct RUMOperationStepVitalCommand: RUMCommand {
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue] = [:]
     var attributes: [AttributeKey: AttributeValue]
-    let canStartBackgroundView = false
+    let canStartBackgroundView = true
     let isUserInteraction = false
     let missedEventType: SessionEndedMetric.MissedEventType? = nil
     let canStartApplicationLaunchView = true

--- a/DatadogRUM/Sources/RUMMonitor/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMFeatureOperationManager.swift
@@ -96,14 +96,29 @@ internal class RUMFeatureOperationManager {
 
         let vitalEvent = RUMVitalEvent(
             dd: .init(),
+            account: .init(context: context),
             application: .init(id: parent.context.rumApplicationID),
+            buildId: context.buildId,
+            buildVersion: context.buildNumber,
+            ciTest: dependencies.ciTest,
+            connectivity: .init(context: context),
+            container: nil,
             context: .init(contextInfo: mergedAttributes),
             date: command.time.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.toInt64Milliseconds,
+            ddtags: context.ddTags,
+            device: context.normalizedDevice(),
+            display: nil,
+            os: context.os,
+            service: context.service,
             session: .init(
                 hasReplay: context.hasReplay,
                 id: parent.context.sessionID.toRUMDataFormat,
                 type: dependencies.sessionType
             ),
+            source: .init(rawValue: context.source) ?? .ios,
+            synthetics: dependencies.syntheticsTest,
+            usr: .init(context: context),
+            version: context.version,
             view: .init(
                 id: (activeView?.viewUUID).orNull.toRUMDataFormat,
                 url: activeView?.viewPath ?? ""


### PR DESCRIPTION
### What and why?

A Feature Operation can start a background view, for example after a user taps a push notification. This PR fixes this by setting `canStartBackgroundView` to `true` in `RUMCommand`.

Some properties were also missing from the `RUMVitalEvent`, including the synthetics test ID, which prevented to filter out events happening during s8s tests in dashboards.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
