### PR TITLE
FFL-1015 feat: Simplify `FlagsClient.Configuration`

### DIFF
--- a/DatadogFlags/Sources/FlagsClient.swift
+++ b/DatadogFlags/Sources/FlagsClient.swift
@@ -8,19 +8,19 @@ import Foundation
 import DatadogInternal
 
 public class FlagsClient {
-    private let configuration: FlagsClientConfiguration
+    private let configuration: FlagsClient.Configuration
     private let httpClient: FlagsHttpClient
     private let store: FlagsStore
     private let featureScope: FeatureScope
 
-    internal init(configuration: FlagsClientConfiguration, httpClient: FlagsHttpClient, store: FlagsStore, featureScope: FeatureScope) {
+    internal init(configuration: FlagsClient.Configuration, httpClient: FlagsHttpClient, store: FlagsStore, featureScope: FeatureScope) {
         self.configuration = configuration
         self.httpClient = httpClient
         self.store = store
         self.featureScope = featureScope
     }
 
-    public static func create(with configuration: FlagsClientConfiguration, in core: DatadogCoreProtocol = CoreRegistry.default) -> FlagsClient {
+    public static func create(with configuration: FlagsClient.Configuration, in core: DatadogCoreProtocol = CoreRegistry.default) -> FlagsClient {
         do {
             // To ensure the correct registration order between Core and Features,
             // the entire initialization flow is synchronized on the main thread.
@@ -33,7 +33,7 @@ public class FlagsClient {
         }
     }
 
-    internal static func createOrThrow(with configuration: FlagsClientConfiguration, in core: DatadogCoreProtocol) throws -> FlagsClient {
+    internal static func createOrThrow(with configuration: FlagsClient.Configuration, in core: DatadogCoreProtocol) throws -> FlagsClient {
         guard core.get(feature: FlagsFeature.self) != nil else {
             throw ProgrammerError(
                 description: "`FlagsClient.create()` produces a non-functional client because the `Flags` feature was not enabled."

--- a/DatadogFlags/Sources/FlagsConfiguration.swift
+++ b/DatadogFlags/Sources/FlagsConfiguration.swift
@@ -7,18 +7,20 @@
 import Foundation
 import DatadogInternal
 
-public struct FlagsClientConfiguration {
-    public let baseURL: String?
-    public let customHeaders: [String: String]
-    public let flaggingProxy: String?
+extension FlagsClient {
+    public struct Configuration {
+        public let baseURL: String?
+        public let customHeaders: [String: String]
+        public let flaggingProxy: String?
 
-    public init(
-        baseURL: String? = nil,
-        customHeaders: [String: String] = [:],
-        flaggingProxy: String? = nil
-    ) {
-        self.baseURL = baseURL
-        self.customHeaders = customHeaders
-        self.flaggingProxy = flaggingProxy
+        public init(
+            baseURL: String? = nil,
+            customHeaders: [String: String] = [:],
+            flaggingProxy: String? = nil
+        ) {
+            self.baseURL = baseURL
+            self.customHeaders = customHeaders
+            self.flaggingProxy = flaggingProxy
+        }
     }
 }

--- a/DatadogFlags/Sources/FlagsConfiguration.swift
+++ b/DatadogFlags/Sources/FlagsConfiguration.swift
@@ -8,27 +8,16 @@ import Foundation
 import DatadogInternal
 
 public struct FlagsClientConfiguration {
-    public let clientToken: String
-    public let environment: String
     public let baseURL: String?
-    public let site: DatadogSite
-    public let applicationId: String?
     public let customHeaders: [String: String]
     public let flaggingProxy: String?
+
     public init(
-        clientToken: String,
-        environment: String = "prod",
         baseURL: String? = nil,
-        site: DatadogSite = .us1,
-        applicationId: String? = nil,
         customHeaders: [String: String] = [:],
         flaggingProxy: String? = nil
     ) {
-        self.clientToken = clientToken
-        self.environment = environment
         self.baseURL = baseURL
-        self.site = site
-        self.applicationId = applicationId
         self.customHeaders = customHeaders
         self.flaggingProxy = flaggingProxy
     }

--- a/DatadogFlags/Sources/FlagsHttpClient.swift
+++ b/DatadogFlags/Sources/FlagsHttpClient.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 internal protocol FlagsHttpClient {
     func postPrecomputeAssignments(
         context: FlagsEvaluationContext,
-        configuration: FlagsClientConfiguration,
+        configuration: FlagsClient.Configuration,
         sdkContext: DatadogContext,
         completion: @escaping (Result<(Data, URLResponse), Error>) -> Void
     )
@@ -29,7 +29,7 @@ internal class NetworkFlagsHttpClient: FlagsHttpClient {
 
     func postPrecomputeAssignments(
         context: FlagsEvaluationContext,
-        configuration: FlagsClientConfiguration,
+        configuration: FlagsClient.Configuration,
         sdkContext: DatadogContext,
         completion: @escaping (Result<(Data, URLResponse), Error>) -> Void
     ) {

--- a/DatadogFlags/Tests/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/FlagsClientTests.swift
@@ -14,7 +14,7 @@ final class FlagsClientTests: XCTestCase {
         let core = FeatureRegistrationCoreMock()
         Flags.enable(in: core)
 
-        let config = FlagsClientConfiguration()
+        let config = FlagsClient.Configuration()
         let client = FlagsClient.create(with: config, in: core)
 
         XCTAssertNotNil(client) // TODO: FFL-1016 Assert that it is not a NOPFlagsClient
@@ -25,7 +25,7 @@ final class FlagsClientTests: XCTestCase {
 
         let mockHttpClient = MockFlagsHttpClient()
         let mockStore = MockFlagsStore()
-        let config = FlagsClientConfiguration()
+        let config = FlagsClient.Configuration()
         let client = FlagsClient(
             configuration: config,
             httpClient: mockHttpClient,
@@ -66,7 +66,7 @@ final class FlagsClientTests: XCTestCase {
     func testContextAttributeSerialization() {
         let expectation = expectation(description: "Context serialization test")
 
-        let config = FlagsClientConfiguration()
+        let config = FlagsClient.Configuration()
         let client = FlagsClient(
             configuration: config,
             httpClient: AttributeSerializationTestClient(),
@@ -105,7 +105,7 @@ final class FlagsClientTests: XCTestCase {
 private class MockFlagsHttpClient: FlagsHttpClient {
     func postPrecomputeAssignments(
         context: FlagsEvaluationContext,
-        configuration: FlagsClientConfiguration,
+        configuration: FlagsClient.Configuration,
         sdkContext: DatadogContext,
         completion: @escaping (Result<(Data, URLResponse), Error>) -> Void
     ) {
@@ -151,7 +151,7 @@ private class MockFlagsStore: FlagsStore {
 private class AttributeSerializationTestClient: FlagsHttpClient {
     func postPrecomputeAssignments(
         context: FlagsEvaluationContext,
-        configuration: FlagsClientConfiguration,
+        configuration: FlagsClient.Configuration,
         sdkContext: DatadogContext,
         completion: @escaping (Result<(Data, URLResponse), Error>) -> Void
     ) {

--- a/DatadogFlags/Tests/FlagsConfigurationTests.swift
+++ b/DatadogFlags/Tests/FlagsConfigurationTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class FlagsConfigurationTests: XCTestCase {
     func testFlagsClientConfiguration() {
-        let config = FlagsClientConfiguration(
+        let config = FlagsClient.Configuration(
             baseURL: "https://custom.example.com"
         )
 
@@ -18,7 +18,7 @@ final class FlagsConfigurationTests: XCTestCase {
     }
 
     func testFlagsClientConfigurationDefaults() {
-        let config = FlagsClientConfiguration()
+        let config = FlagsClient.Configuration()
 
         XCTAssertNil(config.baseURL)
         XCTAssertTrue(config.customHeaders.isEmpty)
@@ -27,7 +27,7 @@ final class FlagsConfigurationTests: XCTestCase {
 
     func testFlagsClientConfigurationWithAllParameters() {
         let customHeaders = ["X-Custom": "value", "X-Test": "test"]
-        let config = FlagsClientConfiguration(
+        let config = FlagsClient.Configuration(
             baseURL: "https://custom.example.com",
             customHeaders: customHeaders,
             flaggingProxy: "proxy.example.com"

--- a/DatadogFlags/Tests/FlagsConfigurationTests.swift
+++ b/DatadogFlags/Tests/FlagsConfigurationTests.swift
@@ -11,24 +11,16 @@ import XCTest
 final class FlagsConfigurationTests: XCTestCase {
     func testFlagsClientConfiguration() {
         let config = FlagsClientConfiguration(
-            clientToken: "test-token",
-            environment: "staging",
             baseURL: "https://custom.example.com"
         )
 
-        XCTAssertEqual(config.clientToken, "test-token")
-        XCTAssertEqual(config.environment, "staging")
         XCTAssertEqual(config.baseURL, "https://custom.example.com")
     }
 
     func testFlagsClientConfigurationDefaults() {
-        let config = FlagsClientConfiguration(clientToken: "test-token")
+        let config = FlagsClientConfiguration()
 
-        XCTAssertEqual(config.clientToken, "test-token")
-        XCTAssertEqual(config.environment, "prod")
         XCTAssertNil(config.baseURL)
-        XCTAssertEqual(config.site, .us1)
-        XCTAssertNil(config.applicationId)
         XCTAssertTrue(config.customHeaders.isEmpty)
         XCTAssertNil(config.flaggingProxy)
     }
@@ -36,20 +28,12 @@ final class FlagsConfigurationTests: XCTestCase {
     func testFlagsClientConfigurationWithAllParameters() {
         let customHeaders = ["X-Custom": "value", "X-Test": "test"]
         let config = FlagsClientConfiguration(
-            clientToken: "test-token",
-            environment: "staging",
             baseURL: "https://custom.example.com",
-            site: .eu1,
-            applicationId: "app-123",
             customHeaders: customHeaders,
             flaggingProxy: "proxy.example.com"
         )
 
-        XCTAssertEqual(config.clientToken, "test-token")
-        XCTAssertEqual(config.environment, "staging")
         XCTAssertEqual(config.baseURL, "https://custom.example.com")
-        XCTAssertEqual(config.site, .eu1)
-        XCTAssertEqual(config.applicationId, "app-123")
         XCTAssertEqual(config.customHeaders, customHeaders)
         XCTAssertEqual(config.flaggingProxy, "proxy.example.com")
     }


### PR DESCRIPTION
### What and why?

📦 This PR simplifies `FlagsClient` configuration by sourcing properties directly from the SDK core.

### How?

- Removed `clientToken`, `site`, `env`, and `applicationId` from `FlagsClientConfiguration` - these values are now read from `DatadogContext`.  
- Renamed `FlagsClientConfiguration` to `FlagsClient.Configuration` to match conventions used in other modules (e.g. `Logger.Configuration`, `RUM.Configuration`).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
