### PR TITLE
FFL-1022: Send feature flag exposure events to intake

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -466,6 +466,8 @@
 		5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */; };
 		5BB294B02E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
 		5BB294B12E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
+		5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BC2E82E66200CAA44B /* FlagValue.swift */; };
+		5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BC2E82E66200CAA44B /* FlagValue.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */; };
 		5BE0EA2D2E66EFA300216E1C /* Path+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */; };
@@ -2593,6 +2595,7 @@
 		5BA8C3212E785B6F00B1DA80 /* DatadogFlagsTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogFlagsTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
 		5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureRequestBuilderTests.swift; sourceTree = "<group>"; };
+		5BB294BC2E82E66200CAA44B /* FlagValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagValue.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilder.swift; sourceTree = "<group>"; };
 		5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SessionReplay.swift"; sourceTree = "<group>"; };
@@ -4257,8 +4260,8 @@
 			isa = PBXGroup;
 			children = (
 				5BB294AE2E82CC9100CAA44B /* Feature */,
-				8DADC3DD2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift */,
 				8DADC3D12E7CCF670060F558 /* Resources */,
+				8DADC3DD2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift */,
 				8DADC3C02E7CCF190060F558 /* FlagsClientTests.swift */,
 				8DADC3C12E7CCF190060F558 /* FlagsClientConfigurationTests.swift */,
 				8DADC3C22E7CCF190060F558 /* FlagsEndpointBuilderTests.swift */,
@@ -4272,6 +4275,7 @@
 		5BB294AA2E82864300CAA44B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5BB294BC2E82E66200CAA44B /* FlagValue.swift */,
 				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 			);
 			path = Models;
@@ -8702,6 +8706,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DADC3BA2E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
+				5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3BC2E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
 				8DADC3BD2E7CCF0D0060F558 /* FlagsStore.swift in Sources */,
@@ -8720,6 +8725,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DADC3B42E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
+				5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3B62E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
 				8DADC3B72E7CCF0D0060F558 /* FlagsStore.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -461,6 +461,10 @@
 		5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
 		5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
 		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
+		5B4F552C2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
+		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
+		5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
+		5B4F55302E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
 		5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E42E41FD5C005485E6 /* Drawing.swift */; };
@@ -2601,6 +2605,8 @@
 		5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignmentsResponse.swift; sourceTree = "<group>"; };
 		5B16A3722E8434140046A863 /* ExposureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureMocks.swift; sourceTree = "<group>"; };
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
+		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
+		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
 		5B9CB9E42E41FD5C005485E6 /* Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drawing.swift; sourceTree = "<group>"; };
@@ -4314,6 +4320,8 @@
 		5BB294AE2E82CC9100CAA44B /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */,
+				5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */,
 				5B16A3722E8434140046A863 /* ExposureMocks.swift */,
 				5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */,
 			);
@@ -8787,6 +8795,8 @@
 				5BB294B12E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */,
 				8DADC3C42E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DF2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
+				5B4F552C2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */,
+				5B4F55302E853D7700A241C3 /* FlagsClientMocks.swift in Sources */,
 				8DADC3C52E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
 				5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3C62E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
@@ -8803,6 +8813,8 @@
 				5BB294B02E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */,
 				8DADC3C82E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DE2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
+				5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */,
+				5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
 				5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3CA2E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -462,6 +462,8 @@
 		5BA8C3352E785E3400B1DA80 /* TestUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D257958B298ABB83008A1BE5 /* TestUtilities.framework */; };
 		5BA8C33A2E785FD500B1DA80 /* Flags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA8C30F2E785A2000B1DA80 /* Flags.swift */; };
 		5BA8C33B2E785FE100B1DA80 /* FlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA8C3122E785A5E00B1DA80 /* FlagsTests.swift */; };
+		5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */; };
+		5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */; };
 		5BE0EA2D2E66EFA300216E1C /* Path+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */; };
@@ -2587,6 +2589,7 @@
 		5BA8C3122E785A5E00B1DA80 /* FlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsTests.swift; sourceTree = "<group>"; };
 		5BA8C3192E785B6F00B1DA80 /* DatadogFlags.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogFlags.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BA8C3212E785B6F00B1DA80 /* DatadogFlagsTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogFlagsTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilder.swift; sourceTree = "<group>"; };
 		5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SessionReplay.swift"; sourceTree = "<group>"; };
@@ -4232,6 +4235,7 @@
 		5BA8C30E2E7859EC00B1DA80 /* DatadogFlags */ = {
 			isa = PBXGroup;
 			children = (
+				5BB294AA2E82864300CAA44B /* Models */,
 				8DADC3E02E7E4B4A0060F558 /* FlagsHTTPClient.swift */,
 				614964462E7D7B0D00D9EFFF /* Feature */,
 				8DADC3D72E7D24740060F558 /* PrecomputeAssignmentsRequest.swift */,
@@ -4259,6 +4263,14 @@
 			);
 			name = DatadogFlagsTests;
 			path = ../DatadogFlags/Tests;
+			sourceTree = "<group>";
+		};
+		5BB294AA2E82864300CAA44B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
@@ -8678,6 +8690,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DADC3BA2E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
+				5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3BC2E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
 				8DADC3BD2E7CCF0D0060F558 /* FlagsStore.swift in Sources */,
 				8DADC3BE2E7CCF0D0060F558 /* FlagsEndpointBuilder.swift in Sources */,
@@ -8695,6 +8708,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DADC3B42E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
+				5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3B62E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
 				8DADC3B72E7CCF0D0060F558 /* FlagsStore.swift in Sources */,
 				8DADC3B82E7CCF0D0060F558 /* FlagsEndpointBuilder.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -465,6 +465,8 @@
 		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
 		5B4F55302E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
+		5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
+		5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
 		5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E42E41FD5C005485E6 /* Drawing.swift */; };
@@ -2607,6 +2609,7 @@
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
 		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
+		5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagDetails.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
 		5B9CB9E42E41FD5C005485E6 /* Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drawing.swift; sourceTree = "<group>"; };
@@ -4308,11 +4311,12 @@
 		5BB294AA2E82864300CAA44B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5B16A3652E83E3BF0046A863 /* AnyValue.swift */,
+				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 				5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */,
 				5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */,
-				5B16A3652E83E3BF0046A863 /* AnyValue.swift */,
+				5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */,
 				5BB294BC2E82E66200CAA44B /* FlagValue.swift */,
-				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -8745,6 +8749,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3BA2E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
@@ -8768,6 +8773,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3B42E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -458,6 +458,8 @@
 		5B16A36E2E83E5210046A863 /* FlagAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */; };
 		5B16A3702E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */; };
 		5B16A3712E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */; };
+		5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
+		5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
 		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
@@ -2597,6 +2599,7 @@
 		5B16A3692E83E46F0046A863 /* AnyValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyValueTests.swift; sourceTree = "<group>"; };
 		5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignment.swift; sourceTree = "<group>"; };
 		5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignmentsResponse.swift; sourceTree = "<group>"; };
+		5B16A3722E8434140046A863 /* ExposureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureMocks.swift; sourceTree = "<group>"; };
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
@@ -4311,6 +4314,7 @@
 		5BB294AE2E82CC9100CAA44B /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				5B16A3722E8434140046A863 /* ExposureMocks.swift */,
 				5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */,
 			);
 			path = Feature;
@@ -8784,6 +8788,7 @@
 				8DADC3C42E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DF2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C52E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
+				5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3C62E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
 				5B16A36A2E83E46F0046A863 /* AnyValueTests.swift in Sources */,
 				8DADC3C72E7CCF190060F558 /* FlagsTypesTests.swift in Sources */,
@@ -8799,6 +8804,7 @@
 				8DADC3C82E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DE2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
+				5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3CA2E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
 				5B16A36B2E83E46F0046A863 /* AnyValueTests.swift in Sources */,
 				8DADC3CB2E7CCF190060F558 /* FlagsTypesTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -450,6 +450,14 @@
 		49D8C0BE2AC5F2BC0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
 		5B0A9B8B2E3BB98E00A8131C /* GraphicsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */; };
 		5B0A9B8D2E3BBB4500A8131C /* GraphicsFilter+Reflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */; };
+		5B16A3662E83E3BF0046A863 /* AnyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3652E83E3BF0046A863 /* AnyValue.swift */; };
+		5B16A3672E83E3BF0046A863 /* AnyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3652E83E3BF0046A863 /* AnyValue.swift */; };
+		5B16A36A2E83E46F0046A863 /* AnyValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3692E83E46F0046A863 /* AnyValueTests.swift */; };
+		5B16A36B2E83E46F0046A863 /* AnyValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3692E83E46F0046A863 /* AnyValueTests.swift */; };
+		5B16A36D2E83E5210046A863 /* FlagAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */; };
+		5B16A36E2E83E5210046A863 /* FlagAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */; };
+		5B16A3702E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */; };
+		5B16A3712E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */; };
 		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
@@ -468,6 +476,8 @@
 		5BB294B12E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
 		5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BC2E82E66200CAA44B /* FlagValue.swift */; };
 		5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BC2E82E66200CAA44B /* FlagValue.swift */; };
+		5BB294C02E83E02900CAA44B /* ExposureLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */; };
+		5BB294C12E83E02900CAA44B /* ExposureLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */; };
 		5BE0EA2D2E66EFA300216E1C /* Path+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */; };
@@ -2583,6 +2593,10 @@
 		49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logs+Internal.swift"; sourceTree = "<group>"; };
 		5B0A9B8A2E3BB98500A8131C /* GraphicsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicsFilter.swift; sourceTree = "<group>"; };
 		5B0A9B8C2E3BBB3D00A8131C /* GraphicsFilter+Reflection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphicsFilter+Reflection.swift"; sourceTree = "<group>"; };
+		5B16A3652E83E3BF0046A863 /* AnyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyValue.swift; sourceTree = "<group>"; };
+		5B16A3692E83E46F0046A863 /* AnyValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyValueTests.swift; sourceTree = "<group>"; };
+		5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignment.swift; sourceTree = "<group>"; };
+		5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignmentsResponse.swift; sourceTree = "<group>"; };
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
@@ -2596,6 +2610,7 @@
 		5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
 		5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureRequestBuilderTests.swift; sourceTree = "<group>"; };
 		5BB294BC2E82E66200CAA44B /* FlagValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagValue.swift; sourceTree = "<group>"; };
+		5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLogger.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilder.swift; sourceTree = "<group>"; };
 		5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SessionReplay.swift"; sourceTree = "<group>"; };
@@ -4230,6 +4245,14 @@
 			path = WatchdogTerminations;
 			sourceTree = "<group>";
 		};
+		5B16A3682E83E40E0046A863 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5B16A3692E83E46F0046A863 /* AnyValueTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		5B3AF8A82E4B3A7F009E5375 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -4260,6 +4283,7 @@
 			isa = PBXGroup;
 			children = (
 				5BB294AE2E82CC9100CAA44B /* Feature */,
+				5B16A3682E83E40E0046A863 /* Models */,
 				8DADC3D12E7CCF670060F558 /* Resources */,
 				8DADC3DD2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift */,
 				8DADC3C02E7CCF190060F558 /* FlagsClientTests.swift */,
@@ -4275,6 +4299,9 @@
 		5BB294AA2E82864300CAA44B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */,
+				5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */,
+				5B16A3652E83E3BF0046A863 /* AnyValue.swift */,
 				5BB294BC2E82E66200CAA44B /* FlagValue.swift */,
 				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 			);
@@ -5396,6 +5423,7 @@
 		614964462E7D7B0D00D9EFFF /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */,
 				614964442E7D7B0D00D9EFFF /* ExposureRequestBuilder.swift */,
 				614964452E7D7B0D00D9EFFF /* FlagsFeature.swift */,
 			);
@@ -8709,14 +8737,18 @@
 				5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3BC2E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
+				5B16A36E2E83E5210046A863 /* FlagAssignment.swift in Sources */,
 				8DADC3BD2E7CCF0D0060F558 /* FlagsStore.swift in Sources */,
 				8DADC3BE2E7CCF0D0060F558 /* FlagsEndpointBuilder.swift in Sources */,
 				614964492E7D7B0D00D9EFFF /* ExposureRequestBuilder.swift in Sources */,
 				6149644A2E7D7B0D00D9EFFF /* FlagsFeature.swift in Sources */,
+				5B16A3662E83E3BF0046A863 /* AnyValue.swift in Sources */,
 				8DADC3BF2E7CCF0D0060F558 /* FlagsClient.swift in Sources */,
 				5BA8C3102E785A2000B1DA80 /* Flags.swift in Sources */,
 				8DADC3E12E7E4B4A0060F558 /* FlagsHTTPClient.swift in Sources */,
+				5B16A3702E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */,
 				8DADC3D92E7D24740060F558 /* PrecomputeAssignmentsRequest.swift in Sources */,
+				5BB294C02E83E02900CAA44B /* ExposureLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8728,14 +8760,18 @@
 				5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
 				8DADC3B62E7CCF0D0060F558 /* FlagsTypes.swift in Sources */,
+				5B16A36D2E83E5210046A863 /* FlagAssignment.swift in Sources */,
 				8DADC3B72E7CCF0D0060F558 /* FlagsStore.swift in Sources */,
 				8DADC3B82E7CCF0D0060F558 /* FlagsEndpointBuilder.swift in Sources */,
 				614964472E7D7B0D00D9EFFF /* ExposureRequestBuilder.swift in Sources */,
 				614964482E7D7B0D00D9EFFF /* FlagsFeature.swift in Sources */,
+				5B16A3672E83E3BF0046A863 /* AnyValue.swift in Sources */,
 				8DADC3B92E7CCF0D0060F558 /* FlagsClient.swift in Sources */,
 				5BA8C33A2E785FD500B1DA80 /* Flags.swift in Sources */,
 				8DADC3E22E7E4B4A0060F558 /* FlagsHTTPClient.swift in Sources */,
+				5B16A3712E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */,
 				8DADC3D82E7D24740060F558 /* PrecomputeAssignmentsRequest.swift in Sources */,
+				5BB294C12E83E02900CAA44B /* ExposureLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8749,6 +8785,7 @@
 				8DADC3DF2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C52E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
 				8DADC3C62E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
+				5B16A36A2E83E46F0046A863 /* AnyValueTests.swift in Sources */,
 				8DADC3C72E7CCF190060F558 /* FlagsTypesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8763,6 +8800,7 @@
 				8DADC3DE2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
 				8DADC3CA2E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
+				5B16A36B2E83E46F0046A863 /* AnyValueTests.swift in Sources */,
 				8DADC3CB2E7CCF190060F558 /* FlagsTypesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -464,6 +464,8 @@
 		5BA8C33B2E785FE100B1DA80 /* FlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA8C3122E785A5E00B1DA80 /* FlagsTests.swift */; };
 		5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */; };
 		5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */; };
+		5BB294B02E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
+		5BB294B12E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */; };
 		5BE0EA2D2E66EFA300216E1C /* Path+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */; };
@@ -2590,6 +2592,7 @@
 		5BA8C3192E785B6F00B1DA80 /* DatadogFlags.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogFlags.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BA8C3212E785B6F00B1DA80 /* DatadogFlagsTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogFlagsTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEvent.swift; sourceTree = "<group>"; };
+		5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureRequestBuilderTests.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BE0EA2A2E66E8A200216E1C /* ShapeResourceBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilder.swift; sourceTree = "<group>"; };
 		5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SessionReplay.swift"; sourceTree = "<group>"; };
@@ -4235,9 +4238,9 @@
 		5BA8C30E2E7859EC00B1DA80 /* DatadogFlags */ = {
 			isa = PBXGroup;
 			children = (
+				614964462E7D7B0D00D9EFFF /* Feature */,
 				5BB294AA2E82864300CAA44B /* Models */,
 				8DADC3E02E7E4B4A0060F558 /* FlagsHTTPClient.swift */,
-				614964462E7D7B0D00D9EFFF /* Feature */,
 				8DADC3D72E7D24740060F558 /* PrecomputeAssignmentsRequest.swift */,
 				8DADC3AE2E7CCF0D0060F558 /* FlagsClient.swift */,
 				8DADC3AF2E7CCF0D0060F558 /* FlagsClientConfiguration.swift */,
@@ -4253,6 +4256,7 @@
 		5BA8C3112E785A2D00B1DA80 /* DatadogFlagsTests */ = {
 			isa = PBXGroup;
 			children = (
+				5BB294AE2E82CC9100CAA44B /* Feature */,
 				8DADC3DD2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift */,
 				8DADC3D12E7CCF670060F558 /* Resources */,
 				8DADC3C02E7CCF190060F558 /* FlagsClientTests.swift */,
@@ -4271,6 +4275,14 @@
 				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		5BB294AE2E82CC9100CAA44B /* Feature */ = {
+			isa = PBXGroup;
+			children = (
+				5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */,
+			);
+			path = Feature;
 			sourceTree = "<group>";
 		};
 		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
@@ -8726,6 +8738,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BA8C33B2E785FE100B1DA80 /* FlagsTests.swift in Sources */,
+				5BB294B12E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */,
 				8DADC3C42E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DF2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C52E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
@@ -8739,6 +8752,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BF228702E795DF800D79E8A /* FlagsTests.swift in Sources */,
+				5BB294B02E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */,
 				8DADC3C82E7CCF190060F558 /* FlagsClientConfigurationTests.swift in Sources */,
 				8DADC3DE2E7D250E0060F558 /* PrecomputeAssignmentsRequestTests.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,

--- a/DatadogFlags/Sources/Feature/ExposureLogger.swift
+++ b/DatadogFlags/Sources/Feature/ExposureLogger.swift
@@ -7,11 +7,65 @@
 import Foundation
 import DatadogInternal
 
-internal final class ExposureLogger {
+internal protocol ExposureLogging {
+    func logExposure(at date: Date, for flagKey: String, flagAssignment: FlagAssignment)
+}
+
+internal final class ExposureLogger: ExposureLogging {
     private struct Exposure: Hashable {
         let targetingKey: String
         let flagKey: String
         let allocationKey: String
         let variationKey: String
+    }
+
+    private let flagsEvaluationContext: FlagsEvaluationContext
+    private let featureScope: FeatureScope
+
+    private var loggedExposures: Set<Exposure> = []
+
+    init(
+        flagsEvaluationContext: FlagsEvaluationContext,
+        featureScope: FeatureScope
+    ) {
+        self.featureScope = featureScope
+        self.flagsEvaluationContext = flagsEvaluationContext
+    }
+
+    func logExposure(at date: Date, for flagKey: String, flagAssignment: FlagAssignment) {
+        guard flagAssignment.doLog else {
+            return
+        }
+
+        featureScope.eventWriteContext { [weak self] _, writer in
+            guard let self else {
+                return
+            }
+
+            let exposure = Exposure(
+                targetingKey: flagsEvaluationContext.targetingKey,
+                flagKey: flagKey,
+                allocationKey: flagAssignment.allocationKey,
+                variationKey: flagAssignment.variationKey
+            )
+
+            guard !loggedExposures.contains(exposure) else {
+                return
+            }
+            loggedExposures.insert(exposure)
+
+            let exposureEvent = ExposureEvent(
+                timestamp: date.timeIntervalSince1970.toInt64Milliseconds,
+                allocation: .init(key: flagAssignment.allocationKey),
+                flag: .init(key: flagKey),
+                variant: .init(key: flagAssignment.variationKey),
+                subject: .init(
+                    id: flagsEvaluationContext.targetingKey,
+                    attributes: flagsEvaluationContext.attributes
+                )
+            )
+
+            writer.write(value: exposureEvent)
+        }
     }
 }

--- a/DatadogFlags/Sources/Feature/ExposureLogger.swift
+++ b/DatadogFlags/Sources/Feature/ExposureLogger.swift
@@ -41,7 +41,7 @@ internal final class ExposureLogger: ExposureLogging {
             return
         }
 
-        featureScope.eventWriteContext { [weak self] _, writer in
+        featureScope.eventWriteContext { [weak self] ddContext, writer in
             guard let self else {
                 return
             }
@@ -58,8 +58,9 @@ internal final class ExposureLogger: ExposureLogging {
             }
             loggedExposures.insert(exposure)
 
+            let adjustedDate = date.addingTimeInterval(ddContext.serverTimeOffset)
             let exposureEvent = ExposureEvent(
-                timestamp: date.timeIntervalSince1970.toInt64Milliseconds,
+                timestamp: adjustedDate.timeIntervalSince1970.toInt64Milliseconds,
                 allocation: .init(key: assignment.allocationKey),
                 flag: .init(key: flagKey),
                 variant: .init(key: assignment.variationKey),

--- a/DatadogFlags/Sources/Feature/ExposureLogger.swift
+++ b/DatadogFlags/Sources/Feature/ExposureLogger.swift
@@ -5,11 +5,13 @@
  */
 
 import Foundation
+import DatadogInternal
 
-public protocol FlagValue {}
-
-extension Bool: FlagValue {}
-extension String: FlagValue {}
-extension Int: FlagValue {}
-extension Double: FlagValue {}
-extension AnyValue: FlagValue {}
+internal final class ExposureLogger {
+    private struct Exposure: Hashable {
+        let targetingKey: String
+        let flagKey: String
+        let allocationKey: String
+        let variationKey: String
+    }
+}

--- a/DatadogFlags/Sources/Feature/ExposureRequestBuilder.swift
+++ b/DatadogFlags/Sources/Feature/ExposureRequestBuilder.swift
@@ -21,18 +21,25 @@ internal struct ExposureRequestBuilder: FeatureRequestBuilder {
         let builder = URLRequestBuilder(
             url: url(with: context),
             queryItems: [
-                // TODO: FFL-1022 Send Exposure event data to /api/v2/exposures
+                .ddsource(source: context.source)
             ],
             headers: [
-                // TODO: FFL-1022 Send Exposure event data to /api/v2/exposures
+                .contentTypeHeader(contentType: .applicationJSON),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device,
+                    os: context.os
+                ),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.ciAppOrigin ?? context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader()
             ],
             telemetry: telemetry
         )
 
-        return builder.uploadRequest(
-            with: exposureEventData,
-            compress: true // TODO: FFL-1022 If /api/v2/exposures supports compression
-        )
+        return builder.uploadRequest(with: exposureEventData, compress: false)
     }
 
     private func url(with context: DatadogContext) -> URL {

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -24,8 +24,6 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             telemetry: featureScope.telemetry
         )
         messageReceiver = NOPFeatureMessageReceiver()
-        performanceOverride = PerformancePresetOverride(
-            maxObjectsInFile: 1 // to send only one Exposure event per request
-        )
+        performanceOverride = PerformancePresetOverride(maxObjectsInFile: 50)
     }
 }

--- a/DatadogFlags/Sources/FlagsClient.swift
+++ b/DatadogFlags/Sources/FlagsClient.swift
@@ -88,49 +88,40 @@ public class FlagsClient {
         }
     }
 
+    @inlinable
     public func getBooleanValue(key: String, defaultValue: Bool) -> Bool {
-        let flags = store.getFlags()
-        if let flagData = flags[key] as? [String: Any],
-           let value = flagData["variationValue"] as? Bool {
-            return value
-        }
-        return defaultValue
+        getValue(key: key, defaultValue: defaultValue)
     }
 
+    @inlinable
     public func getStringValue(key: String, defaultValue: String) -> String {
-        let flags = store.getFlags()
-        if let flagData = flags[key] as? [String: Any],
-           let value = flagData["variationValue"] as? String {
-            return value
-        }
-        return defaultValue
+        getValue(key: key, defaultValue: defaultValue)
     }
 
+    @inlinable
     public func getIntegerValue(key: String, defaultValue: Int64) -> Int64 {
-        let flags = store.getFlags()
-        if let flagData = flags[key] as? [String: Any],
-           let value = flagData["variationValue"] as? NSNumber {
-            return value.int64Value
-        }
-        return defaultValue
+        getValue(key: key, defaultValue: defaultValue)
     }
 
+    @inlinable
     public func getDoubleValue(key: String, defaultValue: Double) -> Double {
-        let flags = store.getFlags()
-        if let flagData = flags[key] as? [String: Any],
-           let value = flagData["variationValue"] as? NSNumber {
-            return value.doubleValue
-        }
-        return defaultValue
+        getValue(key: key, defaultValue: defaultValue)
     }
 
     // TODO: FFL-1047 Replace [String: Any] with OpenFeature.Value-compatible type
+    @inlinable
     public func getObjectValue(key: String, defaultValue: [String: Any]) -> [String: Any] {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+
+    public func getValue<T: FlagValue>(key: String, defaultValue: T) -> T {
         let flags = store.getFlags()
-        if let flagData = flags[key] as? [String: Any],
-           let value = flagData["variationValue"] as? [String: Any] {
-            return value
+        guard
+            let flagData = flags[key] as? [String: Any],
+            let value = flagData["variationValue"] as? T
+        else {
+            return defaultValue
         }
-        return defaultValue
+        return value
     }
 }

--- a/DatadogFlags/Sources/FlagsClient.swift
+++ b/DatadogFlags/Sources/FlagsClient.swift
@@ -78,7 +78,7 @@ public class FlagsClient {
                 configuration: configuration,
                 sdkContext: sdkContext
             ) { [weak self] result in
-                guard let self = self else {
+                guard let self else {
                     completion(.failure(.clientNotInitialized))
                     return
                 }
@@ -95,7 +95,7 @@ public class FlagsClient {
 
                     do {
                         let response = try JSONDecoder().decode(FlagAssignmentsResponse.self, from: data)
-                        self.store.setFlags(response.flags)
+                        self.store.setFlagAssignments(response.flags, for: context, date: dateProvider.now)
                         completion(.success(()))
                     } catch {
                         completion(.failure(.invalidResponse))
@@ -145,7 +145,7 @@ public class FlagsClient {
         }
         let value = flagAssignment.variation(as: T.self) ?? defaultValue
 
-        if let context = store.getFlagsMetadata()?.context {
+        if let context = store.context {
             exposureLogger.logExposure(
                 at: dateProvider.now,
                 for: key,

--- a/DatadogFlags/Sources/FlagsStore.swift
+++ b/DatadogFlags/Sources/FlagsStore.swift
@@ -8,7 +8,12 @@ import Foundation
 
 // TODO: FFL-1048 Use the Core SDK’s DataStore instead
 internal class FlagsStore {
-    private var cachedFlags: [String: Any] = [:]
+    private struct State: Codable {
+        let flags: [String: FlagAssignment]
+        let metadata: FlagsMetadata?
+    }
+
+    private var cachedFlags: [String: FlagAssignment] = [:]
     private var flagsMetadata: FlagsMetadata?
     private let syncQueue = DispatchQueue(label: "com.datadoghq.flags.store", attributes: .concurrent)
     private let cacheFileURL: URL?
@@ -40,15 +45,13 @@ internal class FlagsStore {
         return cacheDirectoryURL.appendingPathComponent("flags-cache.json", isDirectory: false)
     }
 
-    func getFlags() -> [String: Any] {
-        return syncQueue.sync { self.cachedFlags }
+    func flagAssignment(for key: String) -> FlagAssignment? {
+        syncQueue.sync {
+            self.cachedFlags[key]
+        }
     }
 
-    func setFlags(_ flags: [String: Any]) {
-        setFlags(flags, context: nil)
-    }
-
-    func setFlags(_ flags: [String: Any], context: FlagsEvaluationContext?) {
+    func setFlags(_ flags: [String: FlagAssignment], context: FlagsEvaluationContext? = nil) {
         let timestamp = Date().timeIntervalSince1970 * 1_000 // JavaScript-style timestamp in milliseconds
 
         syncQueue.sync(flags: .barrier) {
@@ -75,26 +78,9 @@ internal class FlagsStore {
                 return
             }
             do {
-                var cacheData: [String: Any] = [
-                    "flags": self.cachedFlags
-                ]
+                let state = State(flags: self.cachedFlags, metadata: self.flagsMetadata)
+                let data = try JSONEncoder().encode(state)
 
-                if let metadata = self.flagsMetadata {
-                    var metadataDict: [String: Any] = [
-                        "fetchedAt": metadata.fetchedAt
-                    ]
-
-                    if let context = metadata.context {
-                        metadataDict["context"] = [
-                            "targetingKey": context.targetingKey,
-                            "attributes": context.attributes
-                        ]
-                    }
-
-                    cacheData["metadata"] = metadataDict
-                }
-
-                let data = try JSONSerialization.data(withJSONObject: cacheData, options: [])
                 try data.write(to: cacheFileURL, options: .atomic)
             } catch {
                 print("Error saving flags to disk: \(error)")
@@ -109,34 +95,10 @@ internal class FlagsStore {
 
         do {
             let data = try Data(contentsOf: cacheFileURL)
-            if let cacheData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                // Load flags
-                if let flags = cacheData["flags"] as? [String: Any] {
-                    self.cachedFlags = flags
-                }
+            let state = try JSONDecoder().decode(State.self, from: data)
 
-                // Load metadata if available
-                if let metadataDict = cacheData["metadata"] as? [String: Any],
-                   let fetchedAt = metadataDict["fetchedAt"] as? Double {
-                    var context: FlagsEvaluationContext?
-                    if let contextDict = metadataDict["context"] as? [String: Any],
-                       let targetingKey = contextDict["targetingKey"] as? String,
-                       let attributesAny = contextDict["attributes"] as? [String: Any] {
-                        // Convert [String: Any] to [String: String] for type safety
-                        let attributes: [String: String] = attributesAny.compactMapValues { value in
-                            return value as? String ?? String(describing: value)
-                        }
-                        context = FlagsEvaluationContext(targetingKey: targetingKey, attributes: attributes)
-                    }
-
-                    self.flagsMetadata = FlagsMetadata(fetchedAt: fetchedAt, context: context)
-                }
-            } else {
-                // Handle legacy cache format (just flags without metadata)
-                if let flags = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    self.cachedFlags = flags
-                }
-            }
+            self.cachedFlags = state.flags
+            self.flagsMetadata = state.metadata
         } catch {
             print("No flags found on disk or error decoding: \(error)")
         }

--- a/DatadogFlags/Sources/FlagsTypes.swift
+++ b/DatadogFlags/Sources/FlagsTypes.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class FlagsEvaluationContext {
+public class FlagsEvaluationContext: Codable {
     public let targetingKey: String
     public let attributes: [String: String]
     public init(targetingKey: String, attributes: [String: String] = [:]) {
@@ -23,7 +23,7 @@ public enum FlagsError: Error {
     case unsupportedSite(String)
 }
 
-internal struct FlagsMetadata {
+internal struct FlagsMetadata: Codable {
     let fetchedAt: Double // Timestamp in milliseconds (JavaScript-style)
     let context: FlagsEvaluationContext?
 }

--- a/DatadogFlags/Sources/FlagsTypes.swift
+++ b/DatadogFlags/Sources/FlagsTypes.swift
@@ -22,8 +22,3 @@ public enum FlagsError: Error {
     case invalidConfiguration
     case unsupportedSite(String)
 }
-
-internal struct FlagsMetadata: Codable {
-    let fetchedAt: Double // Timestamp in milliseconds (JavaScript-style)
-    let context: FlagsEvaluationContext?
-}

--- a/DatadogFlags/Sources/FlagsTypes.swift
+++ b/DatadogFlags/Sources/FlagsTypes.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class FlagsEvaluationContext: Codable {
+public struct FlagsEvaluationContext: Equatable, Codable {
     public let targetingKey: String
     public let attributes: [String: String]
     public init(targetingKey: String, attributes: [String: String] = [:]) {

--- a/DatadogFlags/Sources/Models/AnyValue.swift
+++ b/DatadogFlags/Sources/Models/AnyValue.swift
@@ -16,13 +16,6 @@ public enum AnyValue: Equatable {
     case null
 }
 
-extension AnyValue {
-    public func `as`<T>(_ type: T.Type, using decoder: JSONDecoder = .init()) throws -> T where T: Decodable {
-        let data = try JSONEncoder().encode(self)
-        return try decoder.decode(T.self, from: data)
-    }
-}
-
 extension AnyValue: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/DatadogFlags/Sources/Models/AnyValue.swift
+++ b/DatadogFlags/Sources/Models/AnyValue.swift
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public enum AnyValue: Equatable {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case dictionary([String: AnyValue])
+    case array([AnyValue])
+    case null
+}
+
+extension AnyValue {
+    public func `as`<T>(_ type: T.Type, using decoder: JSONDecoder = .init()) throws -> T where T: Decodable {
+        let data = try JSONEncoder().encode(self)
+        return try decoder.decode(T.self, from: data)
+    }
+}
+
+extension AnyValue: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode([String: AnyValue].self) {
+            self = .dictionary(value)
+        } else if let value = try? container.decode([AnyValue].self) {
+            self = .array(value)
+        } else if container.decodeNil() {
+            self = .null
+        } else {
+            let context = DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Cannot decode AnyValue"
+            )
+            throw DecodingError.typeMismatch(AnyValue.self, context)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case let .string(value):
+            try container.encode(value)
+        case let .int(value):
+            try container.encode(value)
+        case let .double(value):
+            try container.encode(value)
+        case let .bool(value):
+            try container.encode(value)
+        case let .dictionary(value):
+            try container.encode(value)
+        case let .array(value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -16,7 +16,7 @@ internal struct ExposureEvent: Codable {
         let attributes: [String: String]
     }
 
-    let timestamp: Int
+    let timestamp: Int64
     let allocation: Identifier
     let flag: Identifier
     let variant: Identifier

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct ExposureEvent: Codable {
+    struct Identifier: Codable {
+        let key: String
+    }
+
+    struct Subject: Codable {
+        let id: String
+        let attributes: [String: String]
+    }
+
+    let timestamp: Int64
+    let allocation: Identifier
+    let flag: Identifier
+    let variant: Identifier
+    let subject: Subject
+}

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -6,12 +6,12 @@
 
 import Foundation
 
-internal struct ExposureEvent: Codable {
-    struct Identifier: Codable {
+internal struct ExposureEvent: Equatable, Codable {
+    struct Identifier: Equatable, Codable {
         let key: String
     }
 
-    struct Subject: Codable {
+    struct Subject: Equatable, Codable {
         let id: String
         let attributes: [String: String]
     }

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -16,7 +16,7 @@ internal struct ExposureEvent: Codable {
         let attributes: [String: String]
     }
 
-    let timestamp: Int64
+    let timestamp: Int
     let allocation: Identifier
     let flag: Identifier
     let variant: Identifier

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct FlagAssignment: Equatable {
+    enum Variation: Equatable {
+        case boolean(Bool)
+        case string(String)
+        case integer(Int)
+        case double(Double)
+        case object(AnyValue)
+    }
+
+    let allocationKey: String
+    let variationKey: String
+    let variation: Variation
+    let doLog: Bool
+
+    func variation<T: FlagValue>(as type: T.Type) -> T? {
+        switch self.variation {
+        case .boolean(let value):
+            return value as? T
+        case .string(let value):
+            return value as? T
+        case .integer(let value):
+            return value as? T
+        case .double(let value):
+            return value as? T
+        case .object(let value):
+            return value as? T
+        }
+    }
+}
+
+extension FlagAssignment: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case allocationKey
+        case variationKey
+        case variationType
+        case variationValue
+        case doLog
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.allocationKey = try container.decode(String.self, forKey: .allocationKey)
+        self.variationKey = try container.decode(String.self, forKey: .variationKey)
+        self.doLog = try container.decode(Bool.self, forKey: .doLog)
+
+        let variationType = try container.decode(String.self, forKey: .variationType)
+
+        switch variationType {
+        case "BOOLEAN":
+            self.variation = try .boolean(container.decode(Bool.self, forKey: .variationValue))
+        case "STRING":
+            self.variation = try .string(container.decode(String.self, forKey: .variationValue))
+        case "NUMBER":
+            // Check integer first, then double
+            if let number = try? container.decode(Int.self, forKey: .variationValue) {
+                self.variation = .integer(number)
+            } else {
+                self.variation = try .double(container.decode(Double.self, forKey: .variationValue))
+            }
+        case "OBJECT", "JSON":
+            self.variation = try .object(container.decode(AnyValue.self, forKey: .variationValue))
+        default:
+            let context = DecodingError.Context(
+                codingPath: container.codingPath + [CodingKeys.variationType],
+                debugDescription: "Unrecognized variation type \(variationType)"
+            )
+            throw DecodingError.typeMismatch(FlagAssignment.self, context)
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(allocationKey, forKey: .allocationKey)
+        try container.encode(variationKey, forKey: .variationKey)
+        try container.encode(doLog, forKey: .doLog)
+
+        switch variation {
+        case .boolean(let value):
+            try container.encode("BOOLEAN", forKey: .variationType)
+            try container.encode(value, forKey: .variationValue)
+        case .string(let value):
+            try container.encode("STRING", forKey: .variationType)
+            try container.encode(value, forKey: .variationValue)
+        case .double(let value):
+            try container.encode("NUMBER", forKey: .variationType)
+            try container.encode(value, forKey: .variationValue)
+        case .integer(let value):
+            try container.encode("NUMBER", forKey: .variationType)
+            try container.encode(value, forKey: .variationValue)
+        case .object(let value):
+            try container.encode("JSON", forKey: .variationType)
+            try container.encode(value, forKey: .variationValue)
+        }
+    }
+}

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -18,6 +18,7 @@ internal struct FlagAssignment: Equatable {
     var allocationKey: String
     var variationKey: String
     var variation: Variation
+    var reason: String
     var doLog: Bool
 
     func variation<T: FlagValue>(as type: T.Type) -> T? {
@@ -42,6 +43,7 @@ extension FlagAssignment: Codable {
         case variationKey
         case variationType
         case variationValue
+        case reason
         case doLog
     }
 
@@ -50,6 +52,7 @@ extension FlagAssignment: Codable {
 
         self.allocationKey = try container.decode(String.self, forKey: .allocationKey)
         self.variationKey = try container.decode(String.self, forKey: .variationKey)
+        self.reason = try container.decode(String.self, forKey: .reason)
         self.doLog = try container.decode(Bool.self, forKey: .doLog)
 
         let variationType = try container.decode(String.self, forKey: .variationType)
@@ -82,6 +85,7 @@ extension FlagAssignment: Codable {
 
         try container.encode(allocationKey, forKey: .allocationKey)
         try container.encode(variationKey, forKey: .variationKey)
+        try container.encode(reason, forKey: .reason)
         try container.encode(doLog, forKey: .doLog)
 
         switch variation {

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -15,10 +15,10 @@ internal struct FlagAssignment: Equatable {
         case object(AnyValue)
     }
 
-    let allocationKey: String
-    let variationKey: String
-    let variation: Variation
-    let doLog: Bool
+    var allocationKey: String
+    var variationKey: String
+    var variation: Variation
+    var doLog: Bool
 
     func variation<T: FlagValue>(as type: T.Type) -> T? {
         switch self.variation {

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -66,7 +66,7 @@ extension FlagAssignment: Codable {
             } else {
                 self.variation = try .double(container.decode(Double.self, forKey: .variationValue))
             }
-        case "OBJECT", "JSON":
+        case "JSON":
             self.variation = try .object(container.decode(AnyValue.self, forKey: .variationValue))
         default:
             let context = DecodingError.Context(

--- a/DatadogFlags/Sources/Models/FlagAssignmentsResponse.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignmentsResponse.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct FlagAssignmentsResponse: Equatable {
+    let flags: [String: FlagAssignment]
+}
+
+extension FlagAssignmentsResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case data
+        case attributes
+        case flags
+    }
+
+    init(from decoder: any Decoder) throws {
+        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
+        let dataContainer = try rootContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .data)
+        let attributesContainer = try dataContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .attributes)
+
+        self.flags = try attributesContainer.decode([String: FlagAssignment].self, forKey: .flags)
+    }
+}

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public enum FlagEvaluationError: Error {
+    case flagNotFound
+    case typeMismatch
+}
+
+public struct FlagDetails<T>: Equatable where T: Equatable {
+    public var key: String
+    public var value: T
+    public var variant: String?
+    public var reason: String?
+    public var error: FlagEvaluationError?
+
+    public init(
+        key: String,
+        value: T,
+        variant: String? = nil,
+        reason: String? = nil,
+        error: FlagEvaluationError? = nil
+    ) {
+        self.key = key
+        self.value = value
+        self.variant = variant
+        self.reason = reason
+        self.error = error
+    }
+}

--- a/DatadogFlags/Sources/Models/FlagValue.swift
+++ b/DatadogFlags/Sources/Models/FlagValue.swift
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol FlagValue {}
+
+extension Bool: FlagValue {}
+extension String: FlagValue {}
+extension Int64: FlagValue {}
+extension Double: FlagValue {}
+
+// TODO: FFL-1047 Replace [String: Any] with OpenFeature.Value-compatible type
+extension Dictionary: FlagValue where Key == String, Value == Any {}

--- a/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
+++ b/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
@@ -25,6 +25,7 @@ final class ExposureLoggerTests: XCTestCase {
                 allocationKey: "allocation-123",
                 variationKey: "variation-123",
                 variation: .mockAnyBoolean(),
+                reason: .mockAny(),
                 doLog: true
             ),
             context: .mockAny()

--- a/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
+++ b/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogFlags
+
+final class ExposureLoggerTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+
+    func testLogExposure() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: "some-flag",
+            assignment: .init(
+                allocationKey: "allocation-123",
+                variationKey: "variation-123",
+                variation: .mockAnyBoolean(),
+                doLog: true
+            ),
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(
+            featureScope.exposureEventsWritten,
+            [
+                .init(
+                    timestamp: Date.mockAny().timeIntervalSince1970.toInt64Milliseconds,
+                    allocation: .init(key: "allocation-123"),
+                    flag: .init(key: "some-flag"),
+                    variant: .init(key: "variation-123"),
+                    subject: .init(id: .mockAny(), attributes: .mockAny())
+                )
+            ]
+        )
+    }
+
+    func testLogExposureLoggingDisabled() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(doLog: false),
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertTrue(featureScope.eventsWritten.isEmpty)
+    }
+
+    func testLogExposureDeduplication() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(),
+            context: .mockAny()
+        )
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(),
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(featureScope.eventsWritten.count, 1)
+    }
+
+    func testLogExposureDifferentVariation() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+        let assignment1 = FlagAssignment.mockAnyBoolean()
+        var assignment2 = assignment1
+        assignment2.variationKey = "other-variation"
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: assignment1,
+            context: .mockAny()
+        )
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: assignment2,
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "Same flag with different variation should be not deduplicated")
+    }
+
+    func testLogExposureDifferentAllocation() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+        let assignment1 = FlagAssignment.mockAnyBoolean()
+        var assignment2 = assignment1
+        assignment2.allocationKey = "other-allocation"
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: assignment1,
+            context: .mockAny()
+        )
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: assignment2,
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "Same flag with different allocation should be not deduplicated")
+    }
+
+    func testLogExposureDifferentFlag() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(),
+            context: .mockAny()
+        )
+        logger.logExposure(
+            at: .mockAny(),
+            for: "other-flag",
+            assignment: .mockAnyBoolean(),
+            context: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "Different flags should be not deduplicated")
+    }
+
+    func testLogExposureDifferentTargeting() {
+        // Given
+        let logger = ExposureLogger(featureScope: featureScope)
+
+        // When
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(),
+            context: .mockAny()
+        )
+        logger.logExposure(
+            at: .mockAny(),
+            for: .mockAny(),
+            assignment: .mockAnyBoolean(),
+            context: .init(targetingKey: "other-targeting", attributes: .mockAny())
+        )
+
+        // Then
+        XCTAssertEqual(featureScope.eventsWritten.count, 2, "Same flag with different targeting should be not deduplicated")
+    }
+}
+
+extension FeatureScopeMock {
+    fileprivate var exposureEventsWritten: [ExposureEvent] {
+        eventsWritten.compactMap {
+            $0 as? ExposureEvent
+        }
+    }
+}

--- a/DatadogFlags/Tests/Feature/ExposureMocks.swift
+++ b/DatadogFlags/Tests/Feature/ExposureMocks.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+
+@testable import DatadogFlags
+
+extension ExposureEvent: AnyMockable, RandomMockable {
+    public static func mockAny() -> ExposureEvent {
+        .init(
+            timestamp: .mockAny(),
+            allocation: .mockAny(),
+            flag: .mockAny(),
+            variant: .mockAny(),
+            subject: .mockAny()
+        )
+    }
+
+    public static func mockRandom() -> ExposureEvent {
+        .init(
+            timestamp: .mockRandom(),
+            allocation: .mockRandom(),
+            flag: .mockRandom(),
+            variant: .mockRandom(),
+            subject: .mockRandom()
+        )
+    }
+}
+
+extension ExposureEvent.Identifier: AnyMockable, RandomMockable {
+    public static func mockAny() -> ExposureEvent.Identifier {
+        .init(key: .mockAny())
+    }
+
+    public static func mockRandom() -> ExposureEvent.Identifier {
+        .init(key: .mockRandom())
+    }
+}
+
+extension ExposureEvent.Subject: AnyMockable, RandomMockable {
+    public static func mockAny() -> ExposureEvent.Subject {
+        .init(id: .mockAny(), attributes: .mockAny())
+    }
+
+    public static func mockRandom() -> ExposureEvent.Subject {
+        .init(id: .mockRandom(), attributes: .mockRandom())
+    }
+}
+
+final class ExposureLoggerMock: ExposureLogging {
+    var logExposureCalls: [(
+        date: Date,
+        flagKey: String,
+        assignment: FlagAssignment,
+        context: FlagsEvaluationContext
+    )] = []
+
+    func logExposure(
+        at date: Date,
+        for flagKey: String,
+        assignment: FlagAssignment,
+        context: FlagsEvaluationContext
+    ) {
+        logExposureCalls.append((date, flagKey, assignment, context))
+    }
+}

--- a/DatadogFlags/Tests/Feature/ExposureRequestBuilderTests.swift
+++ b/DatadogFlags/Tests/Feature/ExposureRequestBuilderTests.swift
@@ -1,0 +1,167 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogFlags
+
+final class ExposureRequestBuilderTests: XCTestCase {
+    private let mockEvents: [Event] = [
+        .init(data: "event 1".utf8Data),
+        .init(data: "event 2".utf8Data),
+        .init(data: "event 3".utf8Data)
+    ]
+
+    func testItCreatesPOSTRequest() throws {
+        // Given
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: nil,
+            telemetry: NOPTelemetry()
+        )
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockAny(), execution: .mockAny())
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
+    }
+
+    func testItSetsExposuresIntakeURL() {
+        // Given
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: nil,
+            telemetry: NOPTelemetry()
+        )
+
+        // When
+        func url(for site: DatadogSite) -> String {
+            let request = try! builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
+            return request.url!.absoluteStringWithoutQuery!
+        }
+
+        // Then
+        XCTAssertEqual(url(for: .us1), "https://browser-intake-datadoghq.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .us3), "https://browser-intake-us3-datadoghq.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .us5), "https://browser-intake-us5-datadoghq.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .eu1), "https://browser-intake-datadoghq.eu/api/v2/exposures")
+        XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/exposures")
+    }
+
+    func testItSetsCustomIntakeURL() throws {
+        // Given
+        let randomURL: URL = .mockRandom()
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: randomURL,
+            telemetry: NOPTelemetry()
+        )
+
+        // When
+        func url(for site: DatadogSite) -> String {
+            let request = try! builder.request(for: mockEvents, with: .mockWith(site: site), execution: .mockAny())
+            return request.url!.absoluteStringWithoutQuery!
+        }
+
+        // Then
+        let expectedURL = randomURL.absoluteStringWithoutQuery
+        XCTAssertEqual(url(for: .us1), expectedURL)
+        XCTAssertEqual(url(for: .us3), expectedURL)
+        XCTAssertEqual(url(for: .us5), expectedURL)
+        XCTAssertEqual(url(for: .eu1), expectedURL)
+        XCTAssertEqual(url(for: .ap1), expectedURL)
+        XCTAssertEqual(url(for: .ap2), expectedURL)
+        XCTAssertEqual(url(for: .us1_fed), expectedURL)
+    }
+
+    func testItSetsExposureQueryParameters() throws {
+        let randomSource: String = .mockRandom(among: .alphanumerics)
+
+        // Given
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: nil,
+            telemetry: NOPTelemetry()
+        )
+        let context: DatadogContext = .mockWith(source: randomSource)
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
+
+        // Then
+        let expectedQuery = "ddsource=\(randomSource)"
+        XCTAssertEqual(request.url?.query, expectedQuery)
+    }
+
+    func testItSetsExposureHTTPHeaders() throws {
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
+        let randomVersion: String = .mockRandom(among: .decimalDigits)
+        let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomOrigin: String = .mockRandom(among: .alphanumerics)
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
+        let randomClientToken: String = .mockRandom()
+        let randomDeviceName: String = .mockRandom()
+        let randomDeviceOSName: String = .mockRandom()
+        let randomDeviceOSVersion: String = .mockRandom()
+
+        // Given
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: nil,
+            telemetry: NOPTelemetry()
+        )
+        let context: DatadogContext = .mockWith(
+            clientToken: randomClientToken,
+            version: randomVersion,
+            source: randomSource,
+            sdkVersion: randomSDKVersion,
+            ciAppOrigin: randomOrigin,
+            applicationName: randomApplicationName,
+            device: .mockWith(name: randomDeviceName),
+            os: .mockWith(
+                name: randomDeviceOSName,
+                version: randomDeviceOSVersion
+            )
+        )
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context, execution: .mockAny())
+
+        // Then
+        XCTAssertEqual(
+            request.allHTTPHeaderFields?["User-Agent"],
+            """
+            \(randomApplicationName)/\(randomVersion) CFNetwork (\(randomDeviceName); \(randomDeviceOSName)/\(randomDeviceOSVersion))
+            """
+        )
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "text/plain;charset=UTF-8")
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomOrigin)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
+    }
+
+    func testItSetsHTTPBodyInExpectedFormat() throws {
+        // Given
+        let builder = ExposureRequestBuilder(
+            customIntakeURL: nil,
+            telemetry: NOPTelemetry()
+        )
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockAny(), execution: .mockAny())
+
+        // Then
+        let httpBodyData = try XCTUnwrap(request.httpBody)
+        let actual = String(data: httpBodyData, encoding: .utf8)
+        let expected = """
+        event 1
+        event 2
+        event 3
+        """
+        XCTAssertEqual(expected, actual, "It must separate each event with newline character")
+    }
+}

--- a/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
+++ b/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
@@ -1,0 +1,121 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+
+@testable import DatadogFlags
+
+extension FlagsEvaluationContext: AnyMockable, RandomMockable {
+    public static func mockAny() -> FlagsEvaluationContext {
+        .init(targetingKey: .mockAny(), attributes: .mockAny())
+    }
+
+    public static func mockRandom() -> FlagsEvaluationContext {
+        .init(targetingKey: .mockRandom(), attributes: .mockRandom())
+    }
+}
+
+extension FlagAssignment: AnyMockable, RandomMockable {
+    public static func mockAny() -> FlagAssignment {
+        .mockAnyBoolean()
+    }
+
+    public static func mockRandom() -> FlagAssignment {
+        .init(
+            allocationKey: .mockRandom(),
+            variationKey: .mockRandom(),
+            variation: .mockRandom(),
+            doLog: .mockRandom()
+        )
+    }
+
+    static func mockAnyBoolean(doLog: Bool = true) -> FlagAssignment {
+        .init(
+            allocationKey: .mockAny(),
+            variationKey: .mockAny(),
+            variation: .mockAnyBoolean(),
+            doLog: doLog
+        )
+    }
+
+    static func mockAnyString(doLog: Bool = true) -> FlagAssignment {
+        .init(
+            allocationKey: .mockAny(),
+            variationKey: .mockAny(),
+            variation: .mockAnyString(),
+            doLog: doLog
+        )
+    }
+
+    static func mockAnyInteger(doLog: Bool = true) -> FlagAssignment {
+        .init(
+            allocationKey: .mockAny(),
+            variationKey: .mockAny(),
+            variation: .mockAnyInteger(),
+            doLog: doLog
+        )
+    }
+
+    static func mockAnyDouble(doLog: Bool = true) -> FlagAssignment {
+        .init(
+            allocationKey: .mockAny(),
+            variationKey: .mockAny(),
+            variation: .mockAnyDouble(),
+            doLog: doLog
+        )
+    }
+
+    static func mockAnyObject(doLog: Bool = true) -> FlagAssignment {
+        .init(
+            allocationKey: .mockAny(),
+            variationKey: .mockAny(),
+            variation: .mockAnyObject(),
+            doLog: doLog
+        )
+    }
+}
+
+extension FlagAssignment.Variation: AnyMockable, RandomMockable {
+    public static func mockAny() -> FlagAssignment.Variation {
+        .mockAnyBoolean()
+    }
+
+    public static func mockRandom() -> FlagAssignment.Variation {
+        .boolean(.mockRandom())
+    }
+
+    static func mockAnyBoolean() -> FlagAssignment.Variation {
+        .boolean(.mockAny())
+    }
+
+    static func mockAnyString() -> FlagAssignment.Variation {
+        .string(.mockAny())
+    }
+
+    static func mockAnyInteger() -> FlagAssignment.Variation {
+        .integer(.mockAny())
+    }
+
+    static func mockAnyDouble() -> FlagAssignment.Variation {
+        .double(.mockAny())
+    }
+
+    static func mockAnyObject() -> FlagAssignment.Variation {
+        .object(.mockAny())
+    }
+}
+
+extension AnyValue: AnyMockable, RandomMockable {
+    public static func mockAny() -> AnyValue {
+        .string(.mockAny())
+    }
+
+    public static func mockRandom() -> AnyValue {
+        .string(.mockRandom())
+    }
+}

--- a/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
+++ b/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
@@ -30,6 +30,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockRandom(),
             variationKey: .mockRandom(),
             variation: .mockRandom(),
+            reason: .mockRandom(),
             doLog: .mockRandom()
         )
     }
@@ -39,6 +40,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyBoolean(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -48,6 +50,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyString(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -57,6 +60,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyInteger(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -66,6 +70,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyDouble(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -75,6 +80,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyObject(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }

--- a/DatadogFlags/Tests/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/FlagsClientTests.swift
@@ -147,18 +147,24 @@ private class MockFlagsHTTPClient: FlagsHTTPClient {
 }
 
 private class MockFlagsStore: FlagsStore {
-    private var flags: [String: FlagAssignment] = [:]
+    private struct MockState {
+        var flags: [String: FlagAssignment]
+        var context: FlagsEvaluationContext
+        var date: Date
+    }
+
+    private var mockState: MockState?
 
     init() {
         super.init(withPersistentCache: false)
     }
 
     override func flagAssignment(for key: String) -> FlagAssignment? {
-        flags[key]
+        mockState?.flags[key]
     }
 
-    override func setFlags(_ flags: [String: FlagAssignment], context: FlagsEvaluationContext? = nil) {
-        self.flags = flags
+    override func setFlagAssignments(_ flags: [String: FlagAssignment], for context: FlagsEvaluationContext, date: Date) {
+        self.mockState = .init(flags: flags, context: context, date: date)
     }
 }
 

--- a/DatadogFlags/Tests/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/FlagsClientTests.swift
@@ -35,6 +35,8 @@ final class FlagsClientTests: XCTestCase {
             configuration: config,
             httpClient: mockHttpClient,
             store: mockStore,
+            exposureLogger: ExposureLoggerMock(),
+            dateProvider: DateProviderMock(),
             featureScope: FeatureScopeMock()
         )
 
@@ -85,6 +87,8 @@ final class FlagsClientTests: XCTestCase {
             configuration: config,
             httpClient: AttributeSerializationTestClient(),
             store: MockFlagsStore(),
+            exposureLogger: ExposureLoggerMock(),
+            dateProvider: DateProviderMock(),
             featureScope: FeatureScopeMock()
         )
 

--- a/DatadogFlags/Tests/FlagsTypesTests.swift
+++ b/DatadogFlags/Tests/FlagsTypesTests.swift
@@ -30,24 +30,4 @@ final class FlagsTypesTests: XCTestCase {
         XCTAssertEqual(context.targetingKey, "user-456")
         XCTAssertTrue(context.attributes.isEmpty)
     }
-
-    func testFlagsMetadata() {
-        let context = FlagsEvaluationContext(targetingKey: "test-user", attributes: ["key": "value"])
-        let timestamp: Double = 1_234_567_890_123.0
-
-        let metadata = FlagsMetadata(fetchedAt: timestamp, context: context)
-
-        XCTAssertEqual(metadata.fetchedAt, timestamp)
-        XCTAssertEqual(metadata.context?.targetingKey, "test-user")
-        XCTAssertEqual(metadata.context?.attributes["key"], "value")
-    }
-
-    func testFlagsMetadataWithoutContext() {
-        let timestamp: Double = 1_234_567_890_123.0
-
-        let metadata = FlagsMetadata(fetchedAt: timestamp, context: nil)
-
-        XCTAssertEqual(metadata.fetchedAt, timestamp)
-        XCTAssertNil(metadata.context)
-    }
 }

--- a/DatadogFlags/Tests/Models/AnyValueTests.swift
+++ b/DatadogFlags/Tests/Models/AnyValueTests.swift
@@ -276,30 +276,4 @@ final class AnyValueTests: XCTestCase {
         // Then
         XCTAssertEqual(expected, result)
     }
-
-    func testAsDecodable() throws {
-        // Given
-        struct Foo: Equatable, Decodable {
-            let value: String
-        }
-        let data = """
-        [
-          {
-            "value" : "bar"
-          },
-          {
-            "value" : "baz"
-          }
-        ]
-        """.data(using: .utf8)!
-        let expected = [Foo(value: "bar"), Foo(value: "baz")]
-
-        // When
-        let result = try JSONDecoder()
-            .decode(AnyValue.self, from: data)
-            .as([Foo].self)
-
-        // Then
-        XCTAssertEqual(expected, result)
-    }
 }

--- a/DatadogFlags/Tests/Models/AnyValueTests.swift
+++ b/DatadogFlags/Tests/Models/AnyValueTests.swift
@@ -1,0 +1,305 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogFlags
+
+final class AnyValueTests: XCTestCase {
+    struct Model: Codable, Equatable {
+        let value: AnyValue
+    }
+
+    func testDecodeString() throws {
+        // Given
+        let data = """
+        {
+          "value" : "lorem ipsum"
+        }
+        """.data(using: .utf8)!
+        let expected = Model(value: .string("lorem ipsum"))
+
+        // When
+        let result = try JSONDecoder().decode(Model.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeString() throws {
+        // Given
+        let model = Model(value: .string("lorem ipsum"))
+        let expected = """
+        {
+          "value" : "lorem ipsum"
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(model)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeBool() throws {
+        // Given
+        let data = """
+        {
+          "value" : true
+        }
+        """.data(using: .utf8)!
+        let expected = Model(value: .bool(true))
+
+        // When
+        let result = try JSONDecoder().decode(Model.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeBool() throws {
+        // Given
+        let model = Model(value: .bool(true))
+        let expected = """
+        {
+          "value" : true
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(model)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeInt() throws {
+        // Given
+        let data = """
+        {
+          "value" : 42
+        }
+        """.data(using: .utf8)!
+        let expected = Model(value: .int(42))
+
+        // When
+        let result = try JSONDecoder().decode(Model.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeInt() throws {
+        // Given
+        let model = Model(value: .int(42))
+        let expected = """
+        {
+          "value" : 42
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(model)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeDouble() throws {
+        // Given
+        let data = """
+        {
+          "value" : 3.141592
+        }
+        """.data(using: .utf8)!
+        let expected = Model(value: .double(3.141592))
+
+        // When
+        let result = try JSONDecoder().decode(Model.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeDouble() throws {
+        // Given
+        let model = Model(value: .double(3))
+        let expected = """
+        {
+          "value" : 3
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(model)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeDictionary() throws {
+        // Given
+        let data = """
+        {
+          "foo" : ["bar", "baz"],
+          "object" : {
+            "foo": 42
+          }
+        }
+        """.data(using: .utf8)!
+        let expected: AnyValue = .dictionary([
+            "foo": .array([.string("bar"), .string("baz")]),
+            "object": .dictionary(["foo": .int(42)]),
+        ])
+
+        // When
+        let result = try JSONDecoder().decode(AnyValue.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeDictionary() throws {
+        // Given
+        let value: AnyValue = .dictionary([
+            "foo": .array([.string("bar"), .string("baz")]),
+            "object": .dictionary(["foo": .int(42)]),
+        ])
+        let expected = """
+        {
+          "foo" : [
+            "bar",
+            "baz"
+          ],
+          "object" : {
+            "foo" : 42
+          }
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        // When
+        let result = try encoder.encode(value)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeArray() throws {
+        // Given
+        let data = """
+        [
+          true,
+          {
+            "foo" : "bar"
+          }
+        ]
+        """.data(using: .utf8)!
+        let expected: AnyValue = .array([
+            .bool(true),
+            .dictionary(["foo": .string("bar")]),
+        ])
+
+        // When
+        let result = try JSONDecoder().decode(AnyValue.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeArray() throws {
+        // Given
+        let value: AnyValue = .array([
+            .bool(true),
+            .dictionary(["foo": .string("bar")]),
+        ])
+        let expected = """
+        [
+          true,
+          {
+            "foo" : "bar"
+          }
+        ]
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(value)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testDecodeNull() throws {
+        // Given
+        let data = """
+        {
+          "value" : null
+        }
+        """.data(using: .utf8)!
+        let expected = Model(value: .null)
+
+        // When
+        let result = try JSONDecoder().decode(Model.self, from: data)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testEncodeNull() throws {
+        // Given
+        let model = Model(value: .null)
+        let expected = """
+        {
+          "value" : null
+        }
+        """.data(using: .utf8)!
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        // When
+        let result = try encoder.encode(model)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+
+    func testAsDecodable() throws {
+        // Given
+        struct Foo: Equatable, Decodable {
+            let value: String
+        }
+        let data = """
+        [
+          {
+            "value" : "bar"
+          },
+          {
+            "value" : "baz"
+          }
+        ]
+        """.data(using: .utf8)!
+        let expected = [Foo(value: "bar"), Foo(value: "baz")]
+
+        // When
+        let result = try JSONDecoder()
+            .decode(AnyValue.self, from: data)
+            .as([Foo].self)
+
+        // Then
+        XCTAssertEqual(expected, result)
+    }
+}

--- a/DatadogFlags/Tests/Resources/precomputed-v1.json
+++ b/DatadogFlags/Tests/Resources/precomputed-v1.json
@@ -55,7 +55,7 @@
         "json-flag": {
           "allocationKey": "allocation-127",
           "variationKey": "variation-127",
-          "variationType": "OBJECT",
+          "variationType": "JSON",
           "variationValue": { "key": "value", "prop": 123 },
           "extraLogging": {
             "experiment": true


### PR DESCRIPTION
### What and why?

This PR implements the infrastructure for sending exposure events when feature flags are accessed. When users evaluate feature flags through the `FlagsClient`, exposure events are now automatically logged and sent to the corresponding intake endpoint for analytics and monitoring purposes.

This PR implements exposure event logging for the `DatadogFlags` module. When users evaluate feature flags through the `FlagsClient`, exposure events are now automatically logged and sent to the corresponding intake endpoint for analytics and monitoring.

The PR also includes several foundational improvements to support type-safe flag handling and performance optimizations.

### How?
#### Exposure Event Infrastructure (FFL-1022)

- `ExposureEvent` model: Complete event structure with allocation, flag, variant, and subject information following the schema used in the [Javascript client](https://github.com/DataDog/openfeature-js-client/blob/ec575fbcb21c1578df4c7c303c06b5f5974c5047/packages/core/src/configuration/exposureEvent.types.ts).
- `ExposureLogger`: Automatic exposure logging when flags are evaluated, integrating with the SDK's event persistence system.
- `ExposureRequestBuilder`: Enhanced to handle batched exposure events using newline-delimited JSON format, with proper headers and endpoint.
- Updated `FlagsFeature` to support batching (up to 50 events) instead of single-event sends

#### Type-Safe Flag System (FFL-1070, FFL-1047)
- `AnyValue` implementation: Comprehensive type system for handling arbitrary flag values with proper JSON encoding/decoding.
- `FlagValue`, `FlagAssignment` and `FlagAssignmentsResponse`: Type-safe models for flag evaluation results and precomputed assignments
- Enhanced `FlagsClient`: Added generic `getValue` method with type safety and improved flag evaluation logic
- Cleaned up and simplified type definitions

#### Performance & Thread Safety (FFL-1052)
- `ReadWriteLock` optimization: Replaced synchronous queue usage with `ReadWriteLock` in `FlagsStore` for better performance

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)