### PR TITLE
FFL-1065: Add `getDetails` methods

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -465,6 +465,8 @@
 		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
 		5B4F55302E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
+		5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
+		5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
 		5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */; };
 		5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9CB9E42E41FD5C005485E6 /* Drawing.swift */; };
@@ -2607,6 +2609,7 @@
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
 		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
+		5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagDetails.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
 		5B9CB9E42E41FD5C005485E6 /* Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drawing.swift; sourceTree = "<group>"; };
@@ -4308,11 +4311,12 @@
 		5BB294AA2E82864300CAA44B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5B16A3652E83E3BF0046A863 /* AnyValue.swift */,
+				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 				5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */,
 				5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */,
-				5B16A3652E83E3BF0046A863 /* AnyValue.swift */,
+				5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */,
 				5BB294BC2E82E66200CAA44B /* FlagValue.swift */,
-				5BB294AB2E8286AC00CAA44B /* ExposureEvent.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -8745,6 +8749,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3BA2E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AD2E8286B200CAA44B /* ExposureEvent.swift in Sources */,
@@ -8768,6 +8773,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3B42E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BB294BE2E82E66500CAA44B /* FlagValue.swift in Sources */,
 				5BB294AC2E8286B200CAA44B /* ExposureEvent.swift in Sources */,

--- a/DatadogFlags/Sources/Models/AnyValue.swift
+++ b/DatadogFlags/Sources/Models/AnyValue.swift
@@ -16,13 +16,6 @@ public enum AnyValue: Equatable {
     case null
 }
 
-extension AnyValue {
-    public func `as`<T>(_ type: T.Type, using decoder: JSONDecoder = .init()) throws -> T where T: Decodable {
-        let data = try JSONEncoder().encode(self)
-        return try decoder.decode(T.self, from: data)
-    }
-}
-
 extension AnyValue: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -18,6 +18,7 @@ internal struct FlagAssignment: Equatable {
     var allocationKey: String
     var variationKey: String
     var variation: Variation
+    var reason: String
     var doLog: Bool
 
     func variation<T: FlagValue>(as type: T.Type) -> T? {
@@ -42,6 +43,7 @@ extension FlagAssignment: Codable {
         case variationKey
         case variationType
         case variationValue
+        case reason
         case doLog
     }
 
@@ -50,6 +52,7 @@ extension FlagAssignment: Codable {
 
         self.allocationKey = try container.decode(String.self, forKey: .allocationKey)
         self.variationKey = try container.decode(String.self, forKey: .variationKey)
+        self.reason = try container.decode(String.self, forKey: .reason)
         self.doLog = try container.decode(Bool.self, forKey: .doLog)
 
         let variationType = try container.decode(String.self, forKey: .variationType)
@@ -82,6 +85,7 @@ extension FlagAssignment: Codable {
 
         try container.encode(allocationKey, forKey: .allocationKey)
         try container.encode(variationKey, forKey: .variationKey)
+        try container.encode(reason, forKey: .reason)
         try container.encode(doLog, forKey: .doLog)
 
         switch variation {

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public enum FlagEvaluationError: Error {
+    case flagNotFound
+    case typeMismatch
+}
+
+public struct FlagDetails<T>: Equatable where T: Equatable {
+    public var key: String
+    public var value: T
+    public var variant: String?
+    public var reason: String?
+    public var error: FlagEvaluationError?
+
+    public init(
+        key: String,
+        value: T,
+        variant: String? = nil,
+        reason: String? = nil,
+        error: FlagEvaluationError? = nil
+    ) {
+        self.key = key
+        self.value = value
+        self.variant = variant
+        self.reason = reason
+        self.error = error
+    }
+}

--- a/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
+++ b/DatadogFlags/Tests/Feature/ExposureLoggerTests.swift
@@ -25,6 +25,7 @@ final class ExposureLoggerTests: XCTestCase {
                 allocationKey: "allocation-123",
                 variationKey: "variation-123",
                 variation: .mockAnyBoolean(),
+                reason: .mockAny(),
                 doLog: true
             ),
             context: .mockAny()

--- a/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
+++ b/DatadogFlags/Tests/Feature/FlagsClientMocks.swift
@@ -30,6 +30,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockRandom(),
             variationKey: .mockRandom(),
             variation: .mockRandom(),
+            reason: .mockRandom(),
             doLog: .mockRandom()
         )
     }
@@ -39,6 +40,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyBoolean(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -48,6 +50,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyString(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -57,6 +60,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyInteger(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -66,6 +70,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyDouble(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }
@@ -75,6 +80,7 @@ extension FlagAssignment: AnyMockable, RandomMockable {
             allocationKey: .mockAny(),
             variationKey: .mockAny(),
             variation: .mockAnyObject(),
+            reason: .mockAny(),
             doLog: doLog
         )
     }

--- a/DatadogFlags/Tests/Models/AnyValueTests.swift
+++ b/DatadogFlags/Tests/Models/AnyValueTests.swift
@@ -276,30 +276,4 @@ final class AnyValueTests: XCTestCase {
         // Then
         XCTAssertEqual(expected, result)
     }
-
-    func testAsDecodable() throws {
-        // Given
-        struct Foo: Equatable, Decodable {
-            let value: String
-        }
-        let data = """
-        [
-          {
-            "value" : "bar"
-          },
-          {
-            "value" : "baz"
-          }
-        ]
-        """.data(using: .utf8)!
-        let expected = [Foo(value: "bar"), Foo(value: "baz")]
-
-        // When
-        let result = try JSONDecoder()
-            .decode(AnyValue.self, from: data)
-            .as([Foo].self)
-
-        // Then
-        XCTAssertEqual(expected, result)
-    }
 }


### PR DESCRIPTION
### What and why?

This PR adds `getDetails` methods to the `FlagsClient` that return detailed flag evaluation information including variant, reason, and error details.

This allows users to access comprehensive flag metadata alongside the evaluated values, which is essential for debugging and advanced feature flag workflows.

### How?

The implementation adds:

- A new `FlagDetails<T>` model that wraps flag values with metadata
- Error handling via `FlagEvaluationError`, with `flagNotFound` and `typeMismatch` cases
- `getDetails<T>` method that evaluates flags and returns comprehensive details
   - Maintains existing exposure logging behavior
- Comprehensive test coverage for the new methods and error scenarios

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
