### PR TITLE
FFL-1016: Add support for multiple named clients

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -471,6 +471,8 @@
 		5B5B8CBA2E8BD44700A6740E /* FlagsDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */; };
 		5B5B8CBF2E8BDB1000A6740E /* FlagsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */; };
 		5B5B8CC02E8BDB1000A6740E /* FlagsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */; };
+		5B5B8CC22E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */; };
+		5B5B8CC32E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */; };
 		5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
@@ -2618,6 +2620,7 @@
 		5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepositoryTests.swift; sourceTree = "<group>"; };
 		5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsDataStore.swift; sourceTree = "<group>"; };
 		5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsData.swift; sourceTree = "<group>"; };
+		5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientProtocol.swift; sourceTree = "<group>"; };
 		5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagDetails.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
@@ -4345,6 +4348,7 @@
 			isa = PBXGroup;
 			children = (
 				5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */,
+				5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */,
 				8DADC3AE2E7CCF0D0060F558 /* FlagsClient.swift */,
 				5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */,
 				5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */,
@@ -8783,6 +8787,7 @@
 				5B16A3662E83E3BF0046A863 /* AnyValue.swift in Sources */,
 				5B5B8CBF2E8BDB1000A6740E /* FlagsData.swift in Sources */,
 				8DADC3BF2E7CCF0D0060F558 /* FlagsClient.swift in Sources */,
+				5B5B8CC32E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */,
 				5BA8C3102E785A2000B1DA80 /* Flags.swift in Sources */,
 				8DADC3E12E7E4B4A0060F558 /* FlagsHTTPClient.swift in Sources */,
 				5B16A3702E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */,
@@ -8809,6 +8814,7 @@
 				5B16A3672E83E3BF0046A863 /* AnyValue.swift in Sources */,
 				5B5B8CC02E8BDB1000A6740E /* FlagsData.swift in Sources */,
 				8DADC3B92E7CCF0D0060F558 /* FlagsClient.swift in Sources */,
+				5B5B8CC22E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */,
 				5BA8C33A2E785FD500B1DA80 /* Flags.swift in Sources */,
 				8DADC3E22E7E4B4A0060F558 /* FlagsHTTPClient.swift in Sources */,
 				5B16A3712E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -460,6 +460,8 @@
 		5B16A3712E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */; };
 		5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
 		5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16A3722E8434140046A863 /* ExposureMocks.swift */; };
+		5B1D026D2E8D079F00AB2391 /* NOPFlagsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D026C2E8D078F00AB2391 /* NOPFlagsClientTests.swift */; };
+		5B1D026E2E8D079F00AB2391 /* NOPFlagsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D026C2E8D078F00AB2391 /* NOPFlagsClientTests.swift */; };
 		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
 		5B4F552C2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
@@ -2616,6 +2618,7 @@
 		5B16A36C2E83E51D0046A863 /* FlagAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignment.swift; sourceTree = "<group>"; };
 		5B16A36F2E83EE2B0046A863 /* FlagAssignmentsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignmentsResponse.swift; sourceTree = "<group>"; };
 		5B16A3722E8434140046A863 /* ExposureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureMocks.swift; sourceTree = "<group>"; };
+		5B1D026C2E8D078F00AB2391 /* NOPFlagsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NOPFlagsClientTests.swift; sourceTree = "<group>"; };
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
 		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
 		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
@@ -4296,6 +4299,7 @@
 				5B16A3722E8434140046A863 /* ExposureMocks.swift */,
 				5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */,
 				8DADC3C02E7CCF190060F558 /* FlagsClientTests.swift */,
+				5B1D026C2E8D078F00AB2391 /* NOPFlagsClientTests.swift */,
 				5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */,
 			);
 			path = Client;
@@ -8840,6 +8844,7 @@
 				5B4F552C2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */,
 				5B4F55302E853D7700A241C3 /* FlagsClientMocks.swift in Sources */,
 				8DADC3C52E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
+				5B1D026D2E8D079F00AB2391 /* NOPFlagsClientTests.swift in Sources */,
 				5B16A3742E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3C62E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
 				5B5B8CB72E8BCA6A00A6740E /* FlagsRepositoryTests.swift in Sources */,
@@ -8859,6 +8864,7 @@
 				5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */,
 				5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
+				5B1D026E2E8D079F00AB2391 /* NOPFlagsClientTests.swift in Sources */,
 				5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */,
 				8DADC3CA2E7CCF190060F558 /* FlagsEndpointBuilderTests.swift in Sources */,
 				5B5B8CB62E8BCA6A00A6740E /* FlagsRepositoryTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -473,6 +473,8 @@
 		5B5B8CC02E8BDB1000A6740E /* FlagsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */; };
 		5B5B8CC22E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */; };
 		5B5B8CC32E8C0E9100A6740E /* FlagsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */; };
+		5B5B8CC52E8C14B900A6740E /* FlagsClientRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC42E8C14B200A6740E /* FlagsClientRegistry.swift */; };
+		5B5B8CC62E8C14B900A6740E /* FlagsClientRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CC42E8C14B200A6740E /* FlagsClientRegistry.swift */; };
 		5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */; };
 		5B9B20C52E460A0600C95B6C /* ShapeResourceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */; };
@@ -2621,6 +2623,7 @@
 		5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsDataStore.swift; sourceTree = "<group>"; };
 		5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsData.swift; sourceTree = "<group>"; };
 		5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientProtocol.swift; sourceTree = "<group>"; };
+		5B5B8CC42E8C14B200A6740E /* FlagsClientRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientRegistry.swift; sourceTree = "<group>"; };
 		5B9565FB2E86BBF600EAF677 /* FlagDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagDetails.swift; sourceTree = "<group>"; };
 		5B9B20C42E4609FC00C95B6C /* ShapeResourceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeResourceBuilderTests.swift; sourceTree = "<group>"; };
 		5B9CB9E22E41F6F6005485E6 /* ImageRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepresentable.swift; sourceTree = "<group>"; };
@@ -4348,8 +4351,9 @@
 			isa = PBXGroup;
 			children = (
 				5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */,
-				5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */,
 				8DADC3AE2E7CCF0D0060F558 /* FlagsClient.swift */,
+				5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */,
+				5B5B8CC42E8C14B200A6740E /* FlagsClientRegistry.swift */,
 				5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */,
 				5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */,
 				5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */,
@@ -8773,6 +8777,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B5B8CC52E8C14B900A6740E /* FlagsClientRegistry.swift in Sources */,
 				5B9565FD2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3BA2E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BD6C6572E8AC5E900F5D2CC /* FlagsRepository.swift in Sources */,
@@ -8800,6 +8805,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B5B8CC62E8C14B900A6740E /* FlagsClientRegistry.swift in Sources */,
 				5B9565FC2E86BBFA00EAF677 /* FlagDetails.swift in Sources */,
 				8DADC3B42E7CCF0D0060F558 /* FlagsClientConfiguration.swift in Sources */,
 				5BD6C6562E8AC5E900F5D2CC /* FlagsRepository.swift in Sources */,

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -61,7 +61,12 @@ public class FlagsClient {
                     description: "Flags feature must be enabled before calling `FlagsClient.instance(named:in:)`."
                 )
             }
-            return clientRegistry.client(named: name)
+            guard let client = clientRegistry.client(named: name) else {
+                throw ProgrammerError(
+                    description: "Flags client '\(name)' not found. Make sure that you call `FlagsClient.create(name:with:in:)` first."
+                )
+            }
+            return client
         } catch let error {
             consolePrint("\(error)", .error)
             return NOPFlagsClient()

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -69,7 +69,9 @@ public class FlagsClient {
             featureScope: featureScope
         )
     }
+}
 
+extension FlagsClient: FlagsClientProtocol {
     public func setEvaluationContext(_ context: FlagsEvaluationContext, completion: @escaping (Result<Void, FlagsError>) -> Void) {
         featureScope.context { [httpClient, configuration] sdkContext in
             httpClient.postPrecomputeAssignments(
@@ -132,66 +134,5 @@ public class FlagsClient {
         }
 
         return details
-    }
-}
-
-// MARK: - Convenience flag evaluation methods
-
-extension FlagsClient {
-    @inlinable
-    public func getValue<T>(key: String, defaultValue: T) -> T where T: Equatable, T: FlagValue {
-        getDetails(key: key, defaultValue: defaultValue).value
-    }
-
-    @inlinable
-    public func getBooleanValue(key: String, defaultValue: Bool) -> Bool {
-        getValue(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getStringValue(key: String, defaultValue: String) -> String {
-        getValue(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getIntegerValue(key: String, defaultValue: Int) -> Int {
-        getValue(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getDoubleValue(key: String, defaultValue: Double) -> Double {
-        getValue(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getObjectValue(key: String, defaultValue: AnyValue) -> AnyValue {
-        getValue(key: key, defaultValue: defaultValue)
-    }
-}
-
-extension FlagsClient {
-    @inlinable
-    public func getBooleanDetails(key: String, defaultValue: Bool) -> FlagDetails<Bool> {
-        getDetails(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getStringDetails(key: String, defaultValue: String) -> FlagDetails<String> {
-        getDetails(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getIntegerDetails(key: String, defaultValue: Int) -> FlagDetails<Int> {
-        getDetails(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getDoubleDetails(key: String, defaultValue: Double) -> FlagDetails<Double> {
-        getDetails(key: key, defaultValue: defaultValue)
-    }
-
-    @inlinable
-    public func getObjectDetails(key: String, defaultValue: AnyValue) -> FlagDetails<AnyValue> {
-        getDetails(key: key, defaultValue: defaultValue)
     }
 }

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -33,6 +33,7 @@ public class FlagsClient {
         self.featureScope = featureScope
     }
 
+    @discardableResult
     public static func create(
         name: String = FlagsClient.defaultName,
         with configuration: FlagsClient.Configuration = .init(),
@@ -51,7 +52,7 @@ public class FlagsClient {
     }
 
     public static func instance(
-        named name: String,
+        named name: String = FlagsClient.defaultName,
         in core: DatadogCoreProtocol = CoreRegistry.default
     ) -> FlagsClientProtocol {
         do {

--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+public protocol FlagsClientProtocol {
+    func setEvaluationContext(
+        _ context: FlagsEvaluationContext,
+        completion: @escaping (Result<Void, FlagsError>) -> Void
+    )
+
+    func getDetails<T>(key: String, defaultValue: T) -> FlagDetails<T> where T: Equatable, T: FlagValue
+}
+
+// MARK: - Convenience flag evaluation methods
+
+extension FlagsClientProtocol {
+    @inlinable
+    public func getValue<T>(key: String, defaultValue: T) -> T where T: Equatable, T: FlagValue {
+        getDetails(key: key, defaultValue: defaultValue).value
+    }
+
+    @inlinable
+    public func getBooleanValue(key: String, defaultValue: Bool) -> Bool {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getStringValue(key: String, defaultValue: String) -> String {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getIntegerValue(key: String, defaultValue: Int) -> Int {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getDoubleValue(key: String, defaultValue: Double) -> Double {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getObjectValue(key: String, defaultValue: AnyValue) -> AnyValue {
+        getValue(key: key, defaultValue: defaultValue)
+    }
+}
+
+// MARK: - Convenience flag details methods
+
+extension FlagsClientProtocol {
+    @inlinable
+    public func getBooleanDetails(key: String, defaultValue: Bool) -> FlagDetails<Bool> {
+        getDetails(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getStringDetails(key: String, defaultValue: String) -> FlagDetails<String> {
+        getDetails(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getIntegerDetails(key: String, defaultValue: Int) -> FlagDetails<Int> {
+        getDetails(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getDoubleDetails(key: String, defaultValue: Double) -> FlagDetails<Double> {
+        getDetails(key: key, defaultValue: defaultValue)
+    }
+
+    @inlinable
+    public func getObjectDetails(key: String, defaultValue: AnyValue) -> FlagDetails<AnyValue> {
+        getDetails(key: key, defaultValue: defaultValue)
+    }
+}
+
+// MARK: - NOPFlagsClient
+
+internal final class NOPFlagsClient: FlagsClientProtocol {
+    func setEvaluationContext(
+        _: FlagsEvaluationContext,
+        completion: @escaping (Result<Void, FlagsError>) -> Void
+    ) {
+        warn()
+        completion(.failure(.clientNotInitialized))
+    }
+
+    func getDetails<T>(key: String, defaultValue: T) -> FlagDetails<T> where T: Equatable, T: FlagValue {
+        warn()
+        return FlagDetails(key: key, value: defaultValue)
+    }
+
+    private func warn(method: StaticString = #function) {
+        DD.logger.critical(
+            """
+            Calling `\(method)` on NOPFlagsClient.
+            Make sure Flags feature is enabled and that the `FlagsClient` was created successfully.
+            """
+        )
+    }
+}

--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -92,7 +92,7 @@ internal final class NOPFlagsClient: FlagsClientProtocol {
 
     func getDetails<T>(key: String, defaultValue: T) -> FlagDetails<T> where T: Equatable, T: FlagValue {
         warn()
-        return FlagDetails(key: key, value: defaultValue)
+        return FlagDetails(key: key, value: defaultValue, error: .invalidClient)
     }
 
     private func warn(method: StaticString = #function) {

--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-public protocol FlagsClientProtocol {
+public protocol FlagsClientProtocol: AnyObject {
     func setEvaluationContext(
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void

--- a/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+internal final class FlagsClientRegistry {
+    @ReadWriteLock
+    private var clients: [String: FlagsClientProtocol] = [:]
+
+    func register(_ client: FlagsClientProtocol, named name: String) {
+        guard !isRegistered(clientName: name) else {
+            DD.logger.warn("A flags client with name \(name) has already been registered.")
+            return
+        }
+        clients[name] = client
+    }
+
+    func isRegistered(clientName: String) -> Bool {
+        clients[clientName] != nil
+    }
+
+    @discardableResult
+    func unregisterClient(named name: String) -> FlagsClientProtocol? {
+        clients.removeValue(forKey: name)
+    }
+
+    func client(named name: String) -> FlagsClientProtocol {
+        clients[name] ?? NOPFlagsClient()
+    }
+}

--- a/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
@@ -28,7 +28,7 @@ internal final class FlagsClientRegistry {
         clients.removeValue(forKey: name)
     }
 
-    func client(named name: String) -> FlagsClientProtocol {
-        clients[name] ?? NOPFlagsClient()
+    func client(named name: String) -> FlagsClientProtocol? {
+        clients[name]
     }
 }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -12,6 +12,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
 
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
+    let clientRegistry: FlagsClientRegistry
 
     let performanceOverride: PerformancePresetOverride
 
@@ -24,6 +25,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             telemetry: featureScope.telemetry
         )
         messageReceiver = NOPFeatureMessageReceiver()
+        clientRegistry = FlagsClientRegistry()
         performanceOverride = PerformancePresetOverride(maxObjectsInFile: 50)
     }
 }

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 public enum FlagEvaluationError: Error {
+    case invalidClient
     case flagNotFound
     case typeMismatch
 }

--- a/DatadogFlags/Tests/Client/NOPFlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/NOPFlagsClientTests.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogFlags
+
+final class NOPFlagsClientTests: XCTestCase {
+    func testSetEvaluationContext() {
+        // Given
+        let client = NOPFlagsClient()
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When
+        let clientNotInitializedError = expectation(description: "clientNotInitializedError")
+        client.setEvaluationContext(.mockAny()) { result in
+            if case .failure(.clientNotInitialized) = result {
+                clientNotInitializedError.fulfill()
+            }
+        }
+
+        // Then
+        waitForExpectations(timeout: 0)
+        XCTAssertEqual(dd.logger.criticalMessages.count, 1)
+        XCTAssertEqual(
+            dd.logger.criticalMessages.first,
+            """
+            Calling `setEvaluationContext(_:completion:)` on NOPFlagsClient.
+            Make sure Flags feature is enabled and that the `FlagsClient` was created successfully.
+            """
+        )
+    }
+
+    func testGetDetails() {
+        // Given
+        let client = NOPFlagsClient()
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When
+        let flagDetails = client.getDetails(key: "booleanFlag", defaultValue: false)
+
+        // Then
+        XCTAssertEqual(
+            flagDetails,
+            FlagDetails(key: "booleanFlag", value: false, error: .invalidClient)
+        )
+        XCTAssertEqual(dd.logger.criticalMessages.count, 1)
+        XCTAssertEqual(
+            dd.logger.criticalMessages.first,
+            """
+            Calling `getDetails(key:defaultValue:)` on NOPFlagsClient.
+            Make sure Flags feature is enabled and that the `FlagsClient` was created successfully.
+            """
+        )
+    }
+}


### PR DESCRIPTION
### What and why?

This PR implements support for named `FlagsClient` instances, enabling SDK users to create and manage multiple independent feature flag clients with isolated data storage. This work continues the implementation started in #2489.

### How?

Core Implementation:
- Introduced `FlagsClientProtocol` to define the public interface for flag evaluation and define a consistent contract between `FlagsClient` and `NOPFlagsClient`
- Added `FlagsClient.create(name:with:in:)` to create new named client instances
- Added `FlagsClient.instance(named:in:)` to retrieve existing named clients from the registry
- Implemented `FlagsClientRegistry` to manage multiple client instances with thread-safe registration and retrieval

API Design:
- Default client name is `"default"` when no name is specified
- Creating a duplicate client returns `NOPFlagsClient` and logs an error
- Retrieving a non-existent client returns `NOPFlagsClient` (graceful degradation)
- Both methods default to `CoreRegistry.default` for the SDK instance parameter

Testing:
- Added unit tests for `FlagsClient.create(name:with:in:)` covering happy paths, duplicate detection, and error cases
- Added unit tests for `FlagsClient.instance(named:in:)` verifying client retrieval, identity, and error handling

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
