### PR TITLE
FFL-1144: Migrate `FlagsEvaluationContext` attributes to `AnyValue`

### DIFF
--- a/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
@@ -56,7 +56,7 @@ internal struct FlagAssignmentsRequestBody {
         }
 
         let targetingKey: String
-        let targetingAttributes: [String: String]
+        let targetingAttributes: [String: AnyValue]
     }
 
     struct Environment: Encodable {

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -13,7 +13,7 @@ internal struct ExposureEvent: Equatable, Codable {
 
     struct Subject: Equatable, Codable {
         let id: String
-        let attributes: [String: String]
+        let attributes: [String: AnyValue]
     }
 
     let timestamp: Int64

--- a/DatadogFlags/Sources/Models/FlagsEvaluationContext.swift
+++ b/DatadogFlags/Sources/Models/FlagsEvaluationContext.swift
@@ -8,8 +8,8 @@ import Foundation
 
 public struct FlagsEvaluationContext: Equatable, Codable {
     public let targetingKey: String
-    public let attributes: [String: String]
-    public init(targetingKey: String, attributes: [String: String] = [:]) {
+    public let attributes: [String: AnyValue]
+    public init(targetingKey: String, attributes: [String: AnyValue] = [:]) {
         self.targetingKey = targetingKey
         self.attributes = attributes
     }

--- a/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
@@ -17,7 +17,10 @@ final class FlagAssignmentsRequestTests: XCTestCase {
         // Given
         let evaluationContext = FlagsEvaluationContext(
             targetingKey: "user123",
-            attributes: ["plan": "premium", "userId": "123"]
+            attributes: [
+                "plan": .string("premium"),
+                "userId": .string("123")
+            ]
         )
         let context = DatadogContext.mockWith(
             clientToken: "test-token",

--- a/DatadogFlags/Tests/Client/RUMExposureLoggerTests.swift
+++ b/DatadogFlags/Tests/Client/RUMExposureLoggerTests.swift
@@ -34,7 +34,10 @@ final class RUMExposureLoggerTests: XCTestCase {
 
         let evaluationContext = FlagsEvaluationContext(
             targetingKey: "user-123",
-            attributes: ["email": "test@example.com", "plan": "premium"]
+            attributes: [
+                "email": .string("test@example.com"),
+                "plan": .string("premium")
+            ]
         )
 
         // When
@@ -66,7 +69,7 @@ final class RUMExposureLoggerTests: XCTestCase {
         XCTAssertEqual(flagExposure.timestamp, expectedTimestamp, accuracy: 0.001)
 
         let subjectAttributes = flagExposure.subjectAttributes
-        XCTAssertEqual(subjectAttributes["email"] as? String, "test@example.com")
-        XCTAssertEqual(subjectAttributes["plan"] as? String, "premium")
+        XCTAssertEqual(subjectAttributes["email"] as? AnyValue, .string("test@example.com"))
+        XCTAssertEqual(subjectAttributes["plan"] as? AnyValue, .string("premium"))
     }
 }


### PR DESCRIPTION
### What and why?

This PR migrates the `FlagsEvaluationContext.attributes` property from `[String: String]` to `[String: AnyValue]` to support rich, typed attribute values in feature flag evaluation contexts.

Depends on #2502

### How?

The implementation changes the attributes type across the evaluation context pipeline:

- Core Model Changes:
   - Updated `FlagsEvaluationContext.attributes` from `[String: String]` to `[String: AnyValue]`
   - Updated `ExposureEvent.Subject.attributes` to use `AnyValue`
   - Updated `FlagAssignmentsRequestBody.Subject.targetingAttributes` to use `AnyValue`

- Cross-Module Integration:
   - Kept `RUMFlagExposureMessage.subjectAttributes` as `[String: any Encodable]` to avoid moving `AnyValue` to `DatadogInternal`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
