### PR TITLE
 chore: Surface view attributes' APIs to Objective-C

### DIFF
--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -60,14 +60,20 @@
     [monitor currentSessionIDWithCompletion:^(NSString * _Nullable sessionID) {}];
     [monitor stopSession];
 
+    [monitor addViewAttributeForKey:@"key" value: @"value"];
+    [monitor addViewAttributes:@{@"string": @"value", @"integer": @1, @"boolean": @true}];
+    [monitor removeViewAttributeForKey:@"key"];
+    [monitor removeViewAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor startViewWithViewController:anyVC name:@"" attributes:@{}];
     [monitor stopViewWithViewController:anyVC attributes:@{}];
     [monitor startViewWithKey:@"" name:nil attributes:@{}];
     [monitor stopViewWithKey:@"" attributes:@{}];
     [monitor addViewLoadingTimeWithOverwrite:YES];
+
     [monitor addErrorWithMessage:@"" stack:nil source:DDRUMErrorSourceCustom attributes:@{}];
     [monitor addErrorWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:-100 userInfo:nil]
                         source:DDRUMErrorSourceNetwork attributes:@{}];
+
     [monitor startResourceWithResourceKey:@"" request:[NSURLRequest new] attributes:@{}];
     [monitor startResourceWithResourceKey:@"" url:[NSURL new] attributes:@{}];
     [monitor startResourceWithResourceKey:@"" httpMethod:DDRUMMethodGet urlString:@"" attributes:@{}];

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -522,6 +522,22 @@ public class objc_RUMMonitor: NSObject {
         swiftRUMMonitor.stopSession()
     }
 
+    public func addViewAttribute(forKey key: String, value: Any) {
+        swiftRUMMonitor.addViewAttribute(forKey: key, value: AnyEncodable(value))
+    }
+
+    public func addViewAttributes(_ attributes: [String: Any]) {
+        swiftRUMMonitor.addViewAttributes(attributes.dd.swiftAttributes)
+    }
+
+    public func removeViewAttribute(forKey key: String) {
+        swiftRUMMonitor.removeViewAttribute(forKey: key)
+    }
+
+    public func removeViewAttributes(forKeys keys: [String]) {
+        swiftRUMMonitor.removeViewAttributes(forKeys: keys)
+    }
+
     public func startView(
         viewController: UIViewController,
         name: String?,

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -2348,6 +2348,10 @@ public class objc_RUMMonitor: NSObject
     public static func shared() -> objc_RUMMonitor
     public func currentSessionID(completion: @escaping (String?) -> Void)
     public func stopSession()
+    public func addViewAttribute(forKey key: String, value: Any)
+    public func addViewAttributes(_ attributes: [String: Any])
+    public func removeViewAttribute(forKey key: String)
+    public func removeViewAttributes(forKeys keys: [String])
     public func startView(viewController: UIViewController,name: String?,attributes: [String: Any])
     public func stopView(viewController: UIViewController,attributes: [String: Any])
     public func startView(key: String,name: String?,attributes: [String: Any])


### PR DESCRIPTION
### What and why?

This PR surfaces, to the Objective-C runtime, the new APIs to add View attributes.

### How?
It updates the `objc_RUMMonitor` class with the new interfaces:
```swift
    public func addViewAttribute(forKey key: String, value: Any)
    public func addViewAttributes(_ attributes: [String: Any])
    public func removeViewAttribute(forKey key: String)
    public func removeViewAttributes(forKeys keys: [String])
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
