### PR TITLE
FFL-1162: Flags / RUM integration tests

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -487,6 +487,8 @@
 		5B1D02972E8ED6D000AB2391 /* FlagExposureReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02962E8ED6CE00AB2391 /* FlagExposureReceiverTests.swift */; };
 		5B1D02982E8ED6D000AB2391 /* FlagExposureReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02962E8ED6CE00AB2391 /* FlagExposureReceiverTests.swift */; };
 		5B3AF8AA2E4B3AE9009E5375 /* EnrichedResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */; };
+		5B4F37692E93C5C90093778F /* FlagsRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F37682E93C5B80093778F /* FlagsRUMIntegrationTests.swift */; };
+		5B4F376A2E93C5C90093778F /* FlagsRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F37682E93C5B80093778F /* FlagsRUMIntegrationTests.swift */; };
 		5B4F552C2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
@@ -2638,6 +2640,7 @@
 		5B1D02932E8ED6BE00AB2391 /* FlagEvaluationReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagEvaluationReceiverTests.swift; sourceTree = "<group>"; };
 		5B1D02962E8ED6CE00AB2391 /* FlagExposureReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagExposureReceiverTests.swift; sourceTree = "<group>"; };
 		5B3AF8A92E4B3AE6009E5375 /* EnrichedResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichedResourceTests.swift; sourceTree = "<group>"; };
+		5B4F37682E93C5B80093778F /* FlagsRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRUMIntegrationTests.swift; sourceTree = "<group>"; };
 		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
 		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
 		5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepositoryTests.swift; sourceTree = "<group>"; };
@@ -4301,6 +4304,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		5B4F37672E93C59A0093778F /* Flags */ = {
+			isa = PBXGroup;
+			children = (
+				5B4F37682E93C5B80093778F /* FlagsRUMIntegrationTests.swift */,
+			);
+			path = Flags;
+			sourceTree = "<group>";
+		};
 		5B5B8CB42E8BCA3C00A6740E /* Client */ = {
 			isa = PBXGroup;
 			children = (
@@ -4901,6 +4912,7 @@
 				6179DB542B60229D00E9E04E /* CrashReporting */,
 				61E8C5062B28896100E709B4 /* RUM */,
 				61F3E36B2BC7D51400C7881E /* Trace */,
+				5B4F37672E93C59A0093778F /* Flags */,
 				610ABD4A2A6930AB00AFEA34 /* Public */,
 				618353BA2A6946F40085F84A /* Internal */,
 			);
@@ -8715,6 +8727,7 @@
 				6119DDCB2DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift in Sources */,
 				6119DDCC2DD24A9600DA80F9 /* RUMSessionStopTests.swift in Sources */,
 				6119DDCD2DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift in Sources */,
+				5B4F37692E93C5C90093778F /* FlagsRUMIntegrationTests.swift in Sources */,
 				118248722D908D3400E3D16F /* CoreMetricsIntegrationTests.swift in Sources */,
 				1182486B2D908CF400E3D16F /* WebEventIntegrationTests.swift in Sources */,
 				118247BE2D908BEF00E3D16F /* RUMViewEndedMetricIntegrationTests.swift in Sources */,
@@ -8756,6 +8769,7 @@
 				118249372D9096B400E3D16F /* HeadBasedSamplingTests.swift in Sources */,
 				118249382D9096B400E3D16F /* RUMAttributesIntegrationTests.swift in Sources */,
 				118249392D9096B400E3D16F /* SendingCrashReportTests.swift in Sources */,
+				5B4F376A2E93C5C90093778F /* FlagsRUMIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/IntegrationUnitTests/Flags/FlagsRUMIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Flags/FlagsRUMIntegrationTests.swift
@@ -1,0 +1,181 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogFlags
+@testable import DatadogRUM
+
+/// Covers integration scenarios between Flags and RUM features.
+final class FlagsRUMIntegrationTests: XCTestCase {
+    private enum Fixtures {
+        static let flagsRepositoryState = FlagsData(
+            flags: [
+                "string-flag": .init(
+                    allocationKey: "allocation-123",
+                    variationKey: "variation-123",
+                    variation: .string("red"),
+                    reason: "TARGETING_MATCH",
+                    doLog: true
+                ),
+                "boolean-flag": .init(
+                    allocationKey: "allocation-124",
+                    variationKey: "variation-124",
+                    variation: .boolean(true),
+                    reason: "TARGETING_MATCH",
+                    doLog: true
+                )
+            ],
+            context: .init(
+                targetingKey: "user-123",
+                attributes: ["foo": .string("bar")]
+            ),
+            date: .mockAny()
+        )
+    }
+
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy(context: .mockWith(trackingConsent: .granted))
+    }
+
+    override func tearDownWithError() throws {
+        try core.flushAndTearDown()
+        core = nil
+        super.tearDown()
+    }
+
+    private func createFlagsClient(state: FlagsData? = Fixtures.flagsRepositoryState) -> FlagsClientProtocol {
+        let featureScope = core.scope(for: FlagsFeature.self)
+        let dateProvider = SystemDateProvider()
+
+        return FlagsClient(
+            repository: FlagsRepositoryMock(
+                clientName: "default",
+                state: state
+            ),
+            exposureLogger: ExposureLogger(
+                dateProvider: dateProvider,
+                featureScope: featureScope
+            ),
+            rumExposureLogger: RUMExposureLogger(
+                dateProvider: dateProvider,
+                featureScope: featureScope
+            )
+        )
+    }
+
+    func testWhenFlagIsEvaluated_itAddsFeatureFlagToRUMView() throws {
+        // Given
+        RUM.enable(with: .init(applicationID: "test-app-id"), in: core)
+        Flags.enable(in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+        let client = createFlagsClient()
+
+        // When
+        monitor.startView(key: "test-view", name: "Test View")
+
+        let boolValue = client.getBooleanValue(key: "boolean-flag", defaultValue: false)
+        let stringValue = client.getStringValue(key: "string-flag", defaultValue: "blue")
+        core.flush()
+
+        monitor.stopView(key: "test-view")
+
+        // Then
+        let rumEvents = core.waitAndReturnEvents(
+            ofFeature: RUMFeature.name,
+            ofType: RUMViewEvent.self
+        )
+        let viewEvent = try XCTUnwrap(
+            rumEvents.last,
+            "Should have at least one view event"
+        )
+        let featureFlags = try XCTUnwrap(
+            viewEvent.featureFlags?.featureFlagsInfo,
+            "View should have feature flags"
+        )
+
+        XCTAssertEqual(featureFlags["boolean-flag"] as? Bool, boolValue)
+        XCTAssertEqual(featureFlags["string-flag"] as? String, stringValue)
+    }
+
+    func testWhenFlagIsEvaluated_itCreatesRUMActionWithExposureDetails() throws {
+        // Given
+        RUM.enable(with: .init(applicationID: "test-app-id"), in: core)
+        Flags.enable(in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+        let client = createFlagsClient()
+
+        // When
+        monitor.startView(key: "test-view", name: "Test View")
+        _ = client.getBooleanValue(key: "boolean-flag", defaultValue: false)
+
+        // Then
+        let rumActionEvents = core.waitAndReturnEvents(
+            ofFeature: RUMFeature.name,
+            ofType: RUMActionEvent.self
+        )
+        XCTAssertEqual(rumActionEvents.count, 1)
+        let exposureAction = try XCTUnwrap(rumActionEvents.first)
+
+        XCTAssertEqual(exposureAction.action.type, .custom)
+        XCTAssertEqual(exposureAction.action.target?.name, "__dd_exposure")
+
+        let contextInfo = try XCTUnwrap(exposureAction.context?.contextInfo)
+        XCTAssertNotNil(contextInfo["timestamp"])
+        XCTAssertEqual(contextInfo["flag_key"] as? String, "boolean-flag")
+        XCTAssertEqual(contextInfo["allocation_key"] as? String, "allocation-124")
+        XCTAssertEqual(contextInfo["exposure_key"] as? String, "boolean-flag-allocation-124")
+        XCTAssertEqual(contextInfo["subject_key"] as? String, "user-123")
+        XCTAssertEqual(contextInfo["variant_key"] as? String, "variation-124")
+        XCTAssertNotNil(contextInfo["subject_attributes"])
+    }
+}
+
+// MARK: - FlagsRepositoryMock
+
+final class FlagsRepositoryMock: FlagsRepositoryProtocol {
+    let clientName: String
+
+    @ReadWriteLock
+    private var state: FlagsData?
+    private let setEvaluationContextStub: ((FlagsEvaluationContext, @escaping (Result<Void, FlagsError>) -> Void) -> Void)?
+
+    init(
+        clientName: String,
+        state: FlagsData? = nil,
+        setEvaluationContextStub: ((FlagsEvaluationContext, @escaping (Result<Void, FlagsError>) -> Void) -> Void)? = nil
+    ) {
+        self.clientName = clientName
+        self.state = state
+        self.setEvaluationContextStub = setEvaluationContextStub
+    }
+
+    var context: FlagsEvaluationContext? {
+        state?.context
+    }
+
+    func setEvaluationContext(
+        _ context: FlagsEvaluationContext,
+        completion: @escaping (Result<Void, FlagsError>) -> Void
+    ) {
+        setEvaluationContextStub?(context, completion)
+    }
+
+    func flagAssignment(for key: String) -> DatadogFlags.FlagAssignment? {
+        state?.flags[key]
+    }
+
+    func reset() {
+        state = nil
+    }
+}

--- a/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
+++ b/DatadogCore/Sources/SDKMetrics/BatchMetrics.swift
@@ -19,6 +19,7 @@ internal enum BatchMetric {
         case "tracing":         return "trace"
         case "session-replay":  return "sr"
         case "session-replay-resources":  return "sr-resources"
+        case "flags":           return "flags"
         default:                return nil
         }
     }

--- a/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
@@ -109,7 +109,7 @@ public struct RUMFlagEvaluationMessage {
 
 /// Flag exposure message consumed by RUM on the message-bus.
 public struct RUMFlagExposureMessage {
-    /// The timestamp of the exposure
+    /// The timestamp of the exposure (server time with NTP correction)
     public let timestamp: TimeInterval
     /// The flag key
     public let flagKey: String

--- a/DatadogRUM/Sources/Integrations/FlagExposureReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/FlagExposureReceiver.swift
@@ -9,6 +9,9 @@ import DatadogInternal
 
 /// Receives flag exposure messages and adds them as custom RUM actions.
 internal struct FlagExposureReceiver: FeatureMessageReceiver {
+    private enum Constants {
+        static let exposureActionName = "__dd_exposure"
+    }
     /// The RUM monitor instance.
     let monitor: Monitor
 
@@ -20,7 +23,7 @@ internal struct FlagExposureReceiver: FeatureMessageReceiver {
 
         monitor.addAction(
             type: .custom,
-            name: "__dd_exposure",
+            name: Constants.exposureActionName,
             attributes: [
                 "timestamp": exposure.timestamp.toInt64Milliseconds,
                 "flag_key": exposure.flagKey,


### PR DESCRIPTION
### What and why?

This PR adds integration tests that verify the end-to-end communication between the `DatadogFlags` and `DatadogRUM` modules. These tests ensure that flag evaluations correctly trigger RUM events and that all metadata flows through the integration layer properly.

### How?

Created `Datadog/IntegrationUnitTests/Flags/FlagsRUMIntegrationTests.swift` with two test cases:

1. `testWhenFlagIsEvaluated_itAddsFeatureFlagToRUMView()`
   - Verifies flag evaluations appear in `RUMViewEvent.featureFlags`
   - Validates `RUMFlagEvaluationMessage` → `FlagEvaluationReceiver` integration

2. `testWhenFlagIsEvaluated_itCreatesRUMActionWithExposureDetails()`
   - Verifies custom `__dd_exposure` RUM actions are created
   - Validates `RUMFlagExposureMessage` → `FlagExposureReceiver` integration

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
