### PR TITLE
chore: Switch to Dependabot multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,20 @@
 # Dependabot configuration for GitHub Actions and Python dependencies
-# This will automatically create PRs to update GitHub Actions and Python packages to their latest versions
+# This will automatically create PR to update GitHub Actions and Python packages to their latest versions
 
 version: 2
+
+multi-ecosystem-groups:
+  repo-dependencies:
+    schedule:
+      interval: "monthly"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      gh-actions-packages:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "repo-dependencies"
   
   - package-ecosystem: "pip"
     directory: "/tools/issue_handler"
-    schedule:
-      interval: "monthly"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "repo-dependencies"


### PR DESCRIPTION
### What and why?

📦 This PR enables the `multi-ecosystem-groups` setting in Dependabot to simplify dependency management and consolidate updates into a single monthly PR.

### How?

Replaced separate update configurations with one [`multi-ecosystem-group`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#multi-ecosystem-group).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
