### PR TITLE
FFL-1161: Replace test helpers with behavioral tests

### DIFF
--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -24,16 +24,6 @@ public class FlagsClient {
         self.rumExposureLogger = rumExposureLogger
     }
 
-    // MARK: - Internal Testing Helpers
-
-    internal var isUsingNOPExposureLogger: Bool {
-        return exposureLogger is NOPExposureLogger
-    }
-
-    internal var isUsingNOPRUMLogger: Bool {
-        return rumExposureLogger is NOPRUMExposureLogger
-    }
-
     @discardableResult
     public static func create(
         name: String = FlagsClient.defaultName,
@@ -89,22 +79,15 @@ public class FlagsClient {
         }
 
         let featureScope = core.scope(for: FlagsFeature.self)
-        let dateProvider = SystemDateProvider()
         let client = FlagsClient(
             repository: FlagsRepository(
                 clientName: name,
                 flagAssignmentsFetcher: feature.flagAssignmentsFetcher,
-                dateProvider: dateProvider,
+                dateProvider: SystemDateProvider(),
                 featureScope: featureScope
             ),
-            exposureLogger: feature.trackExposures ? ExposureLogger(
-                dateProvider: dateProvider,
-                featureScope: featureScope
-            ) : NOPExposureLogger(),
-            rumExposureLogger: feature.rumIntegrationEnabled ? RUMExposureLogger(
-                dateProvider: dateProvider,
-                featureScope: featureScope
-            ) : NOPRUMExposureLogger()
+            exposureLogger: feature.makeExposureLogger(featureScope),
+            rumExposureLogger: feature.makeRUMExposureLogger(featureScope)
         )
 
         feature.clientRegistry.register(client, named: name)

--- a/DatadogFlags/Tests/Client/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientTests.swift
@@ -266,7 +266,7 @@ final class FlagsClientTests: XCTestCase {
         // Then
         XCTAssertEqual(value, .mockAny())
         XCTAssertEqual(core.events(ofType: ExposureEvent.self).count, 0, "No exposure events should be written")
-        XCTAssertEqual(messageReceiver.messages.count(where: \.isFlagsRUMMessage), 2, "RUM integration should still work")
+        XCTAssertEqual(messageReceiver.messages.filter(\.isFlagsRUMMessage).count, 2, "RUM integration should still work")
     }
 
     func testRUMIntegrationDisabled() throws {
@@ -294,7 +294,7 @@ final class FlagsClientTests: XCTestCase {
 
         // Then
         XCTAssertEqual(value, .mockAny())
-        XCTAssertEqual(messageReceiver.messages.count(where: \.isFlagsRUMMessage), 0, "No RUM messages should be sent")
+        XCTAssertEqual(messageReceiver.messages.filter(\.isFlagsRUMMessage).count, 0, "No RUM messages should be sent")
         XCTAssertEqual(core.events(ofType: ExposureEvent.self).count, 1, "Exposure should still be logged")
     }
 }


### PR DESCRIPTION
### What and why?

This PR refactors the exposure logging dependency injection to improve testability and code quality:

### How?

- Removes test helper methods (`isUsingNOPExposureLogger`, `isUsingNOPRUMLogger`) in `FlagsClient`
- Replaces direct logger creation with factory pattern in `FlagsFeature`
- Implements proper behavioral tests that verify actual events/messages instead of implementation details

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
