### PR TITLE
RUM-12033 Fix warning message for Crash Reporting + Remove Logs from Crash reporting scenarios

### DIFF
--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -303,8 +303,8 @@ class CrashReporterTests: XCTestCase {
         let logs = dd.logger.warnLogs
 
         XCTAssert(logs.contains(where: { $0.message == """
-            In order to use Crash Reporting, RUM or Logging feature must be enabled.
-            Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
+            In order to use Crash Reporting, RUM feature must be enabled.
+            Make sure `RUM.enable(with:)` is called when initializing Datadog SDK.
             """
         }))
     }

--- a/DatadogCrashReporting/Sources/CrashReportingFeature.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingFeature.swift
@@ -19,7 +19,7 @@ internal final class CrashReportingFeature: DatadogFeature {
 
     /// An interface for accessing the `DDCrashReportingPlugin` from `DatadogCrashReporting`.
     let plugin: CrashReportingPlugin
-    /// Integration enabling sending crash reports as Logs or RUM Errors.
+    /// Integration enabling sending crash reports as RUM Errors.
     let sender: CrashReportSender
     /// Telemetry interface.
     let telemetry: Telemetry

--- a/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/Integrations/CrashReportSender.swift
@@ -48,8 +48,8 @@ internal struct MessageBusSender: CrashReportSender {
             else: {
                 DD.logger.warn(
                     """
-                    In order to use Crash Reporting, RUM or Logging feature must be enabled.
-                    Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
+                    In order to use Crash Reporting, RUM feature must be enabled.
+                    Make sure `RUM.enable(with:)` is called when initializing Datadog SDK.
                     """
                 )
             }

--- a/IntegrationTests/IntegrationTests.xcodeproj/xcshareddata/xcschemes/Runner iOS.xcscheme
+++ b/IntegrationTests/IntegrationTests.xcodeproj/xcshareddata/xcschemes/Runner iOS.xcscheme
@@ -208,11 +208,6 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_CLASS_NAME"
-            value = "CrashReportingCollectOrSendWithLoggingScenario"
-            isEnabled = "NO">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "DD_TEST_SCENARIO_CLASS_NAME"
             value = "WebViewTrackingScenario"
             isEnabled = "NO">
          </EnvironmentVariable>

--- a/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
@@ -6,7 +6,6 @@
 
 import UIKit
 import DatadogCore
-import DatadogLogs
 
 internal class CrashReportingViewController: UIViewController {
     @IBOutlet weak var sendingCrashReportLabel: UILabel!
@@ -16,9 +15,6 @@ internal class CrashReportingViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        Logs.addAttribute(forKey: "global-attribute", value: "string-a")        
-        Logs.addAttribute(forKey: "global-attribute-2", value: 1_150)
 
         let testScenario = (appConfiguration.testScenario as! CrashReportingBaseScenario)
         sendingCrashReportLabel.isHidden = !testScenario.hadPendingCrashReportDataOnStartup

--- a/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -7,7 +7,6 @@
 import UIKit
 
 import DatadogCore
-import DatadogLogs
 import DatadogRUM
 import DatadogCrashReporting
 
@@ -60,27 +59,6 @@ final class CrashReportingCollectOrSendWithRUMScenario: CrashReportingBaseScenar
         rumConfig.errorEventMapper = rumErrorEventMapper
 
         RUM.enable(with: rumConfig)
-
-        CrashReporting.enable()
-    }
-}
-
-/// A `CrashReportingScenario` which uploads the crash report as "EMERGENCY" Log.
-final class CrashReportingCollectOrSendWithLoggingScenario: CrashReportingBaseScenario, TestScenario {
-    func logEventMapper(event: LogEvent) -> LogEvent? {
-        var event = event
-        event.error?.fingerprint = "mapped fingerprint"
-        return event
-    }
-
-    func configureFeatures() {
-        // Enable Logs
-        Logs.enable(
-            with: Logs.Configuration(
-                eventMapper: logEventMapper,
-                customEndpoint: Environment.serverMockConfiguration()?.logsEndpoint
-            )
-        )
 
         CrashReporting.enable()
     }


### PR DESCRIPTION
### What and why?

In v3, Crash Reporting can only be enabled with RUM (see [migration guide](https://docs.datadoghq.com/real_user_monitoring/guide/mobile-sdk-upgrade/?tab=ios#logs)). The following SDK warning message is misleading:
```
In order to use Crash Reporting, RUM or Logging feature must be enabled.
Make sure `RUM` or `Logs` are enabled when initializing Datadog SDK.
``` 

This was reported by a customer in https://github.com/DataDog/dd-sdk-ios/issues/2519.

### How?

- Fixed warning message 
- Removed Crash Reporting scenario with Logs from integration tests

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
