### PR TITLE
RUM-12227: Notify all SDK instances of the `UIApplication.didBecomeActive` notification

### DIFF
--- a/DatadogCore/Private/include/ObjcAppLaunchHandler.h
+++ b/DatadogCore/Private/include/ObjcAppLaunchHandler.h
@@ -57,7 +57,7 @@ typedef void (^UIApplicationDidBecomeActiveCallback)(NSTimeInterval timeInterval
 /// and is not retained for subsequent activations.
 ///
 /// - Parameter callback: A closure executed upon app activation.
-- (void)setApplicationDidBecomeActiveCallback:(UIApplicationDidBecomeActiveCallback)callback;
+- (void)setApplicationDidBecomeActiveCallback:(nonnull UIApplicationDidBecomeActiveCallback)callback;
 
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchInfoPublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/LaunchInfoPublisherTests.swift
@@ -189,6 +189,47 @@ class AppLaunchHandlerTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    func testSetApplicationDidBecomeActiveCallbackByMultipleEntities() {
+        // Given
+        let handler = AppLaunchHandler()
+        let callbacksCount = 10
+        let notified = expectation(description: "All callbacks notified")
+        notified.expectedFulfillmentCount = callbacksCount
+
+        (0..<callbacksCount).forEach { _ in
+            handler.setApplicationDidBecomeActiveCallback { _ in notified.fulfill() }
+        }
+
+        // When
+        handler.observe(notificationCenter)
+        notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+
+        // Then
+        waitForExpectations(timeout: 1)
+    }
+
+    func testApplicationDidBecomeActiveMultipleTimesInMultipleEntities() {
+        // Given
+        let handler = AppLaunchHandler()
+        let callbacksCount: Int = .mockRandom(min: 3, max: 10)
+        let notificationsCount: Int = .mockRandom(min: 3, max: 10)
+        let notified = expectation(description: "All callbacks notified")
+        notified.expectedFulfillmentCount = callbacksCount
+
+        (0..<callbacksCount).forEach { _ in
+            handler.setApplicationDidBecomeActiveCallback { _ in notified.fulfill() }
+        }
+
+        // When
+        handler.observe(notificationCenter)
+        (0..<notificationsCount).forEach { _ in
+            notificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+    }
+
     func testThreadSafety() {
         let handler = AppLaunchHandler()
 


### PR DESCRIPTION
### What and why?

This PR improves how the `UIApplicationDidBecomeActiveNotification` is broadcast to all SDK instances initialized in the app.

### How?

The `AppLaunchHandler` now retains an array of callbacks and notifies all registered instances when the notification is received.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
