### PR TITLE
RUM-11466: Remove `application_start` action from `ApplicationLaunch`

### DIFF
--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
@@ -37,6 +37,13 @@ extension AppRunStep {
         })
     }
 
+    static func appDisplaysFirstFrame(after dt: TimeInterval = 0) -> AppRunStep {
+        return AppRunStep({ app in
+            app.advanceTime(by: dt)
+            app.displayFirstFrame(after: dt)
+        })
+    }
+
     // MARK: - RUM Use Cases
 
     static func enableRUM(
@@ -135,5 +142,15 @@ extension AppRunStep {
             app.advanceTime(by: dt)
             app.rum.stopResource(resourceKey: key, response: .mockAny())
         })
+    }
+}
+
+// MARK: - Test Utils
+
+extension AppRunStep {
+    static func flushDatadogContext() -> AppRunStep {
+        AppRunStep { app in
+            DatadogContextProvider.defaultQueue.sync {}
+        }
     }
 }

--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
@@ -20,6 +20,7 @@ internal class AppRunner {
         let taskPolicyRole: Int
         let processInfoEnvironment: [String: String]
         let processLaunchDate: Date
+        let runtimeLoadDate: Date
         let initialAppState: AppState
         let description: String
 
@@ -39,6 +40,7 @@ internal class AppRunner {
                 taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
+                runtimeLoadDate: processLaunchDate,
                 initialAppState: .background,
                 description: "user launch (with scene-delegate)"
             )
@@ -59,6 +61,7 @@ internal class AppRunner {
                 taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
+                runtimeLoadDate: processLaunchDate,
                 initialAppState: .inactive,
                 description: "user launch (with app-delegate)"
             )
@@ -70,11 +73,12 @@ internal class AppRunner {
         /// in prewarming scenarios. This uncertainty is acceptable, as the `"ActivePrewarm"` flag in
         /// `ProcessInfo.environment` takes precedence when classifying prewarming.
         @available(tvOS, unavailable)
-        static func osPrewarm(processLaunchDate: Date) -> ProcessLaunchType {
+        static func osPrewarm(processLaunchDate: Date, runtimeLoadDate: Date) -> ProcessLaunchType {
             return .init(
                 taskPolicyRole: Int(TASK_DARWINBG_APPLICATION.rawValue),
                 processInfoEnvironment: ["ActivePrewarm": "1"],
                 processLaunchDate: processLaunchDate,
+                runtimeLoadDate: runtimeLoadDate,
                 initialAppState: .background,
                 description: "os prewarm"
             )
@@ -96,6 +100,7 @@ internal class AppRunner {
                 taskPolicyRole: taskPolicyRole,
                 processInfoEnvironment: [:],
                 processLaunchDate: processLaunchDate,
+                runtimeLoadDate: processLaunchDate,
                 initialAppState: .background,
                 description: "background launch"
             )
@@ -130,6 +135,7 @@ internal class AppRunner {
     private var dateProvider: DateProviderMock!
     private var appStateProvider: AppStateProviderMock!
     private var appLaunchHandler: AppLaunchHandlerMock!
+    private var frameInfoProvider: FrameInfoProviderMock!
     private var core: DatadogCoreProxy!
     // swiftlint:enable implicitly_unwrapped_optional
     private var appStateObservers: [NSObjectProtocol] = []
@@ -146,6 +152,7 @@ internal class AppRunner {
         appLaunchHandler = AppLaunchHandlerMock(
             taskPolicyRole: launchType.taskPolicyRole,
             processLaunchDate: launchType.processLaunchDate,
+            runtimeLoadDate: launchType.runtimeLoadDate,
             didBecomeActiveDate: nil // will wait for SimulationStep.changeAppState(_:)
         )
 
@@ -203,6 +210,11 @@ internal class AppRunner {
 
     private var lastAppearedViewController: UIViewController?
 
+    /// Simulates the first frame of an app launch.
+    func displayFirstFrame(after interval: TimeInterval) {
+        self.frameInfoProvider.triggerCallback(interval: interval)
+    }
+
     /// Simulates `viewDidAppear()` for a given view controller.
     /// If another view controller had previously appeared, it will automatically simulate `viewDidDisappear()` for it.
     func viewDidAppear(vc: UIViewController) {
@@ -255,7 +267,13 @@ internal class AppRunner {
     func enableRUM(_ rumSetup: RUMSetup = { _ in }) {
         var config = RUM.Configuration(applicationID: "mock-application-id")
         config.dateProvider = dateProvider
+        config.mediaTimeProvider = MediaTimeProviderMock(current: 0)
         config.notificationCenter = notificationCenter
+        config.frameInfoProviderFactory = { [weak self] in
+            let frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
+            self?.frameInfoProvider = frameInfoProvider
+            return frameInfoProvider
+        }
         rumSetup(&config)
         RUM.enable(with: config, in: core)
     }

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionStartInBackgroundTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionStartInBackgroundTests.swift
@@ -20,7 +20,7 @@ class RUMSessionStartInBackgroundTests: RUMSessionTestsBase {
 
     // MARK: - OS Prewarm Launch
 
-    private var osPrewarmLaunch: AppRunner.ProcessLaunchType { .osPrewarm(processLaunchDate: processLaunchDate) }
+    private var osPrewarmLaunch: AppRunner.ProcessLaunchType { .osPrewarm(processLaunchDate: processLaunchDate, runtimeLoadDate: runtimeLoadDate) }
 
     func testGivenOSPrewarmLaunch_whenNoEventIsTracked() throws {
         // Given
@@ -67,8 +67,8 @@ class RUMSessionStartInBackgroundTests: RUMSessionTestsBase {
         for when in [when3, when4] {
             // Then
             let session = try when.then().takeSingle()
-            XCTAssertNil(session.applicationStartAction)
-            XCTAssertNil(session.applicationStartupTime)
+            XCTAssertNil(session.ttidEvent)
+            XCTAssertNil(session.timeToInitialDisplay)
             DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
             DDAssertEqual(session.duration, dt2, accuracy: accuracy)
             XCTAssertEqual(session.sessionPrecondition, .prewarm)
@@ -143,8 +143,8 @@ class RUMSessionStartInBackgroundTests: RUMSessionTestsBase {
 
         for when in [when3, when4] {
             let session = try when.then().takeSingle()
-            XCTAssertNil(session.applicationStartAction)
-            XCTAssertNil(session.applicationStartupTime)
+            XCTAssertNil(session.ttidEvent)
+            XCTAssertNil(session.timeToInitialDisplay)
             DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
             DDAssertEqual(session.duration, dt2, accuracy: accuracy)
             XCTAssertEqual(session.sessionPrecondition, .backgroundLaunch)

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionStopTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionStopTests.swift
@@ -34,14 +34,15 @@ class RUMSessionStopTests: RUMSessionTestsBase {
         for given in [given1, given2, given3, given4, given5, given6] {
             // When
             let when = given
+                .and(.flushDatadogContext())
                 .when(.stopSession(after: dt1))
                 .and(.trackTwoActions(after1: dt2, after2: dt3))
 
             // Then
             // - It tracks "stopped" session:
             let (session1, session2) = try when.then().takeTwo()
-            XCTAssertNotNil(session1.applicationStartAction)
-            DDAssertEqual(session1.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+            XCTAssertNotNil(session1.ttidEvent)
+            DDAssertEqual(session1.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
             DDAssertEqual(session1.sessionStartDate, processLaunchDate, accuracy: accuracy)
             DDAssertEqual(session1.duration, timeToSDKInit + timeToAppBecomeActive + dt1, accuracy: accuracy)
             XCTAssertEqual(session1.sessionPrecondition, .userAppLaunch)
@@ -58,8 +59,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             }
 
             // - It creates new session with restarting the last view for tracking new events:
-            XCTAssertNil(session2.applicationStartAction)
-            XCTAssertNil(session2.applicationStartupTime)
+            XCTAssertNil(session2.ttidEvent)
+            XCTAssertNil(session2.timeToInitialDisplay)
             DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + timeToAppBecomeActive + dt1 + dt2, accuracy: accuracy)
             DDAssertEqual(session2.duration, dt3, accuracy: accuracy)
             XCTAssertEqual(session2.sessionPrecondition, .explicitStop)
@@ -82,9 +83,11 @@ class RUMSessionStopTests: RUMSessionTestsBase {
         for given in [given1, given2, given3, given4, given5, given6] {
             // When
             let when2 = given
+                .and(.flushDatadogContext())
                 .when(.stopSession(after: dt1))
                 .and(.trackResource(after: dt2, duration: dt3))
             let when3 = given
+                .and(.flushDatadogContext())
                 .when(.stopSession(after: dt1))
                 .and(.trackTwoLongTasks(after1: dt2, after2: dt3))
 
@@ -92,8 +95,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "stopped" session:
                 let session = try when.then().takeSingle()
-                XCTAssertNotNil(session.applicationStartAction)
-                DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+                XCTAssertNotNil(session.ttidEvent)
+                DDAssertEqual(session.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 DDAssertEqual(session.duration, timeToSDKInit + timeToAppBecomeActive + dt1, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
@@ -259,6 +262,7 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             // When
             // - "stop" → BG
             let when1 = given
+                .and(.flushDatadogContext())
                 .when(.stopSession(after: dt1))
                 .and(.appEntersBackground(after: dt2))
 
@@ -270,8 +274,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "stopped" session (background events are skipped due to BET disabled):
                 let session = try when.then().takeSingle()
-                XCTAssertNotNil(session.applicationStartAction)
-                DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+                XCTAssertNotNil(session.ttidEvent)
+                DDAssertEqual(session.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 DDAssertEqual(session.duration, timeToSDKInit + timeToAppBecomeActive + dt1, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
@@ -292,6 +296,7 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             // - BG → "stop"
             let when2 = given
                 .when(.appEntersBackground(after: dt1))
+                .and(.flushDatadogContext())
                 .and(.stopSession(after: dt2))
 
             for when in [
@@ -302,8 +307,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "stopped" session (background events are skipped due to BET disabled):
                 let session = try when.then().takeSingle()
-                XCTAssertNotNil(session.applicationStartAction)
-                DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+                XCTAssertNotNil(session.ttidEvent)
+                DDAssertEqual(session.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
                 if given == given1 { // session with `ApplicationLaunch` view
@@ -355,8 +360,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 XCTAssertEqual(session1.sessionPrecondition, .userAppLaunch)
 
                 // - It creates new session for tracking background events:
-                XCTAssertNil(session2.applicationStartAction)
-                XCTAssertNil(session2.applicationStartupTime)
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + timeToAppBecomeActive + dt1 + dt2 + dt3, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt4, accuracy: accuracy)
                 XCTAssertEqual(session2.sessionPrecondition, .explicitStop)
@@ -446,8 +451,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             // Then
             // - It tracks "stopped" background session:
             let (session1, session2) = try when.then().takeTwo()
-            XCTAssertNil(session1.applicationStartAction)
-            XCTAssertNil(session1.applicationStartupTime)
+            XCTAssertNil(session1.ttidEvent)
+            XCTAssertNil(session1.timeToInitialDisplay)
             DDAssertEqual(session1.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
             DDAssertEqual(session1.duration, dt2 + dt3, accuracy: accuracy)
             XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -457,8 +462,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             XCTAssertEqual(session1.views[0].resourceEvents.count, 1)
 
             // - It creates new session for tracking background events:
-            XCTAssertNil(session2.applicationStartAction)
-            XCTAssertNil(session2.applicationStartupTime)
+            XCTAssertNil(session2.ttidEvent)
+            XCTAssertNil(session2.timeToInitialDisplay)
             DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + dt4, accuracy: accuracy)
             DDAssertEqual(session2.duration, dt5, accuracy: accuracy)
             XCTAssertEqual(session2.sessionPrecondition, .explicitStop)
@@ -490,8 +495,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It tracks "stopped" session (events other than action are dropped after `sessionStop()`):
                 let session = try when.then().takeSingle()
-                XCTAssertNil(session.applicationStartAction)
-                XCTAssertNil(session.applicationStartupTime)
+                XCTAssertNil(session.ttidEvent)
+                XCTAssertNil(session.timeToInitialDisplay)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session.duration, dt2 + dt3, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -560,8 +565,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "stopped" background session (foreground events are skipped due to "no view"):
                 let session = try when.then().takeSingle()
-                XCTAssertNil(session.applicationStartAction)
-                XCTAssertNil(session.applicationStartupTime)
+                XCTAssertNil(session.ttidEvent)
+                XCTAssertNil(session.timeToInitialDisplay)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session.duration, dt2 + dt3, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -584,8 +589,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "stopped" background session (foreground events are skipped due to "no view"):
                 let session = try when.then().takeSingle()
-                XCTAssertNil(session.applicationStartAction)
-                XCTAssertNil(session.applicationStartupTime)
+                XCTAssertNil(session.ttidEvent)
+                XCTAssertNil(session.timeToInitialDisplay)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session.duration, dt2, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -625,8 +630,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                     // Then
                     // - It only tracks foreground session ("stopped" background session is skipped due to BET disabled):
                     let session = try when.then().takeSingle()
-                    XCTAssertNil(session.applicationStartAction)
-                    XCTAssertNil(session.applicationStartupTime)
+                    XCTAssertNil(session.ttidEvent)
+                    XCTAssertNil(session.timeToInitialDisplay)
                     DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + dt4 + dt5, accuracy: accuracy)
                     DDAssertEqual(session.duration, dt6, accuracy: accuracy)
                     XCTAssertEqual(session.sessionPrecondition, .explicitStop)
@@ -670,8 +675,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It tracks "stopped" background session:
                 let (session1, session2) = try when.then().takeTwo()
-                XCTAssertNil(session1.applicationStartAction)
-                XCTAssertNil(session1.applicationStartupTime)
+                XCTAssertNil(session1.ttidEvent)
+                XCTAssertNil(session1.timeToInitialDisplay)
                 DDAssertEqual(session1.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session1.duration, dt2 + dt3, accuracy: accuracy)
                 XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -681,8 +686,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 XCTAssertEqual(session1.views[0].resourceEvents.count, 1)
 
                 // - It creates new session for tracking view in foreground:
-                XCTAssertNil(session2.applicationStartAction)
-                XCTAssertNil(session2.applicationStartupTime)
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + dt4 + dt5, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt6, accuracy: accuracy)
                 XCTAssertEqual(session2.sessionPrecondition, .explicitStop)
@@ -708,8 +713,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 // Then
                 // - It tracks "stopped" background session:
                 let (session1, session2) = try when.then().takeTwo()
-                XCTAssertNil(session1.applicationStartAction)
-                XCTAssertNil(session1.applicationStartupTime)
+                XCTAssertNil(session1.ttidEvent)
+                XCTAssertNil(session1.timeToInitialDisplay)
                 DDAssertEqual(session1.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session1.duration, dt2, accuracy: accuracy)
                 XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -719,8 +724,8 @@ class RUMSessionStopTests: RUMSessionTestsBase {
                 XCTAssertEqual(session1.views[0].resourceEvents.count, 1)
 
                 // - It creates new session for tracking view in foreground:
-                XCTAssertNil(session2.applicationStartAction)
-                XCTAssertNil(session2.applicationStartupTime)
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + dt4 + dt5, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt6, accuracy: accuracy)
                 XCTAssertEqual(session2.sessionPrecondition, .explicitStop)

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
@@ -34,12 +34,15 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
         for given in [given1, given2, given3, given4, given5, given6] {
             // When
             let when1 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.trackTwoActions(after1: dt1, after2: dt2))
             let when2 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.trackResource(after: dt1, duration: dt2))
             let when3 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.trackTwoLongTasks(after1: dt1, after2: dt2))
 
@@ -47,8 +50,9 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 // Then
                 // - It tracks "timed out" session:
                 let (session1, session2) = try when.then().takeTwo()
-                XCTAssertNotNil(session1.applicationStartAction)
-                DDAssertEqual(session1.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+
+                XCTAssertNotNil(session1.ttidEvent)
+                DDAssertEqual(session1.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session1.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 XCTAssertEqual(session1.sessionPrecondition, .userAppLaunch)
                 if given == given1 || given == given2 { // session with `ApplicationLaunch` view
@@ -66,8 +70,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 }
 
                 // - It creates new session with restarting the last view for tracking new events:
-                XCTAssertNil(session2.applicationStartAction)
-                XCTAssertNil(session2.applicationStartupTime)
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + timeToAppBecomeActive + sessionTimeoutDuration + dt1, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt2, accuracy: accuracy)
                 XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
@@ -221,6 +225,7 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
             // When
             // - "time out" → BG
             let when1 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.appEntersBackground(after: dt1))
 
@@ -232,8 +237,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "timed out" session (background events are skipped due to BET disabled):
                 let session = try when.then().takeSingle()
-                XCTAssertNotNil(session.applicationStartAction)
-                DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+                XCTAssertNotNil(session.ttidEvent)
+                DDAssertEqual(session.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
                 if given == given1 { // session with `ApplicationLaunch` view
@@ -254,6 +259,7 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
             // When
             // - BG → "time out"
             let when2 = given
+                .and(.flushDatadogContext())
                 .and(.appEntersBackground(after: dt1))
                 .when(.timeoutSession())
 
@@ -265,8 +271,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 // Then
                 // - It only tracks "timed out" session (background events are skipped due to BET disabled):
                 let session = try when.then().takeSingle()
-                XCTAssertNotNil(session.applicationStartAction)
-                DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+                XCTAssertNotNil(session.ttidEvent)
+                DDAssertEqual(session.timeToInitialDisplay, timeToInitialDisplay, accuracy: accuracy)
                 DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
                 XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
                 if given == given1 { // session with `ApplicationLaunch` view
@@ -303,9 +309,11 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
         for given in [given1, given2, given3] {
             // When
             let when1 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.appEntersBackground(after: dt1))
             let when2 = given
+                .and(.flushDatadogContext())
                 .and(.appEntersBackground(after: dt1))
                 .when(.timeoutSession())
 
@@ -322,8 +330,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     XCTAssertEqual(session1.sessionPrecondition, .userAppLaunch)
 
                     // - It creates new session for tracking background events:
-                    XCTAssertNil(session2.applicationStartAction)
-                    XCTAssertNil(session2.applicationStartupTime)
+                    XCTAssertNil(session2.ttidEvent)
+                    XCTAssertNil(session2.timeToInitialDisplay)
                     DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + timeToAppBecomeActive + sessionTimeoutDuration + dt1 + dt2, accuracy: accuracy)
                     DDAssertEqual(session2.duration, dt3, accuracy: accuracy)
                     XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
@@ -387,9 +395,11 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
         for given in [given1, given2] {
             // When
             let when1 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.trackTwoActions(after1: dt3, after2: dt4))
             let when2 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .and(.trackResource(after: dt3, duration: dt4))
 
@@ -397,8 +407,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 // Then
                 // - It tracks "timed out" background session:
                 let (session1, session2) = try when.then().takeTwo()
-                XCTAssertNil(session1.applicationStartAction)
-                XCTAssertNil(session1.applicationStartupTime)
+                XCTAssertNil(session1.ttidEvent)
+                XCTAssertNil(session1.timeToInitialDisplay)
                 DDAssertEqual(session1.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                 DDAssertEqual(session1.duration, dt2, accuracy: accuracy)
                 XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -408,8 +418,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 XCTAssertEqual(session1.views[0].resourceEvents.count, 1)
 
                 // - It creates new session for tracking background events:
-                XCTAssertNil(session2.applicationStartAction)
-                XCTAssertNil(session2.applicationStartupTime)
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt4, accuracy: accuracy)
                 XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
@@ -422,14 +432,15 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
 
             // When
             let when3 = given
+                .and(.flushDatadogContext())
                 .when(.timeoutSession())
                 .when(.trackTwoLongTasks(after1: dt2, after2: dt3))
 
             // Then
             // - It only tracks "timed out" session (long tasks are skipped in background regardless BET enabled):
             let session = try when3.then().takeSingle()
-            XCTAssertNil(session.applicationStartAction)
-            XCTAssertNil(session.applicationStartupTime)
+            XCTAssertNil(session.ttidEvent)
+            XCTAssertNil(session.timeToInitialDisplay)
             DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
             DDAssertEqual(session.duration, dt2, accuracy: accuracy)
             XCTAssertEqual(session.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -468,8 +479,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     // Then
                     // - It only tracks foreground session ("timed out" session is skipped due to BET disabled):
                     let session = try when.then().takeSingle()
-                    XCTAssertNil(session.applicationStartAction)
-                    XCTAssertNil(session.applicationStartupTime)
+                    XCTAssertNil(session.ttidEvent)
+                    XCTAssertNil(session.timeToInitialDisplay)
                     DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3 + dt4, accuracy: accuracy)
                     DDAssertEqual(session.duration, dt5, accuracy: accuracy)
                     XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
@@ -511,8 +522,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     // Then
                     // - It only tracks "timed out" background session (foreground events are skipped due to "no view"):
                     let session = try when.then().takeSingle()
-                    XCTAssertNil(session.applicationStartAction)
-                    XCTAssertNil(session.applicationStartupTime)
+                    XCTAssertNil(session.ttidEvent)
+                    XCTAssertNil(session.timeToInitialDisplay)
                     DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                     DDAssertEqual(session.duration, dt2, accuracy: accuracy)
                     XCTAssertEqual(session.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -553,8 +564,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     // Then
                     // - It only tracks foreground session ("timed out" background session is skipped due to BET disabled):
                     let session = try when.then().takeSingle()
-                    XCTAssertNil(session.applicationStartAction)
-                    XCTAssertNil(session.applicationStartupTime)
+                    XCTAssertNil(session.ttidEvent)
+                    XCTAssertNil(session.timeToInitialDisplay)
                     DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3 + dt4, accuracy: accuracy)
                     DDAssertEqual(session.duration, dt5, accuracy: accuracy)
                     XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
@@ -602,8 +613,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     // Then
                     // - It tracks "timed out" background session:
                     let (session1, session2) = try when.then().takeTwo()
-                    XCTAssertNil(session1.applicationStartAction)
-                    XCTAssertNil(session1.applicationStartupTime)
+                    XCTAssertNil(session1.ttidEvent)
+                    XCTAssertNil(session1.timeToInitialDisplay)
                     DDAssertEqual(session1.sessionStartDate, processLaunchDate + timeToSDKInit + dt1, accuracy: accuracy)
                     DDAssertEqual(session1.duration, dt2, accuracy: accuracy)
                     XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
@@ -613,8 +624,8 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                     XCTAssertEqual(session1.views[0].resourceEvents.count, 1)
 
                     // - It creates new session for tracking view in foreground:
-                    XCTAssertNil(session2.applicationStartAction)
-                    XCTAssertNil(session2.applicationStartupTime)
+                    XCTAssertNil(session2.ttidEvent)
+                    XCTAssertNil(session2.timeToInitialDisplay)
                     DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3 + dt4, accuracy: accuracy)
                     DDAssertEqual(session2.duration, dt5, accuracy: accuracy)
                     XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTrackingTests.swift
@@ -34,6 +34,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         // Move to foreground, start "FirstView" and track events:
         run = run
             .and(.appBecomesActive(after: timeToAppBecomeActive))
+            .and(.appDisplaysFirstFrame())
             .and(.startAutomaticView(after: 0, viewController: createMockView(viewControllerClassName: "FirstView")))
             .and(.trackResource(after: dt, duration: dt))
             .and(.trackTwoLongTasks(after1: dt, after2: dt))
@@ -65,8 +66,8 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         session: RUMSessionMatcher,
         expectBackgroundView: Bool
     ) {
-        XCTAssertNotNil(session.applicationStartAction)
-        DDAssertEqual(session.applicationStartupTime, timeToSDKInit, accuracy: accuracy)
+        XCTAssertNotNil(session.ttidEvent)
+        DDAssertEqual(session.timeToInitialDisplay, timeToSDKInit + 4 + timeToAppBecomeActive, accuracy: accuracy)
         DDAssertEqual(session.sessionStartDate, processLaunchDate, accuracy: accuracy)
         DDAssertEqual(session.duration, timeToSDKInit + 4 * dt + timeToAppBecomeActive + 18 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, .userAppLaunch)
@@ -75,7 +76,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         var nextView = views.removeFirst()
         XCTAssertEqual(nextView.name, applicationLaunchViewName)
         DDAssertEqual(nextView.duration, timeToSDKInit + 4 * dt + timeToAppBecomeActive, accuracy: accuracy)
-        XCTAssertEqual(nextView.actionEvents.count, 3)
+        XCTAssertEqual(nextView.actionEvents.count, 2)
         XCTAssertEqual(nextView.resourceEvents.count, 0)
         XCTAssertEqual(nextView.longTaskEvents.count, 2)
 
@@ -167,8 +168,8 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         session: RUMSessionMatcher,
         expectedSessionPrecondition: RUMSessionPrecondition
     ) {
-        XCTAssertNil(session.applicationStartAction)
-        XCTAssertNil(session.applicationStartupTime)
+        XCTAssertNil(session.ttidEvent)
+        XCTAssertNil(session.timeToInitialDisplay)
         DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
         DDAssertEqual(session.duration, 5 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 6 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
@@ -183,7 +184,7 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
     }
 
     @available(tvOS, unavailable)
-    private var osPrewarmLaunch: AppRunner.ProcessLaunchType { .osPrewarm(processLaunchDate: processLaunchDate) }
+    private var osPrewarmLaunch: AppRunner.ProcessLaunchType { .osPrewarm(processLaunchDate: processLaunchDate, runtimeLoadDate: runtimeLoadDate) }
 
     @available(tvOS, unavailable)
     func testGivenPrewarmedLaunch_whenTrackingBackgroundSession() throws {
@@ -267,8 +268,8 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         session: RUMSessionMatcher,
         expectedSessionPrecondition: RUMSessionPrecondition
     ) {
-        XCTAssertNil(session.applicationStartAction)
-        XCTAssertNil(session.applicationStartupTime)
+        XCTAssertNil(session.ttidEvent)
+        XCTAssertNil(session.timeToInitialDisplay)
         DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt, accuracy: accuracy)
         DDAssertEqual(session.duration, 3 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 2 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)
@@ -286,8 +287,8 @@ class RUMSessionTrackingTests: RUMSessionTestsBase {
         session: RUMSessionMatcher,
         expectedSessionPrecondition: RUMSessionPrecondition
     ) {
-        XCTAssertNil(session.applicationStartAction)
-        XCTAssertNil(session.applicationStartupTime)
+        XCTAssertNil(session.ttidEvent)
+        XCTAssertNil(session.timeToInitialDisplay)
         DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + 6 * dt + LaunchReasonResolver.Constants.launchWindowThreshold + 2.hours, accuracy: accuracy)
         DDAssertEqual(session.duration, 4 * dt, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, expectedSessionPrecondition)

--- a/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
+++ b/DatadogCore/Sources/Core/Context/DatadogContextProvider.swift
@@ -37,16 +37,17 @@ import DatadogInternal
 ///
 /// All subscriptions will be cancelled when the provider is deallocated.
 internal final class DatadogContextProvider {
+    static let defaultQueue = DispatchQueue(
+        label: "com.datadoghq.core-context",
+        qos: .utility
+    )
     /// The current `context`.
     ///
     /// The value must be accessed from the `queue` only.
     private var context: DatadogContext
 
     /// The queue used to synchronize the access to the `DatadogContext`.
-    internal let queue = DispatchQueue(
-        label: "com.datadoghq.core-context",
-        qos: .utility
-    )
+    internal let queue: DispatchQueue
 
     /// List of receivers to invoke when the context changes.
     private var receivers: [ContextValueReceiver<DatadogContext>]
@@ -57,9 +58,12 @@ internal final class DatadogContextProvider {
     /// Creates a context provider to perform reads and writes on the
     /// shared Datadog context.
     ///
-    /// - Parameter context: The inital context value.
-    init(context: DatadogContext) {
+    /// - Parameters:
+    ///   - context: The initial context value.
+    ///   - queue: The queue to synchronize the access to the `DatadogContext`.
+    init(context: DatadogContext, queue: DispatchQueue = DatadogContextProvider.defaultQueue) {
         self.context = context
+        self.queue = queue
         self.receivers = []
         self.subscriptions = []
     }

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -1114,13 +1114,9 @@ class RUMMonitorTests: XCTestCase {
             return resourceEvent
         }
         config.actionEventMapper = { actionEvent in
-            if actionEvent.action.type == .applicationStart {
-                return nil // drop `.applicationStart` action
-            } else {
-                var actionEvent = actionEvent
-                actionEvent.action.target?.name = "Modified tap action name"
-                return actionEvent
-            }
+            var actionEvent = actionEvent
+            actionEvent.action.target?.name = "Modified tap action name"
+            return actionEvent
         }
         config.errorEventMapper = { errorEvent in
             var errorEvent = errorEvent
@@ -1163,7 +1159,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testDroppingEventsBeforeTheyGetSent() throws {
         config.resourceEventMapper = { _ in nil }
-        config.actionEventMapper = { event in event.action.type == .applicationStart ? event : nil }
+        config.actionEventMapper = { _ in nil }
         config.errorEventMapper = { _ in nil }
         config.longTaskEventMapper = { _ in nil }
         RUM.enable(with: config, in: core)

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/FirstFrameReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/FirstFrameReaderTests.swift
@@ -15,7 +15,7 @@ final class FirstFrameReaderTests: XCTestCase {
         let reader = FirstFrameReader(dateProvider: DateProviderMock(), mediaTimeProvider: MediaTimeProviderMock(current: 0))
         let rumCommandSubscriber = RUMCommandSubscriberMock()
         reader.publish(to: rumCommandSubscriber)
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 60)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 2

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/ViewHitchesReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/ViewHitchesReaderTests.swift
@@ -18,7 +18,7 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenRenderLoopAt60FPS() {
         let reader = ViewHitchesReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 60)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -50,7 +50,7 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenRenderLoopAt60FPS_and2VSyncsOfAcceptableLatency() {
         let reader = ViewHitchesReader(acceptableLatency: 0.032)
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 60)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -89,7 +89,8 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenRenderLoopAt60FPS_andHangThreshold() {
         let reader = ViewHitchesReader(hangThreshold: 0.1)
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 20)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 20
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -129,7 +130,8 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenRenderLoopAt120FPS() {
         let reader = ViewHitchesReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -167,7 +169,8 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenAdaptiveSyncDisplay() {
         let reader = ViewHitchesReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -206,7 +209,8 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenAdaptiveSyncDisplayWithViewHitches() {
         let reader = ViewHitchesReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0
@@ -238,7 +242,8 @@ final class ViewHitchesReaderTests: XCTestCase {
     */
     func testViewHitches_givenAdaptiveSyncDisplayWithQuickerThanExpectedFrames() {
         let reader = ViewHitchesReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // 1st frame
         frameInfoProvider.currentFrameTimestamp = 0

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
@@ -19,7 +19,7 @@ final class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_given60HzFixedRateDisplay() {
         let reader = VitalRefreshRateReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 60)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
 
         // first frame recorded
         frameInfoProvider.currentFrameTimestamp = 0
@@ -47,7 +47,8 @@ final class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_given120HzFixedRateDisplay_normalizesTo60Hz() {
         let reader = VitalRefreshRateReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // first frame recorded
         frameInfoProvider.currentFrameTimestamp = 0
@@ -80,7 +81,8 @@ final class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_givenAdaptiveSyncDisplay() {
         let reader = VitalRefreshRateReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // first frame recorded
         frameInfoProvider.currentFrameTimestamp = 0
@@ -114,7 +116,8 @@ final class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_givenAdaptiveSyncDisplayWithFreezingFrames() {
         let reader = VitalRefreshRateReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // first frame recorded
         frameInfoProvider.currentFrameTimestamp = 0
@@ -142,7 +145,8 @@ final class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_givenAdaptiveSyncDisplayWithQuickerThanExpectedFrames() {
         let reader = VitalRefreshRateReader()
-        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
+        let frameInfoProvider = FrameInfoProviderMock(target: self, selector: .noOp)
+        frameInfoProvider.maximumDeviceFramesPerSecond = 120
 
         // first frame recorded
         frameInfoProvider.currentFrameTimestamp = 0

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -82,7 +82,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
              accessibilityReader = AccessibilityReader(notificationCenter: configuration.notificationCenter)
         }
 
-        let firstFrameReader = FirstFrameReader()
+        let firstFrameReader = FirstFrameReader(dateProvider: configuration.dateProvider, mediaTimeProvider: configuration.mediaTimeProvider)
 
         let dependencies = RUMScopeDependencies(
             featureScope: featureScope,
@@ -115,7 +115,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     return nil
                 }
             }(),
-            renderLoopObserver: DisplayLinker(notificationCenter: configuration.notificationCenter),
+            renderLoopObserver: DisplayLinker(
+                notificationCenter: configuration.notificationCenter,
+                frameInfoProviderFactory: configuration.frameInfoProviderFactory
+            ),
             firstFrameReader: firstFrameReader,
             viewHitchesReaderFactory: {
                 configuration.featureFlags[.viewHitches]

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import DatadogInternal
+import QuartzCore
 
 // swiftlint:disable duplicate_imports
 @_exported import enum DatadogInternal.URLSessionInstrumentation
@@ -360,13 +361,18 @@ extension RUM {
         internal var traceIDGenerator: TraceIDGenerator = DefaultTraceIDGenerator()
         internal var spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator()
 
+        /// The provider of the current date.
         internal var dateProvider: DateProvider = SystemDateProvider()
+        /// The provider of the current media uptime.
+        internal var mediaTimeProvider: CACurrentMediaTimeProvider = MediaTimeProvider()
         /// The main queue, subject to App Hangs monitoring.
         internal var mainQueue: DispatchQueue = .main
         /// Identifier of the current process, used to check if fatal App Hang originated in a previous process instance.
         internal var processID: UUID = currentProcessID
         /// The default notification center used for subscribing to app lifecycle events and system notifications.
         internal var notificationCenter: NotificationCenter = .default
+        /// The factory to create the frame info provider. Defaults to the `CADisplayLink`.
+        internal var frameInfoProviderFactory: (Any, Selector) -> FrameInfoProvider = { CADisplayLink(target: $0, selector: $1) }
         /// The bundle object that contains the current executable.
         internal var bundle: Bundle = .main
 

--- a/DatadogRUM/Sources/RUMVitals/RenderLoop/FirstFrameReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/RenderLoop/FirstFrameReader.swift
@@ -17,14 +17,12 @@ internal final class FirstFrameReader: RUMCommandPublisher {
     private var firstFrameTimestamp: Double?
     private var firstFrameDate: Date?
 
+    @ReadWriteLock
     private(set) var isActive: Bool = true
 
     private(set) weak var subscriber: RUMCommandSubscriber?
 
-    init(
-        dateProvider: DateProvider = SystemDateProvider(),
-        mediaTimeProvider: CACurrentMediaTimeProvider = MediaTimeProvider()
-    ) {
+    init(dateProvider: DateProvider, mediaTimeProvider: CACurrentMediaTimeProvider) {
         self.dateProvider = dateProvider
         self.mediaTimeProvider = mediaTimeProvider
     }

--- a/DatadogRUM/Sources/RUMVitals/RenderLoop/Providers/FrameInfoProvider.swift
+++ b/DatadogRUM/Sources/RUMVitals/RenderLoop/Providers/FrameInfoProvider.swift
@@ -20,6 +20,9 @@ internal protocol FrameInfoProvider {
     /// Maximum number of frames per second supported by the device
     var maximumDeviceFramesPerSecond: Int { get }
 
+    /// Initializer of the frame info provider. It has the same signature as the `CADisplayLink` init.
+    init(target: Any, selector: Selector)
+
     /// Adds the receiver to the given run-loop and mode. Unless paused, it will fire every vsync until removed.
     func add(to runloop: RunLoop, forMode mode: RunLoop.Mode)
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -93,76 +93,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(scope.userActionScope?.actionUUID))
     }
 
-    func testWhenConfigurationSourceIsSet_applicationStartUsesTheConfigurationSource() throws {
-        // Given
-        let currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let source = String.mockAnySource()
-        let customContext: DatadogContext = .mockWith(
-            source: source,
-            launchInfo: .mockWith(processLaunchDate: currentTime),
-            applicationStateHistory: .mockWith(initialState: .inactive, date: .distantPast)
-        )
-
-        let scope = RUMViewScope(
-            isInitialView: true,
-            parent: parent,
-            dependencies: .mockAny(),
-            identity: .mockViewIdentifier(),
-            path: "com/datadog/application-launch/view",
-            name: "ApplicationLaunch",
-            customTimings: [:],
-            startTime: currentTime,
-            serverTimeOffset: .zero,
-            interactionToNextViewMetric: INVMetricMock(),
-            viewIndexInSession: .mockAny()
-        )
-
-        // When
-        _ = scope.process(
-            command: RUMApplicationStartCommand(time: currentTime, attributes: [:]),
-            context: customContext,
-            writer: writer
-        )
-
-        // Then
-        let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
-        XCTAssertEqual(event.source, .init(rawValue: source))
-    }
-
-    func testWhenTimeToDidBecomeActiveTime_itSendsApplicationStartAction_basedOnLoadingDate() throws {
-        // Given
-        var context = self.context
-        let date = context.sdkInitDate
-        let processLaunchDate = date.addingTimeInterval(-2)
-        context.launchInfo = .mockWith(
-            launchReason: .userLaunch,
-            processLaunchDate: processLaunchDate,
-            didBecomeActiveDate: nil
-        )
-        context.applicationStateHistory = .mockWith(initialState: .inactive, date: .distantPast)
-
-        let scope: RUMViewScope = .mockWith(
-            isInitialView: true,
-            parent: parent,
-            dependencies: .mockAny(),
-            identity: .mockViewIdentifier(),
-            path: "com/datadog/application-launch/view",
-            name: "ApplicationLaunch",
-            startTime: processLaunchDate
-        )
-
-        // When
-        _ = scope.process(
-            command: RUMApplicationStartCommand(time: date.addingTimeInterval(1), attributes: [:]),
-            context: context,
-            writer: writer
-        )
-
-        // Then
-        let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
-        XCTAssertEqual(event.action.loadingTime, 3_000_000_000) // 2e+9 ns
-    }
-
     func testWhenInitialViewReceivesAnyCommand_itSendsViewUpdateEvent() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
@@ -849,7 +779,7 @@ class RUMViewScopeTests: XCTestCase {
         viewEvents.forEach { XCTAssertEqual($0.dd.session?.sessionPrecondition, randomPrecondition) }
 
         let actionEvents = writer.events(ofType: RUMActionEvent.self)
-        XCTAssertGreaterThan(actionEvents.count, 1)
+        XCTAssertEqual(actionEvents.count, 1)
         actionEvents.forEach { XCTAssertEqual($0.dd.session?.sessionPrecondition, randomPrecondition) }
 
         let errorEvents = writer.events(ofType: RUMErrorEvent.self)
@@ -3606,9 +3536,7 @@ class RUMViewScopeTests: XCTestCase {
                 resourceEventMapper: {
                     resourceMapperHolder.resourceEventMapper?($0)
                 },
-                actionEventMapper: { event in
-                    event.action.type == .applicationStart ? event : nil
-                }
+                actionEventMapper: { _ in nil }
             )
         )
         let dependencies: RUMScopeDependencies = .mockWith(

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Core/StopCoreScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Core/StopCoreScenarioTests.swift
@@ -152,7 +152,7 @@ class StopCoreScenarioTests: IntegrationTests, LoggingCommonAsserts, TracingComm
     private func assertInitialRUMSessionWasCollected(by serverSession: ServerSession) throws {
         // Get RUM Sessions with expected number of Action events:
         let recordedRequests = try serverSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.actionEventMatchers.count == 8
+            try RUMSessionMatcher.singleSession(from: requests)?.actionEventMatchers.count == 7
         }
 
         assertRUM(requests: recordedRequests)
@@ -161,8 +161,9 @@ class StopCoreScenarioTests: IntegrationTests, LoggingCommonAsserts, TracingComm
         sendCIAppLog(session)
 
         XCTAssertTrue(session.views[0].isApplicationLaunchView())
-        XCTAssertEqual(session.views[0].actionEvents.count, 2)
-        XCTAssertEqual(session.views[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertEqual(session.views[0].actionEvents.count, 1)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "Home")
         XCTAssertEqual(session.views[1].actionEvents.count, 3)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
@@ -54,15 +54,15 @@ class CrashReportingWithRUMScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let sessions = try RUMSessionMatcher.sessions(maxCount: 2, from: recordedRequests)
             .sorted { session1, session2 in
-                // Sort sessions by their "application_start" action date
-                return session1.views[0].actionEvents[0].date < session2.views[0].actionEvents[0].date
+                // Sort sessions by their startTimestamp
+                return session1.views[0].startTimestampMs < session2.views[0].startTimestampMs
             }
         let crashedSession = try XCTUnwrap(sessions.first)
         sendCIAppLog("Crashed session: \n\(crashedSession)")
 
         let initialView = crashedSession.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(crashedSession.ttidEvent)
 
         XCTAssertEqual(crashedSession.views[1].name, "Runner.CrashReportingViewController")
         XCTAssertEqual(

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -59,7 +59,8 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         let view1 = session.views[1]
         XCTAssertEqual(view1.name, "SendRUMFixture1View")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -56,8 +56,8 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
-        XCTAssertGreaterThan(initialView.actionEvents[0].action.loadingTime!, 0)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "Screen")
         XCTAssertEqual(session.views[1].path, "Runner.RUMMVSViewController")
@@ -134,8 +134,8 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
-        XCTAssertGreaterThan(initialView.actionEvents[0].action.loadingTime!, 0)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "Screen")
         XCTAssertEqual(session.views[1].path, "Runner.RUMMVSViewController")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -63,7 +63,8 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "Screen1")
         XCTAssertEqual(session.views[1].path, "UIViewController")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -164,7 +164,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         // Asserts in `SendFirstPartyRequestsVC` RUM View
         XCTAssertEqual(session.views[1].name, expectations.expectedFirstPartyRequestsViewControllerName)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -34,7 +34,8 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         let view = session.views[1]
         XCTAssertGreaterThan(view.viewEvents.count, 0)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMStopSessionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMStopSessionScenarioTests.swift
@@ -81,7 +81,7 @@ class RUMStopSessionScenarioTests: IntegrationTests, RUMCommonAsserts {
 
             let initialView = appStartSession.views[0]
             XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-            XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+            XCTAssertNotNil(appStartSession.ttidEvent)
             XCTAssertTrue(initialView.viewEvents.allSatisfy { $0.dd.session?.sessionPrecondition == .userAppLaunch })
 
             let view1 = appStartSession.views[1]

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIAutoInstrumentationTests.swift
@@ -46,7 +46,8 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "NavigationStackHostingController<AnyView>")
         RUMSessionMatcher.assertViewWasEventuallyInactive(session.views[1])
@@ -120,7 +121,8 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         // Tab 0: Navigation View
         XCTAssertEqual(session.views[1].name, "AutoTracked_HostingController_Fallback")
@@ -207,7 +209,7 @@ class RUMSwiftUIAutoInstrumentationTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
         RUMSessionMatcher.assertViewWasEventuallyInactive(session.views[0])
 
         let mainView = session.views[1]

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIManualInstrumentationScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMSwiftUIManualInstrumentationScenarioTests.swift
@@ -60,7 +60,8 @@ class RUMSwiftUIManualInstrumentationScenarioTests: IntegrationTests, RUMCommonA
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "SwiftUI View 1")
         XCTAssertTrue(session.views[1].path.matches(regex: "SwiftUI View 1\\/[0-9]*"))

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -50,7 +50,8 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "Screen A")
         XCTAssertEqual(session.views[1].path, "UIViewController")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -108,7 +108,8 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].name, "MenuView")
         XCTAssertEqual(session.views[1].path, "Runner.RUMTASScreen1ViewController")

--- a/IntegrationTests/IntegrationScenarios/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
@@ -203,7 +203,8 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].path, "Runner.TSHomeViewController")
 
@@ -302,7 +303,8 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
 
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         XCTAssertEqual(session.views[1].path, "Runner.TSHomeViewController")
         XCTAssertGreaterThan(session.views[1].actionEvents.count, 0)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
@@ -44,7 +44,8 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
         // Check iOS SDK events:
         let initialView = session.views[0]
         XCTAssertTrue(initialView.isApplicationLaunchView(), "The session should start with 'application launch' view")
-        XCTAssertEqual(initialView.actionEvents[0].action.type, .applicationStart)
+        XCTAssertNotNil(session.ttidEvent)
+        XCTAssertGreaterThan(session.timeToInitialDisplay!, 0)
 
         let nativeView = session.views[1]
         XCTAssertEqual(nativeView.name, "Runner.WebViewTrackingFixtureViewController")

--- a/IntegrationTests/Runner/Scenarios/RUM/StopSessionScenario/KioskViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/StopSessionScenario/KioskViewController.swift
@@ -12,7 +12,9 @@ internal class KioskViewController: UIViewController {
         rumMonitor.startView(viewController: self, name: "KioskViewController")
 
         // Stop session
-        rumMonitor.stopSession()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            rumMonitor.stopSession()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1051,7 +1051,7 @@ extension RUMScopeDependencies {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         renderLoopObserver: RenderLoopObserver? = nil,
-        firstFrameReader: RenderLoopReader = FirstFrameReader(),
+        firstFrameReader: RenderLoopReader = FirstFrameReader(dateProvider: DateProviderMock(), mediaTimeProvider: MediaTimeProviderMock()),
         viewHitchesReaderFactory: @escaping () -> (ViewHitchesModel & RenderLoopReader)? = { ViewHitchesMock.mockAny() },
         vitalsReaders: VitalsReaders? = nil,
         accessibilityReader: AccessibilityReading? = nil,

--- a/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/VitalMocks.swift
@@ -8,23 +8,29 @@ import Foundation
 
 @testable import DatadogRUM
 
-public struct FrameInfoProviderMock: FrameInfoProvider {
-    public var maximumDeviceFramesPerSecond: Int
-    public var currentFrameTimestamp: CFTimeInterval
-    public var nextFrameTimestamp: CFTimeInterval
+public class FrameInfoProviderMock: FrameInfoProvider {
+    public var maximumDeviceFramesPerSecond: Int = 60
+    public var currentFrameTimestamp: CFTimeInterval = 0
+    public var nextFrameTimestamp: CFTimeInterval = 0
 
-    public init(
-        maximumDeviceFramesPerSecond: Int = 60,
-        currentFrameTimestamp: CFTimeInterval = 0,
-        nextFrameTimestamp: CFTimeInterval = 0
-    ) {
-        self.maximumDeviceFramesPerSecond = maximumDeviceFramesPerSecond
-        self.currentFrameTimestamp = currentFrameTimestamp
-        self.nextFrameTimestamp = nextFrameTimestamp
+    private let target: Any
+    private let selector: Selector
+
+    public required init(target: Any, selector: Selector) {
+        self.target = target
+        self.selector = selector
     }
 
     public func add(to runloop: RunLoop, forMode mode: RunLoop.Mode) { }
     public func invalidate() { }
+    public func triggerCallback(interval: TimeInterval) {
+        currentFrameTimestamp = interval
+        _ = (target as AnyObject).perform(selector, with: self)
+    }
+}
+
+public extension Selector {
+    static let noOp = #selector(NSObject.description)
 }
 
 public final class ViewHitchesMock: ViewHitchesModel {


### PR DESCRIPTION
### What and why?

This PR removes the legacy event used to measure app launch timings.
From now on, [TTID](https://github.com/DataDog/dd-sdk-ios/pull/2517) and [TTFD](https://github.com/DataDog/dd-sdk-ios/pull/2522) will serve as the primary metrics for app launch performance.

### How?

It deletes the `application_start` action event that was previously reported in `RUMViewScope` and attached to `ApplicationLaunch`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
