### PR TITLE
Enable Github issue workflow

### DIFF
--- a/.github/workflows/issue_notification.yml
+++ b/.github/workflows/issue_notification.yml
@@ -1,7 +1,13 @@
 name: Github Issue Notification
 
 on:
-  workflow_dispatch:    # Trigger manually
+  # When a new issue is opened
+  issues:
+    types:
+    - opened
+
+  # When manually triggering the workflow
+  workflow_dispatch:
     inputs:
       issue_number:
         description: 'Issue number to process'


### PR DESCRIPTION
### What and why?

Up until now, the workflow posting a Slack notification when a new Github issue is opened is manual. This PR makes it automatic.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
