### PR TITLE
Report generator failure as stderr

### DIFF
--- a/tools/rum-models-generator/Sources/rum-models-generator/main.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/main.swift
@@ -38,17 +38,13 @@ private struct RootCommand: ParsableCommand {
         @Option(help: "Convention of decorating generated code: 'rum' (default) or 'sr'.")
         var convention: Convention = .rum
 
-        func run() {
-            do {
-                let schemaURL = URL(fileURLWithPath: path)
-                switch convention {
-                case .rum:
-                    print(try generateRUMSwiftModels(from: schemaURL))
-                case .sessionReplay:
-                    print(try generateSRSwiftModels(from: schemaURL))
-                }
-            } catch {
-                print("Failed to generate Swift models: \(error)")
+        func run() throws {
+            let schemaURL = URL(fileURLWithPath: path)
+            switch convention {
+            case .rum:
+                print(try generateRUMSwiftModels(from: schemaURL))
+            case .sessionReplay:
+                print(try generateSRSwiftModels(from: schemaURL))
             }
         }
     }
@@ -68,17 +64,13 @@ private struct RootCommand: ParsableCommand {
         @Option(help: "List of type names to skip from code generation.")
         var skip: [String] = []
 
-        func run() {
-            do {
-                let schemaURL = URL(fileURLWithPath: path)
-                switch convention {
-                case .rum:
-                    print(try generateRUMObjcInteropModels(from: schemaURL, skip: .init(skip)))
-                case .sessionReplay:
-                    print(try generateSRObjcInteropModels(from: schemaURL, skip: .init(skip)))
-                }
-            } catch {
-                print("Failed to generate Objc models: \(error)")
+        func run() throws {
+            let schemaURL = URL(fileURLWithPath: path)
+            switch convention {
+            case .rum:
+                print(try generateRUMObjcInteropModels(from: schemaURL, skip: .init(skip)))
+            case .sessionReplay:
+                print(try generateSRObjcInteropModels(from: schemaURL, skip: .init(skip)))
             }
         }
     }


### PR DESCRIPTION
### What and why?

The generator cli doesn't return an error as stderr, instead it prints the error in the generated files. This prevent from failing [this job](https://github.com/DataDog/rum-events-format/pull/317) to check the format validity in Swift and ObjC.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
