### PR TITLE
RUM-11472: Add view to app launch vitals

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -267,12 +267,12 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                     activeView: activeView
                 )
             case let command as RUMTimeToInitialDisplayCommand:
-                appLaunchManager.process(command, context: context, writer: writer)
+                appLaunchManager.process(command, context: context, writer: writer, activeView: viewScopes.first { $0.isActiveView })
                 dependencies.renderLoopObserver?.unregister(dependencies.firstFrameReader)
                 // command doesn't need to be propagated to other scopes
                 return true
             case let command as RUMTimeToFullDisplayCommand:
-                appLaunchManager.process(command, context: context, writer: writer)
+                appLaunchManager.process(command, context: context, writer: writer, activeView: viewScopes.first { $0.isActiveView })
                 // command doesn't need to be propagated to other scopes
                 return true
             default:

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -62,7 +62,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 1)
 
         let event = try XCTUnwrap(vitalEvents.first)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")
@@ -116,7 +116,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 1)
 
         let event = try XCTUnwrap(vitalEvents.first)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")
@@ -145,7 +145,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 1)
 
         let event = try XCTUnwrap(vitalEvents.first)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")
@@ -244,7 +244,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 2)
 
         let event = try XCTUnwrap(vitalEvents.last)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")
@@ -303,7 +303,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 2)
 
         let event = try XCTUnwrap(vitalEvents.last)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")
@@ -337,7 +337,7 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 2)
 
         let event = try XCTUnwrap(vitalEvents.last)
-        XCTAssertNil(event.view)
+        XCTAssertNotNil(event.view)
 
         guard case let .appLaunchProperties(value: vital) = event.vital else {
             return XCTFail("Expected event.vital to be .appLaunchProperties, but got \(event.vital)")


### PR DESCRIPTION
### What and why?

This PR adds the view parameter to the app launch measurements [TTID](https://github.com/DataDog/dd-sdk-ios/pull/2517) and [TTFD](https://github.com/DataDog/dd-sdk-ios/pull/2522).
This is the follow up on the discussions on the [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5629674495/RFC+Vital+architecture+for+TTID+TTFD).

### How?

If there is an active view, it will be injected in the `RUMAppLaunchManager` during the processing of the app launch measurements. 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
