### PR TITLE
chore: Fix "No such module 'DatadogFlags'" in IntegrationTests target

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -975,6 +975,10 @@
 		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
 		61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
 		61DCC84F2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
+		61E262D42EB2592C0041E70F /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
+		61E262D52EB2592C0041E70F /* DatadogFlags.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61E262D92EB259330041E70F /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C3192E785B6F00B1DA80 /* DatadogFlags.framework */; };
+		61E262DA2EB259330041E70F /* DatadogFlags.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C3192E785B6F00B1DA80 /* DatadogFlags.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
 		61E95D882695C00200EA3115 /* DDCrashReportExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E95D872695C00200EA3115 /* DDCrashReportExporterTests.swift */; };
 		61ED39D426C2A36B002C0F26 /* DataUploadStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ED39D326C2A36B002C0F26 /* DataUploadStatus.swift */; };
@@ -2213,6 +2217,20 @@
 			remoteGlobalIDString = 61B7885325C180CB002675B5;
 			remoteInfo = DatadogCrashReporting;
 		};
+		61E262D62EB2592C0041E70F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5BA8C2EC2E784B3C00B1DA80;
+			remoteInfo = "DatadogFlags iOS";
+		};
+		61E262DB2EB259330041E70F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5BA8C3182E785B6F00B1DA80;
+			remoteInfo = "DatadogFlags tvOS";
+		};
 		D207318529A5226B00ECBF94 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -2391,6 +2409,28 @@
 			dstSubfolderSpec = 10;
 			files = (
 				5BF2286C2E795D8C00D79E8A /* DatadogFlags.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61E262D82EB2592C0041E70F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				61E262D52EB2592C0041E70F /* DatadogFlags.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61E262DD2EB259330041E70F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				61E262DA2EB259330041E70F /* DatadogFlags.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3531,6 +3571,7 @@
 				118248532D908BEF00E3D16F /* DatadogSessionReplay.framework in Frameworks */,
 				118248542D908BEF00E3D16F /* DatadogTrace.framework in Frameworks */,
 				118248552D908BEF00E3D16F /* DatadogRUM.framework in Frameworks */,
+				61E262D42EB2592C0041E70F /* DatadogFlags.framework in Frameworks */,
 				118248562D908BEF00E3D16F /* DatadogCrashReporting.framework in Frameworks */,
 				118248572D908BEF00E3D16F /* DatadogLogs.framework in Frameworks */,
 				118248582D908BEF00E3D16F /* TestUtilities.framework in Frameworks */,
@@ -3547,6 +3588,7 @@
 				118249072D9094EA00E3D16F /* DatadogCrashReporting.framework in Frameworks */,
 				118249082D9094EA00E3D16F /* DatadogLogs.framework in Frameworks */,
 				118249092D9094EA00E3D16F /* TestUtilities.framework in Frameworks */,
+				61E262D92EB259330041E70F /* DatadogFlags.framework in Frameworks */,
 				1182490A2D9094EA00E3D16F /* DatadogCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7333,11 +7375,13 @@
 				118248512D908BEF00E3D16F /* Frameworks */,
 				1182485B2D908BEF00E3D16F /* Resources */,
 				1182485C2D908BEF00E3D16F /* ⚙️ Run linter */,
+				61E262D82EB2592C0041E70F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				118247B42D908BEF00E3D16F /* PBXTargetDependency */,
+				61E262D72EB2592C0041E70F /* PBXTargetDependency */,
 			);
 			name = "DatadogIntegrationTests iOS";
 			productName = DatadogTests;
@@ -7352,11 +7396,13 @@
 				118249042D9094EA00E3D16F /* Frameworks */,
 				1182490C2D9094EA00E3D16F /* Resources */,
 				1182490D2D9094EA00E3D16F /* ⚙️ Run linter */,
+				61E262DD2EB259330041E70F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				118248862D9094EA00E3D16F /* PBXTargetDependency */,
+				61E262DC2EB259330041E70F /* PBXTargetDependency */,
 			);
 			name = "DatadogIntegrationTests tvOS";
 			productName = DatadogTests;
@@ -10966,6 +11012,16 @@
 			isa = PBXTargetDependency;
 			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */;
 			targetProxy = 61B7885E25C180CB002675B5 /* PBXContainerItemProxy */;
+		};
+		61E262D72EB2592C0041E70F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5BA8C2EC2E784B3C00B1DA80 /* DatadogFlags iOS */;
+			targetProxy = 61E262D62EB2592C0041E70F /* PBXContainerItemProxy */;
+		};
+		61E262DC2EB259330041E70F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5BA8C3182E785B6F00B1DA80 /* DatadogFlags tvOS */;
+			targetProxy = 61E262DB2EB259330041E70F /* PBXContainerItemProxy */;
 		};
 		D207318629A5226B00ECBF94 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
### What and why?

🩹 Fixes `"No such module 'DatadogFlags'"` build error when running `DatadogIntegrationTests` in local.

<img width="413" height="142" alt="Screenshot 2025-10-29 at 15 15 57" src="https://github.com/user-attachments/assets/cf2334e0-6d84-4f92-8537-4bae09403b6f" />

### How?

Added `DatadogFlags` to "Frameworks and Libraries" for both iOS and tvOS target.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
