### PR TITLE
GraphQLHeaders constants

### DIFF
--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -140,7 +140,7 @@ public struct CrossPlatformAttributes {
     public static let graphqlPayload = "_dd.graphql.payload"
 
     /// Custom attribute passed when starting GraphQL RUM resources resources from a cross platform SDK.
-    /// It sets the GraphQL varibles as a JSON string if they were defined by the developer.
+    /// It sets the GraphQL variables as a JSON string if they were defined by the developer.
     /// Expects `String` value.
     public static let graphqlVariables = "_dd.graphql.variables"
 
@@ -158,6 +158,22 @@ public struct CrossPlatformAttributes {
     /// Custom value for Interaction To Next view.
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete ocurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
+}
+
+/// HTTP header names used to pass GraphQL metadata from the application to the SDK.
+/// These headers are read from intercepted requests and mapped to internal attributes.
+public struct GraphQLHeaders {
+    /// HTTP header name for GraphQL operation name.
+    public static let operationName: String = "_dd-custom-header-graph-ql-operation-name"
+
+    /// HTTP header name for GraphQL operation type.
+    public static let operationType: String = "_dd-custom-header-graph-ql-operation-type"
+
+    /// HTTP header name for GraphQL variables.
+    public static let variables: String = "_dd-custom-header-graph-ql-variables"
+
+    /// HTTP header name for GraphQL payload.
+    public static let payload: String = "_dd-custom-header-graph-ql-payload"
 }
 
 public struct LaunchArguments {

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -118,16 +118,16 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 
         // Extract GraphQL attributes from request headers
         var combinedAttributes = userAttributes
-        if let operationName = originalRequest.value(forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-name") {
+        if let operationName = originalRequest.value(forHTTPHeaderField: GraphQLHeaders.operationName) {
             combinedAttributes[CrossPlatformAttributes.graphqlOperationName] = operationName
         }
-        if let operationType = originalRequest.value(forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-type") {
+        if let operationType = originalRequest.value(forHTTPHeaderField: GraphQLHeaders.operationType) {
             combinedAttributes[CrossPlatformAttributes.graphqlOperationType] = operationType
         }
-        if let variables = originalRequest.value(forHTTPHeaderField: "_dd-custom-header-graph-ql-variables") {
+        if let variables = originalRequest.value(forHTTPHeaderField: GraphQLHeaders.variables) {
             combinedAttributes[CrossPlatformAttributes.graphqlVariables] = variables
         }
-        if let payload = originalRequest.value(forHTTPHeaderField: "_dd-custom-header-graph-ql-payload") {
+        if let payload = originalRequest.value(forHTTPHeaderField: GraphQLHeaders.payload) {
             combinedAttributes[CrossPlatformAttributes.graphqlPayload] = payload
         }
 

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -954,10 +954,10 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         // Given
         var mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
-        mockRequest.setValue("GetUser", forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-name")
-        mockRequest.setValue("query", forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-type")
-        mockRequest.setValue("{\"userId\":\"123\"}", forHTTPHeaderField: "_dd-custom-header-graph-ql-variables")
-        mockRequest.setValue("query GetUser($userId: ID!) { user(id: $userId) { name } }", forHTTPHeaderField: "_dd-custom-header-graph-ql-payload")
+        mockRequest.setValue("GetUser", forHTTPHeaderField: GraphQLHeaders.operationName)
+        mockRequest.setValue("query", forHTTPHeaderField: GraphQLHeaders.operationType)
+        mockRequest.setValue("{\"userId\":\"123\"}", forHTTPHeaderField: GraphQLHeaders.variables)
+        mockRequest.setValue("query GetUser($userId: ID!) { user(id: $userId) { name } }", forHTTPHeaderField: GraphQLHeaders.payload)
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
         let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
@@ -989,8 +989,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         // Given
         var mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
-        mockRequest.setValue("FailedMutation", forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-name")
-        mockRequest.setValue("mutation", forHTTPHeaderField: "_dd-custom-header-graph-ql-operation-type")
+        mockRequest.setValue("FailedMutation", forHTTPHeaderField: GraphQLHeaders.operationName)
+        mockRequest.setValue("mutation", forHTTPHeaderField: GraphQLHeaders.operationType)
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
         let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)


### PR DESCRIPTION
### What and why?

Introduce GraphQLHeaders constants to centralize the HTTP header names used to pass GraphQL metadata from the app to the SDK.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
