### PR TITLE
Chore: Add counterpart for GraphQL constants for tests

### DIFF
--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -954,10 +954,10 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         // Given
         var mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
-        mockRequest.setValue("GetUser", forHTTPHeaderField: GraphQLHeaders.operationName)
-        mockRequest.setValue("query", forHTTPHeaderField: GraphQLHeaders.operationType)
-        mockRequest.setValue("{\"userId\":\"123\"}", forHTTPHeaderField: GraphQLHeaders.variables)
-        mockRequest.setValue("query GetUser($userId: ID!) { user(id: $userId) { name } }", forHTTPHeaderField: GraphQLHeaders.payload)
+        mockRequest.setValue("GetUser", forHTTPHeaderField: ExpectedGraphQLHeaders.operationName)
+        mockRequest.setValue("query", forHTTPHeaderField: ExpectedGraphQLHeaders.operationType)
+        mockRequest.setValue("{\"userId\":\"123\"}", forHTTPHeaderField: ExpectedGraphQLHeaders.variables)
+        mockRequest.setValue("query GetUser($userId: ID!) { user(id: $userId) { name } }", forHTTPHeaderField: ExpectedGraphQLHeaders.payload)
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
         let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
@@ -989,8 +989,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         // Given
         var mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
-        mockRequest.setValue("FailedMutation", forHTTPHeaderField: GraphQLHeaders.operationName)
-        mockRequest.setValue("mutation", forHTTPHeaderField: GraphQLHeaders.operationType)
+        mockRequest.setValue("FailedMutation", forHTTPHeaderField: ExpectedGraphQLHeaders.operationName)
+        mockRequest.setValue("mutation", forHTTPHeaderField: ExpectedGraphQLHeaders.operationType)
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
         let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
@@ -1027,4 +1027,13 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         return dict
     }
+}
+
+// MARK: - Test Helpers
+
+struct ExpectedGraphQLHeaders {
+    static let operationName: String = "_dd-custom-header-graph-ql-operation-name"
+    static let operationType: String = "_dd-custom-header-graph-ql-operation-type"
+    static let variables: String = "_dd-custom-header-graph-ql-variables"
+    static let payload: String = "_dd-custom-header-graph-ql-payload"
 }


### PR DESCRIPTION
### What and why?

This PR adds the counterpart for the GraphQL constants for testing to ensure if typo occurs the tests do break.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
