### PR TITLE
RUM-12420 Generate backtrace using KSCrash

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1457,6 +1457,10 @@
 		D24C9C6129A7CB0C002057CF /* DatadogLogsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* DatadogLogsFeatureTests.swift */; };
 		D24EC3D92DD1F117007A7E8F /* SessionReplayCoreContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24EC3D82DD1F117007A7E8F /* SessionReplayCoreContext.swift */; };
 		D24EC3DA2DD1F117007A7E8F /* SessionReplayCoreContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24EC3D82DD1F117007A7E8F /* SessionReplayCoreContext.swift */; };
+		D253E65B2EBA31C40074BEC4 /* KSCrashBacktrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253E65A2EBA31C40074BEC4 /* KSCrashBacktrace.swift */; };
+		D253E65C2EBA31C40074BEC4 /* KSCrashBacktrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253E65A2EBA31C40074BEC4 /* KSCrashBacktrace.swift */; };
+		D253E65E2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253E65D2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift */; };
+		D253E65F2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253E65D2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift */; };
 		D253EE962B988CA90010B589 /* ViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE952B988CA90010B589 /* ViewCache.swift */; };
 		D253EE972B988CA90010B589 /* ViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE952B988CA90010B589 /* ViewCache.swift */; };
 		D253EE9B2B98B37B0010B589 /* ViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D253EE982B98B3690010B589 /* ViewCacheTests.swift */; };
@@ -3451,6 +3455,8 @@
 		D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIViewHandler.swift; sourceTree = "<group>"; };
 		D24C9C3E29A79772002057CF /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		D24EC3D82DD1F117007A7E8F /* SessionReplayCoreContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayCoreContext.swift; sourceTree = "<group>"; };
+		D253E65A2EBA31C40074BEC4 /* KSCrashBacktrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KSCrashBacktrace.swift; sourceTree = "<group>"; };
+		D253E65D2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KSCrashBacktraceTests.swift; sourceTree = "<group>"; };
 		D253EE952B988CA90010B589 /* ViewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCache.swift; sourceTree = "<group>"; };
 		D253EE982B98B3690010B589 /* ViewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCacheTests.swift; sourceTree = "<group>"; };
 		D2546BF029AF4F550054E00B /* DatadogTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTracer.swift; sourceTree = "<group>"; };
@@ -6604,6 +6610,7 @@
 			isa = PBXGroup;
 			children = (
 				D22689C22EB12D3D00875E44 /* KSCrashPlugin.swift */,
+				D253E65A2EBA31C40074BEC4 /* KSCrashBacktrace.swift */,
 				D2268AD42EB4DA5800875E44 /* CrashFieldDictionary.swift */,
 				D2268AEC2EB51F6300875E44 /* DatadogCrashReportFilter.swift */,
 				D2268AD72EB4DAC400875E44 /* AnyCrashReport.swift */,
@@ -6623,6 +6630,7 @@
 				D2268AE32EB4F5CA00875E44 /* DatadogMinifyFilterTests.swift */,
 				D2268AE92EB50F7F00875E44 /* DatadogDiagnosticFilterTests.swift */,
 				D2268AEF2EB51FB600875E44 /* DatadogCrashReportFilterTests.swift */,
+				D253E65D2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift */,
 			);
 			path = KSCrashIntegration;
 			sourceTree = "<group>";
@@ -9463,6 +9471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D253E65C2EBA31C40074BEC4 /* KSCrashBacktrace.swift in Sources */,
 				D214DA8929DF2D6A004D0AE8 /* CrashReportSender.swift in Sources */,
 				D2268AD22EB4DA4100875E44 /* DatadogTypeSafeFilter.swift in Sources */,
 				D293302C2A137DAD0029C9EA /* CrashReportingFeature.swift in Sources */,
@@ -9501,6 +9510,7 @@
 				61FDBA15269722B4001D9D43 /* CrashReportInfoMinifierTests.swift in Sources */,
 				D22689C82EB2151F00875E44 /* KSCrashPluginTests.swift in Sources */,
 				61E95D882695C00200EA3115 /* DDCrashReportExporterTests.swift in Sources */,
+				D253E65F2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift in Sources */,
 				61B7886225C180CB002675B5 /* CrashReportingPluginTests.swift in Sources */,
 				615CC4132695957C0005F08C /* CrashReportInfoTests.swift in Sources */,
 				D2268AE42EB4F5CA00875E44 /* DatadogMinifyFilterTests.swift in Sources */,
@@ -10686,6 +10696,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D253E65B2EBA31C40074BEC4 /* KSCrashBacktrace.swift in Sources */,
 				D214DA8C29DF2D6B004D0AE8 /* CrashReportSender.swift in Sources */,
 				D2268AD32EB4DA4100875E44 /* DatadogTypeSafeFilter.swift in Sources */,
 				D293302D2A137DAD0029C9EA /* CrashReportingFeature.swift in Sources */,
@@ -10724,6 +10735,7 @@
 				D2CB6FDD27C5352300A62B57 /* CrashReportInfoMinifierTests.swift in Sources */,
 				D22689C72EB2151F00875E44 /* KSCrashPluginTests.swift in Sources */,
 				D2CB6FDE27C5352300A62B57 /* DDCrashReportExporterTests.swift in Sources */,
+				D253E65E2EBA478E0074BEC4 /* KSCrashBacktraceTests.swift in Sources */,
 				D2CB6FE027C5352300A62B57 /* CrashReportingPluginTests.swift in Sources */,
 				D2CB6FE127C5352300A62B57 /* CrashReportInfoTests.swift in Sources */,
 				D2268AE52EB4F5CA00875E44 /* DatadogMinifyFilterTests.swift in Sources */,

--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
@@ -1,0 +1,114 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+// swiftlint:disable duplicate_imports
+#if COCOAPODS
+import KSCrash
+#elseif swift(>=6.0)
+internal import KSCrashRecording
+#else
+@_implementationOnly import KSCrashRecording
+#endif
+// swiftlint:enable duplicate_imports
+
+/// A backtrace generator that uses KSCrash to capture stack traces for threads.
+///
+/// This implementation uses KSCrash's low-level symbolication capabilities to generate
+/// backtraces for specified threads, including thread information, stack frames, and
+/// binary image metadata.
+internal struct KSCrashBacktrace: BacktraceReporting {
+    /// Telemetry interface for reporting errors during backtrace generation.
+    let telemetry: Telemetry
+
+    /// Creates a new KSCrash-based backtrace generator.
+    /// - Parameter telemetry: The telemetry interface for error reporting. Defaults to `NOPTelemetry()`.
+    init(telemetry: Telemetry = NOPTelemetry()) {
+        self.telemetry = telemetry
+    }
+
+    func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport? {
+        // Convert Mach thread_t to pthread_t
+        guard let pthread = pthread_from_mach_thread_np(threadID) else {
+            telemetry.error("[KSCrashBacktrace] Failed to get pthread for thread with ID: \(threadID)")
+            return nil
+        }
+
+        // Capture backtrace for the thread. Initialize count with the maximum number of frames
+        // we want to capture, which will be updated with the actual number of frames captured.
+        var count = DatadogMinifyFilter.Constants.maxNumberOfStackFrames
+        var addresses = [uintptr_t](repeating: 0, count: count)
+        count = Int(captureBacktrace(thread: pthread, addresses: &addresses, count: Int32(count)))
+
+        guard count > 0 else {
+            return nil
+        }
+
+        var binaryImages: [UInt64: BinaryImage] = [:]
+        let stack = (0..<count).compactMap { index in
+            let address = addresses[index]
+
+            var symbolInfo = SymbolInformation()
+            guard
+                symbolicate(address: address, result: &symbolInfo),
+                let imageName = symbolInfo.imageName,
+                let path = NSString(utf8String: imageName),
+                let imageUUID = symbolInfo.imageUUID
+            else {
+                return String(format: "%-4ld ??? 0x%016llx 0x0 + 0", index, address) // no binary image info
+            }
+
+            let libraryName = path.lastPathComponent
+            let loadAddress = UInt64(symbolInfo.imageAddress)
+
+            let uuid = UUID(uuid: imageUUID.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee })
+
+            if binaryImages[loadAddress] == nil {
+                let binaryImage = BinaryImage(
+                    libraryName: libraryName,
+                    uuid: uuid.uuidString,
+                    architecture: String(cString: kscpu_currentArch()),
+                    path: path,
+                    loadAddress: loadAddress,
+                    maxAddress: loadAddress + symbolInfo.imageSize
+                )
+
+                binaryImages[loadAddress] = binaryImage
+            }
+
+            // Format: frame_index (4 chars left-aligned) + library_name (35 chars left-aligned) + addresses + offset
+            return String(format: "%-4ld %-35@ 0x%016llx 0x%016llx + %lld", index, libraryName, address, loadAddress, UInt64(address) - loadAddress)
+        }
+        .joined(separator: "\n")
+
+        // Create thread info
+        let thread = DDThread(
+            name: getThreadName(pthread: pthread) ?? "Thread \(threadID)",
+            stack: stack,
+            crashed: false,
+            state: nil
+        )
+
+        return BacktraceReport(
+            stack: stack,
+            threads: [thread],
+            binaryImages: Array(binaryImages.values),
+            wasTruncated: false
+        )
+    }
+
+    /// Get the name of a pthread
+    private func getThreadName(pthread: pthread_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: 256)
+        guard pthread_getname_np(pthread, &buffer, buffer.count) == KERN_SUCCESS, buffer[0] != 0 else {
+            telemetry.error("[KSCrashBacktrace] Failed to get pthread name")
+            return nil // fails or empty
+        }
+        return String(cString: buffer)
+    }
+}

--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashPlugin.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashPlugin.swift
@@ -24,8 +24,9 @@ internal import KSCrashFilters
 @objc
 internal class KSCrashPlugin: NSObject, CrashReportingPlugin {
     private let kscrash: KSCrash
+    private let telemetry: Telemetry
 
-    init(_ kscrash: KSCrash = .shared) throws {
+    init(_ kscrash: KSCrash = .shared, telemetry: Telemetry = NOPTelemetry()) throws {
         try kscrash.install(with: .datadog())
         kscrash.reportStore?.sink = CrashReportFilterPipeline(
             filters: [
@@ -37,6 +38,7 @@ internal class KSCrashPlugin: NSObject, CrashReportingPlugin {
         )
 
         self.kscrash = kscrash
+        self.telemetry = telemetry
     }
 
     // MARK: - CrashReportingPlugin
@@ -74,10 +76,7 @@ internal class KSCrashPlugin: NSObject, CrashReportingPlugin {
         kscrash.userInfo = [CrashField.dd.rawValue: contextBase64]
     }
 
-    var backtraceReporter: BacktraceReporting? {
-        /* no-op */
-        return nil
-    }
+    var backtraceReporter: BacktraceReporting? { KSCrashBacktrace(telemetry: telemetry) }
 }
 
 extension KSCrashConfiguration {

--- a/DatadogCrashReporting/Tests/KSCrashIntegration/KSCrashBacktraceTests.swift
+++ b/DatadogCrashReporting/Tests/KSCrashIntegration/KSCrashBacktraceTests.swift
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogCrashReporting
+
+class KSCrashBacktraceTests: XCTestCase {
+    /// Regex pattern to match stack frame format: index library_name address load_address + offset
+    /// Library name can contain spaces (e.g., "DatadogCrashReportingTests iOS")
+    let regex = try! NSRegularExpression(pattern: #"^\d+\s+.+?\s+0x[0-9a-f]+\s+0x[0-9a-f]+\s+\+\s+\d+$"#, options: [.anchorsMatchLines])
+
+    // MARK: - Current Thread Tests
+
+    func testCurrentThreadStackContainsTestFrames() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+        let currentThreadID = Thread.currentThreadID
+
+        // When
+        let report = try XCTUnwrap(try backtrace.generateBacktrace(threadID: currentThreadID))
+
+        // Then
+        report.stack.split(separator: "\n").forEach { line in
+            let range = NSRange(line.startIndex..., in: line)
+
+            // Validate each line matches the expected format
+            XCTAssertNotNil(
+                regex.firstMatch(in: String(line), range: range),
+                "Stack line should match format 'index library address load_address + offset': \(line)"
+            )
+        }
+
+        let userImage = report.binaryImages.first(where: { $0.libraryName.contains("DatadogCrashReportingTests") })
+        let systemImage = report.binaryImages.first(where: { $0.libraryName == "xctest" })
+
+        XCTAssertFalse(userImage?.isSystemLibrary ?? true, "Should include current binary image")
+        XCTAssertTrue(systemImage?.isSystemLibrary ?? false, "Should include xctest system image")
+        XCTAssertEqual(report.threads.count, 1, "Should have one thread")
+        XCTAssertEqual(report.stack, report.threads[0].stack)
+        XCTAssertFalse(report.threads[0].name.isEmpty, "Thread should have a name")
+    }
+
+    // MARK: - Other Thread Tests
+
+    func testGenerateBacktraceForBackgroundThread() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+        let expectation = XCTestExpectation(description: "Background thread backtrace")
+        var backgroundThreadID: ThreadID?
+        var capturedReport: BacktraceReport?
+
+        // When - Create a background thread
+        Thread.detachNewThread {
+            let semaphore = DispatchSemaphore(value: 0)
+            backgroundThreadID = Thread.currentThreadID
+
+            // Capture backtrace from main thread
+            DispatchQueue.global().async {
+                do {
+                    capturedReport = try backtrace.generateBacktrace(threadID: backgroundThreadID!)
+                    expectation.fulfill()
+                } catch {
+                    XCTFail("Failed to generate backtrace: \(error)")
+                    expectation.fulfill()
+                }
+
+                semaphore.signal()
+            }
+
+            // keep thread alive to generate its backtrace
+            semaphore.wait()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        // Then
+        XCTAssertNotNil(capturedReport, "Should generate backtrace for background thread")
+        let report = try XCTUnwrap(capturedReport)
+
+        report.stack.split(separator: "\n").forEach { line in
+            let range = NSRange(line.startIndex..., in: line)
+
+            // Validate each line matches the expected format
+            XCTAssertNotNil(
+                regex.firstMatch(in: String(line), range: range),
+                "Stack line should match format 'index library address load_address + offset': \(line)"
+            )
+        }
+
+        let userImage = report.binaryImages.first(where: { $0.libraryName.contains("DatadogCrashReportingTests") })
+        let systemImage = report.binaryImages.first(where: { $0.libraryName == "Foundation" })
+
+        XCTAssertFalse(userImage?.isSystemLibrary ?? true, "Should include current binary image")
+        XCTAssertTrue(systemImage?.isSystemLibrary ?? false, "Should include Foundation system image")
+        XCTAssertFalse(report.binaryImages.contains(where: { $0.libraryName == "xctest" }), "Should not include xctest")
+        XCTAssertEqual(report.threads.count, 1, "Should have one thread")
+        XCTAssertEqual(report.stack, report.threads[0].stack)
+        XCTAssertFalse(report.threads[0].name.isEmpty, "Thread should have a name")
+    }
+
+    func testInvalidThreadIDReturnsNil() throws {
+        // Given - An invalid thread ID
+        let backtrace = KSCrashBacktrace()
+        let invalidThreadID: ThreadID = 0
+
+        // When
+        let report = try backtrace.generateBacktrace(threadID: invalidThreadID)
+
+        // Then
+        XCTAssertNil(report, "Should return nil for invalid thread ID")
+    }
+}


### PR DESCRIPTION
### What and why?

Add `KSCrashBacktrace` implementation for capturing thread backtraces using KSCrash's native APIs.

### How?

The implementation uses KSCrash's low-level backtrace APIs (`ksbt_captureBacktrace` and `ksbt_symbolicateAddress`) to capture and symbolicate stack frames for any thread.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
