### PR TITLE
RUM-11578: Obj-C API for user and account IDs

### DIFF
--- a/DatadogCore/Sources/Datadog+objc.swift
+++ b/DatadogCore/Sources/Datadog+objc.swift
@@ -67,6 +67,11 @@ public final class objc_Datadog: NSObject {
         Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes)
     }
 
+    /// Returns the current user ID if set.
+    public static func currentUserId() -> String? {
+        (CoreRegistry.default as? DatadogCore)?.userInfoPublisher.current.id
+    }
+
     public static func clearUserInfo() {
         Datadog.clearUserInfo()
     }
@@ -77,6 +82,11 @@ public final class objc_Datadog: NSObject {
 
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:]) {
         Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes)
+    }
+
+    /// Returns the current account ID if set.
+    public static func currentAccountId() -> String? {
+        (CoreRegistry.default as? DatadogCore)?.accountInfoPublisher.current?.id
     }
 
     public static func addAccountExtraInfo(_ extraInfo: [String: Any]) {

--- a/DatadogCore/Tests/Objc/DDDatadogTests.swift
+++ b/DatadogCore/Tests/Objc/DDDatadogTests.swift
@@ -151,6 +151,29 @@ class DDDatadogTests: XCTestCase {
         XCTAssertNil(userInfo.current.email)
         XCTAssertTrue(userInfo.current.extraInfo.isEmpty)
 
+        XCTAssertEqual(objc_Datadog.currentUserId(), "id")
+
+        Datadog.flushAndDeinitialize()
+    }
+
+    func testItReturnsCurrentUserAndAccountIdsFromObjcAPI() throws {
+        objc_Datadog.initialize(
+            configuration: objc_Configuration(clientToken: "abcefghi", env: "tests"),
+            trackingConsent: randomConsent().objc
+        )
+
+        objc_Datadog.setUserInfo(userId: "user-id", name: nil, email: nil, extraInfo: [:])
+        objc_Datadog.setAccountInfo(accountId: "account-id", name: nil, extraInfo: [:])
+
+        XCTAssertEqual(objc_Datadog.currentUserId(), "user-id")
+        XCTAssertEqual(objc_Datadog.currentAccountId(), "account-id")
+
+        objc_Datadog.clearUserInfo()
+        objc_Datadog.clearAccountInfo()
+
+        XCTAssertNil(objc_Datadog.currentUserId())
+        XCTAssertNil(objc_Datadog.currentAccountId())
+
         Datadog.flushAndDeinitialize()
     }
 

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDDatadog+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDDatadog+apiTests.m
@@ -36,7 +36,9 @@
     [DDDatadog setVerbosityLevel:verbosity];
 
     [DDDatadog setUserInfoWithUserId:@"" name:@"" email:@"" extraInfo:@{}];
+    [DDDatadog currentUserId];
     [DDDatadog addUserExtraInfo:@{}];
+    [DDDatadog currentAccountId];
     [DDDatadog setTrackingConsentWithConsent:[DDTrackingConsent notGranted]];
 
     [DDDatadog clearAllData];

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -11,9 +11,11 @@ public final class objc_Datadog: NSObject
     public static func setVerbosityLevel(_ verbosityLevel: objc_CoreLoggerLevel)
     public static func verbosityLevel() -> objc_CoreLoggerLevel
     public static func setUserInfo(userId: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
+    public static func currentUserId() -> String?
     public static func clearUserInfo()
     public static func addUserExtraInfo(_ extraInfo: [String: Any])
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:])
+    public static func currentAccountId() -> String?
     public static func addAccountExtraInfo(_ extraInfo: [String: Any])
     public static func clearAccountInfo()
     public static func setTrackingConsent(consent: objc_TrackingConsent)


### PR DESCRIPTION
### What and why?

Adds Objective-C APIs to read the current user ID and account ID.

### How?

Added two new public static methods to `objc_Datadog`:
- `currentUserId()` - Returns the current user ID if set
- `currentAccountId()` - Returns the current account ID if set

Both methods safely access the respective publishers from `DatadogCore` and return optional strings.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)