### PR TITLE
Remove Xcode 15 validation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -267,25 +267,6 @@ SPM Build (Swift 5.10):
     - make spm-build-macos
     - make spm-build-watchos
 
-SPM Build (Swift 5.9):
-  stage: smoke-test
-  rules: 
-    - !reference [.test-pipeline-job, rules]
-    - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:ventura
-    - specific:true
-  variables:
-    XCODE: "15.2.0"
-  script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --visionOS --watchOS
-    - make clean repo-setup ENV=ci
-    - make spm-build-ios
-    - make spm-build-tvos
-    - make spm-build-visionos
-    - make spm-build-macos
-    - make spm-build-watchos
-
 SPI Docs Build:
   stage: lint
   rules: 


### PR DESCRIPTION
### What and why?

Xcode 16 is now the minimum required Xcode version.
We will add Xcode 16 validation when migrating main pipelines to Xcode 26 in following PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
