### PR TITLE
Remove Trace ID param

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -208,7 +208,7 @@ extension DistributedTracing {
             payload: request.value(forHTTPHeaderField: GraphQLHeaders.payload)
         )
 
-        let sampler = sampler(sessionID: rumSessionId, traceID: traceID.idLo)
+        let sampler = sampler(sessionID: rumSessionId)
         let injectedSpanContext = TraceContext(
             traceID: traceID,
             spanID: spanID,
@@ -298,9 +298,8 @@ extension DistributedTracing {
     ///
     /// - Parameters:
     ///   - sessionID: The RUM session ID
-    ///   - traceID: The trace ID as a fallback
     /// - Returns: A `Sampling` instance that will consistently sample based on the provided seed
-    private func sampler(sessionID: String?, traceID: UInt64?) -> Sampling {
+    private func sampler(sessionID: String?) -> Sampling {
         if let sessionID,
            // For a UUID with value aaaaaaaa-bbbb-Mccc-Nddd-1234567890ab
            // we use as the base id the last part: 0x1234567890ab


### PR DESCRIPTION
### What and why?

Removing `traceId` parameter in `URLSessionRUMResourcesHandler` sampler.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
