### PR TITLE
RUM-13469: Add `totalRam` and `logicalCpuCount` to DeviceInfo

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/WatchdogTerminationsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WatchdogTerminationsMonitoringTests.swift
@@ -21,7 +21,9 @@ class WatchdogTerminationsMonitoringTests: XCTestCase {
         isSimulator: false,
         vendorId: .mockAny(),
         isDebugging: false,
-        systemBootTime: .init()
+        systemBootTime: .init(),
+        logicalCpuCount: .mockRandom(),
+        totalRam: .mockRandom()
     )
 
     override func setUp() {

--- a/DatadogCore/Tests/Datadog/LoggerTests.swift
+++ b/DatadogCore/Tests/Datadog/LoggerTests.swift
@@ -42,7 +42,9 @@ class LoggerTests: XCTestCase {
             device: .mockWith(
                 name: "Device Name",
                 model: "Model Name",
-                architecture: "testArch"
+                architecture: "testArch",
+                logicalCpuCount: 4,
+                totalRam: 4_096
             ),
             os: .mockWith(
                 name: "testOS",
@@ -78,10 +80,12 @@ class LoggerTests: XCTestCase {
             "brightness_level": 0.5,
             "locale": "en-US",
             "locales": ["en"],
+            "logical_cpu_count": 4,
             "name": "Device Name",
             "model": "Model Name",
             "power_saving_mode": 0,
             "time_zone": "Europe/Paris",
+            "total_ram": 4096,
             "type": "other"
           },
           "service" : "default-service-name",

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -45,7 +45,9 @@ class TracerTests: XCTestCase {
             device: .mockWith(
                 name: "iPhone",
                 model: "iPhone10,1",
-                architecture: "arm64"
+                architecture: "arm64",
+                logicalCpuCount: 4,
+                totalRam: 2_048
             ),
             os: .mockWith(
                 version: "15.4.1",
@@ -85,10 +87,12 @@ class TracerTests: XCTestCase {
                 "brand": "Apple",
                 "brightness_level": 0,
                 "locale": "en-US",
+                "logical_cpu_count": 4,
                 "model": "iPhone10,1",
                 "name": "iPhone",
                 "power_saving_mode": 0,
                 "time_zone": "Europe/Paris",
+                "total_ram": 2048,
                 "type": "mobile"
               },
               "meta.os": {

--- a/DatadogInternal/Sources/Context/DeviceInfo.swift
+++ b/DatadogInternal/Sources/Context/DeviceInfo.swift
@@ -35,6 +35,12 @@ public struct DeviceInfo: Equatable {
     /// Returns system boot time since epoch.
     public let systemBootTime: TimeInterval
 
+    /// Number of logical processors available to the system.
+    public let logicalCpuCount: Double?
+
+    /// Total physical memory (RAM) in megabytes.
+    public let totalRam: Double?
+
     public init(
         name: String,
         model: String,
@@ -43,7 +49,9 @@ public struct DeviceInfo: Equatable {
         isSimulator: Bool,
         vendorId: String?,
         isDebugging: Bool,
-        systemBootTime: TimeInterval
+        systemBootTime: TimeInterval,
+        logicalCpuCount: Double?,
+        totalRam: Double?
     ) {
         self.brand = "Apple"
         self.name = name
@@ -54,6 +62,8 @@ public struct DeviceInfo: Equatable {
         self.vendorId = vendorId
         self.isDebugging = isDebugging
         self.systemBootTime = systemBootTime
+        self.logicalCpuCount = logicalCpuCount
+        self.totalRam = totalRam
     }
 }
 
@@ -145,7 +155,9 @@ extension DeviceInfo {
             isSimulator: false,
             vendorId: device.identifierForVendor?.uuidString,
             isDebugging: isDebugging ?? false,
-            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate
+            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate,
+            logicalCpuCount: Double(processInfo.processorCount),
+            totalRam: Double(processInfo.physicalMemory / (1_024 * 1_024))
         )
         #else
         let model = processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] ?? device.model
@@ -158,7 +170,9 @@ extension DeviceInfo {
             isSimulator: true,
             vendorId: device.identifierForVendor?.uuidString,
             isDebugging: isDebugging ?? false,
-            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate
+            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate,
+            logicalCpuCount: Double(processInfo.processorCount),
+            totalRam: Double(processInfo.physicalMemory / (1_024 * 1_024))
         )
         #endif
     }
@@ -196,7 +210,9 @@ extension DeviceInfo {
             isSimulator: isSimulator,
             vendorId: nil,
             isDebugging: isDebugging ?? false,
-            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate
+            systemBootTime: systemBootTime ?? Date.timeIntervalSinceReferenceDate,
+            logicalCpuCount: Double(processInfo.processorCount),
+            totalRam: Double(processInfo.physicalMemory / (1_024 * 1_024))
         )
     }
 }
@@ -255,10 +271,12 @@ extension DatadogContext {
             brightnessLevel: brightness,
             locale: localeInfo.currentLocale,
             locales: locales,
+            logicalCpuCount: device.logicalCpuCount,
             model: device.model,
             name: device.name,
             powerSavingMode: isLowPowerModeEnabled,
             timeZone: localeInfo.timeZoneIdentifier,
+            totalRam: device.totalRam,
             type: device.type.normalizedDeviceType
         )
     }

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -25,13 +25,16 @@ public struct Device: Codable {
     public let brightnessLevel: Double?
 
     /// Whether the device is considered a low RAM device (Android)
-    public let isLowRamDevice: Bool?
+    public let isLowRam: Bool?
 
     /// The user’s locale as a language tag combining language and region, e.g. 'en-US'.
     public let locale: String?
 
     /// Ordered list of the user’s preferred system languages as IETF language tags.
     public let locales: [String]?
+
+    /// Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
+    public let logicalCpuCount: Double?
 
     /// Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.
     public let model: String?
@@ -41,9 +44,6 @@ public struct Device: Codable {
 
     /// Whether the device is in power saving mode.
     public let powerSavingMode: Bool?
-
-    /// Number of device processors
-    public let processorCount: Double?
 
     /// The device’s current time zone identifier, e.g. 'Europe/Berlin'.
     public let timeZone: String?
@@ -59,13 +59,13 @@ public struct Device: Codable {
         case batteryLevel = "battery_level"
         case brand = "brand"
         case brightnessLevel = "brightness_level"
-        case isLowRamDevice = "is_low_ram_device"
+        case isLowRam = "is_low_ram"
         case locale = "locale"
         case locales = "locales"
+        case logicalCpuCount = "logical_cpu_count"
         case model = "model"
         case name = "name"
         case powerSavingMode = "power_saving_mode"
-        case processorCount = "processor_count"
         case timeZone = "time_zone"
         case totalRam = "total_ram"
         case type = "type"
@@ -78,13 +78,13 @@ public struct Device: Codable {
     ///   - batteryLevel: Current battery level of the device (0.0 to 1.0).
     ///   - brand: Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.
     ///   - brightnessLevel: Current screen brightness level (0.0 to 1.0).
-    ///   - isLowRamDevice: Whether the device is considered a low RAM device (Android)
+    ///   - isLowRam: Whether the device is considered a low RAM device (Android)
     ///   - locale: The user’s locale as a language tag combining language and region, e.g. 'en-US'.
     ///   - locales: Ordered list of the user’s preferred system languages as IETF language tags.
+    ///   - logicalCpuCount: Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
     ///   - model: Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.
     ///   - name: Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.
     ///   - powerSavingMode: Whether the device is in power saving mode.
-    ///   - processorCount: Number of device processors
     ///   - timeZone: The device’s current time zone identifier, e.g. 'Europe/Berlin'.
     ///   - totalRam: Total RAM in megabytes
     ///   - type: Device type info
@@ -93,13 +93,13 @@ public struct Device: Codable {
         batteryLevel: Double? = nil,
         brand: String? = nil,
         brightnessLevel: Double? = nil,
-        isLowRamDevice: Bool? = nil,
+        isLowRam: Bool? = nil,
         locale: String? = nil,
         locales: [String]? = nil,
+        logicalCpuCount: Double? = nil,
         model: String? = nil,
         name: String? = nil,
         powerSavingMode: Bool? = nil,
-        processorCount: Double? = nil,
         timeZone: String? = nil,
         totalRam: Double? = nil,
         type: DeviceType? = nil
@@ -108,13 +108,13 @@ public struct Device: Codable {
         self.batteryLevel = batteryLevel
         self.brand = brand
         self.brightnessLevel = brightnessLevel
-        self.isLowRamDevice = isLowRamDevice
+        self.isLowRam = isLowRam
         self.locale = locale
         self.locales = locales
+        self.logicalCpuCount = logicalCpuCount
         self.model = model
         self.name = name
         self.powerSavingMode = powerSavingMode
-        self.processorCount = processorCount
         self.timeZone = timeZone
         self.totalRam = totalRam
         self.type = type
@@ -4583,13 +4583,13 @@ public struct RUMTelemetryDevice: Codable {
     public let brand: String?
 
     /// Whether the device is considered a low RAM device (Android)
-    public let isLowRamDevice: Bool?
+    public let isLowRam: Bool?
+
+    /// Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
+    public let logicalCpuCount: Double?
 
     /// Model of the device
     public let model: String?
-
-    /// Number of device processors
-    public let processorCount: Double?
 
     /// Total RAM in megabytes
     public let totalRam: Double?
@@ -4597,9 +4597,9 @@ public struct RUMTelemetryDevice: Codable {
     public enum CodingKeys: String, CodingKey {
         case architecture = "architecture"
         case brand = "brand"
-        case isLowRamDevice = "is_low_ram_device"
+        case isLowRam = "is_low_ram"
+        case logicalCpuCount = "logical_cpu_count"
         case model = "model"
-        case processorCount = "processor_count"
         case totalRam = "total_ram"
     }
 
@@ -4608,23 +4608,23 @@ public struct RUMTelemetryDevice: Codable {
     /// - Parameters:
     ///   - architecture: Architecture of the device
     ///   - brand: Brand of the device
-    ///   - isLowRamDevice: Whether the device is considered a low RAM device (Android)
+    ///   - isLowRam: Whether the device is considered a low RAM device (Android)
+    ///   - logicalCpuCount: Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
     ///   - model: Model of the device
-    ///   - processorCount: Number of device processors
     ///   - totalRam: Total RAM in megabytes
     public init(
         architecture: String? = nil,
         brand: String? = nil,
-        isLowRamDevice: Bool? = nil,
+        isLowRam: Bool? = nil,
+        logicalCpuCount: Double? = nil,
         model: String? = nil,
-        processorCount: Double? = nil,
         totalRam: Double? = nil
     ) {
         self.architecture = architecture
         self.brand = brand
-        self.isLowRamDevice = isLowRamDevice
+        self.isLowRam = isLowRam
+        self.logicalCpuCount = logicalCpuCount
         self.model = model
-        self.processorCount = processorCount
         self.totalRam = totalRam
     }
 }
@@ -11313,6 +11313,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
             /// Schema of mobile specific features usage
             public enum TelemetryMobileFeaturesUsage: Codable {
                 case addViewLoadingTime(value: AddViewLoadingTime)
+                case trackWebView(value: TrackWebView)
 
                 // MARK: - Codable
 
@@ -11323,6 +11324,8 @@ public struct TelemetryUsageEvent: RUMDataModel {
                     switch self {
                     case .addViewLoadingTime(let value):
                         try container.encode(value)
+                    case .trackWebView(let value):
+                        try container.encode(value)
                     }
                 }
 
@@ -11332,6 +11335,10 @@ public struct TelemetryUsageEvent: RUMDataModel {
 
                     if let value = try? container.decode(AddViewLoadingTime.self) {
                         self = .addViewLoadingTime(value: value)
+                        return
+                    }
+                    if let value = try? container.decode(TrackWebView.self) {
+                        self = .trackWebView(value: value)
                         return
                     }
                     let error = DecodingError.Context(
@@ -11378,6 +11385,17 @@ public struct TelemetryUsageEvent: RUMDataModel {
                         self.noView = noView
                         self.overwritten = overwritten
                     }
+                }
+
+                public struct TrackWebView: Codable {
+                    /// trackWebView API
+                    public let feature: String = "trackWebView"
+
+                    public enum CodingKeys: String, CodingKey {
+                        case feature = "feature"
+                    }
+
+                    public init() { }
                 }
             }
         }
@@ -11438,4 +11456,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9095192ef42663e455f26376202b447649e0acd6
+// Generated from https://github.com/DataDog/rum-events-format/tree/32918d999701fb7bfd876369e27ced77d6de1809

--- a/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
@@ -29,6 +29,8 @@ class LogEventBuilderTests: XCTestCase {
         let randomName: String = .mockRandom()
         let randomModel: String = .mockRandom()
         let randomArchitecture: String = .mockRandom()
+        let randomProcessorCount: Double = .mockRandom()
+        let randomTotalRam: Double = .mockRandom()
 
         // Given
         let builder = LogEventBuilder(
@@ -53,7 +55,9 @@ class LogEventBuilderTests: XCTestCase {
                 device: .mockWith(
                     name: randomName,
                     model: randomModel,
-                    architecture: randomArchitecture
+                    architecture: randomArchitecture,
+                    logicalCpuCount: randomProcessorCount,
+                    totalRam: randomTotalRam
                 ),
                 os: .mockWith(
                     name: randomOsName,
@@ -81,6 +85,8 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.device.name, randomName)
             XCTAssertEqual(log.device.model, randomModel)
             XCTAssertEqual(log.device.architecture, randomArchitecture)
+            XCTAssertEqual(log.device.logicalCpuCount, randomProcessorCount)
+            XCTAssertEqual(log.device.totalRam, randomTotalRam)
             XCTAssertEqual(log.os.name, randomOsName)
             XCTAssertEqual(log.os.version, randomOsVersion)
             XCTAssertEqual(log.os.build, randomOsBuildNumber)
@@ -107,6 +113,8 @@ class LogEventBuilderTests: XCTestCase {
         let randomModel: String = .mockRandom()
         let randomOSVersion: String = .mockRandom()
         let randomOSBuild: String = .mockRandom()
+        let randomProcessorCount: Double = .mockRandom()
+        let randomTotalRam: Double = .mockRandom()
 
         let randomSDKContext: DatadogContext = .mockWith(
             env: randomEnvironment,
@@ -116,7 +124,9 @@ class LogEventBuilderTests: XCTestCase {
             serverTimeOffset: randomServerOffset,
             device: .mockWith(
                 name: randomName,
-                model: randomModel
+                model: randomModel,
+                logicalCpuCount: randomProcessorCount,
+                totalRam: randomTotalRam
             ),
             os: .mockWith(
                 version: randomOSVersion,
@@ -164,6 +174,8 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.device.brand, "Apple")
             XCTAssertEqual(log.device.name, randomName)
             XCTAssertEqual(log.device.model, randomModel)
+            XCTAssertEqual(log.device.logicalCpuCount, randomProcessorCount)
+            XCTAssertEqual(log.device.totalRam, randomTotalRam)
             XCTAssertEqual(log.os.version, randomOSVersion)
             XCTAssertEqual(log.os.build, randomOSBuild)
             expectation.fulfill()

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -887,8 +887,8 @@ public class objc_RUMActionEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -897,6 +897,10 @@ public class objc_RUMActionEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -909,10 +913,6 @@ public class objc_RUMActionEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -1839,8 +1839,8 @@ public class objc_RUMErrorEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -1849,6 +1849,10 @@ public class objc_RUMErrorEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -1861,10 +1865,6 @@ public class objc_RUMErrorEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -3500,8 +3500,8 @@ public class objc_RUMLongTaskEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -3510,6 +3510,10 @@ public class objc_RUMLongTaskEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -3522,10 +3526,6 @@ public class objc_RUMLongTaskEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -4627,8 +4627,8 @@ public class objc_RUMResourceEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -4637,6 +4637,10 @@ public class objc_RUMResourceEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -4649,10 +4653,6 @@ public class objc_RUMResourceEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -6316,8 +6316,8 @@ public class objc_RUMViewEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -6326,6 +6326,10 @@ public class objc_RUMViewEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -6338,10 +6342,6 @@ public class objc_RUMViewEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -8212,8 +8212,8 @@ public class objc_RUMVitalAppLaunchEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -8222,6 +8222,10 @@ public class objc_RUMVitalAppLaunchEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -8234,10 +8238,6 @@ public class objc_RUMVitalAppLaunchEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -9200,8 +9200,8 @@ public class objc_RUMVitalDurationEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -9210,6 +9210,10 @@ public class objc_RUMVitalDurationEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -9222,10 +9226,6 @@ public class objc_RUMVitalDurationEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -10127,8 +10127,8 @@ public class objc_RUMVitalOperationStepEventDevice: NSObject {
         root.swiftModel.device!.brightnessLevel as NSNumber?
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -10137,6 +10137,10 @@ public class objc_RUMVitalOperationStepEventDevice: NSObject {
 
     public var locales: [String]? {
         root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -10149,10 +10153,6 @@ public class objc_RUMVitalOperationStepEventDevice: NSObject {
 
     public var powerSavingMode: NSNumber? {
         root.swiftModel.device!.powerSavingMode as NSNumber?
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.device!.processorCount as NSNumber?
     }
 
     public var timeZone: String? {
@@ -11433,16 +11433,16 @@ public class objc_TelemetryConfigurationEventTelemetryRUMTelemetryDevice: NSObje
         root.swiftModel.telemetry.device!.brand
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.telemetry.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.telemetry.device!.isLowRam as NSNumber?
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.telemetry.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
         root.swiftModel.telemetry.device!.model
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.telemetry.device!.processorCount as NSNumber?
     }
 
     public var totalRam: NSNumber? {
@@ -11702,16 +11702,16 @@ public class objc_TelemetryDebugEventTelemetryRUMTelemetryDevice: NSObject {
         root.swiftModel.telemetry.device!.brand
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.telemetry.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.telemetry.device!.isLowRam as NSNumber?
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.telemetry.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
         root.swiftModel.telemetry.device!.model
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.telemetry.device!.processorCount as NSNumber?
     }
 
     public var totalRam: NSNumber? {
@@ -11975,16 +11975,16 @@ public class objc_TelemetryErrorEventTelemetryRUMTelemetryDevice: NSObject {
         root.swiftModel.telemetry.device!.brand
     }
 
-    public var isLowRamDevice: NSNumber? {
-        root.swiftModel.telemetry.device!.isLowRamDevice as NSNumber?
+    public var isLowRam: NSNumber? {
+        root.swiftModel.telemetry.device!.isLowRam as NSNumber?
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.telemetry.device!.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
         root.swiftModel.telemetry.device!.model
-    }
-
-    public var processorCount: NSNumber? {
-        root.swiftModel.telemetry.device!.processorCount as NSNumber?
     }
 
     public var totalRam: NSNumber? {
@@ -12051,4 +12051,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9095192ef42663e455f26376202b447649e0acd6
+// Generated from https://github.com/DataDog/rum-events-format/tree/32918d999701fb7bfd876369e27ced77d6de1809

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -478,7 +478,9 @@ fileprivate extension RUMTelemetryDevice {
         self.init(
             architecture: device.architecture,
             brand: device.brand,
-            model: device.model
+            logicalCpuCount: device.logicalCpuCount,
+            model: device.model,
+            totalRam: device.totalRam
         )
     }
 }

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -464,6 +464,8 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(device.model, deviceMock.model)
         XCTAssertEqual(device.brand, deviceMock.brand)
         XCTAssertEqual(device.architecture, deviceMock.architecture)
+        XCTAssertEqual(device.logicalCpuCount, deviceMock.logicalCpuCount)
+        XCTAssertEqual(device.totalRam, deviceMock.totalRam)
         let os = try XCTUnwrap(event?.telemetry.os)
         XCTAssertEqual(os.version, osMock.version)
         XCTAssertEqual(os.name, osMock.name)

--- a/DatadogRUM/Tests/RUMEvent/RUMDeviceInfoTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMDeviceInfoTests.swift
@@ -18,6 +18,8 @@ final class DeviceInfoTests: XCTestCase {
         let brightnessLevel: Double = .mockRandom()
         let powerSavingMode: Bool = .mockRandom()
         let locale: String = "en"
+        let logicalCpuCount: Double = .mockRandom()
+        let totalRam: Double = .mockRandom()
 
         let info: Device = .mockWith(
             architecture: randomArch,
@@ -26,7 +28,9 @@ final class DeviceInfoTests: XCTestCase {
             locale: locale,
             model: randomModel,
             name: randomName,
-            powerSavingMode: powerSavingMode
+            powerSavingMode: powerSavingMode,
+            logicalCpuCount: logicalCpuCount,
+            totalRam: totalRam
         )
 
         XCTAssertEqual(info.brand, "Apple")
@@ -37,6 +41,8 @@ final class DeviceInfoTests: XCTestCase {
         XCTAssertEqual(info.brightnessLevel, brightnessLevel)
         XCTAssertEqual(info.locale, locale)
         XCTAssertEqual(info.powerSavingMode, powerSavingMode)
+        XCTAssertEqual(info.logicalCpuCount, logicalCpuCount)
+        XCTAssertEqual(info.totalRam, totalRam)
     }
 
     func testItInfersDeviceTypeFromDeviceModel() {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -16,7 +16,7 @@ class RUMViewScopeTests: XCTestCase {
         version: "test-version",
         buildNumber: "test-build",
         buildId: .mockRandom(),
-        device: .mockWith(name: "device-name"),
+        device: .mockWith(name: "device-name", logicalCpuCount: 4, totalRam: 2_048),
         os: .mockWith(
             name: "device-os",
             version: "os-version",
@@ -147,6 +147,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -235,6 +237,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -310,6 +314,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -445,6 +451,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -523,6 +531,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -586,6 +596,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
@@ -2951,6 +2963,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.buildVersion, "test-build")
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
+        XCTAssertEqual(event.device?.logicalCpuCount, 4)
+        XCTAssertEqual(event.device?.totalRam, 2_048)
         XCTAssertEqual(event.os?.name, "device-os")
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")

--- a/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
@@ -173,7 +173,9 @@ extension DeviceInfo {
         isSimulator: Bool = true,
         vendorId: String? = "xyz",
         isDebugging: Bool = false,
-        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate
+        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate,
+        logicalCpuCount: Double = 6,
+        totalRam: Double = 2_048
     ) -> DeviceInfo {
         .init(
             name: name,
@@ -183,7 +185,9 @@ extension DeviceInfo {
             isSimulator: isSimulator,
             vendorId: vendorId,
             isDebugging: isDebugging,
-            systemBootTime: systemBootTime
+            systemBootTime: systemBootTime,
+            logicalCpuCount: logicalCpuCount,
+            totalRam: totalRam
         )
     }
 
@@ -196,7 +200,9 @@ extension DeviceInfo {
             isSimulator: .mockRandom(),
             vendorId: .mockRandom(),
             isDebugging: .mockRandom(),
-            systemBootTime: .mockRandom()
+            systemBootTime: .mockRandom(),
+            logicalCpuCount: .mockRandom(),
+            totalRam: .mockRandom()
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -118,6 +118,8 @@ extension Device: AnyMockable, RandomMockable {
         model: String = "iPhone10,1",
         name: String = "iPhone",
         powerSavingMode: Bool = false,
+        logicalCpuCount: Double = 6,
+        totalRam: Double = 2_048,
         type: DeviceType = .mobile
     ) -> Device {
         .init(
@@ -126,9 +128,11 @@ extension Device: AnyMockable, RandomMockable {
             brand: brand,
             brightnessLevel: brightnessLevel,
             locale: locale,
+            logicalCpuCount: logicalCpuCount,
             model: model,
             name: name,
             powerSavingMode: powerSavingMode,
+            totalRam: totalRam,
             type: type
         )
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -502,13 +502,13 @@ public class objc_RUMActionEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMActionEventDeviceDeviceType
@@ -688,13 +688,13 @@ public class objc_RUMErrorEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMErrorEventDeviceDeviceType
@@ -1020,13 +1020,13 @@ public class objc_RUMLongTaskEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMLongTaskEventDeviceDeviceType
@@ -1243,13 +1243,13 @@ public class objc_RUMResourceEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMResourceEventDeviceDeviceType
@@ -1576,13 +1576,13 @@ public class objc_RUMViewEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMViewEventDeviceDeviceType
@@ -1949,13 +1949,13 @@ public class objc_RUMVitalAppLaunchEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMVitalAppLaunchEventDeviceDeviceType
@@ -2143,13 +2143,13 @@ public class objc_RUMVitalDurationEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMVitalDurationEventDeviceDeviceType
@@ -2326,13 +2326,13 @@ public class objc_RUMVitalOperationStepEventDevice: NSObject
     public var batteryLevel: NSNumber?
     public var brand: String?
     public var brightnessLevel: NSNumber?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
     public var model: String?
     public var name: String?
     public var powerSavingMode: NSNumber?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var timeZone: String?
     public var totalRam: NSNumber?
     public var type: objc_RUMVitalOperationStepEventDeviceDeviceType
@@ -2584,9 +2584,9 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationViewTrackingSt
 public class objc_TelemetryConfigurationEventTelemetryRUMTelemetryDevice: NSObject
     public var architecture: String?
     public var brand: String?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var model: String?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var totalRam: NSNumber?
 public class objc_TelemetryConfigurationEventTelemetryRUMTelemetryOperatingSystem: NSObject
     public var build: String?
@@ -2636,9 +2636,9 @@ public class objc_TelemetryDebugEventTelemetry: NSObject
 public class objc_TelemetryDebugEventTelemetryRUMTelemetryDevice: NSObject
     public var architecture: String?
     public var brand: String?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var model: String?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var totalRam: NSNumber?
 public class objc_TelemetryDebugEventTelemetryRUMTelemetryOperatingSystem: NSObject
     public var build: String?
@@ -2689,9 +2689,9 @@ public class objc_TelemetryErrorEventTelemetry: NSObject
 public class objc_TelemetryErrorEventTelemetryRUMTelemetryDevice: NSObject
     public var architecture: String?
     public var brand: String?
-    public var isLowRamDevice: NSNumber?
+    public var isLowRam: NSNumber?
     public var model: String?
-    public var processorCount: NSNumber?
+    public var logicalCpuCount: NSNumber?
     public var totalRam: NSNumber?
 public class objc_TelemetryErrorEventTelemetryError: NSObject
     public var kind: String?


### PR DESCRIPTION
### What and why?

Adds new attributes to the Device Info:

- **logicalCpuCount**: Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.
- **totalRam**: The total RAM in megabytes

These attributes allow us to classify devices as low-, mid-, or high-tier, which improves our ability to diagnose performance issues.

### How?

- `logicalCpuCount` is retrieved from `ProcessInfo.processInfo.processorCount`, which returns the number of processor cores available on the device ([ref](https://developer.apple.com/documentation/foundation/processinfo/processorcount))
- `totalRam` is retrieved from `ProcessInfo.processInfo.physicalMemory`, which returns the amount of physical memory on the device in bytes ([ref](https://developer.apple.com/documentation/foundation/processinfo/physicalmemory))

### Additional Notes

- Schema Changes: 
  - https://github.com/DataDog/rum-events-format/pull/323 (original)
  - https://github.com/DataDog/rum-events-format/pull/337 (refactoring)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
