### PR TITLE
Fix: Some session Replay tests fails when using dark mode

### DIFF
--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -17,6 +17,7 @@ class UIHostingViewRecorderTests: XCTestCase {
     private enum Constants {
         static let bundledImageName = "dd_logo"
         static let nonBundledImageName = "flower"
+        static let colorFormatPredicate = NSPredicate(format: "SELF MATCHES %@", "^#[0-9A-Fa-f]{8}$")
     }
 
     // MARK: Text
@@ -25,7 +26,8 @@ class UIHostingViewRecorderTests: XCTestCase {
         XCTAssertEqual(wireframes.count, 1)
         let wireframe = try XCTUnwrap(wireframes.first?.textWireframe)
         XCTAssertEqual(wireframe.text, "Hello, World!")
-        XCTAssertEqual(wireframe.textStyle.color, "#000000FF")
+        // Check color format is valid
+        XCTAssertTrue(Constants.colorFormatPredicate.evaluate(with: wireframe.textStyle.color))
         XCTAssertEqual(wireframe.textStyle.family, "-apple-system, BlinkMacSystemFont, \'Roboto\', sans-serif")
         XCTAssertEqual(wireframe.textStyle.size, 28)
         XCTAssertEqual(wireframe.x, 74, accuracy: 5)
@@ -47,7 +49,8 @@ class UIHostingViewRecorderTests: XCTestCase {
         XCTAssertEqual(wireframes.count, 1)
         let wireframe = try XCTUnwrap(wireframes.first?.textWireframe)
         XCTAssertEqual(wireframe.text, "xxxxxx xxxxxx")
-        XCTAssertEqual(wireframe.textStyle.color, "#000000FF")
+        // Check color format is valid
+        XCTAssertTrue(Constants.colorFormatPredicate.evaluate(with: wireframe.textStyle.color))
         XCTAssertEqual(wireframe.textStyle.family, "-apple-system, BlinkMacSystemFont, \'Roboto\', sans-serif")
         XCTAssertEqual(wireframe.textStyle.size, 28)
         XCTAssertEqual(wireframe.x, 74, accuracy: 5)


### PR DESCRIPTION
### What and why?

Makes `UIHostingViewRecorderTests` independent of light/dark mode by removing hard-coded color assertions and validating only the color format. This prevents the test from failing when the simulator is in dark mode.

Fixes #2594 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
