### PR TITLE
RUM-9045: Add support for SwiftUI vector image assets

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage+Reflection.swift
@@ -30,6 +30,28 @@ extension GraphicsImage.Contents: Reflection {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
         case let (.enum("cgImage"), cgImage as CGImage):
             self = .cgImage(cgImage)
+        case let (.enum("vectorLayer"), contents):
+            self = try .vectorImage(reflector.reflect(contents))
+        default:
+            self = .unknown
+        }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension GraphicsImage.VectorImage: Reflection {
+    init(from reflector: Reflector) throws {
+        location = try reflector.descendant("location")
+        name = try reflector.descendant("name")
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension GraphicsImage.Location: Reflection {
+    init(from reflector: Reflector) throws {
+        switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
+        case let (.enum("bundle"), bundle as Bundle):
+            self = .bundle(bundle)
         default:
             self = .unknown
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage.swift
@@ -16,8 +16,26 @@ internal struct GraphicsImage {
     let orientation: SwiftUI.Image.Orientation
     let maskColor: SwiftUI.Color._Resolved?
 
+    enum Location {
+        case bundle(Bundle)
+        case unknown
+    }
+
+    struct VectorImage {
+        let location: Location
+        let name: String
+
+        var bundle: Bundle? {
+            guard case let .bundle(bundle) = location else {
+                return nil
+            }
+            return bundle
+        }
+    }
+
     enum Contents {
         case cgImage(CGImage)
+        case vectorImage(VectorImage)
         case unknown
     }
 }


### PR DESCRIPTION
### What and why?

Add support for capturing SwiftUI vector image assets in Session Replay. Previously, only bitmap (`cgImage`) content was supported. SwiftUI's Image views with vector assets (PDF or SVG-based images from asset catalogs) now render correctly in session replays instead of appearing as unsupported placeholders.

### How?

- Extended `GraphicsImage.Contents` enum to handle `.vectorImage` case alongside existing `.cgImage`
- Added reflection support to extract vector asset metadata (bundle location and asset name) from SwiftUI's internal `vectorLayer` representation.
- Load vector images using `UIImage(named:in:with:)` and render them as image wireframes
- Vector images are treated as bundled assets for privacy level evaluation (same as other asset catalog images)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)