### PR TITLE
Add Accept-Encoding gzip header to FFE CDN requests

### DIFF
--- a/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
@@ -18,6 +18,7 @@ extension URLRequest {
         request.httpMethod = "POST"
 
         request.setValue("application/vnd.api+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("gzip, deflate, br", forHTTPHeaderField: "Accept-Encoding")
         request.setValue(context.clientToken, forHTTPHeaderField: "dd-client-token")
 
         if let applicationId = context.additionalContext(ofType: RUMCoreContext.self)?.applicationID {

--- a/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
@@ -61,6 +61,7 @@ final class FlagAssignmentsRequestTests: XCTestCase {
         XCTAssertEqual(request.url, testURL)
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.api+json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept-Encoding"), "gzip, deflate, br")
         XCTAssertEqual(request.value(forHTTPHeaderField: "dd-client-token"), "test-token")
         XCTAssertEqual(request.value(forHTTPHeaderField: "dd-application-id"), "test-app-id")
         XCTAssertEqual(request.value(forHTTPHeaderField: "X-Custom-Header"), "custom-value")


### PR DESCRIPTION
### What and why?

The FFE precompute assignments API recently enabled gzip compression; it is advantageous to use it in the mobile context to reduce payload size.

<img width="1362" height="814" alt="Screenshot 2025-12-16 at 12 21 32 AM" src="https://github.com/user-attachments/assets/02da734c-22f3-4b6c-b023-db7e68de5296" />

Our staging server already demonstrates a sizable reduction in bytes server.

### How?

Add Accept-Encoding header to FFE CDN requests
Request gzip, deflate, and br (Brotli) compression for FFE CDN
responses. Excludes zstd which requires iOS 16.4+ to maintain
compatibility with our minimum deployment target of iOS 12.

## Testing

Synthetics test validates that the API supports these protocols.

https://app.datadoghq.com/synthetics/multi-step/steps/kc3-nhr-cm8

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
