### PR TITLE
RUM-11471: Add app launch telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -276,6 +276,12 @@
 		1182FAC52DA2F827007FE71A /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9CB2DA2F827007FE71A /* RUMSessionMatcher.swift */; };
 		1182FAC62DA2F827007FE71A /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9D12DA2F827007FE71A /* BacktraceReportMocks.swift */; };
 		1182FAC72DA2F827007FE71A /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9E12DA2F827007FE71A /* DatadogRemoteFeatureMock.swift */; };
+		118ACA3C2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */; };
+		118ACA3D2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA392EEED247004E7F20 /* AppLaunchMetric.swift */; };
+		118ACA3E2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */; };
+		118ACA3F2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA392EEED247004E7F20 /* AppLaunchMetric.swift */; };
+		118ACA442EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */; };
+		118ACA452EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */; };
 		11A2F24A2E70CC08006EDC52 /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */; };
 		11A2F24B2E70CC08006EDC52 /* MediaTimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */; };
 		11A2F24C2E70CC08006EDC52 /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */; };
@@ -2598,6 +2604,9 @@
 		1182FA1A2DA2F827007FE71A /* DatadogCoreProxy+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogCoreProxy+Utils.swift"; sourceTree = "<group>"; };
 		1182FA1B2DA2F827007FE71A /* ServerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerMock.swift; sourceTree = "<group>"; };
 		1182FA1D2DA2F827007FE71A /* PrintFunctionSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFunctionSpy.swift; sourceTree = "<group>"; };
+		118ACA392EEED247004E7F20 /* AppLaunchMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchMetric.swift; sourceTree = "<group>"; };
+		118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchMetricController.swift; sourceTree = "<group>"; };
+		118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchMetricControllerTests.swift; sourceTree = "<group>"; };
 		11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameInfoProvider.swift; sourceTree = "<group>"; };
 		11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTimeProvider.swift; sourceTree = "<group>"; };
 		11A2F2512E71B730006EDC52 /* MediaTimeProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTimeProviderMock.swift; sourceTree = "<group>"; };
@@ -4218,6 +4227,15 @@
 			path = ../TestUtilities/Sources;
 			sourceTree = SOURCE_ROOT;
 		};
+		118ACA3B2EEED247004E7F20 /* AppLaunch */ = {
+			isa = PBXGroup;
+			children = (
+				118ACA392EEED247004E7F20 /* AppLaunchMetric.swift */,
+				118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */,
+			);
+			path = AppLaunch;
+			sourceTree = "<group>";
+		};
 		11A2F2472E70CBCC006EDC52 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
@@ -5832,6 +5850,7 @@
 		6174D60E2BFDEA1F00EC7469 /* SDKMetrics */ = {
 			isa = PBXGroup;
 			children = (
+				118ACA3B2EEED247004E7F20 /* AppLaunch */,
 				6174D60F2BFDEA4600EC7469 /* SessionEndedMetric.swift */,
 				6174D61F2C009C6300EC7469 /* SessionEndedMetricController.swift */,
 				615E2B8D2D39444300D85243 /* ViewEndedController.swift */,
@@ -5844,6 +5863,7 @@
 		6174D6182BFE447600EC7469 /* SDKMetrics */ = {
 			isa = PBXGroup;
 			children = (
+				118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */,
 				6174D6192BFE449300EC7469 /* SessionEndedMetricTests.swift */,
 				61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */,
 			);
@@ -9735,6 +9755,8 @@
 				965497062D761FCB006428EE /* SwiftUIViewNameExtractor.swift in Sources */,
 				11F55FDA2DCE183500DE4944 /* RUMDataModels+objc.swift in Sources */,
 				D23F8E7129DDCD28001CFAE8 /* RUMEventBuilder.swift in Sources */,
+				118ACA3E2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */,
+				118ACA3F2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */,
 				D23F8E7229DDCD28001CFAE8 /* ErrorMessageReceiver.swift in Sources */,
 				96F70D462DD793C400D3736B /* RUMAction.swift in Sources */,
 				D23F8E7329DDCD28001CFAE8 /* SwiftUIActionModifier.swift in Sources */,
@@ -9855,6 +9877,7 @@
 				6167E6DB2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,
 				3C0D5DEA2A543EA300446CF9 /* RUMViewEventsFilterTests.swift in Sources */,
 				1124D5332EA6D4050002E053 /* RUMAppLaunchManagerTests.swift in Sources */,
+				118ACA452EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */,
 				D23F8EC429DDCD38001CFAE8 /* RUMCommandTests.swift in Sources */,
 				9678E2762E55CD200094B106 /* RUMFeatureOperationManagerTests.swift in Sources */,
 			);
@@ -10223,6 +10246,8 @@
 				965497052D761FCB006428EE /* SwiftUIViewNameExtractor.swift in Sources */,
 				11F55FD92DCE183500DE4944 /* RUMDataModels+objc.swift in Sources */,
 				D29A9F7C29DD85BB005C54A4 /* RUMEventBuilder.swift in Sources */,
+				118ACA3C2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */,
+				118ACA3D2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */,
 				D29A9F8829DD85BB005C54A4 /* ErrorMessageReceiver.swift in Sources */,
 				96F70D452DD793C400D3736B /* RUMAction.swift in Sources */,
 				D29A9F8729DD85BB005C54A4 /* SwiftUIActionModifier.swift in Sources */,
@@ -10343,6 +10368,7 @@
 				6167E6DA2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */,
 				3C0D5DE92A543EA200446CF9 /* RUMViewEventsFilterTests.swift in Sources */,
 				1124D5322EA6D4050002E053 /* RUMAppLaunchManagerTests.swift in Sources */,
+				118ACA442EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */,
 				D29A9FA729DDB483005C54A4 /* RUMCommandTests.swift in Sources */,
 				9678E2772E55CD200094B106 /* RUMFeatureOperationManagerTests.swift in Sources */,
 			);

--- a/DatadogInternal/Sources/Context/LaunchInfo.swift
+++ b/DatadogInternal/Sources/Context/LaunchInfo.swift
@@ -20,7 +20,7 @@ public enum LaunchReason: Codable {
 }
 
 /// The phase for app startup.
-public enum LaunchPhase: Codable {
+public enum LaunchPhase: String, Codable {
     case processLaunch
     case runtimeLoad
     case runtimePreMain

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -51,7 +51,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }()
     /// App launch manager to process TTID and TTFD commands.
     private lazy var appLaunchManager: RUMAppLaunchManager = {
-        RUMAppLaunchManager(parent: self, dependencies: dependencies)
+        RUMAppLaunchManager(
+            parent: self,
+            dependencies: dependencies,
+            telemetryController: AppLaunchMetricController(telemetry: dependencies.telemetry)
+        )
     }()
 
     /// Information about this session state, shared with `CrashContext`.
@@ -247,10 +251,10 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             case let startViewCommand as RUMStartViewCommand:
                 // Start view scope explicitly on receiving "start view" command
                 startView(on: startViewCommand, context: context)
-
+                appLaunchManager.process(command, context: context, writer: writer)
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .didEnterBackground:
                 hadApplicationLaunchViewWhenEnteringBackground = activeViewPath == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
-
+                appLaunchManager.process(command, context: context, writer: writer)
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .willEnterForeground:
                 if hadApplicationLaunchViewWhenEnteringBackground == true {
                     startApplicationLaunchView(on: appLifecycleCommand, context: context, writer: writer)

--- a/DatadogRUM/Sources/SDKMetrics/AppLaunch/AppLaunchMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/AppLaunch/AppLaunchMetric.swift
@@ -1,0 +1,161 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Tracks app launch telemetry and exports attributes under the "RUM App Launch" metric.
+internal final class AppLaunchMetric {
+    /// Definition of fields in "RUM App Launch" telemetry, following the "RUM App Launch" telemetry spec.
+    internal enum Constants {
+        /// The name of this metric, included in telemetry log.
+        static let name = "RUM App Launch"
+        /// Metric type value.
+        static let typeValue = Self.name.lowercased()
+        /// Namespace for bundling metric attributes.
+        static let appLaunchKey = "rum_app_launch"
+    }
+
+    /// Duration of the TTID in nanoseconds.
+    private var ttidDurationNs: Int64 = 0
+    /// Duration of the TTFD in nanoseconds, if tracked before TTID.
+    private var ttfdDurationNs: Int64?
+    /// Startup type of the vitals. Can be either "cold_start" of "warm_start".
+    private var startupType: String?
+    /// Rule used to determine the "cold_start" type.
+    private var coldStartRule: String?
+
+    /// The reason for app startup.
+    private let launchReason: LaunchReason
+    /// Indicates how the process was started (e.g., user vs. background launch).
+    private let taskPolicyRole: String
+    /// Value if the system pre warmed the app launch.
+    private let isPrewarmed: Bool
+
+    /// Profiling status when the TTID was reported.
+    private var profilingStatus: String?
+    /// Profiling error when the TTID was reported.
+    private var profilingError: String?
+
+    /// App launch points of interest.
+    private let launchPOIs: [String: String]
+
+    /// Number of extra ignored TTIDs.
+    private var extraTTIDsCount: Int = 0
+
+    /// Error message when the app launch TTID is not sent.
+    private let errorMessage: String?
+
+    init(context: DatadogContext, duration: Int64, errorMessage: String? = nil) {
+        self.errorMessage = errorMessage
+        self.ttidDurationNs = duration
+
+        launchReason = context.launchInfo.launchReason
+        taskPolicyRole = context.launchInfo.raw.taskPolicyRole
+        isPrewarmed = context.launchInfo.launchReason == .prewarming
+
+        launchPOIs = context.launchInfo.launchPhaseDates.reduce(into: [String: String]()) { result, element in
+            result[element.key.rawValue] = iso8601DateFormatter.string(from: element.value)
+        }
+    }
+
+    convenience init?(vitalEvent: RUMVitalAppLaunchEvent, context: DatadogContext, coldStartRule: ColdStartRule? = nil) {
+        guard vitalEvent.vital.appLaunchMetric == .ttid else {
+            return nil
+        }
+        self.init(context: context, duration: Int64.ddWithNoOverflow(vitalEvent.vital.duration))
+        self.coldStartRule = coldStartRule?.rawValue
+        startupType = vitalEvent.vital.startupType?.rawValue
+
+        if let profiling = vitalEvent.dd.profiling {
+            profilingStatus = profiling.status?.rawValue
+            profilingError = profiling.errorReason?.rawValue
+        }
+    }
+
+    /// Increments the number of extra TTIDs collected.
+    func incrementTTIDCounter() {
+        extraTTIDsCount += 1
+    }
+
+    /// Tracks the duration of the TTFD vital.
+    func track(ttfd: Int64) {
+        ttfdDurationNs = ttfd
+    }
+}
+
+// MARK: - AppLaunchMetric errors
+
+extension AppLaunchMetric {
+    static func largeTTID(context: DatadogContext, duration: TimeInterval) -> AppLaunchMetric {
+        .init(context: context, duration: duration.dd.toInt64Nanoseconds, errorMessage: "The TTID collected exceeds the limit.")
+    }
+
+    static func launchNotSupported(context: DatadogContext, duration: TimeInterval) -> AppLaunchMetric {
+        .init(context: context, duration: duration.dd.toInt64Nanoseconds, errorMessage: "The launch is not supported.")
+    }
+}
+
+// MARK: - MetricAttributesConvertible
+
+extension AppLaunchMetric: MetricAttributesConvertible {
+    var metricName: String { Constants.name }
+
+    func asMetricAttributes() -> [String: Encodable]? {
+        [
+            SDKMetricFields.typeKey: Constants.typeValue,
+            Constants.appLaunchKey: Attributes(
+                ttidDurationNs: ttidDurationNs,
+                ttfdDurationNs: ttfdDurationNs,
+                startupType: startupType,
+                coldStartRule: coldStartRule,
+                isPrewarmed: isPrewarmed,
+                launchReason: launchReason,
+                taskPolicyRole: taskPolicyRole,
+                profilingStatus: profilingStatus,
+                profilingError: profilingError,
+                extraTTIDsCount: extraTTIDsCount,
+                pois: launchPOIs,
+                errorMessage: errorMessage
+            )
+        ]
+    }
+}
+
+// MARK: - Exporting Attributes
+
+extension AppLaunchMetric {
+    /// Container to encode "RUM App Launch" data according to the spec.
+    internal struct Attributes: Encodable {
+        let ttidDurationNs: Int64
+        let ttfdDurationNs: Int64?
+        let startupType: String?
+        let coldStartRule: String?
+        let isPrewarmed: Bool
+        let launchReason: LaunchReason
+        let taskPolicyRole: String
+        let profilingStatus: String?
+        let profilingError: String?
+        let extraTTIDsCount: Int
+        let pois: [String: String]
+        let errorMessage: String?
+
+        enum CodingKeys: String, CodingKey {
+            case ttidDurationNs = "ttid_duration"
+            case ttfdDurationNs = "ttfd_duration"
+            case startupType = "startup_type"
+            case coldStartRule = "cold_start_rule"
+            case isPrewarmed = "is_prewarmed"
+            case launchReason = "launch_reason"
+            case taskPolicyRole = "task_policy_role"
+            case profilingStatus = "profiling_status"
+            case profilingError = "profiling_error"
+            case extraTTIDsCount = "extra_ttids_count"
+            case pois = "points_of_interest"
+            case errorMessage = "error_message"
+        }
+    }
+}

--- a/DatadogRUM/Sources/SDKMetrics/AppLaunch/AppLaunchMetricController.swift
+++ b/DatadogRUM/Sources/SDKMetrics/AppLaunch/AppLaunchMetricController.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Controller responsible for managing "RUM App Launch" metrics.
+internal final class AppLaunchMetricController {
+    /// The default sample rate for "RUM App Launch" metric (20%),
+    /// applied in addition to the telemetry sample rate (20% by default).
+    static let defaultSampleRate: SampleRate = 20
+    /// Telemetry endpoint for sending metrics.
+    let telemetry: Telemetry
+    /// The sample rate for "RUM App Launch" metric.
+    let sampleRate: SampleRate
+
+    /// Metric that wraps all the app launch details.
+    private var appLaunchMetric: AppLaunchMetric?
+
+    /// Rule used to determine the "cold_start" type.
+    private var coldStartRule: ColdStartRule?
+
+    init(
+        sampleRate: SampleRate = AppLaunchMetricController.defaultSampleRate,
+        telemetry: Telemetry = NOPTelemetry()
+    ) {
+        self.sampleRate = sampleRate
+        self.telemetry = telemetry
+    }
+
+    /// Sends the telemetry metric.
+    func sendMetric() {
+        guard let appLaunchMetric else {
+            return
+        }
+
+        send(metric: appLaunchMetric)
+
+        // The metric will be reported only once
+        self.appLaunchMetric = nil
+    }
+
+    /// Sends the telemetry metric.
+    func send(metric appLaunchMetric: AppLaunchMetric) {
+        guard let metricAttributes = appLaunchMetric.asMetricAttributes() else {
+            telemetry.debug("Failed to compute attributes for app launch metric.")
+            return
+        }
+
+        telemetry.metric(name: appLaunchMetric.metricName, attributes: metricAttributes, sampleRate: sampleRate)
+    }
+
+    /// Tracks the TTID info with the Datadog context.
+    func track(ttidEvent: RUMVitalAppLaunchEvent, context: DatadogContext) {
+        appLaunchMetric = .init(vitalEvent: ttidEvent, context: context, coldStartRule: coldStartRule)
+    }
+
+    /// Tracks the rule used to determine a  "cold_start" type.
+    func track(coldStartRule: ColdStartRule) {
+        self.coldStartRule = coldStartRule
+    }
+
+    /// Increments the number of extra TTIDs collected.
+    func incrementTTIDCounter() {
+        appLaunchMetric?.incrementTTIDCounter()
+    }
+
+    /// Tracks the duration of the TTFD vital.
+    func trackTTFD(duration: Int64) {
+        appLaunchMetric?.track(ttfd: duration)
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -32,7 +32,8 @@ final class RUMAppLaunchManagerTests: XCTestCase {
 
         manager = RUMAppLaunchManager(
             parent: mockParent,
-            dependencies: mockDependencies
+            dependencies: mockDependencies,
+            telemetryController: .init()
         )
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/StartupTypeHandlerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/StartupTypeHandlerTests.swift
@@ -15,7 +15,7 @@ final class StartupTypeHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         appStateManager = AppStateManagerMock()
-        handler = StartupTypeHandler(appStateManager: appStateManager)
+        handler = StartupTypeHandler(appStateManager: appStateManager, telemetryController: .init())
     }
 
     override func tearDown() {

--- a/DatadogRUM/Tests/SDKMetrics/AppLaunchMetricControllerTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/AppLaunchMetricControllerTests.swift
@@ -1,0 +1,175 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+final class AppLaunchMetricControllerTests: XCTestCase {
+    private let telemetry = TelemetryMock()
+
+    func testTrackingAppLaunchMetric() throws {
+        // Given
+        let datadogContext: DatadogContext = .mockRandom()
+        let vitalEvent: RUMVitalAppLaunchEvent = .mockWith(
+            vital: .mockWith(
+                appLaunchMetric: .ttid,
+                isPrewarmed: datadogContext.launchInfo.launchReason == .prewarming
+            )
+        )
+        let coldStartRule: ColdStartRule = .appUpdate
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+
+        // When
+        controller.track(coldStartRule: coldStartRule)
+        controller.track(ttidEvent: vitalEvent, context: datadogContext)
+        controller.sendMetric()
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.appLaunchMetric)
+        XCTAssertEqual(metric.ttidDurationNs, vitalEvent.vital.duration.dd.toInt64Nanoseconds)
+        XCTAssertEqual(metric.startupType, vitalEvent.vital.startupType?.rawValue)
+        XCTAssertEqual(metric.coldStartRule, coldStartRule.rawValue)
+        XCTAssertEqual(metric.isPrewarmed, vitalEvent.vital.isPrewarmed)
+        XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+        XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+        XCTAssertEqual(metric.pois.count, 5)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: AppLaunchMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingLargeTTID() throws {
+        // Given
+        let datadogContext: DatadogContext = .mockRandom()
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+        let duration: TimeInterval = 1_000
+
+        // When
+        controller.send(metric: .largeTTID(context: datadogContext, duration: duration))
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.appLaunchMetric)
+        XCTAssertEqual(metric.ttidDurationNs, duration.dd.toInt64Nanoseconds)
+        XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+        XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+        XCTAssertEqual(metric.isPrewarmed, datadogContext.launchInfo.launchReason == .prewarming)
+        XCTAssertEqual(metric.pois.count, 5)
+        XCTAssertFalse(metric.errorMessage?.isEmpty ?? true)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: AppLaunchMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingLaunchNotSupported() throws {
+        // Given
+        let datadogContext: DatadogContext = .mockRandom()
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+        let duration: TimeInterval = 1_000
+
+        // When
+        controller.send(metric: .launchNotSupported(context: datadogContext, duration: duration))
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.appLaunchMetric)
+        XCTAssertEqual(metric.ttidDurationNs, duration.dd.toInt64Nanoseconds)
+        XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+        XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+        XCTAssertEqual(metric.isPrewarmed, datadogContext.launchInfo.launchReason == .prewarming)
+        XCTAssertEqual(metric.pois.count, 5)
+        XCTAssertFalse(metric.errorMessage?.isEmpty ?? true)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: AppLaunchMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingAppLaunchMetric_withTTFDRecordedFirst() throws {
+        // Given
+        let datadogContext: DatadogContext = .mockRandom()
+        let vitalEvent: RUMVitalAppLaunchEvent = .mockAny()
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+        let ttfdDuration: Int64 = 1_000
+
+        // When
+        controller.track(ttidEvent: vitalEvent, context: datadogContext)
+        controller.trackTTFD(duration: ttfdDuration)
+        controller.sendMetric()
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.appLaunchMetric)
+        XCTAssertEqual(metric.ttidDurationNs, vitalEvent.vital.duration.dd.toInt64Nanoseconds)
+        XCTAssertEqual(metric.startupType, vitalEvent.vital.startupType?.rawValue)
+        XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+        XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+        XCTAssertEqual(metric.pois.count, 5)
+        XCTAssertEqual(metric.ttfdDurationNs, ttfdDuration)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: AppLaunchMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingMoreThanOneTTID() throws {
+        // Given
+        let datadogContext: DatadogContext = .mockRandom()
+        let vitalEvent: RUMVitalAppLaunchEvent = .mockAny()
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+
+        // When
+        controller.track(ttidEvent: vitalEvent, context: datadogContext)
+        controller.incrementTTIDCounter()
+        controller.incrementTTIDCounter()
+        controller.sendMetric()
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.appLaunchMetric)
+        XCTAssertEqual(metric.ttidDurationNs, vitalEvent.vital.duration.dd.toInt64Nanoseconds)
+        XCTAssertEqual(metric.startupType, vitalEvent.vital.startupType?.rawValue)
+        XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+        XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+        XCTAssertEqual(metric.pois.count, 5)
+        XCTAssertEqual(metric.extraTTIDsCount, 2)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: AppLaunchMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingMultipleAppLaunchMetrics() throws {
+        // Given
+        let iterations = 10
+        let datadogContext: DatadogContext = .mockRandom()
+        let vitalEvent: RUMVitalAppLaunchEvent = .mockAny()
+        let controller = AppLaunchMetricController(telemetry: telemetry)
+        let appLaunchMetric = try XCTUnwrap(AppLaunchMetric(vitalEvent: vitalEvent, context: datadogContext))
+
+        // When
+        (0..<iterations).forEach { _ in
+            controller.send(metric: appLaunchMetric)
+        }
+
+        // Then
+        XCTAssertEqual(telemetry.messages.count, iterations)
+        try (0..<iterations).forEach {
+            let metric = try XCTUnwrap(telemetry.messages[$0]
+                .asMetric?.attributes[AppLaunchMetric.Constants.appLaunchKey] as? AppLaunchMetric.Attributes)
+
+            XCTAssertEqual(metric.ttidDurationNs, vitalEvent.vital.duration.dd.toInt64Nanoseconds)
+            XCTAssertEqual(metric.startupType, vitalEvent.vital.startupType?.rawValue)
+            XCTAssertEqual(metric.launchReason, datadogContext.launchInfo.launchReason)
+            XCTAssertEqual(metric.taskPolicyRole, datadogContext.launchInfo.raw.taskPolicyRole)
+            XCTAssertEqual(metric.pois.count, 5)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension Array where Element == TelemetryMessage {
+    var appLaunchMetric: AppLaunchMetric.Attributes? {
+        lastMetric(named: AppLaunchMetric.Constants.name)?
+            .attributes[AppLaunchMetric.Constants.appLaunchKey] as? AppLaunchMetric.Attributes
+    }
+}

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -759,6 +759,52 @@ extension RUMVitalOperationStepEvent: RandomMockable {
     }
 }
 
+extension RUMVitalDurationEvent: RandomMockable {
+    public static func mockRandom() -> Self {
+        return RUMVitalDurationEvent(
+            dd: .init(),
+            application: .init(id: .mockRandom()),
+            date: .mockRandom(),
+            session: .init(id: .mockRandom(), type: .user),
+            view: .init(id: .mockRandom(), url: .mockRandom()),
+            vital: .mockRandom()
+        )
+    }
+}
+
+extension RUMVitalAppLaunchEvent: RandomMockable, AnyMockable {
+    public static func mockRandom() -> Self {
+        return RUMVitalAppLaunchEvent(
+            dd: .init(),
+            application: .init(id: .mockRandom()),
+            date: .mockRandom(),
+            session: .init(id: .mockRandom(), type: .user),
+            view: .init(id: .mockRandom(), url: .mockRandom()),
+            vital: .mockRandom()
+        )
+    }
+
+    public static func mockAny() -> Self { .mockWith() }
+
+    public static func mockWith(
+        dd: DD = .init(),
+        application: Application = .init(id: .mockAny()),
+        date: Int64 = .mockAny(),
+        session: Session = .init(id: .mockAny(), type: .user),
+        view: View = .init(id: .mockAny(), url: .mockAny()),
+        vital: Vital = .mockAny()
+    ) -> Self {
+        .init(
+            dd: dd,
+            application: application,
+            date: date,
+            session: session,
+            view: view,
+            vital: vital
+        )
+    }
+}
+
 extension RUMVitalDurationEvent.Vital: RandomMockable {
     public static func mockRandom() -> Self {
         .init(
@@ -769,7 +815,7 @@ extension RUMVitalDurationEvent.Vital: RandomMockable {
     }
 }
 
-extension RUMVitalAppLaunchEvent.Vital: RandomMockable {
+extension RUMVitalAppLaunchEvent.Vital: RandomMockable, AnyMockable {
     public static func mockRandom() -> Self {
         .init(
             appLaunchMetric: .mockRandom(),
@@ -778,6 +824,26 @@ extension RUMVitalAppLaunchEvent.Vital: RandomMockable {
             isPrewarmed: .mockRandom(),
             name: .mockRandom(),
             startupType: .mockRandom()
+        )
+    }
+
+    public static func mockAny() -> Self { .mockWith() }
+
+    public static func mockWith(
+        appLaunchMetric: AppLaunchMetric = .ttid,
+        duration: Double = .mockAny(),
+        id: String = .mockAny(),
+        isPrewarmed: Bool? = .mockAny(),
+        name: String? = .mockAny(),
+        startupType: StartupType? = .coldStart
+    ) -> Self {
+        .init(
+            appLaunchMetric: appLaunchMetric,
+            duration: duration,
+            id: id,
+            isPrewarmed: isPrewarmed,
+            name: name,
+            startupType: startupType
         )
     }
 }


### PR DESCRIPTION
### What and why?

This PR adds telemetry for App launch vitals, in line with the [internal spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5903974405/RUM+App+Launch+Telemetry+-+Spec). 
The goal is to understand the timing characteristics of each app launch type, with a particular focus on the variations across cold starts.

### How?

It introduces a new telemetry controller, `AppLaunchMetricController`, responsible for collecting information during app launch through the `AppLaunchMetric` metric.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
