### PR TITLE
RUM-13256 Fix stacktrace symbolication info

### DIFF
--- a/DatadogCrashReporting/Tests/KSCrashIntegration/DatadogCrashReportFilterTests.swift
+++ b/DatadogCrashReporting/Tests/KSCrashIntegration/DatadogCrashReportFilterTests.swift
@@ -64,7 +64,7 @@ class DatadogCrashReportFilterTests: XCTestCase {
                             "contents": [
                                 {
                                     "instruction_addr": 4096,
-                                    "symbol_addr": 4000,
+                                    "object_addr": 4000,
                                     "object_name": "MyApp"
                                 }
                             ]
@@ -77,7 +77,9 @@ class DatadogCrashReportFilterTests: XCTestCase {
                     "name": "/var/containers/Bundle/Application/MyApp/MyApp",
                     "uuid": "12345678-1234-1234-1234-123456789012",
                     "image_addr": 4096,
-                    "image_size": 8192
+                    "image_size": 8192,
+                    "cpu_type": 16777228,
+                    "cpu_subtype": 0
                 }
             ],
             "user": {
@@ -211,7 +213,7 @@ class DatadogCrashReportFilterTests: XCTestCase {
                             "contents": [
                                 {
                                     "instruction_addr": 1000,
-                                    "symbol_addr": 900,
+                                    "object_addr": 900,
                                     "object_name": "libsystem"
                                 }
                             ]
@@ -224,12 +226,12 @@ class DatadogCrashReportFilterTests: XCTestCase {
                             "contents": [
                                 {
                                     "instruction_addr": 5000,
-                                    "symbol_addr": 4900,
+                                    "object_addr": 4900,
                                     "object_name": "MyFramework"
                                 },
                                 {
                                     "instruction_addr": 5120,
-                                    "symbol_addr": 4900,
+                                    "object_addr": 4900,
                                     "object_name": "MyFramework"
                                 }
                             ]
@@ -311,13 +313,17 @@ class DatadogCrashReportFilterTests: XCTestCase {
                     "name": "/Contents/Developer/Platforms/Frameworks/Foundation.framework/Foundation",
                     "uuid": "12345678-1234-1234-1234-123456789ABC",
                     "image_addr": 4096,
-                    "image_size": 8192
+                    "image_size": 8192,
+                    "cpu_type": 16777228,
+                    "cpu_subtype": 0
                 },
                 {
                     "name": "/var/containers/Bundle/Application/MyApp/MyApp",
                     "uuid": "ABCDEF01-2345-6789-ABCD-EF0123456789",
                     "image_addr": 16384,
-                    "image_size": 32768
+                    "image_size": 32768,
+                    "cpu_type": 16777228,
+                    "cpu_subtype": 0
                 }
             ],
             "user": {
@@ -381,7 +387,7 @@ class DatadogCrashReportFilterTests: XCTestCase {
                             "contents": [
                                 {
                                     "instruction_addr": 1000,
-                                    "symbol_addr": 900,
+                                    "object_addr": 900,
                                     "object_name": "MyApp"
                                 }
                             ],


### PR DESCRIPTION
### What and why?

Fixed crash report symbolication issues where binary images were incorrectly labeled with system-level architecture instead of their individual architectures. This caused symbolication to fail when binaries had different architectures (e.g., arm64e vs arm64), correct symbolication relies on correct architecture information.

Also fixed stack frame format to use image base address (`object_addr`) instead of symbol start address (`symbol_addr`), which is required for complete symbolication of the crash report.

### How?

**Crash Reports ([DatadogCrashReportFilter.swift](DatadogCrashReporting/Sources/KSCrashIntegration/DatadogCrashReportFilter.swift)):**
- Extract `cpuType` and `cpuSubType` from each binary image's KSCrash metadata
- Use `kscpu_archForCPU()` to convert type codes to architecture strings (e.g., "arm64e")
- Fixed stack frame format to use `object_addr` (image base address) instead of `symbol_addr` for complete symbolication (line 157)

**Live Backtraces ([KSCrashBacktrace.swift](DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift)):**
- Created new `symbolicate()` function that bypasses KSCrash's limited `ksbt_symbolicateAddress()` API
- Directly calls `ksdl_dladdr()` and `ksdl_binaryImageForHeader()` to access full `KSBinaryImage` struct with CPU type information
- Ensures each binary image reports its actual architecture

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)