### PR TITLE
RUM-12429 Add Dual-Mode to Automatic Network Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FEATURE] Report time to initial display (TTID). See [#2517][] [#2464][] 
 - [FEATURE] Add public API to report time to full display (TTFD). See [#2522][]
 - [IMPROVEMENT] Remove `application_start` action from `ApplicationLaunch`. See [#2533][]
+- [FEATURE] Automatic network instrumentation now tracks `URLSession` requests without requiring delegate registration. See [#2620][]
 - [IMPROVEMENT] Upgrade `DatadogTrace` to OpenTelemetryApi 2.3.0. See [#2614][]
 - [IMPROVEMENT] RUM auto-instrumentation now supports Alerts, Confirmation Dialogs and Action Sheets. See [#2612][] 
 
@@ -1012,6 +1013,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2598]: https://github.com/DataDog/dd-sdk-ios/pull/2598
 [#2599]: https://github.com/DataDog/dd-sdk-ios/pull/2599
 [#2614]: https://github.com/DataDog/dd-sdk-ios/pull/2614
+[#2620]: https://github.com/DataDog/dd-sdk-ios/pull/2620
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1080,6 +1080,8 @@
 		96155A3E2D7F01250029034E /* CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D382D6E2490004BB999 /* CustomDump.swift */; };
 		96155A3F2D7F013A0029034E /* ReflectionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D392D6E2490004BB999 /* ReflectionMirror.swift */; };
 		96155A402D7F014D0029034E /* Reflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A0D3A2D6E2490004BB999 /* Reflector.swift */; };
+		961583BC2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961583BB2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift */; };
+		961583BD2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961583BB2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift */; };
 		962223592DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */; };
 		9622235A2DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */; };
 		9622235B2DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */; };
@@ -1115,6 +1117,8 @@
 		96867B9B2D0883DD004AE0BC /* ColorReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96867B9A2D0883DD004AE0BC /* ColorReflectionTests.swift */; };
 		969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */; };
 		969B3B232C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */; };
+		96CD20642ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */; };
+		96CD20652ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */; };
 		96D331ED2CFF740700649EE8 /* GraphicImagePrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D331EC2CFF740700649EE8 /* GraphicImagePrivacyTests.swift */; };
 		96E414142C2AF56F005A6119 /* UIProgressViewRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */; };
 		96E414162C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */; };
@@ -3279,6 +3283,7 @@
 		960B26BF2D0360EE00D7196F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		960B26C22D075BD200D7196F /* DisplayListReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayListReflectionTests.swift; sourceTree = "<group>"; };
 		96155A282D79A4DF0029034E /* SwiftUIViewNameExtractorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewNameExtractorIntegrationTests.swift; sourceTree = "<group>"; };
+		961583BB2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskStateSwizzlerTests.swift; sourceTree = "<group>"; };
 		962223572DFC233000D58EEC /* DDSwiftUIRUMActionsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSwiftUIRUMActionsPredicateTests.swift; sourceTree = "<group>"; };
 		962223582DFC233000D58EEC /* DDSwiftUIRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSwiftUIRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		962900232D8351A7008DFE39 /* TopLevelReflector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLevelReflector.swift; sourceTree = "<group>"; };
@@ -3300,6 +3305,7 @@
 		96867B9A2D0883DD004AE0BC /* ColorReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorReflectionTests.swift; sourceTree = "<group>"; };
 		969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorder.swift; sourceTree = "<group>"; };
 		969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorderTests.swift; sourceTree = "<group>"; };
+		96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskStateSwizzler.swift; sourceTree = "<group>"; };
 		96D331EC2CFF740700649EE8 /* GraphicImagePrivacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicImagePrivacyTests.swift; sourceTree = "<group>"; };
 		96E414132C2AF56F005A6119 /* UIProgressViewRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorder.swift; sourceTree = "<group>"; };
 		96E414152C2AF5C1005A6119 /* UIProgressViewRecorderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewRecorderTests.swift; sourceTree = "<group>"; };
@@ -6650,6 +6656,7 @@
 		D2160CC029C0DED100FAA9A5 /* URLSession */ = {
 			isa = PBXGroup;
 			children = (
+				96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */,
 				614A708D2BF754D700D9AF42 /* ImmutableRequest.swift */,
 				D2181A8A2B0500BB00A518C0 /* NetworkInstrumentationSwizzler.swift */,
 				D270CDDC2B46E3DB0002EACD /* URLSessionDataDelegateSwizzler.swift */,
@@ -7313,6 +7320,7 @@
 				D2160CCD29C0DF6700FAA9A5 /* NetworkInstrumentationFeatureTests.swift */,
 				D2160CCF29C0DF6700FAA9A5 /* FirstPartyHostsTests.swift */,
 				D2160CD129C0DF6700FAA9A5 /* HostsSanitizerTests.swift */,
+				961583BB2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift */,
 				D2160CD229C0DF6700FAA9A5 /* URLSessionTaskInterceptionTests.swift */,
 				61E45BCE2450A6EC00F2C652 /* TraceIDTests.swift */,
 				3CCECDB12BC68A0A0013C125 /* SpanIDTests.swift */,
@@ -9665,6 +9673,7 @@
 				11B5439F2DE9C40B006F6C0A /* OperatingSystem+Utils.swift in Sources */,
 				D2EBEE2929BA160F00B15732 /* HTTPHeadersWriter.swift in Sources */,
 				D2432CF929EDB22C00D93657 /* Flushable.swift in Sources */,
+				96CD20652ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */,
 				D23039F7298D5236001A1FA3 /* AttributesSanitizer.swift in Sources */,
 				D23039EB298D5236001A1FA3 /* DatadogFeature.swift in Sources */,
 				D2BEEDBA2B33638F0065F3AC /* NetworkInstrumentationSwizzler.swift in Sources */,
@@ -10823,6 +10832,7 @@
 				D2DA2358298D57AA00C6C7E6 /* CoreLogger.swift in Sources */,
 				D2160CA329C0DE5700FAA9A5 /* NetworkInstrumentationFeature.swift in Sources */,
 				D2EBEE2D29BA161100B15732 /* HTTPHeadersReader.swift in Sources */,
+				96CD20642ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */,
 				D24EC3DA2DD1F117007A7E8F /* SessionReplayCoreContext.swift in Sources */,
 				E2AA55E82C32C6D9002FEF28 /* ApplicationNotifications.swift in Sources */,
 				D22789362D64A0D7007E9DB0 /* UploadQualityMetric.swift in Sources */,
@@ -10981,6 +10991,7 @@
 				D2160CE929C0E00200FAA9A5 /* MethodSwizzlerTests.swift in Sources */,
 				115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */,
 				D2160CDC29C0DF6700FAA9A5 /* HostsSanitizerTests.swift in Sources */,
+				961583BD2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift in Sources */,
 				615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */,
 				6156A9072BF75A7C00DF66C3 /* ImmutableRequestTests.swift in Sources */,
 				D2F44FB8299AA1DA0074B0D9 /* DataCompressionTests.swift in Sources */,
@@ -11010,6 +11021,7 @@
 				D21AE6BD29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */,
 				115F480B2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */,
 				D2DA23B1298D59DC00C6C7E6 /* AnyEncodableTests.swift in Sources */,
+				961583BC2EEAD89C006899B0 /* URLSessionTaskStateSwizzlerTests.swift in Sources */,
 				3CCECDB02BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB529DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,
 				6174D6172BFDF29B00EC7469 /* BundleTypeTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/NetworkInstrumentationIntegrationTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+@_spi(Internal)
 import DatadogInternal
 
 @testable import DatadogRUM
@@ -41,11 +42,6 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
             with: config,
             in: core
         )
-
-        URLSessionInstrumentation.enable(
-            with: URLSessionInstrumentation.Configuration(delegateClass: SessionDataDelegateMock.self),
-            in: core
-        )
     }
 
     override func tearDownWithError() throws {
@@ -56,7 +52,11 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
     func testParentSpanPropagation() throws {
         let expectation = expectation(description: "request completes")
         // Given
-        let request: URLRequest = .mockWith(url: "https://www.example.com")
+        URLSessionInstrumentation.enable(
+            with: URLSessionInstrumentation.Configuration(delegateClass: SessionDataDelegateMock.self),
+            in: core
+        )
+        let request: URLRequest = .mockWith(url: .mockAny())
         let span = Tracer.shared(in: core).startRootSpan(operationName: "root")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
         let session = server.getInterceptedURLSession(delegate: SessionDataDelegateMock())
@@ -74,6 +74,7 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 1)
         let matchers = try core.waitAndReturnSpanMatchers()
+        XCTAssertEqual(matchers.count, 2)
 
         let matcher1 = try XCTUnwrap(matchers.first)
         try XCTAssertEqual(matcher1.operationName(), "root")
@@ -125,14 +126,14 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
             delegate: InstrumentedSessionDelegate(),
             delegateQueue: nil
         )
-        var request = URLRequest(url: URL(string: "https://www.datadoghq.com/")!)
+        var request = URLRequest(url: .mockAny())
         request.httpMethod = "GET"
 
         let task = session.dataTask(with: request)
         task.resume()
 
         wait(for: [providerExpectation], timeout: 10)
-        XCTAssertTrue(providerDataCount > 0)
+        XCTAssertTrue(providerDataCount > 0, "Data should be available in metrics mode")
     }
 
     func testResourceAttributesProvider_givenURLSessionDataTaskRequestWithCompletionHandler() {
@@ -173,25 +174,22 @@ class NetworkInstrumentationIntegrationTests: XCTestCase {
             delegate: InstrumentedSessionDelegate(),
             delegateQueue: nil
         )
-        let request = URLRequest(url: URL(string: "https://www.datadoghq.com/")!)
+        let request = URLRequest(url: .mockAny())
 
         let taskExpectation = self.expectation(description: "task completed")
         var taskInfo: (resp: URLResponse?, data: Data?, err: Error?)?
 
-        let task = session.dataTask(with: request) { resp, data, err in
-            taskInfo = (data, resp, err)
+        let task = session.dataTask(with: request) { data, resp, err in
+            taskInfo = (resp, data, err)
             taskExpectation.fulfill()
         }
         task.resume()
 
         wait(for: [providerExpectation, taskExpectation], timeout: 10)
         XCTAssertEqual(providerInfo?.resp, taskInfo?.resp)
-        XCTAssertEqual(providerInfo?.data, taskInfo?.data)
+        XCTAssertEqual(providerInfo?.data, taskInfo?.data, "Data should be available with completion handler")
         XCTAssertEqual(providerInfo?.err as? NSError, taskInfo?.err as? NSError)
     }
 
-    class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {
-        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        }
-    }
+    private class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {}
 }

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 @testable import DatadogTrace
+@_spi(Internal)
 import DatadogInternal
 import TestUtilities
 
@@ -21,7 +22,7 @@ class HeadBasedSamplingTests: XCTestCase {
         traceConfig = Trace.Configuration()
     }
 
-        override func tearDownWithError() throws {
+    override func tearDownWithError() throws {
         try core.flushAndTearDown()
         core = nil
         traceConfig = nil

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -57,7 +57,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         // Given
         let request: ImmutableRequest = .mockWith(httpMethod: "POST")
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .metrics)
         interception.register(metrics: .mockAny())
         interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
 
@@ -85,7 +86,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             httpMethod: "GET"
         )
         let error = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .metrics)
         interception.register(response: nil, error: error)
         interception.register(
             metrics: .mockWith(
@@ -154,7 +156,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         // Given
         let request: ImmutableRequest = .mockWith(httpMethod: "GET")
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .metrics)
         interception.register(response: .mockResponseWith(statusCode: 404), error: nil)
         interception.register(
             metrics: .mockWith(

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -313,8 +313,7 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
 }
 
 extension NetworkInstrumentationFeature {
-
-    /// Determines whether this swizzler should intercept a given task based on the configuration mode.
+    /// Determines whether a task should be intercepted based on the tracking mode.
     ///
     /// - Metrics mode (delegate class configured): Only intercepts tasks with the registered delegate
     /// - Automatic mode (no delegate class): Intercepts all tasks except those with delegates registered in metrics mode

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -14,11 +14,11 @@ import Foundation
 ///     let core: DatadogCoreProtocol
 ///
 ///     let handler: DatadogURLSessionHandler = CustomURLSessionHandler()
-///     core.register(urlSessionInterceptor: handler)
+///     core.register(urlSessionHandler: handler)
 ///
-/// Registering multiple interceptor will aggregate instrumentation.
+/// Registering multiple handlers will aggregate instrumentation.
 internal final class NetworkInstrumentationFeature: DatadogFeature {
-    /// The Feature name: "trace-propagation".
+    /// The Feature name: "network-instrumentation".
     static let name = "network-instrumentation"
 
     /// Network Instrumentation serial queue for safe and serialized access to the
@@ -43,6 +43,12 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
     @ReadWriteLock
     private var swizzlers: [ObjectIdentifier: NetworkInstrumentationSwizzler] = [:]
 
+    /// Tracks delegate classes registered in metrics mode.
+    /// Used to prevent automatic mode from processing tasks that are handled by metrics mode.
+    /// Maps ObjectIdentifier to the actual class type for isKind(of:) checks.
+    @ReadWriteLock
+    private var registeredDelegateClasses: [ObjectIdentifier: AnyClass] = [:]
+
     /// Maps `URLSessionTask` to its `TaskInterception` object.
     ///
     /// The interceptions **must** be accessed using the `queue`.
@@ -56,87 +62,174 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
         self.messageReceiver = messageReceiver
     }
 
-    /// Swizzles `URLSessionTaskDelegate`, `URLSessionDataDelegate`, and `URLSessionTask` methods
-    /// to intercept `URLSessionTask` lifecycles.
+    /// Configures network instrumentation for the specified tracking mode.
     ///
-    /// - Parameter configuration: The configuration to use for swizzling.
-    /// Note: We are only concerned with type of the delegate here but to provide compile time safety, we
-    ///      use the instance of the delegate to get the type.
-    internal func bind(configuration: URLSessionInstrumentation.Configuration) throws {
-        let configuredFirstPartyHosts = FirstPartyHosts(firstPartyHosts: configuration.firstPartyHostsTracing) ?? .init()
-
-        let identifier = ObjectIdentifier(configuration.delegateClass)
-
-        if let swizzler = swizzlers[identifier] {
-            DD.logger.warn(
-                """
-                The delegate class \(configuration.delegateClass) is already instrumented.
-                The previous instrumentation will be disabled in favor of the new one.
-                """
-            )
-
-            swizzler.unswizzle()
+    /// This method supports two modes:
+    /// - Automatic Mode (`configuration == nil`): Tracks all tasks without requiring delegate registration.
+    ///   Uses setState and completion handler swizzling. Does not capture `URLSessionTaskMetrics`.
+    /// - Metrics Mode (`configuration != nil`): Tracks tasks with registered delegate class.
+    ///   Additionally swizzles delegate methods to capture detailed timing breakdown.
+    ///
+    /// - Parameter configuration: The configuration to use. If `nil`, enables Automatic Mode.
+    ///   If provided, enables Metrics Mode for the specified delegate class.
+    internal func bind(configuration: URLSessionInstrumentation.Configuration?) throws {
+        // Prepare mode (validates prerequisites and returns identifier)
+        guard let identifier = prepareMode(for: configuration) else {
+            return // Validation failed or already enabled
         }
 
         let swizzler = NetworkInstrumentationSwizzler()
         swizzlers[identifier] = swizzler
 
+        // Determine tracking mode based on configuration
+        let trackingMode: TrackingMode = configuration?.delegateClass != nil ? .metrics : .automatic
+
+        // Intercept when the task is started
         try swizzler.swizzle(
             interceptResume: { [weak self] task in
-                // intercept task if delegate match
-                guard let self = self, task.dd.delegate?.isKind(of: configuration.delegateClass) == true else {
+                guard let self = self else {
                     return
                 }
 
-                var injectedTraceContexts: [TraceContext]?
-
-                if let currentRequest = task.currentRequest {
-                    let (request, traceContexts) = self.intercept(request: currentRequest, additionalFirstPartyHosts: configuredFirstPartyHosts)
-                    task.dd.override(currentRequest: request)
-                    injectedTraceContexts = traceContexts
+                // Skip Datadog's own intake requests to prevent infinite recursion
+                if self.isDatadogIntakeRequest(task.currentRequest) {
+                    return
                 }
 
-                self.intercept(task: task, with: injectedTraceContexts ?? [], additionalFirstPartyHosts: configuredFirstPartyHosts)
-            }
-        )
-
-        try swizzler.swizzle(
-            delegateClass: configuration.delegateClass,
-            interceptDidFinishCollecting: { [weak self] session, task, metrics in
-                self?.task(task, didFinishCollecting: metrics)
-
-                if #available(iOS 15, tvOS 15, *), !task.dd.hasCompletion {
-                    // iOS 15 and above, didCompleteWithError is not called hence we use task state to detect task completion
-                    // while prior to iOS 15, task state doesn't change to completed hence we use didCompleteWithError to detect task completion
-                    self?.task(task, didCompleteWithError: task.error)
+                // Determine if this swizzler should intercept this task
+                let shouldIntercept: Bool
+                if let delegateClass = configuration?.delegateClass {
+                    // Metrics mode: only intercept tasks with the registered delegate
+                    shouldIntercept = task.dd.delegate?.isKind(of: delegateClass) == true
+                } else {
+                    // Automatic mode: skip if task has a delegate registered in metrics mode
+                    if let delegate = task.dd.delegate, self.isRegisteredDelegate(delegate) {
+                        shouldIntercept = false
+                    } else {
+                        shouldIntercept = true
+                    }
                 }
-            },
-            interceptDidCompleteWithError: { [weak self] session, task, error in
-                self?.task(task, didCompleteWithError: error)
+
+                // Only perform interception if this swizzler should handle this task
+                // This allows the swizzler chain to continue for tasks we don't handle
+                if shouldIntercept {
+                    var injectedTraceContexts: [TraceContext]?
+
+                    let configuredFirstPartyHosts = FirstPartyHosts(firstPartyHosts: configuration?.firstPartyHostsTracing) ?? .init()
+                    if let currentRequest = task.currentRequest {
+                        let (request, traceContexts) = self.intercept(request: currentRequest, additionalFirstPartyHosts: configuredFirstPartyHosts)
+                        task.dd.override(currentRequest: request)
+                        injectedTraceContexts = traceContexts
+                    }
+
+                    self.intercept(task: task, with: injectedTraceContexts ?? [], additionalFirstPartyHosts: configuredFirstPartyHosts, trackingMode: trackingMode)
+                }
             }
         )
 
-        try swizzler.swizzle(
-            delegateClass: configuration.delegateClass,
-            interceptDidReceive: { [weak self] session, task, data in
-                self?.task(task, didReceive: data)
-            }
-        )
+        // In Metrics Mode (delegate class provided), swizzle delegate methods to capture data and metrics
+        if let delegateClass = configuration?.delegateClass {
+            // Swizzle delegate methods for metrics collection and completion detection:
+            // - didFinishCollecting: Captures `URLSessionTaskMetrics` for detailed timing information
+            // - didCompleteWithError: Detects completion on pre-iOS 15 where setState doesn't fire
+            //
+            // Completion detection strategy:
+            // For tasks WITHOUT completion handlers:
+            //   - iOS 15+: setState swizzling detects completion (didCompleteWithError is not called by URLSession)
+            //   - Pre-iOS 15: didCompleteWithError delegate detects completion (setState doesn't change to completed)
+            // For tasks WITH completion handlers:
+            //   - All iOS versions: Completion handler swizzling detects completion
+            try swizzler.swizzle(
+                delegateClass: delegateClass,
+                interceptDidFinishCollecting: { [weak self] session, task, metrics in
+                    self?.task(task, didFinishCollecting: metrics)
 
+                    if #available(iOS 15, tvOS 15, *), !task.dd.hasCompletion {
+                        // iOS 15 and above, didCompleteWithError is not called hence we use task state to detect task completion
+                        // while prior to iOS 15, task state doesn't change to completed hence we use didCompleteWithError to detect task completion
+                        self?.task(task, didCompleteWithError: task.error)
+                    }
+                },
+                interceptDidCompleteWithError: { [weak self] session, task, error in
+                    self?.task(task, didCompleteWithError: error)
+                }
+            )
+
+            // Swizzle didReceive to capture response data in metrics mode
+            // This ensures data is available for:
+            // - ResourceAttributesProvider to access response body and add custom attributes
+            // - GraphQL error detection (GraphQL errors are in response body, not HTTP status)
+            try swizzler.swizzle(
+                delegateClass: delegateClass,
+                interceptDidReceive: { [weak self] session, task, data in
+                    self?.task(task, didReceive: data)
+                }
+            )
+        }
+
+        // Swizzle completion handlers for `URLSession.dataTask(with:completionHandler:)` methods
+        //
+        // In dual-mode (automatic + metrics), both modes swizzle completion handlers.
+        // To prevent double-counting, automatic mode skips tasks with registered delegates.
         try swizzler.swizzle(
             interceptCompletionHandler: { [weak self] task, _, error in
-                self?.task(task, didCompleteWithError: error)
+                guard let self = self else {
+                    return
+                }
+
+                // Determine if this swizzler should process this task
+                if let delegateClass = configuration?.delegateClass {
+                    // Metrics mode: only process if task has our registered delegate
+                    guard let delegate = task.dd.delegate, delegate.isKind(of: delegateClass) else {
+                        return
+                    }
+                    self.task(task, didCompleteWithError: error)
+                } else {
+                    // Automatic mode: skip if task has a delegate registered in metrics mode
+                    if let delegate = task.dd.delegate, self.isRegisteredDelegate(delegate) {
+                        return
+                    }
+                    self.task(task, didCompleteWithError: error)
+                }
             }, didReceive: { [weak self] task, data in
-                self?.task(task, didReceive: data)
+                guard let self = self else {
+                    return
+                }
+
+                // Determine if this swizzler should process this task
+                if let delegateClass = configuration?.delegateClass {
+                    // Metrics mode: only process if task has our registered delegate
+                    guard let delegate = task.dd.delegate, delegate.isKind(of: delegateClass) else {
+                        return
+                    }
+                    self.task(task, didReceive: data)
+                } else {
+                    // Automatic mode: skip if task has a delegate registered in metrics mode
+                    if let delegate = task.dd.delegate, self.isRegisteredDelegate(delegate) {
+                        return
+                    }
+                    self.task(task, didReceive: data)
+                }
+            }
+        )
+
+        // Swizzle `setState:` to detect completion for tasks without completion handlers
+        // This is necessary because:
+        // - Async/await APIs use internal delegates that cannot be swizzled
+        // - Tasks without completion handlers and without delegates won't trigger any other callback
+        try swizzler.swizzle(
+            interceptSetState: { [weak self] task, state in
+                self?.task(task, didChangeToState: state)
             }
         )
     }
 
-    /// Unswizzles `URLSessionTaskDelegate`, `URLSessionDataDelegate`, `URLSessionTask` and `URLSession` methods
+    /// Unswizzles `URLSessionTaskDelegate` methods for the given delegate class.
     /// - Parameter delegateClass: The delegate class to unswizzle.
     internal func unbind(delegateClass: URLSessionDataDelegate.Type) {
         let identifier = ObjectIdentifier(delegateClass)
         swizzlers.removeValue(forKey: identifier)
+        registeredDelegateClasses.removeValue(forKey: identifier)
     }
 
     private func removeGraphQLHeadersFromRequest(_ request: URLRequest) -> URLRequest {
@@ -150,9 +243,137 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
 
         return modifiedRequest
     }
+
+    // MARK: - Mode Preparation
+
+    /// Prepares the tracking mode by validating prerequisites and determining the swizzler identifier.
+    ///
+    /// - Parameter configuration: The configuration to prepare. If `nil`, prepares Automatic Mode. If provided, prepares Metrics Mode.
+    /// - Returns: The identifier for the swizzler, or `nil` if validation failed.
+    private func prepareMode(for configuration: URLSessionInstrumentation.Configuration?) -> ObjectIdentifier? {
+        if let delegateClass = configuration?.delegateClass {
+            return prepareMetricsMode(for: delegateClass)
+        } else {
+            return prepareAutomaticMode()
+        }
+    }
+
+    /// Prepares Metrics Mode for the specified delegate class.
+    ///
+    /// - Parameter delegateClass: The delegate class to register for metrics tracking.
+    /// - Returns: The identifier for the swizzler, or `nil` if validation failed.
+    private func prepareMetricsMode(for delegateClass: URLSessionDataDelegate.Type) -> ObjectIdentifier? {
+        // Require automatic mode to be enabled first
+        let automaticModeIdentifier = ObjectIdentifier(NetworkInstrumentationFeature.self)
+        guard swizzlers[automaticModeIdentifier] != nil else {
+            DD.logger.error(
+                """
+                Metrics mode requires automatic network instrumentation to be enabled first.
+                Please enable RUM or Trace with `urlSessionTracking` parameter before enabling metrics mode.
+                """
+            )
+            return nil
+        }
+
+        // Use delegate class as identifier
+        let identifier = ObjectIdentifier(delegateClass)
+
+        // Register this delegate class so automatic mode can skip processing its tasks
+        registeredDelegateClasses[identifier] = delegateClass
+
+        // If already instrumented, unswizzle the previous instance
+        if let existingSwizzler = swizzlers[identifier] {
+            DD.logger.warn(
+                """
+                The delegate class \(delegateClass) is already instrumented.
+                The previous instrumentation will be disabled in favor of the new one.
+                """
+            )
+            existingSwizzler.unswizzle()
+        }
+
+        return identifier
+    }
+
+    /// Prepares Automatic Mode.
+    ///
+    /// - Returns: The identifier for the swizzler, or `nil` if already enabled.
+    private func prepareAutomaticMode() -> ObjectIdentifier? {
+        // Use sentinel identifier for Automatic mode
+        let identifier = ObjectIdentifier(NetworkInstrumentationFeature.self)
+
+        if swizzlers[identifier] != nil {
+            DD.logger.debug("Automatic network instrumentation is already enabled.")
+            return nil
+        }
+
+        return identifier
+    }
+
+    /// Checks if a delegate is a kind of any registered delegate class.
+    /// Uses `isKind(of:)` to properly handle subclasses, preventing automatic mode
+    /// from processing tasks that should be handled by metrics mode.
+    ///
+    /// - Parameter delegate: The delegate to check
+    /// - Returns: `true` if the delegate is a kind of any registered class, `false` otherwise
+    private func isRegisteredDelegate(_ delegate: AnyObject) -> Bool {
+        return registeredDelegateClasses.values.contains { delegateClass in
+            delegate.isKind(of: delegateClass)
+        }
+    }
 }
 
 extension NetworkInstrumentationFeature {
+    /// Checks if a URLRequest is an SDK internal request that should not be tracked.
+    ///
+    /// Uses two filtering mechanisms:
+    /// 1. **Domain-based filtering**: Checks for production Datadog intake domains (datadoghq.com, datad0g.com)
+    /// 2. **Header-based filtering**: Checks for DD-REQUEST-ID header present in all SDK upload requests
+    ///
+    /// The header-based check is necessary for custom endpoints used in tests (e.g., in `RUMResourcesScenarioTests` in our UI Integration tests),
+    /// where SDK upload requests would otherwise be tracked as RUM resources.
+    ///
+    /// - Parameter request: The URLRequest to check.
+    /// - Returns: `true` if the request is an SDK internal request, `false` otherwise.
+    ///
+    ///   Will be filtered (SDK domains):
+    ///     - browser-intake-datadoghq.com
+    ///     - instrumentation.datadoghq.com
+    ///     - logs.browser-intake-datadoghq.com
+    ///
+    ///   Will NOT be filtered (public domains):
+    ///     - imgix.datadoghq.com (CDN - no "intake" or "instrumentation")
+    ///     - www.datadoghq.com (website)
+    private func isDatadogIntakeRequest(_ request: URLRequest?) -> Bool {
+        // Check domain
+        if isDatadogIntakeRequest(request?.url) {
+            return true
+        }
+
+        // Check for DD-REQUEST-ID header (present in all SDK upload requests, including custom endpoints)
+        return request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddRequestIDHeaderField) != nil
+    }
+
+    /// Checks if the given URL is a Datadog intake request to prevent infinite recursion.
+    ///
+    /// - Parameter url: The URL to check.
+    /// - Returns: `true` if the URL is a Datadog intake request, `false` otherwise.
+    private func isDatadogIntakeRequest(_ url: URL?) -> Bool {
+        guard let host = url?.host else {
+            return false
+        }
+
+        // Filter Datadog intake domains
+        // Must contain "intake" or "instrumentation" to avoid false positives (e.g., imgix.datadoghq.com)
+        let isDatadogDomain = host.hasSuffix("datadoghq.com")
+                           || host.hasSuffix("datadoghq.eu")
+                           || host.hasSuffix("ddog-gov.com")
+                           || host.hasSuffix("datad0g.com")
+        let isIntakeOrInstrumentation = host.contains("intake") || host.contains("instrumentation")
+
+        return isDatadogDomain && isIntakeOrInstrumentation
+    }
+
     /// Intercepts the provided request by injecting trace headers based on first-party hosts configuration.
     ///
     /// Only requests with URLs that match the list of first-party hosts have tracing headers injected.
@@ -162,7 +383,7 @@ extension NetworkInstrumentationFeature {
     ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception, used in conjunction with hosts defined in each handler.
     /// - Returns: A tuple containing the modified request and the list of injected TraceContexts, one or none for each handler. If no trace is injected (e.g., due to sampling),
     ///            the list will be empty.
-    func intercept(request: URLRequest, additionalFirstPartyHosts: FirstPartyHosts?) -> (URLRequest, [TraceContext]) {
+    internal func intercept(request: URLRequest, additionalFirstPartyHosts: FirstPartyHosts?) -> (URLRequest, [TraceContext]) {
         let headerTypes = firstPartyHosts(with: additionalFirstPartyHosts)
             .tracingHeaderTypes(for: request.url)
 
@@ -193,7 +414,8 @@ extension NetworkInstrumentationFeature {
     ///   - task: The URLSession task to intercept.
     ///   - injectedTraceContexts: The list of trace contexts injected into the task's request, one or none for each handler.
     ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception, used in conjunction with hosts defined in each handler.
-    func intercept(task: URLSessionTask, with injectedTraceContexts: [TraceContext], additionalFirstPartyHosts: FirstPartyHosts?) {
+    ///   - trackingMode: The tracking mode to use for this interception (automatic or metrics).
+    internal func intercept(task: URLSessionTask, with injectedTraceContexts: [TraceContext], additionalFirstPartyHosts: FirstPartyHosts?, trackingMode: TrackingMode) {
         // In response to https://github.com/DataDog/dd-sdk-ios/issues/1638 capture the current request object on the
         // caller thread and freeze its attributes through `ImmutableRequest`. This is to avoid changing the request
         // object from multiple threads:
@@ -209,10 +431,21 @@ extension NetworkInstrumentationFeature {
 
             let firstPartyHosts = self.firstPartyHosts(with: additionalFirstPartyHosts)
 
+            // Check if interception already exists for this task
+            let isNewInterception = self.interceptions[task] == nil
+
+            // In dual-mode (automatic + metrics), prevent automatic mode from overriding metrics mode
+            // Metrics mode provides more detailed tracking, so it takes priority
+            if let existingInterception = self.interceptions[task],
+               existingInterception.trackingMode == .metrics && trackingMode == .automatic {
+                return
+            }
+
             let interception = self.interceptions[task] ??
                 URLSessionTaskInterception(
                     request: request,
-                    isFirstParty: firstPartyHosts.isFirstParty(url: request.url)
+                    isFirstParty: firstPartyHosts.isFirstParty(url: request.url),
+                    trackingMode: trackingMode
                 )
 
             interception.register(request: request)
@@ -228,7 +461,12 @@ extension NetworkInstrumentationFeature {
             }
 
             self.interceptions[task] = interception
-            self.handlers.forEach { $0.interceptionDidStart(interception: interception) }
+
+            // Only notify handlers when the interception is first created, not when it's reused
+            // This prevents double notifications when both automatic and metrics modes are enabled
+            if isNewInterception {
+                self.handlers.forEach { $0.interceptionDidStart(interception: interception) }
+            }
         }
     }
 
@@ -237,17 +475,20 @@ extension NetworkInstrumentationFeature {
     /// - Parameters:
     ///   - task: The task whose metrics have been collected.
     ///   - metrics: The collected metrics.
-    func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+    internal func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
         queue.async { [weak self] in
             guard let self = self, let interception = self.interceptions[task] else {
                 return
             }
 
-            interception.register(
-                metrics: ResourceMetrics(taskMetrics: metrics)
-            )
+            let resourceMetrics = ResourceMetrics(taskMetrics: metrics)
+            interception.register(metrics: resourceMetrics)
 
-            if interception.isDone {
+            // Populate interception.responseSize for metrics mode
+            self.captureResponseSize(for: interception, from: task, metrics: resourceMetrics)
+
+            // Don't finish yet if task has completion handler - let completion handler finish after capturing data
+            if interception.isDone && !task.dd.hasCompletion {
                 self.finish(task: task, interception: interception)
             }
         }
@@ -258,9 +499,12 @@ extension NetworkInstrumentationFeature {
     /// - Parameters:
     ///   - task: The task that provided data.
     ///   - data: A data object containing the transferred data.
-    func task(_ task: URLSessionTask, didReceive data: Data) {
+    internal func task(_ task: URLSessionTask, didReceive data: Data) {
         queue.async { [weak self] in
-            self?.interceptions[task]?.register(nextData: data)
+            guard let self = self, let interception = self.interceptions[task] else {
+                return
+            }
+            interception.register(nextData: data)
         }
     }
 
@@ -269,7 +513,7 @@ extension NetworkInstrumentationFeature {
     /// - Parameters:
     ///   - task: The task that has finished transferring data.
     ///   - error: If an error occurred, an error object indicating how the transfer failed, otherwise NULL.
-    func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
+    internal func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
         queue.async { [weak self] in
             guard let self = self, let interception = self.interceptions[task] else {
                 return
@@ -293,6 +537,72 @@ extension NetworkInstrumentationFeature {
     private func finish(task: URLSessionTask, interception: URLSessionTaskInterception) {
         handlers.forEach { $0.interceptionDidComplete(interception: interception) }
         interceptions[task] = nil
+    }
+
+    /// Tells the interceptors that the task's state has changed.
+    ///
+    /// - Parameters:
+    ///   - task: The task whose state has changed.
+    ///   - state: The new state of the task (0=Suspended, 1=Running, 2=Canceling, 3=Completed).
+    internal func task(_ task: URLSessionTask, didChangeToState state: Int) {
+        queue.async { [weak self] in
+            guard let self = self, let interception = self.interceptions[task] else {
+                return
+            }
+
+            // Register the state change
+            interception.register(state: state)
+
+            // When task completes (state >= 2), also register the response/error if not already done
+            // This ensures completion is recorded even for async/await or delegate-less tasks without completion handlers
+            if state >= 2 && interception.completion == nil {
+                interception.register(
+                    response: task.response,
+                    error: task.error
+                )
+
+                // Also capture response size for automatic mode (when data is not available)
+                // This provides the "size" component of "duration, status, size, errors" tracking
+                if interception.responseSize == nil {
+                    interception.register(responseSize: task.countOfBytesReceived)
+                }
+            }
+
+            // Check if the interception is now complete and finish if needed.
+            // However, if the task has a completion handler, wait for it to fire instead of finishing here.
+            // This ensures we capture the response data through completion handler swizzling before finishing.
+            // The completion handler will call finish() after capturing the data.
+            if interception.isDone && !task.dd.hasCompletion {
+                self.finish(task: task, interception: interception)
+            }
+        }
+    }
+
+    /// Captures response size for an interception.
+    ///
+    /// For metrics mode, prefers the response size from URLSessionTaskMetrics.
+    /// Falls back to task.countOfBytesReceived when metrics don't have the size
+    /// (e.g., upload tasks where URLSessionTaskMetrics reports 0).
+    ///
+    /// - Parameters:
+    ///   - interception: The interception to populate.
+    ///   - task: The task to get countOfBytesReceived from.
+    ///   - metrics: The metrics containing responseSize from URLSessionTaskMetrics.
+    private func captureResponseSize(
+        for interception: URLSessionTaskInterception,
+        from task: URLSessionTask,
+        metrics: ResourceMetrics
+    ) {
+        guard interception.responseSize == nil else {
+            return
+        }
+
+        let metricsSize = metrics.responseSize ?? 0
+        let responseSize = metricsSize > 0 ? metricsSize : task.countOfBytesReceived
+
+        if responseSize > 0 {
+            interception.register(responseSize: responseSize)
+        }
     }
 }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -553,9 +553,9 @@ extension NetworkInstrumentationFeature {
             // Register the state change
             interception.register(state: state)
 
-            // When task completes (state >= 2), also register the response/error if not already done
+            // When task completes (state == 3), also register the response/error if not already done
             // This ensures completion is recorded even for async/await or delegate-less tasks without completion handlers
-            if state >= 2 && interception.completion == nil {
+            if state == 3 && interception.completion == nil {
                 interception.register(
                     response: task.response,
                     error: task.error

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/NetworkInstrumentationSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/NetworkInstrumentationSwizzler.swift
@@ -12,6 +12,7 @@ internal final class NetworkInstrumentationSwizzler {
     let urlSessionTaskSwizzler: URLSessionTaskSwizzler
     let urlSessionTaskDelegateSwizzler: URLSessionTaskDelegateSwizzler
     let urlSessionDataDelegateSwizzler: URLSessionDataDelegateSwizzler
+    let urlSessionTaskStateSwizzler: URLSessionTaskStateSwizzler
 
     init() {
         let lock = NSRecursiveLock()
@@ -19,6 +20,7 @@ internal final class NetworkInstrumentationSwizzler {
         urlSessionTaskSwizzler = URLSessionTaskSwizzler(lock: lock)
         urlSessionTaskDelegateSwizzler = URLSessionTaskDelegateSwizzler(lock: lock)
         urlSessionDataDelegateSwizzler = URLSessionDataDelegateSwizzler(lock: lock)
+        urlSessionTaskStateSwizzler = URLSessionTaskStateSwizzler(lock: lock)
     }
 
     /// Swizzles `URLSession.dataTask(with:completionHandler:)` methods (with `URL` and `URLRequest`).
@@ -39,7 +41,7 @@ internal final class NetworkInstrumentationSwizzler {
         try urlSessionTaskSwizzler.swizzle(interceptResume: interceptResume)
     }
 
-    /// Swizzles  methods:
+    /// Swizzles methods:
     /// - `URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:)`
     /// - `URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:)`
     func swizzle(
@@ -54,8 +56,7 @@ internal final class NetworkInstrumentationSwizzler {
         )
     }
 
-    /// Swizzles  methods:
-    /// - `URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)`
+    /// Swizzles `URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)` method.
     func swizzle(
         delegateClass: URLSessionDataDelegate.Type,
         interceptDidReceive: @escaping (URLSession, URLSessionDataTask, Data) -> Void
@@ -66,11 +67,19 @@ internal final class NetworkInstrumentationSwizzler {
         )
     }
 
+    /// Swizzles `URLSessionTask.setState:` method.
+    func swizzle(
+        interceptSetState: @escaping (URLSessionTask, Int) -> Void
+    ) throws {
+        try urlSessionTaskStateSwizzler.swizzle(interceptSetState: interceptSetState)
+    }
+
     /// Unswizzles all.
     func unswizzle() {
         urlSessionSwizzler.unswizzle()
         urlSessionTaskSwizzler.unswizzle()
         urlSessionTaskDelegateSwizzler.unswizzle()
         urlSessionDataDelegateSwizzler.unswizzle()
+        urlSessionTaskStateSwizzler.unswizzle()
     }
 }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInstrumentation.swift
@@ -25,7 +25,8 @@ public enum URLSessionInstrumentation {
         }
     }
 
-    internal static func enableOrThrow(with configuration: URLSessionInstrumentation.Configuration, in core: DatadogCoreProtocol) throws {
+    @_spi(Internal)
+    public static func enableOrThrow(with configuration: URLSessionInstrumentation.Configuration?, in core: DatadogCoreProtocol) throws {
         guard let feature = core.get(feature: NetworkInstrumentationFeature.self) else {
             throw ProgrammerError(description: "URLSession tracking must be enabled before enabling URLSessionInstrumentation using either RUM or Trace feature.")
         }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskDelegateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskDelegateSwizzler.swift
@@ -16,7 +16,7 @@ internal class URLSessionTaskDelegateSwizzler {
         self.lock = lock
     }
 
-    /// Swizzles  methods:
+    /// Swizzles methods:
     /// - `URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:)`
     /// - `URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:)`
     func swizzle(

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -60,8 +60,7 @@ public class URLSessionTaskInterception {
     /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
     public private(set) var origin: String?
     /// Task state tracked via `setState:` swizzling.
-    /// State values: 0=Suspended, 1=Running, 2=Canceling, 3=Completed
-    private var taskState: Int?
+    internal var taskState: URLSessionTask.State?
 
     init(request: ImmutableRequest, isFirstParty: Bool, trackingMode: TrackingMode) {
         self.identifier = UUID()
@@ -102,7 +101,7 @@ public class URLSessionTaskInterception {
     }
 
     func register(state: Int) {
-        self.taskState = state
+        self.taskState = URLSessionTask.State(rawValue: state)
     }
 
     func register(responseSize: Int64) {
@@ -119,8 +118,7 @@ public class URLSessionTaskInterception {
         switch trackingMode {
         case .automatic:
             // In automatic mode, complete as soon as we have completion or state completion
-            // Task state == 3 means Completed
-            let isStateComplete = (taskState ?? 0) == 3
+            let isStateComplete = taskState == .completed
             return completion != nil || isStateComplete
         case .metrics:
             // In metrics mode, wait for both metrics AND completion

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -6,6 +6,17 @@
 
 import Foundation
 
+/// Defines the tracking mode for network instrumentation.
+public enum TrackingMode {
+    /// Automatic mode: tracks all tasks without requiring delegate registration.
+    /// Does not capture detailed timing data.
+    case automatic
+
+    /// Metrics mode: tracks tasks with registered delegate.
+    /// Captures `URLSessionTaskMetrics` for detailed timing breakdown (DNS, SSL, TTFB, etc.).
+    case metrics
+}
+
 public class URLSessionTaskInterception {
     /// An identifier uniquely identifying the task interception across all `URLSessions`.
     public let identifier: UUID
@@ -14,10 +25,31 @@ public class URLSessionTaskInterception {
     public private(set) var request: ImmutableRequest
     /// Tells if the `request` is send to a 1st party host.
     public let isFirstPartyRequest: Bool
+    /// The tracking mode for this interception (automatic or metrics).
+    internal let trackingMode: TrackingMode
     /// Task metrics collected during this interception.
     public private(set) var metrics: ResourceMetrics?
-    /// Task data received during this interception. Can be `nil` if task completed with error.
+    /// Task data received during this interception.
+    ///
+    /// Data is collected in:
+    /// - Metrics mode: via `URLSessionDataDelegate.urlSession(_:dataTask:didReceive:)` swizzling
+    /// - Automatic mode: via completion handler swizzling (only for tasks with completion handlers)
+    ///
+    /// Can be `nil` if:
+    /// - Task completed with error
+    /// - Task has no completion handler in automatic mode (e.g., async/await, tasks without handlers)
+    /// - Task is a download task (data is saved to file instead of captured in memory)
     public private(set) var data: Data?
+    /// Response size in bytes received during this interception.
+    ///
+    /// This is captured via `task.countOfBytesReceived` and serves as a fallback when `metrics.responseSize` is unavailable.
+    ///
+    /// Priority for response size:
+    /// 1. `metrics.responseSize` - Most accurate, from `URLSessionTaskMetrics` (only available in metrics mode)
+    /// 2. `responseSize` - Fallback from `task.countOfBytesReceived` (available in both modes)
+    ///
+    /// Available even when data is not captured (e.g., for tasks without completion handlers in automatic mode).
+    public private(set) var responseSize: Int64?
     /// Task completion collected during this interception.
     public private(set) var completion: ResourceCompletion?
     /// Trace context injected to request headers. Can be `nil` if the trace was not sampled or if modifying
@@ -27,11 +59,15 @@ public class URLSessionTaskInterception {
     ///
     /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
     public private(set) var origin: String?
+    /// Task state tracked via `setState:` swizzling.
+    /// State values: 0=Suspended, 1=Running, 2=Canceling, 3=Completed
+    private var taskState: Int?
 
-    init(request: ImmutableRequest, isFirstParty: Bool) {
+    init(request: ImmutableRequest, isFirstParty: Bool, trackingMode: TrackingMode) {
         self.identifier = UUID()
         self.request = request
         self.isFirstPartyRequest = isFirstParty
+        self.trackingMode = trackingMode
     }
 
     func register(metrics: ResourceMetrics) {
@@ -65,9 +101,32 @@ public class URLSessionTaskInterception {
         self.origin = origin
     }
 
-    /// Tells if the interception is done (mean: both metrics and completion were collected).
+    func register(state: Int) {
+        self.taskState = state
+    }
+
+    func register(responseSize: Int64) {
+        self.responseSize = responseSize
+    }
+
+    /// Tells if the interception is done.
+    ///
+    /// The completion criteria depends on the tracking mode:
+    /// - Automatic mode: Task is done when we have completion OR task state indicates completion.
+    /// - Metrics mode: Task is done when we have BOTH metrics AND completion.
+    ///   We must wait for metrics to ensure detailed timing data is captured.
     public var isDone: Bool {
-        metrics != nil && completion != nil
+        switch trackingMode {
+        case .automatic:
+            // In automatic mode, complete as soon as we have completion or state completion
+            // Task state >= 2 means Canceling (2) or Completed (3)
+            let isStateComplete = (taskState ?? 0) >= 2
+            return completion != nil || isStateComplete
+        case .metrics:
+            // In metrics mode, wait for both metrics AND completion
+            // to ensure we capture detailed timing data
+            return completion != nil && metrics != nil
+        }
     }
 }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -119,8 +119,8 @@ public class URLSessionTaskInterception {
         switch trackingMode {
         case .automatic:
             // In automatic mode, complete as soon as we have completion or state completion
-            // Task state >= 2 means Canceling (2) or Completed (3)
-            let isStateComplete = (taskState ?? 0) >= 2
+            // Task state == 3 means Completed
+            let isStateComplete = (taskState ?? 0) == 3
             return completion != nil || isStateComplete
         case .metrics:
             // In metrics mode, wait for both metrics AND completion

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Swizzles `URLSessionTask.setState:` private method to detect task completion.
+///
+/// This swizzler is necessary to capture completion for:
+/// - Async/await APIs: These use internal delegates that cannot be swizzled
+/// - Delegate-less tasks without completion handlers
+///
+/// By observing state transitions to `Canceling` (2) or `Completed` (3), we can detect
+/// when these tasks finish without relying on delegate callbacks or completion handlers.
+///
+internal final class URLSessionTaskStateSwizzler {
+    private let lock: NSLocking
+    private var taskSetState: TaskSetState?
+
+    init(lock: NSLocking = NSLock()) {
+        self.lock = lock
+    }
+
+    /// Swizzles `URLSessionTask.setState:` method.
+    func swizzle(
+        interceptSetState: @escaping (URLSessionTask, Int) -> Void
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        taskSetState = try TaskSetState.build()
+        taskSetState?.swizzle(intercept: interceptSetState)
+    }
+
+    /// Unswizzles all.
+    ///
+    /// This method is called during deinit.
+    func unswizzle() {
+        lock.lock()
+        taskSetState?.unswizzle()
+        lock.unlock()
+    }
+
+    deinit {
+        unswizzle()
+    }
+
+    /// Swizzles `URLSessionTask.setState:` method.
+    class TaskSetState: MethodSwizzler<@convention(c) (URLSessionTask, Selector, Int) -> Void, @convention(block) (URLSessionTask, Int) -> Void> {
+        private static let selector = NSSelectorFromString("setState:")
+
+        private let method: Method
+
+        static func build() throws -> TaskSetState {
+            let className = "__NSCFLocalSessionTask"
+            guard let klass = NSClassFromString(className) else {
+                throw InternalError(description: "Failed to swizzle `URLSessionTask.setState:`: `\(className)` class not found.")
+            }
+            return try TaskSetState(selector: self.selector, klass: klass)
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try dd_class_getInstanceMethod(klass, selector)
+            super.init()
+        }
+
+        func swizzle(intercept: @escaping (URLSessionTask, Int) -> Void) {
+            typealias Signature = @convention(block) (URLSessionTask, Int) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { task, state in
+                    intercept(task, state)
+                    previousImplementation(task, Self.selector, state)
+                }
+            }
+        }
+    }
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
@@ -53,6 +53,9 @@ internal final class URLSessionTaskStateSwizzler {
         private let method: Method
 
         static func build() throws -> TaskSetState {
+            // RUM-2690: We swizzle private `__NSCFLocalSessionTask` class as it appears to be uniformly used
+            // in iOS versions 12.x - 17.x. Swizzling the public `URLSessionTask.resume()` doesn't work in 12.x and 13.x.
+            // See https://github.com/DataDog/dd-sdk-ios/pull/1637 for full `URLSessionTask` class dumps in major iOS versions.
             let className = "__NSCFLocalSessionTask"
             guard let klass = NSClassFromString(className) else {
                 throw InternalError(description: "Failed to swizzle `URLSessionTask.setState:`: `\(className)` class not found.")

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1795,52 +1795,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     // MARK: - Filtering Out Intake Requests
 
-    func testAutomaticMode_doesNotTrackDatadogIntakeRequests() throws {
-        // Given - Enable automatic mode
-        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
-
-        // Create a real URLSession (not using server mock since we're testing filtering)
-        let session = URLSession(configuration: .ephemeral)
-
-        // Track if any Datadog intake requests are intercepted
-        var interceptedDatadogRequests: [URLSessionTaskInterception] = []
-        handler.onInterceptionDidStart = { interception in
-            guard let urlString = interception.request.url?.absoluteString else {
-                return
-            }
-            // If this is a Datadog intake request, track it (should not happen)
-            if urlString.contains("datadoghq.com") ||
-                urlString.contains("datad0g.com") {
-                interceptedDatadogRequests.append(interception)
-            }
-        }
-
-        // When - Make requests to Datadog intake domains
-        let datadogURLs = [
-            URL(string: "https://browser-intake-datadoghq.com/api/v2/rum")!,
-            URL(string: "https://logs.browser-intake-datadoghq.com/api/v2/logs")!,
-            URL(string: "https://session-replay.browser-intake-datadoghq.com/api/v2/replay")!,
-            URL(string: "https://instrumentation.datadoghq.com/api/v2/apmtelemetry")!,
-        ]
-
-        let tasksCompleted = expectation(description: "All tasks completed")
-        tasksCompleted.expectedFulfillmentCount = datadogURLs.count
-
-        for url in datadogURLs {
-            let task = session.dataTask(with: url) { _, _, _ in
-                tasksCompleted.fulfill()
-            }
-            task.resume()
-        }
-
-        // Wait for all tasks to complete
-        wait(for: [tasksCompleted], timeout: 10)
-
-        // Then - Verify no Datadog intake requests were intercepted
-        XCTAssertEqual(interceptedDatadogRequests.count, 0, "Should not intercept Datadog intake requests")
-    }
-
-    func testAutomaticMode_doesNotTrackSDKRequestsWithCustomEndpoints() throws {
+    func testAutomaticMode_doesNotTrackSDKRequests() throws {
         // Given - Enable automatic mode
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1429,7 +1429,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
         XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
 
-        // CRITICAL: Verify that the error is captured for cancelled tasks
         let completion = try XCTUnwrap(interception.completion, "Should capture completion")
         let error = try XCTUnwrap(completion.error, "Should capture cancellation error") as NSError
         XCTAssertEqual(error.domain, NSURLErrorDomain, "Error should be NSURLError")

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+@_spi(Internal)
 @testable import DatadogInternal
 
 class NetworkInstrumentationFeatureTests: XCTestCase {
@@ -27,26 +28,44 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Interception Flow
+    // MARK: - Test Helpers
 
-    func testGivenURLSessionWithDatadogDelegate_whenUsingTaskWithURL_itNotifiesInterceptor() throws {
+    /// Sets up a test with interception expectations for single-request scenarios.
+    /// Returns server, start expectation, and complete expectation.
+    private func setupInterceptionTest(
+        dataSize: Int = 10,
+        statusCode: Int = 200,
+        skipIsMainThreadCheck: Bool = false
+    ) -> (ServerMock, XCTestExpectation, XCTestExpectation) {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: statusCode), data: .mock(ofSize: dataSize)),
+            skipIsMainThreadCheck: true
+        )
 
-        handler.onInterceptionDidStart = { _ in
-            notifyInterceptionDidStart.fulfill()
-        }
-        handler.onInterceptionDidComplete = { _ in
-            notifyInterceptionDidComplete.fulfill()
-        }
+        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        return (server, notifyInterceptionDidStart, notifyInterceptionDidComplete)
+    }
+
+    // MARK: - Metrics Mode
+
+    func testMetricsMode_capturesMetricsForDataTaskWithURL() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
         // Given
+        // Automatic mode (required)
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
         let delegate = SessionDataDelegateMock()
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
         let session = server.getInterceptedURLSession(delegate: delegate)
 
-        // When
+        // When - using data task with URL
         let task = session.dataTask(with: URL.mockAny())
         task.resume()
 
@@ -60,12 +79,19 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             enforceOrder: true
         )
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Metrics mode should capture data")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    func testGivenURLSessionWithDatadogDelegate_whenUsingTaskWithURLRequest_itNotifiesInterceptor() throws {
+    func testMetricsMode_capturesMetricsForDataTaskWithURLRequest() throws {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         handler.onRequestMutation = { _, _, _ in notifyRequestMutation.fulfill() }
@@ -77,11 +103,14 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.firstPartyHosts = .init(
             hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
         )
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
         let delegate = SessionDataDelegateMock()
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+        // Session with delegate
         let session = server.getInterceptedURLSession(delegate: delegate)
 
-        // When
+        // When - using data task with URLRequest
         session
             .dataTask(with: URLRequest(url: url))
             .resume()
@@ -97,31 +126,104 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             enforceOrder: true
         )
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Metrics mode should capture data")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testMetricsMode_capturesMetricsForUploadTask() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using upload task
+        let task = session.uploadTask(with: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20))
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Metrics mode should capture data")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testMetricsMode_capturesMetricsForDownloadTask() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using download task
+        let task = session.downloadTask(with: URL.mockAny())
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Download task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data not captured for download tasks (saved to file)")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithCustomDelegate_whenUsingAsyncDataFromURL_itNotifiesInterceptor() async throws {
+    func testMetricsMode_capturesMetricsForAsyncDataFromURL() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
 
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
 
         // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
         let delegate = SessionDataDelegateMock()
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
         let session = server.getInterceptedURLSession(delegate: delegate)
 
-        // When
+        // When - using async data API with delegate
         _ = try await session.data(from: URL.mockAny(), delegate: delegate)
 
         // Then
@@ -135,31 +237,34 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
 
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Async APIs return data directly to caller, bypassing delegate's didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithCustomDelegate_whenUsingAsyncDataFromURLWithoutDelegate_itNotifiesInterceptor() async throws {
+    func testMetricsMode_capturesMetricsForAsyncDataWithSessionDelegate() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
 
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
 
         // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
         let delegate = SessionDataDelegateMock()
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
         let session = server.getInterceptedURLSession(delegate: delegate)
 
-        // When
+        // When - using async data API without delegate
         _ = try await session.data(from: URL.mockAny())
 
         // Then
@@ -173,29 +278,462 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
 
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Async APIs return data directly to caller, bypassing delegate's didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithCustomDelegate_whenUsingCombineDataFromURL_itNotifiesInterceptor() throws {
+    func testMetricsMode_capturesMetricsForAsyncDataWithPerTaskDelegate() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
 
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session without delegate
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - using async data API with delegate
+        _ = try await session.data(from: URL.mockAny(), delegate: delegate)
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Async APIs return data directly to caller, bypassing delegate's didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testMetricsMode_capturesMetricsForAsyncUploadWithPerTaskDelegate() async throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session without delegate
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - using async upload API with delegate
+        _ = try await session.upload(for: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20), delegate: delegate)
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data is not captured when using Async API")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testMetricsMode_capturesMetricsForAsyncUploadWithSessionDelegate() async throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using async upload API
+        _ = try await session.upload(for: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20))
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Async APIs return data directly to caller, bypassing delegate's didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testMetricsMode_capturesMetricsForAsyncDataTaskWithURLRequest() async throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         let server = ServerMock(
             delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
             skipIsMainThreadCheck: true
         )
 
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidStart = { interception in
+            XCTAssertTrue(interception.isFirstPartyRequest)
+            notifyInterceptionDidStart.fulfill()
+        }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
         // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        let url: URL = .mockAny()
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
+
+        // Metrics mode
         let delegate = SessionDataDelegateMock()
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
         let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using async data API with delegate
+        _ = try await session.data(for: URLRequest(url: url), delegate: delegate)
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Async APIs return data directly to caller, bypassing delegate's didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testMetricsMode_capturesMetricsForCombineDataTask() throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When using data task publisher
+        let cancellable = session.dataTaskPublisher(for: URL.mockAny())
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { _ in }
+            )
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+        _ = cancellable // extend lifetime of Combine subscription
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Metrics mode should capture data")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testMetricsMode_capturesMetricsForCompletionHandlerDataTask() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using completion handler data task
+        let task = session.dataTask(with: URL.mockAny()) { _, _, _ in }
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Metrics mode should capture data")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testMetricsMode_capturesMetricsForCompletionHandlerUploadTask() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Metrics mode
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Session with delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When - using completion handler upload task
+        let task = session.uploadTask(
+            with: URLRequest(url: URL.mockAny()),
+            from: Data.mockRandom(ofSize: 20)
+        ) { _, _, _ in }
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with session using registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Upload tasks with completion handler don't capture data via delegate")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    // MARK: - Automatic Mode
+
+    // TODO: RUM-12429 Add missing automatic mode tests to match metrics mode coverage:
+    // - Session with unregistered delegate
+    // - First-party hosts with request mutation (trace header injection without delegate)
+
+    func testAutomaticMode_tracksTasksWithoutDelegateRegistration() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Automatic mode (no delegate class)
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Session without delegate
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - using data task completion handler
+        let task = session.dataTask(with: URL.mockAny()) { _, _, _ in }
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Data should be captured by completion handler")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, *)
+    func testAutomaticMode_tracksAsyncAwaitTasks() async throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true)
+
+        // Given - Automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Session without delegate
+        let session = server.getInterceptedURLSession()
+
+        // When - using async data API
+        let url = URL.mockAny()
+        _ = try? await session.data(from: url)
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data should not be captured in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testAutomaticMode_tracksTaskWithURL() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        // Session without delegate
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - using data task
+        let task = session.dataTask(with: URL.mockAny())
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data should not be captured in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testAutomaticMode_tracksTaskWithURLRequest() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When
+        let request = URLRequest(url: URL.mockAny())
+        session.dataTask(with: request).resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data should not be captured in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testAutomaticMode_tracksCombineTasks() throws {
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
 
         // When
         let cancellable = session.dataTaskPublisher(for: URL.mockAny())
@@ -216,103 +754,25 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         _ = server.waitAndReturnRequests(count: 1)
         _ = cancellable // extend lifetime of Combine subscription
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Data should be captured via completion handler")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    func testGivenURLSessionWithCustomDelegate_whenUsingCompletionHandlerDataFromURL_itNotifiesInterceptor() throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+    func testAutomaticMode_tracksUploadTaskWithCompletionHandler() throws {
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
 
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
-
-        // When
-        let task = session.dataTask(with: URL.mockAny()) { _, _, _ in }
-        task.resume()
-
-        // Then
-        wait(
-            for: [
-                notifyInterceptionDidStart,
-                notifyInterceptionDidComplete
-            ],
-            timeout: 5,
-            enforceOrder: true
-        )
-        _ = server.waitAndReturnRequests(count: 1)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithoutDelegate_whenUsingAsyncDataFromURLWithDelegate_itNotifiesInterceptor() async throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        guard #available(iOS 16, tvOS 16, *) else {
-            return
-        }
-
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         let session = server.getInterceptedURLSession(delegate: nil)
-
-        // When
-        _ = try await session.data(from: URL.mockAny(), delegate: delegate)
-
-        // Then
-        await dd_fulfillment(
-            for: [
-                notifyInterceptionDidStart,
-                notifyInterceptionDidComplete
-            ],
-            timeout: 5,
-            enforceOrder: true
-        )
-
-        _ = server.waitAndReturnRequests(count: 1)
-    }
-
-    func testGivenURLSessionWithDelegate_whenUsingCompletionHandlerUploadTask_itNotifiesInterceptor() throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        guard #available(iOS 16, tvOS 16, *) else {
-            return
-        }
-
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let task = session.uploadTask(
@@ -332,104 +792,25 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
 
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Upload tasks don't capture response data in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithoutDelegate_whenUsingAsyncUploadDataWithDelegate_itNotifiesInterceptor() async throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+    func testAutomaticMode_tracksUploadTaskWithoutCompletionHandler() throws {
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
 
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         let session = server.getInterceptedURLSession(delegate: nil)
-
-        // When
-        _ = try await session.upload(for: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20), delegate: delegate)
-
-        // Then
-        await dd_fulfillment(
-            for: [
-                notifyInterceptionDidStart,
-                notifyInterceptionDidComplete
-            ],
-            timeout: 5,
-            enforceOrder: true
-        )
-
-        _ = server.waitAndReturnRequests(count: 1)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithDelegate_whenUsingAsyncUploadDataWithoutDelegate_itNotifiesInterceptor() async throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        guard #available(iOS 16, tvOS 16, *) else {
-            return
-        }
-
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
-
-        // When
-        _ = try await session.upload(for: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20))
-
-        // Then
-        await dd_fulfillment(
-            for: [
-                notifyInterceptionDidStart,
-                notifyInterceptionDidComplete
-            ],
-            timeout: 5,
-            enforceOrder: true
-        )
-
-        _ = server.waitAndReturnRequests(count: 1)
-    }
-
-    func testGivenURLSessionWithDelegate_whenUsingUploadTask_itNotifiesInterceptor() throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        guard #available(iOS 16, tvOS 16, *) else {
-            return
-        }
-
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let task = session.uploadTask(with: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20))
@@ -446,38 +827,29 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
 
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data should not be captured in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithCustomDelegate_whenUsingAsyncDataForURLRequest_itNotifiesInterceptor() async throws {
-        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+    @available(iOS 13.0, *)
+    func testAutomaticMode_tracksAsyncUploadTasks() async throws {
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
 
-        handler.onInterceptionDidStart = { interception in
-            XCTAssertTrue(interception.isFirstPartyRequest)
-            notifyInterceptionDidStart.fulfill()
-        }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
-        // Given
-        let url: URL = .mockAny()
-        handler.firstPartyHosts = .init(
-            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
-        )
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
 
-        // When
-        _ = try await session.data(for: URLRequest(url: url), delegate: delegate)
+        // When - Use async/await upload API
+        _ = try? await session.upload(for: URLRequest(url: URL.mockAny()), from: Data.mockRandom(ofSize: 20))
 
         // Then
         await dd_fulfillment(
@@ -490,15 +862,541 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
 
         _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data is not captured when using Async API")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    // MARK: - Interception Values
+    func testAutomaticMode_tracksDownloadTask() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
-    func testGivenURLSessionWithDatadogDelegate_whenTaskCompletesWithFailure_itPassesAllValuesToTheInterceptor() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - using download task
+        let task = session.downloadTask(with: URL.mockAny())
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Download task should use automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data not captured in automatic mode for download tasks")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testAutomaticMode_doesNotCaptureMetricsEvenWithDelegate() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable ONLY automatic mode (don't register delegate for metrics)
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Session has a delegate, but it's not registered for metrics mode
+        let delegate = SessionDataDelegateMock()
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When
+        let task = session.dataTask(with: URL.mockAny())
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data is not captured in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    // MARK: - Both Modes Enabled
+
+    func testGivenBothModesEnabled_whenSessionDoesNotRegisterDelegate_itInterceptsAutomatically() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Both modes enabled, but session doesn't use registered delegate
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+        let session = server.getInterceptedURLSession() // no delegate
+
+        // When
+        let url: URL = .mockRandom()
+        session.dataTask(with: url).resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        XCTAssertEqual(handler.interceptions.count, 1, "Task should be intercepted")
+
+        // Verify automatic mode is used for tasks without registered delegate
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        XCTAssertEqual(interception.trackingMode, .automatic, "Task without registered delegate should use automatic mode")
+
+        // Automatic mode should NOT capture metrics or data without completion handler
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture URLSessionTaskMetrics")
+        XCTAssertNil(interception.data, "Data not captured in automatic mode")
+
+        // But should capture response size and completion
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testGivenBothModesEnabled_whenPerTaskDelegate_itUsesCorrectTrackingMode() throws {
+        // pre iOS 15 cannot set delegate per task
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
+
+        // Given - Enable both automatic and metrics modes (reflects real-world usage)
+        let delegate1 = MockDelegate()
+        let delegate2 = MockDelegate2()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core) // Automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core) // Metrics mode
+
+        let session = server.getInterceptedURLSession()
+
+        // When
+        let url1 = URL.mockWith(url: "https://www.foo.com/1")
+        let task1 = session.dataTask(with: url1) // intercepted by metrics mode
+        task1.delegate = delegate1
+        task1.resume()
+
+        let url2 = URL.mockWith(url: "https://www.foo.com/2")
+        let task2 = session.dataTask(with: url2) // intercepted by automatic mode
+        task2.delegate = delegate2
+        task2.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 2)
+        XCTAssertEqual(handler.interceptions.count, 2, "All tasks should be intercepted")
+
+        // Verify tracking modes are correct based on delegate type
+
+        let interception1 = try XCTUnwrap(handler.interception(for: url1))
+        XCTAssertEqual(interception1.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception1.metrics, "Should capture metrics in metrics mode")
+        XCTAssertEqual(interception1.data?.count, 10, "Should capture data in metrics mode")
+
+        let interception2 = try XCTUnwrap(handler.interception(for: url2))
+        XCTAssertEqual(interception2.trackingMode, .automatic, "Task without registered delegate should be in automatic mode")
+        XCTAssertNil(interception2.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertNil(interception2.data, "Should not capture data in automatic mode")
+        XCTAssertEqual(interception2.responseSize, 10, "Should capture response size in automatic mode")
+        XCTAssertNotNil(interception2.completion, "Should capture completion")
+    }
+
+    func testGivenBothModesEnabled_whenSessionWithDelegateAndCompletionHandler_itCapturesMetrics() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both automatic and metrics modes
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core) // Automatic
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core) // Metrics
+
+        let delegate = SessionDataDelegateMock()
+        let session = server.getInterceptedURLSession(delegate: delegate)
+
+        // When
+        let task = session.dataTask(with: URL.mockAny()) { _, _, _ in }
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception.metrics, "Metrics mode should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Data size should match expected size")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenRegisteredDelegateWithCompletionHandler_itCapturesMetricsAndData() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes
+        let registeredDelegate = MockDelegate()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task with registered delegate AND completion handler
+        let url = URL.mockAny()
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.delegate = registeredDelegate
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .metrics, "Should use metrics mode")
+        XCTAssertNotNil(interception.metrics, "Should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Should capture data via completion handler")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenRegisteredDelegateWithoutCompletionHandler_itCapturesMetricsAndData() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes
+        let registeredDelegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task with registered delegate WITHOUT completion handler
+        let url = URL.mockAny()
+        let task = session.dataTask(with: url)
+        task.delegate = registeredDelegate
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .metrics, "Should use metrics mode")
+        XCTAssertNotNil(interception.metrics, "Should capture URLSessionTaskMetrics")
+        XCTAssertEqual(interception.data?.count, 10, "Should capture data via delegate didReceive")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenUnregisteredDelegateWithCompletionHandler_itUsesAutomaticMode() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes, but task uses unregistered delegate
+        let unregisteredDelegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task with unregistered delegate AND completion handler
+        let url = URL.mockAny()
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.delegate = unregisteredDelegate
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should use automatic mode for unregistered delegate")
+        XCTAssertNil(interception.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertEqual(interception.data?.count, 10, "Should capture data via completion handler without double-counting")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenUnregisteredDelegateWithoutCompletionHandler_itUsesAutomaticMode() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes, but task uses unregistered delegate
+        let unregisteredDelegate = MockDelegate2()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task with unregistered delegate WITHOUT completion handler
+        let url = URL.mockAny()
+        let task = session.dataTask(with: url)
+        task.delegate = unregisteredDelegate
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should use automatic mode for unregistered delegate")
+        XCTAssertNil(interception.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertNil(interception.data, "Should not capture data without completion handler in automatic mode")
+        XCTAssertNotNil(interception.responseSize, "Should capture response size via setState")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenNoDelegateWithCompletionHandler_itUsesAutomaticMode() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task without delegate AND with completion handler
+        let url = URL.mockAny()
+        session.dataTask(with: url) { _, _, _ in }.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should use automatic mode when no delegate")
+        XCTAssertNil(interception.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertEqual(interception.data?.count, 10, "Should capture data via completion handler without double-counting")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    func testGivenBothModesEnabled_whenNoDelegateWithoutCompletionHandler_itUsesAutomaticMode() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Enable both modes
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: MockDelegate.self), in: core)
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Task without delegate and WITHOUT completion handler
+        let url = URL.mockAny()
+        session.dataTask(with: url).resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should use automatic mode when no delegate")
+        XCTAssertNil(interception.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertNil(interception.data, "Should not capture data without completion handler in automatic mode")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
+    func testGivenBothModesEnabled_whenUsingAsyncAPI_itCapturesAllValues() async throws {
+        /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
+        guard #available(iOS 16, tvOS 16, *) else {
+            return
+        }
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         notifyInterceptionDidStart.expectedFulfillmentCount = 2
         notifyInterceptionDidComplete.expectedFulfillmentCount = 2
+
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
+
+        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        // Given - Enable both modes
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        let session = server.getInterceptedURLSession() // No session-level delegate
+
+        // When - Using Async/await API
+        let url1: URL = .mockRandom()
+        _ = try? await session.data(from: url1, delegate: delegate) // Metrics mode (explicit delegate)
+        let url2: URL = .mockRandom()
+        _ = try? await session.data(from: url2) // Automatic mode (no delegate at all)
+
+        // Then
+        await dd_fulfillment(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+
+        _ = server.waitAndReturnRequests(count: 2)
+
+        XCTAssertEqual(handler.interceptions.count, 2, "Interceptor should record 2 tasks")
+
+        let interception1 = try XCTUnwrap(handler.interception(for: url1))
+        XCTAssertEqual(interception1.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+        XCTAssertNotNil(interception1.metrics, "Task in metrics mode should collect metrics")
+        XCTAssertNil(interception1.data, "Data should not be recorded for tasks with no completion handler")
+        XCTAssertEqual(interception1.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception1.completion, "Should capture completion")
+
+        let interception2 = try XCTUnwrap(handler.interception(for: url2))
+        XCTAssertEqual(interception2.trackingMode, .automatic, "Task with no registered delegate should be in automatic mode")
+        XCTAssertNil(interception2.metrics, "Task in automatic mode should not collect metrics")
+        XCTAssertNil(interception2.data, "Data should not be recorded for tasks with no completion handler")
+        XCTAssertEqual(interception2.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception2.completion, "Should capture completion")
+    }
+
+    func testGivenBothModesEnabled_whenUsingDownloadTask_itUsesCorrectTrackingMode() throws {
+        // pre iOS 15 cannot set delegate per task
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
+
+        // Given - Both modes enabled
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core) // Automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core) // Metrics mode
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Download task with per-task delegate (metrics mode)
+        let url1 = URL.mockWith(url: "https://www.foo.com/download1")
+        let task1 = session.downloadTask(with: url1)
+        task1.delegate = delegate
+        task1.resume()
+
+        // Download task without delegate (automatic mode)
+        let url2 = URL.mockWith(url: "https://www.foo.com/download2")
+        let task2 = session.downloadTask(with: url2)
+        task2.resume()
+
+        // Then
+        wait(for: [notifyInterceptionDidComplete], timeout: 5)
+        _ = server.waitAndReturnRequests(count: 2)
+
+        // Verify task with delegate uses metrics mode
+        let interception1 = try XCTUnwrap(handler.interception(for: url1))
+        XCTAssertEqual(interception1.trackingMode, .metrics, "Download task with registered per-task delegate should use metrics mode")
+        XCTAssertNotNil(interception1.metrics, "Should capture metrics")
+        XCTAssertNil(interception1.data, "Data not captured for download tasks")
+        XCTAssertEqual(interception1.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception1.completion, "Should capture completion")
+
+        // Verify task without delegate uses automatic mode
+        let interception2 = try XCTUnwrap(handler.interception(for: url2))
+        XCTAssertEqual(interception2.trackingMode, .automatic, "Download task without delegate should use automatic mode")
+        XCTAssertNil(interception2.metrics, "Should not capture metrics in automatic mode")
+        XCTAssertNil(interception2.data, "Data not captured for download tasks")
+        XCTAssertEqual(interception2.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception2.completion, "Should capture completion")
+    }
+
+    // MARK: - Content Validation
+
+    func testGivenMetricsMode_whenTaskCompletesWithFailure_itCapturesError() throws {
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
 
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
         let server = ServerMock(delivery: .failure(error: expectedError))
@@ -506,70 +1404,145 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
-        let dateBeforeAnyRequests = Date()
+        let dateBeforeRequest = Date()
 
         // Given
         let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
-        let url1: URL = .mockRandom()
-        session
-            .dataTask(with: url1)
-            .resume()
-
-        let url2: URL = .mockRandom()
-        session
-            .dataTask(with: URLRequest(url: url2)) { _,_,_ in }
-            .resume()
+        let url = URL.mockRandom()
+        session.dataTask(with: url).resume()
 
         // Then
-        _ = server.waitAndReturnRequests(count: 2)
+        _ = server.waitAndReturnRequests(count: 1)
 
         waitForExpectations(timeout: 5, handler: nil)
-        let dateAfterAllRequests = Date()
+        let dateAfterRequest = Date()
 
-        XCTAssertEqual(handler.interceptions.count, 2, "Interceptor should record metrics for 2 tasks")
+        let interception = try XCTUnwrap(handler.interception(for: url))
 
-        try [url1, url2].forEach { url in
-            let interception = try XCTUnwrap(handler.interception(for: url))
-            let metrics = try XCTUnwrap(interception.metrics)
-            XCTAssertGreaterThan(metrics.fetch.start, dateBeforeAnyRequests)
-            XCTAssertLessThan(metrics.fetch.end, dateAfterAllRequests)
-            XCTAssertNil(interception.data, "Data should not be recorded for \(url)")
-            XCTAssertEqual((interception.completion?.error as? NSError)?.localizedDescription, "some error")
-        }
+        // Metrics mode captures metrics and completion (even on failure)
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+
+        let metrics = try XCTUnwrap(interception.metrics, "Should capture metrics even on failure")
+        XCTAssertGreaterThan(metrics.fetch.start, dateBeforeRequest)
+        XCTAssertLessThan(metrics.fetch.end, dateAfterRequest)
+
+        // Data is NOT captured without completion handler
+        XCTAssertNil(interception.data, "Data not captured without completion handler")
+
+        // Error is captured via setState
+        let completion = try XCTUnwrap(interception.completion, "Should capture completion")
+        XCTAssertEqual((completion.error as? NSError)?.localizedDescription, "some error")
     }
 
-    func testGivenURLSessionWithCustomDelegate_whenNotInstrumented_itDoesNotInterceptTasks() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: Data()))
+    func testGivenMetricsMode_whenTaskCompletesWithSuccess_itCapturesAllValues() throws {
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mockRandom()))
+
+        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        let dateBeforeRequest = Date()
 
         // Given
+        let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession() // no custom delegate
+        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
-        let url1: URL = .mockRandom()
-        session
-            .dataTask(with: url1)
-            .resume()
-
-        let url2: URL = .mockRandom()
-        session
-            .dataTask(with: URLRequest(url: url2))
-            .resume()
+        let url = URL.mockRandom()
+        session.dataTask(with: url).resume()
 
         // Then
-        _ = server.waitAndReturnRequests(count: 2)
-        XCTAssertEqual(handler.interceptions.count, 0, "Interceptor should not record tasks")
+        _ = server.waitAndReturnRequests(count: 1)
+
+        waitForExpectations(timeout: 5, handler: nil)
+        let dateAfterRequest = Date()
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        // Metrics mode captures metrics and completion
+        XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+
+        let metrics = try XCTUnwrap(interception.metrics, "Should capture metrics")
+        XCTAssertGreaterThan(metrics.fetch.start, dateBeforeRequest)
+        XCTAssertLessThan(metrics.fetch.end, dateAfterRequest)
+
+        // Data is captured in metrics mode via didReceive delegate swizzling
+        XCTAssertNotNil(interception.data, "Data should be captured in metrics mode via didReceive swizzling")
+        XCTAssertNotNil(interception.responseSize, "Should capture response size")
+        XCTAssertGreaterThan(interception.responseSize ?? 0, 0, "Response size should be greater than 0")
+
+        // Completion is captured via setState
+        let completion = try XCTUnwrap(interception.completion, "Should capture completion")
+        XCTAssertNil(completion.error, "Should capture no error")
     }
 
-    func testGivenURLSessionWithDatadogDelegate_whenTaskCompletesWithSuccess_itPassesAllValuesToTheInterceptor() throws {
+    func testGivenAutomaticMode_whenTaskWithoutCompletionHandler_itCapturesBasicValues() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        notifyInterceptionDidStart.expectedFulfillmentCount = 2
-        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mockRandom()))
+
+        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        // Given - Enable only automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - Task WITHOUT completion handler
+        let url = URL.mockRandom()
+        session.dataTask(with: url).resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        XCTAssertEqual(handler.interceptions.count, 1, "Should capture 1 interception")
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        // Automatic mode captures basic values
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture detailed metrics")
+
+        // Duration: captured via setState
+        XCTAssertNotNil(interception.completion, "Should capture completion for duration")
+
+        // Status: captured via task.response in setState
+        XCTAssertEqual(interception.completion?.httpResponse?.statusCode, 200, "Should capture status code")
+
+        // Size: captured via task.countOfBytesReceived in setState
+        XCTAssertNotNil(interception.responseSize, "Should capture response size for automatic mode")
+        XCTAssertGreaterThan(interception.responseSize ?? 0, 0, "Response size should be greater than 0")
+        // Data itself is NOT captured without completion handler or delegate
+        XCTAssertNil(interception.data, "Data not captured without completion handler or delegate")
+
+        // Errors: captured via task.error in setState
+        XCTAssertNil(interception.completion?.error, "Should capture error status")
+
+        // Request: captured
+        XCTAssertEqual(interception.request.url, url, "Should capture request URL")
+    }
+
+    func testGivenAutomaticMode_whenTaskWithCompletionHandler_itCapturesAllBasicValues() throws {
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
 
         let randomData: Data = .mockRandom()
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: randomData))
@@ -577,50 +1550,99 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
-        let dateBeforeAnyRequests = Date()
+        // Given - Enable only automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
 
-        // Given
-        let delegate = SessionDataDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-        let session = server.getInterceptedURLSession(delegate: delegate)
-
-        // When
-        let url1 = URL.mockRandom()
-        session
-            .dataTask(with: url1)
-            .resume()
-
-        let url2 = URL.mockRandom()
-        session
-            .dataTask(with: URLRequest(url: url2))
-            .resume()
+        // When - Task WITH completion handler
+        let url = URL.mockRandom()
+        session.dataTask(with: url) { _, _, _ in }.resume()
 
         // Then
-        _ = server.waitAndReturnRequests(count: 2)
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
 
-        waitForExpectations(timeout: 5, handler: nil)
-        let dateAfterAllRequests = Date()
-        XCTAssertEqual(handler.interceptions.count, 2, "Interceptor should record metrics for 2 tasks")
+        XCTAssertEqual(handler.interceptions.count, 1, "Should capture 1 interception")
 
-        try [url1, url2].forEach { url in
-            let interception = try XCTUnwrap(handler.interception(for: url))
-            let metrics = try XCTUnwrap(interception.metrics)
-            XCTAssertGreaterThan(metrics.fetch.start, dateBeforeAnyRequests)
-            XCTAssertLessThan(metrics.fetch.end, dateAfterAllRequests)
-            XCTAssertEqual(interception.data, randomData)
-            XCTAssertNotNil(interception.completion)
-            XCTAssertNil(interception.completion?.error)
-        }
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        // Automatic mode captures all basic values when completion handler is present
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture detailed metrics")
+
+        // Duration: captured
+        let completion = try XCTUnwrap(interception.completion, "Should capture completion for duration")
+
+        // Status: captured
+        XCTAssertEqual(completion.httpResponse?.statusCode, 200, "Should capture status code")
+
+        // Size: captured via completion handler data
+        XCTAssertEqual(interception.data, randomData, "Should capture response data via completion handler")
+        XCTAssertNotNil(interception.responseSize, "Should capture response size")
+
+        // Errors: captured
+        XCTAssertNil(completion.error, "Should capture error status")
+
+        // Request: captured
+        XCTAssertEqual(interception.request.url, url, "Should capture request URL")
+    }
+
+    func testGivenAutomaticMode_whenTaskCompletesWithFailure_itCapturesError() throws {
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+
+        let testError = NSError(domain: "test", code: 123, userInfo: nil)
+        let server = ServerMock(delivery: .failure(error: testError))
+
+        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        // Given - Enable only automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When - Task that fails with error
+        let url = URL.mockRandom()
+        session.dataTask(with: url).resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        // Should capture error
+        XCTAssertEqual(interception.trackingMode, .automatic, "Should be in automatic mode")
+        XCTAssertNil(interception.metrics, "Automatic mode should not capture metrics")
+        XCTAssertNil(interception.data, "Data not captured when task fails")
+        XCTAssertEqual(interception.responseSize, 0, "Response size should be 0 for failed tasks")
+        let completion = try XCTUnwrap(interception.completion, "Should capture completion")
+        XCTAssertNotNil(completion.error, "Should capture error")
+        XCTAssertEqual((completion.error as? NSError)?.code, 123, "Should capture correct error code")
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    func testGivenURLSessionWithCustomDelegate_whenUsingAsyncData_itPassesAllValuesToTheInterceptor() async throws {
+    func testGivenMetricsMode_whenUsingAsyncAPI_itCapturesAllValues() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
             return
         }
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         notifyInterceptionDidStart.expectedFulfillmentCount = 2
         notifyInterceptionDidComplete.expectedFulfillmentCount = 2
 
@@ -637,13 +1659,13 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Given
         let delegate = SessionDataDelegateMock()
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
         let session = server.getInterceptedURLSession()
 
         // When
         _ = try? await session.data(from: .mockRandom(), delegate: delegate) // intercepted
         _ = try? await session.data(for: URLRequest(url: .mockRandom()), delegate: delegate) // intercepted
-        _ = try? await session.data(for: URLRequest(url: .mockRandom())) // not intercepted
 
         // Then
         await dd_fulfillment(
@@ -655,67 +1677,57 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             enforceOrder: true
         )
 
-        _ = server.waitAndReturnRequests(count: 3)
+        _ = server.waitAndReturnRequests(count: 2)
 
         let dateAfterAllRequests = Date()
 
         XCTAssertEqual(handler.interceptions.count, 2, "Interceptor should record metrics for 2 tasks")
 
         handler.interceptions.forEach { id, interception in
+            XCTAssertEqual(interception.trackingMode, .metrics, "Task with registered delegate should be in metrics mode")
+            XCTAssertNotNil(interception.metrics, "Should capture metrics for \(id)")
             XCTAssertGreaterThan(interception.metrics?.fetch.start ?? .distantPast, dateBeforeAnyRequests)
             XCTAssertLessThan(interception.metrics?.fetch.end ?? .distantFuture, dateAfterAllRequests)
             XCTAssertNil(interception.data, "Data should not be recorded for \(id)")
+            XCTAssertEqual(interception.responseSize, 0, "Response size should be 0 for failed tasks")
+            XCTAssertNotNil(interception.completion, "Should capture completion for \(id)")
             XCTAssertEqual((interception.completion?.error as? NSError)?.localizedDescription, "some error")
         }
     }
 
-    func testGivenURLSessionTask_withCustomDelegate_itInterceptsRequests() throws {
-        // pre iOS 15 cannot set delegate per task
-        guard #available(iOS 15, tvOS 15, *) else {
-            return
-        }
-
-        let notifyInterceptionDidComplete = expectation(description: "Notify intercepion did complete")
-        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
-
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        // Given
-        let delegate1 = SessionDataDelegateMock()
-        let delegate2 = SessionTaskDelegateMock()
-        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
-
-        let session = server.getInterceptedURLSession()
-
-        // When
-        let task1 = session.dataTask(with: URL.mockWith(url: "https://www.foo.com/1")) // intercepted
-        task1.delegate = delegate1
-        task1.resume()
-
-        let task2 = session.dataTask(with: URL.mockWith(url: "https://www.foo.com/2")) // intercepted
-        task2.delegate = delegate1
-        task2.resume()
-
-        let task3 = session.dataTask(with: URL.mockWith(url: "https://www.foo.com/3")) // not intercepted
-        task3.delegate = delegate2
-        task3.resume()
-
-        // Then
-        _ = server.waitAndReturnRequests(count: 3)
-        waitForExpectations(timeout: 5, handler: nil)
-        XCTAssertEqual(handler.interceptions.count, 2, "Interceptor should intercept 2 tasks")
-    }
-
     // MARK: - Usage
 
-    func testWhenEnableInstrumentationOnTheSameDelegate_thenItPrintsAWarning() {
+    func testAutomaticMode_enabledOnlyOnce() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // When - Try to enable again
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Then - Should not crash or cause issues (idempotent)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        XCTAssertNotNil(feature)
+    }
+
+    func testWhenEnableAutomaticModeTwice_thenItPrintsAWarning() throws {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Then
+        XCTAssertEqual(
+            dd.logger.debugLog?.message,
+            "Automatic network instrumentation is already enabled."
+        )
+    }
+
+    func testWhenEnableMetricsModeOnTheSameDelegate_thenItPrintsAWarning() throws {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         URLSessionInstrumentation.enable(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
         URLSessionInstrumentation.enable(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
 
@@ -729,6 +1741,101 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
     }
 
+    func testWhenEnableMetricsModeBeforeAutomaticMode_thenItPrintsAnError() {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When - Try to enable metrics mode without enabling automatic mode first
+        URLSessionInstrumentation.enable(with: .init(delegateClass: SessionDataDelegateMock.self), in: core)
+
+        // Then
+        XCTAssertEqual(
+            dd.logger.errorLog?.message,
+            """
+            Metrics mode requires automatic network instrumentation to be enabled first.
+            Please enable RUM or Trace with `urlSessionTracking` parameter before enabling metrics mode.
+            """
+        )
+    }
+
+    // MARK: - Filtering Out Intake Requests
+
+    func testAutomaticMode_doesNotTrackDatadogIntakeRequests() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Create a real URLSession (not using server mock since we're testing filtering)
+        let session = URLSession(configuration: .ephemeral)
+
+        // Track if any Datadog intake requests are intercepted
+        var interceptedDatadogRequests: [URLSessionTaskInterception] = []
+        handler.onInterceptionDidStart = { interception in
+            guard let urlString = interception.request.url?.absoluteString else {
+                return
+            }
+            // If this is a Datadog intake request, track it (should not happen)
+            if urlString.contains("datadoghq.com") ||
+                urlString.contains("datad0g.com") {
+                interceptedDatadogRequests.append(interception)
+            }
+        }
+
+        // When - Make requests to Datadog intake domains
+        let datadogURLs = [
+            URL(string: "https://browser-intake-datadoghq.com/api/v2/rum")!,
+            URL(string: "https://logs.browser-intake-datadoghq.com/api/v2/logs")!,
+            URL(string: "https://session-replay.browser-intake-datadoghq.com/api/v2/replay")!,
+            URL(string: "https://instrumentation.datadoghq.com/api/v2/apmtelemetry")!,
+        ]
+
+        let tasksCompleted = expectation(description: "All tasks completed")
+        tasksCompleted.expectedFulfillmentCount = datadogURLs.count
+
+        for url in datadogURLs {
+            let task = session.dataTask(with: url) { _, _, _ in
+                tasksCompleted.fulfill()
+            }
+            task.resume()
+        }
+
+        // Wait for all tasks to complete
+        wait(for: [tasksCompleted], timeout: 10)
+
+        // Then - Verify no Datadog intake requests were intercepted
+        XCTAssertEqual(interceptedDatadogRequests.count, 0, "Should not intercept Datadog intake requests")
+    }
+
+    func testAutomaticMode_doesNotTrackSDKRequestsWithCustomEndpoints() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Create a real URLSession
+        let session = URLSession(configuration: .ephemeral)
+
+        // Track if any requests with DD-REQUEST-ID are intercepted
+        var interceptedSDKRequests: [URLSessionTaskInterception] = []
+        handler.onInterceptionDidStart = { interception in
+            interceptedSDKRequests.append(interception)
+        }
+
+        // When - Make a request to a custom endpoint with DD-REQUEST-ID header (simulating SDK internal request)
+        let customEndpointURL = URL(string: "http://custom-endpoint.example.com/api/v2/intake")!
+        var request = URLRequest(url: customEndpointURL)
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "DD-REQUEST-ID")
+
+        let taskCompleted = expectation(description: "Task completed")
+        let task = session.dataTask(with: request) { _, _, _ in
+            taskCompleted.fulfill()
+        }
+        task.resume()
+
+        // Wait for task to complete
+        wait(for: [taskCompleted], timeout: 10)
+
+        // Then - Verify SDK request with DD-REQUEST-ID was not intercepted
+        XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-REQUEST-ID header, even to custom endpoints")
+    }
+
     // MARK: - URLSessionTask Interception
 
     func testWhenInterceptingTaskWithMultipleTraceContexts_itTakesTheFirstContext() throws {
@@ -740,7 +1847,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // When
         let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
-        feature.intercept(task: .mockAny(), with: traceContexts, additionalFirstPartyHosts: nil)
+        feature.intercept(task: .mockAny(), with: traceContexts, additionalFirstPartyHosts: nil, trackingMode: .mockRandom())
         feature.flush()
 
         // Then
@@ -750,11 +1857,40 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     // MARK: - First Party Hosts
 
-    func testGivenHandler_whenInterceptingRequests_itDetectFirstPartyHost() throws {
+    func testAutomaticMode_detectsFirstPartyHosts() throws {
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+
+        // Given - Configure first-party hosts without delegate registration
+        let url = URL(string: "https://api.example.com")!
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
+
+        handler.onInterceptionDidStart = { interception in
+            // Then - First-party host is detected in automatic mode
+            XCTAssertTrue(interception.isFirstPartyRequest, "First-party host should be detected in automatic mode")
+            notifyInterceptionDidStart.fulfill()
+        }
+
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let session = server.getInterceptedURLSession(delegate: nil)
+
+        // When
+        let request = URLRequest(url: url)
+        session.dataTask(with: request).resume()
+
+        // Then
+        waitForExpectations(timeout: 5, handler: nil)
+        _ = server.waitAndReturnRequests(count: 1)
+    }
+
+    func testMetricsMode_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         // Given
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         let delegate = SessionDataDelegateMock()
         let firstPartyHosts: URLSessionInstrumentation.FirstPartyHostsTracing = .traceWithHeaders(hostsWithHeaders: ["test.com": [.datadog]])
         try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: SessionDataDelegateMock.self, firstPartyHostsTracing: firstPartyHosts), in: core)
@@ -820,7 +1956,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             closures: [
                 { feature.handlers = [self.handler] },
                 { _ = feature.intercept(request: requests.randomElement()!, additionalFirstPartyHosts: nil) },
-                { feature.intercept(task: tasks.randomElement()!, with: [], additionalFirstPartyHosts: nil) },
+                { feature.intercept(task: tasks.randomElement()!, with: [], additionalFirstPartyHosts: nil, trackingMode: .automatic) },
                 { feature.task(tasks.randomElement()!, didReceive: .mockRandom()) },
                 { feature.task(tasks.randomElement()!, didFinishCollecting: .mockAny()) },
                 { feature.task(tasks.randomElement()!, didCompleteWithError: nil) },
@@ -907,9 +2043,59 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNil(provider.currentNetworkContext)
     }
 
+    // MARK: - Subclass Delegate Handling
+
+    func testGivenBothModesEnabled_whenUsingDelegateSubclass_itOnlyProcessesInMetricsMode() throws {
+        // pre iOS 15 cannot set delegate per task
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        // Given - Register BASE delegate class for metrics mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core) // Automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: .init(delegateClass: DelegateBaseClass.self), in: core) // Metrics mode
+
+        let session = server.getInterceptedURLSession()
+
+        // When - Use subclass delegate at runtime with a completion handler
+        let subclassDelegate = DelegateSubClass()
+        let url = URL.mockAny()
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.delegate = subclassDelegate
+        task.resume()
+
+        // Then
+        wait(
+            for: [
+                notifyInterceptionDidStart,
+                notifyInterceptionDidComplete
+            ],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+
+        // Should use metrics mode (because subclass delegate matches registered base class via isKind(of:))
+        XCTAssertEqual(interception.trackingMode, .metrics, "Subclass delegate should be handled by metrics mode")
+        XCTAssertNotNil(interception.metrics, "Should capture metrics")
+        XCTAssertEqual(interception.data?.count, 10, "Should capture data once (not duplicated, automatic capture is skipped)")
+        XCTAssertEqual(interception.responseSize, 10, "Should capture response size")
+        XCTAssertNotNil(interception.completion, "Should capture completion")
+    }
+
     class MockDelegate: NSObject, URLSessionDataDelegate {
     }
 
     class MockDelegate2: NSObject, URLSessionDataDelegate {
+    }
+
+    class DelegateBaseClass: NSObject, URLSessionDataDelegate {
+    }
+
+    class DelegateSubClass: DelegateBaseClass {
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionDataDelegateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionDataDelegateSwizzlerTests.swift
@@ -27,9 +27,8 @@ class URLSessionDataDelegateSwizzlerTests: XCTestCase {
 
         // When
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let url = URL(string: "https://www.datadoghq.com/")!
         session
-            .dataTask(with: url)
+            .dataTask(with: URL.mockAny())
             .resume() // intercepted
 
         wait(for: [didReceiveData], timeout: 5)
@@ -52,9 +51,8 @@ class URLSessionDataDelegateSwizzlerTests: XCTestCase {
 
         // When
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let url = URL(string: "https://www.datadoghq.com/")!
         session
-            .dataTask(with: url)
+            .dataTask(with: URL.mockAny())
             .resume() // intercepted
 
         wait(for: [didReceiveData], timeout: 5)
@@ -77,9 +75,8 @@ class URLSessionDataDelegateSwizzlerTests: XCTestCase {
 
         // When
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let url = URL(string: "https://www.datadoghq.com/")!
         session
-            .dataTask(with: url)
+            .dataTask(with: URL.mockAny())
             .resume() // not intercepted
 
         swizzler.unswizzle()

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -55,8 +55,8 @@ class URLSessionTaskInterceptionTests: XCTestCase {
     func testInAutomaticMode_whenInterceptionReceivesCompletionState_itIsConsideredDone() {
         let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
 
-        // When - Register state >= 2 (Canceling or Completed)
-        interception.register(state: 3) // Completed
+        // When - Register completed state
+        interception.register(state: URLSessionTask.State.completed.rawValue) // Completed
 
         // Then - In automatic mode, state-based completion is sufficient
         XCTAssertTrue(interception.isDone)
@@ -65,10 +65,20 @@ class URLSessionTaskInterceptionTests: XCTestCase {
     func testInAutomaticMode_whenInterceptionReceivesOnlyRunningState_itIsNotDone() {
         let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
 
-        // When - Register state = 1 (Running)
-        interception.register(state: 1)
+        // When - Register running state
+        interception.register(state: URLSessionTask.State.running.rawValue)
 
-        // Then - In automatic mode, running state alone is not sufficient for completion (state must be >= 2)
+        // Then - In automatic mode, running state alone is not sufficient for completion
+        XCTAssertFalse(interception.isDone)
+    }
+
+    func testInAutomaticMode_whenInterceptionReceivesOnlySuspendedState_itIsNotDone() {
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
+
+        // When - Register suspended state
+        interception.register(state: URLSessionTask.State.suspended.rawValue)
+
+        // Then - In automatic mode, suspended state alone is not sufficient for completion
         XCTAssertFalse(interception.isDone)
     }
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -1,0 +1,233 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+
+@testable import DatadogInternal
+
+/// Tests for `URLSessionTaskStateSwizzler` which intercepts `setState:` on `URLSessionTask`.
+///
+/// **Important Note on `assertForOverFulfill`:**
+/// URLSession's internal implementation can call `setState:` multiple times with the same state value.
+/// For example, `Completed(3)` may be called twice in rapid succession from the same thread.
+/// This is URLSession's internal behavior, not a bug in our swizzling.
+/// Tests use `expectation.assertForOverFulfill = false` to handle this legitimate behavior.
+
+class URLSessionTaskStateSwizzlerTests: XCTestCase {
+    func testSwizzling_setState_interceptsSuccessfulCompletion() throws {
+        let completionExpectation = self.expectation(description: "setState completion")
+        completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+        var interceptedStates: [Int] = []
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, state in
+                interceptedStates.append(state)
+                // Only fulfill when we see Completed state
+                if state == 3 {
+                    completionExpectation.fulfill()
+                }
+            }
+        )
+
+        // When
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://www.datadoghq.com/")!
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.resume()
+
+        // Then - Wait for completion state
+        wait(for: [completionExpectation], timeout: 3)
+
+        // Verify we intercepted state changes (Running and Completed)
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 1 }), "Should intercept Running state")
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+
+        swizzler.unswizzle()
+    }
+
+    func testSwizzling_setState_interceptsFailedCompletion() throws {
+        let completionExpectation = self.expectation(description: "setState completion")
+        completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+        var interceptedStates: [Int] = []
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, state in
+                interceptedStates.append(state)
+                // Only fulfill when we see Completed state
+                if state == 3 {
+                    completionExpectation.fulfill()
+                }
+            }
+        )
+
+        // When - Use invalid URL for immediate connection failure
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://localhost:1")!
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.resume()
+
+        // Then - Wait for completion state
+        wait(for: [completionExpectation], timeout: 3)
+
+        // Verify we intercepted state changes (Running and Completed)
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 1 }), "Should intercept Running state")
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+
+        swizzler.unswizzle()
+    }
+
+    func testSwizzling_setState_interceptsCancelledTasks() throws {
+        let completionExpectation = self.expectation(description: "setState completion for cancelled task")
+        completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+        var interceptedStates: [Int] = []
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, state in
+                interceptedStates.append(state)
+                // Only fulfill when we see a completion state (Canceling or Completed)
+                if state >= 2 {
+                    completionExpectation.fulfill()
+                }
+            }
+        )
+
+        // When - Cancel task to trigger cancellation
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://www.datadoghq.com/")!
+        let task = session.dataTask(with: url) { _, _, _ in }
+        task.resume()
+        Thread.sleep(forTimeInterval: 0.1) // Let task start
+        task.cancel() // Triggers Running → Canceling → Completed (Canceling state may be very brief)
+
+        // Then - Wait for completion state
+        wait(for: [completionExpectation], timeout: 3)
+
+        // Verify we intercepted cancellation state
+        // Note: Canceling (2) is very brief and may be missed due to timing - we may only see Completed (3)
+        XCTAssertTrue(interceptedStates.contains(where: { $0 >= 2 }), "Should intercept Canceling or Completed state")
+
+        swizzler.unswizzle()
+    }
+
+    func testSwizzling_setState_unswizzleStopsInterception() throws {
+        let task1Expectation = self.expectation(description: "setState called for task1")
+        task1Expectation.expectedFulfillmentCount = 2 // At least Running and Completed
+        task1Expectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+
+        var interceptionCount = 0
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, _ in
+                interceptionCount += 1
+                task1Expectation.fulfill()
+            }
+        )
+
+        // When - First task is intercepted
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://www.datadoghq.com/")!
+        let task1 = session.dataTask(with: url) { _, _, _ in }
+        task1.resume()
+
+        wait(for: [task1Expectation], timeout: 3)
+        let countAfterTask1 = interceptionCount
+        XCTAssertGreaterThanOrEqual(countAfterTask1, 2, "Task1 should have at least 2 state changes")
+
+        // Unswizzle
+        swizzler.unswizzle()
+
+        // When - Second task should NOT be intercepted
+        let task2 = session.dataTask(with: url) { _, _, _ in }
+        task2.resume()
+
+        // Give task2 time to complete
+        Thread.sleep(forTimeInterval: 1)
+
+        // Then - interception count should not have increased after unswizzle
+        XCTAssertEqual(interceptionCount, countAfterTask1, "Task2 should not be intercepted after unswizzle")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testSwizzling_setState_interceptsAsyncAwaitTasks() async throws {
+        let completionExpectation = self.expectation(description: "setState for async/await")
+        completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+        var interceptedStates: [Int] = []
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, state in
+                interceptedStates.append(state)
+                // Only fulfill when we see Completed state
+                if state == 3 {
+                    completionExpectation.fulfill()
+                }
+            }
+        )
+
+        // When - Use async/await API
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://www.datadoghq.com/")!
+
+        Task {
+            _ = try? await session.data(from: url)
+        }
+
+        // Then
+        await fulfillment(of: [completionExpectation], timeout: 5)
+
+        // Verify we intercepted Completed state
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+
+        swizzler.unswizzle()
+    }
+
+    func testSwizzling_setState_interceptsDelegatelessTasks() throws {
+        let completionExpectation = self.expectation(description: "setState for delegate-less task")
+        completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state
+        var interceptedStates: [Int] = []
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+
+        try swizzler.swizzle(
+            interceptSetState: { _, state in
+                interceptedStates.append(state)
+                // Only fulfill when we see Completed state
+                if state == 3 {
+                    completionExpectation.fulfill()
+                }
+            }
+        )
+
+        // When - Create task without delegate and without completion handler
+        let session = URLSession(configuration: .ephemeral)
+        let url = URL(string: "https://www.datadoghq.com/")!
+        let task = session.dataTask(with: url)
+        task.resume()
+
+        // Then - Wait for completion state
+        wait(for: [completionExpectation], timeout: 5)
+
+        // Verify we intercepted Completed state
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+
+        swizzler.unswizzle()
+    }
+}

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -28,8 +28,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptSetState: { _, state in
                 interceptedStates.append(state)
-                // Only fulfill when we see Completed state
-                if state == 3 {
+                // Only fulfill when we see completed state
+                if state == URLSessionTask.State.completed.rawValue {
                     completionExpectation.fulfill()
                 }
             }
@@ -44,9 +44,9 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         // Then - Wait for completion state
         wait(for: [completionExpectation], timeout: 3)
 
-        // Verify we intercepted state changes (Running and Completed)
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 1 }), "Should intercept Running state")
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+        // Verify we intercepted state changes
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.running.rawValue }), "Should intercept running state")
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.completed.rawValue }), "Should intercept completed state")
 
         swizzler.unswizzle()
     }
@@ -62,8 +62,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptSetState: { _, state in
                 interceptedStates.append(state)
-                // Only fulfill when we see Completed state
-                if state == 3 {
+                // Only fulfill when we see completed state
+                if state == URLSessionTask.State.completed.rawValue {
                     completionExpectation.fulfill()
                 }
             }
@@ -78,9 +78,9 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         // Then - Wait for completion state
         wait(for: [completionExpectation], timeout: 3)
 
-        // Verify we intercepted state changes (Running and Completed)
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 1 }), "Should intercept Running state")
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+        // Verify we intercepted state changes
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.running.rawValue }), "Should intercept running state")
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.completed.rawValue }), "Should intercept completed state")
 
         swizzler.unswizzle()
     }
@@ -96,8 +96,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptSetState: { _, state in
                 interceptedStates.append(state)
-                // Only fulfill when we see a completion state (Canceling or Completed)
-                if state >= 2 {
+                // Only fulfill when we see canceling or completed state
+                if state >= URLSessionTask.State.canceling.rawValue {
                     completionExpectation.fulfill()
                 }
             }
@@ -109,14 +109,17 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         let task = session.dataTask(with: url) { _, _, _ in }
         task.resume()
         Thread.sleep(forTimeInterval: 0.1) // Let task start
-        task.cancel() // Triggers Running → Canceling → Completed (Canceling state may be very brief)
+        task.cancel() // Triggers running → canceling → completed (canceling state may be very brief)
 
         // Then - Wait for completion state
         wait(for: [completionExpectation], timeout: 3)
 
         // Verify we intercepted cancellation state
-        // Note: Canceling (2) is very brief and may be missed due to timing - we may only see Completed (3)
-        XCTAssertTrue(interceptedStates.contains(where: { $0 >= 2 }), "Should intercept Canceling or Completed state")
+        // Note: Canceling state is very brief and may be missed due to timing - we may only see completed
+        XCTAssertTrue(
+            interceptedStates.contains(where: { $0 >= URLSessionTask.State.canceling.rawValue }),
+            "Should intercept canceling or completed state"
+        )
 
         swizzler.unswizzle()
     }
@@ -174,8 +177,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptSetState: { _, state in
                 interceptedStates.append(state)
-                // Only fulfill when we see Completed state
-                if state == 3 {
+                // Only fulfill when we see completed state
+                if state == URLSessionTask.State.completed.rawValue {
                     completionExpectation.fulfill()
                 }
             }
@@ -192,8 +195,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         // Then
         await fulfillment(of: [completionExpectation], timeout: 5)
 
-        // Verify we intercepted Completed state
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+        // Verify we intercepted completed state
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.completed.rawValue }), "Should intercept completed state")
 
         swizzler.unswizzle()
     }
@@ -209,8 +212,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         try swizzler.swizzle(
             interceptSetState: { _, state in
                 interceptedStates.append(state)
-                // Only fulfill when we see Completed state
-                if state == 3 {
+                // Only fulfill when we see completed state
+                if state == URLSessionTask.State.completed.rawValue {
                     completionExpectation.fulfill()
                 }
             }
@@ -225,8 +228,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         // Then - Wait for completion state
         wait(for: [completionExpectation], timeout: 5)
 
-        // Verify we intercepted Completed state
-        XCTAssertTrue(interceptedStates.contains(where: { $0 == 3 }), "Should intercept Completed state")
+        // Verify we intercepted completed state
+        XCTAssertTrue(interceptedStates.contains(where: { $0 == URLSessionTask.State.completed.rawValue }), "Should intercept completed state")
 
         swizzler.unswizzle()
     }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -148,6 +148,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         }
 
         if let httpResponse = interception.completion?.httpResponse {
+            // Prefer `metrics.responseSize`, but fallback to `responseSize` when metrics size is `nil` or 0
+            let metricsSize = interception.metrics?.responseSize ?? 0
+            let size = metricsSize > 0 ? metricsSize : interception.responseSize
+
             subscriber.process(
                 command: RUMStopResourceCommand(
                     resourceKey: interception.identifier.uuidString,
@@ -155,7 +159,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                     attributes: combinedAttributes,
                     kind: RUMResourceType(response: httpResponse),
                     httpStatusCode: httpResponse.statusCode,
-                    size: interception.metrics?.responseSize ?? interception.responseSize
+                    size: size
                 )
             )
         }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -36,7 +36,7 @@ internal struct DistributedTracing {
 internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RUMCommandPublisher {
     /// The date provider
     let dateProvider: DateProvider
-    /// DistributinTracing
+    /// Distributed Tracing
     let distributedTracing: DistributedTracing?
     /// Attributes-providing callback.
     /// It is configured by the user and should be used to associate additional RUM attributes with intercepted RUM Resource.
@@ -155,7 +155,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                     attributes: combinedAttributes,
                     kind: RUMResourceType(response: httpResponse),
                     httpStatusCode: httpResponse.statusCode,
-                    size: interception.metrics?.responseSize
+                    size: interception.metrics?.responseSize ?? interception.responseSize
                 )
             )
         }

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
 
 extension RUM: InternalExtended {}
@@ -78,5 +79,8 @@ extension InternalExtension where ExtendedType == RUM {
         // Connect URLSession instrumentation to RUM monitor:
         urlSessionHandler.publish(to: rum.monitor)
         try core.register(urlSessionHandler: urlSessionHandler)
+
+        // Enable network tracking automatically (no delegate registration required)
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -555,7 +555,7 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     let isNetworkError: Bool
     /// Error stacktrace.
     let stack: String?
-    /// HTTP status code of the Ressource error.
+    /// HTTP status code of the Resource error.
     let httpStatusCode: Int?
     let missedEventType: SessionEndedMetric.MissedEventType? = .error
 

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -488,7 +488,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             url: .mockRandom(),
             httpMethod: ["GET", "POST", "PUT", "DELETE"].randomElement()!
         )
-        let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random(), trackingMode: .mockRandom())
         XCTAssertNil(taskInterception.trace)
 
         // When
@@ -523,7 +523,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             )
         )
 
-        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .mockRandom())
         taskInterception.register(trace: TraceContext(
             traceID: 100,
             spanID: 200,
@@ -557,7 +557,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .mockRandom())
         let resourceMetrics: ResourceMetrics = .mockAny()
         taskInterception.register(metrics: resourceMetrics)
         let response: HTTPURLResponse = .mockResponseWith(statusCode: 200)
@@ -594,7 +594,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .mockRandom())
         let taskError = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
         let resourceMetrics: ResourceMetrics = .mockAny()
         taskInterception.register(metrics: resourceMetrics)
@@ -650,7 +650,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // When
-        let taskInterception = URLSessionTaskInterception(request: mockRequest, isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: mockRequest, isFirstParty: .random(), trackingMode: .mockRandom())
         taskInterception.register(nextData: mockData)
         taskInterception.register(metrics: .mockAny())
         taskInterception.register(response: mockResponse, error: nil)
@@ -686,7 +686,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // When
-        let taskInterception = URLSessionTaskInterception(request: mockRequest, isFirstParty: .random())
+        let taskInterception = URLSessionTaskInterception(request: mockRequest, isFirstParty: .random(), trackingMode: .mockRandom())
         taskInterception.register(metrics: .mockAny())
         taskInterception.register(response: nil, error: mockError)
         handler.interceptionDidComplete(interception: taskInterception)
@@ -993,7 +993,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // Given
         let mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
         let immutableRequest = ImmutableRequest(request: mockRequest)
-        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
+        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false, trackingMode: .mockRandom())
 
         // Register trace context with GraphQL attributes
         let traceContext = TraceContext(
@@ -1041,7 +1041,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // Given
         let mockRequest: URLRequest = .mockWith(url: "https://graphql.example.com/api")
         let immutableRequest = ImmutableRequest(request: mockRequest)
-        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
+        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false, trackingMode: .mockRandom())
 
         // Register trace context with GraphQL attributes
         let traceContext = TraceContext(
@@ -1130,7 +1130,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         """
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
-        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
+        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false, trackingMode: .mockRandom())
         let response: HTTPURLResponse = .mockWith(statusCode: 200, mimeType: "application/json")
         taskInterception.register(nextData: responseWithErrors.data(using: .utf8)!)
         taskInterception.register(response: response, error: nil)
@@ -1170,7 +1170,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         """
 
         let immutableRequest = ImmutableRequest(request: mockRequest)
-        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false)
+        let taskInterception = URLSessionTaskInterception(request: immutableRequest, isFirstParty: false, trackingMode: .mockRandom())
         let nonJSONResponse: HTTPURLResponse = .mockWith(statusCode: 200, mimeType: "text/html")
         taskInterception.register(nextData: responseWithErrors.data(using: .utf8)!)
         taskInterception.register(response: nonJSONResponse, error: nil)

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -584,6 +584,48 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStopCommand.size, taskInterception.metrics?.responseSize)
     }
 
+    func testGivenTaskInterceptionWithZeroMetricsSize_whenInterceptionCompletes_itFallsBackToResponseSize() throws {
+        let receiveCommands = expectation(description: "Receive 2 RUM commands")
+        receiveCommands.expectedFulfillmentCount = 2
+        var commandsReceived: [RUMCommand] = []
+        commandSubscriber.onCommandReceived = { command in
+            commandsReceived.append(command)
+            receiveCommands.fulfill()
+        }
+
+        // Given
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .metrics)
+
+        // Create metrics with responseSize = 0
+        let resourceMetrics = ResourceMetrics.mockWith(responseSize: 0)
+        taskInterception.register(metrics: resourceMetrics)
+
+        // Set responseSize from countOfBytesReceived
+        taskInterception.register(responseSize: 10)
+
+        let response: HTTPURLResponse = .mockResponseWith(statusCode: 200)
+        taskInterception.register(response: response, error: nil)
+
+        // When
+        handler.interceptionDidComplete(interception: taskInterception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let resourceMetricsCommand = try XCTUnwrap(commandsReceived[0] as? RUMAddResourceMetricsCommand)
+        XCTAssertEqual(resourceMetricsCommand.resourceKey, taskInterception.identifier.uuidString)
+        DDAssertReflectionEqual(resourceMetricsCommand.metrics, taskInterception.metrics)
+
+        let resourceStopCommand = try XCTUnwrap(commandsReceived[1] as? RUMStopResourceCommand)
+        XCTAssertEqual(resourceStopCommand.resourceKey, taskInterception.identifier.uuidString)
+        XCTAssertEqual(resourceStopCommand.kind, RUMResourceType(response: response))
+        XCTAssertEqual(resourceStopCommand.httpStatusCode, 200)
+
+        // Verify fallback to responseSize when metrics.responseSize is 0
+        XCTAssertEqual(resourceStopCommand.size, 10, "Should fallback to interception.responseSize when metrics.responseSize is 0")
+        XCTAssertNotEqual(resourceStopCommand.size, taskInterception.metrics?.responseSize, "Should not use metrics.responseSize when it is 0")
+    }
+
     func testGivenTaskInterceptionWithMetricsAndError_whenInterceptionCompletes_itStopsRUMResourceWithErrorAndMetrics() throws {
         let receiveCommands = expectation(description: "Receive 2 RUM commands")
         receiveCommands.expectedFulfillmentCount = 2

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -97,11 +97,15 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
     }
 
     func interceptionDidComplete(interception: DatadogInternal.URLSessionTaskInterception) {
+        // TODO: RUM-13455 - Add support for automatic mode in tracing
+        // Currently, tracing requires metrics mode because spans need accurate timing (fetch start/end).
+        // Automatic mode doesn't capture timing without URLSessionTaskMetrics.
+        // Investigate if we want to support automatic mode for Tracing.
         guard
             interception.isFirstPartyRequest, // `Span` should be only send for 1st party requests
             interception.origin != "rum", // if that request was tracked as RUM resource, the RUM backend will create the span on our behalf
             let tracer = tracer,
-            let resourceMetrics = interception.metrics,
+            let resourceMetrics = interception.metrics, // Currently requires metrics mode for accurate timing
             let resourceCompletion = interception.completion
         else {
             return

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
 
 /// An entry point to Datadog Trace feature.
@@ -69,6 +70,11 @@ public enum Trace {
             )
 
             try core.register(urlSessionHandler: urlSessionHandler)
+
+            // Enable automatic network tracking as the foundation for metrics mode.
+            // Distributed tracing requires metrics mode (enabled separately via URLSessionInstrumentation.enable)
+            // to capture accurate timing from URLSessionTaskMetrics.
+            try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
         }
     }
 }

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -244,9 +244,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let isKept: Bool = true
 
         // Given
+        // TODO: RUM-13455 - Trace requires metrics mode for now
         let interception = URLSessionTaskInterception(
             request: .mockAny(),
-            isFirstParty: true
+            isFirstParty: true,
+            trackingMode: .metrics
         )
         interception.register(response: .mockAny(), error: nil)
         interception.register(
@@ -290,7 +292,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         // Given
         let request: ImmutableRequest = .mockWith(httpMethod: "POST")
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .metrics)
         interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
         interception.register(
             metrics: .mockWith(
@@ -326,7 +329,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // Given
-        let incompleteInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let incompleteInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true, trackingMode: .metrics)
         // `incompleteInterception` has no metrics and no completion
 
         // When
@@ -343,7 +347,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // Given
-        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: false)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: false, trackingMode: .metrics)
         interception.register(response: .mockAny(), error: nil)
         interception.register(
             metrics: .mockWith(
@@ -371,7 +376,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let request: ImmutableRequest = .mockWith(
             allHTTPHeaderFields: [TracingHTTPHeaders.originField: "rum"]
         )
-        let interception = URLSessionTaskInterception(request: request, isFirstParty: false)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: false, trackingMode: .metrics)
         interception.register(response: .mockAny(), error: nil)
 
         // When
@@ -387,7 +393,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // Given
-        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true, trackingMode: .metrics)
         interception.register(response: .mockAny(), error: nil)
         interception.register(
             metrics: .mockWith(
@@ -427,7 +434,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         core.context.applicationStateHistory = .mockAppInForeground()
 
-        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true)
+        // TODO: RUM-13455 - Trace requires metrics mode for now
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true, trackingMode: .metrics)
         interception.register(response: .mockAny(), error: nil)
         interception.register(
             metrics: .mockWith(

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -224,3 +224,13 @@ extension ResourceMetrics: AnyMockable {
         )
     }
 }
+
+extension TrackingMode: AnyMockable, RandomMockable {
+    public static func mockAny() -> DatadogInternal.TrackingMode {
+        return .automatic
+    }
+
+    public static func mockRandom() -> DatadogInternal.TrackingMode {
+        return [.automatic, .metrics].randomElement()!
+    }
+}

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -219,7 +219,9 @@ extension Calendar {
 
 extension URL: AnyMockable, RandomMockable {
     public static func mockAny() -> URL {
-        return URL(string: "https://www.datadoghq.com")!
+        // Use a non-Datadog URL to avoid being filtered by intake request checks
+        // Tests that specifically need to test Datadog URLs should use mockWith(url:)
+        return URL(string: "https://www.example.com")!
     }
 
     public static func mockWith(pathComponent: String) -> URL {


### PR DESCRIPTION
## What and why?

This PR improves **Automatic Network Instrumentation**, enabling network request tracking **without requiring delegate registration**. This significantly simplifies SDK integration while maintaining backward compatibility with the existing metrics-based approach.

## Key Changes

- **Automatic Mode**: Tracks all `URLSession` tasks without delegate registration
- **Metrics Mode**: Original delegate-based approach that captures detailed timings
- **Dual-Mode Architecture**: Both modes can coexist
  - Automatic mode provides baseline tracking
  - Metrics mode builds on automatic mode by additionally capturing detailed timings (opt-in)

See [RFC](https://datadoghq.atlassian.net/wiki/x/u4DDVQE) (internal) for more details on the decided approach.

## Core Implementation

**1. Tracking Modes** (`TrackingMode` enum in `URLSessionTaskInterception`):
- `automatic`: Tracks all tasks via `setState:` and completion handler swizzling
- `metrics`: Tracks tasks with registered delegates and captures `URLSessionTaskMetrics`

**2. Swizzling Strategy**:
- **setState:**: Detects task completion for delegate-less and async/await tasks
  - New `URLSessionTaskStateSwizzler`
  - Follows the existing swizzling pattern used by existing swizzlers
- **Completion handlers**: Captures data and errors for tasks with completion handlers
- **Delegate methods**: Captures `URLSessionTaskMetrics` and data chunks (metrics mode only)

**3. Updated Completion Logic** (`isDone` in `URLSessionTaskInterception`):
- **Automatic mode**: Complete when `completion != nil` OR `state >= 2` (no metrics required)
- **Metrics mode**: Complete when `completion != nil` AND `metrics != nil` (wait for both)

**4. SDK Request Filtering**:
- Domain-based: Filters Datadog intake domains (`*-intake-datadoghq.com`, `instrumentation.datadoghq.com`, etc.)
- Header-based: Filters requests with `DD-REQUEST-ID` header (for custom endpoints in tests)
- Prevents SDK internal requests from being tracked as RUM resources

## API Changes

**`URLSessionInstrumentation.enableOrThrow(with:in:)` Signature Change:**

```swift
// Before: configuration was required
internal static func enableOrThrow(with configuration: Configuration, in core: DatadogCoreProtocol)

// After: configuration is optional and method is @_spi(Internal) public
@_spi(Internal)
public static func enableOrThrow(with configuration: Configuration?, in core: DatadogCoreProtocol)
```

Optional configuration parameter: `configuration == nil` enables automatic mode, `configuration != nil` enables metrics mode.

1. This design allows:
- RUM and Trace to enable automatic mode by calling `enableOrThrow(with: nil, in: core)`
- Customers to optionally enable metrics mode by calling `enable(with: .init(delegateClass: ...))`

2. Visibility: Made `@_spi(Internal) public` so it can be called from RUM and Trace modules.

**Automatic Mode Enablement** (no code changes required):
- Enabled automatically when `RUM.enable(with:)` or `Trace.enable(with:)` is called with `urlSessionTracking` configuration
- Tracks all `URLSession` tasks globally without any delegate registration

**Metrics Mode Enablement** (optional):
```swift
// Enable metrics mode for detailed timing breakdown
URLSessionInstrumentation.enable(with: .init(delegateClass: MyDelegate.self))
```
Note: this API will be deprecated in a follow-up PR in favor of a new, clearer API. 

## Data Captured

| Feature               | Automatic Mode                    | Metrics Mode                                |
|-----------------------|-----------------------------------|---------------------------------------------|
| Duration              | ✅ Yes                            | ✅ Yes                                      |
| Status code           | ✅ Yes                            | ✅ Yes                                      |
| Response size         | ✅ Yes (via `countOfBytesReceived`) | ✅ Yes (via `URLSessionTaskMetrics`)          |
| Errors                | ✅ Yes                            | ✅ Yes                                      |
| Response data         | Completion handlers only | ✅ Yes |
| Detailed timing       | ❌ No                             | ✅ Yes (DNS, SSL, TTFB, connect, download)  |

Note on data capture: Response data is available in `ResourceAttributesProvider` callback for:
- Automatic mode: Tasks with completion handlers
- Metrics mode: All tasks (via delegate didReceive or completion handler)

Async/await and delegate-only tasks in automatic mode will receive nil for the data parameter, but all other parameters (request, response, error) remain available.

## Tests

**Unit tests**:
- ✅ `setState:` swizzling in `URLSessionTaskStateSwizzlerTests`
- In `NetworkInstrumentationFeatureTests`: 
  - ✅ All mode combinations: automatic only, metrics only, dual-mode
  - ✅ Multiple `URLSession` request types covered:
    - dataTask (with URL, URLRequest, completion handler)
    - uploadTask (with/without completion handler)
    - downloadTask
    - async/await tasks
    - Combine tasks
  - ✅ Intake filtering (domain-based + header-based)

**Integration tests**:
- ❌ No new integration tests specifically for dual-mode, will come-up in a follow-up PR
- ✅ Fixed and validated existing integration tests that now exercise automatic mode (`NetworkInstrumentationIntegrationTests`, `RUMResourcesScenarioTests`, `TracingURLSessionScenarioTests`, etc.) 

## Notes

- **Backward Compatible**: No breaking changes - existing metrics mode behavior unchanged
  - As stated in the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5733843131/RFC+-+iOS+Automatic+Network+Instrumentation) (internal), more requests will be captured by default; customers can filter them out by using the `resourceEventMapper` in [RUMConfiguration](https://github.com/DataDog/dd-sdk-ios/blob/develop/DatadogRUM/Sources/RUMConfiguration.swift#L28).

- **Distributed Tracing**: when customers call `Trace.enable(with:)`, automatic mode is enabled, but they still need to call `URLSessionInstrumentation.enable(with:)` with their delegate to enable metrics mode if they want distributed tracing to work. Spans need accurate timing from `URLSessionTaskMetrics`. [RUM-13455](https://datadoghq.atlassian.net/browse/RUM-13455) is tracking if we want to add automatic mode support for distributed tracing as well.

- **Delegate Swizzling:** An earlier iteration attempted to clean-up `NetworkInstrumentationFeature`'s implementation and minimize delegate swizzling in metrics mode (only swizzling `didFinishCollecting` for metrics capture). However, the full delegate swizzling was kept for two reasons:
  1. **Data capture for `ResourceAttributesProvider`**: Swizzling `didReceive` is necessary to provide response data to customers via the `resourceAttributesProvider` callback.
  2. **iOS 15 compatibility**: Full delegate swizzling ensures backward compatibility with iOS 15, which couldn't be fully tested due to Xcode version constraints; keeping comprehensive swizzling minimizes risk for older OS versions.


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)


[RUM-13455]: https://datadoghq.atlassian.net/browse/RUM-13455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces dual-mode network tracking with automatic `URLSession` instrumentation and preserves metrics mode for detailed timing.
> 
> - Adds automatic mode: tracks tasks via `setState:` and completion-handler swizzling; no delegate required; filtered out SDK intake requests (via `DD-REQUEST-ID`)
> - Keeps metrics mode: delegate-based; now coexists with automatic mode and captures `URLSessionTaskMetrics` and response data
> - New `URLSessionTaskStateSwizzler` and updates to `NetworkInstrumentationFeature` to manage modes, delegate registration, and interception flow
> - Updates `URLSessionInstrumentation.enableOrThrow` to accept optional config and be `@_spi(Internal) public`; RUM now enables automatic mode by default
> - Enhances `URLSessionTaskInterception`: adds `TrackingMode`, response-size fallback, and mode-specific `isDone` logic; RUM resource size now falls back to `responseSize`
> - Extensive new/updated tests covering automatic, metrics, and dual-mode paths, async/await, Combine, uploads/downloads, and filtering; project files updated accordingly
> - CHANGELOG entry added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51df984450a8a9b29488b7d5201063a29819f2fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->