### PR TITLE
[ctshibasu] modified GH action Logic to account for RUM Feature update job

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -20,10 +20,12 @@ jobs:
               run: |
                   mkdir -p publish_folder
                   cp CHANGELOG.md publish_folder/dd-ios-sdk-changelog.md
-                  cp DatadogRUM/RUM_FEATURE.md publish_folder/dd-sdk-ios-RUM_FEATURE.md
-                  cp DatadogSessionReplay/SESSION_REPLAY_FEATURE.md publish_folder/dd-sdk-ios-SESSION_REPLAY_FEATURE.md
                   echo "Publishing CHANGELOG.md"
+                  
+                  cp DatadogRUM/RUM_FEATURE.md publish_folder/dd-sdk-ios-rum-feature.md
                   echo "Publishing RUM_FEATURE.md"
+                  
+                  cp DatadogSessionReplay/SESSION_REPLAY_FEATURE.md publish_folder/dd-sdk-ios-session-replay-feature.md
                   echo "Publishing SESSION_REPLAY_FEATURE.md"
 
             - name: Publish Markdown to Confluence


### PR DESCRIPTION
### What and why?
Modified GH action Logic to account for RUM and SESSION_REPLAY Feature update job.
**Reason:** So that EEKs is also able to read from the `RUM_FEATURE` and `SESSION_REPLAY_FEATURE` file containing troubleshooting hints/tips

The changes introduced here are explicit references to publishing the iOS `RUM_FEATURE` and `SESSION_REPLAY_FEATURE` file - allowing EEKs to also read and ingest this information and answer on troubleshooting more accurately on support-rum channel

### How? & Implementation Details
By adding additional instructions within the workflow `.yaml` file and renaming the action to reflect the change in the action.
Once the action is triggered; the release notes AND `FEATURE` files will be sent to the same publish folder in the Confluence page. Example of output in test environment shown below:
<img width="1848" height="778" alt="RUM_FEATURE" src="https://github.com/user-attachments/assets/4b76d9ee-2bac-4c7c-9add-318b077af9ca" />

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
