### PR TITLE
chore: Update certificate for e2e runner profile

### DIFF
--- a/E2ETests/exportOptions.plist
+++ b/E2ETests/exportOptions.plist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>distributionBundleIdentifier</key>
+	<string>com.datadoghq.e2e.Runner</string>
+	<key>method</key>
+	<string>development</string>
+	<key>provisioningProfiles</key>
 	<dict>
-		<key>distributionBundleIdentifier</key>
-		<string>com.datadoghq.e2e.Runner</string>
-		<key>method</key>
-		<string>development</string>
-		<key>provisioningProfiles</key>
-		<dict>
-			<key>com.datadoghq.e2e.Runner</key>
-			<string>Datadog E2E Runner</string>
-		</dict>
-		<key>signingCertificate</key>
-		<string>Apple Development: Robot Bitrise (9HKDHCMCGH)</string>
-		<key>teamID</key>
-		<string>JKFCB4CN7C</string>
+		<key>com.datadoghq.e2e.Runner</key>
+		<string>Datadog E2E Runner</string>
 	</dict>
+	<key>signingCertificate</key>
+	<string>Apple Development: Simao Seica (35XV3565V6)</string>
+	<key>teamID</key>
+	<string>JKFCB4CN7C</string>
+</dict>
 </plist>

--- a/E2ETests/xcconfigs/Synthetics.xcconfig
+++ b/E2ETests/xcconfigs/Synthetics.xcconfig
@@ -1,6 +1,6 @@
 #include "Runner.xcconfig"
 
 CODE_SIGN_STYLE = Manual
-CODE_SIGN_IDENTITY = Apple Development: Robot Bitrise (9HKDHCMCGH)
+CODE_SIGN_IDENTITY = Apple Development: Simao Seica (35XV3565V6)
 DEVELOPMENT_TEAM = JKFCB4CN7C
 PROVISIONING_PROFILE_SPECIFIER = Datadog E2E Runner


### PR DESCRIPTION
### What and why?

It updates the code sign identity of the provision profile used to sign the e2e Runner app. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
