### PR TITLE
Fix xcframework validation

### DIFF
--- a/tools/release/validate-xcframeworks.sh
+++ b/tools/release/validate-xcframeworks.sh
@@ -138,7 +138,7 @@ validate_xcframework() {
     # List any remaining unexpected files
     list_remaining_files "$framework_path" "$framework_name"
 
-    # Step 65: Clean up
+    # Clean up
     rm -rf "$framework_path"
 }
 


### PR DESCRIPTION
### What and why?

`DatadogCrashReporting.xcframework` now only includes `arm64` slice only due to SPM limitation and dependency to `KSCrash`. This fails the released validation.

### How?

Use patterns to validate the xcframeworks that are not architecture dependenct, the script now validates the following on all platforms:
- Info.plist
- dSYMs
- Framework Binary
- Swift Module Interfaces

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
