### PR TITLE
Add `DDLogEventUserInfo.anonymousId` property in ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Add `DDLogEventUserInfo.anonymousId` property in ObjC API. See [#2640][]
+
 # 3.5.0 / 12-01-2025
 
 - [FEATURE] Report time to initial display (TTID). See [#2517][] [#2464][] 
@@ -1019,6 +1021,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2614]: https://github.com/DataDog/dd-sdk-ios/pull/2614
 [#2631]: https://github.com/DataDog/dd-sdk-ios/pull/2631
 [#2633]: https://github.com/DataDog/dd-sdk-ios/pull/2633
+[#2640]: https://github.com/DataDog/dd-sdk-ios/pull/2640
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogLogs/Sources/LogsDataModels+objc.swift
+++ b/DatadogLogs/Sources/LogsDataModels+objc.swift
@@ -198,6 +198,10 @@ public class objc_LogEventUserInfo: NSObject {
         root.swiftModel.userInfo.email
     }
 
+    public var anonymousId: String? {
+        root.swiftModel.userInfo.anonymousId
+    }
+
     public var extraInfo: [String: Any] {
         set { root.swiftModel.userInfo.extraInfo = newValue.dd.swiftAttributes }
         get { root.swiftModel.userInfo.extraInfo.dd.objCAttributes }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -168,6 +168,7 @@ public class objc_LogEventUserInfo: NSObject
     public var id: String?
     public var name: String?
     public var email: String?
+    public var anonymousId: String?
     public var extraInfo: [String: Any]
 public class objc_LogEventAccountInfo: NSObject
     public var id: String


### PR DESCRIPTION
### What and why?

This property was added to Swift API in https://github.com/DataDog/dd-sdk-ios/pull/2225, but ObjC API was missing.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
