### PR TITLE
Fix Logger flaxy test

### DIFF
--- a/DatadogLogs/Tests/LoggerTests.swift
+++ b/DatadogLogs/Tests/LoggerTests.swift
@@ -164,7 +164,7 @@ class LoggerTests: XCTestCase {
         )
 
         // Then
-        wait(for: [completionExpectation], timeout: 0)
+        wait(for: [completionExpectation], timeout: 0.5)
         XCTAssertTrue(logger is CombinedLogger)
     }
 


### PR DESCRIPTION
### What and why?

`testWhenCriticalLoggedFromInternal_itCallCompletionOnce` (`LoggerTests`) is flaky.

### How?

Increasing timeout from `0` to `0.5`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
