### PR TITLE
Enable screen change scheduling in benchmark tests

### DIFF
--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
@@ -40,7 +40,10 @@ struct SessionReplaySwiftUIScenario: Scenario {
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
                 touchPrivacyLevel: .show,
-                featureFlags: [.swiftui: true]
+                featureFlags: [
+                    .swiftui: true,
+                    .screenChangeScheduling: true
+                ]
             )
         )
 

--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
@@ -38,7 +38,8 @@ struct SessionReplayScenario: Scenario {
                 replaySampleRate: 100,
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
-                touchPrivacyLevel: .show
+                touchPrivacyLevel: .show,
+                featureFlags: [.screenChangeScheduling: true]
             )
         )
 


### PR DESCRIPTION
### What and why?

Enable screen change scheduling in Session Replay benchmark scenarios to prevent performance regressions.

### How?

Enable the `screenChangeScheduling` feature flag in Session Replay benchmark scenarios