### PR TITLE
RUM-14055: Encoded and decoded response body sizes

### DIFF
--- a/DatadogCore/Tests/Datadog/RUM/RUMInternalProxyTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMInternalProxyTests.swift
@@ -107,7 +107,7 @@ class RUMInternalProxyTests: XCTestCase {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            responseSize: 42
+            responseBodySize: (encoded: 30, decoded: 42)
         )
 
         monitor.stopResource(resourceKey: "/resource/1", response: .mockWith(statusCode: 200, mimeType: "image/png"))

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -606,7 +606,7 @@ extension NetworkInstrumentationFeature {
             return
         }
 
-        let metricsSize = metrics.responseSize ?? 0
+        let metricsSize = metrics.responseBodySize?.decoded ?? 0
         let responseSize = metricsSize > 0 ? metricsSize : task.countOfBytesReceived
 
         if responseSize > 0 {

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -228,11 +228,6 @@ public struct ResourceMetrics {
     /// Properties of the download phase for the resource.
     public let download: DateInterval?
 
-    /// The size of the request body.
-    /// - `encoded`: Size after encoding/compression, as transmitted.
-    /// - `decoded`: Size before encoding/compression.
-    public let requestBodySize: (encoded: Int64, decoded: Int64)?
-
     /// The size of the response body.
     /// - `encoded`: Size as received, before decoding/decompression.
     /// - `decoded`: Size after decoding/decompression.
@@ -246,7 +241,6 @@ public struct ResourceMetrics {
         ssl: DateInterval?,
         firstByte: DateInterval?,
         download: DateInterval?,
-        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) {
         self.fetch = fetch
@@ -256,7 +250,6 @@ public struct ResourceMetrics {
         self.ssl = ssl
         self.firstByte = firstByte
         self.download = download
-        self.requestBodySize = requestBodySize
         self.responseBodySize = responseBodySize
     }
 }
@@ -298,7 +291,6 @@ extension ResourceMetrics {
         var ssl: DateInterval? = nil
         var firstByte: DateInterval? = nil
         var download: DateInterval? = nil
-        var requestBodySize: (encoded: Int64, decoded: Int64)? = nil
         var responseBodySize: (encoded: Int64, decoded: Int64)? = nil
 
         if let mainTransaction = mainTransaction {
@@ -328,12 +320,9 @@ extension ResourceMetrics {
             }
 
             if #available(iOS 13.0, tvOS 13, *) {
-                let requestEncoded = mainTransaction.countOfRequestBodyBytesSent
-                let requestDecoded = mainTransaction.countOfRequestBodyBytesBeforeEncoding
                 let responseEncoded = mainTransaction.countOfResponseBodyBytesReceived
                 let responseDecoded = mainTransaction.countOfResponseBodyBytesAfterDecoding
 
-                requestBodySize = (encoded: requestEncoded, decoded: requestDecoded)
                 responseBodySize = (encoded: responseEncoded, decoded: responseDecoded)
             }
         }
@@ -346,7 +335,6 @@ extension ResourceMetrics {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            requestBodySize: requestBodySize,
             responseBodySize: responseBodySize
         )
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -42,10 +42,10 @@ public class URLSessionTaskInterception {
     public private(set) var data: Data?
     /// Response size in bytes received during this interception.
     ///
-    /// This is captured via `task.countOfBytesReceived` and serves as a fallback when `metrics.responseSize` is unavailable.
+    /// This is captured via `task.countOfBytesReceived` and serves as a fallback when `metrics.responseBodySize?.decoded` is unavailable.
     ///
     /// Priority for response size:
-    /// 1. `metrics.responseSize` - Most accurate, from `URLSessionTaskMetrics` (only available with registered delegate)
+    /// 1. `metrics.responseBodySize?.decoded` - Most accurate, from `URLSessionTaskMetrics` (only available with registered delegate)
     /// 2. `responseSize` - Fallback from `task.countOfBytesReceived` (available in both modes)
     ///
     /// Available even when data is not captured (e.g., for tasks without completion handlers in automatic mode).
@@ -82,10 +82,11 @@ public class URLSessionTaskInterception {
         return metrics?.fetch.end ?? endDate
     }
 
-    /// Returns the most accurate size available.
-    /// Prefers `metrics.responseSize`, but fallbacks to `responseSize` when metrics size is `nil` or 0
+    /// Returns the most accurate response size available.
+    /// Prefers `metrics.responseBodySize?.decoded` (from URLSessionTaskMetrics in registered delegate mode),
+    /// but falls back to `responseSize` (from task.countOfBytesReceived in automatic mode) when metrics are unavailable.
     public var mostAccurateResponseSize: Int64? {
-        let metricsSize = metrics?.responseSize ?? 0
+        let metricsSize = metrics?.responseBodySize?.decoded ?? 0
         return metricsSize > 0 ? metricsSize : responseSize
     }
 
@@ -227,8 +228,15 @@ public struct ResourceMetrics {
     /// Properties of the download phase for the resource.
     public let download: DateInterval?
 
-    /// The size of data delivered to delegate or completion handler.
-    public let responseSize: Int64?
+    /// The size of the request body.
+    /// - `encoded`: Size after encoding/compression, as transmitted.
+    /// - `decoded`: Size before encoding/compression.
+    public let requestBodySize: (encoded: Int64, decoded: Int64)?
+
+    /// The size of the response body.
+    /// - `encoded`: Size as received, before decoding/decompression.
+    /// - `decoded`: Size after decoding/decompression.
+    public let responseBodySize: (encoded: Int64, decoded: Int64)?
 
     public init(
         fetch: DateInterval,
@@ -238,7 +246,8 @@ public struct ResourceMetrics {
         ssl: DateInterval?,
         firstByte: DateInterval?,
         download: DateInterval?,
-        responseSize: Int64?
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        responseBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) {
         self.fetch = fetch
         self.redirection = redirection
@@ -247,7 +256,8 @@ public struct ResourceMetrics {
         self.ssl = ssl
         self.firstByte = firstByte
         self.download = download
-        self.responseSize = responseSize
+        self.requestBodySize = requestBodySize
+        self.responseBodySize = responseBodySize
     }
 }
 
@@ -288,7 +298,8 @@ extension ResourceMetrics {
         var ssl: DateInterval? = nil
         var firstByte: DateInterval? = nil
         var download: DateInterval? = nil
-        var responseSize: Int64? = nil
+        var requestBodySize: (encoded: Int64, decoded: Int64)? = nil
+        var responseBodySize: (encoded: Int64, decoded: Int64)? = nil
 
         if let mainTransaction = mainTransaction {
             if let dnsStart = mainTransaction.domainLookupStartDate,
@@ -317,7 +328,13 @@ extension ResourceMetrics {
             }
 
             if #available(iOS 13.0, tvOS 13, *) {
-                responseSize = mainTransaction.countOfResponseBodyBytesAfterDecoding
+                let requestEncoded = mainTransaction.countOfRequestBodyBytesSent
+                let requestDecoded = mainTransaction.countOfRequestBodyBytesBeforeEncoding
+                let responseEncoded = mainTransaction.countOfResponseBodyBytesReceived
+                let responseDecoded = mainTransaction.countOfResponseBodyBytesAfterDecoding
+
+                requestBodySize = (encoded: requestEncoded, decoded: requestDecoded)
+                responseBodySize = (encoded: responseEncoded, decoded: responseDecoded)
             }
         }
 
@@ -329,7 +346,8 @@ extension ResourceMetrics {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            responseSize: responseSize
+            requestBodySize: requestBodySize,
+            responseBodySize: responseBodySize
         )
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -183,8 +183,6 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.firstByte?.end, taskTransaction.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.start, taskTransaction.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.end, taskTransaction.responseEndDate!)
-        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, taskTransaction.countOfRequestBodyBytesBeforeEncoding)
-        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, taskTransaction.countOfRequestBodyBytesSent)
         XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, taskTransaction.countOfResponseBodyBytesReceived)
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, taskTransaction.countOfResponseBodyBytesAfterDecoding)
     }
@@ -247,8 +245,6 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.firstByte?.end, transaction3.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.start, transaction3.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.end, transaction3.responseEndDate!)
-        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, transaction3.countOfRequestBodyBytesBeforeEncoding)
-        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, transaction3.countOfRequestBodyBytesSent)
         XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, transaction3.countOfResponseBodyBytesReceived)
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, transaction3.countOfResponseBodyBytesAfterDecoding)
     }
@@ -301,10 +297,6 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertNil(
             resourceMetrics.download,
             "`download` should not be tracked for cache transactions."
-        )
-        XCTAssertNil(
-            resourceMetrics.requestBodySize,
-            "`requestBodySize` should not be tracked for cache transactions."
         )
         XCTAssertNil(
             resourceMetrics.responseBodySize,

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -183,7 +183,10 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.firstByte?.end, taskTransaction.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.start, taskTransaction.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.end, taskTransaction.responseEndDate!)
-        XCTAssertEqual(resourceMetrics.responseSize, taskTransaction.countOfResponseBodyBytesAfterDecoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, taskTransaction.countOfRequestBodyBytesBeforeEncoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, taskTransaction.countOfRequestBodyBytesSent)
+        XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, taskTransaction.countOfResponseBodyBytesReceived)
+        XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, taskTransaction.countOfResponseBodyBytesAfterDecoding)
     }
 
     func testWhenTaskMakesMultipleFetchesFromNetwork_thenAllMetricsAreCollected() {
@@ -244,7 +247,10 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.firstByte?.end, transaction3.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.start, transaction3.responseStartDate!)
         XCTAssertEqual(resourceMetrics.download?.end, transaction3.responseEndDate!)
-        XCTAssertEqual(resourceMetrics.responseSize, transaction3.countOfResponseBodyBytesAfterDecoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, transaction3.countOfRequestBodyBytesBeforeEncoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, transaction3.countOfRequestBodyBytesSent)
+        XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, transaction3.countOfResponseBodyBytesReceived)
+        XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, transaction3.countOfResponseBodyBytesAfterDecoding)
     }
 
     func testWhenTaskMakesFetchFromLocalCache_thenOnlyFetchMetricIsCollected() {
@@ -297,8 +303,12 @@ class ResourceMetricsTests: XCTestCase {
             "`download` should not be tracked for cache transactions."
         )
         XCTAssertNil(
-            resourceMetrics.responseSize,
-            "`responseSize` should not be tracked for cache transactions."
+            resourceMetrics.requestBodySize,
+            "`requestBodySize` should not be tracked for cache transactions."
+        )
+        XCTAssertNil(
+            resourceMetrics.responseBodySize,
+            "`responseBodySize` should not be tracked for cache transactions."
         )
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -160,32 +160,16 @@ internal class RUMResourceScope: RUMScope {
         if let metrics = resourceMetrics {
             resourceStartTime = metrics.fetch.start
             resourceDuration = metrics.fetch.end.timeIntervalSince(metrics.fetch.start)
-            size = metrics.responseBodySize?.decoded ?? command.size
+            let metricsSize = metrics.responseBodySize?.decoded ?? 0
+            size = metricsSize > 0 ? metricsSize : command.size
         } else {
             resourceStartTime = resourceLoadingStartTime
             resourceDuration = command.time.timeIntervalSince(resourceLoadingStartTime)
             size = command.size
         }
 
-        let encodedBodySize: Int64? = {
-            guard let metrics = resourceMetrics else {
-                return nil
-            }
-            let requestEncoded = metrics.requestBodySize?.encoded ?? 0
-            let responseEncoded = metrics.responseBodySize?.encoded ?? 0
-            let total = requestEncoded + responseEncoded
-            return total > 0 ? total : nil
-        }()
-
-        let decodedBodySize: Int64? = {
-            guard let metrics = resourceMetrics else {
-                return nil
-            }
-            let requestDecoded = metrics.requestBodySize?.decoded ?? 0
-            let responseDecoded = metrics.responseBodySize?.decoded ?? 0
-            let total = requestDecoded + responseDecoded
-            return total > 0 ? total : nil
-        }()
+        let encodedBodySize = resourceMetrics?.responseBodySize?.encoded
+        let decodedBodySize = resourceMetrics?.responseBodySize?.decoded
 
         // Write resource event
         let resourceEvent = RUMResourceEvent(

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -127,7 +127,8 @@ public struct DatadogInternalInterface {
     ///   - ssl: properties of the secure connect phase for the resource.
     ///   - firstByte: properties of the TTFB phase for the resource.
     ///   - download: properties of the download phase for the resource.
-    ///   - responseSize: the size of data delivered to delegate or completion handler.
+    ///   - requestBodySize: the request body sizes (encoded: transmitted bytes, decoded: original bytes).
+    ///   - responseBodySize: the response body sizes (encoded: received bytes, decoded: decompressed bytes).
     ///   - attributes: attributes to process along with this call
     public func addResourceMetrics(
         at time: Date,
@@ -139,7 +140,8 @@ public struct DatadogInternalInterface {
         ssl: (start: Date, end: Date)?,
         firstByte: (start: Date, end: Date)?,
         download: (start: Date, end: Date)?,
-        responseSize: Int64?,
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
         monitor.process(
@@ -155,7 +157,8 @@ public struct DatadogInternalInterface {
                     ssl: ResourceMetrics.DateInterval.create(start: ssl?.start, end: ssl?.end),
                     firstByte: ResourceMetrics.DateInterval.create(start: firstByte?.start, end: firstByte?.end),
                     download: ResourceMetrics.DateInterval.create(start: download?.start, end: download?.end),
-                    responseSize: responseSize
+                    requestBodySize: requestBodySize,
+                    responseBodySize: responseBodySize
                 )
             )
         )

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -127,7 +127,6 @@ public struct DatadogInternalInterface {
     ///   - ssl: properties of the secure connect phase for the resource.
     ///   - firstByte: properties of the TTFB phase for the resource.
     ///   - download: properties of the download phase for the resource.
-    ///   - requestBodySize: the request body sizes (encoded: transmitted bytes, decoded: original bytes).
     ///   - responseBodySize: the response body sizes (encoded: received bytes, decoded: decompressed bytes).
     ///   - attributes: attributes to process along with this call
     public func addResourceMetrics(
@@ -140,7 +139,6 @@ public struct DatadogInternalInterface {
         ssl: (start: Date, end: Date)?,
         firstByte: (start: Date, end: Date)?,
         download: (start: Date, end: Date)?,
-        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
@@ -157,7 +155,6 @@ public struct DatadogInternalInterface {
                     ssl: ResourceMetrics.DateInterval.create(start: ssl?.start, end: ssl?.end),
                     firstByte: ResourceMetrics.DateInterval.create(start: firstByte?.start, end: firstByte?.end),
                     download: ResourceMetrics.DateInterval.create(start: download?.start, end: download?.end),
-                    requestBodySize: requestBodySize,
                     responseBodySize: responseBodySize
                 )
             )

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -588,7 +588,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStopCommand.attributes.count, 0)
         XCTAssertEqual(resourceStopCommand.kind, RUMResourceType(response: response))
         XCTAssertEqual(resourceStopCommand.httpStatusCode, 200)
-        XCTAssertEqual(resourceStopCommand.size, taskInterception.metrics?.responseSize)
+        XCTAssertEqual(resourceStopCommand.size, taskInterception.metrics?.responseBodySize?.decoded)
     }
 
     func testGivenTaskInterceptionWithZeroMetricsSize_whenInterceptionCompletes_itFallsBackToResponseSize() throws {
@@ -603,8 +603,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // Given
         let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .registeredDelegate)
 
-        // Create metrics with responseSize = 0
-        let resourceMetrics = ResourceMetrics.mockWith(responseSize: 0)
+        // Create metrics with responseBodySize.decoded = 0
+        let resourceMetrics = ResourceMetrics.mockWith(responseBodySize: (encoded: 0, decoded: 0))
         taskInterception.register(metrics: resourceMetrics)
 
         // Set responseSize from countOfBytesReceived
@@ -628,9 +628,9 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStopCommand.kind, RUMResourceType(response: response))
         XCTAssertEqual(resourceStopCommand.httpStatusCode, 200)
 
-        // Verify fallback to responseSize when metrics.responseSize is 0
-        XCTAssertEqual(resourceStopCommand.size, 10, "Should fallback to interception.responseSize when metrics.responseSize is 0")
-        XCTAssertNotEqual(resourceStopCommand.size, taskInterception.metrics?.responseSize, "Should not use metrics.responseSize when it is 0")
+        // Verify fallback to responseSize when metrics.responseBodySize?.decoded is 0
+        XCTAssertEqual(resourceStopCommand.size, 10, "Should fallback to interception.responseSize when metrics.responseBodySize?.decoded is 0")
+        XCTAssertNotEqual(resourceStopCommand.size, taskInterception.metrics?.responseBodySize?.decoded, "Should not use metrics.responseBodySize?.decoded when it is 0")
     }
 
     func testGivenTaskInterceptionWithMetricsAndError_whenInterceptionCompletes_itStopsRUMResourceWithErrorAndMetrics() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1051,7 +1051,6 @@ class RUMResourceScopeTests: XCTestCase {
                     start: resourceFetchStart,
                     end: resourceFetchStart.addingTimeInterval(10)
                 ),
-                requestBodySize: (encoded: 512, decoded: 1_024),
                 responseBodySize: (encoded: 1_536, decoded: 2_048)
             )
         )
@@ -1077,10 +1076,8 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Then
         let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
-        // encodedBodySize = request encoded (512) + response encoded (1536) = 2048
-        XCTAssertEqual(event.resource.encodedBodySize, 2_048, "Encoded body size should aggregate request and response")
-        // decodedBodySize = request decoded (1024) + response decoded (2048) = 3072
-        XCTAssertEqual(event.resource.decodedBodySize, 3_072, "Decoded body size should aggregate request and response")
+        XCTAssertEqual(event.resource.encodedBodySize, 1_536, "Encoded body size should match response encoded size")
+        XCTAssertEqual(event.resource.decodedBodySize, 2_048, "Decoded body size should match response decoded size")
     }
 
     func testGivenMultipleResourceScopes_whenSendingResourceEvents_eachEventHasUniqueResourceID() throws {

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -213,7 +213,6 @@ extension ResourceMetrics: AnyMockable {
         ssl: DateInterval? = nil,
         firstByte: DateInterval? = nil,
         download: DateInterval? = nil,
-        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) -> Self {
         return .init(
@@ -224,7 +223,6 @@ extension ResourceMetrics: AnyMockable {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            requestBodySize: requestBodySize,
             responseBodySize: responseBodySize
         )
     }

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -213,7 +213,8 @@ extension ResourceMetrics: AnyMockable {
         ssl: DateInterval? = nil,
         firstByte: DateInterval? = nil,
         download: DateInterval? = nil,
-        responseSize: Int64? = nil
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        responseBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) -> Self {
         return .init(
             fetch: fetch,
@@ -223,7 +224,8 @@ extension ResourceMetrics: AnyMockable {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            responseSize: responseSize
+            requestBodySize: requestBodySize,
+            responseBodySize: responseBodySize
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -673,8 +673,6 @@ extension URLSessionTaskTransactionMetrics {
         let responseEndDate = end
 
         let countOfResponseBodyBytesAfterDecoding: Int64 = .random(in: 512..<1_024)
-        let countOfRequestBodyBytesBeforeEncoding: Int64 = .random(in: 256..<512)
-        let countOfRequestBodyBytesSent: Int64 = .random(in: 128..<256)
         let countOfResponseBodyBytesReceived: Int64 = .random(in: 256..<512)
 
         return URLSessionTaskTransactionMetricsMock(
@@ -690,8 +688,6 @@ extension URLSessionTaskTransactionMetrics {
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
             countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding,
-            countOfRequestBodyBytesBeforeEncoding: countOfRequestBodyBytesBeforeEncoding,
-            countOfRequestBodyBytesSent: countOfRequestBodyBytesSent,
             countOfResponseBodyBytesReceived: countOfResponseBodyBytesReceived
         )
     }
@@ -709,7 +705,6 @@ extension URLSessionTaskTransactionMetrics {
         requestStartDate: Date? = nil,
         responseStartDate: Date? = nil,
         responseEndDate: Date? = nil,
-        requestBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0),
         responseBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0)
     ) -> URLSessionTaskTransactionMetrics {
         return URLSessionTaskTransactionMetricsMock(
@@ -725,8 +720,6 @@ extension URLSessionTaskTransactionMetrics {
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
             countOfResponseBodyBytesAfterDecoding: responseBodySize.decoded,
-            countOfRequestBodyBytesBeforeEncoding: requestBodySize.decoded,
-            countOfRequestBodyBytesSent: requestBodySize.encoded,
             countOfResponseBodyBytesReceived: responseBodySize.encoded
         )
     }

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -673,6 +673,9 @@ extension URLSessionTaskTransactionMetrics {
         let responseEndDate = end
 
         let countOfResponseBodyBytesAfterDecoding: Int64 = .random(in: 512..<1_024)
+        let countOfRequestBodyBytesBeforeEncoding: Int64 = .random(in: 256..<512)
+        let countOfRequestBodyBytesSent: Int64 = .random(in: 128..<256)
+        let countOfResponseBodyBytesReceived: Int64 = .random(in: 256..<512)
 
         return URLSessionTaskTransactionMetricsMock(
             resourceFetchType: resourceFetchType,
@@ -686,7 +689,10 @@ extension URLSessionTaskTransactionMetrics {
             requestStartDate: requestStartDate,
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
-            countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding
+            countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding,
+            countOfRequestBodyBytesBeforeEncoding: countOfRequestBodyBytesBeforeEncoding,
+            countOfRequestBodyBytesSent: countOfRequestBodyBytesSent,
+            countOfResponseBodyBytesReceived: countOfResponseBodyBytesReceived
         )
     }
 
@@ -703,7 +709,8 @@ extension URLSessionTaskTransactionMetrics {
         requestStartDate: Date? = nil,
         responseStartDate: Date? = nil,
         responseEndDate: Date? = nil,
-        countOfResponseBodyBytesAfterDecoding: Int64 = 0
+        requestBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0),
+        responseBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0)
     ) -> URLSessionTaskTransactionMetrics {
         return URLSessionTaskTransactionMetricsMock(
             resourceFetchType: resourceFetchType,
@@ -717,7 +724,10 @@ extension URLSessionTaskTransactionMetrics {
             requestStartDate: requestStartDate,
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
-            countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding
+            countOfResponseBodyBytesAfterDecoding: responseBodySize.decoded,
+            countOfRequestBodyBytesBeforeEncoding: requestBodySize.decoded,
+            countOfRequestBodyBytesSent: requestBodySize.encoded,
+            countOfResponseBodyBytesReceived: responseBodySize.encoded
         )
     }
 }
@@ -788,6 +798,15 @@ private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMet
     private let _countOfResponseBodyBytesAfterDecoding: Int64
     override var countOfResponseBodyBytesAfterDecoding: Int64 { _countOfResponseBodyBytesAfterDecoding }
 
+    private let _countOfRequestBodyBytesBeforeEncoding: Int64
+    override var countOfRequestBodyBytesBeforeEncoding: Int64 { _countOfRequestBodyBytesBeforeEncoding }
+
+    private let _countOfRequestBodyBytesSent: Int64
+    override var countOfRequestBodyBytesSent: Int64 { _countOfRequestBodyBytesSent }
+
+    private let _countOfResponseBodyBytesReceived: Int64
+    override var countOfResponseBodyBytesReceived: Int64 { _countOfResponseBodyBytesReceived }
+
     init(
         resourceFetchType: URLSessionTaskMetrics.ResourceFetchType,
         fetchStartDate: Date?,
@@ -800,7 +819,10 @@ private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMet
         requestStartDate: Date?,
         responseStartDate: Date?,
         responseEndDate: Date?,
-        countOfResponseBodyBytesAfterDecoding: Int64
+        countOfResponseBodyBytesAfterDecoding: Int64 = 0,
+        countOfRequestBodyBytesBeforeEncoding: Int64 = 0,
+        countOfRequestBodyBytesSent: Int64 = 0,
+        countOfResponseBodyBytesReceived: Int64 = 0
     ) {
         self._resourceFetchType = resourceFetchType
         self._fetchStartDate = fetchStartDate
@@ -814,5 +836,8 @@ private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMet
         self._responseStartDate = responseStartDate
         self._responseEndDate = responseEndDate
         self._countOfResponseBodyBytesAfterDecoding = countOfResponseBodyBytesAfterDecoding
+        self._countOfRequestBodyBytesBeforeEncoding = countOfRequestBodyBytesBeforeEncoding
+        self._countOfRequestBodyBytesSent = countOfRequestBodyBytesSent
+        self._countOfResponseBodyBytesReceived = countOfResponseBodyBytesReceived
     }
 }


### PR DESCRIPTION
### What and why?

We want to support reporting `encodedBodySize` and `decodedBodySize` for network resources in RUM events. 

### How?

The `responseSize` parameter has been removed from `RUMMonitorProtocol._internal.addResourceMetrics()`. This parameter was redundant (duplicate of `responseBodySize.decoded`), never actually used by any SDK (React Native explicitly passes `nil`).

On React Native SDK, we need to remove the `responseSize: nil` line from calls to `addResourceMetrics`. No action needed for Flutter and Unity SDKs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
