### PR TITLE
FFL-1771 Include sdk name/version for flag config requests

### DIFF
--- a/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsRequest.swift
@@ -36,9 +36,9 @@ extension URLRequest {
                 name: context.env,
                 datadogEnvironment: context.env
             ),
-            sdk: FlagAssignmentsRequestBody.SDK(
-                name: "dd-sdk-ios",
-                version: context.sdkVersion
+            source: FlagAssignmentsRequestBody.Source(
+                sdkName: "dd-sdk-ios",
+                sdkVersion: context.sdkVersion
             ),
             subject: FlagAssignmentsRequestBody.Subject(
                 targetingKey: evaluationContext.targetingKey,
@@ -74,13 +74,18 @@ internal struct FlagAssignmentsRequestBody {
         let datadogEnvironment: String
     }
 
-    struct SDK: Encodable {
-        let name: String
-        let version: String
+    struct Source: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case sdkName = "sdk_name"
+            case sdkVersion = "sdk_version"
+        }
+
+        let sdkName: String
+        let sdkVersion: String
     }
 
     let environment: Environment
-    let sdk: SDK
+    let source: Source
     let subject: Subject
 }
 
@@ -91,7 +96,7 @@ extension FlagAssignmentsRequestBody: Encodable {
         case attributes
         case flags
         case environment = "env"
-        case sdk
+        case source
         case subject
     }
 
@@ -103,7 +108,7 @@ extension FlagAssignmentsRequestBody: Encodable {
 
         var attributesContainer = dataContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .attributes)
         try attributesContainer.encode(environment, forKey: .environment)
-        try attributesContainer.encode(sdk, forKey: .sdk)
+        try attributesContainer.encode(source, forKey: .source)
         try attributesContainer.encode(subject, forKey: .subject)
     }
 }

--- a/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsRequestTests.swift
@@ -37,9 +37,9 @@ final class FlagAssignmentsRequestTests: XCTestCase {
                 "dd_env" : "production",
                 "name" : "production"
               },
-              "sdk" : {
-                "name" : "dd-sdk-ios",
-                "version" : "3.5.1"
+              "source" : {
+                "sdk_name" : "dd-sdk-ios",
+                "sdk_version" : "3.5.1"
               },
               "subject" : {
                 "targeting_attributes" : {


### PR DESCRIPTION
### What and why?

New `source: { sdk_name: <sdk-name>, sdk_version: <sdk-version> }` field added to payload of `/precomputed-assignments` flagging endpoint. This will be used for logging feature flagging configuration requests to calculate usage and which versions are being used.

### How?

 Added a Source struct to FlagAssignmentsRequestBody with sdk_name and sdk_version properties. The Source info is populated from context.sdkVersion for the version and uses the hardcoded value "dd-sdk-ios" for the name. The encode function was updated to include the source field in the request attributes alongside env and subject.

  The resulting payload structure:
```
  {
    "data": {
      "type": "precompute-assignments-request",
      "attributes": {
        "env": {
          "name": "production",
          "dd_env": "production"
        },
        "source": {
          "sdk_name": "dd-sdk-ios",
          "sdk_version": "3.5.1"
        },
        "subject": {
          "targeting_key": "user123",
          "targeting_attributes": {...}
        }
      }
    }
  }
```

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
