### PR TITLE
Disable screen change scheduling in benchmark tests

### DIFF
--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
@@ -40,10 +40,7 @@ struct SessionReplaySwiftUIScenario: Scenario {
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
                 touchPrivacyLevel: .show,
-                featureFlags: [
-                    .swiftui: true,
-                    .screenChangeScheduling: true
-                ]
+                featureFlags: [.swiftui: true]
             )
         )
 

--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
@@ -38,8 +38,7 @@ struct SessionReplayScenario: Scenario {
                 replaySampleRate: 100,
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
-                touchPrivacyLevel: .show,
-                featureFlags: [.screenChangeScheduling: true]
+                touchPrivacyLevel: .show
             )
         )
 


### PR DESCRIPTION
### What and why?

Reverts the changes introduced in #2650 to verify that the CPU benchmark goes higher again.

### How?

Update the Session Replay configuration for both scenarios, removing the screen change scheduling feature flag