### PR TITLE
chore: Prevent `WebViewtracking` fatal error

### DIFF
--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -105,6 +105,8 @@ public enum WebViewTracking {
             )
         )
 
+        // Prevent fatal error: `Attempt to add script message handler with name 'DatadogEventBridge' when one already exists.`
+        controller.removeScriptMessageHandler(forName: bridgeName)
         controller.add(messageHandler, name: bridgeName)
 
         // WebKit installs message handlers with the given name format below

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -134,7 +134,7 @@ class WebViewTrackingTests: XCTestCase {
 
         let initialUserScriptCount = controller.userScripts.count
 
-        let multipleTimes = 5
+        let multipleTimes = Int.random(in: 1...5)
         try (0..<multipleTimes).forEach { _ in
             try WebViewTracking.enableOrThrow(
                 tracking: controller,
@@ -159,6 +159,51 @@ class WebViewTrackingTests: XCTestCase {
         )
     }
 
+    func testWhenAddingMessageHandlerMultipleTimes_afterExternalRemovalOfUserScripts_itHandlesCorrectlyTheInstrumentation() {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        let core = PassthroughCoreMock()
+        let configuration = WKWebViewConfiguration()
+        let controller = configuration.userContentController
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+
+        WebViewTracking.enable(webView: webView, in: core)
+
+        XCTAssertEqual(controller.userScripts.count, 1)
+        // Simulates external code wiping user scripts.
+        controller.removeAllUserScripts()
+        XCTAssertTrue(controller.userScripts.isEmpty)
+
+        WebViewTracking.enable(webView: webView, in: core)
+
+        XCTAssertEqual(controller.userScripts.count, 1)
+        XCTAssertEqual(dd.logger.warnLogs.count, 0)
+    }
+
+    func testWhenStoppingTracking_itCanBeEnabledAgain() throws {
+        let core = PassthroughCoreMock()
+        let controller = DDUserContentController()
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = controller
+        let webview = WKWebView(frame: .zero, configuration: configuration)
+
+        WebViewTracking.enable(webView: webview,in: core)
+
+        XCTAssertEqual(controller.userScripts.count, 1)
+        XCTAssertEqual(controller.messageHandlers.count, 1)
+
+        WebViewTracking.disable(webView: webview)
+
+        XCTAssertEqual(controller.userScripts.count, 0)
+        XCTAssertEqual(controller.messageHandlers.count, 0)
+
+        WebViewTracking.enable(webView: webview,in: core)
+
+        XCTAssertEqual(controller.userScripts.count, 1)
+        XCTAssertEqual(controller.messageHandlers.count, 1)
+    }
+
     func testWhenStoppingTracking_itKeepsNonDatadogComponents() throws {
         let core = PassthroughCoreMock()
         let controller = DDUserContentController()
@@ -171,7 +216,7 @@ class WebViewTrackingTests: XCTestCase {
             in: core
         )
 
-        let componentCount = 10
+        let componentCount = Int.random(in: 1...10)
         for i in 0..<componentCount {
             let userScript = WKUserScript(
                 source: String.mockRandom(),


### PR DESCRIPTION
### What and why?

This PR fixes a fatal `NSInvalidArgumentException` that occurs when `WebViewTracking.enable` is called multiple times for the same `WKUserContentController`.

`WKUserContentController` can be shared across multiple `WKWebView` instances via a shared `WKWebViewConfiguration`. If the `DatadogEventBridge` script message handler is already registered but the Datadog user script has been removed outside of the SDK, `WebViewTracking.enable` can fail due to adding the same script message handler again.

### How?

Removes the `DatadogEventBridge` message handler script on the `WKUserContentController` before adding it again.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
