### PR TITLE
chore: Fix performance preset override

### DIFF
--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDataStoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDataStoreTests.swift
@@ -13,12 +13,14 @@ private struct FeatureAMock: DatadogRemoteFeature {
     static let name: String = "feature-a"
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+    var performanceOverride: DatadogInternal.PerformancePresetOverride?
 }
 
 private struct FeatureBMock: DatadogRemoteFeature {
     static let name: String = "feature-b"
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+    var performanceOverride: DatadogInternal.PerformancePresetOverride?
 }
 
 class DatadogCore_FeatureDataStoreTests: XCTestCase {

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDirectoriesTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCore+FeatureDirectoriesTests.swift
@@ -14,6 +14,7 @@ private struct RemoteFeatureMock: DatadogRemoteFeature {
 
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+    var performanceOverride: DatadogInternal.PerformancePresetOverride?
 }
 
 private struct FeatureMock: DatadogFeature {

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -16,7 +16,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
     let clientRegistry: FlagsClientRegistry
     let makeExposureLogger: (any FeatureScope) -> any ExposureLogging
     let makeRUMFlagEvaluationReporter: (any FeatureScope) -> any RUMFlagEvaluationReporting
-    let performanceOverride: PerformancePresetOverride
+    let performanceOverride: PerformancePresetOverride?
     let issueReporter: IssueReporter
 
     init(

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -50,6 +50,7 @@ final class FlagsTests: XCTestCase {
         // Then
         let flags = try XCTUnwrap(core.get(feature: FlagsFeature.self))
         let flagAssignmentFetcher = try XCTUnwrap(flags.flagAssignmentsFetcher as? FlagAssignmentsFetcher)
+        XCTAssertEqual(flags.performanceOverride?.maxObjectsInFile, 50)
         XCTAssertEqual(flagAssignmentFetcher.customEndpoint, config.customFlagsEndpoint)
         XCTAssertEqual(flagAssignmentFetcher.customHeaders, config.customFlagsHeaders)
         let requestBuilder = try XCTUnwrap(flags.requestBuilder as? ExposureRequestBuilder)

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -32,7 +32,3 @@ public protocol DatadogRemoteFeature: DatadogFeature {
     /// (Optional) `PerformancePresetOverride` allows overriding certain performance presets if needed.
     var performanceOverride: PerformancePresetOverride? { get }
 }
-
-extension DatadogRemoteFeature {
-    public var performanceOverride: PerformancePresetOverride? { nil }
-}

--- a/DatadogLogs/Sources/Feature/LogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/LogsFeature.swift
@@ -24,6 +24,9 @@ internal struct LogsFeature: DatadogRemoteFeature {
     /// Time provider.
     let dateProvider: DateProvider
 
+    /// Allows overriding certain performance presets if needed. Default is nil.
+    let performanceOverride: PerformancePresetOverride?
+
     init(
         logEventMapper: LogEventMapper?,
         dateProvider: DateProvider,
@@ -59,5 +62,6 @@ internal struct LogsFeature: DatadogRemoteFeature {
         self.dateProvider = dateProvider
         self.backtraceReporter = backtraceReporter
         self.attributes = SynchronizedAttributes(attributes: [:])
+        self.performanceOverride = nil
     }
 }

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -26,7 +26,7 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
 
     /// Setting max-file-age to minimum will force creating a batch per profile.
     /// It is necessary as the profiling intake only accepts one profile per request.
-    let performanceOverride = PerformancePresetOverride(maxFileSize: .min)
+    let performanceOverride: PerformancePresetOverride? = PerformancePresetOverride(maxFileSize: .min)
 
     init(
         requestBuilder: FeatureRequestBuilder,

--- a/DatadogProfiling/Tests/ProfilingTest.swift
+++ b/DatadogProfiling/Tests/ProfilingTest.swift
@@ -25,7 +25,9 @@ class ProfilingTest: XCTestCase {
         // Then
         let feature = core.feature(named: ProfilerFeature.name, type: ProfilerFeature.self)
         let requestBuilder = feature?.requestBuilder as? RequestBuilder
+        XCTAssertEqual(feature?.performanceOverride?.maxFileSize, .min)
         XCTAssertEqual(requestBuilder?.customUploadURL, configuration.customEndpoint)
+        XCTAssertEqual(feature?.telemetryController.sampleRate, 20)
 
         let context = try XCTUnwrap(core.context.additionalContext(ofType: ProfilingContext.self))
         XCTAssertEqual(context.status, .running)

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -23,7 +23,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
     let anonymousIdentifierManager: AnonymousIdentifierManaging
 
-    let performanceOverride = PerformancePresetOverride(
+    /// Overrides the max file age.
+    let performanceOverride: PerformancePresetOverride? = PerformancePresetOverride(
         maxFileAgeForRead: 24.hours // RUM intake can ingest events up to 24hrs old
     )
 

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -89,7 +89,7 @@ class RUMTests: XCTestCase {
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
         let telemetryReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: TelemetryReceiver.self)
         let crashReportReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
-        XCTAssertEqual(rum.performanceOverride.maxFileAgeForRead, 24.hours)
+        XCTAssertEqual(rum.performanceOverride?.maxFileAgeForRead, 24.hours)
         XCTAssertEqual(monitor.scopes.dependencies.rumApplicationID, applicationID)
         XCTAssertEqual(monitor.scopes.dependencies.sessionSampler.samplingRate, 100)
         XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.sampleRate, 15)

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -16,6 +16,9 @@ internal final class TraceFeature: DatadogRemoteFeature {
     let tracer: DatadogTracer
     let contextReceiver: ContextMessageReceiver
 
+    /// Allows overriding certain performance presets if needed. Default is nil.
+    let performanceOverride: PerformancePresetOverride?
+
     init(
         in core: DatadogCoreProtocol,
         configuration: Trace.Configuration
@@ -46,6 +49,7 @@ internal final class TraceFeature: DatadogRemoteFeature {
                 telemetry: core.telemetry
             )
         )
+        self.performanceOverride = nil
 
         // Send configuration telemetry:
         core.telemetry.configuration(useTracing: true)

--- a/TestUtilities/Sources/Mocks/DatadogInternal/MockFeature.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/MockFeature.swift
@@ -12,6 +12,7 @@ internal class MockFeature: DatadogRemoteFeature {
 
     var messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     var requestBuilder: FeatureRequestBuilder = MockRequestBuilder()
+    var performanceOverride: PerformancePresetOverride?
 }
 
 internal class MockRequestBuilder: FeatureRequestBuilder {


### PR DESCRIPTION
### What and why?

This PR fixes an issue where `performanceOverride` defined by some `DatadogRemoteFeatures` was silently ignored.

### How?

It removes the default `performanceOverride` implementation from the `DatadogRemoteFeature` extension and makes the property explicit for every conforming feature.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
