### PR TITLE
Fix: Use String-based JSON array for GraphQL errors to support cross-platform SDKs

### DIFF
--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -145,8 +145,8 @@ public struct CrossPlatformAttributes {
     public static let graphqlVariables = "_dd.graphql.variables"
 
     /// Custom attribute passed when completing GraphQL RUM resources that contain errors in the response.
-    /// It sets the GraphQL errors from the response body as JSON data.
-    /// Expects `Data` value.
+    /// It sets the GraphQL errors array as a JSON string.
+    /// Expects `String` value containing a JSON array of errors.
     public static let graphqlErrors = "_dd.graphql.errors"
 
     /// Override the `source_type` of errors reported by the native crash handler. This is used on

--- a/DatadogRUM/Sources/DataModels/GraphQLResponse.swift
+++ b/DatadogRUM/Sources/DataModels/GraphQLResponse.swift
@@ -20,12 +20,6 @@ internal struct GraphQLResponseHasErrors: Decodable {
     }
 }
 
-/// Full decoder for GraphQL response with errors array.
-/// Used when we need to extract the actual error details.
-internal struct GraphQLResponse: Decodable {
-    let errors: [GraphQLResponseError]?
-}
-
 /// Represents a GraphQL error in the response.
 ///
 /// Note: Some GraphQL implementations may include `code` at the error level (legacy pattern)

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -157,8 +157,8 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         }
 
         // Extract GraphQL errors from response if present
-        if let errorsData = extractGraphQLErrorsIfPresent(from: interception) {
-            combinedAttributes[CrossPlatformAttributes.graphqlErrors] = errorsData
+        if let errorsString = extractGraphQLErrorsIfPresent(from: interception) {
+            combinedAttributes[CrossPlatformAttributes.graphqlErrors] = errorsString
         }
 
         if let resourceMetrics = interception.metrics {
@@ -200,9 +200,9 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         }
     }
 
-    /// Extracts GraphQL errors from JSON response if present.
+    /// Extracts GraphQL errors from JSON response if present and returns them as a JSON string.
     /// Only the errors array is extracted to avoid storing potentially large response data fields.
-    private func extractGraphQLErrorsIfPresent(from interception: URLSessionTaskInterception) -> Data? {
+    private func extractGraphQLErrorsIfPresent(from interception: URLSessionTaskInterception) -> String? {
         guard let data = interception.data,
               let httpResponse = interception.completion?.httpResponse,
               let mimeType = httpResponse.mimeType,
@@ -216,7 +216,20 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
             return nil
         }
 
-        return data
+        // Extract just the errors array from the response
+        do {
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            guard let errorsArray = json?["errors"] else {
+                return nil
+            }
+
+            // Convert just the errors array back to JSON string
+            let errorsData = try JSONSerialization.data(withJSONObject: errorsArray)
+            return String(data: errorsData, encoding: .utf8)
+        } catch {
+            DD.logger.debug("Failed to extract GraphQL errors array: \(error)")
+            return nil
+        }
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -138,10 +138,10 @@ internal class RUMResourceScope: RUMScope {
         let graphqlOperationName: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationName)?.dd.decode()
         let graphqlPayload: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlPayload)?.dd.decode()
         let graphqlVariables: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlVariables)?.dd.decode()
-        let graphqlErrorsData: Data? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlErrors)?.dd.decode()
+        let graphqlErrorsString: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlErrors)?.dd.decode()
 
         // Parse GraphQL errors if present
-        let graphqlErrors = parseGraphQLErrors(from: graphqlErrorsData)
+        let graphqlErrors = parseGraphQLErrors(from: graphqlErrorsString)
 
         if
             let rawGraphqlOperationType: String = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationType)?.dd.decode(),
@@ -418,18 +418,24 @@ internal class RUMResourceScope: RUMScope {
         return duration.dd.toInt64Nanoseconds
     }
 
-    /// Decodes GraphQL errors from JSON data and returns them as RUM event errors
-    private func parseGraphQLErrors(from data: Data?) -> [RUMResourceEvent.Resource.Graphql.Errors]? {
-        guard let data else {
+    /// Decodes GraphQL errors from JSON string and returns them as RUM event errors
+    private func parseGraphQLErrors(from jsonString: String?) -> [RUMResourceEvent.Resource.Graphql.Errors]? {
+        guard let jsonString, !jsonString.isEmpty else {
+            return nil
+        }
+
+        guard let data = jsonString.data(using: .utf8) else {
+            DD.logger.debug("Failed to convert GraphQL errors string to UTF-8 data")
             return nil
         }
 
         do {
-            let response = try JSONDecoder().decode(GraphQLResponse.self, from: data)
+            let responseErrors = try JSONDecoder().decode([GraphQLResponseError].self, from: data)
 
-            guard let responseErrors = response.errors, !responseErrors.isEmpty else {
+            guard !responseErrors.isEmpty else {
                 return nil
             }
+
             let parsedErrors = responseErrors.map { error in
                 RUMResourceEvent.Resource.Graphql.Errors(
                     code: error.code,

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -1194,9 +1194,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
         XCTAssertNotNil(attributes[CrossPlatformAttributes.graphqlErrors])
-        let errorsData = try XCTUnwrap(attributes[CrossPlatformAttributes.graphqlErrors] as? Data)
-        let errorsJSON = try XCTUnwrap(String(data: errorsData, encoding: .utf8))
-        XCTAssertTrue(errorsJSON.contains("Not found"))
+        let errorsString = try XCTUnwrap(attributes[CrossPlatformAttributes.graphqlErrors] as? String)
+        XCTAssertTrue(errorsString.contains("Not found"))
     }
 
     func testGivenGraphQLResponseWithNonJSONContentType_whenInterceptionCompletes_itDoesNotParseErrors() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1544,46 +1544,29 @@ class RUMResourceScopeTests: XCTestCase {
             httpMethod: .post
         )
 
-        let graphQLResponseJSON = """
-        {
-          "errors": [
-            {
-              "message": "Book not found",
-              "locations": [
-                { "line": 2, "column": 7 },
-                { "line": 5, "column": 12 }
-              ],
-              "path": ["library", "book", "1234"],
-              "extensions": {
-                "code": "NOT_FOUND",
-                "timestamp": "2024-01-15T10:00:00Z"
-              }
-            },
-            {
-              "message": "Unauthorized access to user profile",
-              "locations": [{ "line": 10, "column": 3 }],
-              "path": ["user", "profile"],
-              "extensions": {
-                "code": "UNAUTHORIZED"
-              }
-            }
-          ],
-          "data": {
-            "library": {
-              "book": null
-            },
-            "user": null,
-            "firstShip": "3001",
-            "secondShip": null,
-            "launch": [
-              {
-                "id": "1",
-                "status": null
-              }
+        let graphQLErrorsJSON = """
+        [
+          {
+            "message": "Book not found",
+            "locations": [
+              { "line": 2, "column": 7 },
+              { "line": 5, "column": 12 }
             ],
-            "oldField": "some value"
+            "path": ["library", "book", "1234"],
+            "extensions": {
+              "code": "NOT_FOUND",
+              "timestamp": "2024-01-15T10:00:00Z"
+            }
+          },
+          {
+            "message": "Unauthorized access to user profile",
+            "locations": [{ "line": 10, "column": 3 }],
+            "path": ["user", "profile"],
+            "extensions": {
+              "code": "UNAUTHORIZED"
+            }
           }
-        }
+        ]
         """
 
         // When
@@ -1593,7 +1576,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/graphql",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.graphqlErrors: graphQLResponseJSON.data(using: .utf8)!,
+                        CrossPlatformAttributes.graphqlErrors: graphQLErrorsJSON,
                         CrossPlatformAttributes.graphqlOperationType: "query",
                         CrossPlatformAttributes.graphqlOperationName: "GetBookAndUser"
                     ],
@@ -1664,7 +1647,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/graphql",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.graphqlErrors: "{ invalid json }".data(using: .utf8)!,
+                        CrossPlatformAttributes.graphqlErrors: "{ invalid json }",
                         CrossPlatformAttributes.graphqlOperationType: "query"
                     ],
                     kind: .xhr,
@@ -1694,10 +1677,7 @@ class RUMResourceScopeTests: XCTestCase {
         )
 
         let emptyErrorsJSON = """
-        {
-            "errors": [],
-            "data": null
-        }
+        []
         """
 
         // When
@@ -1707,7 +1687,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/graphql",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.graphqlErrors: emptyErrorsJSON.data(using: .utf8)!,
+                        CrossPlatformAttributes.graphqlErrors: emptyErrorsJSON,
                         CrossPlatformAttributes.graphqlOperationType: "query"
                     ],
                     kind: .xhr,


### PR DESCRIPTION
### What and why?

This PR changes GraphQL error handling to use a String-based JSON array format instead of iOS-specific `Data` type, enabling cross-platform SDKs to easily pass GraphQL errors without platform-specific conversions.

### How?

The iOS SDK now extracts only the errors array from GraphQL responses and converts it to a JSON string, which is decoded directly to `[GraphQLResponseError]` without wrapper structs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
