### PR TITLE
Add GraphQL to telemetry usage

### DIFF
--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -40,7 +40,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             firstPartyHosts: .init([
                 "www.example.com": [.datadog]
             ]),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
     }
 

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -181,6 +181,16 @@ public struct GraphQLHeaders {
     public static let payload: String = "_dd-custom-header-graph-ql-payload"
 }
 
+extension URLRequest {
+    /// Whether this request contains GraphQL headers indicating a GraphQL request.
+    public var hasGraphQLHeaders: Bool {
+        value(forHTTPHeaderField: GraphQLHeaders.operationName) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.operationType) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.variables) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.payload) != nil
+    }
+}
+
 public struct LaunchArguments {
     /// Each product should consider this argument to offer simple debugging experience. 
     /// For example, if this flag is present it can use no sampling.

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -118,6 +118,8 @@ public struct UsageTelemetry: SampledTelemetry {
         case addViewLoadingTime(ViewLoadingTime)
         /// addOperationStepVital API
         case addOperationStepVital(TelemetryUsageEvent.Telemetry.Usage.TelemetryCommonFeaturesUsage.AddOperationStepVital)
+        /// GraphQL request detected
+        case addGraphQLRequest
 
         /// Describes the properties of `addViewLoadingTime` usage telemetry.
         public struct ViewLoadingTime {

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -247,6 +247,10 @@ public class objc_RUMActionEventDDActionTarget: NSObject {
         root.swiftModel.dd.action!.target!.height as NSNumber?
     }
 
+    public var permanentId: String? {
+        root.swiftModel.dd.action!.target!.permanentId
+    }
+
     public var selector: String? {
         root.swiftModel.dd.action!.target!.selector
     }
@@ -7519,12 +7523,39 @@ public class objc_RUMViewEventViewPerformanceLCP: NSObject {
         get { root.swiftModel.view.performance!.lcp!.resourceUrl }
     }
 
+    public var subParts: objc_RUMViewEventViewPerformanceLCPSubParts? {
+        root.swiftModel.view.performance!.lcp!.subParts != nil ? objc_RUMViewEventViewPerformanceLCPSubParts(root: root) : nil
+    }
+
     public var targetSelector: String? {
         root.swiftModel.view.performance!.lcp!.targetSelector
     }
 
     public var timestamp: NSNumber {
         root.swiftModel.view.performance!.lcp!.timestamp as NSNumber
+    }
+}
+
+@objc(DDRUMViewEventViewPerformanceLCPSubParts)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewEventViewPerformanceLCPSubParts: NSObject {
+    internal let root: objc_RUMViewEvent
+
+    internal init(root: objc_RUMViewEvent) {
+        self.root = root
+    }
+
+    public var loadDelay: NSNumber {
+        root.swiftModel.view.performance!.lcp!.subParts!.loadDelay as NSNumber
+    }
+
+    public var loadTime: NSNumber {
+        root.swiftModel.view.performance!.lcp!.subParts!.loadTime as NSNumber
+    }
+
+    public var renderDelay: NSNumber {
+        root.swiftModel.view.performance!.lcp!.subParts!.renderDelay as NSNumber
     }
 }
 
@@ -12051,4 +12082,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/32918d999701fb7bfd876369e27ced77d6de1809
+// Generated from https://github.com/DataDog/rum-events-format/tree/6c939c467f255990d7941ce160e48823465e7780

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -375,6 +375,8 @@ private extension TelemetryUsageEvent.Telemetry.Usage {
                     )
                 )
             )
+        case .addGraphQLRequest:
+            self = .telemetryCommonFeaturesUsage(value: .graphQLRequest(value: .init()))
         }
     }
 }

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -72,7 +72,8 @@ extension InternalExtension where ExtendedType == RUM {
         let urlSessionHandler = URLSessionRUMResourcesHandler(
             dateProvider: rumConfiguration.dateProvider,
             rumAttributesProvider: configuration.resourceAttributesProvider,
-            distributedTracing: distributedTracing
+            distributedTracing: distributedTracing,
+            telemetry: core.telemetry
         )
 
         // Connect URLSession instrumentation to RUM monitor:

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -15,12 +15,14 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
 
     private func createHandler(
         rumAttributesProvider: RUM.ResourceAttributesProvider? = nil,
-        distributedTracing: DistributedTracing? = nil
+        distributedTracing: DistributedTracing? = nil,
+        telemetry: Telemetry = NOPTelemetry()
     ) -> URLSessionRUMResourcesHandler {
         let handler = URLSessionRUMResourcesHandler(
             dateProvider: dateProvider,
             rumAttributesProvider: rumAttributesProvider,
-            distributedTracing: distributedTracing
+            distributedTracing: distributedTracing,
+            telemetry: telemetry
         )
         handler.publish(to: commandSubscriber)
         return handler

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -18,6 +18,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
 
         /// The active span at the time of request instrumentation, if any, `nil` otherwise.
         let activeSpan: OTSpan?
+        /// Whether GraphQL headers were detected in the request
+        let hasGraphQLHeaders: Bool
     }
 
     /// Integration with Core Context.
@@ -28,6 +30,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
     let samplingRate: SampleRate
     /// Trace context injection configuration to determine whether the trace context should be injected or not.
     let traceContextInjection: TraceContextInjection
+    /// Telemetry interface for tracking SDK usage
+    let telemetry: Telemetry
 
     weak var tracer: DatadogTracer?
 
@@ -49,13 +53,15 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         contextReceiver: ContextMessageReceiver,
         samplingRate: SampleRate,
         firstPartyHosts: FirstPartyHosts,
-        traceContextInjection: TraceContextInjection
+        traceContextInjection: TraceContextInjection,
+        telemetry: Telemetry
     ) {
         self.tracer = tracer
         self.contextReceiver = contextReceiver
         self.samplingRate = samplingRate
         self.firstPartyHosts = firstPartyHosts
         self.traceContextInjection = traceContextInjection
+        self.telemetry = telemetry
     }
 
     func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?, URLSessionHandlerCapturedState?) {
@@ -140,10 +146,18 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
          Read the comment in interceptionDidStart(…) to know how this information propagates.
          */
 
+        // Detect GraphQL requests by checking for GraphQL headers
+        let hasGraphQLHeaders = request.hasGraphQLHeaders
+
+        // Return captured state with both active span and GraphQL detection
+        let capturedState: URLSessionHandlerCapturedState? = (tracer.activeSpan != nil || hasGraphQLHeaders)
+            ? TracingURLSessionHandlerCapturedState(activeSpan: tracer.activeSpan, hasGraphQLHeaders: hasGraphQLHeaders)
+            : nil
+
         return (
             request,
             hasSetAnyHeader ? injectedSpanContext : nil,
-            tracer.activeSpan.map { TracingURLSessionHandlerCapturedState(activeSpan: $0) }
+            capturedState
         )
     }
 
@@ -163,8 +177,18 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
          span is used.
          */
         // TODO: RUM-13769 This code can be simplified since we never use more than one handler simultaneously.
-        capturedStates.compactMap({ ($0 as? TracingURLSessionHandlerCapturedState)?.activeSpan }).first.map {
+        let capturedState = capturedStates.compactMap({ $0 as? TracingURLSessionHandlerCapturedState }).first
+
+        capturedState?.activeSpan.map {
             interception.register(activeSpanContext: $0.context)
+        }
+
+        // Check if GraphQL was detected in the captured state
+        if capturedState?.hasGraphQLHeaders == true {
+            telemetry.send(telemetry: .usage(.init(
+                event: .addGraphQLRequest,
+                sampleRate: UsageTelemetry.defaultSampleRate
+            )))
         }
     }
 
@@ -340,5 +364,14 @@ private extension HTTPURLResponse {
         }
         let message = "\(statusCode) " + HTTPURLResponse.localizedString(forStatusCode: statusCode)
         return NSError(domain: "HTTPURLResponse", code: statusCode, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+private extension URLRequest {
+    var hasGraphQLHeaders: Bool {
+        value(forHTTPHeaderField: GraphQLHeaders.operationName) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.operationType) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.variables) != nil ||
+        value(forHTTPHeaderField: GraphQLHeaders.payload) != nil
     }
 }

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -68,7 +68,8 @@ public enum Trace {
                 contextReceiver: trace.contextReceiver,
                 samplingRate: configuration.debugSDK ? 100 : tracingSampleRate,
                 firstPartyHosts: firstPartyHosts,
-                traceContextInjection: traceContextInjection
+                traceContextInjection: traceContextInjection,
+                telemetry: core.telemetry
             )
 
             try core.register(urlSessionHandler: urlSessionHandler)

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -35,7 +35,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             firstPartyHosts: .init([
                 "www.example.com": [.datadog]
             ]),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
     }
 
@@ -51,7 +52,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         // When
@@ -99,7 +101,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         // When
@@ -155,7 +158,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: 0,
             firstPartyHosts: .init(),
-            traceContextInjection: .sampled
+            traceContextInjection: .sampled,
+            telemetry: NOPTelemetry()
         )
 
         // When
@@ -196,7 +200,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         let span = tracer.startRootSpan(operationName: "root")
@@ -248,7 +253,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         let span = tracer.startRootSpan(operationName: "root")
@@ -301,7 +307,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         let span = tracer.startRootSpan(operationName: "root")
@@ -354,7 +361,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: ContextMessageReceiver(),
             samplingRate: 0,
             firstPartyHosts: .init(),
-            traceContextInjection: .sampled
+            traceContextInjection: .sampled,
+            telemetry: NOPTelemetry()
         )
 
         let span = tracer.startRootSpan(operationName: "root")
@@ -579,7 +587,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
             contextReceiver: receiver,
             samplingRate: .maxSampleRate,
             firstPartyHosts: .init(),
-            traceContextInjection: .all
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry()
         )
 
         core.context.applicationStateHistory = .mockAppInForeground()


### PR DESCRIPTION
### What and why?

This PR updates the `RUMDataModels` and then adds telemetry usage for GraphQL applied with the default sample rate of 15%.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
