### PR TITLE
Fix protocol conformance

### DIFF
--- a/DatadogFlags/Sources/Feature/FlagsEvaluationFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsEvaluationFeature.swift
@@ -12,7 +12,7 @@ internal struct FlagsEvaluationFeature: DatadogRemoteFeature {
 
     let requestBuilder: any FeatureRequestBuilder
     let messageReceiver: any FeatureMessageReceiver
-    let performanceOverride: PerformancePresetOverride
+    let performanceOverride: PerformancePresetOverride?
 
     init(
         customIntakeURL: URL?,


### PR DESCRIPTION
### What and why?

CI is red because the recent change of protocol in [this PR](https://github.com/DataDog/dd-sdk-ios/pull/2667) hasn't been included in [this PR](https://github.com/DataDog/dd-sdk-ios/pull/2646)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
