### PR TITLE
RUM-14354 Add watchOS support to TestUtilities

### DIFF
--- a/TestUtilities/Package.swift
+++ b/TestUtilities/Package.swift
@@ -4,10 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "TestUtilities",
-    platforms: [
-        .iOS(.v11),
-        .tvOS(.v11),
-    ],
+    platforms: [.iOS(.v12), .tvOS(.v12), .macOS(.v12), .watchOS(.v7)],
     products: [
         .library(
             name: "TestUtilities",

--- a/TestUtilities/Sources/Helpers/UIKitHelpers.swift
+++ b/TestUtilities/Sources/Helpers/UIKitHelpers.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if !os(watchOS)
 import UIKit
 
 /// The library name for UIKit framework as it will appear in unsymbolicated stack trace.
@@ -47,3 +48,4 @@ extension UIView {
         return result
     }
 }
+#endif

--- a/TestUtilities/Sources/Mocks/DatadogRUM/MediaTimeProviderMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/MediaTimeProviderMock.swift
@@ -13,9 +13,15 @@ import QuartzCore
 public final class MediaTimeProviderMock: CACurrentMediaTimeProvider {
     private let _current: ReadWriteLock<CFTimeInterval>
 
+    #if os(watchOS)
+    public init(current: CFTimeInterval = 0) {
+        self._current = .init(wrappedValue: current)
+    }
+    #else
     public init(current: CFTimeInterval = CACurrentMediaTime()) {
         self._current = .init(wrappedValue: current)
     }
+    #endif
 
     public var current: CFTimeInterval {
         get { _current.wrappedValue }

--- a/TestUtilities/Sources/Mocks/DatadogRUM/WatchdogTerminationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/WatchdogTerminationMocks.swift
@@ -90,6 +90,7 @@ public final class WatchdogTerminationReporterMock: WatchdogTerminationReporting
     }
 }
 
+#if !os(watchOS)
 extension WatchdogTerminationReporter: RandomMockable {
     public static func mockRandom() -> Self {
         .init(
@@ -99,6 +100,7 @@ extension WatchdogTerminationReporter: RandomMockable {
         )
     }
 }
+#endif
 
 extension WatchdogTerminationChecker: RandomMockable {
     public static func mockRandom() -> WatchdogTerminationChecker {
@@ -131,6 +133,7 @@ extension RUMDataStore: RandomMockable {
     }
 }
 
+#if !os(watchOS)
 extension WatchdogTerminationMonitor: RandomMockable {
     public static func mockRandom() -> WatchdogTerminationMonitor {
         return .init(
@@ -142,6 +145,7 @@ extension WatchdogTerminationMonitor: RandomMockable {
         )
     }
 }
+#endif
 
 extension LaunchReport: RandomMockable {
     public static func mockRandom() -> DatadogInternal.LaunchReport {

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/CoreGraphicsMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/CoreGraphicsMocks.swift
@@ -5,7 +5,9 @@
  */
 
 import CoreGraphics
+#if !os(watchOS)
 import UIKit
+#endif
 
 extension CGFloat: AnyMockable, RandomMockable {
     public static func mockAny() -> CGFloat {
@@ -91,6 +93,7 @@ extension CGSize: AnyMockable, RandomMockable {
     }
 }
 
+#if !os(watchOS)
 extension CGColor: AnyMockable, RandomMockable {
     public static func mockAny() -> Self {
         return UIColor.mockAny().cgColor as! Self
@@ -100,3 +103,4 @@ extension CGColor: AnyMockable, RandomMockable {
         return UIColor.mockRandom().cgColor as! Self
     }
 }
+#endif

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/UIKitMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/UIKitMocks.swift
@@ -4,8 +4,33 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if canImport(UIKit)
 import UIKit
+
+#if os(watchOS)
+
+import WatchKit
+
+public class UIDeviceMock: WKInterfaceDevice {
+    override public var model: String { _model }
+    override public var systemName: String { _systemName }
+    override public var systemVersion: String { _systemVersion }
+
+    private var _model: String
+    private var _systemName: String
+    private var _systemVersion: String
+
+    public init(
+        model: String = .mockAny(),
+        systemName: String = .mockAny(),
+        systemVersion: String = .mockAny()
+    ) {
+        self._model = model
+        self._systemName = systemName
+        self._systemVersion = systemVersion
+    }
+}
+
+#else
 
 public class UIDeviceMock: UIDevice {
     override public var model: String { _model }
@@ -85,8 +110,6 @@ extension UIDevice.BatteryState: AnyMockable {
         return .full
     }
 }
-#endif
-
 #endif
 
 extension UIEvent {
@@ -319,3 +342,5 @@ extension UIImage: RandomMockable {
         return UIImage(cgImage: cgImage) as! Self
     }
 }
+
+#endif

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/WebKitMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/WebKitMocks.swift
@@ -4,7 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(tvOS)
+#if canImport(WebKit)
 import Foundation
 import WebKit
 @testable import DatadogWebViewTracking


### PR DESCRIPTION
### What and why?

This PR adds watchOS support to the TestUtilities module, which is a prerequisite for enabling watchOS support across other SDK modules.

### How?

- Added watchOS platform support to Package.swift
- Updated mocks to support watchOS platform with appropriate conditional compilation
- Extended UIKit helpers and mocks with watchOS compatibility

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs