### PR TITLE
RUM-14354 Disable web view tracking on watchOS

### DIFF
--- a/DatadogWebViewTracking/Sources/DDScriptMessageHandler.swift
+++ b/DatadogWebViewTracking/Sources/DDScriptMessageHandler.swift
@@ -4,7 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(tvOS)
+#if canImport(WebKit)
 
 import Foundation
 import WebKit

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -7,9 +7,7 @@
 import Foundation
 import DatadogInternal
 
-#if os(tvOS)
-#warning("Datadog WebView Tracking does not support tvOS")
-#else
+#if canImport(WebKit)
 import WebKit
 
 @objc(DDWebViewTracking)

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -7,9 +7,7 @@
 import Foundation
 import DatadogInternal
 
-#if os(tvOS)
-#warning("Datadog WebView Tracking does not support tvOS")
-#else
+#if canImport(WebKit)
 import WebKit
 #endif
 
@@ -24,7 +22,7 @@ import WebKit
 /// - Scope the root cause of latency to web pages or native components in mobile applications
 /// - Support users that have difficulty loading web pages on mobile devices
 public enum WebViewTracking {
-#if !os(tvOS)
+#if canImport(WebKit)
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session.
     /// 
     /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -4,7 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(tvOS)
+#if canImport(WebKit)
 
 import XCTest
 import WebKit

--- a/TestUtilities/Sources/Mocks/DatadogWebViewTracking/WebViewTrackingMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogWebViewTracking/WebViewTrackingMocks.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-#if !os(tvOS)
+#if canImport(WebKit)
 import WebKit
 
 @testable import DatadogWebViewTracking


### PR DESCRIPTION
### What and why?

This PR disables web view tracking on watchOS since WKWebView and related WebKit APIs are not available on watchOS.

### How?

- Updated platform availability annotations across WebViewTracking sources and tests

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs