### PR TITLE
Ignore local Claude settings files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pycache__
 
 # CI job artifacts
 artifacts/
+
+# AI files
+.claude/settings.local.json


### PR DESCRIPTION
### What and why?

Add `.claude/settings.local.json` to `.gitignore` so that developers' local Claude Code settings are not accidentally committed to the repository. These files contain per-user preferences and should remain local.

### How?

Added a new "AI files" section to `.gitignore` with the `.claude/settings.local.json` pattern.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs 
- [ ] Run `make api-surface` when adding new APIs 