### PR TITLE
[PANA-5863] Prevent re-entrant captures in `RecordingCoordinator`

### DIFF
--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -174,6 +174,26 @@ class RecordingCoordinatorTests: XCTestCase {
         XCTAssertEqual(metric.name, "Method Called")
     }
 
+    func test_whenCaptureReenters_itSkipsNestedCapture() {
+        // Given
+        var didTriggerReentry = false
+        recordingMock.captureNextRecordClosure = { _ in
+            guard !didTriggerReentry else {
+                return
+            }
+
+            didTriggerReentry = true
+            self.scheduler.start()
+        }
+        prepareRecordingCoordinator()
+
+        // When
+        rumContextObserver.notify(rumContext: .mockRandom())
+
+        // Then
+        XCTAssertEqual(recordingMock.captureNextRecordCallsCount, 1)
+    }
+
     // MARK: StartRecordingImmediately Initialization Tests
 
     func test_whenStartRecordingImmediatelyIsDefault_itShouldRecord() throws {


### PR DESCRIPTION
### What and why?

This PR prevents nested Session Replay capture execution in `RecordingCoordinator`.

The Mobile App team reported an intermittent blank modal issue, reproducible only when screen-change scheduling was enabled. One likely cause is re-entrant capture calls triggered while a capture is already in progress. This change enforces a single in-flight capture to avoid recursive capture loops.

### How?

- Added a re-entrancy guard in `RecordingCoordinator.captureNextRecord()`
- Added regression coverage.
  - `test_whenCaptureReenters_itSkipsNestedCapture` simulates re-entry by triggering scheduler execution during `captureNextRecord` and verifies only one capture is executed.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
