### PR TITLE
Propagate feature flags to fatal error RUM events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [IMPROVEMENT] Skip malformed Logs attributes individually instead of dropping the entire event, and log clear error messages. See [#2665][]
 - [IMPROVEMENT] Improve span attribute encoding error messages to include attribute name and context. See [#2676][]
 - [IMPROVEMENT] Expose public entities from `DatadogInternal` to prevent `DatadogInternal` imports in customer code. See [#2666][]
+- [FIX] Propagate feature flags to RUM error and view events for crashes, fatal app hangs, and watchdog terminations.
 
 # 3.6.1 / 02-02-2026
 

--- a/DatadogRUM/Sources/FatalErrorBuilder.swift
+++ b/DatadogRUM/Sources/FatalErrorBuilder.swift
@@ -119,6 +119,7 @@ internal struct FatalErrorBuilder {
                 type: errorType,
                 wasTruncated: errorWasTruncated
             ),
+            featureFlags: lastRUMView.featureFlags.map { .init(featureFlagsInfo: $0.featureFlagsInfo) },
             freeze: nil, // `@error.freeze.duration` is not yet supported for fatal App Hangs
             os: lastRUMView.os,
             service: lastRUMView.service,
@@ -167,6 +168,7 @@ internal struct FatalErrorBuilder {
             ddtags: context.ddTags,
             device: original.device,
             display: original.display,
+            featureFlags: original.featureFlags,
             os: original.os,
             privacy: original.privacy,
             service: original.service,

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -241,7 +241,8 @@ extension RUMViewEvent: RandomMockable {
         viewTimeSpent: Int64 = .mockRandom(),
         viewURL: String = .mockRandom(),
         crashCount: Int64? = nil,
-        hasReplay: Bool? = nil
+        hasReplay: Bool? = nil,
+        featureFlags: RUMViewEvent.FeatureFlags? = nil
     ) -> RUMViewEvent {
         return RUMViewEvent(
             dd: .init(
@@ -268,6 +269,7 @@ extension RUMViewEvent: RandomMockable {
             ddtags: .mockRandomDDTags(),
             device: .mockRandom(),
             display: nil,
+            featureFlags: featureFlags,
             os: .mockRandom(),
             privacy: nil,
             service: .mockRandom(),


### PR DESCRIPTION
## Summary

- Fix missing `featureFlags` propagation in `FatalErrorBuilder` when constructing RUM error and view events for crashes, fatal app hangs, and watchdog terminations
- Feature flags present on the last RUM view were silently dropped in the resulting events sent to the backend
- Add test coverage for feature flags propagation in `CrashReportReceiverTests`

## Changes

- **`FatalErrorBuilder.createRUMError()`**: pass `featureFlags` from the last `RUMViewEvent` to the `RUMErrorEvent`
- **`FatalErrorBuilder.updateRUMViewWithError()`**: preserve `featureFlags` from the original `RUMViewEvent`
- **`RUMDataModelMocks`**: thread `featureFlags` parameter through `mockRandomWith()`
- **`CHANGELOG.md`**: add `[FIX]` entry under Unreleased

## Test plan

- [x] New test `testGivenCrashDuringRUMSessionWithActiveViewAndFeatureFlags_itSendsEventsWithFeatureFlags` verifies both error and view events propagate feature flags
- [x] All 25 existing `CrashReportReceiverTests` pass (no regressions)
- [x] SwiftLint passes with 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)