### PR TITLE
Use dd-octo-sts to clone snapshot repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,9 +187,11 @@ UI Tests:
 
 SR Snapshot Tests:
   stage: ui-test
-  rules: 
+  rules:
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
+  id_tokens:
+    <<: *dd-octo-sts-id-token
   variables:
     PLATFORM: "iOS Simulator"
     IOS_OS: "17.5"

--- a/tools/sr-snapshot-test.sh
+++ b/tools/sr-snapshot-test.sh
@@ -41,6 +41,13 @@ TEST_SCHEME="SRSnapshotTests"
 TEST_WORKSPACE="$REPO_ROOT/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace"
 TEST_ARTIFACTS_PATH="$REPO_ROOT/$artifacts_path/sr-snapshot-tests"
 
+# On CI, get GitHub token for accessing snapshots repository
+if [ "$CI" = "true" ] && [ -z "$GH_TOKEN" ]; then
+    export GH_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/dd-mobile-session-replay-snapshots --policy dd-sdk-ios)
+    # Set up trap to always revoke token on script exit (success, failure, or interruption)
+    trap 'dd-octo-sts --disable-tracing revoke --token $GH_TOKEN' EXIT
+fi
+
 pull_snapshots() {
     echo_subtitle "Pull SR snapshots to '$SNAPSHOTS_DIR'"
     cd "$SNAPSHOTS_CLI_PATH"


### PR DESCRIPTION
### What and why?

- Allow cloning Snapshots repo using GH token
- Use dd-octo-sts to get a short-lived/read-only token

Use policy added in https://github.com/DataDog/dd-mobile-session-replay-snapshots/pull/3

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
