### PR TITLE
RUM-14503 Add request encoded and decoded body sizes to RUM resource events

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -929,6 +929,7 @@ public struct RUMActionEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -1043,6 +1044,7 @@ public struct RUMActionEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -1671,6 +1673,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -2337,6 +2340,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -2945,6 +2949,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -3246,6 +3251,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -3744,6 +3750,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -3819,7 +3826,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Connect phase properties
         public let connect: Connect?
 
-        /// Size in octet of the resource after removing any applied encoding
+        /// Size in octet of the response body after removing any applied encoding
         public let decodedBodySize: Int64?
 
         /// Delivery type of the resource
@@ -3834,7 +3841,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Duration of the resource
         public let duration: Int64?
 
-        /// Size in octet of the resource before removing any applied content encodings
+        /// Size in octet of the response body before removing any applied content encodings
         public let encodedBodySize: Int64?
 
         /// First Byte phase properties
@@ -3861,6 +3868,9 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Render blocking status of the resource
         public let renderBlockingStatus: RenderBlockingStatus?
 
+        /// Request properties
+        public let request: Request?
+
         /// Size in octet of the resource response body
         public let size: Int64?
 
@@ -3870,7 +3880,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// HTTP status code of the resource
         public let statusCode: Int64?
 
-        /// Size in octet of the fetched resource
+        /// Size in octet of the fetched response resource
         public let transferSize: Int64?
 
         /// Resource type
@@ -3898,6 +3908,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case provider = "provider"
             case redirect = "redirect"
             case renderBlockingStatus = "render_blocking_status"
+            case request = "request"
             case size = "size"
             case ssl = "ssl"
             case statusCode = "status_code"
@@ -3911,12 +3922,12 @@ public struct RUMResourceEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - connect: Connect phase properties
-        ///   - decodedBodySize: Size in octet of the resource after removing any applied encoding
+        ///   - decodedBodySize: Size in octet of the response body after removing any applied encoding
         ///   - deliveryType: Delivery type of the resource
         ///   - dns: DNS phase properties
         ///   - download: Download phase properties
         ///   - duration: Duration of the resource
-        ///   - encodedBodySize: Size in octet of the resource before removing any applied content encodings
+        ///   - encodedBodySize: Size in octet of the response body before removing any applied content encodings
         ///   - firstByte: First Byte phase properties
         ///   - graphql: GraphQL requests parameters
         ///   - id: UUID of the resource
@@ -3925,10 +3936,11 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - provider: The provider for this resource
         ///   - redirect: Redirect phase properties
         ///   - renderBlockingStatus: Render blocking status of the resource
+        ///   - request: Request properties
         ///   - size: Size in octet of the resource response body
         ///   - ssl: SSL phase properties
         ///   - statusCode: HTTP status code of the resource
-        ///   - transferSize: Size in octet of the fetched resource
+        ///   - transferSize: Size in octet of the fetched response resource
         ///   - type: Resource type
         ///   - url: URL of the resource
         ///   - worker: Worker phase properties
@@ -3948,6 +3960,7 @@ public struct RUMResourceEvent: RUMDataModel {
             provider: Provider? = nil,
             redirect: Redirect? = nil,
             renderBlockingStatus: RenderBlockingStatus? = nil,
+            request: Request? = nil,
             size: Int64? = nil,
             ssl: SSL? = nil,
             statusCode: Int64? = nil,
@@ -3971,6 +3984,7 @@ public struct RUMResourceEvent: RUMDataModel {
             self.provider = provider
             self.redirect = redirect
             self.renderBlockingStatus = renderBlockingStatus
+            self.request = request
             self.size = size
             self.ssl = ssl
             self.statusCode = statusCode
@@ -4351,6 +4365,33 @@ public struct RUMResourceEvent: RUMDataModel {
             case nonBlocking = "non-blocking"
         }
 
+        /// Request properties
+        public struct Request: Codable {
+            /// Size in octet of the request body before any encoding
+            public let decodedBodySize: Int64?
+
+            /// Size in octet of the request body sent over the network (after encoding)
+            public let encodedBodySize: Int64?
+
+            public enum CodingKeys: String, CodingKey {
+                case decodedBodySize = "decoded_body_size"
+                case encodedBodySize = "encoded_body_size"
+            }
+
+            /// Request properties
+            ///
+            /// - Parameters:
+            ///   - decodedBodySize: Size in octet of the request body before any encoding
+            ///   - encodedBodySize: Size in octet of the request body sent over the network (after encoding)
+            public init(
+                decodedBodySize: Int64? = nil,
+                encodedBodySize: Int64? = nil
+            ) {
+                self.decodedBodySize = decodedBodySize
+                self.encodedBodySize = encodedBodySize
+            }
+        }
+
         /// SSL phase properties
         public struct SSL: Codable {
             /// Duration in ns of the resource ssl phase
@@ -4465,6 +4506,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -5331,6 +5373,7 @@ public struct RUMViewEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -5549,6 +5592,7 @@ public struct RUMViewEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -6723,6 +6767,9 @@ public struct RUMViewEvent: RUMDataModel {
                 /// Longest duration in ns between an interaction and the next paint
                 public let duration: Int64
 
+                /// Sub-parts of the INP
+                public let subParts: SubParts?
+
                 /// CSS selector path of the interacted element for the INP interaction
                 public let targetSelector: String?
 
@@ -6731,6 +6778,7 @@ public struct RUMViewEvent: RUMDataModel {
 
                 public enum CodingKeys: String, CodingKey {
                     case duration = "duration"
+                    case subParts = "sub_parts"
                     case targetSelector = "target_selector"
                     case timestamp = "timestamp"
                 }
@@ -6739,16 +6787,53 @@ public struct RUMViewEvent: RUMDataModel {
                 ///
                 /// - Parameters:
                 ///   - duration: Longest duration in ns between an interaction and the next paint
+                ///   - subParts: Sub-parts of the INP
                 ///   - targetSelector: CSS selector path of the interacted element for the INP interaction
                 ///   - timestamp: Time of the start of the INP interaction, in ns since view start.
                 public init(
                     duration: Int64,
+                    subParts: SubParts? = nil,
                     targetSelector: String? = nil,
                     timestamp: Int64? = nil
                 ) {
                     self.duration = duration
+                    self.subParts = subParts
                     self.targetSelector = targetSelector
                     self.timestamp = timestamp
+                }
+
+                /// Sub-parts of the INP
+                public struct SubParts: Codable {
+                    /// Time from the start of the input event to the start of the processing of the event
+                    public let inputDelay: Int64
+
+                    /// Rendering time happening after processing
+                    public let presentationDelay: Int64
+
+                    /// Event handler execution time
+                    public let processingTime: Int64
+
+                    public enum CodingKeys: String, CodingKey {
+                        case inputDelay = "input_delay"
+                        case presentationDelay = "presentation_delay"
+                        case processingTime = "processing_time"
+                    }
+
+                    /// Sub-parts of the INP
+                    ///
+                    /// - Parameters:
+                    ///   - inputDelay: Time from the start of the input event to the start of the processing of the event
+                    ///   - presentationDelay: Rendering time happening after processing
+                    ///   - processingTime: Event handler execution time
+                    public init(
+                        inputDelay: Int64,
+                        presentationDelay: Int64,
+                        processingTime: Int64
+                    ) {
+                        self.inputDelay = inputDelay
+                        self.presentationDelay = presentationDelay
+                        self.processingTime = processingTime
+                    }
                 }
             }
 
@@ -7365,6 +7450,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -7479,6 +7565,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -7987,6 +8074,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -8101,6 +8189,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -8569,6 +8658,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             case roku = "roku"
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
+            case electron = "electron"
         }
 
         /// Attributes of the view's container
@@ -8683,6 +8773,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case roku = "roku"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// Stream properties
@@ -9003,6 +9094,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         case reactNative = "react-native"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// The telemetry configuration information
@@ -9835,6 +9927,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             public enum SessionPersistence: String, Codable {
                 case localStorage = "local-storage"
                 case cookie = "cookie"
+                case memory = "memory"
             }
 
             /// The opt-in configuration to add trace context
@@ -10133,6 +10226,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         case reactNative = "react-native"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// The telemetry log information
@@ -10420,6 +10514,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         case reactNative = "react-native"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// The telemetry log information
@@ -10743,6 +10838,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         case reactNative = "react-native"
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
     }
 
     /// The telemetry usage information
@@ -11522,4 +11618,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/6c939c467f255990d7941ce160e48823465e7780
+// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -233,6 +233,11 @@ public struct ResourceMetrics {
     /// - `decoded`: Size after decoding/decompression.
     public let responseBodySize: (encoded: Int64, decoded: Int64)?
 
+    /// The size of the request body.
+    /// - `encoded`: Size after encoding (sent over the network).
+    /// - `decoded`: Size before encoding (original content size).
+    public let requestBodySize: (encoded: Int64, decoded: Int64)?
+
     public init(
         fetch: DateInterval,
         redirection: DateInterval?,
@@ -241,7 +246,8 @@ public struct ResourceMetrics {
         ssl: DateInterval?,
         firstByte: DateInterval?,
         download: DateInterval?,
-        responseBodySize: (encoded: Int64, decoded: Int64)? = nil
+        responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) {
         self.fetch = fetch
         self.redirection = redirection
@@ -251,6 +257,7 @@ public struct ResourceMetrics {
         self.firstByte = firstByte
         self.download = download
         self.responseBodySize = responseBodySize
+        self.requestBodySize = requestBodySize
     }
 }
 
@@ -292,6 +299,7 @@ extension ResourceMetrics {
         var firstByte: DateInterval? = nil
         var download: DateInterval? = nil
         var responseBodySize: (encoded: Int64, decoded: Int64)? = nil
+        var requestBodySize: (encoded: Int64, decoded: Int64)? = nil
 
         if let mainTransaction = mainTransaction {
             if let dnsStart = mainTransaction.domainLookupStartDate,
@@ -324,6 +332,10 @@ extension ResourceMetrics {
                 let responseDecoded = mainTransaction.countOfResponseBodyBytesAfterDecoding
 
                 responseBodySize = (encoded: responseEncoded, decoded: responseDecoded)
+
+                let requestEncoded = mainTransaction.countOfRequestBodyBytesSent
+                let requestDecoded = mainTransaction.countOfRequestBodyBytesBeforeEncoding
+                requestBodySize = (encoded: requestEncoded, decoded: requestDecoded)
             }
         }
 
@@ -335,7 +347,8 @@ extension ResourceMetrics {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            responseBodySize: responseBodySize
+            responseBodySize: responseBodySize,
+            requestBodySize: requestBodySize
         )
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -185,6 +185,8 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.download?.end, taskTransaction.responseEndDate!)
         XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, taskTransaction.countOfResponseBodyBytesReceived)
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, taskTransaction.countOfResponseBodyBytesAfterDecoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, taskTransaction.countOfRequestBodyBytesBeforeEncoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, taskTransaction.countOfRequestBodyBytesSent)
     }
 
     func testWhenTaskMakesMultipleFetchesFromNetwork_thenAllMetricsAreCollected() {
@@ -247,6 +249,8 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.download?.end, transaction3.responseEndDate!)
         XCTAssertEqual(resourceMetrics.responseBodySize?.encoded, transaction3.countOfResponseBodyBytesReceived)
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, transaction3.countOfResponseBodyBytesAfterDecoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, transaction3.countOfRequestBodyBytesBeforeEncoding)
+        XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, transaction3.countOfRequestBodyBytesSent)
     }
 
     func testWhenTaskMakesFetchFromLocalCache_thenOnlyFetchMetricIsCollected() {
@@ -301,6 +305,10 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertNil(
             resourceMetrics.responseBodySize,
             "`responseBodySize` should not be tracked for cache transactions."
+        )
+        XCTAssertNil(
+            resourceMetrics.requestBodySize,
+            "`requestBodySize` should not be tracked for cache transactions."
         )
     }
 }

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -808,6 +808,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -821,6 +822,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -832,6 +834,7 @@ public enum objc_RUMActionEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMActionEventContainerView)
@@ -1093,6 +1096,7 @@ public enum objc_RUMActionEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -1107,6 +1111,7 @@ public enum objc_RUMActionEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -1119,6 +1124,7 @@ public enum objc_RUMActionEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMActionEventStream)
@@ -1760,6 +1766,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -1773,6 +1780,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -1784,6 +1792,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMErrorEventContainerView)
@@ -2675,6 +2684,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -2689,6 +2699,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -2701,6 +2712,7 @@ public enum objc_RUMErrorEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMErrorEventStream)
@@ -3421,6 +3433,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -3434,6 +3447,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -3445,6 +3459,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMLongTaskEventContainerView)
@@ -3873,6 +3888,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -3887,6 +3903,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -3899,6 +3916,7 @@ public enum objc_RUMLongTaskEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMLongTaskEventStream)
@@ -4548,6 +4566,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -4561,6 +4580,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -4572,6 +4592,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMResourceEventContainerView)
@@ -4840,6 +4861,10 @@ public class objc_RUMResourceEventResource: NSObject {
 
     public var renderBlockingStatus: objc_RUMResourceEventResourceRenderBlockingStatus {
         .init(swift: root.swiftModel.resource.renderBlockingStatus)
+    }
+
+    public var request: objc_RUMResourceEventResourceRequest? {
+        root.swiftModel.resource.request != nil ? objc_RUMResourceEventResourceRequest(root: root) : nil
     }
 
     public var size: NSNumber? {
@@ -5284,6 +5309,25 @@ public enum objc_RUMResourceEventResourceRenderBlockingStatus: Int {
     case nonBlocking
 }
 
+@objc(DDRUMResourceEventResourceRequest)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceRequest: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var decodedBodySize: NSNumber? {
+        root.swiftModel.resource.request!.decodedBodySize as NSNumber?
+    }
+
+    public var encodedBodySize: NSNumber? {
+        root.swiftModel.resource.request!.encodedBodySize as NSNumber?
+    }
+}
+
 @objc(DDRUMResourceEventResourceSSL)
 @objcMembers
 @_spi(objc)
@@ -5431,6 +5475,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -5445,6 +5490,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -5457,6 +5503,7 @@ public enum objc_RUMResourceEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMResourceEventStream)
@@ -6237,6 +6284,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -6250,6 +6298,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -6261,6 +6310,7 @@ public enum objc_RUMViewEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMViewEventContainerView)
@@ -6616,6 +6666,7 @@ public enum objc_RUMViewEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -6630,6 +6681,7 @@ public enum objc_RUMViewEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -6642,6 +6694,7 @@ public enum objc_RUMViewEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMViewEventStream)
@@ -7499,12 +7552,39 @@ public class objc_RUMViewEventViewPerformanceINP: NSObject {
         root.swiftModel.view.performance!.inp!.duration as NSNumber
     }
 
+    public var subParts: objc_RUMViewEventViewPerformanceINPSubParts? {
+        root.swiftModel.view.performance!.inp!.subParts != nil ? objc_RUMViewEventViewPerformanceINPSubParts(root: root) : nil
+    }
+
     public var targetSelector: String? {
         root.swiftModel.view.performance!.inp!.targetSelector
     }
 
     public var timestamp: NSNumber? {
         root.swiftModel.view.performance!.inp!.timestamp as NSNumber?
+    }
+}
+
+@objc(DDRUMViewEventViewPerformanceINPSubParts)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewEventViewPerformanceINPSubParts: NSObject {
+    internal let root: objc_RUMViewEvent
+
+    internal init(root: objc_RUMViewEvent) {
+        self.root = root
+    }
+
+    public var inputDelay: NSNumber {
+        root.swiftModel.view.performance!.inp!.subParts!.inputDelay as NSNumber
+    }
+
+    public var presentationDelay: NSNumber {
+        root.swiftModel.view.performance!.inp!.subParts!.presentationDelay as NSNumber
+    }
+
+    public var processingTime: NSNumber {
+        root.swiftModel.view.performance!.inp!.subParts!.processingTime as NSNumber
     }
 }
 
@@ -8160,6 +8240,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -8173,6 +8254,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -8184,6 +8266,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalAppLaunchEventContainerView)
@@ -8445,6 +8528,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -8459,6 +8543,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -8471,6 +8556,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalAppLaunchEventStream)
@@ -9148,6 +9234,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -9161,6 +9248,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -9172,6 +9260,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalDurationEventContainerView)
@@ -9433,6 +9522,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -9447,6 +9537,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -9459,6 +9550,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalDurationEventStream)
@@ -10075,6 +10167,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .roku: self = .roku
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -10088,6 +10181,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -10099,6 +10193,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalOperationStepEventContainerView)
@@ -10360,6 +10455,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .roku?: self = .roku
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
         }
     }
 
@@ -10374,6 +10470,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -10386,6 +10483,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
     case roku
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDRUMVitalOperationStepEventStream)
@@ -10717,6 +10815,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .reactNative: self = .reactNative
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -10729,6 +10828,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .reactNative: return .reactNative
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -10739,6 +10839,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
     case reactNative
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDTelemetryConfigurationEventTelemetry)
@@ -11319,6 +11420,7 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationSessionPersist
         case nil: self = .none
         case .localStorage?: self = .localStorage
         case .cookie?: self = .cookie
+        case .memory?: self = .memory
         }
     }
 
@@ -11327,12 +11429,14 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationSessionPersist
         case .none: return nil
         case .localStorage: return .localStorage
         case .cookie: return .cookie
+        case .memory: return .memory
         }
     }
 
     case none
     case localStorage
     case cookie
+    case memory
 }
 
 @objc(DDTelemetryConfigurationEventTelemetryConfigurationTraceContextInjection)
@@ -11655,6 +11759,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .reactNative: self = .reactNative
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -11667,6 +11772,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .reactNative: return .reactNative
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -11677,6 +11783,7 @@ public enum objc_TelemetryDebugEventSource: Int {
     case reactNative
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDTelemetryDebugEventTelemetry)
@@ -11924,6 +12031,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .reactNative: self = .reactNative
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
         }
     }
 
@@ -11936,6 +12044,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .reactNative: return .reactNative
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 
@@ -11946,6 +12055,7 @@ public enum objc_TelemetryErrorEventSource: Int {
     case reactNative
     case unity
     case kotlinMultiplatform
+    case electron
 }
 
 @objc(DDTelemetryErrorEventTelemetry)
@@ -12082,4 +12192,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/6c939c467f255990d7941ce160e48823465e7780
+// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d

--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -57,6 +57,7 @@ internal extension RUMViewEvent.Source {
         case .roku: return .roku
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
         }
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -171,6 +171,13 @@ internal class RUMResourceScope: RUMScope {
         let encodedBodySize = resourceMetrics?.responseBodySize?.encoded
         let decodedBodySize = resourceMetrics?.responseBodySize?.decoded
 
+        let request: RUMResourceEvent.Resource.Request? = resourceMetrics?.requestBodySize.map { size in
+            .init(
+                decodedBodySize: size.decoded,
+                encodedBodySize: size.encoded
+            )
+        }
+
         // Write resource event
         let resourceEvent = RUMResourceEvent(
             dd: .init(
@@ -245,6 +252,7 @@ internal class RUMResourceScope: RUMScope {
                     )
                 },
                 renderBlockingStatus: nil,
+                request: request,
                 size: size ?? 0,
                 ssl: resourceMetrics?.ssl.map { metric in
                     .init(

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Internal.swift
@@ -128,6 +128,7 @@ public struct DatadogInternalInterface {
     ///   - firstByte: properties of the TTFB phase for the resource.
     ///   - download: properties of the download phase for the resource.
     ///   - responseBodySize: the response body sizes (encoded: received bytes, decoded: decompressed bytes).
+    ///   - requestBodySize: the request body sizes (encoded: sent bytes, decoded: original bytes before encoding).
     ///   - attributes: attributes to process along with this call
     public func addResourceMetrics(
         at time: Date,
@@ -140,6 +141,7 @@ public struct DatadogInternalInterface {
         firstByte: (start: Date, end: Date)?,
         download: (start: Date, end: Date)?,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
         monitor.process(
@@ -155,7 +157,8 @@ public struct DatadogInternalInterface {
                     ssl: ResourceMetrics.DateInterval.create(start: ssl?.start, end: ssl?.end),
                     firstByte: ResourceMetrics.DateInterval.create(start: firstByte?.start, end: firstByte?.end),
                     download: ResourceMetrics.DateInterval.create(start: download?.start, end: download?.end),
-                    responseBodySize: responseBodySize
+                    responseBodySize: responseBodySize,
+                    requestBodySize: requestBodySize
                 )
             )
         )

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -131,6 +131,9 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.ssl)
         XCTAssertNil(event.resource.firstByte)
         XCTAssertNil(event.resource.download)
+        XCTAssertNil(event.resource.decodedBodySize)
+        XCTAssertNil(event.resource.encodedBodySize)
+        XCTAssertNil(event.resource.request)
         XCTAssertEqual(try XCTUnwrap(event.action?.id.stringValue), provider.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.dd.traceId, "64")
@@ -955,7 +958,8 @@ class RUMResourceScopeTests: XCTestCase {
                     start: resourceFetchStart.addingTimeInterval(9),
                     end: resourceFetchStart.addingTimeInterval(10)
                 ),
-                responseBodySize: (encoded: 1_500, decoded: 2_048)
+                responseBodySize: (encoded: 1_500, decoded: 2_048),
+                requestBodySize: (encoded: 512, decoded: 1_024)
             )
         )
 
@@ -1007,6 +1011,10 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.resource.firstByte?.duration, 1_000_000_000)
         XCTAssertEqual(event.resource.download?.start, 9_000_000_000)
         XCTAssertEqual(event.resource.download?.duration, 1_000_000_000)
+        XCTAssertEqual(event.resource.encodedBodySize, 1_500)
+        XCTAssertEqual(event.resource.decodedBodySize, 2_048)
+        XCTAssertEqual(event.resource.request?.encodedBodySize, 512)
+        XCTAssertEqual(event.resource.request?.decodedBodySize, 1_024)
         XCTAssertEqual(try XCTUnwrap(event.action?.id.stringValue), provider.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.source, .ios)
@@ -1016,9 +1024,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.buildId, context.buildId)
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
-        // Body size metrics (only response body size was provided)
-        XCTAssertEqual(event.resource.encodedBodySize, 1_500)
-        XCTAssertEqual(event.resource.decodedBodySize, 2_048)
     }
 
     func testGivenStartedResource_whenResourceReceivesMetricsWithRequestAndResponseBodySizes_itAggregatesThemInSentResourceEvent() throws {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -396,6 +396,7 @@ extension RUMResourceEvent: RandomMockable {
                 ),
                 redirect: .init(duration: .mockRandom(), start: .mockRandom()),
                 renderBlockingStatus: nil,
+                request: Bool.random() ? .init(decodedBodySize: .mockRandom(), encodedBodySize: .mockRandom()) : nil,
                 size: .mockRandom(),
                 ssl: .init(duration: .mockRandom(), start: .mockRandom()),
                 statusCode: .mockRandom(),

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -213,7 +213,8 @@ extension ResourceMetrics: AnyMockable {
         ssl: DateInterval? = nil,
         firstByte: DateInterval? = nil,
         download: DateInterval? = nil,
-        responseBodySize: (encoded: Int64, decoded: Int64)? = nil
+        responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil
     ) -> Self {
         return .init(
             fetch: fetch,
@@ -223,7 +224,8 @@ extension ResourceMetrics: AnyMockable {
             ssl: ssl,
             firstByte: firstByte,
             download: download,
-            responseBodySize: responseBodySize
+            responseBodySize: responseBodySize,
+            requestBodySize: requestBodySize
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -673,6 +673,8 @@ extension URLSessionTaskTransactionMetrics {
         let responseEndDate = end
 
         let countOfResponseBodyBytesAfterDecoding: Int64 = .random(in: 512..<1_024)
+        let countOfRequestBodyBytesBeforeEncoding: Int64 = .random(in: 256..<512)
+        let countOfRequestBodyBytesSent: Int64 = .random(in: 128..<256)
         let countOfResponseBodyBytesReceived: Int64 = .random(in: 256..<512)
 
         return URLSessionTaskTransactionMetricsMock(
@@ -688,6 +690,8 @@ extension URLSessionTaskTransactionMetrics {
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
             countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding,
+            countOfRequestBodyBytesBeforeEncoding: countOfRequestBodyBytesBeforeEncoding,
+            countOfRequestBodyBytesSent: countOfRequestBodyBytesSent,
             countOfResponseBodyBytesReceived: countOfResponseBodyBytesReceived
         )
     }
@@ -705,7 +709,8 @@ extension URLSessionTaskTransactionMetrics {
         requestStartDate: Date? = nil,
         responseStartDate: Date? = nil,
         responseEndDate: Date? = nil,
-        responseBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0)
+        responseBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0),
+        requestBodySize: (encoded: Int64, decoded: Int64) = (encoded: 0, decoded: 0)
     ) -> URLSessionTaskTransactionMetrics {
         return URLSessionTaskTransactionMetricsMock(
             resourceFetchType: resourceFetchType,
@@ -720,6 +725,8 @@ extension URLSessionTaskTransactionMetrics {
             responseStartDate: responseStartDate,
             responseEndDate: responseEndDate,
             countOfResponseBodyBytesAfterDecoding: responseBodySize.decoded,
+            countOfRequestBodyBytesBeforeEncoding: requestBodySize.decoded,
+            countOfRequestBodyBytesSent: requestBodySize.encoded,
             countOfResponseBodyBytesReceived: responseBodySize.encoded
         )
     }


### PR DESCRIPTION
### What and why?

Followup of #2655. Adds `resource.request.encoded_body_size` and `resource.request.decoded_body_size` for request body sizes, using the same tuple pattern as response body sizes.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs