### PR TITLE
RUM-14563 Add header capture configuration API and HeaderProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # 3.7.0 / 18-02-2026
 
+- [FEATURE] Add `trackResourceHeaders` configuration to capture HTTP request and response headers in RUM Resource events. See [#2699][]
 - [FEATURE] Add evaluation logging to `DatadogFlags` module. See [#2646][]
 - [FEATURE] Automatic network instrumentation now tracks `URLSession` requests without requiring delegate registration. See [#2620][]
 - [FEATURE] Deprecate `URLSessionInstrumentation.enable(with:in:)` API in favor of `URLSessionInstrumentation.enableDurationBreakdown(with:in:)`. See [#2634][]

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -400,6 +400,10 @@
 		261255882E2167E40015042B /* BaggageHeaderMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255862E2167E40015042B /* BaggageHeaderMerger.swift */; };
 		2612558A2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
 		2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
+		261255912E2167E40015042B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
+		261255922E2167E40015042B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
+		261255942E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
+		261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
 		265496D32D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		265496D42D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		266BFA5E2D6F4E31003041A5 /* AccountInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */; };
@@ -2907,6 +2911,8 @@
 		1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOTelTracingViewController.swift; sourceTree = "<group>"; };
 		261255862E2167E40015042B /* BaggageHeaderMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMerger.swift; sourceTree = "<group>"; };
 		261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMergerTests.swift; sourceTree = "<group>"; };
+		261255902E2167E40015042B /* HeaderProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessor.swift; sourceTree = "<group>"; };
+		261255932E2167F10015042B /* HeaderProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessorTests.swift; sourceTree = "<group>"; };
 		265496D22D81C5AE0094B6E2 /* RUMAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAccount.swift; sourceTree = "<group>"; };
 		266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisherTests.swift; sourceTree = "<group>"; };
 		2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisher.swift; sourceTree = "<group>"; };
@@ -5903,10 +5909,19 @@
 		613F23EF252B1287006CD2D7 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				261255972E2167F10015042B /* HeaderCapture */,
 				261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */,
 				D2BCB12129D34A5F00737A9A /* URLSessionRUMResourcesHandlerTests.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		261255972E2167F10015042B /* HeaderCapture */ = {
+			isa = PBXGroup;
+			children = (
+				261255932E2167F10015042B /* HeaderProcessorTests.swift */,
+			);
+			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
 		6141014C251A577D00E3C2D9 /* Actions */ = {
@@ -6054,10 +6069,19 @@
 		6157FA5C252767B3009A8A3B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				261255962E2167E40015042B /* HeaderCapture */,
 				261255862E2167E40015042B /* BaggageHeaderMerger.swift */,
 				D2BCB11E29D30AF000737A9A /* URLSessionRUMResourcesHandler.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		261255962E2167E40015042B /* HeaderCapture */ = {
+			isa = PBXGroup;
+			children = (
+				261255902E2167E40015042B /* HeaderProcessor.swift */,
+			);
+			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
 		615950EC291C057D00470E0C /* Integrations */ = {
@@ -10539,6 +10563,7 @@
 				D23F8E7629DDCD28001CFAE8 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D23F8E7729DDCD28001CFAE8 /* UIKitRUMViewsPredicate.swift in Sources */,
 				261255882E2167E40015042B /* BaggageHeaderMerger.swift in Sources */,
+				261255912E2167E40015042B /* HeaderProcessor.swift in Sources */,
 				9629FFDE2D81C317008DFE39 /* SwiftUIViewPath.swift in Sources */,
 				111201C12E93C13000375DA3 /* AppStateManager.swift in Sources */,
 				111201C22E93C13000375DA3 /* AppStateInfo.swift in Sources */,
@@ -10609,6 +10634,7 @@
 				D23F8EAE29DDCD38001CFAE8 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D23F8EAF29DDCD38001CFAE8 /* RUMScopeTests.swift in Sources */,
 				2612558A2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */,
+				261255942E2167F10015042B /* HeaderProcessorTests.swift in Sources */,
 				A7E6EA842D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D23F8EB029DDCD38001CFAE8 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B72A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,
@@ -11032,6 +11058,7 @@
 				D29A9F5829DD85BB005C54A4 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D29A9F5E29DD85BB005C54A4 /* UIKitRUMViewsPredicate.swift in Sources */,
 				261255872E2167E40015042B /* BaggageHeaderMerger.swift in Sources */,
+				261255922E2167E40015042B /* HeaderProcessor.swift in Sources */,
 				9629FFDF2D81C317008DFE39 /* SwiftUIViewPath.swift in Sources */,
 				111201C32E93C13000375DA3 /* AppStateManager.swift in Sources */,
 				111201C42E93C13000375DA3 /* AppStateInfo.swift in Sources */,
@@ -11101,6 +11128,7 @@
 				D29A9FCC29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */,
 				2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */,
+				261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */,
 				A7E6EA852D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B62A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -75,6 +75,33 @@ class DDRUMConfigurationTests: XCTestCase {
         DDAssertReflectionEqual(swift.urlSessionTracking, .init(firstPartyHostsTracing: .traceWithHeaders(hostsWithHeaders: ["foo.com": [.b3, .datadog]], sampleRate: 99)))
     }
 
+    func testSetDDRUMURLSessionTrackingWithTrackResourceHeaders() {
+        let tracking = objc_URLSessionTracking()
+
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, RUM.Configuration.URLSessionTracking())
+
+        tracking.setTrackResourceHeaders(.disabled)
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .disabled))
+
+        tracking.setTrackResourceHeaders(.defaults)
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .defaults))
+
+        tracking.setTrackResourceHeaders(.custom([.defaults]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.defaults])))
+
+        tracking.setTrackResourceHeaders(.custom([.matchHeaders(["x-request-id", "x-trace-id"])]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.matchHeaders(["x-request-id", "x-trace-id"])])))
+
+        tracking.setTrackResourceHeaders(.custom([.defaults, .matchHeaders(["x-request-id"])]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.defaults, .matchHeaders(["x-request-id"])])))
+    }
+
     func testSetDDRUMURLSessionTrackingWithResourceAttributesProvider() {
         let tracking = objc_URLSessionTracking()
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Processes HTTP headers from intercepted URLSession requests, applying security filtering,
+/// size limits, and header resolution based on the configured `TrackResourceHeaders`.
+internal struct HeaderProcessor {
+    /// Maximum byte size for a single header value.
+    static let maxValueSize = 128
+    /// Maximum number of headers per direction (request/response).
+    static let maxHeaderCount = 100
+    /// Maximum total byte size for all collected headers combined (both key and value).
+    static let maxTotalSize = 2_048
+
+    /// Default request headers to capture.
+    static let defaultRequestHeaders: Set<String> = [
+        "cache-control",
+        "content-type"
+    ]
+
+    /// Default response headers to capture.
+    static let defaultResponseHeaders: Set<String> = [
+        "cache-control",
+        "content-encoding",
+        "content-length",
+        "content-type",
+        "etag",
+        "age",
+        "expires",
+        "vary",
+        "server-timing",
+        "x-cache"
+    ]
+
+    /// iOS-managed headers that are always omitted from request capture.
+    /// These are set by the URL Loading System and should not be reported as user-provided request headers.
+    /// Ref: https://developer.apple.com/documentation/foundation/nsurlrequest#Reserved-HTTP-headers
+    static let reservedRequestHeaders: Set<String> = [
+        "content-length",
+        "authorization",
+        "connection",
+        "host",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "www-authenticate"
+    ]
+
+    /// Regex pattern to catch sensitive headers (auth, cookies, tokens, secrets, IPs, etc.).
+    // swiftlint:disable:next force_try
+    static let securityPattern: NSRegularExpression = try! NSRegularExpression(
+        pattern: "(token|cookie|secret|authorization|password|credential|bearer|(api|secret|access|app).?key|forwarded|real.?ip|connecting.?ip|client.?ip)",
+        options: .caseInsensitive
+    )
+
+    private let config: RUM.Configuration.URLSessionTracking.TrackResourceHeaders
+
+    init(config: RUM.Configuration.URLSessionTracking.TrackResourceHeaders) {
+        self.config = config
+    }
+
+    /// Processes request and response headers based on the configured rules.
+    ///
+    /// - Parameters:
+    ///   - requestHeaders: The request headers from `URLRequest.allHTTPHeaderFields`.
+    ///   - responseHeaders: The response headers from `HTTPURLResponse.allHeaderFields`.
+    /// - Returns: A tuple of filtered request and response header dictionaries.
+    func process(
+        requestHeaders: [String: String]?,
+        responseHeaders: [AnyHashable: Any]?
+    ) -> (request: [String: String], response: [String: String]) {
+        guard case .disabled = config else {
+            let (captureRequest, captureResponse) = buildCaptureList()
+            let request = filterRequestHeaders(requestHeaders, capturing: captureRequest)
+            let response = filterResponseHeaders(responseHeaders, capturing: captureResponse)
+            return (request: request, response: response)
+        }
+        return (request: [:], response: [:])
+    }
+
+    // MARK: - Private
+
+    /// Resolves the set of header names to capture for request and response based on the configuration rules.
+    private func buildCaptureList() -> (request: Set<String>, response: Set<String>) {
+        var requestHeaders = Set<String>()
+        var responseHeaders = Set<String>()
+
+        let rules: [RUM.Configuration.URLSessionTracking.HeaderCaptureRule]
+
+        switch config {
+        case .disabled:
+            return (request: [], response: [])
+        case .defaults:
+            rules = [.defaults]
+        case .custom(let customRules):
+            rules = customRules
+        }
+
+        for rule in rules {
+            switch rule {
+            case .defaults:
+                requestHeaders.formUnion(Self.defaultRequestHeaders)
+                responseHeaders.formUnion(Self.defaultResponseHeaders)
+            case .matchHeaders(let names):
+                let lowercased = Set(names.map { $0.lowercased() })
+                requestHeaders.formUnion(lowercased)
+                responseHeaders.formUnion(lowercased)
+            }
+        }
+
+        return (request: requestHeaders, response: responseHeaders)
+    }
+
+    /// Filters request headers.
+    private func filterRequestHeaders(_ headers: [String: String]?, capturing: Set<String>) -> [String: String] {
+        guard let headers else {
+            return [:]
+        }
+        return filterHeaders(headers.map { ($0.key, $0.value) }, capturing: capturing, excluded: Self.reservedRequestHeaders)
+    }
+
+    /// Filters response headers.
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: Set<String>) -> [String: String] {
+        guard let headers else {
+            return [:]
+        }
+        let stringPairs = headers.compactMap { rawKey, rawValue -> (String, String)? in
+            guard let key = rawKey as? String, let value = rawValue as? String else {
+                return nil
+            }
+            return (key, value)
+        }
+        return filterHeaders(stringPairs, capturing: capturing)
+    }
+
+    /// Shared filtering logic: applies capture list, security pattern, excluded set, and size limits.
+    private func filterHeaders(_ headers: [(String, String)], capturing: Set<String>, excluded: Set<String> = []) -> [String: String] {
+        guard !headers.isEmpty else {
+            return [:]
+        }
+
+        var result: [String: String] = [:]
+        var totalSize = 0
+
+        for (key, value) in headers {
+            let lowercasedKey = key.lowercased()
+
+            guard capturing.contains(lowercasedKey) else { continue }
+            guard !excluded.contains(lowercasedKey) else { continue }
+            guard !matchesSecurityPattern(lowercasedKey) else { continue }
+            guard result.count < Self.maxHeaderCount else { break }
+
+            let truncatedValue = truncateValue(value)
+            let entrySize = key.utf8.count + truncatedValue.utf8.count
+
+            guard totalSize + entrySize <= Self.maxTotalSize else { break }
+
+            result[key] = truncatedValue
+            totalSize += entrySize
+        }
+
+        return result
+    }
+
+    /// Truncates a header value to `maxValueSize` bytes, ensuring valid UTF-8.
+    private func truncateValue(_ value: String) -> String {
+        guard value.utf8.count > Self.maxValueSize else {
+            return value
+        }
+
+        // Truncate at UTF-8 byte boundary
+        let utf8 = value.utf8
+        let truncatedUTF8 = utf8.prefix(Self.maxValueSize)
+
+        // Ensure we don't cut in the middle of a multi-byte character
+        return String(truncatedUTF8) ?? String(value.prefix(Self.maxValueSize))
+    }
+
+    /// Checks whether the header name matches the security regex pattern.
+    private func matchesSecurityPattern(_ lowercasedName: String) -> Bool {
+        let range = NSRange(lowercasedName.startIndex..., in: lowercasedName)
+        return Self.securityPattern.firstMatch(in: lowercasedName, range: range) != nil
+    }
+}

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -351,6 +351,51 @@ public class objc_URLSessionTracking: NSObject {
             return objcAttributes?.dd.swiftAttributes
         }
     }
+
+    public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders) {
+        swiftConfig.trackResourceHeaders = trackResourceHeaders.swiftType
+    }
+}
+
+@objc(DDRUMHeaderCaptureRule)
+@objcMembers
+@_spi(objc)
+public final class objc_HeaderCaptureRule: NSObject {
+    internal let swiftType: RUM.Configuration.URLSessionTracking.HeaderCaptureRule
+
+    private init(_ swiftType: RUM.Configuration.URLSessionTracking.HeaderCaptureRule) {
+        self.swiftType = swiftType
+    }
+
+    /// Include the predefined set of default headers.
+    public static let defaults = objc_HeaderCaptureRule(.defaults)
+
+    /// Match headers by exact name (case-insensitive).
+    public static func matchHeaders(_ names: [String]) -> objc_HeaderCaptureRule {
+        objc_HeaderCaptureRule(.matchHeaders(names))
+    }
+}
+
+@objc(DDRUMTrackResourceHeaders)
+@objcMembers
+@_spi(objc)
+public final class objc_TrackResourceHeaders: NSObject {
+    internal let swiftType: RUM.Configuration.URLSessionTracking.TrackResourceHeaders
+
+    private init(_ swiftType: RUM.Configuration.URLSessionTracking.TrackResourceHeaders) {
+        self.swiftType = swiftType
+    }
+
+    /// No header capture. This is the default.
+    public static let disabled = objc_TrackResourceHeaders(.disabled)
+
+    /// Capture a predefined set of common request and response headers.
+    public static let defaults = objc_TrackResourceHeaders(.defaults)
+
+    /// Capture headers based on custom rules.
+    public static func custom(_ rules: [objc_HeaderCaptureRule]) -> objc_TrackResourceHeaders {
+        objc_TrackResourceHeaders(.custom(rules.map { $0.swiftType }))
+    }
 }
 
 @objc(DDRUMConfiguration)

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -342,11 +342,11 @@ extension RUM {
 
             /// Configuration for capturing HTTP headers from network requests and responses.
             ///
-            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests
-            /// and includes them in RUM Resource events. Headers are filtered for security (sensitive headers
-            /// like `Authorization`, `Cookie`, etc. are never captured) and size limits are enforced.
+            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests and responses
+            /// and includes them in RUM Resource events. Sensitive headers are filtered out for security reasons
+            /// (e.g., `Authorization` and `Cookie` headers are never captured) and size limits are enforced.
             ///
-            /// - `.disabled`: No header capture (default).
+            /// - `.disabled`: No header capture.
             /// - `.defaults`: Capture a predefined set of common request and response headers.
             /// - `.custom([rules])`: Capture headers based on custom rules.
             ///

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -340,6 +340,19 @@ extension RUM {
             /// Default: `nil`.
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
 
+            /// Configuration for capturing HTTP headers from network requests and responses.
+            ///
+            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests
+            /// and includes them in RUM Resource events. Headers are filtered for security (sensitive headers
+            /// like `Authorization`, `Cookie`, etc. are never captured) and size limits are enforced.
+            ///
+            /// - `.disabled`: No header capture (default).
+            /// - `.defaults`: Capture a predefined set of common request and response headers.
+            /// - `.custom([rules])`: Capture headers based on custom rules.
+            ///
+            /// Default: `.disabled`.
+            public var trackResourceHeaders: TrackResourceHeaders = .disabled
+
             /// Private init to avoid `invalid redeclaration of synthesized memberwise init(...:)` in extension.
             private init() {}
         }
@@ -420,16 +433,50 @@ extension RUM.Configuration.URLSessionTracking {
         )
     }
 
+    /// Configuration for capturing HTTP headers from network requests and responses.
+    public enum TrackResourceHeaders {
+        /// No header capture. This is the default.
+        case disabled
+
+        /// Capture a predefined set of common request and response headers for all URLs.
+        ///
+        /// Default request headers: `cache-control`, `content-type`.
+        /// Default response headers: `cache-control`, `content-encoding`, `content-length`,
+        /// `content-type`, `etag`, `age`, `expires`, `vary`, `server-timing`, `x-cache`.
+        case defaults
+
+        /// Capture headers based on custom rules for all URLs.
+        ///
+        /// Multiple rules can be combined. For example, to capture default headers plus
+        /// additional custom headers:
+        /// ```swift
+        /// .custom([.defaults, .matchHeaders(["x-request-id"])])
+        /// ```
+        case custom([HeaderCaptureRule])
+    }
+
+    /// A rule that defines which HTTP headers to capture.
+    public enum HeaderCaptureRule {
+        /// Include the predefined set of default headers.
+        case defaults
+
+        /// Match headers by exact name (case-insensitive).
+        case matchHeaders([String])
+    }
+
     /// Configuration for automatic RUM resources tracking.
     /// - Parameters:
     ///   - firstPartyHostsTracing: Distributed tracing configuration for particular first-party hosts.
     ///   - resourceAttributesProvider: Custom attributes provider for intercepted RUM resources.
+    ///   - trackResourceHeaders: Configuration for capturing HTTP headers. Default: `.disabled`.
     public init(
         firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,
-        resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil
+        resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,
+        trackResourceHeaders: TrackResourceHeaders = .disabled
     ) {
         self.firstPartyHostsTracing = firstPartyHostsTracing
         self.resourceAttributesProvider = resourceAttributesProvider
+        self.trackResourceHeaders = trackResourceHeaders
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
@@ -1,0 +1,403 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogRUM
+
+class HeaderProcessorTests: XCTestCase {
+    // MARK: - Disabled Configuration
+
+    func testWhenDisabled_itReturnsEmptyHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .disabled)
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["content-type": "application/json"],
+            responseHeaders: ["content-type": "text/html"]
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    // MARK: - Defaults Configuration
+
+    func testWhenDefaults_itCapturesDefaultRequestHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "cache-control": "no-cache",
+                "content-type": "application/json",
+                "authorization": "Bearer secret",
+                "accept": "text/html"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, [
+            "cache-control": "no-cache",
+            "content-type": "application/json"
+        ])
+    }
+
+    func testWhenDefaults_itCapturesDefaultResponseHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: [
+                "cache-control": "max-age=3600",
+                "etag": "\"abc123\"",
+                "age": "120",
+                "expires": "Thu, 01 Dec 2025 16:00:00 GMT",
+                "content-type": "application/json",
+                "content-encoding": "gzip",
+                "content-length": "1024",
+                "vary": "Accept-Encoding",
+                "server-timing": "db;dur=53",
+                "x-cache": "HIT",
+                "x-custom-header": "should-not-appear",
+                "set-cookie": "session=abc"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.response.count, 10)
+        XCTAssertEqual(result.response["cache-control"], "max-age=3600")
+        XCTAssertEqual(result.response["etag"], "\"abc123\"")
+        XCTAssertEqual(result.response["age"], "120")
+        XCTAssertEqual(result.response["expires"], "Thu, 01 Dec 2025 16:00:00 GMT")
+        XCTAssertEqual(result.response["content-type"], "application/json")
+        XCTAssertEqual(result.response["content-encoding"], "gzip")
+        XCTAssertEqual(result.response["content-length"], "1024")
+        XCTAssertEqual(result.response["vary"], "Accept-Encoding")
+        XCTAssertEqual(result.response["server-timing"], "db;dur=53")
+        XCTAssertEqual(result.response["x-cache"], "HIT")
+        XCTAssertNil(result.response["x-custom-header"])
+        XCTAssertNil(result.response["set-cookie"])
+    }
+
+    // MARK: - Custom Configuration
+
+    func testWhenCustomMatchHeaders_itCapturesOnlySpecifiedHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["x-request-id"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "application/json"
+            ],
+            responseHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "text/html"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, ["x-request-id": "abc-123"])
+        XCTAssertEqual(result.response, ["x-request-id": "abc-123"])
+    }
+
+    func testWhenCustomWithDefaultsAndMatchHeaders_itMergesBoth() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.defaults, .matchHeaders(["x-request-id"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "cache-control": "no-cache",
+                "content-type": "application/json",
+                "x-request-id": "abc-123",
+                "accept": "text/html"
+            ],
+            responseHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "text/html"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, [
+            "cache-control": "no-cache",
+            "content-type": "application/json",
+            "x-request-id": "abc-123"
+        ])
+        XCTAssertEqual(result.response, [
+            "x-request-id": "abc-123",
+            "content-type": "text/html"
+        ])
+    }
+
+    // MARK: - Security Filtering
+
+    func testItNeverCapturesSensitiveHeaders() {
+        // Given
+        let sensitiveNames = [
+            "authorization",
+            "proxy-authorization",
+            "x-api-key",
+            "x-access-token",
+            "x-auth-token",
+            "x-session-token",
+            "cookie",
+            "set-cookie",
+            "x-forwarded-for",
+            "x-real-ip",
+            "cf-connecting-ip",
+            "true-client-ip",
+            "x-csrf-token",
+            "x-xsrf-token",
+            "x-security-token"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(sensitiveNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "authorization": "Bearer secret",
+                "proxy-authorization": "Basic abc",
+                "x-api-key": "key123",
+                "x-access-token": "token",
+                "x-auth-token": "auth",
+                "x-session-token": "session",
+                "cookie": "id=abc",
+                "x-forwarded-for": "1.2.3.4",
+                "x-real-ip": "1.2.3.4",
+                "cf-connecting-ip": "1.2.3.4",
+                "true-client-ip": "1.2.3.4",
+                "x-csrf-token": "csrf",
+                "x-xsrf-token": "xsrf",
+                "x-security-token": "sec"
+            ],
+            responseHeaders: [
+                "set-cookie": "session=abc"
+            ]
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    func testItFiltersHeadersMatchingSecurityPattern() {
+        // Given
+        let sensitiveNames = [
+            "x-custom-token",
+            "my-secret-header",
+            "x-app-key",
+            "x-bearer-auth",
+            "x-password-hash",
+            "x-credential-id",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(sensitiveNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "x-custom-token": "value",
+                "my-secret-header": "value",
+                "x-app-key": "value",
+                "x-bearer-auth": "value",
+                "x-password-hash": "value",
+                "x-credential-id": "value",
+                "content-type": "application/json"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, ["content-type": "application/json"])
+    }
+
+    // MARK: - Reserved Request Headers
+
+    func testItFiltersReservedHeadersFromRequest() {
+        // Given
+        let reservedNames = [
+            "content-length",
+            "connection",
+            "host",
+            "proxy-authenticate",
+            "www-authenticate",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(reservedNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "Content-Length": "1024",
+                "Connection": "keep-alive",
+                "Host": "example.com",
+                "Proxy-Authenticate": "Basic",
+                "WWW-Authenticate": "Bearer",
+                "Content-Type": "application/json"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then - Only content-type should pass (others are reserved for requests)
+        XCTAssertEqual(result.request.count, 1)
+        XCTAssertNotNil(result.request.first(where: { $0.key.lowercased() == "content-type" }))
+    }
+
+    func testItDoesNotFilterReservedHeadersFromResponse() {
+        // Given
+        let headerNames = [
+            "content-length",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: [
+                "Content-Length": "1024",
+                "Content-Type": "application/json"
+            ]
+        )
+
+        // Then - Content-Length is valid in responses
+        XCTAssertEqual(result.response.count, 2)
+    }
+
+    // MARK: - Case Sensitivity
+
+    func testItMatchesHeadersCaseInsensitively() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["Content-Type"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["content-type": "application/json"],
+            responseHeaders: ["CONTENT-TYPE": "text/html"]
+        )
+
+        // Then
+        XCTAssertEqual(result.request.count, 1)
+        XCTAssertEqual(result.request.first(where: { $0.key.lowercased() == "content-type" })?.value, "application/json")
+        XCTAssertEqual(result.response.count, 1)
+        XCTAssertEqual(result.response.first(where: { $0.key.lowercased() == "content-type" })?.value, "text/html")
+    }
+
+    // MARK: - Value Truncation
+
+    func testItTruncatesValuesExceeding128Bytes() throws {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["x-long-header"])]))
+        let longValue = String(repeating: "a", count: 200)
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["x-long-header": longValue],
+            responseHeaders: [:]
+        )
+
+        // Then
+        let capturedValue = try XCTUnwrap(result.request["x-long-header"])
+        XCTAssertLessThanOrEqual(capturedValue.utf8.count, 128)
+    }
+
+    // MARK: - Header Count Limit
+
+    func testItLimitsTo100Headers() {
+        // Given
+        var headerNames: [String] = []
+        var requestHeaders: [String: String] = [:]
+        for i in 0..<150 {
+            let name = "x-header-\(i)"
+            headerNames.append(name)
+            requestHeaders[name] = "value-\(i)"
+        }
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: requestHeaders,
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertLessThanOrEqual(result.request.count, 100)
+    }
+
+    // MARK: - Total Size Limit
+
+    func testItEnforces2KBTotalSizeLimit() {
+        // Given
+        var headerNames: [String] = []
+        var requestHeaders: [String: String] = [:]
+        for i in 0..<50 {
+            let name = "x-header-\(i)"
+            headerNames.append(name)
+            // Each value is 100 bytes, 50 headers = ~5KB > 2KB limit
+            requestHeaders[name] = String(repeating: "x", count: 100)
+        }
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: requestHeaders,
+            responseHeaders: [:]
+        )
+
+        // Then - Total size should be at most 2KB
+        let totalSize = result.request.reduce(0) { $0 + $1.key.utf8.count + $1.value.utf8.count }
+        XCTAssertLessThanOrEqual(totalSize, 2_048)
+    }
+
+    // MARK: - Nil Input
+
+    func testWhenInputIsNil_itReturnsEmptyHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: nil,
+            responseHeaders: nil
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    // MARK: - Response AnyHashable Cast
+
+    func testItHandlesResponseHeadersWithAnyHashableKeys() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+        let responseHeaders: [AnyHashable: Any] = [
+            "content-type": "application/json",
+            "cache-control": "no-cache",
+            42: "should-be-ignored" // non-String key
+        ]
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: responseHeaders
+        )
+
+        // Then
+        XCTAssertEqual(result.response["content-type"], "application/json")
+        XCTAssertEqual(result.response["cache-control"], "no-cache")
+    }
+}

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -2822,6 +2822,14 @@ public class objc_URLSessionTracking: NSObject
     override public init()
     public func setFirstPartyHostsTracing(_ firstPartyHostsTracing: objc_FirstPartyHostsTracing)
     public func setResourceAttributesProvider(_ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [String: Any]?)
+    public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders)
+public final class objc_HeaderCaptureRule: NSObject
+    public static let defaults = objc_HeaderCaptureRule(.defaults)
+    public static func matchHeaders(_ names: [String]) -> objc_HeaderCaptureRule
+public final class objc_TrackResourceHeaders: NSObject
+    public static let disabled = objc_TrackResourceHeaders(.disabled)
+    public static let defaults = objc_TrackResourceHeaders(.defaults)
+    public static func custom(_ rules: [objc_HeaderCaptureRule]) -> objc_TrackResourceHeaders
 public class objc_RUMConfiguration: NSObject
     public init(applicationID: String)
     public var applicationID: String

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -420,6 +420,7 @@ public enum RUM
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
+            public var trackResourceHeaders: TrackResourceHeaders = .disabled
         public enum VitalsFrequency: String
             case frequent
             case average
@@ -428,7 +429,14 @@ public enum RUM
     public enum FirstPartyHostsTracing
         case trace(hosts: Set<String>,sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
         case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
-    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
+    public enum TrackResourceHeaders
+        case disabled
+        case defaults
+        case custom([HeaderCaptureRule])
+    public enum HeaderCaptureRule
+        case defaults
+        case matchHeaders([String])
+    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled)
 [?] extension RUM.Configuration
     public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration


### PR DESCRIPTION
### What and why?

This is the first PR for Network Header Capture. It adds the public configuration API (`TrackResourceHeaders`, `HeaderCaptureRule`) on `URLSessionTracking` to let users opt into capturing HTTP request and response headers on RUM resources. It also introduces `HeaderProcessor`, which resolves the capture list from configuration rules, applies security filtering (regex-based sensitive header detection, reserved iOS headers exclusion), and enforces size limits. RUM models are regenerated to include `request.headers` and `response.headers` on `RUMResourceEvent`.

Follow-up PR will wire the processor into the resource interception pipeline.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs