### PR TITLE
RUM-14563 Wire header capture into resource interception pipeline

### DIFF
--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -163,6 +163,16 @@ public struct CrossPlatformAttributes {
     /// Custom value for Interaction To Next view.
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
+
+    /// HTTP headers captured from the resource request, serialized as a JSON string.
+    /// Used to transport request headers through the RUM command pipeline.
+    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
+    public static let resourceRequestHeaders = "_dd.resource.request_headers"
+
+    /// HTTP headers captured from the resource response, serialized as a JSON string.
+    /// Used to transport response headers through the RUM command pipeline.
+    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
+    public static let resourceResponseHeaders = "_dd.resource.response_headers"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -164,12 +164,12 @@ public struct CrossPlatformAttributes {
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
 
-    /// Request headers passed from CP SDK or captured from native URLSession interception.
+    /// Request headers passed from Cross-Platform SDK or captured from native URLSession interception.
     /// Used in RUM resources to transport request headers through the RUM command pipeline.
     /// Expects `[String: String]` value containing header keys and values.
     public static let requestHeaders = "_dd.request_headers"
 
-    /// Response headers passed from CP SDK or captured from native URLSession interception.
+    /// Response headers passed from Cross-Platform SDK or captured from native URLSession interception.
     /// Used in RUM resources to transport response headers through the RUM command pipeline.
     /// Expects `[String: String]` value containing header keys and values.
     public static let responseHeaders = "_dd.response_headers"

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -164,15 +164,15 @@ public struct CrossPlatformAttributes {
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
 
-    /// HTTP headers captured from the resource request, serialized as a JSON string.
-    /// Used to transport request headers through the RUM command pipeline.
-    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
-    public static let resourceRequestHeaders = "_dd.resource.request_headers"
+    /// Request headers passed from CP SDK or captured from native URLSession interception.
+    /// Used in RUM resources to transport request headers through the RUM command pipeline.
+    /// Expects `[String: String]` value containing header keys and values.
+    public static let requestHeaders = "_dd.request_headers"
 
-    /// HTTP headers captured from the resource response, serialized as a JSON string.
-    /// Used to transport response headers through the RUM command pipeline.
-    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
-    public static let resourceResponseHeaders = "_dd.resource.response_headers"
+    /// Response headers passed from CP SDK or captured from native URLSession interception.
+    /// Used in RUM resources to transport response headers through the RUM command pipeline.
+    /// Expects `[String: String]` value containing header keys and values.
+    public static let responseHeaders = "_dd.response_headers"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -3869,7 +3869,10 @@ public struct RUMResourceEvent: RUMDataModel {
         public let renderBlockingStatus: RenderBlockingStatus?
 
         /// Request properties
-        public let request: Request?
+        public var request: Request?
+
+        /// Response properties
+        public var response: Response?
 
         /// Size in octet of the resource response body
         public let size: Int64?
@@ -3909,6 +3912,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case redirect = "redirect"
             case renderBlockingStatus = "render_blocking_status"
             case request = "request"
+            case response = "response"
             case size = "size"
             case ssl = "ssl"
             case statusCode = "status_code"
@@ -3937,6 +3941,7 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - redirect: Redirect phase properties
         ///   - renderBlockingStatus: Render blocking status of the resource
         ///   - request: Request properties
+        ///   - response: Response properties
         ///   - size: Size in octet of the resource response body
         ///   - ssl: SSL phase properties
         ///   - statusCode: HTTP status code of the resource
@@ -3961,6 +3966,7 @@ public struct RUMResourceEvent: RUMDataModel {
             redirect: Redirect? = nil,
             renderBlockingStatus: RenderBlockingStatus? = nil,
             request: Request? = nil,
+            response: Response? = nil,
             size: Int64? = nil,
             ssl: SSL? = nil,
             statusCode: Int64? = nil,
@@ -3985,6 +3991,7 @@ public struct RUMResourceEvent: RUMDataModel {
             self.redirect = redirect
             self.renderBlockingStatus = renderBlockingStatus
             self.request = request
+            self.response = response
             self.size = size
             self.ssl = ssl
             self.statusCode = statusCode
@@ -4373,9 +4380,13 @@ public struct RUMResourceEvent: RUMDataModel {
             /// Size in octet of the request body sent over the network (after encoding)
             public let encodedBodySize: Int64?
 
+            /// HTTP headers of the resource request
+            public var headers: Headers?
+
             public enum CodingKeys: String, CodingKey {
                 case decodedBodySize = "decoded_body_size"
                 case encodedBodySize = "encoded_body_size"
+                case headers = "headers"
             }
 
             /// Request properties
@@ -4383,12 +4394,65 @@ public struct RUMResourceEvent: RUMDataModel {
             /// - Parameters:
             ///   - decodedBodySize: Size in octet of the request body before any encoding
             ///   - encodedBodySize: Size in octet of the request body sent over the network (after encoding)
+            ///   - headers: HTTP headers of the resource request
             public init(
                 decodedBodySize: Int64? = nil,
-                encodedBodySize: Int64? = nil
+                encodedBodySize: Int64? = nil,
+                headers: Headers? = nil
             ) {
                 self.decodedBodySize = decodedBodySize
                 self.encodedBodySize = encodedBodySize
+                self.headers = headers
+            }
+
+            /// HTTP headers of the resource request
+            public struct Headers: Codable {
+                public var headersInfo: [String: String]
+
+                /// HTTP headers of the resource request
+                ///
+                /// - Parameters:
+                ///   - headersInfo:
+                public init(
+                    headersInfo: [String: String]
+                ) {
+                    self.headersInfo = headersInfo
+                }
+            }
+        }
+
+        /// Response properties
+        public struct Response: Codable {
+            /// HTTP headers of the resource response
+            public var headers: Headers?
+
+            public enum CodingKeys: String, CodingKey {
+                case headers = "headers"
+            }
+
+            /// Response properties
+            ///
+            /// - Parameters:
+            ///   - headers: HTTP headers of the resource response
+            public init(
+                headers: Headers? = nil
+            ) {
+                self.headers = headers
+            }
+
+            /// HTTP headers of the resource response
+            public struct Headers: Codable {
+                public var headersInfo: [String: String]
+
+                /// HTTP headers of the resource response
+                ///
+                /// - Parameters:
+                ///   - headersInfo:
+                public init(
+                    headersInfo: [String: String]
+                ) {
+                    self.headersInfo = headersInfo
+                }
             }
         }
 
@@ -4567,6 +4631,46 @@ public struct RUMResourceEvent: RUMDataModel {
             self.name = name
             self.referrer = referrer
             self.url = url
+        }
+    }
+}
+
+extension RUMResourceEvent.Resource.Request.Headers {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try headersInfo.forEach {
+            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.headersInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.headersInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
+        }
+    }
+}
+
+extension RUMResourceEvent.Resource.Response.Headers {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try headersInfo.forEach {
+            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.headersInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.headersInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
         }
     }
 }
@@ -11618,4 +11722,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d
+// Generated from https://github.com/DataDog/rum-events-format/tree/302e837c3d49b38587fa58ef16f9aaa7d79be455

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -4867,6 +4867,10 @@ public class objc_RUMResourceEventResource: NSObject {
         root.swiftModel.resource.request != nil ? objc_RUMResourceEventResourceRequest(root: root) : nil
     }
 
+    public var response: objc_RUMResourceEventResourceResponse? {
+        root.swiftModel.resource.response != nil ? objc_RUMResourceEventResourceResponse(root: root) : nil
+    }
+
     public var size: NSNumber? {
         root.swiftModel.resource.size as NSNumber?
     }
@@ -5325,6 +5329,57 @@ public class objc_RUMResourceEventResourceRequest: NSObject {
 
     public var encodedBodySize: NSNumber? {
         root.swiftModel.resource.request!.encodedBodySize as NSNumber?
+    }
+
+    public var headers: objc_RUMResourceEventResourceRequestHeaders? {
+        root.swiftModel.resource.request!.headers != nil ? objc_RUMResourceEventResourceRequestHeaders(root: root) : nil
+    }
+}
+
+@objc(DDRUMResourceEventResourceRequestHeaders)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceRequestHeaders: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headersInfo: [String: String] {
+        set { root.swiftModel.resource.request!.headers!.headersInfo = newValue }
+        get { root.swiftModel.resource.request!.headers!.headersInfo }
+    }
+}
+
+@objc(DDRUMResourceEventResourceResponse)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceResponse: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headers: objc_RUMResourceEventResourceResponseHeaders? {
+        root.swiftModel.resource.response!.headers != nil ? objc_RUMResourceEventResourceResponseHeaders(root: root) : nil
+    }
+}
+
+@objc(DDRUMResourceEventResourceResponseHeaders)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceResponseHeaders: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headersInfo: [String: String] {
+        set { root.swiftModel.resource.response!.headers!.headersInfo = newValue }
+        get { root.swiftModel.resource.response!.headers!.headersInfo }
     }
 }
 
@@ -12192,4 +12247,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d
+// Generated from https://github.com/DataDog/rum-events-format/tree/302e837c3d49b38587fa58ef16f9aaa7d79be455

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -85,11 +85,9 @@ internal struct HeaderProcessor {
 
     // MARK: - Private
 
-    /// Resolves the set of header names to capture for request and response based on the configuration rules.
-    private func buildCaptureList() -> (request: Set<String>, response: Set<String>) {
-        var requestHeaders = Set<String>()
-        var responseHeaders = Set<String>()
-
+    /// Resolves the ordered list of header names to capture for request and response based on the configuration rules.
+    /// Default headers are always placed first to ensure they get budget priority over custom headers.
+    private func buildCaptureList() -> (request: [String], response: [String]) {
         let rules: [RUM.Configuration.URLSessionTracking.HeaderCaptureRule]
 
         switch config {
@@ -101,15 +99,30 @@ internal struct HeaderProcessor {
             rules = customRules
         }
 
+        var requestHeaders: [String] = []
+        var responseHeaders: [String] = []
+        var seenRequest = Set<String>()
+        var seenResponse = Set<String>()
+
         for rule in rules {
             switch rule {
             case .defaults:
-                requestHeaders.formUnion(Self.defaultRequestHeaders)
-                responseHeaders.formUnion(Self.defaultResponseHeaders)
+                for name in Self.defaultRequestHeaders where seenRequest.insert(name).inserted {
+                    requestHeaders.append(name)
+                }
+                for name in Self.defaultResponseHeaders where seenResponse.insert(name).inserted {
+                    responseHeaders.append(name)
+                }
             case .matchHeaders(let names):
-                let lowercased = Set(names.map { $0.lowercased() })
-                requestHeaders.formUnion(lowercased)
-                responseHeaders.formUnion(lowercased)
+                for name in names {
+                    let lowercased = name.lowercased()
+                    if seenRequest.insert(lowercased).inserted {
+                        requestHeaders.append(lowercased)
+                    }
+                    if seenResponse.insert(lowercased).inserted {
+                        responseHeaders.append(lowercased)
+                    }
+                }
             }
         }
 
@@ -117,55 +130,60 @@ internal struct HeaderProcessor {
     }
 
     /// Filters request headers.
-    private func filterRequestHeaders(_ headers: [String: String]?, capturing: Set<String>) -> [String: String] {
+    private func filterRequestHeaders(_ headers: [String: String]?, capturing: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
-        return filterHeaders(headers.map { ($0.key, $0.value) }, capturing: capturing, excluded: Self.reservedRequestHeaders)
+        // Build a case-insensitive lookup from the raw headers
+        let normalized = Dictionary(headers.map { ($0.key.lowercased(), ($0.key, $0.value)) }, uniquingKeysWith: { _, last in last })
+        return filterHeaders(normalized, capturing: capturing, excluded: Self.reservedRequestHeaders)
     }
 
     /// Filters response headers.
-    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: Set<String>) -> [String: String] {
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
-        let stringPairs = headers.compactMap { rawKey, rawValue -> (String, String)? in
-            guard let key = rawKey as? String, let value = rawValue as? String else {
-                return nil
-            }
-            return (key, value)
+        // Build a case-insensitive lookup, keeping only String key/value pairs
+        var normalized: [String: (String, String)] = [:]
+        for (rawKey, rawValue) in headers {
+            guard let key = rawKey as? String, let value = rawValue as? String else { continue }
+            normalized[key.lowercased()] = (key, value)
         }
-        return filterHeaders(stringPairs, capturing: capturing)
+        return filterHeaders(normalized, capturing: capturing)
     }
 
-    /// Shared filtering logic: applies capture list, security pattern, excluded set, and size limits.
-    private func filterHeaders(_ headers: [(String, String)], capturing: Set<String>, excluded: Set<String> = []) -> [String: String] {
-        guard !headers.isEmpty else {
+    /// Shared filtering logic: iterates over the ordered capture list to ensure default headers
+    /// get budget priority over custom ones. Applies security pattern, excluded set, and size limits.
+    private func filterHeaders(
+        _ headersByLowercasedName: [String: (originalKey: String, value: String)],
+        capturing: [String],
+        excluded: Set<String> = []
+    ) -> [String: String] {
+        guard !headersByLowercasedName.isEmpty else {
             return [:]
         }
 
         var result: [String: String] = [:]
         var totalSize = 0
 
-        for (key, value) in headers {
-            let lowercasedKey = key.lowercased()
-
-            // Only capture headers in the configured list
-            guard capturing.contains(lowercasedKey) else { continue }
+        for name in capturing {
+            // Look up the header in the input (name is already lowercased)
+            guard let (originalKey, value) = headersByLowercasedName[name] else { continue }
             // Skip iOS reserved headers
-            guard !excluded.contains(lowercasedKey) else { continue }
+            guard !excluded.contains(name) else { continue }
             // Skip sensitive headers (auth, cookies, tokens, etc.)
-            guard !matchesSecurityPattern(lowercasedKey) else { continue }
+            guard !matchesSecurityPattern(name) else { continue }
             // Enforce max header count
             guard result.count < Self.maxHeaderCount else { break }
 
             let truncatedValue = truncateValue(value)
-            let entrySize = key.utf8.count + truncatedValue.utf8.count
+            let entrySize = originalKey.utf8.count + truncatedValue.utf8.count
 
             // Enforce total size budget
             guard totalSize + entrySize <= Self.maxTotalSize else { break }
 
-            result[key] = truncatedValue
+            result[originalKey] = truncatedValue
             totalSize += entrySize
         }
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -77,8 +77,8 @@ internal struct HeaderProcessor {
             return (request: [:], response: [:])
         case .defaults, .custom:
             let (captureRequest, captureResponse) = buildCaptureList()
-            let request = filterRequestHeaders(requestHeaders, capturing: captureRequest)
-            let response = filterResponseHeaders(responseHeaders, capturing: captureResponse)
+            let request = filterRequestHeaders(requestHeaders, capturedHeaders: captureRequest)
+            let response = filterResponseHeaders(responseHeaders, capturedHeaders: captureResponse)
             return (request: request, response: response)
         }
     }
@@ -101,25 +101,25 @@ internal struct HeaderProcessor {
 
         var requestHeaders: [String] = []
         var responseHeaders: [String] = []
-        var seenRequest = Set<String>()
-        var seenResponse = Set<String>()
+        var seenRequests = Set<String>()
+        var seenResponses = Set<String>()
 
         for rule in rules {
             switch rule {
             case .defaults:
-                for name in Self.defaultRequestHeaders where seenRequest.insert(name).inserted {
+                for name in Self.defaultRequestHeaders where seenRequests.insert(name).inserted {
                     requestHeaders.append(name)
                 }
-                for name in Self.defaultResponseHeaders where seenResponse.insert(name).inserted {
+                for name in Self.defaultResponseHeaders where seenResponses.insert(name).inserted {
                     responseHeaders.append(name)
                 }
             case .matchHeaders(let names):
                 for name in names {
                     let lowercased = name.lowercased()
-                    if seenRequest.insert(lowercased).inserted {
+                    if seenRequests.insert(lowercased).inserted {
                         requestHeaders.append(lowercased)
                     }
-                    if seenResponse.insert(lowercased).inserted {
+                    if seenResponses.insert(lowercased).inserted {
                         responseHeaders.append(lowercased)
                     }
                 }
@@ -130,17 +130,17 @@ internal struct HeaderProcessor {
     }
 
     /// Filters request headers.
-    private func filterRequestHeaders(_ headers: [String: String]?, capturing: [String]) -> [String: String] {
+    private func filterRequestHeaders(_ headers: [String: String]?, capturedHeaders: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
         // Build a case-insensitive lookup from the raw headers
         let normalized = Dictionary(headers.map { ($0.key.lowercased(), ($0.key, $0.value)) }, uniquingKeysWith: { _, last in last })
-        return filterHeaders(normalized, capturing: capturing, excluded: Self.reservedRequestHeaders)
+        return filterHeaders(normalized, capturedHeaders: capturedHeaders, excluded: Self.reservedRequestHeaders)
     }
 
     /// Filters response headers.
-    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: [String]) -> [String: String] {
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturedHeaders: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
@@ -150,14 +150,14 @@ internal struct HeaderProcessor {
             guard let key = rawKey as? String, let value = rawValue as? String else { continue }
             normalized[key.lowercased()] = (key, value)
         }
-        return filterHeaders(normalized, capturing: capturing)
+        return filterHeaders(normalized, capturedHeaders: capturedHeaders)
     }
 
     /// Shared filtering logic: iterates over the ordered capture list to ensure default headers
     /// get budget priority over custom ones. Applies security pattern, excluded set, and size limits.
     private func filterHeaders(
         _ headersByLowercasedName: [String: (originalKey: String, value: String)],
-        capturing: [String],
+        capturedHeaders: [String],
         excluded: Set<String> = []
     ) -> [String: String] {
         guard !headersByLowercasedName.isEmpty else {
@@ -167,7 +167,7 @@ internal struct HeaderProcessor {
         var result: [String: String] = [:]
         var totalSize = 0
 
-        for name in capturing {
+        for name in capturedHeaders {
             // Look up the header in the input (name is already lowercased)
             guard let (originalKey, value) = headersByLowercasedName[name] else { continue }
             // Skip iOS reserved headers

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -176,10 +176,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                 responseHeaders: interception.completion?.httpResponse?.allHeaderFields
             )
             if !headers.request.isEmpty {
-                combinedAttributes[CrossPlatformAttributes.resourceRequestHeaders] = headers.request
+                combinedAttributes[CrossPlatformAttributes.requestHeaders] = headers.request
             }
             if !headers.response.isEmpty {
-                combinedAttributes[CrossPlatformAttributes.resourceResponseHeaders] = headers.response
+                combinedAttributes[CrossPlatformAttributes.responseHeaders] = headers.response
             }
         }
 

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -70,10 +70,20 @@ extension InternalExtension where ExtendedType == RUM {
             distributedTracing = nil
         }
 
+        let headerProcessor: HeaderProcessor? = {
+            switch configuration.trackResourceHeaders {
+            case .disabled:
+                return nil
+            case .defaults, .custom:
+                return HeaderProcessor(config: configuration.trackResourceHeaders)
+            }
+        }()
+
         let urlSessionHandler = URLSessionRUMResourcesHandler(
             dateProvider: rumConfiguration.dateProvider,
             rumAttributesProvider: configuration.resourceAttributesProvider,
             distributedTracing: distributedTracing,
+            headerProcessor: headerProcessor,
             telemetry: core.telemetry
         )
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -176,16 +176,18 @@ internal class RUMResourceScope: RUMScope {
         let decodedBodySize = resourceMetrics?.responseBodySize?.decoded
 
         let requestHeadersObj = requestHeaders.flatMap { $0.isEmpty ? nil : RUMResourceEvent.Resource.Request.Headers(headersInfo: $0) }
-        var request: RUMResourceEvent.Resource.Request? = resourceMetrics?.requestBodySize.map { size in
-            .init(
-                decodedBodySize: size.decoded,
-                encodedBodySize: size.encoded,
+        let request: RUMResourceEvent.Resource.Request? = {
+            let hasBodySize = resourceMetrics?.requestBodySize != nil
+            let hasHeaders = requestHeadersObj != nil
+
+            guard hasBodySize || hasHeaders else { return nil }
+
+            return .init(
+                decodedBodySize: resourceMetrics?.requestBodySize?.decoded,
+                encodedBodySize: resourceMetrics?.requestBodySize?.encoded,
                 headers: requestHeadersObj
             )
-        }
-        if request == nil, let requestHeadersObj {
-            request = .init(headers: requestHeadersObj)
-        }
+        }()
 
         let response: RUMResourceEvent.Resource.Response? = responseHeaders.flatMap { headers in
             headers.isEmpty ? nil : .init(headers: .init(headersInfo: headers))

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -180,7 +180,9 @@ internal class RUMResourceScope: RUMScope {
             let hasBodySize = resourceMetrics?.requestBodySize != nil
             let hasHeaders = requestHeadersObj != nil
 
-            guard hasBodySize || hasHeaders else { return nil }
+            guard hasBodySize || hasHeaders else {
+                return nil
+            }
 
             return .init(
                 decodedBodySize: resourceMetrics?.requestBodySize?.decoded,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -157,8 +157,8 @@ internal class RUMResourceScope: RUMScope {
         }
 
         // Extract captured HTTP headers
-        let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.resourceRequestHeaders)?.dd.decode()
-        let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.resourceResponseHeaders)?.dd.decode()
+        let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
+        let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.responseHeaders)?.dd.decode()
 
         // Metrics values take precedence over other values.
         if let metrics = resourceMetrics {

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -1283,8 +1283,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        let requestHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.resourceRequestHeaders] as? [String: String])
-        let responseHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.resourceResponseHeaders] as? [String: String])
+        let requestHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.requestHeaders] as? [String: String])
+        let responseHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.responseHeaders] as? [String: String])
 
         XCTAssertEqual(requestHeaders.first(where: { $0.key.lowercased() == "content-type" })?.value, "application/json")
         XCTAssertEqual(requestHeaders.first(where: { $0.key.lowercased() == "cache-control" })?.value, "no-cache")
@@ -1324,8 +1324,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceRequestHeaders])
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceResponseHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.requestHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.responseHeaders])
     }
 
     func testWhenHeaderCaptureEnabled_andNoMatchingHeaders_itDoesNotAddEmptyAttributes() throws {
@@ -1363,8 +1363,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceRequestHeaders])
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceResponseHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.requestHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.responseHeaders])
     }
 
     // MARK: - Helper Methods

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1869,6 +1869,60 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(headers.headersInfo["etag"], "\"abc\"")
     }
 
+    func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .post
+        )
+
+        let resourceFetchStart = Date.mockDecember15th2019At10AMUTC()
+        let metricsCommand = RUMAddResourceMetricsCommand(
+            resourceKey: "/api/data",
+            time: .mockDecember15th2019At10AMUTC(),
+            attributes: [:],
+            metrics: .mockWith(
+                fetch: .init(
+                    start: resourceFetchStart,
+                    end: resourceFetchStart.addingTimeInterval(10)
+                ),
+                requestBodySize: (encoded: 512, decoded: 1_024)
+            )
+        )
+
+        // When
+        XCTAssertTrue(scope.process(command: metricsCommand, context: context, writer: writer))
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [
+                        CrossPlatformAttributes.requestHeaders: ["content-type": "application/json"]
+                    ],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        let request = try XCTUnwrap(event.resource.request)
+        XCTAssertEqual(request.encodedBodySize, 512)
+        XCTAssertEqual(request.decodedBodySize, 1_024)
+        let headers = try XCTUnwrap(request.headers)
+        XCTAssertEqual(headers.headersInfo["content-type"], "application/json")
+    }
+
     func testWhenStopCommandHasNoHeaders_requestAndResponseAreUnaffected() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1813,7 +1813,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/api/data",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.resourceRequestHeaders: ["content-type": "application/json", "cache-control": "no-cache"]
+                        CrossPlatformAttributes.requestHeaders: ["content-type": "application/json", "cache-control": "no-cache"]
                     ],
                     kind: .xhr,
                     httpStatusCode: 200,
@@ -1850,7 +1850,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/api/data",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.resourceResponseHeaders: ["content-type": "text/html", "etag": "\"abc\""]
+                        CrossPlatformAttributes.responseHeaders: ["content-type": "text/html", "etag": "\"abc\""]
                     ],
                     kind: .xhr,
                     httpStatusCode: 200,


### PR DESCRIPTION
### What and why?

This is the second PR for Network Header Capture (following #2699). It wires the `HeaderProcessor` into the resource interception pipeline so that captured headers flow through handler → command → scope → RUM event, and appear as `resource.request.headers` and `resource.response.headers` in the Datadog dashboard.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs