### PR TITLE
RUM-14313: Fix `Failed to decode AppStateInfo` error during app login

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -321,6 +321,8 @@
 		118ACA422EEEE0BD004E7F20 /* ProfilingTelemetryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA402EEEE0BD004E7F20 /* ProfilingTelemetryControllerTests.swift */; };
 		118ACA442EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */; };
 		118ACA452EEEED24004E7F20 /* AppLaunchMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */; };
+		119F75F42F438C2100845833 /* DataStoreAsyncMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */; };
+		119F75F52F438C2100845833 /* DataStoreAsyncMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */; };
 		11A2F24A2E70CC08006EDC52 /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */; };
 		11A2F24B2E70CC08006EDC52 /* MediaTimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */; };
 		11A2F24C2E70CC08006EDC52 /* FrameInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */; };
@@ -2871,6 +2873,7 @@
 		118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchMetricController.swift; sourceTree = "<group>"; };
 		118ACA402EEEE0BD004E7F20 /* ProfilingTelemetryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingTelemetryControllerTests.swift; sourceTree = "<group>"; };
 		118ACA432EEEED1F004E7F20 /* AppLaunchMetricControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchMetricControllerTests.swift; sourceTree = "<group>"; };
+		119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreAsyncMock.swift; sourceTree = "<group>"; };
 		11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameInfoProvider.swift; sourceTree = "<group>"; };
 		11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTimeProvider.swift; sourceTree = "<group>"; };
 		11A2F2512E71B730006EDC52 /* MediaTimeProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTimeProviderMock.swift; sourceTree = "<group>"; };
@@ -4481,6 +4484,7 @@
 				1182F9DF2DA2F827007FE71A /* AttributesMocks.swift */,
 				1182F9E02DA2F827007FE71A /* DatadogContextMock.swift */,
 				1182F9E12DA2F827007FE71A /* DatadogRemoteFeatureMock.swift */,
+				119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */,
 				1182F9E22DA2F827007FE71A /* DataStoreMock.swift */,
 				1182F9E32DA2F827007FE71A /* DateProviderMock.swift */,
 				1182F9E42DA2F827007FE71A /* DDErrorMocks.swift */,
@@ -4492,7 +4496,9 @@
 				1182F9EB2DA2F827007FE71A /* FileWriterMock.swift */,
 				1182F9EC2DA2F827007FE71A /* HostsSanitizerMock.swift */,
 				1182F9ED2DA2F827007FE71A /* MockFeature.swift */,
+				D233E7D72E463DDD00E7CFDE /* MultipartBuilderSpy.swift */,
 				1182F9EE2DA2F827007FE71A /* PassthroughCoreMock.swift */,
+				D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */,
 				1182F9EF2DA2F827007FE71A /* SamplerMock.swift */,
 				1182F9F02DA2F827007FE71A /* SingleFeatureCoreMock.swift */,
 				1182F9F12DA2F827007FE71A /* TelemetryMocks.swift */,
@@ -4500,8 +4506,6 @@
 				1182F9F32DA2F827007FE71A /* UploadMock.swift */,
 				1182F9F42DA2F827007FE71A /* UploadMocks.swift */,
 				269035A12E41F93F00F1A830 /* UserConfigurationContextMocks.swift */,
-				D266ECF82DBA5B1800CB9B3A /* RUMDataModelMocks.swift */,
-				D233E7D72E463DDD00E7CFDE /* MultipartBuilderSpy.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -10731,6 +10735,7 @@
 				1182FA542DA2F827007FE71A /* DDCrashReportMocks.swift in Sources */,
 				1182FA552DA2F827007FE71A /* WebViewTrackingMocks.swift in Sources */,
 				1182FA562DA2F827007FE71A /* SnapshotProducerMocks.swift in Sources */,
+				119F75F52F438C2100845833 /* DataStoreAsyncMock.swift in Sources */,
 				1182FA572DA2F827007FE71A /* FeatureRegistrationCoreMock.swift in Sources */,
 				1182FA582DA2F827007FE71A /* DDThreadMocks.swift in Sources */,
 				1182FA592DA2F827007FE71A /* Mockable.swift in Sources */,
@@ -10830,6 +10835,7 @@
 				1182FAA82DA2F827007FE71A /* DDCrashReportMocks.swift in Sources */,
 				1182FAA92DA2F827007FE71A /* WebViewTrackingMocks.swift in Sources */,
 				1182FAAA2DA2F827007FE71A /* SnapshotProducerMocks.swift in Sources */,
+				119F75F42F438C2100845833 /* DataStoreAsyncMock.swift in Sources */,
 				1182FAAB2DA2F827007FE71A /* FeatureRegistrationCoreMock.swift in Sources */,
 				1182FAAC2DA2F827007FE71A /* DDThreadMocks.swift in Sources */,
 				1182FAAD2DA2F827007FE71A /* Mockable.swift in Sources */,

--- a/DatadogRUM/Sources/Instrumentation/AppState/AppStateInfo.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppState/AppStateInfo.swift
@@ -56,6 +56,7 @@ extension AppStateInfo: CustomDebugStringConvertible {
         - appVersion: \(appVersion)
         - osVersion: \(osVersion)
         - systemBootTime: \(systemBootTime)
+        - appLaunchTime: \(appLaunchTime)
         - isDebugging: \(isDebugging)
         - wasTerminated: \(wasTerminated)
         - isActive: \(isActive)

--- a/DatadogRUM/Sources/Instrumentation/AppState/AppStateManager.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppState/AppStateManager.swift
@@ -8,21 +8,24 @@ import Foundation
 import DatadogInternal
 
 internal protocol AppStateManaging {
-    /// The app state information of the last application run.
-    var previousAppStateInfo: AppStateInfo? { get }
-    /// Deletes the app state from the data store.
-    func deleteAppState()
     /// Updates the app state based on the given application state.
     func updateAppState(state: AppState)
+    /// Returns the previous app state via `completion` callback.
+    func previousAppStateInfo(completion: @escaping (AppStateInfo?) -> Void)
     /// Builds the current app state.
     func currentAppStateInfo(completion: @escaping (AppStateInfo) -> Void)
-    /// Builds the current app state and stores it in the data store.
-    func storeCurrentAppState()
 }
 
 /// Manages the app state changes observed during application lifecycle events such as application start, resume and termination.
 internal final class AppStateManager: AppStateManaging {
-    let featureScope: FeatureScope
+    private static let defaultQueue = DispatchQueue(
+        label: "com.datadoghq.app-state-manager",
+        qos: .utility
+    )
+
+    private let featureScope: FeatureScope
+    private let initialStateGroup = DispatchGroup()
+    private let initialStateQueue: DispatchQueue
 
     /// The last app state observed during application lifecycle events.
     @ReadWriteLock
@@ -30,7 +33,7 @@ internal final class AppStateManager: AppStateManaging {
 
     /// The app state information of the last application run.
     @ReadWriteLock
-    private(set) var previousAppStateInfo: AppStateInfo?
+    private var previousAppStateInfo: AppStateInfo?
 
     /// The process identifier of the app whose state is being monitored.
     let processId: UUID
@@ -41,26 +44,24 @@ internal final class AppStateManager: AppStateManaging {
     init(
         featureScope: FeatureScope,
         processId: UUID,
-        syntheticsEnvironment: Bool
+        syntheticsEnvironment: Bool,
+        queue: DispatchQueue = AppStateManager.defaultQueue
     ) {
         self.featureScope = featureScope
         self.processId = processId
         self.syntheticsEnvironment = syntheticsEnvironment
+        self.initialStateQueue = queue
 
         start()
     }
 
     private func start() {
+        initialStateGroup.enter()
         self.readAppState { [weak self] in
             self?.previousAppStateInfo = $0
             self?.storeCurrentAppState()
+            self?.initialStateGroup.leave()
         }
-    }
-
-    /// Deletes the app state from the data store.
-    func deleteAppState() {
-        DD.logger.debug("Deleting app state from data store")
-        featureScope.rumDataStore.removeValue(forKey: .appStateKey)
     }
 
     /// Updates the app state based on the given application state.
@@ -78,16 +79,16 @@ internal final class AppStateManager: AppStateManaging {
         }
         switch state {
         case .active:
-            updateAppState { state in
-                state?.isActive = true
+            updateAppState { stateInfo in
+                stateInfo?.isActive = true
             }
         case .inactive, .background:
-            updateAppState { state in
-                state?.isActive = false
+            updateAppState { stateInfo in
+                stateInfo?.isActive = false
             }
         case .terminated:
-            updateAppState { state in
-                state?.wasTerminated = true
+            updateAppState { stateInfo in
+                stateInfo?.wasTerminated = true
             }
         }
         lastAppState = state
@@ -96,11 +97,21 @@ internal final class AppStateManager: AppStateManaging {
     /// Updates the app state in the data store with the given block.
     /// - Parameter block: The block to update the app state.
     private func updateAppState(block: @escaping (inout AppStateInfo?) -> Void) {
-        featureScope.rumDataStore.value(forKey: .appStateKey) { (appState: AppStateInfo?) in
-            var appState = appState
-            block(&appState)
-            DD.logger.debug("Updating app state in data store")
-            self.featureScope.rumDataStore.setValue(appState, forKey: .appStateKey)
+        onInitialStateLoaded { [weak self] in
+            self?.featureScope.rumDataStore.value(forKey: .appStateKey) { (appState: AppStateInfo?) in
+                var appState = appState
+                block(&appState)
+                DD.logger.debug("Updating app state in data store")
+                self?.featureScope.rumDataStore.setValue(appState, forKey: .appStateKey)
+            }
+        }
+    }
+
+    /// Returns the previous app state via `completion` block.
+    /// - Parameter completion: The completion block called with the previous app state.
+    func previousAppStateInfo(completion: @escaping (AppStateInfo?) -> Void) {
+        onInitialStateLoaded { [weak self] in
+            completion(self?.previousAppStateInfo)
         }
     }
 
@@ -139,5 +150,21 @@ internal final class AppStateManager: AppStateManaging {
             DD.logger.debug("Reading app state from data store.")
             completion(state)
         }
+    }
+
+    /// Runs `completion` once initial state completes.
+    private func onInitialStateLoaded(_ completion: @escaping () -> Void) {
+        initialStateGroup.notify(queue: initialStateQueue, execute: completion)
+    }
+}
+
+// MARK: - Testing funcs
+
+extension AppStateManager {
+    /// Deletes the app state from the data store.
+    /// Used for testing only.
+    func deleteAppState() {
+        DD.logger.debug("Deleting app state from data store")
+        featureScope.rumDataStore.removeValue(forKey: .appStateKey)
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationChecker.swift
@@ -31,11 +31,12 @@ internal final class WatchdogTerminationChecker {
     ///   - launch: The launch report containing information about the app launch.
     ///   - completion: The completion block called with the result.
     func isWatchdogTermination(launch: LaunchReport, completion: @escaping (Bool, AppStateInfo?) -> Void) {
-        appStateManager.currentAppStateInfo { [weak self] current in
-            self?.featureScope.context { [weak self] context in
-                let previous = self?.appStateManager.previousAppStateInfo
-                let isWatchdogTermination = self?.isWatchdogTermination(launch: launch, deviceInfo: context.device, from: previous, to: current)
-                completion(isWatchdogTermination ?? false, previous)
+        appStateManager.previousAppStateInfo { [weak self] previousAppStateInfo in
+            self?.appStateManager.currentAppStateInfo { [weak self] current in
+                self?.featureScope.context { [weak self] context in
+                    let isWatchdogTermination = self?.isWatchdogTermination(launch: launch, deviceInfo: context.device, from: previousAppStateInfo, to: current)
+                    completion(isWatchdogTermination ?? false, previousAppStateInfo)
+                }
             }
         }
     }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -24,7 +24,7 @@ internal class RUMAppLaunchManager {
     private var timeToFullDisplay: Double?
     private var startupType: RUMVitalAppLaunchEvent.Vital.StartupType?
 
-    private lazy var startupTypeHandler = StartupTypeHandler(appStateManager: dependencies.appStateManager, telemetryController: telemetryController)
+    private lazy var startupTypeHandler = StartupTypeHandler(telemetryController: telemetryController)
 
     // MARK: - Initialization
 
@@ -71,47 +71,49 @@ private extension RUMAppLaunchManager {
 
         sendProfilerStopMessage(id: ttidVitalId, activeView: activeView)
 
-        dependencies.appStateManager.currentAppStateInfo { [weak self] currentAppStateInfo in
-            guard let self else {
-                return
-            }
+        dependencies.appStateManager.previousAppStateInfo { [weak self] previousAppStateInfo in
+            self?.dependencies.appStateManager.currentAppStateInfo { [weak self] currentAppStateInfo in
+                guard let self else {
+                    return
+                }
 
-            let attributes = command.globalAttributes
-                .merging(command.attributes) { $1 }
+                let attributes = command.globalAttributes
+                    .merging(command.attributes) { $1 }
 
-            let startupType = self.startupTypeHandler.startupType(currentAppState: currentAppStateInfo)
-            self.startupType = startupType
+                let startupType = self.startupTypeHandler.startupType(previousAppState: previousAppStateInfo, currentAppState: currentAppStateInfo)
+                self.startupType = startupType
 
-            self.writeVitalEvent(
-                vitalId: ttidVitalId,
-                duration: Double(ttid.dd.toInt64Nanoseconds),
-                appLaunchMetric: .ttid,
-                startupType: startupType,
-                attributes: attributes,
-                context: context,
-                writer: writer,
-                activeView: activeView,
-                profiling: profiling
-            )
-
-            // The TTFD is always written after the TTID. If it exists already, means it was not written before.
-            if let timeToFullDisplay {
-                let ttfd = max(ttid, timeToFullDisplay)
                 self.writeVitalEvent(
-                    vitalId: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
-                    duration: Double(ttfd.dd.toInt64Nanoseconds),
-                    appLaunchMetric: .ttfd,
+                    vitalId: ttidVitalId,
+                    duration: Double(ttid.dd.toInt64Nanoseconds),
+                    appLaunchMetric: .ttid,
                     startupType: startupType,
                     attributes: attributes,
                     context: context,
                     writer: writer,
-                    activeView: activeView
+                    activeView: activeView,
+                    profiling: profiling
                 )
 
-                telemetryController.trackTTFD(duration: timeToFullDisplay.dd.toInt64Nanoseconds)
-            }
+                // The TTFD is always written after the TTID. If it exists already, means it was not written before.
+                if let timeToFullDisplay {
+                    let ttfd = max(ttid, timeToFullDisplay)
+                    self.writeVitalEvent(
+                        vitalId: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                        duration: Double(ttfd.dd.toInt64Nanoseconds),
+                        appLaunchMetric: .ttfd,
+                        startupType: startupType,
+                        attributes: attributes,
+                        context: context,
+                        writer: writer,
+                        activeView: activeView
+                    )
 
-            telemetryController.sendMetric()
+                    telemetryController.trackTTFD(duration: timeToFullDisplay.dd.toInt64Nanoseconds)
+                }
+
+                telemetryController.sendMetric()
+            }
         }
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/StartupTypeHandler.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/StartupTypeHandler.swift
@@ -19,43 +19,40 @@ internal final class StartupTypeHandler {
         // Maximum time for a long interval between app launches
         static let maxInactivityDuration: TimeInterval = 604_800 // 1 week
     }
-    private let appStateManager: AppStateManaging
     private let telemetryController: AppLaunchMetricController
     private let coldStartRules: [ColdStartRule]
 
     init(
-        appStateManager: AppStateManaging,
         telemetryController: AppLaunchMetricController,
         coldStartRules: [ColdStartRule] = ColdStartRule.allCases
     ) {
-        self.appStateManager = appStateManager
         self.telemetryController = telemetryController
         self.coldStartRules = coldStartRules
     }
 
-    func startupType(currentAppState: AppStateInfo) -> RUMVitalAppLaunchEvent.Vital.StartupType {
+    func startupType(previousAppState: AppStateInfo?, currentAppState: AppStateInfo) -> RUMVitalAppLaunchEvent.Vital.StartupType {
         for rule in coldStartRules {
             switch rule {
             case .freshInstall:
-                if appStateManager.previousAppStateInfo == nil {
+                if previousAppState == nil {
                     telemetryController.track(coldStartRule: rule)
                     return .coldStart
                 }
             case .appUpdate:
-                if let previousAppStateInfo = appStateManager.previousAppStateInfo,
-                   previousAppStateInfo.appVersion != currentAppState.appVersion {
+                if let previousAppState,
+                   previousAppState.appVersion != currentAppState.appVersion {
                     telemetryController.track(coldStartRule: rule)
                     return .coldStart
                 }
             case .systemRestart:
-                if let previousAppStateInfo = appStateManager.previousAppStateInfo,
-                   previousAppStateInfo.systemBootTime < currentAppState.systemBootTime {
+                if let previousAppState,
+                   previousAppState.systemBootTime < currentAppState.systemBootTime {
                     telemetryController.track(coldStartRule: rule)
                     return .coldStart
                 }
             case .longInactivity:
-                if let previousAppStateInfo = appStateManager.previousAppStateInfo,
-                   (currentAppState.appLaunchTime - previousAppStateInfo.appLaunchTime) > Constants.maxInactivityDuration {
+                if let previousAppState,
+                   (currentAppState.appLaunchTime - previousAppState.appLaunchTime) > Constants.maxInactivityDuration {
                     telemetryController.track(coldStartRule: rule)
                     return .coldStart
                 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/StartupTypeHandlerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/StartupTypeHandlerTests.swift
@@ -15,7 +15,7 @@ final class StartupTypeHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         appStateManager = AppStateManagerMock()
-        handler = StartupTypeHandler(appStateManager: appStateManager, telemetryController: .init())
+        handler = StartupTypeHandler(telemetryController: .init())
     }
 
     override func tearDown() {
@@ -29,7 +29,7 @@ final class StartupTypeHandlerTests: XCTestCase {
         let currentAppState: AppStateInfo = .mockAny()
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: nil, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .coldStart)
@@ -37,11 +37,11 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testAppUpdate_returnsColdStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(appVersion: "1.0.0")
+        let previousAppState: AppStateInfo = .mockWith(appVersion: "1.0.0")
         let currentAppState: AppStateInfo = .mockWith(appVersion: "2.0.0")
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .coldStart)
@@ -49,11 +49,11 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testSystemRestart_returnsColdStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(systemBootTime: 1_000_000)
+        let previousAppState: AppStateInfo = .mockWith(systemBootTime: 1_000_000)
         let currentAppState: AppStateInfo = .mockWith(systemBootTime: 1_100_000)
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .coldStart)
@@ -61,11 +61,11 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testLongInactivity_returnsColdStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(appLaunchTime: 1_000_000)
+        let previousAppState: AppStateInfo = .mockWith(appLaunchTime: 1_000_000)
         let currentAppState: AppStateInfo = .mockWith(appLaunchTime: 1_000_000 + StartupTypeHandler.Constants.maxInactivityDuration + 1)
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .coldStart)
@@ -73,11 +73,11 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testOneWeekInactivity_returnsWarmStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(appLaunchTime: 1_000_000)
+        let previousAppState: AppStateInfo = .mockWith(appLaunchTime: 1_000_000)
         let currentAppState: AppStateInfo = .mockWith(appLaunchTime: 1_000_000 + StartupTypeHandler.Constants.maxInactivityDuration)
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .warmStart)
@@ -85,7 +85,7 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testSimilarAppLaunch_returnsWarmStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(
+        let previousAppState: AppStateInfo = .mockWith(
             appVersion: "1.0.0",
             systemBootTime: 1_000_000,
             appLaunchTime: 1_000_000
@@ -97,7 +97,7 @@ final class StartupTypeHandlerTests: XCTestCase {
         )
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .warmStart)
@@ -105,7 +105,7 @@ final class StartupTypeHandlerTests: XCTestCase {
 
     func testMultipleColdConditions_returnsColdStart() {
         // Given
-        (appStateManager as? AppStateManagerMock)?.previousAppStateInfo = .mockWith(
+        let previousAppState: AppStateInfo = .mockWith(
             appVersion: "1.0.0",
             systemBootTime: 1_000_000,
             appLaunchTime: 1_000_000
@@ -117,7 +117,7 @@ final class StartupTypeHandlerTests: XCTestCase {
         )
 
         // When
-        let result = handler.startupType(currentAppState: currentAppState)
+        let result = handler.startupType(previousAppState: previousAppState, currentAppState: currentAppState)
 
         // Then
         XCTAssertEqual(result, .coldStart)

--- a/TestUtilities/Sources/Mocks/DatadogInternal/DataStoreAsyncMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/DataStoreAsyncMock.swift
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// A `DataStore` that schedules all operations on its internal queue.
+public final class DataStoreAsyncMock: DataStore {
+    @ReadWriteLock
+    public var storage: [String: DataStoreValueResult]
+
+    private let queue = DispatchQueue(label: "com.datadoghq.datastore-async-mock")
+
+    public init(storage: [String: DataStoreValueResult] = [:]) {
+        self.storage = storage
+    }
+
+    public func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
+        queue.async {
+            self.storage[key] = .value(value, version)
+        }
+    }
+
+    public func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        queue.async {
+            callback(self.storage[key] ?? .noValue)
+        }
+    }
+
+    public func removeValue(forKey key: String) {
+        queue.async {
+            self.storage[key] = nil
+        }
+    }
+
+    public func clearAllData() {
+        queue.async {
+            self.storage.removeAll()
+        }
+    }
+
+    /// Function to wait until all scheduled operations complete.
+    public func flush() {
+        queue.sync {}
+    }
+}

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureScopeMock.swift
@@ -24,9 +24,14 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
     private var events: [(event: Encodable, metadata: Encodable?, bypassConsent: Bool)] = []
     @ReadWriteLock
     private var messages: [FeatureMessage] = []
+    public let dataStore: DataStore
 
-    public init(context: DatadogContext = .mockAny()) {
+    public init(
+        context: DatadogContext = .mockAny(),
+        dataStore: DataStore = DataStoreMock()
+    ) {
         self.contextMock = context
+        self.dataStore = dataStore
     }
 
     public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
@@ -36,8 +41,6 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
     public func context(_ block: @escaping (DatadogContext) -> Void) {
         block(contextMock)
     }
-
-    public var dataStore: DataStore { dataStoreMock }
 
     public var telemetry: Telemetry { telemetryMock }
 
@@ -73,7 +76,12 @@ public final class FeatureScopeMock: FeatureScope, @unchecked Sendable {
     // swiftlint:enable function_default_parameter_at_end
 
     /// Retrieve data written in Data Store.
-    public let dataStoreMock = DataStoreMock()
+    public var dataStoreMock: DataStoreMock {
+        guard let dataStoreMock = dataStore as? DataStoreMock else {
+            preconditionFailure("FeatureScopeMock initialized with a non-DataStoreMock store")
+        }
+        return dataStoreMock
+    }
 
     /// Retrieve telemetries sent to Telemetry endpoint.
     public let telemetryMock = TelemetryMock()

--- a/TestUtilities/Sources/Mocks/DatadogRUM/AppStateManagerMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/AppStateManagerMock.swift
@@ -15,6 +15,9 @@ public final class AppStateManagerMock: AppStateManaging {
 
     public func deleteAppState() {}
     public func updateAppState(state: AppState) {}
+    public func previousAppStateInfo(completion: @escaping (DatadogRUM.AppStateInfo?) -> Void) {
+        completion(previousAppStateInfo)
+    }
     public func currentAppStateInfo(completion: @escaping (AppStateInfo) -> Void) {
         completion(currentAppStateInfo)
     }


### PR DESCRIPTION
### What and why?

This PR improves determinism around `AppStateManager` startup/update behavior.

It addresses a timing race between `WatchdogTerminationChecker` and `AppStateManager` where the `previousAppStateInfo` might not be available in time to report a watchdog termination.

### How?
- Updates `AppStateManager` to gate dependent work with a `DispatchGroup` so callbacks run only after initial state loading completes.
- Updates `AppStateManaging` to expose `previousAppStateInfo` through a `completion` callback instead of direct property access.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
