### PR TITLE
Add support of renaming Objective-C runtime classes for generated RUM models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVEMENT] Rename `DDRUMErrorEventErrorMeta` to `DDRUMErrorEventErrorMetaInfo`, add support of custom Objective-C runtime names for generated RUM models. See [#2705][]
+
 # 3.7.0 / 18-02-2026
 
 - [FEATURE] Add evaluation logging to `DatadogFlags` module. See [#2646][]
@@ -1057,6 +1059,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2674]: https://github.com/DataDog/dd-sdk-ios/pull/2674
 [#2676]: https://github.com/DataDog/dd-sdk-ios/pull/2676
 [#2688]: https://github.com/DataDog/dd-sdk-ios/pull/2688
+[#2705]: https://github.com/DataDog/dd-sdk-ios/pull/2705
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -2261,7 +2261,7 @@ public enum objc_RUMErrorEventErrorHandling: Int {
     case unhandled
 }
 
-@objc(DDRUMErrorEventErrorMeta)
+@objc(DDRUMErrorEventErrorMetaInfo)
 @objcMembers
 @_spi(objc)
 public class objc_RUMErrorEventErrorMeta: NSObject {

--- a/tools/rum-models-generator/Sources/rum-models-generator/GenerateRUMModels.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/GenerateRUMModels.swift
@@ -43,6 +43,9 @@ internal func generateRUMSwiftModels(from schema: URL) throws -> String {
 
 internal func generateRUMObjcInteropModels(from schema: URL, skip typesToSkip: Set<String>) throws -> String {
     let generator = ModelsGenerator()
+    let objcRuntimeNameOverrides = [
+        "objc_RUMErrorEventErrorMeta": "DDRUMErrorEventErrorMetaInfo"
+    ]
 
     let template = OutputTemplate(
         header: """
@@ -66,7 +69,10 @@ internal func generateRUMObjcInteropModels(from schema: URL, skip typesToSkip: S
 
             """
     )
-    let printer = ObjcInteropPrinter(objcTypeNamesPrefix: "objc_")
+    let printer = ObjcInteropPrinter(
+        objcTypeNamesPrefix: "objc_",
+        objcRuntimeNameOverrides: objcRuntimeNameOverrides
+    )
 
     return try generator
         .generateCode(from: schema)

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
@@ -129,6 +129,26 @@ final class ObjcInteropPrinterTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
+    func testPrintingObjcInteropWithCustomObjcRuntimeNameOverride() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [],
+            conformance: []
+        )
+
+        let objcInteropTypes = try SwiftToObjcInteropTypeTransformer()
+            .transform(swiftTypes: [fooStruct])
+        let objcInteropPrinter = ObjcInteropPrinter(
+            objcTypeNamesPrefix: "objc_",
+            objcRuntimeNameOverrides: ["objc_Foo": "DDCustomFoo"]
+        )
+        let output = try objcInteropPrinter.print(objcInteropTypes: objcInteropTypes)
+
+        XCTAssertTrue(output.contains("@objc(DDCustomFoo)"))
+        XCTAssertFalse(output.contains("@objc(DDFoo)"))
+    }
+
     func testPrintingObjcInteropForSwiftStructWithIntProperties() throws {
         let fooStruct = SwiftStruct(
             name: "Foo",


### PR DESCRIPTION
### What and why?

Inspired by https://github.com/DataDog/dd-sdk-kotlin-multiplatform/issues/233.

There is `DDRUMErrorEventErrorMeta` class in the native iOS SDK which has to be renamed to the `DDRUMErrorEventErrorMetaInfo` in case of usage from KMP SDK, because otherwise there is clash with a class generated by the KMP (it generates `*Meta` classes for every ObjC class).

This worked till Kotlin 2.3.20, where build tooling seems to be updated and now one more workaround has to be added on the client side.

It is simpler just to give this class a different name in iOS SDK to avoid having such issue.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
