### PR TITLE
RUM-14563 HTTP header capture for RUM resource events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # 3.7.0 / 18-02-2026
 
+- [FEATURE] Add `trackResourceHeaders` configuration to capture HTTP request and response headers in RUM Resource events. See [#2699][]
 - [FEATURE] Add evaluation logging to `DatadogFlags` module. See [#2646][]
 - [FEATURE] Automatic network instrumentation now tracks `URLSession` requests without requiring delegate registration. See [#2620][]
 - [FEATURE] Deprecate `URLSessionInstrumentation.enable(with:in:)` API in favor of `URLSessionInstrumentation.enableDurationBreakdown(with:in:)`. See [#2634][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
 
 - [IMPROVEMENT] Rename `DDRUMErrorEventErrorMeta` to `DDRUMErrorEventErrorMetaInfo`, add support of custom Objective-C runtime names for generated RUM models. See [#2705][]
+- [FEATURE] Add `trackResourceHeaders` configuration to capture HTTP request and response headers in RUM Resource events. See [#2721][]
 
 # 3.7.0 / 18-02-2026
 
-- [FEATURE] Add `trackResourceHeaders` configuration to capture HTTP request and response headers in RUM Resource events. See [#2699][]
 - [FEATURE] Add evaluation logging to `DatadogFlags` module. See [#2646][]
 - [FEATURE] Automatic network instrumentation now tracks `URLSession` requests without requiring delegate registration. See [#2620][]
 - [FEATURE] Deprecate `URLSessionInstrumentation.enable(with:in:)` API in favor of `URLSessionInstrumentation.enableDurationBreakdown(with:in:)`. See [#2634][]
@@ -1061,6 +1061,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2676]: https://github.com/DataDog/dd-sdk-ios/pull/2676
 [#2688]: https://github.com/DataDog/dd-sdk-ios/pull/2688
 [#2705]: https://github.com/DataDog/dd-sdk-ios/pull/2705
+[#2721]: https://github.com/DataDog/dd-sdk-ios/pull/2721
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -402,6 +402,10 @@
 		261255882E2167E40015042B /* BaggageHeaderMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255862E2167E40015042B /* BaggageHeaderMerger.swift */; };
 		2612558A2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
 		2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
+		261255912E2167E40015042B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
+		261255922E2167E40015042B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
+		261255942E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
+		261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
 		265496D32D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		265496D42D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		266BFA5E2D6F4E31003041A5 /* AccountInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */; };
@@ -2910,6 +2914,8 @@
 		1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOTelTracingViewController.swift; sourceTree = "<group>"; };
 		261255862E2167E40015042B /* BaggageHeaderMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMerger.swift; sourceTree = "<group>"; };
 		261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMergerTests.swift; sourceTree = "<group>"; };
+		261255902E2167E40015042B /* HeaderProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessor.swift; sourceTree = "<group>"; };
+		261255932E2167F10015042B /* HeaderProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessorTests.swift; sourceTree = "<group>"; };
 		265496D22D81C5AE0094B6E2 /* RUMAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAccount.swift; sourceTree = "<group>"; };
 		266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisherTests.swift; sourceTree = "<group>"; };
 		2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisher.swift; sourceTree = "<group>"; };
@@ -5907,10 +5913,19 @@
 		613F23EF252B1287006CD2D7 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				261255972E2167F10015042B /* HeaderCapture */,
 				261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */,
 				D2BCB12129D34A5F00737A9A /* URLSessionRUMResourcesHandlerTests.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		261255972E2167F10015042B /* HeaderCapture */ = {
+			isa = PBXGroup;
+			children = (
+				261255932E2167F10015042B /* HeaderProcessorTests.swift */,
+			);
+			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
 		6141014C251A577D00E3C2D9 /* Actions */ = {
@@ -6058,10 +6073,19 @@
 		6157FA5C252767B3009A8A3B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				261255962E2167E40015042B /* HeaderCapture */,
 				261255862E2167E40015042B /* BaggageHeaderMerger.swift */,
 				D2BCB11E29D30AF000737A9A /* URLSessionRUMResourcesHandler.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		261255962E2167E40015042B /* HeaderCapture */ = {
+			isa = PBXGroup;
+			children = (
+				261255902E2167E40015042B /* HeaderProcessor.swift */,
+			);
+			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
 		615950EC291C057D00470E0C /* Integrations */ = {
@@ -10543,6 +10567,7 @@
 				D23F8E7629DDCD28001CFAE8 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D23F8E7729DDCD28001CFAE8 /* UIKitRUMViewsPredicate.swift in Sources */,
 				261255882E2167E40015042B /* BaggageHeaderMerger.swift in Sources */,
+				261255912E2167E40015042B /* HeaderProcessor.swift in Sources */,
 				9629FFDE2D81C317008DFE39 /* SwiftUIViewPath.swift in Sources */,
 				111201C12E93C13000375DA3 /* AppStateManager.swift in Sources */,
 				111201C22E93C13000375DA3 /* AppStateInfo.swift in Sources */,
@@ -10613,6 +10638,7 @@
 				D23F8EAE29DDCD38001CFAE8 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D23F8EAF29DDCD38001CFAE8 /* RUMScopeTests.swift in Sources */,
 				2612558A2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */,
+				261255942E2167F10015042B /* HeaderProcessorTests.swift in Sources */,
 				A7E6EA842D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D23F8EB029DDCD38001CFAE8 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B72A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,
@@ -11038,6 +11064,7 @@
 				D29A9F5829DD85BB005C54A4 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D29A9F5E29DD85BB005C54A4 /* UIKitRUMViewsPredicate.swift in Sources */,
 				261255872E2167E40015042B /* BaggageHeaderMerger.swift in Sources */,
+				261255922E2167E40015042B /* HeaderProcessor.swift in Sources */,
 				9629FFDF2D81C317008DFE39 /* SwiftUIViewPath.swift in Sources */,
 				111201C32E93C13000375DA3 /* AppStateManager.swift in Sources */,
 				111201C42E93C13000375DA3 /* AppStateInfo.swift in Sources */,
@@ -11107,6 +11134,7 @@
 				D29A9FCC29DDBCC5005C54A4 /* DDTAssertValidRUMUUID.swift in Sources */,
 				D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */,
 				2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */,
+				261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */,
 				A7E6EA852D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B62A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -75,6 +75,33 @@ class DDRUMConfigurationTests: XCTestCase {
         DDAssertReflectionEqual(swift.urlSessionTracking, .init(firstPartyHostsTracing: .traceWithHeaders(hostsWithHeaders: ["foo.com": [.b3, .datadog]], sampleRate: 99)))
     }
 
+    func testSetDDRUMURLSessionTrackingWithTrackResourceHeaders() {
+        let tracking = objc_URLSessionTracking()
+
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, RUM.Configuration.URLSessionTracking())
+
+        tracking.setTrackResourceHeaders(.disabled)
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .disabled))
+
+        tracking.setTrackResourceHeaders(.defaults)
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .defaults))
+
+        tracking.setTrackResourceHeaders(.custom([.defaults]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.defaults])))
+
+        tracking.setTrackResourceHeaders(.custom([.matchHeaders(["x-request-id", "x-trace-id"])]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.matchHeaders(["x-request-id", "x-trace-id"])])))
+
+        tracking.setTrackResourceHeaders(.custom([.defaults, .matchHeaders(["x-request-id"])]))
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.defaults, .matchHeaders(["x-request-id"])])))
+    }
+
     func testSetDDRUMURLSessionTrackingWithResourceAttributesProvider() {
         let tracking = objc_URLSessionTracking()
 

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -163,6 +163,16 @@ public struct CrossPlatformAttributes {
     /// Custom value for Interaction To Next view.
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
+
+    /// HTTP headers captured from the resource request, serialized as a JSON string.
+    /// Used to transport request headers through the RUM command pipeline.
+    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
+    public static let resourceRequestHeaders = "_dd.resource.request_headers"
+
+    /// HTTP headers captured from the resource response, serialized as a JSON string.
+    /// Used to transport response headers through the RUM command pipeline.
+    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
+    public static let resourceResponseHeaders = "_dd.resource.response_headers"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -164,12 +164,12 @@ public struct CrossPlatformAttributes {
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
 
-    /// Request headers passed from CP SDK or captured from native URLSession interception.
+    /// Request headers passed from Cross-Platform SDK or captured from native URLSession interception.
     /// Used in RUM resources to transport request headers through the RUM command pipeline.
     /// Expects `[String: String]` value containing header keys and values.
     public static let requestHeaders = "_dd.request_headers"
 
-    /// Response headers passed from CP SDK or captured from native URLSession interception.
+    /// Response headers passed from Cross-Platform SDK or captured from native URLSession interception.
     /// Used in RUM resources to transport response headers through the RUM command pipeline.
     /// Expects `[String: String]` value containing header keys and values.
     public static let responseHeaders = "_dd.response_headers"

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -164,15 +164,15 @@ public struct CrossPlatformAttributes {
     /// For Flutter this is the amount of time between an action occurring and the First Build Complete occurring on the next view.
     public static let customINVValue: String = "_dd.view.custom_inv_value"
 
-    /// HTTP headers captured from the resource request, serialized as a JSON string.
-    /// Used to transport request headers through the RUM command pipeline.
-    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
-    public static let resourceRequestHeaders = "_dd.resource.request_headers"
+    /// Request headers passed from CP SDK or captured from native URLSession interception.
+    /// Used in RUM resources to transport request headers through the RUM command pipeline.
+    /// Expects `[String: String]` value containing header keys and values.
+    public static let requestHeaders = "_dd.request_headers"
 
-    /// HTTP headers captured from the resource response, serialized as a JSON string.
-    /// Used to transport response headers through the RUM command pipeline.
-    /// Expects `String` value containing a JSON dictionary of `[String: String]`.
-    public static let resourceResponseHeaders = "_dd.resource.response_headers"
+    /// Response headers passed from CP SDK or captured from native URLSession interception.
+    /// Used in RUM resources to transport response headers through the RUM command pipeline.
+    /// Expects `[String: String]` value containing header keys and values.
+    public static let responseHeaders = "_dd.response_headers"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -3869,7 +3869,10 @@ public struct RUMResourceEvent: RUMDataModel {
         public let renderBlockingStatus: RenderBlockingStatus?
 
         /// Request properties
-        public let request: Request?
+        public var request: Request?
+
+        /// Response properties
+        public var response: Response?
 
         /// Size in octet of the resource response body
         public let size: Int64?
@@ -3909,6 +3912,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case redirect = "redirect"
             case renderBlockingStatus = "render_blocking_status"
             case request = "request"
+            case response = "response"
             case size = "size"
             case ssl = "ssl"
             case statusCode = "status_code"
@@ -3937,6 +3941,7 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - redirect: Redirect phase properties
         ///   - renderBlockingStatus: Render blocking status of the resource
         ///   - request: Request properties
+        ///   - response: Response properties
         ///   - size: Size in octet of the resource response body
         ///   - ssl: SSL phase properties
         ///   - statusCode: HTTP status code of the resource
@@ -3961,6 +3966,7 @@ public struct RUMResourceEvent: RUMDataModel {
             redirect: Redirect? = nil,
             renderBlockingStatus: RenderBlockingStatus? = nil,
             request: Request? = nil,
+            response: Response? = nil,
             size: Int64? = nil,
             ssl: SSL? = nil,
             statusCode: Int64? = nil,
@@ -3985,6 +3991,7 @@ public struct RUMResourceEvent: RUMDataModel {
             self.redirect = redirect
             self.renderBlockingStatus = renderBlockingStatus
             self.request = request
+            self.response = response
             self.size = size
             self.ssl = ssl
             self.statusCode = statusCode
@@ -4373,9 +4380,13 @@ public struct RUMResourceEvent: RUMDataModel {
             /// Size in octet of the request body sent over the network (after encoding)
             public let encodedBodySize: Int64?
 
+            /// HTTP headers of the resource request
+            public var headers: Headers?
+
             public enum CodingKeys: String, CodingKey {
                 case decodedBodySize = "decoded_body_size"
                 case encodedBodySize = "encoded_body_size"
+                case headers = "headers"
             }
 
             /// Request properties
@@ -4383,12 +4394,65 @@ public struct RUMResourceEvent: RUMDataModel {
             /// - Parameters:
             ///   - decodedBodySize: Size in octet of the request body before any encoding
             ///   - encodedBodySize: Size in octet of the request body sent over the network (after encoding)
+            ///   - headers: HTTP headers of the resource request
             public init(
                 decodedBodySize: Int64? = nil,
-                encodedBodySize: Int64? = nil
+                encodedBodySize: Int64? = nil,
+                headers: Headers? = nil
             ) {
                 self.decodedBodySize = decodedBodySize
                 self.encodedBodySize = encodedBodySize
+                self.headers = headers
+            }
+
+            /// HTTP headers of the resource request
+            public struct Headers: Codable {
+                public var headersInfo: [String: String]
+
+                /// HTTP headers of the resource request
+                ///
+                /// - Parameters:
+                ///   - headersInfo:
+                public init(
+                    headersInfo: [String: String]
+                ) {
+                    self.headersInfo = headersInfo
+                }
+            }
+        }
+
+        /// Response properties
+        public struct Response: Codable {
+            /// HTTP headers of the resource response
+            public var headers: Headers?
+
+            public enum CodingKeys: String, CodingKey {
+                case headers = "headers"
+            }
+
+            /// Response properties
+            ///
+            /// - Parameters:
+            ///   - headers: HTTP headers of the resource response
+            public init(
+                headers: Headers? = nil
+            ) {
+                self.headers = headers
+            }
+
+            /// HTTP headers of the resource response
+            public struct Headers: Codable {
+                public var headersInfo: [String: String]
+
+                /// HTTP headers of the resource response
+                ///
+                /// - Parameters:
+                ///   - headersInfo:
+                public init(
+                    headersInfo: [String: String]
+                ) {
+                    self.headersInfo = headersInfo
+                }
             }
         }
 
@@ -4567,6 +4631,46 @@ public struct RUMResourceEvent: RUMDataModel {
             self.name = name
             self.referrer = referrer
             self.url = url
+        }
+    }
+}
+
+extension RUMResourceEvent.Resource.Request.Headers {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try headersInfo.forEach {
+            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.headersInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.headersInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
+        }
+    }
+}
+
+extension RUMResourceEvent.Resource.Response.Headers {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try headersInfo.forEach {
+            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.headersInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.headersInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
         }
     }
 }
@@ -11618,4 +11722,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d
+// Generated from https://github.com/DataDog/rum-events-format/tree/302e837c3d49b38587fa58ef16f9aaa7d79be455

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -4867,6 +4867,10 @@ public class objc_RUMResourceEventResource: NSObject {
         root.swiftModel.resource.request != nil ? objc_RUMResourceEventResourceRequest(root: root) : nil
     }
 
+    public var response: objc_RUMResourceEventResourceResponse? {
+        root.swiftModel.resource.response != nil ? objc_RUMResourceEventResourceResponse(root: root) : nil
+    }
+
     public var size: NSNumber? {
         root.swiftModel.resource.size as NSNumber?
     }
@@ -5325,6 +5329,57 @@ public class objc_RUMResourceEventResourceRequest: NSObject {
 
     public var encodedBodySize: NSNumber? {
         root.swiftModel.resource.request!.encodedBodySize as NSNumber?
+    }
+
+    public var headers: objc_RUMResourceEventResourceRequestHeaders? {
+        root.swiftModel.resource.request!.headers != nil ? objc_RUMResourceEventResourceRequestHeaders(root: root) : nil
+    }
+}
+
+@objc(DDRUMResourceEventResourceRequestHeaders)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceRequestHeaders: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headersInfo: [String: String] {
+        set { root.swiftModel.resource.request!.headers!.headersInfo = newValue }
+        get { root.swiftModel.resource.request!.headers!.headersInfo }
+    }
+}
+
+@objc(DDRUMResourceEventResourceResponse)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceResponse: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headers: objc_RUMResourceEventResourceResponseHeaders? {
+        root.swiftModel.resource.response!.headers != nil ? objc_RUMResourceEventResourceResponseHeaders(root: root) : nil
+    }
+}
+
+@objc(DDRUMResourceEventResourceResponseHeaders)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventResourceResponseHeaders: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var headersInfo: [String: String] {
+        set { root.swiftModel.resource.response!.headers!.headersInfo = newValue }
+        get { root.swiftModel.resource.response!.headers!.headersInfo }
     }
 }
 
@@ -12192,4 +12247,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/df49e999b2444a66f3c37089db42e3c20ca5538d
+// Generated from https://github.com/DataDog/rum-events-format/tree/302e837c3d49b38587fa58ef16f9aaa7d79be455

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Processes HTTP headers from intercepted URLSession requests, applying security filtering,
+/// size limits, and header resolution based on the configured `TrackResourceHeaders`.
+internal struct HeaderProcessor {
+    /// Maximum byte size for a single header value.
+    static let maxValueSize = 128
+    /// Maximum number of headers per direction (request/response).
+    static let maxHeaderCount = 100
+    /// Maximum total byte size for all collected headers combined (both key and value).
+    static let maxTotalSize = 2_048
+
+    /// Default request headers to capture.
+    static let defaultRequestHeaders: Set<String> = [
+        "cache-control",
+        "content-type"
+    ]
+
+    /// Default response headers to capture.
+    static let defaultResponseHeaders: Set<String> = [
+        "cache-control",
+        "content-encoding",
+        "content-length",
+        "content-type",
+        "etag",
+        "age",
+        "expires",
+        "vary",
+        "server-timing",
+        "x-cache"
+    ]
+
+    /// iOS-managed headers that are always omitted from request capture.
+    /// These are set by the URL Loading System and should not be reported as user-provided request headers.
+    /// Ref: https://developer.apple.com/documentation/foundation/nsurlrequest#Reserved-HTTP-headers
+    static let reservedRequestHeaders: Set<String> = [
+        "content-length",
+        "authorization",
+        "connection",
+        "host",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "www-authenticate"
+    ]
+
+    /// Regex pattern to catch sensitive headers (auth, cookies, tokens, secrets, IPs, etc.).
+    // swiftlint:disable:next force_try
+    static let securityPattern: NSRegularExpression = try! NSRegularExpression(
+        pattern: "(token|cookie|secret|authorization|password|credential|bearer|(api|secret|access|app).?key|forwarded|real.?ip|connecting.?ip|client.?ip)",
+        options: .caseInsensitive
+    )
+
+    private let config: RUM.Configuration.URLSessionTracking.TrackResourceHeaders
+
+    init(config: RUM.Configuration.URLSessionTracking.TrackResourceHeaders) {
+        self.config = config
+    }
+
+    /// Processes request and response headers based on the configured rules.
+    ///
+    /// - Parameters:
+    ///   - requestHeaders: The request headers from `URLRequest.allHTTPHeaderFields`.
+    ///   - responseHeaders: The response headers from `HTTPURLResponse.allHeaderFields`.
+    /// - Returns: A tuple of filtered request and response header dictionaries.
+    func process(
+        requestHeaders: [String: String]?,
+        responseHeaders: [AnyHashable: Any]?
+    ) -> (request: [String: String], response: [String: String]) {
+        guard case .disabled = config else {
+            let (captureRequest, captureResponse) = buildCaptureList()
+            let request = filterRequestHeaders(requestHeaders, capturing: captureRequest)
+            let response = filterResponseHeaders(responseHeaders, capturing: captureResponse)
+            return (request: request, response: response)
+        }
+        return (request: [:], response: [:])
+    }
+
+    // MARK: - Private
+
+    /// Resolves the set of header names to capture for request and response based on the configuration rules.
+    private func buildCaptureList() -> (request: Set<String>, response: Set<String>) {
+        var requestHeaders = Set<String>()
+        var responseHeaders = Set<String>()
+
+        let rules: [RUM.Configuration.URLSessionTracking.HeaderCaptureRule]
+
+        switch config {
+        case .disabled:
+            return (request: [], response: [])
+        case .defaults:
+            rules = [.defaults]
+        case .custom(let customRules):
+            rules = customRules
+        }
+
+        for rule in rules {
+            switch rule {
+            case .defaults:
+                requestHeaders.formUnion(Self.defaultRequestHeaders)
+                responseHeaders.formUnion(Self.defaultResponseHeaders)
+            case .matchHeaders(let names):
+                let lowercased = Set(names.map { $0.lowercased() })
+                requestHeaders.formUnion(lowercased)
+                responseHeaders.formUnion(lowercased)
+            }
+        }
+
+        return (request: requestHeaders, response: responseHeaders)
+    }
+
+    /// Filters request headers.
+    private func filterRequestHeaders(_ headers: [String: String]?, capturing: Set<String>) -> [String: String] {
+        guard let headers else {
+            return [:]
+        }
+        return filterHeaders(headers.map { ($0.key, $0.value) }, capturing: capturing, excluded: Self.reservedRequestHeaders)
+    }
+
+    /// Filters response headers.
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: Set<String>) -> [String: String] {
+        guard let headers else {
+            return [:]
+        }
+        let stringPairs = headers.compactMap { rawKey, rawValue -> (String, String)? in
+            guard let key = rawKey as? String, let value = rawValue as? String else {
+                return nil
+            }
+            return (key, value)
+        }
+        return filterHeaders(stringPairs, capturing: capturing)
+    }
+
+    /// Shared filtering logic: applies capture list, security pattern, excluded set, and size limits.
+    private func filterHeaders(_ headers: [(String, String)], capturing: Set<String>, excluded: Set<String> = []) -> [String: String] {
+        guard !headers.isEmpty else {
+            return [:]
+        }
+
+        var result: [String: String] = [:]
+        var totalSize = 0
+
+        for (key, value) in headers {
+            let lowercasedKey = key.lowercased()
+
+            guard capturing.contains(lowercasedKey) else { continue }
+            guard !excluded.contains(lowercasedKey) else { continue }
+            guard !matchesSecurityPattern(lowercasedKey) else { continue }
+            guard result.count < Self.maxHeaderCount else { break }
+
+            let truncatedValue = truncateValue(value)
+            let entrySize = key.utf8.count + truncatedValue.utf8.count
+
+            guard totalSize + entrySize <= Self.maxTotalSize else { break }
+
+            result[key] = truncatedValue
+            totalSize += entrySize
+        }
+
+        return result
+    }
+
+    /// Truncates a header value to `maxValueSize` bytes, ensuring valid UTF-8.
+    private func truncateValue(_ value: String) -> String {
+        guard value.utf8.count > Self.maxValueSize else {
+            return value
+        }
+
+        // Truncate at UTF-8 byte boundary
+        let utf8 = value.utf8
+        let truncatedUTF8 = utf8.prefix(Self.maxValueSize)
+
+        // Ensure we don't cut in the middle of a multi-byte character
+        return String(truncatedUTF8) ?? String(value.prefix(Self.maxValueSize))
+    }
+
+    /// Checks whether the header name matches the security regex pattern.
+    private func matchesSecurityPattern(_ lowercasedName: String) -> Bool {
+        let range = NSRange(lowercasedName.startIndex..., in: lowercasedName)
+        return Self.securityPattern.firstMatch(in: lowercasedName, range: range) != nil
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -85,11 +85,9 @@ internal struct HeaderProcessor {
 
     // MARK: - Private
 
-    /// Resolves the set of header names to capture for request and response based on the configuration rules.
-    private func buildCaptureList() -> (request: Set<String>, response: Set<String>) {
-        var requestHeaders = Set<String>()
-        var responseHeaders = Set<String>()
-
+    /// Resolves the ordered list of header names to capture for request and response based on the configuration rules.
+    /// Default headers are always placed first to ensure they get budget priority over custom headers.
+    private func buildCaptureList() -> (request: [String], response: [String]) {
         let rules: [RUM.Configuration.URLSessionTracking.HeaderCaptureRule]
 
         switch config {
@@ -101,15 +99,30 @@ internal struct HeaderProcessor {
             rules = customRules
         }
 
+        var requestHeaders: [String] = []
+        var responseHeaders: [String] = []
+        var seenRequest = Set<String>()
+        var seenResponse = Set<String>()
+
         for rule in rules {
             switch rule {
             case .defaults:
-                requestHeaders.formUnion(Self.defaultRequestHeaders)
-                responseHeaders.formUnion(Self.defaultResponseHeaders)
+                for name in Self.defaultRequestHeaders where seenRequest.insert(name).inserted {
+                    requestHeaders.append(name)
+                }
+                for name in Self.defaultResponseHeaders where seenResponse.insert(name).inserted {
+                    responseHeaders.append(name)
+                }
             case .matchHeaders(let names):
-                let lowercased = Set(names.map { $0.lowercased() })
-                requestHeaders.formUnion(lowercased)
-                responseHeaders.formUnion(lowercased)
+                for name in names {
+                    let lowercased = name.lowercased()
+                    if seenRequest.insert(lowercased).inserted {
+                        requestHeaders.append(lowercased)
+                    }
+                    if seenResponse.insert(lowercased).inserted {
+                        responseHeaders.append(lowercased)
+                    }
+                }
             }
         }
 
@@ -117,55 +130,60 @@ internal struct HeaderProcessor {
     }
 
     /// Filters request headers.
-    private func filterRequestHeaders(_ headers: [String: String]?, capturing: Set<String>) -> [String: String] {
+    private func filterRequestHeaders(_ headers: [String: String]?, capturing: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
-        return filterHeaders(headers.map { ($0.key, $0.value) }, capturing: capturing, excluded: Self.reservedRequestHeaders)
+        // Build a case-insensitive lookup from the raw headers
+        let normalized = Dictionary(headers.map { ($0.key.lowercased(), ($0.key, $0.value)) }, uniquingKeysWith: { _, last in last })
+        return filterHeaders(normalized, capturing: capturing, excluded: Self.reservedRequestHeaders)
     }
 
     /// Filters response headers.
-    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: Set<String>) -> [String: String] {
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
-        let stringPairs = headers.compactMap { rawKey, rawValue -> (String, String)? in
-            guard let key = rawKey as? String, let value = rawValue as? String else {
-                return nil
-            }
-            return (key, value)
+        // Build a case-insensitive lookup, keeping only String key/value pairs
+        var normalized: [String: (String, String)] = [:]
+        for (rawKey, rawValue) in headers {
+            guard let key = rawKey as? String, let value = rawValue as? String else { continue }
+            normalized[key.lowercased()] = (key, value)
         }
-        return filterHeaders(stringPairs, capturing: capturing)
+        return filterHeaders(normalized, capturing: capturing)
     }
 
-    /// Shared filtering logic: applies capture list, security pattern, excluded set, and size limits.
-    private func filterHeaders(_ headers: [(String, String)], capturing: Set<String>, excluded: Set<String> = []) -> [String: String] {
-        guard !headers.isEmpty else {
+    /// Shared filtering logic: iterates over the ordered capture list to ensure default headers
+    /// get budget priority over custom ones. Applies security pattern, excluded set, and size limits.
+    private func filterHeaders(
+        _ headersByLowercasedName: [String: (originalKey: String, value: String)],
+        capturing: [String],
+        excluded: Set<String> = []
+    ) -> [String: String] {
+        guard !headersByLowercasedName.isEmpty else {
             return [:]
         }
 
         var result: [String: String] = [:]
         var totalSize = 0
 
-        for (key, value) in headers {
-            let lowercasedKey = key.lowercased()
-
-            // Only capture headers in the configured list
-            guard capturing.contains(lowercasedKey) else { continue }
+        for name in capturing {
+            // Look up the header in the input (name is already lowercased)
+            guard let (originalKey, value) = headersByLowercasedName[name] else { continue }
             // Skip iOS reserved headers
-            guard !excluded.contains(lowercasedKey) else { continue }
+            guard !excluded.contains(name) else { continue }
             // Skip sensitive headers (auth, cookies, tokens, etc.)
-            guard !matchesSecurityPattern(lowercasedKey) else { continue }
+            guard !matchesSecurityPattern(name) else { continue }
             // Enforce max header count
             guard result.count < Self.maxHeaderCount else { break }
 
             let truncatedValue = truncateValue(value)
-            let entrySize = key.utf8.count + truncatedValue.utf8.count
+            let entrySize = originalKey.utf8.count + truncatedValue.utf8.count
 
             // Enforce total size budget
             guard totalSize + entrySize <= Self.maxTotalSize else { break }
 
-            result[key] = truncatedValue
+            result[originalKey] = truncatedValue
             totalSize += entrySize
         }
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -77,8 +77,8 @@ internal struct HeaderProcessor {
             return (request: [:], response: [:])
         case .defaults, .custom:
             let (captureRequest, captureResponse) = buildCaptureList()
-            let request = filterRequestHeaders(requestHeaders, capturing: captureRequest)
-            let response = filterResponseHeaders(responseHeaders, capturing: captureResponse)
+            let request = filterRequestHeaders(requestHeaders, capturedHeaders: captureRequest)
+            let response = filterResponseHeaders(responseHeaders, capturedHeaders: captureResponse)
             return (request: request, response: response)
         }
     }
@@ -101,25 +101,25 @@ internal struct HeaderProcessor {
 
         var requestHeaders: [String] = []
         var responseHeaders: [String] = []
-        var seenRequest = Set<String>()
-        var seenResponse = Set<String>()
+        var seenRequests = Set<String>()
+        var seenResponses = Set<String>()
 
         for rule in rules {
             switch rule {
             case .defaults:
-                for name in Self.defaultRequestHeaders where seenRequest.insert(name).inserted {
+                for name in Self.defaultRequestHeaders where seenRequests.insert(name).inserted {
                     requestHeaders.append(name)
                 }
-                for name in Self.defaultResponseHeaders where seenResponse.insert(name).inserted {
+                for name in Self.defaultResponseHeaders where seenResponses.insert(name).inserted {
                     responseHeaders.append(name)
                 }
             case .matchHeaders(let names):
                 for name in names {
                     let lowercased = name.lowercased()
-                    if seenRequest.insert(lowercased).inserted {
+                    if seenRequests.insert(lowercased).inserted {
                         requestHeaders.append(lowercased)
                     }
-                    if seenResponse.insert(lowercased).inserted {
+                    if seenResponses.insert(lowercased).inserted {
                         responseHeaders.append(lowercased)
                     }
                 }
@@ -130,17 +130,17 @@ internal struct HeaderProcessor {
     }
 
     /// Filters request headers.
-    private func filterRequestHeaders(_ headers: [String: String]?, capturing: [String]) -> [String: String] {
+    private func filterRequestHeaders(_ headers: [String: String]?, capturedHeaders: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
         // Build a case-insensitive lookup from the raw headers
         let normalized = Dictionary(headers.map { ($0.key.lowercased(), ($0.key, $0.value)) }, uniquingKeysWith: { _, last in last })
-        return filterHeaders(normalized, capturing: capturing, excluded: Self.reservedRequestHeaders)
+        return filterHeaders(normalized, capturedHeaders: capturedHeaders, excluded: Self.reservedRequestHeaders)
     }
 
     /// Filters response headers.
-    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturing: [String]) -> [String: String] {
+    private func filterResponseHeaders(_ headers: [AnyHashable: Any]?, capturedHeaders: [String]) -> [String: String] {
         guard let headers else {
             return [:]
         }
@@ -150,14 +150,14 @@ internal struct HeaderProcessor {
             guard let key = rawKey as? String, let value = rawValue as? String else { continue }
             normalized[key.lowercased()] = (key, value)
         }
-        return filterHeaders(normalized, capturing: capturing)
+        return filterHeaders(normalized, capturedHeaders: capturedHeaders)
     }
 
     /// Shared filtering logic: iterates over the ordered capture list to ensure default headers
     /// get budget priority over custom ones. Applies security pattern, excluded set, and size limits.
     private func filterHeaders(
         _ headersByLowercasedName: [String: (originalKey: String, value: String)],
-        capturing: [String],
+        capturedHeaders: [String],
         excluded: Set<String> = []
     ) -> [String: String] {
         guard !headersByLowercasedName.isEmpty else {
@@ -167,7 +167,7 @@ internal struct HeaderProcessor {
         var result: [String: String] = [:]
         var totalSize = 0
 
-        for name in capturing {
+        for name in capturedHeaders {
             // Look up the header in the input (name is already lowercased)
             guard let (originalKey, value) = headersByLowercasedName[name] else { continue }
             // Skip iOS reserved headers

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -134,8 +134,8 @@ internal struct HeaderProcessor {
         guard let headers else {
             return [:]
         }
-        // Build a case-insensitive lookup from the raw headers
-        let normalized = Dictionary(headers.map { ($0.key.lowercased(), ($0.key, $0.value)) }, uniquingKeysWith: { _, last in last })
+        // Build a case-insensitive lookup from the raw headers (values only, keys will be lowercased in output)
+        let normalized = Dictionary(headers.map { ($0.key.lowercased(), $0.value) }, uniquingKeysWith: { _, last in last })
         return filterHeaders(normalized, capturedHeaders: capturedHeaders, excluded: Self.reservedRequestHeaders)
     }
 
@@ -144,23 +144,24 @@ internal struct HeaderProcessor {
         guard let headers else {
             return [:]
         }
-        // Build a case-insensitive lookup, keeping only String key/value pairs
-        var normalized: [String: (String, String)] = [:]
+        // Build a case-insensitive lookup, keeping only String values (keys will be lowercased in output)
+        var normalized: [String: String] = [:]
         for (rawKey, rawValue) in headers {
             guard let key = rawKey as? String, let value = rawValue as? String else { continue }
-            normalized[key.lowercased()] = (key, value)
+            normalized[key.lowercased()] = value
         }
         return filterHeaders(normalized, capturedHeaders: capturedHeaders)
     }
 
     /// Shared filtering logic: iterates over the ordered capture list to ensure default headers
     /// get budget priority over custom ones. Applies security pattern, excluded set, and size limits.
+    /// All output keys are lowercased for cross-platform consistency.
     private func filterHeaders(
-        _ headersByLowercasedName: [String: (originalKey: String, value: String)],
+        _ valuesByLowercasedName: [String: String],
         capturedHeaders: [String],
         excluded: Set<String> = []
     ) -> [String: String] {
-        guard !headersByLowercasedName.isEmpty else {
+        guard !valuesByLowercasedName.isEmpty else {
             return [:]
         }
 
@@ -168,8 +169,8 @@ internal struct HeaderProcessor {
         var totalSize = 0
 
         for name in capturedHeaders {
-            // Look up the header in the input (name is already lowercased)
-            guard let (originalKey, value) = headersByLowercasedName[name] else { continue }
+            // Look up the header value in the input (name is already lowercased)
+            guard let value = valuesByLowercasedName[name] else { continue }
             // Skip iOS reserved headers
             guard !excluded.contains(name) else { continue }
             // Skip sensitive headers (auth, cookies, tokens, etc.)
@@ -178,12 +179,12 @@ internal struct HeaderProcessor {
             guard result.count < Self.maxHeaderCount else { break }
 
             let truncatedValue = truncateValue(value)
-            let entrySize = originalKey.utf8.count + truncatedValue.utf8.count
+            let entrySize = name.utf8.count + truncatedValue.utf8.count
 
             // Enforce total size budget
             guard totalSize + entrySize <= Self.maxTotalSize else { break }
 
-            result[originalKey] = truncatedValue
+            result[name] = truncatedValue
             totalSize += entrySize
         }
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -176,10 +176,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
                 responseHeaders: interception.completion?.httpResponse?.allHeaderFields
             )
             if !headers.request.isEmpty {
-                combinedAttributes[CrossPlatformAttributes.resourceRequestHeaders] = headers.request
+                combinedAttributes[CrossPlatformAttributes.requestHeaders] = headers.request
             }
             if !headers.response.isEmpty {
-                combinedAttributes[CrossPlatformAttributes.resourceResponseHeaders] = headers.response
+                combinedAttributes[CrossPlatformAttributes.responseHeaders] = headers.response
             }
         }
 

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -70,10 +70,20 @@ extension InternalExtension where ExtendedType == RUM {
             distributedTracing = nil
         }
 
+        let headerProcessor: HeaderProcessor? = {
+            switch configuration.trackResourceHeaders {
+            case .disabled:
+                return nil
+            case .defaults, .custom:
+                return HeaderProcessor(config: configuration.trackResourceHeaders)
+            }
+        }()
+
         let urlSessionHandler = URLSessionRUMResourcesHandler(
             dateProvider: rumConfiguration.dateProvider,
             rumAttributesProvider: configuration.resourceAttributesProvider,
             distributedTracing: distributedTracing,
+            headerProcessor: headerProcessor,
             telemetry: core.telemetry
         )
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -351,6 +351,51 @@ public class objc_URLSessionTracking: NSObject {
             return objcAttributes?.dd.swiftAttributes
         }
     }
+
+    public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders) {
+        swiftConfig.trackResourceHeaders = trackResourceHeaders.swiftType
+    }
+}
+
+@objc(DDRUMHeaderCaptureRule)
+@objcMembers
+@_spi(objc)
+public final class objc_HeaderCaptureRule: NSObject {
+    internal let swiftType: RUM.Configuration.URLSessionTracking.HeaderCaptureRule
+
+    private init(_ swiftType: RUM.Configuration.URLSessionTracking.HeaderCaptureRule) {
+        self.swiftType = swiftType
+    }
+
+    /// Include the predefined set of default headers.
+    public static let defaults = objc_HeaderCaptureRule(.defaults)
+
+    /// Match headers by exact name (case-insensitive).
+    public static func matchHeaders(_ names: [String]) -> objc_HeaderCaptureRule {
+        objc_HeaderCaptureRule(.matchHeaders(names))
+    }
+}
+
+@objc(DDRUMTrackResourceHeaders)
+@objcMembers
+@_spi(objc)
+public final class objc_TrackResourceHeaders: NSObject {
+    internal let swiftType: RUM.Configuration.URLSessionTracking.TrackResourceHeaders
+
+    private init(_ swiftType: RUM.Configuration.URLSessionTracking.TrackResourceHeaders) {
+        self.swiftType = swiftType
+    }
+
+    /// No header capture. This is the default.
+    public static let disabled = objc_TrackResourceHeaders(.disabled)
+
+    /// Capture a predefined set of common request and response headers.
+    public static let defaults = objc_TrackResourceHeaders(.defaults)
+
+    /// Capture headers based on custom rules.
+    public static func custom(_ rules: [objc_HeaderCaptureRule]) -> objc_TrackResourceHeaders {
+        objc_TrackResourceHeaders(.custom(rules.map { $0.swiftType }))
+    }
 }
 
 @objc(DDRUMConfiguration)

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -342,11 +342,11 @@ extension RUM {
 
             /// Configuration for capturing HTTP headers from network requests and responses.
             ///
-            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests
-            /// and includes them in RUM Resource events. Headers are filtered for security (sensitive headers
-            /// like `Authorization`, `Cookie`, etc. are never captured) and size limits are enforced.
+            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests and responses
+            /// and includes them in RUM Resource events. Sensitive headers are filtered out for security reasons
+            /// (e.g., `Authorization` and `Cookie` headers are never captured) and size limits are enforced.
             ///
-            /// - `.disabled`: No header capture (default).
+            /// - `.disabled`: No header capture.
             /// - `.defaults`: Capture a predefined set of common request and response headers.
             /// - `.custom([rules])`: Capture headers based on custom rules.
             ///

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -340,6 +340,19 @@ extension RUM {
             /// Default: `nil`.
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
 
+            /// Configuration for capturing HTTP headers from network requests and responses.
+            ///
+            /// When enabled, the SDK captures configured HTTP headers from intercepted URLSession requests
+            /// and includes them in RUM Resource events. Headers are filtered for security (sensitive headers
+            /// like `Authorization`, `Cookie`, etc. are never captured) and size limits are enforced.
+            ///
+            /// - `.disabled`: No header capture (default).
+            /// - `.defaults`: Capture a predefined set of common request and response headers.
+            /// - `.custom([rules])`: Capture headers based on custom rules.
+            ///
+            /// Default: `.disabled`.
+            public var trackResourceHeaders: TrackResourceHeaders = .disabled
+
             /// Private init to avoid `invalid redeclaration of synthesized memberwise init(...:)` in extension.
             private init() {}
         }
@@ -420,16 +433,50 @@ extension RUM.Configuration.URLSessionTracking {
         )
     }
 
+    /// Configuration for capturing HTTP headers from network requests and responses.
+    public enum TrackResourceHeaders {
+        /// No header capture. This is the default.
+        case disabled
+
+        /// Capture a predefined set of common request and response headers for all URLs.
+        ///
+        /// Default request headers: `cache-control`, `content-type`.
+        /// Default response headers: `cache-control`, `content-encoding`, `content-length`,
+        /// `content-type`, `etag`, `age`, `expires`, `vary`, `server-timing`, `x-cache`.
+        case defaults
+
+        /// Capture headers based on custom rules for all URLs.
+        ///
+        /// Multiple rules can be combined. For example, to capture default headers plus
+        /// additional custom headers:
+        /// ```swift
+        /// .custom([.defaults, .matchHeaders(["x-request-id"])])
+        /// ```
+        case custom([HeaderCaptureRule])
+    }
+
+    /// A rule that defines which HTTP headers to capture.
+    public enum HeaderCaptureRule {
+        /// Include the predefined set of default headers.
+        case defaults
+
+        /// Match headers by exact name (case-insensitive).
+        case matchHeaders([String])
+    }
+
     /// Configuration for automatic RUM resources tracking.
     /// - Parameters:
     ///   - firstPartyHostsTracing: Distributed tracing configuration for particular first-party hosts.
     ///   - resourceAttributesProvider: Custom attributes provider for intercepted RUM resources.
+    ///   - trackResourceHeaders: Configuration for capturing HTTP headers. Default: `.disabled`.
     public init(
         firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,
-        resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil
+        resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,
+        trackResourceHeaders: TrackResourceHeaders = .disabled
     ) {
         self.firstPartyHostsTracing = firstPartyHostsTracing
         self.resourceAttributesProvider = resourceAttributesProvider
+        self.trackResourceHeaders = trackResourceHeaders
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -176,16 +176,18 @@ internal class RUMResourceScope: RUMScope {
         let decodedBodySize = resourceMetrics?.responseBodySize?.decoded
 
         let requestHeadersObj = requestHeaders.flatMap { $0.isEmpty ? nil : RUMResourceEvent.Resource.Request.Headers(headersInfo: $0) }
-        var request: RUMResourceEvent.Resource.Request? = resourceMetrics?.requestBodySize.map { size in
-            .init(
-                decodedBodySize: size.decoded,
-                encodedBodySize: size.encoded,
+        let request: RUMResourceEvent.Resource.Request? = {
+            let hasBodySize = resourceMetrics?.requestBodySize != nil
+            let hasHeaders = requestHeadersObj != nil
+
+            guard hasBodySize || hasHeaders else { return nil }
+
+            return .init(
+                decodedBodySize: resourceMetrics?.requestBodySize?.decoded,
+                encodedBodySize: resourceMetrics?.requestBodySize?.encoded,
                 headers: requestHeadersObj
             )
-        }
-        if request == nil, let requestHeadersObj {
-            request = .init(headers: requestHeadersObj)
-        }
+        }()
 
         let response: RUMResourceEvent.Resource.Response? = responseHeaders.flatMap { headers in
             headers.isEmpty ? nil : .init(headers: .init(headersInfo: headers))

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -180,7 +180,9 @@ internal class RUMResourceScope: RUMScope {
             let hasBodySize = resourceMetrics?.requestBodySize != nil
             let hasHeaders = requestHeadersObj != nil
 
-            guard hasBodySize || hasHeaders else { return nil }
+            guard hasBodySize || hasHeaders else {
+                return nil
+            }
 
             return .init(
                 decodedBodySize: resourceMetrics?.requestBodySize?.decoded,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -157,8 +157,8 @@ internal class RUMResourceScope: RUMScope {
         }
 
         // Extract captured HTTP headers
-        let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.resourceRequestHeaders)?.dd.decode()
-        let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.resourceResponseHeaders)?.dd.decode()
+        let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
+        let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.responseHeaders)?.dd.decode()
 
         // Metrics values take precedence over other values.
         if let metrics = resourceMetrics {

--- a/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
@@ -1,0 +1,403 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogRUM
+
+class HeaderProcessorTests: XCTestCase {
+    // MARK: - Disabled Configuration
+
+    func testWhenDisabled_itReturnsEmptyHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .disabled)
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["content-type": "application/json"],
+            responseHeaders: ["content-type": "text/html"]
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    // MARK: - Defaults Configuration
+
+    func testWhenDefaults_itCapturesDefaultRequestHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "cache-control": "no-cache",
+                "content-type": "application/json",
+                "authorization": "Bearer secret",
+                "accept": "text/html"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, [
+            "cache-control": "no-cache",
+            "content-type": "application/json"
+        ])
+    }
+
+    func testWhenDefaults_itCapturesDefaultResponseHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: [
+                "cache-control": "max-age=3600",
+                "etag": "\"abc123\"",
+                "age": "120",
+                "expires": "Thu, 01 Dec 2025 16:00:00 GMT",
+                "content-type": "application/json",
+                "content-encoding": "gzip",
+                "content-length": "1024",
+                "vary": "Accept-Encoding",
+                "server-timing": "db;dur=53",
+                "x-cache": "HIT",
+                "x-custom-header": "should-not-appear",
+                "set-cookie": "session=abc"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.response.count, 10)
+        XCTAssertEqual(result.response["cache-control"], "max-age=3600")
+        XCTAssertEqual(result.response["etag"], "\"abc123\"")
+        XCTAssertEqual(result.response["age"], "120")
+        XCTAssertEqual(result.response["expires"], "Thu, 01 Dec 2025 16:00:00 GMT")
+        XCTAssertEqual(result.response["content-type"], "application/json")
+        XCTAssertEqual(result.response["content-encoding"], "gzip")
+        XCTAssertEqual(result.response["content-length"], "1024")
+        XCTAssertEqual(result.response["vary"], "Accept-Encoding")
+        XCTAssertEqual(result.response["server-timing"], "db;dur=53")
+        XCTAssertEqual(result.response["x-cache"], "HIT")
+        XCTAssertNil(result.response["x-custom-header"])
+        XCTAssertNil(result.response["set-cookie"])
+    }
+
+    // MARK: - Custom Configuration
+
+    func testWhenCustomMatchHeaders_itCapturesOnlySpecifiedHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["x-request-id"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "application/json"
+            ],
+            responseHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "text/html"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, ["x-request-id": "abc-123"])
+        XCTAssertEqual(result.response, ["x-request-id": "abc-123"])
+    }
+
+    func testWhenCustomWithDefaultsAndMatchHeaders_itMergesBoth() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.defaults, .matchHeaders(["x-request-id"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "cache-control": "no-cache",
+                "content-type": "application/json",
+                "x-request-id": "abc-123",
+                "accept": "text/html"
+            ],
+            responseHeaders: [
+                "x-request-id": "abc-123",
+                "content-type": "text/html"
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, [
+            "cache-control": "no-cache",
+            "content-type": "application/json",
+            "x-request-id": "abc-123"
+        ])
+        XCTAssertEqual(result.response, [
+            "x-request-id": "abc-123",
+            "content-type": "text/html"
+        ])
+    }
+
+    // MARK: - Security Filtering
+
+    func testItNeverCapturesSensitiveHeaders() {
+        // Given
+        let sensitiveNames = [
+            "authorization",
+            "proxy-authorization",
+            "x-api-key",
+            "x-access-token",
+            "x-auth-token",
+            "x-session-token",
+            "cookie",
+            "set-cookie",
+            "x-forwarded-for",
+            "x-real-ip",
+            "cf-connecting-ip",
+            "true-client-ip",
+            "x-csrf-token",
+            "x-xsrf-token",
+            "x-security-token"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(sensitiveNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "authorization": "Bearer secret",
+                "proxy-authorization": "Basic abc",
+                "x-api-key": "key123",
+                "x-access-token": "token",
+                "x-auth-token": "auth",
+                "x-session-token": "session",
+                "cookie": "id=abc",
+                "x-forwarded-for": "1.2.3.4",
+                "x-real-ip": "1.2.3.4",
+                "cf-connecting-ip": "1.2.3.4",
+                "true-client-ip": "1.2.3.4",
+                "x-csrf-token": "csrf",
+                "x-xsrf-token": "xsrf",
+                "x-security-token": "sec"
+            ],
+            responseHeaders: [
+                "set-cookie": "session=abc"
+            ]
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    func testItFiltersHeadersMatchingSecurityPattern() {
+        // Given
+        let sensitiveNames = [
+            "x-custom-token",
+            "my-secret-header",
+            "x-app-key",
+            "x-bearer-auth",
+            "x-password-hash",
+            "x-credential-id",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(sensitiveNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "x-custom-token": "value",
+                "my-secret-header": "value",
+                "x-app-key": "value",
+                "x-bearer-auth": "value",
+                "x-password-hash": "value",
+                "x-credential-id": "value",
+                "content-type": "application/json"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertEqual(result.request, ["content-type": "application/json"])
+    }
+
+    // MARK: - Reserved Request Headers
+
+    func testItFiltersReservedHeadersFromRequest() {
+        // Given
+        let reservedNames = [
+            "content-length",
+            "connection",
+            "host",
+            "proxy-authenticate",
+            "www-authenticate",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(reservedNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [
+                "Content-Length": "1024",
+                "Connection": "keep-alive",
+                "Host": "example.com",
+                "Proxy-Authenticate": "Basic",
+                "WWW-Authenticate": "Bearer",
+                "Content-Type": "application/json"
+            ],
+            responseHeaders: [:]
+        )
+
+        // Then - Only content-type should pass (others are reserved for requests)
+        XCTAssertEqual(result.request.count, 1)
+        XCTAssertNotNil(result.request.first(where: { $0.key.lowercased() == "content-type" }))
+    }
+
+    func testItDoesNotFilterReservedHeadersFromResponse() {
+        // Given
+        let headerNames = [
+            "content-length",
+            "content-type"
+        ]
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: [
+                "Content-Length": "1024",
+                "Content-Type": "application/json"
+            ]
+        )
+
+        // Then - Content-Length is valid in responses
+        XCTAssertEqual(result.response.count, 2)
+    }
+
+    // MARK: - Case Sensitivity
+
+    func testItMatchesHeadersCaseInsensitively() {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["Content-Type"])]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["content-type": "application/json"],
+            responseHeaders: ["CONTENT-TYPE": "text/html"]
+        )
+
+        // Then
+        XCTAssertEqual(result.request.count, 1)
+        XCTAssertEqual(result.request.first(where: { $0.key.lowercased() == "content-type" })?.value, "application/json")
+        XCTAssertEqual(result.response.count, 1)
+        XCTAssertEqual(result.response.first(where: { $0.key.lowercased() == "content-type" })?.value, "text/html")
+    }
+
+    // MARK: - Value Truncation
+
+    func testItTruncatesValuesExceeding128Bytes() throws {
+        // Given
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(["x-long-header"])]))
+        let longValue = String(repeating: "a", count: 200)
+
+        // When
+        let result = processor.process(
+            requestHeaders: ["x-long-header": longValue],
+            responseHeaders: [:]
+        )
+
+        // Then
+        let capturedValue = try XCTUnwrap(result.request["x-long-header"])
+        XCTAssertLessThanOrEqual(capturedValue.utf8.count, 128)
+    }
+
+    // MARK: - Header Count Limit
+
+    func testItLimitsTo100Headers() {
+        // Given
+        var headerNames: [String] = []
+        var requestHeaders: [String: String] = [:]
+        for i in 0..<150 {
+            let name = "x-header-\(i)"
+            headerNames.append(name)
+            requestHeaders[name] = "value-\(i)"
+        }
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: requestHeaders,
+            responseHeaders: [:]
+        )
+
+        // Then
+        XCTAssertLessThanOrEqual(result.request.count, 100)
+    }
+
+    // MARK: - Total Size Limit
+
+    func testItEnforces2KBTotalSizeLimit() {
+        // Given
+        var headerNames: [String] = []
+        var requestHeaders: [String: String] = [:]
+        for i in 0..<50 {
+            let name = "x-header-\(i)"
+            headerNames.append(name)
+            // Each value is 100 bytes, 50 headers = ~5KB > 2KB limit
+            requestHeaders[name] = String(repeating: "x", count: 100)
+        }
+        let processor = HeaderProcessor(config: .custom([.matchHeaders(headerNames)]))
+
+        // When
+        let result = processor.process(
+            requestHeaders: requestHeaders,
+            responseHeaders: [:]
+        )
+
+        // Then - Total size should be at most 2KB
+        let totalSize = result.request.reduce(0) { $0 + $1.key.utf8.count + $1.value.utf8.count }
+        XCTAssertLessThanOrEqual(totalSize, 2_048)
+    }
+
+    // MARK: - Nil Input
+
+    func testWhenInputIsNil_itReturnsEmptyHeaders() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+
+        // When
+        let result = processor.process(
+            requestHeaders: nil,
+            responseHeaders: nil
+        )
+
+        // Then
+        XCTAssertTrue(result.request.isEmpty)
+        XCTAssertTrue(result.response.isEmpty)
+    }
+
+    // MARK: - Response AnyHashable Cast
+
+    func testItHandlesResponseHeadersWithAnyHashableKeys() {
+        // Given
+        let processor = HeaderProcessor(config: .defaults)
+        let responseHeaders: [AnyHashable: Any] = [
+            "content-type": "application/json",
+            "cache-control": "no-cache",
+            42: "should-be-ignored" // non-String key
+        ]
+
+        // When
+        let result = processor.process(
+            requestHeaders: [:],
+            responseHeaders: responseHeaders
+        )
+
+        // Then
+        XCTAssertEqual(result.response["content-type"], "application/json")
+        XCTAssertEqual(result.response["cache-control"], "no-cache")
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
@@ -252,8 +252,7 @@ class HeaderProcessorTests: XCTestCase {
         )
 
         // Then - Only content-type should pass (others are reserved for requests)
-        XCTAssertEqual(result.request.count, 1)
-        XCTAssertNotNil(result.request.first(where: { $0.key.lowercased() == "content-type" }))
+        XCTAssertEqual(result.request, ["content-type": "application/json"])
     }
 
     func testItDoesNotFilterReservedHeadersFromResponse() {
@@ -273,8 +272,8 @@ class HeaderProcessorTests: XCTestCase {
             ]
         )
 
-        // Then - Content-Length is valid in responses
-        XCTAssertEqual(result.response.count, 2)
+        // Then - Content-Length is valid in responses (keys are lowercased in output)
+        XCTAssertEqual(result.response, ["content-length": "1024", "content-type": "application/json"])
     }
 
     // MARK: - Case Sensitivity
@@ -289,11 +288,9 @@ class HeaderProcessorTests: XCTestCase {
             responseHeaders: ["CONTENT-TYPE": "text/html"]
         )
 
-        // Then
-        XCTAssertEqual(result.request.count, 1)
-        XCTAssertEqual(result.request.first(where: { $0.key.lowercased() == "content-type" })?.value, "application/json")
-        XCTAssertEqual(result.response.count, 1)
-        XCTAssertEqual(result.response.first(where: { $0.key.lowercased() == "content-type" })?.value, "text/html")
+        // Then - keys are always lowercased in output
+        XCTAssertEqual(result.request, ["content-type": "application/json"])
+        XCTAssertEqual(result.response, ["content-type": "text/html"])
     }
 
     // MARK: - Value Truncation

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -1283,8 +1283,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        let requestHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.resourceRequestHeaders] as? [String: String])
-        let responseHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.resourceResponseHeaders] as? [String: String])
+        let requestHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.requestHeaders] as? [String: String])
+        let responseHeaders = try XCTUnwrap(attributes[CrossPlatformAttributes.responseHeaders] as? [String: String])
 
         XCTAssertEqual(requestHeaders.first(where: { $0.key.lowercased() == "content-type" })?.value, "application/json")
         XCTAssertEqual(requestHeaders.first(where: { $0.key.lowercased() == "cache-control" })?.value, "no-cache")
@@ -1324,8 +1324,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceRequestHeaders])
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceResponseHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.requestHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.responseHeaders])
     }
 
     func testWhenHeaderCaptureEnabled_andNoMatchingHeaders_itDoesNotAddEmptyAttributes() throws {
@@ -1363,8 +1363,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceRequestHeaders])
-        XCTAssertNil(attributes[CrossPlatformAttributes.resourceResponseHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.requestHeaders])
+        XCTAssertNil(attributes[CrossPlatformAttributes.responseHeaders])
     }
 
     // MARK: - Helper Methods

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1869,6 +1869,60 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(headers.headersInfo["etag"], "\"abc\"")
     }
 
+    func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .post
+        )
+
+        let resourceFetchStart = Date.mockDecember15th2019At10AMUTC()
+        let metricsCommand = RUMAddResourceMetricsCommand(
+            resourceKey: "/api/data",
+            time: .mockDecember15th2019At10AMUTC(),
+            attributes: [:],
+            metrics: .mockWith(
+                fetch: .init(
+                    start: resourceFetchStart,
+                    end: resourceFetchStart.addingTimeInterval(10)
+                ),
+                requestBodySize: (encoded: 512, decoded: 1_024)
+            )
+        )
+
+        // When
+        XCTAssertTrue(scope.process(command: metricsCommand, context: context, writer: writer))
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [
+                        CrossPlatformAttributes.requestHeaders: ["content-type": "application/json"]
+                    ],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        let request = try XCTUnwrap(event.resource.request)
+        XCTAssertEqual(request.encodedBodySize, 512)
+        XCTAssertEqual(request.decodedBodySize, 1_024)
+        let headers = try XCTUnwrap(request.headers)
+        XCTAssertEqual(headers.headersInfo["content-type"], "application/json")
+    }
+
     func testWhenStopCommandHasNoHeaders_requestAndResponseAreUnaffected() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1813,7 +1813,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/api/data",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.resourceRequestHeaders: ["content-type": "application/json", "cache-control": "no-cache"]
+                        CrossPlatformAttributes.requestHeaders: ["content-type": "application/json", "cache-control": "no-cache"]
                     ],
                     kind: .xhr,
                     httpStatusCode: 200,
@@ -1850,7 +1850,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/api/data",
                     time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
                     attributes: [
-                        CrossPlatformAttributes.resourceResponseHeaders: ["content-type": "text/html", "etag": "\"abc\""]
+                        CrossPlatformAttributes.responseHeaders: ["content-type": "text/html", "etag": "\"abc\""]
                     ],
                     kind: .xhr,
                     httpStatusCode: 200,

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -2822,6 +2822,14 @@ public class objc_URLSessionTracking: NSObject
     override public init()
     public func setFirstPartyHostsTracing(_ firstPartyHostsTracing: objc_FirstPartyHostsTracing)
     public func setResourceAttributesProvider(_ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [String: Any]?)
+    public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders)
+public final class objc_HeaderCaptureRule: NSObject
+    public static let defaults = objc_HeaderCaptureRule(.defaults)
+    public static func matchHeaders(_ names: [String]) -> objc_HeaderCaptureRule
+public final class objc_TrackResourceHeaders: NSObject
+    public static let disabled = objc_TrackResourceHeaders(.disabled)
+    public static let defaults = objc_TrackResourceHeaders(.defaults)
+    public static func custom(_ rules: [objc_HeaderCaptureRule]) -> objc_TrackResourceHeaders
 public class objc_RUMConfiguration: NSObject
     public init(applicationID: String)
     public var applicationID: String

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -420,6 +420,7 @@ public enum RUM
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
+            public var trackResourceHeaders: TrackResourceHeaders = .disabled
         public enum VitalsFrequency: String
             case frequent
             case average
@@ -428,7 +429,14 @@ public enum RUM
     public enum FirstPartyHostsTracing
         case trace(hosts: Set<String>,sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
         case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
-    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil)
+    public enum TrackResourceHeaders
+        case disabled
+        case defaults
+        case custom([HeaderCaptureRule])
+    public enum HeaderCaptureRule
+        case defaults
+        case matchHeaders([String])
+    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled)
 [?] extension RUM.Configuration
     public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration

--- a/tools/repo-setup/carthage-bootstrap.sh
+++ b/tools/repo-setup/carthage-bootstrap.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 
 source ./tools/utils/echo-color.sh
 
-./tools/carthage-shim.sh bootstrap --platform iOS,tvOS --use-xcframeworks
+./tools/carthage-shim.sh bootstrap --platform iOS,tvOS,watchOS,visionOS --use-xcframeworks
 
 echo_succ "Using OpenTelemetryApi version: $(cat ./Carthage/Build/.OpenTelemetryApi.version | grep 'commitish' | awk -F'"' '{print $4}')"

--- a/tools/sr-snapshot-test.sh
+++ b/tools/sr-snapshot-test.sh
@@ -42,7 +42,7 @@ TEST_WORKSPACE="$REPO_ROOT/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.
 TEST_ARTIFACTS_PATH="$REPO_ROOT/$artifacts_path/sr-snapshot-tests"
 
 # On CI, get GitHub token for accessing snapshots repository
-if [ "$CI" = "true" ] && [ -z "$GH_TOKEN" ]; then
+if [ "$CI" = "true" ]; then
     export GH_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/dd-mobile-session-replay-snapshots --policy dd-sdk-ios)
     # Set up trap to always revoke token on script exit (success, failure, or interruption)
     trap 'dd-octo-sts --disable-tracing revoke --token $GH_TOKEN' EXIT

--- a/tools/sr-snapshots/Sources/SRSnapshotsCore/Commands.swift
+++ b/tools/sr-snapshots/Sources/SRSnapshotsCore/Commands.swift
@@ -11,6 +11,8 @@ import ArgumentParser
 
 /// Git clone ssh for snapshots repo.
 private let ssh = "git@github.com:DataDog/dd-mobile-session-replay-snapshots.git"
+/// GitHub owner/repo identifier (used with token authentication on CI via gh CLI over HTTPS).
+private let repo = "DataDog/dd-mobile-session-replay-snapshots"
 /// Default branch in snapshots repo.
 private let defaultBranch = "main"
 
@@ -65,7 +67,7 @@ public struct PullSnapshotsCommand: ParsableCommand {
         if options.dryRun {
             git = NOPGitClient()
         } else if let token = ProcessInfo.processInfo.environment["GH_TOKEN"] {
-            git = GitHubClient(repository: ssh, branch: options.remoteBranch, token: token)
+            git = GitHubClient(repository: repo, branch: options.remoteBranch, token: token)
         } else {
             git = BasicGitClient(ssh: ssh, branch: options.remoteBranch)
         }


### PR DESCRIPTION
### What and why?

Adds opt-in HTTP request and response header capture for RUM resource events.

This migration took place in these PRs:
- #2699 
- #2700
- #2722

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs