### PR TITLE
RUM-14907 [Github Assistant] Fix Issue Notification action to use OPENAI_MODEL env var

### DIFF
--- a/.github/workflows/issue_notification.yml
+++ b/.github/workflows/issue_notification.yml
@@ -47,8 +47,7 @@ jobs:
           OPENAI_TOKEN: ${{ secrets.OPENAI_TOKEN }}
           OPENAI_SYSTEM_PROMPT: ${{ vars.OPENAI_SYSTEM_PROMPT }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          OPENAI_TEMPERATURE: ${{ vars.OPENAI_TEMPERATURE }}
-          OPENAI_MAX_RESPONSE_TOKENS: ${{ vars.OPENAI_MAX_RESPONSE_TOKENS }}
+          OPENAI_MAX_COMPLETION_TOKENS: ${{ vars.OPENAI_MAX_COMPLETION_TOKENS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/tools/issue_handler/README.md
+++ b/tools/issue_handler/README.md
@@ -47,9 +47,8 @@ This creates a `.env` file that you will need to fill with the required tokens a
 - `GITHUB_REPOSITORY` - Repository in format `owner/repo`
 
 **Optional variables** (override defaults):
-- `OPENAI_MODEL` - Model to use (default: `gpt-5.2-chat-latest`)
-- `OPENAI_TEMPERATURE` - Response creativity 0.0-1.0 (default: `0.4`)
-- `OPENAI_MAX_RESPONSE_TOKENS` - Max response length (default: `500`)
+- `OPENAI_MODEL` - Model to use
+- `OPENAI_MAX_COMPLETION_TOKENS` - Max response length
 
 ## Usage
 
@@ -80,9 +79,8 @@ The tool runs:
 - `OPENAI_SYSTEM_PROMPT` - OpenAI analysis prompt (stored as variable for easier updates)
 
 **Optional GitHub Variables** (override defaults if needed):
-- `OPENAI_MODEL` - Model to use (default: `gpt-5.2-chat-latest`)
-- `OPENAI_TEMPERATURE` - Response creativity 0.0-1.0 (default: `0.4`)
-- `OPENAI_MAX_RESPONSE_TOKENS` - Max response length (default: `500`)
+- `OPENAI_MODEL` - Model to use
+- `OPENAI_MAX_COMPLETION_TOKENS` - Max response length
 
 **Automatically Provided**:
 - `GITHUB_TOKEN` - Provided by GitHub Actions

--- a/tools/issue_handler/setup_env.sh
+++ b/tools/issue_handler/setup_env.sh
@@ -31,8 +31,7 @@ GITHUB_REPOSITORY=DataDog/dd-sdk-ios
 
 # Optional: Override OpenAI defaults
 # OPENAI_MODEL=gpt-5.2-chat-latest
-# OPENAI_TEMPERATURE=0.4
-# OPENAI_MAX_RESPONSE_TOKENS=500
+# OPENAI_MAX_COMPLETION_TOKENS=500
 EOL
 
 echo "✨ Created .env file"

--- a/tools/issue_handler/src/openai_handler.py
+++ b/tools/issue_handler/src/openai_handler.py
@@ -54,7 +54,7 @@ class OpenAIHandler:
     
     # Content limits to prevent abuse
     MAX_CONTENT_LENGTH = 4000
-    MAX_RESPONSE_TOKENS = int(os.environ.get("OPENAI_MAX_RESPONSE_TOKENS", "500"))
+    MAX_COMPLETION_TOKENS = int(os.environ.get("OPENAI_MAX_COMPLETION_TOKENS", "500"))
 
     def __init__(self, api_key: str):
         """
@@ -117,8 +117,7 @@ class OpenAIHandler:
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                temperature=float(os.environ.get("OPENAI_TEMPERATURE", "0.4")),
-                max_tokens=self.MAX_RESPONSE_TOKENS,
+                max_completion_tokens=self.MAX_COMPLETION_TOKENS,
                 response_format={"type": "json_object"}
             )
 

--- a/tools/issue_handler/tests/test_openai_handler.py
+++ b/tools/issue_handler/tests/test_openai_handler.py
@@ -138,7 +138,7 @@ class TestOpenAIHandler:
             # Verify OpenAI call
             mock_client.chat.completions.create.assert_called_once()
             call_args = mock_client.chat.completions.create.call_args
-            assert call_args[1]["max_tokens"] == 500
+            assert call_args[1]["max_completion_tokens"] == 500
             assert call_args[1]["response_format"] == {"type": "json_object"}
     
     @patch('src.openai_handler.openai.OpenAI')


### PR DESCRIPTION
### What and why?

The `OPENAI_MODEL` variable was not being exported, so it was always using the default model. Since that default model was recently decommissioned, it cannot be used anymore, which led to the Github Assistant failing to report new issues with the following error:
```
Error: Failed to analyze issue: Error code: 404 - {'error': {'message': 'The model `chatgpt-4o-latest` does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
``` 

### How?

- Export `OPENAI_MODEL` in Github action
- Defaulting variable to viable model
- Removing `OPENAI_TEMPERATURE` parameter which is not used anymore in most recent Open AI API, and updated `OPENAI_MAX_RESPONSE_TOKENS` param to `OPENAI_MAX_COMPLETION_TOKENS`

Note: this was fixed on the RN SDK side in https://github.com/DataDog/dd-sdk-reactnative/pull/1177

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
