### PR TITLE
Add spanCustomization callback to Trace URLSession tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ artifacts/
 
 # AI files
 .claude/settings.local.json
+.rum-analysis/
 
 # GSD planning files (local only)
 .planning/

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -978,6 +978,8 @@
 		61A2CC342A44A6030000FF25 /* DatadogRUM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D23F8E9929DDCD28001CFAE8 /* DatadogRUM.framework */; };
 		61A2CC362A44B0A20000FF25 /* TraceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */; };
 		61A2CC372A44B0A20000FF25 /* TraceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */; };
+		7F859F0296CB41419B09C221 /* InterceptedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4209932100E4E73BADD5A3D /* InterceptedRequest.swift */; };
+		817358634A3541559D67A261 /* InterceptedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4209932100E4E73BADD5A3D /* InterceptedRequest.swift */; };
 		61A2CC392A44B0EA0000FF25 /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC382A44B0EA0000FF25 /* Trace.swift */; };
 		61A2CC3A2A44B0EA0000FF25 /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC382A44B0EA0000FF25 /* Trace.swift */; };
 		61A2CC3C2A44BED30000FF25 /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A2CC3B2A44BED30000FF25 /* Tracer.swift */; };
@@ -3400,6 +3402,7 @@
 		61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMConfigurationTests.swift; sourceTree = "<group>"; };
 		61A2CC232A44454D0000FF25 /* DDRUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMTests.swift; sourceTree = "<group>"; };
 		61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceConfiguration.swift; sourceTree = "<group>"; };
+		C4209932100E4E73BADD5A3D /* InterceptedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptedRequest.swift; sourceTree = "<group>"; };
 		61A2CC382A44B0EA0000FF25 /* Trace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trace.swift; sourceTree = "<group>"; };
 		61A2CC3B2A44BED30000FF25 /* Tracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracer.swift; sourceTree = "<group>"; };
 		61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOffViewEventsHandlingRule.swift; sourceTree = "<group>"; };
@@ -7407,6 +7410,7 @@
 				61C5A87E24509A0C00DA608C /* DDSpanContext.swift */,
 				61A2CC382A44B0EA0000FF25 /* Trace.swift */,
 				61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */,
+				C4209932100E4E73BADD5A3D /* InterceptedRequest.swift */,
 				61A2CC3B2A44BED30000FF25 /* Tracer.swift */,
 				09D2B7EA2EF4258D0089F05B /* SamplingDecision.swift */,
 				D2546C0629AF55CE0054E00B /* Feature */,
@@ -10987,6 +10991,7 @@
 				D2C1A4FB29C4C4CB00946C31 /* MessageReceivers.swift in Sources */,
 				3C32359D2B55386C000B4258 /* OTelSpanLink.swift in Sources */,
 				61A2CC362A44B0A20000FF25 /* TraceConfiguration.swift in Sources */,
+				7F859F0296CB41419B09C221 /* InterceptedRequest.swift in Sources */,
 				61A2CC392A44B0EA0000FF25 /* Trace.swift in Sources */,
 				D2C1A50029C4C4CB00946C31 /* ActiveSpansPool.swift in Sources */,
 				3CB012DF2B482E0400557951 /* NOPOTelSpanBuilder.swift in Sources */,
@@ -11296,6 +11301,7 @@
 				D2C1A54129C4F2DF00946C31 /* MessageReceivers.swift in Sources */,
 				3C32359E2B55386C000B4258 /* OTelSpanLink.swift in Sources */,
 				61A2CC372A44B0A20000FF25 /* TraceConfiguration.swift in Sources */,
+				817358634A3541559D67A261 /* InterceptedRequest.swift in Sources */,
 				61A2CC3A2A44B0EA0000FF25 /* Trace.swift in Sources */,
 				D2C1A54229C4F2DF00946C31 /* ActiveSpansPool.swift in Sources */,
 				3CB012E02B482E0400557951 /* NOPOTelSpanBuilder.swift in Sources */,

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -320,7 +320,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         }
 
         spanCustomization?(
-            interception.request.unsafeOriginal,
+            interception.request,
             span,
             resourceCompletion.httpResponse,
             resourceCompletion.error

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -56,16 +56,16 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         samplingRate: SampleRate,
         firstPartyHosts: FirstPartyHosts,
         traceContextInjection: TraceContextInjection,
-        spanCustomization: Trace.Configuration.SpanCustomization? = nil,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        spanCustomization: Trace.Configuration.SpanCustomization? = nil
     ) {
         self.tracer = tracer
         self.contextReceiver = contextReceiver
         self.samplingRate = samplingRate
         self.firstPartyHosts = firstPartyHosts
         self.traceContextInjection = traceContextInjection
-        self.spanCustomization = spanCustomization
         self.telemetry = telemetry
+        self.spanCustomization = spanCustomization
     }
 
     func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?, URLSessionHandlerCapturedState?) {

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -32,6 +32,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
     let traceContextInjection: TraceContextInjection
     /// Telemetry interface for tracking SDK usage
     let telemetry: Telemetry
+    /// Optional callback to customize the span for each intercepted request.
+    let spanCustomization: Trace.Configuration.SpanCustomization?
 
     weak var tracer: DatadogTracer?
 
@@ -54,6 +56,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         samplingRate: SampleRate,
         firstPartyHosts: FirstPartyHosts,
         traceContextInjection: TraceContextInjection,
+        spanCustomization: Trace.Configuration.SpanCustomization? = nil,
         telemetry: Telemetry
     ) {
         self.tracer = tracer
@@ -61,6 +64,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         self.samplingRate = samplingRate
         self.firstPartyHosts = firstPartyHosts
         self.traceContextInjection = traceContextInjection
+        self.spanCustomization = spanCustomization
         self.telemetry = telemetry
     }
 
@@ -314,6 +318,8 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             let doesEndInBackground = history.state(at: endTime) == .background
             span.setTag(key: SpanTags.isBackground, value: didStartInBackground || doesEndInBackground)
         }
+
+        spanCustomization?(interception.request.unsafeOriginal, span)
 
         span.finish(at: endTime)
     }

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -320,7 +320,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         }
 
         spanCustomization?(
-            interception.request,
+            .init(from: interception.request),
             span,
             resourceCompletion.httpResponse,
             resourceCompletion.error

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -319,7 +319,12 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             span.setTag(key: SpanTags.isBackground, value: didStartInBackground || doesEndInBackground)
         }
 
-        spanCustomization?(interception.request.unsafeOriginal, span)
+        spanCustomization?(
+            interception.request.unsafeOriginal,
+            span,
+            resourceCompletion.httpResponse,
+            resourceCompletion.error
+        )
 
         span.finish(at: endTime)
     }

--- a/DatadogTrace/Sources/InterceptedRequest.swift
+++ b/DatadogTrace/Sources/InterceptedRequest.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension Trace.Configuration {
+    /// An immutable snapshot of a network request, passed to ``SpanCustomization`` callbacks.
+    ///
+    /// Properties are copied from the original `URLRequest` at interception time and are safe to read
+    /// from any thread.
+    public struct InterceptedRequest {
+        /// The URL of the request.
+        public let url: URL?
+        /// The HTTP method of the request (e.g. `"GET"`, `"POST"`).
+        public let httpMethod: String?
+        /// The body data of the request.
+        public let httpBody: Data?
+    }
+}
+
+internal extension Trace.Configuration.InterceptedRequest {
+    init(from request: ImmutableRequest) {
+        self.url = request.url
+        self.httpMethod = request.httpMethod
+        // httpBody is Data? — safe to access; the thread-safety concern in ImmutableRequest
+        // applies only to allHTTPHeaderFields (bridged NSMutableDictionary).
+        self.httpBody = request.unsafeOriginal.httpBody
+    }
+}

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -67,8 +67,8 @@ public enum Trace {
                 samplingRate: configuration.debugSDK ? 100 : tracingSampleRate,
                 firstPartyHosts: firstPartyHosts,
                 traceContextInjection: traceContextInjection,
-                spanCustomization: configuration.urlSessionTracking?.spanCustomization,
-                telemetry: core.telemetry
+                telemetry: core.telemetry,
+                spanCustomization: configuration.urlSessionTracking?.spanCustomization
             )
 
             try core.register(urlSessionHandler: urlSessionHandler)

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -67,6 +67,7 @@ public enum Trace {
                 samplingRate: configuration.debugSDK ? 100 : tracingSampleRate,
                 firstPartyHosts: firstPartyHosts,
                 traceContextInjection: traceContextInjection,
+                spanCustomization: configuration.urlSessionTracking?.spanCustomization,
                 telemetry: core.telemetry
             )
 

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -25,24 +25,21 @@ extension Trace {
 
         /// A callback that allows customizing the span created for each intercepted network request.
         ///
-        /// This closure receives the original `URLRequest`, the `OTSpan` created for it, the HTTP response
-        /// (if any), and an error (if any). You can use the span's `setTag(key:value:)` or
-        /// `setOperationName(_:)` methods to add custom attributes.
+        /// This closure receives an ``ImmutableRequest`` (a thread-safe snapshot of the original request),
+        /// the ``OTSpan`` created for it, the HTTP response (if any), and an error (if any). You can use
+        /// the span's `setTag(key:value:)` or `setOperationName(_:)` methods to add custom attributes.
         ///
-        /// Example — tagging GraphQL requests with the operation name:
+        /// Example — tagging requests by URL path:
         /// ```swift
         /// Trace.Configuration.SpanCustomization { request, span, response, error in
-        ///     if let body = request.httpBody,
-        ///        let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
-        ///        let operationName = json["operationName"] as? String {
-        ///         span.setTag(key: "graphql.operation.name", value: operationName)
-        ///         span.setOperationName("graphql.\(operationName)")
+        ///     if let url = request.url {
+        ///         span.setTag(key: "http.route", value: url.path)
         ///     }
         /// }
         /// ```
         ///
         /// - Note: Keep the implementation fast and do not make any assumptions on the thread used to run it.
-        public typealias SpanCustomization = (URLRequest, OTSpan, URLResponse?, Error?) -> Void
+        public typealias SpanCustomization = (ImmutableRequest, OTSpan, URLResponse?, Error?) -> Void
 
         /// The sampling rate for spans created with the default tracer.
         ///

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -115,15 +115,9 @@ extension Trace {
             /// If your backend is also instrumented with Datadog, you will see the full trace (app → backend).
             public var firstPartyHostsTracing: FirstPartyHostsTracing
 
-            /// Custom span customization callback for intercepted network requests.
+            /// Optional callback to customize spans for intercepted network requests.
             ///
-            /// This closure is called for each network request intercepted by the tracer, after the span is created
-            /// and default tags are set, but before the span is finished. Use it to add request-specific tags
-            /// (e.g., GraphQL operation name) or override the operation name.
-            ///
-            /// Keep the implementation fast and do not make any assumptions on the thread used to run it.
-            ///
-            /// Default: `nil`.
+            /// - SeeAlso: ``SpanCustomization``
             public var spanCustomization: SpanCustomization?
 
             /// Defines configuration for first-party hosts in distributed tracing.

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -23,6 +23,26 @@ extension Trace {
     public struct Configuration: SampledTelemetry {
         public typealias EventMapper = (SpanEvent) -> SpanEvent
 
+        /// A callback that allows customizing the span created for each intercepted network request.
+        ///
+        /// This closure receives the original `URLRequest` and the `OTSpan` created for it. You can use
+        /// the span's `setTag(key:value:)` or `setOperationName(_:)` methods to add custom attributes.
+        ///
+        /// Example — tagging GraphQL requests with the operation name:
+        /// ```swift
+        /// Trace.Configuration.SpanCustomization { request, span in
+        ///     if let body = request.httpBody,
+        ///        let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+        ///        let operationName = json["operationName"] as? String {
+        ///         span.setTag(key: "graphql.operation.name", value: operationName)
+        ///         span.setOperationName("graphql.\(operationName)")
+        ///     }
+        /// }
+        /// ```
+        ///
+        /// - Note: Keep the implementation fast and do not make any assumptions on the thread used to run it.
+        public typealias SpanCustomization = (URLRequest, OTSpan) -> Void
+
         /// The sampling rate for spans created with the default tracer.
         ///
         /// It must be a number between 0.0 and 100.0, where 0 means no spans will be collected.
@@ -94,6 +114,17 @@ extension Trace {
             /// If your backend is also instrumented with Datadog, you will see the full trace (app → backend).
             public var firstPartyHostsTracing: FirstPartyHostsTracing
 
+            /// Custom span customization callback for intercepted network requests.
+            ///
+            /// This closure is called for each network request intercepted by the tracer, after the span is created
+            /// and default tags are set, but before the span is finished. Use it to add request-specific tags
+            /// (e.g., GraphQL operation name) or override the operation name.
+            ///
+            /// Keep the implementation fast and do not make any assumptions on the thread used to run it.
+            ///
+            /// Default: `nil`.
+            public var spanCustomization: SpanCustomization?
+
             /// Defines configuration for first-party hosts in distributed tracing.
             public enum FirstPartyHostsTracing {
                 /// Trace the specified hosts using Datadog and W3C `tracecontext` tracing headers.
@@ -123,8 +154,13 @@ extension Trace {
             /// Configuration for automatic network requests tracing.
             /// - Parameters:
             ///   - firstPartyHostsTracing: Distributed tracing configuration for particular first-party hosts.
-            public init(firstPartyHostsTracing: FirstPartyHostsTracing) {
+            ///   - spanCustomization: Optional callback to customize spans for intercepted requests.
+            public init(
+                firstPartyHostsTracing: FirstPartyHostsTracing,
+                spanCustomization: SpanCustomization? = nil
+            ) {
                 self.firstPartyHostsTracing = firstPartyHostsTracing
+                self.spanCustomization = spanCustomization
             }
         }
 

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -25,12 +25,13 @@ extension Trace {
 
         /// A callback that allows customizing the span created for each intercepted network request.
         ///
-        /// This closure receives the original `URLRequest` and the `OTSpan` created for it. You can use
-        /// the span's `setTag(key:value:)` or `setOperationName(_:)` methods to add custom attributes.
+        /// This closure receives the original `URLRequest`, the `OTSpan` created for it, the HTTP response
+        /// (if any), and an error (if any). You can use the span's `setTag(key:value:)` or
+        /// `setOperationName(_:)` methods to add custom attributes.
         ///
         /// Example — tagging GraphQL requests with the operation name:
         /// ```swift
-        /// Trace.Configuration.SpanCustomization { request, span in
+        /// Trace.Configuration.SpanCustomization { request, span, response, error in
         ///     if let body = request.httpBody,
         ///        let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
         ///        let operationName = json["operationName"] as? String {
@@ -41,7 +42,7 @@ extension Trace {
         /// ```
         ///
         /// - Note: Keep the implementation fast and do not make any assumptions on the thread used to run it.
-        public typealias SpanCustomization = (URLRequest, OTSpan) -> Void
+        public typealias SpanCustomization = (URLRequest, OTSpan, URLResponse?, Error?) -> Void
 
         /// The sampling rate for spans created with the default tracer.
         ///

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -25,21 +25,25 @@ extension Trace {
 
         /// A callback that allows customizing the span created for each intercepted network request.
         ///
-        /// This closure receives an ``ImmutableRequest`` (a thread-safe snapshot of the original request),
-        /// the ``OTSpan`` created for it, the HTTP response (if any), and an error (if any). You can use
-        /// the span's `setTag(key:value:)` or `setOperationName(_:)` methods to add custom attributes.
+        /// This closure receives an ``InterceptedRequest`` (a thread-safe snapshot of the original
+        /// request), the ``OTSpan`` created for it, the HTTP response (if any), and an error (if any).
+        /// You can use the span's `setTag(key:value:)` or `setOperationName(_:)` methods to add custom
+        /// attributes.
         ///
-        /// Example — tagging requests by URL path:
+        /// Example — tagging GraphQL requests with the operation name:
         /// ```swift
         /// Trace.Configuration.SpanCustomization { request, span, response, error in
-        ///     if let url = request.url {
-        ///         span.setTag(key: "http.route", value: url.path)
+        ///     if let body = request.httpBody,
+        ///        let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+        ///        let operationName = json["operationName"] as? String {
+        ///         span.setTag(key: "graphql.operation.name", value: operationName)
+        ///         span.setOperationName("graphql.\(operationName)")
         ///     }
         /// }
         /// ```
         ///
         /// - Note: Keep the implementation fast and do not make any assumptions on the thread used to run it.
-        public typealias SpanCustomization = (ImmutableRequest, OTSpan, URLResponse?, Error?) -> Void
+        public typealias SpanCustomization = (InterceptedRequest, OTSpan, URLResponse?, Error?) -> Void
 
         /// The sampling rate for spans created with the default tracer.
         ///

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -1092,7 +1092,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 let url = request.url
                 let method = request.httpMethod
                 let body = request.httpBody
-                guard let index = Int(url?.lastPathComponent ?? "") else { return }
+                guard let index = Int(url?.lastPathComponent ?? "") else {
+                    return
+                }
                 lock.lock()
                 receivedUrls[index] = url
                 receivedMethods[index] = method

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -857,7 +857,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let expectation = expectation(description: "Send span")
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
-        var receivedRequest: URLRequest?
+        var receivedRequest: ImmutableRequest?
         var receivedSpan: OTSpan?
         var receivedResponse: URLResponse?
         var receivedError: Error?

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -853,12 +853,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
     // MARK: - Span Customization Tests
 
-    func testGivenSpanCustomization_whenInterceptionCompletes_itCallsCustomizationWithRequestAndSpan() throws {
+    func testGivenSpanCustomization_whenInterceptionCompletes_itCallsCustomizationWithAllParameters() throws {
         let expectation = expectation(description: "Send span")
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         var receivedRequest: URLRequest?
         var receivedSpan: OTSpan?
+        var receivedResponse: URLResponse?
+        var receivedError: Error?
 
         let handler = TracingURLSessionHandler(
             tracer: tracer,
@@ -868,9 +870,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "www.example.com": [.datadog]
             ]),
             traceContextInjection: .all,
-            spanCustomization: { request, span in
+            spanCustomization: { request, span, response, error in
                 receivedRequest = request
                 receivedSpan = span
+                receivedResponse = response
+                receivedError = error
                 span.setTag(key: "graphql.operation.name", value: "GetUser")
             },
             telemetry: NOPTelemetry()
@@ -902,6 +906,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(receivedRequest?.url?.absoluteString, "https://www.example.com/graphql")
         XCTAssertEqual(receivedRequest?.httpMethod, "POST")
         XCTAssertNotNil(receivedSpan, "Customization callback should receive the span")
+        XCTAssertNotNil(receivedResponse, "Customization callback should receive the response")
+        XCTAssertEqual((receivedResponse as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertNil(receivedError, "Error should be nil for successful requests")
 
         let envelope: SpanEventsEnvelope? = core.events().last
         let span = try XCTUnwrap(envelope?.spans.first)
@@ -960,7 +967,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "www.example.com": [.datadog]
             ]),
             traceContextInjection: .all,
-            spanCustomization: { _, span in
+            spanCustomization: { _, span, _, _ in
                 span.setTag(key: "custom.tag", value: "custom_value")
                 span.setOperationName("graphql.query")
             },

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -912,7 +912,12 @@ class TracingURLSessionHandlerTests: XCTestCase {
 
         let envelope: SpanEventsEnvelope? = core.events().last
         let span = try XCTUnwrap(envelope?.spans.first)
+        // Custom tags set via callback
         XCTAssertEqual(span.tags["graphql.operation.name"], "GetUser")
+        // Default tags still present
+        XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
+        XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
+        XCTAssertEqual(span.tags[OTTags.spanKind], "client")
     }
 
     func testGivenNoSpanCustomization_whenInterceptionCompletes_itCreatesSpanNormally() throws {
@@ -955,9 +960,12 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertFalse(span.isError)
     }
 
-    func testGivenSpanCustomization_whenInterceptionCompletes_customTagsCoexistWithDefaultTags() throws {
+    func testGivenSpanCustomization_whenInterceptionCompletesWithError_itCallsCustomizationWithError() throws {
         let expectation = expectation(description: "Send span")
         core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        var receivedResponse: URLResponse?
+        var receivedError: Error?
 
         let handler = TracingURLSessionHandler(
             tracer: tracer,
@@ -968,16 +976,21 @@ class TracingURLSessionHandlerTests: XCTestCase {
             ]),
             traceContextInjection: .all,
             telemetry: NOPTelemetry(),
-            spanCustomization: { _, span, _, _ in
-                span.setTag(key: "custom.tag", value: "custom_value")
-                span.setOperationName("graphql.query")
+            spanCustomization: { _, span, response, error in
+                receivedResponse = response
+                receivedError = error
+                span.setTag(key: "custom.error.tag", value: "handled")
             }
         )
 
         // Given
-        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
+        let request: ImmutableRequest = .mockWith(
+            url: URL(string: "https://www.example.com/api")!,
+            httpMethod: "GET"
+        )
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
-        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(response: nil, error: networkError)
         interception.register(
             metrics: .mockWith(
                 fetch: .init(
@@ -993,15 +1006,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
+        XCTAssertNil(receivedResponse, "Response should be nil for error-only requests")
+        XCTAssertNotNil(receivedError, "Customization callback should receive the error")
+        XCTAssertEqual((receivedError as? NSError)?.code, NSURLErrorTimedOut)
+
         let envelope: SpanEventsEnvelope? = core.events().last
         let span = try XCTUnwrap(envelope?.spans.first)
-        // Custom tags set via callback
-        XCTAssertEqual(span.tags["custom.tag"], "custom_value")
-        XCTAssertEqual(span.operationName, "graphql.query")
-        // Default tags still present
-        XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
-        XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
-        XCTAssertEqual(span.tags[OTTags.spanKind], "client")
+        XCTAssertTrue(span.isError)
+        XCTAssertEqual(span.tags["custom.error.tag"], "handled")
     }
 
     private func assert(capturedState: URLSessionHandlerCapturedState?, has span: OTSpan?) {

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -851,6 +851,152 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertEqual(span.resource, "404", "404 responses should have resource set to '404'")
     }
 
+    // MARK: - Span Customization Tests
+
+    func testGivenSpanCustomization_whenInterceptionCompletes_itCallsCustomizationWithRequestAndSpan() throws {
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        var receivedRequest: URLRequest?
+        var receivedSpan: OTSpan?
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "www.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            spanCustomization: { request, span in
+                receivedRequest = request
+                receivedSpan = span
+                span.setTag(key: "graphql.operation.name", value: "GetUser")
+            },
+            telemetry: NOPTelemetry()
+        )
+
+        // Given
+        let request: ImmutableRequest = .mockWith(
+            url: URL(string: "https://www.example.com/graphql")!,
+            httpMethod: "POST"
+        )
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        XCTAssertNotNil(receivedRequest, "Customization callback should receive the request")
+        XCTAssertEqual(receivedRequest?.url?.absoluteString, "https://www.example.com/graphql")
+        XCTAssertEqual(receivedRequest?.httpMethod, "POST")
+        XCTAssertNotNil(receivedSpan, "Customization callback should receive the span")
+
+        let envelope: SpanEventsEnvelope? = core.events().last
+        let span = try XCTUnwrap(envelope?.spans.first)
+        XCTAssertEqual(span.tags["graphql.operation.name"], "GetUser")
+    }
+
+    func testGivenNoSpanCustomization_whenInterceptionCompletes_itCreatesSpanNormally() throws {
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "www.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            spanCustomization: nil,
+            telemetry: NOPTelemetry()
+        )
+
+        // Given
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let envelope: SpanEventsEnvelope? = core.events().last
+        let span = try XCTUnwrap(envelope?.spans.first)
+        XCTAssertEqual(span.operationName, "urlsession.request")
+        XCTAssertFalse(span.isError)
+    }
+
+    func testGivenSpanCustomization_whenInterceptionCompletes_customTagsCoexistWithDefaultTags() throws {
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "www.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            spanCustomization: { _, span in
+                span.setTag(key: "custom.tag", value: "custom_value")
+                span.setOperationName("graphql.query")
+            },
+            telemetry: NOPTelemetry()
+        )
+
+        // Given
+        let request: ImmutableRequest = .mockWith(httpMethod: "POST")
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let envelope: SpanEventsEnvelope? = core.events().last
+        let span = try XCTUnwrap(envelope?.spans.first)
+        // Custom tags set via callback
+        XCTAssertEqual(span.tags["custom.tag"], "custom_value")
+        XCTAssertEqual(span.operationName, "graphql.query")
+        // Default tags still present
+        XCTAssertEqual(span.tags[OTTags.httpMethod], "POST")
+        XCTAssertEqual(span.tags[OTTags.httpStatusCode], "200")
+        XCTAssertEqual(span.tags[OTTags.spanKind], "client")
+    }
+
     private func assert(capturedState: URLSessionHandlerCapturedState?, has span: OTSpan?) {
         guard let state = capturedState as? TracingURLSessionHandler.TracingURLSessionHandlerCapturedState else {
             XCTFail("Expected TracingURLSessionHandlerCapturedState instance, got \(String(describing: capturedState))")

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -870,14 +870,14 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "www.example.com": [.datadog]
             ]),
             traceContextInjection: .all,
+            telemetry: NOPTelemetry(),
             spanCustomization: { request, span, response, error in
                 receivedRequest = request
                 receivedSpan = span
                 receivedResponse = response
                 receivedError = error
                 span.setTag(key: "graphql.operation.name", value: "GetUser")
-            },
-            telemetry: NOPTelemetry()
+            }
         )
 
         // Given
@@ -927,8 +927,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "www.example.com": [.datadog]
             ]),
             traceContextInjection: .all,
-            spanCustomization: nil,
-            telemetry: NOPTelemetry()
+            telemetry: NOPTelemetry(),
+            spanCustomization: nil
         )
 
         // Given
@@ -967,11 +967,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 "www.example.com": [.datadog]
             ]),
             traceContextInjection: .all,
+            telemetry: NOPTelemetry(),
             spanCustomization: { _, span, _, _ in
                 span.setTag(key: "custom.tag", value: "custom_value")
                 span.setOperationName("graphql.query")
-            },
-            telemetry: NOPTelemetry()
+            }
         )
 
         // Given

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -857,7 +857,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let expectation = expectation(description: "Send span")
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
-        var receivedRequest: ImmutableRequest?
+        var receivedRequest: Trace.Configuration.InterceptedRequest?
         var receivedSpan: OTSpan?
         var receivedResponse: URLResponse?
         var receivedError: Error?
@@ -881,9 +881,11 @@ class TracingURLSessionHandlerTests: XCTestCase {
         )
 
         // Given
+        let requestBody = #"{"operationName":"GetUser"}"#.data(using: .utf8)
         let request: ImmutableRequest = .mockWith(
             url: URL(string: "https://www.example.com/graphql")!,
-            httpMethod: "POST"
+            httpMethod: "POST",
+            httpBody: requestBody
         )
         let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
         interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
@@ -905,6 +907,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertNotNil(receivedRequest, "Customization callback should receive the request")
         XCTAssertEqual(receivedRequest?.url?.absoluteString, "https://www.example.com/graphql")
         XCTAssertEqual(receivedRequest?.httpMethod, "POST")
+        XCTAssertEqual(receivedRequest?.httpBody, requestBody, "Customization callback should receive the request body")
         XCTAssertNotNil(receivedSpan, "Customization callback should receive the span")
         XCTAssertNotNil(receivedResponse, "Customization callback should receive the response")
         XCTAssertEqual((receivedResponse as? HTTPURLResponse)?.statusCode, 200)
@@ -1014,6 +1017,181 @@ class TracingURLSessionHandlerTests: XCTestCase {
         let span = try XCTUnwrap(envelope?.spans.first)
         XCTAssertTrue(span.isError)
         XCTAssertEqual(span.tags["custom.error.tag"], "handled")
+    }
+
+    func testGivenSpanCustomization_whenRequestHasNoBody_itReceivesNilHttpBody() throws {
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        var receivedHttpBody: Data? = Data() // non-nil sentinel to detect it was set
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "www.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry(),
+            spanCustomization: { request, _, _, _ in
+                receivedHttpBody = request.httpBody
+            }
+        )
+
+        // Given - request with no body
+        let request: ImmutableRequest = .mockWith(
+            url: URL(string: "https://www.example.com/api")!,
+            httpMethod: "GET"
+        )
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertNil(receivedHttpBody, "httpBody should be nil when the request has no body")
+    }
+
+    func testGivenSpanCustomization_whenMultipleConcurrentRequestsComplete_itSafelyReadsPropertiesFromAllCallbacks() throws {
+        // This test simulates multiple URLSession tasks completing simultaneously on different background
+        // threads, each triggering `spanCustomization`. It verifies that reading `InterceptedRequest`
+        // properties is thread-safe: `url` and `httpMethod` are pre-captured value-type snapshots;
+        // `httpBody` is backed by immutable NSData, safe for concurrent reads.
+        let concurrentCount = 5
+        let allSpansWritten = expectation(description: "All spans written")
+        allSpansWritten.expectedFulfillmentCount = concurrentCount
+        core.onEventWriteContext = { _ in allSpansWritten.fulfill() }
+
+        var receivedUrls: [URL?] = Array(repeating: nil, count: concurrentCount)
+        var receivedMethods: [String?] = Array(repeating: nil, count: concurrentCount)
+        var receivedBodies: [Data?] = Array(repeating: nil, count: concurrentCount)
+        let lock = NSLock()
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "www.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry(),
+            spanCustomization: { request, _, _, _ in
+                // Read all InterceptedRequest properties — must be safe from any background thread
+                let url = request.url
+                let method = request.httpMethod
+                let body = request.httpBody
+                guard let index = Int(url?.lastPathComponent ?? "") else { return }
+                lock.lock()
+                receivedUrls[index] = url
+                receivedMethods[index] = method
+                receivedBodies[index] = body
+                lock.unlock()
+            }
+        )
+
+        // Given - prepare one interception per concurrent "task"
+        let interceptions: [URLSessionTaskInterception] = (0..<concurrentCount).map { i in
+            let body = "body-\(i)".data(using: .utf8)
+            let request: ImmutableRequest = .mockWith(
+                url: URL(string: "https://www.example.com/api/\(i)")!,
+                httpMethod: "POST",
+                httpBody: body
+            )
+            let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
+            interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+            interception.register(
+                metrics: .mockWith(
+                    fetch: .init(
+                        start: .mockDecember15th2019At10AMUTC(),
+                        end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                    )
+                )
+            )
+            return interception
+        }
+
+        // When - complete all interceptions concurrently from background threads
+        // (simulating multiple URLSession tasks finishing simultaneously)
+        let concurrentQueue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
+        for interception in interceptions {
+            concurrentQueue.async {
+                handler.interceptionDidComplete(interception: interception)
+            }
+        }
+
+        // Then - all callbacks must complete with correct, non-corrupted property values
+        waitForExpectations(timeout: 2.0, handler: nil)
+        for i in 0..<concurrentCount {
+            XCTAssertEqual(receivedUrls[i]?.absoluteString, "https://www.example.com/api/\(i)")
+            XCTAssertEqual(receivedMethods[i], "POST")
+            XCTAssertEqual(receivedBodies[i], "body-\(i)".data(using: .utf8))
+        }
+    }
+
+    func testGivenSpanCustomization_whenDecodingGraphQLBody_itTagsSpanWithOperationName() throws {
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        let handler = TracingURLSessionHandler(
+            tracer: tracer,
+            contextReceiver: ContextMessageReceiver(),
+            samplingRate: .maxSampleRate,
+            firstPartyHosts: .init([
+                "api.example.com": [.datadog]
+            ]),
+            traceContextInjection: .all,
+            telemetry: NOPTelemetry(),
+            spanCustomization: { request, span, _, _ in
+                // Primary use case: decode GraphQL operation name from request body
+                if let body = request.httpBody,
+                   let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                   let operationName = json["operationName"] as? String {
+                    span.setTag(key: "graphql.operation.name", value: operationName)
+                    span.setOperationName("graphql.\(operationName)")
+                }
+            }
+        )
+
+        // Given
+        let graphQLBody = #"{"operationName":"GetUser","variables":{"id":"123"}}"#.data(using: .utf8)!
+        let request: ImmutableRequest = .mockWith(
+            url: URL(string: "https://api.example.com/graphql")!,
+            httpMethod: "POST",
+            httpBody: graphQLBody
+        )
+        let interception = URLSessionTaskInterception(request: request, isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let envelope: SpanEventsEnvelope? = core.events().last
+        let span = try XCTUnwrap(envelope?.spans.first)
+        XCTAssertEqual(span.operationName, "graphql.GetUser")
+        XCTAssertEqual(span.tags["graphql.operation.name"], "GetUser")
     }
 
     private func assert(capturedState: URLSessionHandlerCapturedState?, has span: OTSpan?) {

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -191,10 +191,12 @@ extension ImmutableRequest: AnyMockable {
     public static func mockWith(
         url: URL = .mockAny(),
         httpMethod: String = "GET",
+        httpBody: Data? = nil,
         allHTTPHeaderFields: [String: String] = .mockAny()
     ) -> ImmutableRequest {
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod
+        request.httpBody = httpBody
         request.allHTTPHeaderFields = allHTTPHeaderFields
         return ImmutableRequest(request: request)
     }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -311,7 +311,7 @@ public enum Trace
         public var networkInfoEnabled: Bool
         public var eventMapper: EventMapper?
         public var customEndpoint: URL?
-        public typealias SpanCustomization = (URLRequest, OTSpan, URLResponse?, Error?) -> Void
+        public typealias SpanCustomization = (ImmutableRequest, OTSpan, URLResponse?, Error?) -> Void
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing
             public var spanCustomization: SpanCustomization?

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -311,12 +311,14 @@ public enum Trace
         public var networkInfoEnabled: Bool
         public var eventMapper: EventMapper?
         public var customEndpoint: URL?
+        public typealias SpanCustomization = (URLRequest, OTSpan) -> Void
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing
+            public var spanCustomization: SpanCustomization?
             public enum FirstPartyHostsTracing
                 case trace(hosts: Set<String>,sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
                 case traceWithHeaders(hostsWithHeaders: [String: Set<TracingHeaderType>],sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)
-            public init(firstPartyHostsTracing: FirstPartyHostsTracing)
+            public init(firstPartyHostsTracing: FirstPartyHostsTracing,spanCustomization: SpanCustomization? = nil)
         public init(sampleRate: SampleRate = .maxSampleRate,service: String? = nil,tags: [String: Encodable]? = nil,urlSessionTracking: URLSessionTracking? = nil,bundleWithRumEnabled: Bool = true,networkInfoEnabled: Bool = false,eventMapper: EventMapper? = nil,customEndpoint: URL? = nil)
 public enum SpanTags
     public static let resource = "resource.name"

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -311,7 +311,11 @@ public enum Trace
         public var networkInfoEnabled: Bool
         public var eventMapper: EventMapper?
         public var customEndpoint: URL?
-        public typealias SpanCustomization = (ImmutableRequest, OTSpan, URLResponse?, Error?) -> Void
+        public typealias SpanCustomization = (InterceptedRequest, OTSpan, URLResponse?, Error?) -> Void
+        public struct InterceptedRequest
+            public let url: URL?
+            public let httpMethod: String?
+            public let httpBody: Data?
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing
             public var spanCustomization: SpanCustomization?

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -311,7 +311,7 @@ public enum Trace
         public var networkInfoEnabled: Bool
         public var eventMapper: EventMapper?
         public var customEndpoint: URL?
-        public typealias SpanCustomization = (URLRequest, OTSpan) -> Void
+        public typealias SpanCustomization = (URLRequest, OTSpan, URLResponse?, Error?) -> Void
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing
             public var spanCustomization: SpanCustomization?


### PR DESCRIPTION
### What and why?

Adds a `spanCustomization` callback to `Trace.Configuration.URLSessionTracking`, allowing users to customize spans for intercepted network requests — adding custom tags or overriding the operation name based on request/response content.

This addresses a long-standing feature request (#1649, 7 reactions, 2+ years) for parity with the Android SDK's `TracedRequestListener`. The key use case is tagging GraphQL requests with operation name/type, but it applies to any scenario where span metadata should depend on the request or response.

### How?

- Adds `Trace.Configuration.SpanCustomization` typealias: `(URLRequest, OTSpan, URLResponse?, Error?) -> Void`
- Adds `spanCustomization` property to `Trace.Configuration.URLSessionTracking`
- The callback is invoked in `TracingURLSessionHandler.interceptionDidComplete` after default tags are set and before `span.finish()`, so users can add custom tags or override the operation name
- Mirrors the existing `RUM.ResourceAttributesProvider` pattern for API consistency

**Usage:**

```swift
Trace.enable(with: .init(
    urlSessionTracking: .init(
        firstPartyHostsTracing: .trace(hosts: ["api.example.com"]),
        spanCustomization: { request, span, response, error in
            if let body = request.httpBody,
               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
               let opName = json["operationName"] as? String {
                span.setTag(key: "graphql.operation.name", value: opName)
                span.setOperationName("graphql.\(opName)")
            }
        }
    )
))
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

Closes #1649