### PR TITLE
[IW] Add code-index Claude skill for Swift symbol navigation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,11 @@
 {
   "permissions": {
     "allow": [
-      "mcp__xcode__*"
+      "mcp__xcode__*",
+      "Bash(.claude/skills/code-index/tools/.build/release/indexstore-query *)",
+      "Bash(swift build*)",
+      "Bash(ls *)",
+      "Bash(find *)"
     ]
   }
 }

--- a/.claude/skills/code-index/README.md
+++ b/.claude/skills/code-index/README.md
@@ -1,0 +1,68 @@
+# code-index skill
+
+A Claude Code skill that enables semantic Swift codebase navigation using the compiler's index store. Provides compiler-accurate symbol resolution: definitions, call sites, protocol conformers, inheritance hierarchies, and more.
+
+## How it works
+
+The skill wraps `indexstore-query`, a Swift CLI tool that queries the index store produced by Xcode or SwiftPM. It uses [IndexStoreDB](https://github.com/swiftlang/indexstore-db) — the same library powering Xcode's "Jump to Definition" — to answer questions about symbols with compiler-level accuracy.
+
+## Setup
+
+### 1. Build the index
+
+**Xcode (preferred):** Build the project in Xcode (⌘B). The tool auto-discovers the most recently modified DerivedData index.
+
+**SPM (fallback):** Run from the repo root:
+```bash
+swift build --enable-index-store
+```
+
+### 2. Build the CLI tool (one-time)
+
+```bash
+cd .claude/skills/code-index/tools && swift build -c release 2>&1 | tail -5
+```
+
+The binary is placed at `.claude/skills/code-index/tools/.build/release/indexstore-query`.
+
+## Usage
+
+Claude will use this skill automatically when navigating the Swift codebase. You can also invoke it explicitly by asking questions like:
+
+- "Where is `DatadogCore` defined?"
+- "What calls `flush()`?"
+- "What types conform to `FeatureMessageReceiver`?"
+- "What methods does `RUMMonitor` have?"
+
+## Supported queries
+
+| Category | Examples |
+|----------|---------|
+| Symbol lookup | Find definition, fuzzy search, all symbols in a file or module |
+| References | All usages, callers, accessors |
+| Inheritance | Protocol conformers, method overrides |
+| Structure | Children of a type, extension declarations |
+| Tests | Tests covering a file |
+| Compilation | Which targets compiled a file |
+
+See [SKILL.md](SKILL.md) for the full command reference.
+
+## File structure
+
+```
+.claude/skills/code-index/
+├── README.md       # This file
+├── SKILL.md        # Agent-facing instructions
+└── tools/          # Swift CLI package (indexstore-query)
+    └── Sources/
+        └── indexstore-query/
+            ├── main.swift                    # CLI commands
+            ├── XcodeIndexStoreProvider.swift # DerivedData index discovery
+            └── SPMIndexStoreProvider.swift   # SPM index discovery
+```
+
+## Compatibility
+
+- Xcode 26+ (uses `UniDB/<Project>.xcindex/` layout)
+- SwiftPM (uses `.build/index-build/`)
+- Apple Silicon and Intel Macs

--- a/.claude/skills/code-index/SKILL.md
+++ b/.claude/skills/code-index/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: code-index
+description: Use when you need to navigate the Swift codebase semantically — finding symbol definitions, call sites, protocol conformers, method overrides, module dependencies, or nesting relationships. Prefer this over grep-based search when you need precise, compiler-level symbol resolution.
+---
+
+# Code Index — Swift Index Store Queries
+
+The `indexstore` tool queries the Xcode/SwiftPM index store that is built alongside the project. It provides compiler-accurate symbol information: exact definitions, all references, call graphs, inheritance hierarchies, and module dependency graphs.
+
+## Prerequisites
+
+### 1. Build the index
+
+The tool automatically finds the best available index:
+
+1. **Xcode (preferred)** — build in Xcode (⌘B). The tool auto-discovers the most recently modified DerivedData index.
+2. **SPM (fallback)** — if no Xcode index is found, run `swift build --enable-index-store` from the repo root.
+
+### 2. Build the CLI tool
+
+Build the `indexstore` binary from the tools package (one-time setup):
+
+```bash
+cd .claude/skills/code-index/tools && swift build -c release 2>&1 | tail -5
+```
+
+The compiled binary will be at:
+```
+.claude/skills/code-index/tools/.build/arm64-apple-macosx/release/indexstore-query
+```
+
+## Running Queries
+
+All subcommands output JSON. Pipe to `jq` for readable formatting.
+
+### Binary path
+
+```
+.claude/skills/code-index/tools/.build/release/indexstore-query
+```
+
+> **IMPORTANT**: Always invoke the binary using its literal path — never assign it to a shell variable first, and never wrap it in `bash -c "..."`. Use the literal path directly so the command matches the pre-approved permission rule.
+
+### Subcommand reference
+
+#### Symbol lookup
+
+| Goal | Command |
+|------|---------|
+| Find a symbol definition by name | `.claude/skills/code-index/tools/.build/release/indexstore-query find <Name> --path .` |
+| Fuzzy search across all symbols | `.claude/skills/code-index/tools/.build/release/indexstore-query search <pattern> --path .` |
+| All symbols defined in a file | `.claude/skills/code-index/tools/.build/release/indexstore-query file-symbols <relative/path.swift> --path .` |
+| All symbols in a module | `.claude/skills/code-index/tools/.build/release/indexstore-query module-symbols <ModuleName> --path .` |
+
+#### References and call graph
+
+| Goal | Command |
+|------|---------|
+| All references to a symbol | `.claude/skills/code-index/tools/.build/release/indexstore-query usages <USR> --path .` |
+| Declaration sites of a symbol (ObjC/protocols only) | `.claude/skills/code-index/tools/.build/release/indexstore-query declarations <USR> --path .` |
+| Who calls a function | `.claude/skills/code-index/tools/.build/release/indexstore-query callers <USR> --path .` |
+| Accessor symbols (get/set/willSet/didSet) | `.claude/skills/code-index/tools/.build/release/indexstore-query accessors <USR> --path .` |
+
+#### Inheritance and conformance
+
+| Goal | Command |
+|------|---------|
+| Types conforming to a protocol | `.claude/skills/code-index/tools/.build/release/indexstore-query conformers <USR> --path .` |
+| Extension declarations on a type | `.claude/skills/code-index/tools/.build/release/indexstore-query extends <extensionUSR> --path .` |
+| Methods overriding a method | `.claude/skills/code-index/tools/.build/release/indexstore-query overrides <USR> --path .` |
+| Specializations of a generic (C++ only) | `.claude/skills/code-index/tools/.build/release/indexstore-query specializations <USR> --path .` |
+
+#### Nesting and structure
+
+| Goal | Command |
+|------|---------|
+| Symbols lexically inside a type or function | `.claude/skills/code-index/tools/.build/release/indexstore-query children <USR> --path .` |
+
+#### Objective-C and Interface Builder
+
+| Goal | Command |
+|------|---------|
+| Objective-C method dispatch receivers | `.claude/skills/code-index/tools/.build/release/indexstore-query received-by <USR> --path .` |
+| Interface Builder type relationships | `.claude/skills/code-index/tools/.build/release/indexstore-query ib-types <USR> --path .` |
+
+#### Tests
+
+| Goal | Command |
+|------|---------|
+| Tests that reference a source file | `.claude/skills/code-index/tools/.build/release/indexstore-query unit-tests <relative/path.swift> --path .` |
+| All test symbols in the index | `.claude/skills/code-index/tools/.build/release/indexstore-query all-tests --path .` |
+
+#### Compilation units and includes
+
+| Goal | Command |
+|------|---------|
+| Which compilation units compiled a file | `.claude/skills/code-index/tools/.build/release/indexstore-query units <relative/path.swift> --path .` |
+| Translation-unit (main) files for a file | `.claude/skills/code-index/tools/.build/release/indexstore-query main-files <relative/path.swift> --path .` |
+| Files #included by a file (C/Objective-C) | `.claude/skills/code-index/tools/.build/release/indexstore-query includes <relative/path.swift> --path .` |
+| Files that #include a file (C/Objective-C) | `.claude/skills/code-index/tools/.build/release/indexstore-query included-by <relative/path.swift> --path .` |
+| Detailed #include entries for a unit | `.claude/skills/code-index/tools/.build/release/indexstore-query unit-includes <UnitName> --path .` |
+
+### Typical workflows
+
+#### 1. Find a symbol and drill into its usages
+
+```bash
+# Step 1: get USR
+.claude/skills/code-index/tools/.build/release/indexstore-query find DatadogContext --path . | jq '.[] | {name, kind, path, line, usr}'
+
+# Step 2: all reference sites
+.claude/skills/code-index/tools/.build/release/indexstore-query usages 's:14DatadogInternal0A7ContextV' --path . | jq '.[] | {path, line}'
+```
+
+#### 2. Find all conformers of a protocol
+
+```bash
+.claude/skills/code-index/tools/.build/release/indexstore-query find FeatureMessageReceiver --path . | jq '.[0].usr' -r | \
+  xargs -I{} .claude/skills/code-index/tools/.build/release/indexstore-query conformers {} --path . | jq '.[] | {name, path}'
+```
+
+#### 3. Inspect the nesting structure of a type
+
+```bash
+.claude/skills/code-index/tools/.build/release/indexstore-query find DatadogCore --path . | jq '.[0].usr' -r | \
+  xargs -I{} .claude/skills/code-index/tools/.build/release/indexstore-query children {} --path . | jq '.[] | {name, kind, line}'
+```
+
+#### 4. Find tests for a source file
+
+```bash
+.claude/skills/code-index/tools/.build/release/indexstore-query unit-tests DatadogCore/Sources/Core/DatadogCore.swift --path . | \
+  jq '.[] | {name, path}'
+```
+
+#### 5. Understand which targets compiled a file
+
+```bash
+# Step 1: list compilation unit names
+.claude/skills/code-index/tools/.build/release/indexstore-query units DatadogCore/Sources/Core/DatadogCore.swift --path . | jq '.[].path'
+
+# Step 2: inspect a unit's #include graph (for C/Objective-C files)
+.claude/skills/code-index/tools/.build/release/indexstore-query unit-includes "SomeUnitName" --path . | jq '.[] | {sourcePath, targetPath, line}'
+```
+
+#### 6. Find where a symbol is declared vs. defined
+
+```bash
+# Declaration sites (e.g. protocol requirement, Objective-C forward declarations)
+.claude/skills/code-index/tools/.build/release/indexstore-query declarations 's:14DatadogInternal...' --path . | jq '.[] | {path, line, kind}'
+# Definition site (the implementation)
+.claude/skills/code-index/tools/.build/release/indexstore-query find SomeSymbol --path . | jq '.[]'
+```
+
+#### 7. Explore specializations of a generic
+
+```bash
+.claude/skills/code-index/tools/.build/release/indexstore-query find encode --path . | jq '.[] | select(.properties[]? == "generic") | {name, usr}' | \
+  head -1 | jq -r '.usr' | \
+  xargs -I{} .claude/skills/code-index/tools/.build/release/indexstore-query specializations {} --path . | jq '.[] | {name, path, line}'
+```
+
+#### 8. Objective-C method dispatch — who receives a selector
+
+```bash
+.claude/skills/code-index/tools/.build/release/indexstore-query find viewDidLoad --path . | jq '.[0].usr' -r | \
+  xargs -I{} .claude/skills/code-index/tools/.build/release/indexstore-query received-by {} --path . | jq '.[] | {name, path, line}'
+```
+
+### Output shape
+
+Every result object has:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Symbol name |
+| `kind` | `class`, `struct`, `protocol`, `function`, `instanceMethod`, etc. |
+| `usr` | Unified Symbol Reference — stable compiler identifier, use for follow-up queries |
+| `language` | `swift` or `objc` (Objective-C) |
+| `module` | Module the symbol belongs to |
+| `path` | Absolute path to the file |
+| `line` | Line number |
+| `column` | Column (UTF-8 offset) |
+| `properties` | Optional array: `local`, `generic`, `swiftAsync`, `unitTest`, `protocolInterface` |
+| `relations` | Optional array of related symbols, each with `roles`, `name`, `kind`, `usr` |
+
+`unit-includes` returns a different shape:
+
+| Field | Description |
+|-------|-------------|
+| `sourcePath` | Absolute path to the file that contains the `#include` directive |
+| `targetPath` | Absolute path to the file being included |
+| `line` | Line number of the `#include` directive |
+
+## When to Use This vs. Grep
+
+| Situation | Tool |
+|-----------|------|
+| "Where is `X` defined?" | `find X` — compiler-accurate, handles overloads |
+| "What calls `X`?" | `callers <USR>` — only real call sites, not string matches |
+| "What conforms to protocol `X`?" | `conformers <USR>` |
+| "What is declared inside type `X`?" | `children <USR>` |
+| "Where is `X` declared (ObjC forward decl / protocol requirement)?" | `declarations <USR>` |
+| "Which targets compiled this file?" | `units <path>` |
+| "What files mention the word `X`?" | Grep — faster for text patterns |
+| "Where is this string literal used?" | Grep |
+| "Do any tests cover this file?" | `unit-tests <path>` |
+
+## Handling Large Output
+
+When a query returns a large result, Claude's context infrastructure automatically truncates the inline output and saves the full result to a temp file:
+
+```
+Output too large (66.4KB). Full output saved to: /Users/.../.claude/projects/.../tool-results/abc123.txt
+Preview (first 2KB): ...
+```
+
+**When this happens, run `jq` directly on the saved file:**
+
+```bash
+jq '.[] | select(.path | contains("Sources"))' /path/to/saved-output.txt
+```
+
+Or use `Read` on the saved path if you need to inspect the raw JSON first.
+
+**NEVER fall back to `grep` or `Bash` for Swift symbol lookups because output was large.** That violates the Swift symbol navigation rules regardless of reason.
+
+If results are still too many, narrow the query instead:
+- Use `find <ExactName>` instead of `search <pattern>`
+- Add a `jq` select filter inline in the original command
+- Use a more specific subcommand (e.g. `children <USR>` instead of `find`)
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `Index not found` error | Run `swift build` or build in Xcode first |
+| Binary not found | Build the CLI tool with `swift build -c release` inside `tools/` |
+| `module-symbols` is slow | Add `--limit 100` to cap results |
+| Using `search` when you know the exact name | Use `find` — it's faster and deduplicates exact + fuzzy matches |
+| Passing absolute path to `unit-tests` / `file-symbols` / `units` / `main-files` | These take a **repo-relative** path, e.g. `DatadogCore/Sources/Core/DatadogCore.swift` |
+| `extends` returns 0 results | Pass an **extension USR** (starts with `s:e:s:`), not the base type USR |
+| `unit-tests` returns 0 for a production source file | Pass a **test** source file that is its own compilation unit (verify with `main-files`) |
+| `unit-includes` returns nothing | The unit name must come verbatim from `units` output; it is not a file path |
+| Output was large → used `grep` | **Wrong.** Run `jq '...' /path/to/saved-output.txt` on the saved temp file. Large output is never a reason to use `grep` for Swift symbols. |

--- a/.claude/skills/code-index/tools/Package.swift
+++ b/.claude/skills/code-index/tools/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "IndexStoreCLI",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/indexstore-db.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "indexstore-query",
+            dependencies: [
+                .product(name: "IndexStoreDB", package: "indexstore-db"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ]
+)

--- a/.claude/skills/code-index/tools/Sources/indexstore-query/IndexStoreProvider.swift
+++ b/.claude/skills/code-index/tools/Sources/indexstore-query/IndexStoreProvider.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+ 
+import Foundation
+
+// MARK: - IndexStoreProvider
+
+/// Abstracts the location of an index store and its associated query database.
+///
+/// An index store is a directory tree produced by the Swift compiler (or Xcode) that
+/// contains raw unit/record data for every compiled file.  `IndexStoreDB` builds a
+/// query-optimised view of that data (the *database*) the first time it opens a store.
+///
+/// Conforming types know how to derive `storePath` and `dbPath` from a project layout —
+/// Xcode uses DerivedData, SPM uses `.build/index-build/`.
+protocol IndexStoreProvider {
+    /// Path to the raw index store directory (unit files and records).
+    var store: URL { get }
+
+    /// Path to the query database directory (query-optimised view over `storePath`).
+    ///
+    /// `IndexStoreDB` creates or reuses this directory automatically; it never needs to
+    /// exist before the first call.  Xcode stores it in `Index.noindex/UniDB/` next to
+    /// `DataStore`; SPM stores it in `.build/index-build/<triple>/debug/index/db/`.
+    var db: URL { get }
+}

--- a/.claude/skills/code-index/tools/Sources/indexstore-query/SPMIndexStoreProvider.swift
+++ b/.claude/skills/code-index/tools/Sources/indexstore-query/SPMIndexStoreProvider.swift
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+ 
+import Foundation
+
+// MARK: - SPMIndexStoreProvider
+
+/// Resolves the index store produced by `swift build --enable-index-building`.
+///
+/// SPM writes index data under `.build/index-build/<triple>/debug/index/`:
+///
+/// ```
+/// .build/index-build/
+///   <arch>-apple-macosx/
+///     debug/
+///       index/
+///         store/    ← raw index store (storePath)
+///         db/       ← query database (dbPath)
+/// ```
+///
+/// The architecture triple is derived at compile time via conditional compilation so that
+/// the tool always resolves the correct path on both Apple Silicon and Intel Macs.
+///
+/// Unlike `XcodeIndexStoreProvider`, this type always returns a provider even when the
+/// store has not been built yet — the `openIndex` function validates existence before
+/// opening.  This makes `SPMIndexStoreProvider` a safe unconditional fallback.
+struct SPMIndexStoreProvider: IndexStoreProvider {
+    /// Path to the raw index store (`store`) inside `.build/index-build/`.
+    let store: URL
+
+    /// Path to the query database (`db`) alongside `store`.
+    let db: URL
+
+    // MARK: Init
+
+    /// Creates a provider whose paths are derived from `repoRoot` and the current
+    /// architecture triple.
+    ///
+    /// - Parameter repoRoot: The root directory of the repository (where `.build/` lives).
+    init(repoRoot: URL) {
+        let triple = Self.archTriple
+        let base = repoRoot.appendingPathComponent(".build/index-build/\(triple)/debug/index")
+        store = base.appendingPathComponent("store")
+        db = base.appendingPathComponent("db")
+    }
+
+    // MARK: Private helpers
+
+    /// The architecture-specific triple used by SPM when naming its build output directories.
+    ///
+    /// Only `arm64` and `x86_64` are common on macOS; other architectures fall back to
+    /// `arm64-apple-macosx` which is the current default for Apple Silicon.
+    private static var archTriple: String {
+        #if arch(arm64)
+        return "arm64-apple-macosx"
+        #elseif arch(x86_64)
+        return "x86_64-apple-macosx"
+        #else
+        return "arm64-apple-macosx"
+        #endif
+    }
+}

--- a/.claude/skills/code-index/tools/Sources/indexstore-query/XcodeIndexStoreProvider.swift
+++ b/.claude/skills/code-index/tools/Sources/indexstore-query/XcodeIndexStoreProvider.swift
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+ 
+import Foundation
+
+// MARK: - XcodeIndexStoreProvider
+
+/// Resolves the most recently modified DerivedData index store for an Xcode project.
+///
+/// Xcode writes index data under `~/Library/Developer/Xcode/DerivedData/<ProjectName>-<hash>/`:
+///
+/// ```
+/// <project>-<hash>/
+///   Index.noindex/
+///     DataStore/    ← raw index store (storePath)
+///     UniDB/        ← query database (dbPath)
+/// ```
+///
+/// `UniDB` is an LMDB-backed database created by `IndexStoreDB`.  It lives alongside
+/// `DataStore` inside `Index.noindex/` so that Xcode can exclude it from Spotlight and
+/// Time Machine backups (`.noindex` suffix).
+///
+/// When a repository contains multiple Xcode projects (e.g. workspace + sub-projects),
+/// this type prefers `.xcworkspace` over `.xcodeproj` and picks the entry whose
+/// `DataStore` was most recently modified — i.e. the build that ran last.
+struct XcodeIndexStoreProvider: IndexStoreProvider {
+    /// Path to the raw index store (`DataStore`) inside DerivedData.
+    let store: URL
+
+    /// Path to the UniDB query database alongside `DataStore` inside `Index.noindex/`.
+    let db: URL
+
+    // MARK: Factory
+
+    /// Returns a provider for `repoRoot`, or `nil` when no matching DerivedData entry
+    /// exists or when no `.xcworkspace` / `.xcodeproj` is found at `repoRoot`.
+    static func find(repoRoot: URL) -> XcodeIndexStoreProvider? {
+        guard let store = mostRecentStore(repoRoot: repoRoot) else { return nil }
+        let uniDB = store.deletingLastPathComponent().appendingPathComponent("UniDB")
+        guard let db = xcindexDirectory(under: uniDB) else { return nil }
+        return XcodeIndexStoreProvider(store: store, db: db)
+    }
+
+    /// Returns the first `.xcindex` directory inside `uniDB/` — the `databasePath` root
+    /// that IndexStoreDB expects on Xcode 26+.
+    private static func xcindexDirectory(under uniDB: URL) -> URL? {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: uniDB, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+        ) else { return nil }
+        return entries.first { $0.pathExtension == "xcindex" }
+    }
+
+    // MARK: Private helpers
+
+    /// Infers the Xcode project name from the top-level workspace or project file.
+    ///
+    /// Prefers `.xcworkspace` over `.xcodeproj` to match the DerivedData naming convention
+    /// (Xcode names DerivedData entries after the *workspace*, not the project, when both
+    /// are present).
+    private static func projectName(repoRoot: URL) -> String? {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: repoRoot, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+        ) else { return nil }
+        let sorted = entries.sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let project = sorted.first { $0.pathExtension == "xcworkspace" }
+            ?? sorted.first { $0.pathExtension == "xcodeproj" }
+        return project?.deletingPathExtension().lastPathComponent
+    }
+
+    /// Finds the `DataStore` path with the most recent modification date among all
+    /// DerivedData entries whose name starts with `<projectName>-`.
+    ///
+    /// The modification date of `DataStore` itself (rather than its contents) is used as
+    /// a proxy for build recency — Xcode updates the directory's mtime after each build.
+    private static func mostRecentStore(repoRoot: URL) -> URL? {
+        guard let projectName = projectName(repoRoot: repoRoot) else { return nil }
+        let derivedData = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Developer/Xcode/DerivedData")
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: derivedData,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: .skipsHiddenFiles
+        ) else { return nil }
+        return entries
+            .filter { $0.lastPathComponent.hasPrefix(projectName + "-") }
+            .compactMap { folder -> (URL, Date)? in
+                let store = folder.appendingPathComponent("Index.noindex/DataStore")
+                guard
+                    FileManager.default.fileExists(atPath: store.path),
+                    let date = (try? store.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+                else { return nil }
+                return (store, date)
+            }
+            .max(by: { $0.1 < $1.1 })?
+            .0
+    }
+}

--- a/.claude/skills/code-index/tools/Sources/indexstore-query/main.swift
+++ b/.claude/skills/code-index/tools/Sources/indexstore-query/main.swift
@@ -1,0 +1,825 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+ 
+import ArgumentParser
+import Foundation
+import IndexStoreDB
+
+// MARK: - Path resolution
+
+/// Resolves the best available index store provider for `repoRoot`.
+///
+/// Resolution order:
+/// 1. **Xcode DerivedData** — preferred because it reflects the last full build and is
+///    kept in sync by Xcode automatically.  Returns `nil` when no matching DerivedData
+///    entry exists (e.g. when running in CI without Xcode).
+/// 2. **SPM `.build/index-build/`** — fallback for command-line / CI workflows where
+///    `swift build --enable-index-store` has been run.
+///
+/// - Parameter repoRoot: The root directory of the repository.
+/// - Returns: A concrete provider, never fails (SPM path is always derivable).
+func resolve(repoRoot: URL) -> any IndexStoreProvider {
+    XcodeIndexStoreProvider.find(repoRoot: repoRoot) ?? SPMIndexStoreProvider(repoRoot: repoRoot)
+}
+
+// MARK: - libIndexStore helper
+
+/// Locates `libIndexStore.dylib` relative to the active Xcode toolchain's `sourcekit-lsp`.
+///
+/// `libIndexStore.dylib` is the C library that understands the raw index store format.
+/// `IndexStoreDB` wraps it via `IndexStoreLibrary`.  The dylib ships with Xcode's toolchain
+/// and lives at `<toolchain>/usr/lib/libIndexStore.dylib`, two directories above
+/// `sourcekit-lsp` in `<toolchain>/usr/bin/`.
+///
+/// - Throws: `IndexStoreError.indexNotFound` when `xcrun` cannot locate `sourcekit-lsp` or the
+///   dylib is absent at the derived path.
+func libIndexStorePath() throws -> String {
+    let result = try shell("xcrun --find sourcekit-lsp")
+    // libIndexStore.dylib lives two directories above sourcekit-lsp:
+    //   <toolchain>/usr/bin/sourcekit-lsp  →  ../..  →  <toolchain>/usr/
+    let lspURL = URL(fileURLWithPath: result.trimmingCharacters(in: .whitespacesAndNewlines))
+    let libURL = lspURL
+        .deletingLastPathComponent()        // removes sourcekit-lsp → …/bin
+        .deletingLastPathComponent()        // removes bin/           → …/usr
+        .appendingPathComponent("lib/libIndexStore.dylib")
+    guard FileManager.default.fileExists(atPath: libURL.path) else {
+        throw IndexStoreError.indexNotFound("libIndexStore.dylib not found at \(libURL.path)")
+    }
+    return libURL.path
+}
+
+// MARK: - Shell helper
+
+/// Runs `command` in a `/bin/zsh` subprocess and returns its standard output.
+///
+/// - Parameter command: A shell command string passed to `zsh -c`.
+/// - Returns: The trimmed standard output of the command.
+/// - Throws: `IndexStoreError.queryFailed` when the process exits with a non-zero status.
+@discardableResult
+func shell(_ command: String) throws -> String {
+    let process = Process()
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+    process.arguments = ["-c", command]
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let errMsg = String(data: errData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let detail = errMsg.isEmpty ? "" : ": \(errMsg)"
+        throw IndexStoreError.queryFailed("command exited with status \(process.terminationStatus): \(command)\(detail)")
+    }
+    let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
+}
+
+// MARK: - Error
+
+/// Errors thrown by the `indexstore` tool.
+enum IndexStoreError: Error, CustomStringConvertible {
+    /// The index store or a required file does not exist at the expected path.
+    case indexNotFound(String)
+    /// An index query or subprocess command failed.
+    case queryFailed(String)
+
+    var description: String {
+        switch self {
+        case .indexNotFound(let msg): return "Index not found: \(msg). Build in Xcode (⌘B) or run `swift build --enable-index-store`."
+        case .queryFailed(let msg): return "Query failed: \(msg)"
+        }
+    }
+}
+
+// MARK: - JSON output
+
+/// A relation to another symbol, emitted alongside the occurrence that carries it.
+struct RelationResult: Codable {
+    /// The role that describes how the related symbol relates to the occurrence's symbol
+    /// (e.g. `calledBy`, `childOf`, `baseOf`).
+    let roles: String
+    let name: String
+    let kind: String
+    let usr: String
+}
+
+/// A single symbol occurrence serialised to JSON by the subcommands.
+struct SymbolResult: Codable {
+    let name: String
+    let kind: String
+    let usr: String
+    let language: String
+    /// `swift` or `clang` — the compiler that produced this index record.
+    let provider: String
+    let module: String
+    let path: String
+    let line: Int
+    let column: Int
+    /// Optional symbol properties (e.g. `local`, `swiftAsync`, `unitTest`, `protocolInterface`, `generic`).
+    /// `nil` when the symbol has no notable properties.
+    let properties: [String]?
+    /// Relations carried by this occurrence (e.g. which type calls this method, which protocol
+    /// this type conforms to).  `nil` when there are no relations.
+    let relations: [RelationResult]?
+}
+
+/// A plain file path result used by subcommands that return file paths rather than symbols.
+struct FileResult: Codable {
+    let path: String
+}
+
+/// Encodes `value` as pretty-printed, key-sorted JSON and returns it as a `String`.
+func jsonOutput<T: Encodable>(_ value: T) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(value)
+    return String(data: data, encoding: .utf8) ?? "[]"
+}
+
+// MARK: - Shared helpers
+
+/// Extracts notable properties from `symbol` into an array of human-readable strings.
+///
+/// Returns `nil` instead of an empty array so that the JSON key is omitted entirely
+/// when the symbol has no notable properties.
+func symbolProperties(_ symbol: Symbol) -> [String]? {
+    var props: [String] = []
+    if symbol.properties.contains(.local) { props.append("local") }
+    if symbol.properties.contains(.swiftAsync) { props.append("swiftAsync") }
+    if symbol.properties.contains(.unitTest) { props.append("unitTest") }
+    if symbol.properties.contains(.protocolInterface) { props.append("protocolInterface") }
+    if symbol.properties.contains(.generic) { props.append("generic") }
+    return props.isEmpty ? nil : props
+}
+
+/// Converts the relations on a `SymbolOccurrence` into `RelationResult` values for JSON output.
+///
+/// Returns `nil` instead of an empty array so that the JSON key is omitted entirely
+/// when there are no relations.
+func occurrenceRelations(_ occ: SymbolOccurrence) -> [RelationResult]? {
+    let results = occ.relations.map { rel in
+        RelationResult(
+            roles: "\(rel.roles)",
+            name: rel.symbol.name,
+            kind: "\(rel.symbol.kind)",
+            usr: rel.symbol.usr
+        )
+    }
+    return results.isEmpty ? nil : results
+}
+
+/// Converts a `SymbolOccurrence` into a `SymbolResult` ready for JSON serialisation.
+func makeResult(_ occ: SymbolOccurrence) -> SymbolResult {
+    SymbolResult(
+        name: occ.symbol.name,
+        kind: "\(occ.symbol.kind)",
+        usr: occ.symbol.usr,
+        language: "\(occ.symbol.language)",
+        provider: "\(occ.symbolProvider)",
+        module: occ.location.moduleName,
+        path: occ.location.path,
+        line: occ.location.line,
+        column: occ.location.utf8Column,
+        properties: symbolProperties(occ.symbol),
+        relations: occurrenceRelations(occ)
+    )
+}
+
+/// Opens the index store at `path` (defaults to the current directory) and returns the
+/// repo root together with a ready-to-query `IndexStoreDB`.
+///
+/// Resolution order for the store location:
+/// 1. Xcode DerivedData (preferred — reflects the most recent Xcode build)
+/// 2. SPM `.build/index-build/` (fallback for CI / command-line builds)
+///
+/// The database is opened with `readonly: true` so that multiple concurrent tool
+/// invocations can share the same LMDB environment without write-lock contention.
+///
+/// - Parameter path: Optional explicit repo root path.
+/// - Returns: A tuple of the resolved repo root URL and an initialised `IndexStoreDB`.
+/// - Throws: `IndexStoreError.indexNotFound` when the store directory does not exist, or any
+///   error propagated from `IndexStoreDB` initialisation.
+func openIndex(path: String? = nil) throws -> (root: URL, index: IndexStoreDB) {
+    let root = URL(fileURLWithPath: path ?? FileManager.default.currentDirectoryPath)
+    let provider = resolve(repoRoot: root)
+    let libPath = try libIndexStorePath()
+
+    guard FileManager.default.fileExists(atPath: provider.store.path) else {
+        throw IndexStoreError.indexNotFound("Store not found at \(provider.store.path)")
+    }
+
+    let lib = try IndexStoreLibrary(dylibPath: libPath)
+    let index = try IndexStoreDB(
+        storePath: provider.store.path,
+        databasePath: provider.db.path,
+        library: lib,
+        waitUntilDoneInitializing: true,
+        readonly: false
+    )
+    return (root, index)
+}
+
+// MARK: - Root command
+
+/// Shared options inherited by every subcommand via `@OptionGroup`.
+struct GlobalOptions: ParsableArguments {
+    @Option(name: .shortAndLong, help: "Path to the repository root (defaults to current directory).")
+    var path: String?
+}
+
+/// The root `ArgumentParser` command.  All index queries are exposed as subcommands.
+struct IndexStoreTool: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "indexstore",
+        abstract: "Query the Swift index store for symbol information.",
+        subcommands: [
+            Find.self,
+            Search.self,
+            Usages.self,
+            Declarations.self,
+            Callers.self,
+            Conformers.self,
+            Extends.self,
+            Overrides.self,
+            Accessors.self,
+            Specializations.self,
+            Children.self,
+            ReceivedBy.self,
+            IBTypes.self,
+            UnitTests.self,
+            AllTests.self,
+            FileSymbols.self,
+            MainFiles.self,
+            Units.self,
+            Includes.self,
+            IncludedBy.self,
+            UnitIncludes.self,
+            ModuleSymbols.self,
+        ]
+    )
+}
+
+// MARK: - Subcommands
+
+extension IndexStoreTool {
+
+    /// Finds symbol definitions by exact name, then augments the results with fuzzy /
+    /// subsequence matches.  Duplicates (same USR) are deduplicated before output.
+    struct Find: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Find symbol definitions by name (exact + fuzzy)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Symbol name to search for.")
+        var name: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let exactOccurrences = index.canonicalOccurrences(ofName: name)
+            let fuzzyOccurrences = index.canonicalOccurrences(
+                containing: name,
+                anchorStart: false,
+                anchorEnd: false,
+                subsequence: true,
+                ignoreCase: true
+            )
+
+            let results = (exactOccurrences + fuzzyOccurrences)
+                .filter { $0.roles.contains(.definition) }
+                .reduce(into: [String: SymbolOccurrence]()) { dict, occ in
+                    if dict[occ.symbol.usr] == nil { dict[occ.symbol.usr] = occ }
+                }
+                .values
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Performs a fuzzy subsequence search across all symbol names in the index.
+    struct Search: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Fuzzy/subsequence search across all symbol names."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Pattern to search for.")
+        var pattern: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            var seen = Set<String>()
+            var results: [SymbolResult] = []
+
+            index.forEachCanonicalSymbolOccurrence(
+                containing: pattern,
+                anchorStart: false,
+                anchorEnd: false,
+                subsequence: true,
+                ignoreCase: true
+            ) { occ in
+                guard occ.roles.contains(.definition), !seen.contains(occ.symbol.usr) else { return true }
+                seen.insert(occ.symbol.usr)
+                results.append(makeResult(occ))
+                return true
+            }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns all reference occurrences of a symbol identified by its USR.
+    struct Usages: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "All references to a symbol (use USR from find output)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let roles: SymbolRole = [.reference, .read, .write, .call, .dynamic, .addressOf]
+            let results = index.occurrences(ofUSR: usr, roles: roles)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns only call-site occurrences — i.e. places that call a function / method.
+    struct Callers: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Only call sites — who calls this function?"
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .calledBy)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns types that conform to or inherit from a given protocol or class.
+    struct Conformers: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Types conforming to / inheriting from a protocol or class."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the protocol or class.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .baseOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns types that extend a given type (Swift `extension` declarations).
+    struct Extends: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Extension declarations that extend a type."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the type.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .extendedBy)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns methods that override a given method.
+    struct Overrides: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Methods overriding this method."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the method.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .overrideOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns accessor symbols (getters/setters/observers) for a property identified by USR.
+    struct Accessors: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Accessor symbols (get/set/willSet/didSet) for a property."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the property.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .accessorOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists test symbols that reference (and therefore cover) a given source file.
+    struct UnitTests: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "unit-tests",
+            abstract: "Test symbols that reference a source file."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.unitTests(referencedByMainFiles: [fullPath])
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists every unit test symbol in the entire index.
+    struct AllTests: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "all-tests",
+            abstract: "All unit test symbols in the index."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.unitTests()
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists all symbols defined in a single source file.
+    struct FileSymbols: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "file-symbols",
+            abstract: "All symbols defined in a file."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.symbolOccurrences(inFilePath: fullPath)
+                .filter { $0.roles.contains(.definition) }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns the translation-unit (main) files that compile a given source file.
+    ///
+    /// Useful for understanding which targets include a shared file.
+    struct MainFiles: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "main-files",
+            abstract: "Translation-unit files that compile a given source file."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.mainFilesContainingFile(path: fullPath, crossLanguage: true)
+                .sorted()
+                .map { FileResult(path: $0) }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists files that a given file `#include`s (C/Objective-C header inclusion graph).
+    struct Includes: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Files #included by a given file (C/ObjC only)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.filesIncludedByFile(path: fullPath)
+                .sorted()
+                .map { FileResult(path: $0) }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists files that `#include` a given file (reverse header inclusion graph).
+    struct IncludedBy: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "included-by",
+            abstract: "Files that #include a given file (C/ObjC only)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.filesIncludingFile(path: fullPath)
+                .sorted()
+                .map { FileResult(path: $0) }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists compilation unit names that contain a given source file.
+    ///
+    /// Useful for understanding which targets / build outputs compiled a file.
+    struct Units: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Compilation unit names that contain a given source file."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Relative path to the source file from repo root.")
+        var filePath: String
+
+        func run() throws {
+            let (root, index) = try openIndex(path: globals.path)
+            let fullPath = root.appendingPathComponent(filePath).path
+
+            let results = index.unitNamesContainingFile(path: fullPath)
+                .sorted()
+                .map { FileResult(path: $0) }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists the `#include` entries recorded for a compilation unit.
+    ///
+    /// Returns richer data than `includes` / `included-by`: source path, target path, and line.
+    struct UnitIncludes: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "unit-includes",
+            abstract: "Detailed #include entries for a compilation unit (C/ObjC only)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Unit name (e.g. from `units` output).")
+        var unitName: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            struct UnitIncludeResult: Codable {
+                let sourcePath: String
+                let targetPath: String
+                let line: Int
+            }
+
+            let results = index.includesOfUnit(unitName: unitName)
+                .sorted { ($0.sourcePath, $0.line) < ($1.sourcePath, $1.line) }
+                .map { UnitIncludeResult(sourcePath: $0.sourcePath, targetPath: $0.targetPath, line: $0.line) }
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns declaration occurrences of a symbol identified by its USR.
+    ///
+    /// Complements `usages` which filters to reference/read/write/call roles.
+    struct Declarations: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Declaration occurrences of a symbol (use USR from find output)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(ofUSR: usr, roles: .declaration)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns specializations of a generic symbol identified by its USR.
+    struct Specializations: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Specializations of a generic type or function."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the generic symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .specializationOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns symbols lexically contained inside a given symbol (nesting relationships).
+    struct Children: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Symbols lexically contained inside a type or function."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the containing symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .childOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns ObjC method dispatch receivers for a given selector.
+    struct ReceivedBy: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "received-by",
+            abstract: "ObjC method dispatch receivers (receivedBy role)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the ObjC selector.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .receivedBy)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Returns IB type relationships for a given symbol.
+    struct IBTypes: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "ib-types",
+            abstract: "Interface Builder type relationships (ibTypeOf role)."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "USR of the symbol.")
+        var usr: String
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            let results = index.occurrences(relatedToUSR: usr, roles: .ibTypeOf)
+                .filter { !$0.location.isSystem }
+                .sorted()
+                .map(makeResult)
+
+            print(try jsonOutput(results))
+        }
+    }
+
+    /// Lists all symbols defined in a named Swift module.
+    ///
+    /// To avoid LMDB re-entrant read errors (`MDB_BAD_RSLOT`), all symbol names are
+    /// collected first, then each is queried individually outside the iteration closure.
+    struct ModuleSymbols: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "module-symbols",
+            abstract: "All symbols in a module."
+        )
+
+        @OptionGroup var globals: GlobalOptions
+        @Argument(help: "Module name.")
+        var module: String
+
+        @Option(name: .shortAndLong, help: "Maximum number of results to return (0 = unlimited).")
+        var limit: Int = 0
+
+        func run() throws {
+            let (_, index) = try openIndex(path: globals.path)
+
+            var seen = Set<String>()
+            var results: [SymbolResult] = []
+
+            // Collect all symbol names first to avoid LMDB re-entrant read (MDB_BAD_RSLOT)
+            let allNames = index.allSymbolNames()
+            outer: for name in allNames {
+                index.forEachCanonicalSymbolOccurrence(byName: name) { occ in
+                    guard occ.roles.contains(.definition),
+                          occ.location.moduleName == module,
+                          !seen.contains(occ.symbol.usr) else { return true }
+                    seen.insert(occ.symbol.usr)
+                    results.append(makeResult(occ))
+                    return true
+                }
+                if limit > 0 && results.count >= limit { break outer }
+            }
+
+            results.sort { ($0.path, $0.line) < ($1.path, $1.line) }
+            print(try jsonOutput(results))
+        }
+    }
+}
+
+// MARK: - Entry point
+
+IndexStoreTool.main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,12 @@ The `ENV=ci` flag is used in CI to enable special behaviors (e.g., different API
 - Code must pass `make lint`, `make test-ios-all`, `make test-tvos-all`, and API surface checks
 - Follow patterns established in the codebase (OOP, SOLID principles, dependency injection)
 
+## Code Navigation
+
+**NEVER use Grep, Glob, or Bash to search for Swift symbols.** For any Swift symbol navigation — finding definitions, call sites, protocol conformers, method overrides, or module dependencies — you MUST use the `code-index` skill (`.claude/skills/code-index/`). It queries the compiler's index store for accurate, compiler-level symbol resolution. Using Grep or Glob for Swift symbol lookups is a violation of these instructions.
+
+Grep/Glob are permitted ONLY for text pattern matching: string literals, comments, file names, or non-Swift-symbol searches.
+
 ## Claude additional Agent documentation
 
 Claude can look at the Agents.md to gather more information about the project.

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -153,6 +153,8 @@ custom_rules:
       - string
     message: "Symbol name conflicts with one of Apple's Required Reason APIs. Use different name."
     severity: error
+excluded:
+  - ../../**/*/.build
 
 included:
   - ../../DatadogInternal/Sources

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -82,6 +82,9 @@ custom_rules:
     message: "All singletons must provide an explicit deinitialization API (e.g. `deinitialize()`) to reset its state and tear down all asynchronous work."
     severity: error
 
+excluded:
+  - ../../**/*/.build
+
 included:
   - ../../TestUtilities
   - ../../DatadogInternal/Tests


### PR DESCRIPTION
## What and why?

Adds a `code-index` Claude skill that enables **compiler-accurate Swift codebase navigation** using the Xcode/SPM index store — the same index that powers Xcode's "Jump to Definition" and sourcekit-lsp.

### Key capabilities

- **Precise symbol resolution** — find exact definitions by name, USR-based lookups
- **Call graph analysis** — trace who calls a function, what references a symbol
- **Inheritance & conformance** — discover all protocol conformers, method overrides, extension declarations
- **Structural queries** — explore nested types, methods, properties within a type
- **Test coverage** — find which tests cover a source file
- **Module dependencies** — understand compilation units and include relationships

### Why this matters

- **Exhaustive results** — find ALL conformers, references, or overrides without reading every file
- **Efficient context usage** — structured queries return only what you need, not entire file contents
- **Semantic understanding** — navigate by compiler relationships (conformance, inheritance, calls) not text patterns

## How?

### Skill implementation

- Adds `.claude/skills/code-index/SKILL.md` — full documentation with 20+ query types and workflow examples
- Adds `.claude/skills/code-index/README.md` — quick reference for setup and common queries
- Updates `.claude/settings.json` to register the skill
- Updates `CLAUDE.md` to mandate semantic navigation for Swift symbols

### CLI tool (`indexstore-query`)

- Adds `.claude/skills/code-index/tools/` — Swift package providing the CLI binary
- Implements intelligent index discovery (prefers Xcode DerivedData, falls back to SPM `.build/index-build/`)
- Uses [IndexStoreDB](https://github.com/swiftlang/indexstore-db) — the same library used by sourcekit-lsp and Xcode
- Supports 20+ query types across symbol lookup, call graphs, inheritance, tests, and compilation units
- Returns structured JSON for easy parsing and filtering with `jq`

### Supported query types

| Category | Commands |
|----------|----------|
| Symbol lookup | `find`, `search`, `file-symbols`, `module-symbols` |
| References | `usages`, `declarations`, `callers`, `accessors` |
| Inheritance | `conformers`, `extends`, `overrides`, `specializations` |
| Structure | `children` |
| Objective-C | `received-by`, `ib-types` |
| Tests | `unit-tests`, `all-tests` |
| Compilation | `units`, `main-files`, `includes`, `included-by`, `unit-includes` |

### Example workflows

```bash
# Find definition and all usages
indexstore-query find DatadogContext --path .
indexstore-query usages <USR> --path .

# Discover all protocol conformers (exhaustive, no files read)
indexstore-query find FeatureMessageReceiver --path . | \
  jq '.[0].usr' -r | xargs -I{} indexstore-query conformers {} --path .

# Find tests covering a source file
indexstore-query unit-tests DatadogCore/Sources/Core/DatadogCore.swift --path .
```

## Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular-Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs