### PR TITLE
Fix flaky TTID tests by flushing all SDK queues

### DIFF
--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
@@ -150,7 +150,7 @@ extension AppRunStep {
 extension AppRunStep {
     static func flushDatadogContext() -> AppRunStep {
         AppRunStep { app in
-            DatadogContextProvider.defaultQueue.sync {}
+            app.flush()
         }
     }
 }

--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
@@ -283,6 +283,11 @@ internal class AppRunner {
 
     // MARK: - Data Retrieval
 
+    /// Flushes all pending SDK operations synchronously.
+    func flush() {
+        core.flush()
+    }
+
     /// Returns grouped RUM sessions recorded during the test.
     /// - Returns: An array of `RUMSessionMatcher` grouped by `session.id`.
     func recordedRUMSessions() throws -> [RUMSessionMatcher] {


### PR DESCRIPTION
### What and why?

The `testGivenUserSession_whenItIsStopped_andNextEventIsTrackedInBackground` and `testGivenUserSession_whenItTimesOut_andNextEventIsTrackedInBackground` tests were flaky: `XCTAssertNotNil(session.ttidEvent)` would intermittently fail because the TTID vital event write hadn't completed before results were collected.

### How?

`flushDatadogContext()` was only syncing `DatadogContextProvider.defaultQueue`, but the TTID write dispatches through two async hops: context queue → `readWriteQueue`. Under load (CI), the write could still be in-flight when results were read.

Fix: added `flush()` to `AppRunner` (delegates to `core.flush()` which drains all SDK queues in the correct order) and updated `flushDatadogContext()` to use it.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs