### PR TITLE
feat: Support a complete flush and upload without shutting down.

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -303,6 +303,17 @@ internal final class DatadogCore {
         stop()
     }
 
+    /// Uploads all pending data immediately without tearing down the SDK.
+    ///
+    /// Unlike `flushAndTearDown()`, this method leaves the SDK fully operational after return.
+    /// Upon return, it is safe to assume that all events were stored and got uploaded.
+    func flushAndUpload() {
+        flush()
+        allStorages.forEach { $0.setIgnoreFilesAgeWhenReading(to: true) }
+        allUploads.forEach { $0.flush() }
+        allStorages.forEach { $0.setIgnoreFilesAgeWhenReading(to: false) }
+    }
+
     /// Stops all processes for this instance of the Datadog core by
     /// deallocating all Features and their storage & upload units.
     func stop() {

--- a/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
+++ b/DatadogCore/Sources/Core/Upload/FeatureUpload.swift
@@ -82,4 +82,13 @@ internal struct FeatureUpload {
         uploader.cancelSynchronously()
         uploader.flushSynchronously()
     }
+
+    /// Flushes all authorised data without tearing down the upload stack.
+    /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
+    /// - Unlike `flushAndTearDown()`, the upload scheduler is kept running after this call.
+    ///
+    /// This method is executed synchronously. After return, all authorized data should be considered uploaded.
+    internal func flush() {
+        uploader.flushSynchronously()
+    }
 }

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -343,6 +343,20 @@ public enum Datadog {
     }
 }
 
+@_spi(Internal)
+public extension Datadog {
+    /// Forces all pending data to upload to intake immediately. Blocks the calling thread until complete.
+    /// The SDK remains fully operational after this call.
+    ///
+    /// - Parameter instanceName: The name of the SDK instance to flush.
+    static func flush(instanceName: String = CoreRegistry.defaultInstanceName) {
+        guard let core = CoreRegistry.instance(named: instanceName) as? DatadogCore else {
+            return
+        }
+        core.flushAndUpload()
+    }
+}
+
 private func isValid(env: String) throws {
     /// 1. cannot be more than 200 chars (including `env:` prefix)
     /// 2. cannot end with `:`

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import TestUtilities
 import DatadogInternal
+@_spi(Internal)
 @testable import DatadogCore
 
 private struct FeatureMock: DatadogRemoteFeature {
@@ -507,6 +508,117 @@ class DatadogCoreTests: XCTestCase {
         XCTAssertNil(userAfterUpdate.id)
         XCTAssertNil(userAfterUpdate.name)
         XCTAssertNil(userAfterUpdate.email)
+    }
+
+    func testFlushAndUpload_uploadsAuthorizedEvents() throws {
+        // Given
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            initialConsent: .granted,
+            performance: .mockRandom(),
+            httpClient: HTTPClientMock(),
+            encryption: nil,
+            contextProvider: .mockAny(),
+            applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
+            backgroundTasksEnabled: .mockAny()
+        )
+        defer { core.stop() }
+
+        let requestBuilderSpy = FeatureRequestBuilderSpy()
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = core.scope(for: FeatureMock.self)
+
+        scope.eventWriteContext { _, writer in
+            writer.write(value: FeatureMock.Event(event: "test"))
+        }
+
+        // When
+        core.flushAndUpload()
+
+        // Then
+        let uploadedEvents = requestBuilderSpy.requestParameters
+            .flatMap { $0.events }
+            .map { $0.data.utf8String }
+
+        XCTAssertEqual(uploadedEvents, [#"{"event":"test"}"#])
+    }
+
+    func testFlushAndUpload_sdkRemainsOperationalAfterFlush() throws {
+        // Given
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            initialConsent: .granted,
+            performance: .mockRandom(),
+            httpClient: HTTPClientMock(),
+            encryption: nil,
+            contextProvider: .mockAny(),
+            applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
+            backgroundTasksEnabled: .mockAny()
+        )
+        defer { core.stop() }
+
+        let requestBuilderSpy = FeatureRequestBuilderSpy()
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = core.scope(for: FeatureMock.self)
+
+        scope.eventWriteContext { _, writer in
+            writer.write(value: FeatureMock.Event(event: "first"))
+        }
+        core.flushAndUpload()
+
+        // When - write more events after flush
+        scope.eventWriteContext { _, writer in
+            writer.write(value: FeatureMock.Event(event: "second"))
+        }
+        core.flushAndUpload()
+
+        // Then
+        let uploadedEvents = requestBuilderSpy.requestParameters
+            .flatMap { $0.events }
+            .map { $0.data.utf8String }
+
+        XCTAssertTrue(uploadedEvents.contains(#"{"event":"first"}"#))
+        XCTAssertTrue(uploadedEvents.contains(#"{"event":"second"}"#))
+    }
+
+    func testDatadogFlush_uploadsEventsAndReturnsSynchronously() throws {
+        // Given
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            initialConsent: .granted,
+            performance: .mockRandom(),
+            httpClient: HTTPClientMock(),
+            encryption: nil,
+            contextProvider: .mockAny(),
+            applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
+            backgroundTasksEnabled: .mockAny()
+        )
+        let requestBuilderSpy = FeatureRequestBuilderSpy()
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = core.scope(for: FeatureMock.self)
+
+        CoreRegistry.register(default: core)
+        defer { Datadog.internalFlushAndDeinitialize() }
+
+        scope.eventWriteContext { _, writer in
+            writer.write(value: FeatureMock.Event(event: "test"))
+        }
+
+        // When
+        Datadog.flush()
+
+        // Then - if flush is synchronous, events are uploaded before this assertion
+        let uploadedEvents = requestBuilderSpy.requestParameters
+            .flatMap { $0.events }
+            .map { $0.data.utf8String }
+
+        XCTAssertEqual(uploadedEvents, [#"{"event":"test"}"#])
     }
 
     func testItClearsAnonymousIdentifier() {


### PR DESCRIPTION
### What and why?

The integration test framework needs to be able to flush all data to quickly test features.

refs: RUM-14895

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
