### PR TITLE
[RUM-15102][Session Replay] Ignore layer changes caused by view tree snapshotting

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
@@ -19,6 +19,7 @@ internal final class CALayerChangeAggregator {
     private let handler: (CALayerChangeSnapshot) -> Void
 
     private var isRunning = false
+    private var isDeliveringChanges = false
     private var pendingChanges: [ObjectIdentifier: CALayerChange] = [:]
     private var lastDeliveryTime: TimeInterval?
     private var scheduledDelivery: (any ScheduledTimer)?
@@ -58,8 +59,8 @@ internal final class CALayerChangeAggregator {
     }
 
     private func record(_ layer: CALayer, aspect: CALayerChange.Aspect.Set) {
-        // Only record on the main thread
-        guard Thread.isMainThread, isRunning else {
+        // Only record on the main thread and ignore changes triggered in the delivery handler
+        guard Thread.isMainThread, isRunning, !isDeliveringChanges else {
             return
         }
 
@@ -116,6 +117,10 @@ internal final class CALayerChangeAggregator {
         lastDeliveryTime = now
 
         if !snapshot.isEmpty {
+            isDeliveringChanges = true
+            defer {
+                isDeliveringChanges = false
+            }
             handler(snapshot)
         }
     }

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
@@ -110,6 +110,43 @@ final class CALayerChangeAggregatorTests: XCTestCase {
         )
     }
 
+    func testIgnoresChangesTriggeredWhileDelivering() {
+        // given
+        let layer = CALayer()
+        let reentrantLayer = CALayer()
+
+        layerChangeAggregator = CALayerChangeAggregator(
+            minimumDeliveryInterval: 0.1,
+            timerScheduler: testTimerScheduler
+        ) { [weak self] snapshot in
+            self?.snapshots.append(snapshot)
+            self?.layerChangeAggregator.layerDidLayoutSublayers(reentrantLayer)
+        }
+
+        // when
+        layerChangeAggregator.start()
+
+        testTimerScheduler.advance(to: 0.02)
+        layerChangeAggregator.layerDidDisplay(layer)
+
+        testTimerScheduler.advance(to: 0.1)
+
+        // then
+        XCTAssertEqual(snapshots.count, 1)
+        XCTAssertEqual(
+            snapshots[0],
+            CALayerChangeSnapshot(
+                [ObjectIdentifier(layer): CALayerChange(layer: layer, aspects: .display)]
+            )
+        )
+
+        // when
+        testTimerScheduler.advance(to: 0.5)
+
+        // then
+        XCTAssertEqual(snapshots.count, 1, "Should ignore changes triggered while delivering")
+    }
+
     func testMergesChangesForMultipleLayersIndependently() {
         // given
         let layerA = CALayer()


### PR DESCRIPTION
### What and why?

Prevents the screen change monitor from delivering changes triggered as a side effect of snapshotting the view tree.

Some view-tree reads performed during Session Replay snapshotting, such as `intrinsicContentSize` or `preferredFrameSize()`, can trigger additional layer updates.

Without this guard, the monitor can observe those snapshotting side effects as fresh screen changes and re-trigger delivery, potentially causing infinite loops like the one described in #2758.

### How?

`CALayerChangeAggregator` now ignores layer changes emitted while it is delivering a snapshot to the handler.

This keeps the existing delivery timing semantics, but prevents the monitor from treating snapshotting side effects as new screen changes.

A regression test was added to verify that layer changes triggered during delivery do not schedule another delivery.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
