### PR TITLE
Fix flaky testWhenTextViewHasText by constraining random font size

### DIFF
--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -39,9 +39,9 @@ class UITextViewRecorderTests: XCTestCase {
         // Given
         let randomText: String = .mockRandom()
         textView.textColor = .mockRandom()
-        textView.font = .systemFont(ofSize: .mockRandom())
-        // RUMM-2681 A valid frame is required to avoid "CALayer position contains NaN: [0 nan]. (...) (CALayerInvalidGeometry)" error.
-        // On iOS 26, TextKit 2 is the default and `layoutManager.allowsNonContiguousLayout` is no longer sufficient.
+        // RUMM-2681 A valid frame and a reasonable font size are required to avoid "CALayer position contains NaN: [0 nan]. (...) (CALayerInvalidGeometry)" error.
+        // On iOS 17+ with TextKit 2, extremely large font sizes overflow the layout engine and produce NaN geometry.
+        textView.font = .systemFont(ofSize: .mockRandom(min: 1, max: 100))
         textView.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
 
         // When


### PR DESCRIPTION
### What and why?

Fix a flaky test in `UITextViewRecorderTests.testWhenTextViewHasText`. Using `CGFloat.mockRandom()` for the font size can produce extremely large values (up to `CGFloat.greatestFiniteMagnitude`), which overflows the layout engine and causes `CALayer position contains NaN` geometry errors.

### How?

Constrain the random font size to a realistic range (1–100pt) using `.mockRandom(min: 1, max: 100)` instead of the unbounded `.mockRandom()`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs