### PR TITLE
[RUM-11993] Add trace context and GraphQL fields to sendErrorEvent

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -298,6 +298,9 @@ public struct RUMActionEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "action"
 
@@ -331,6 +334,7 @@ public struct RUMActionEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -360,6 +364,7 @@ public struct RUMActionEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -384,6 +389,7 @@ public struct RUMActionEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -408,6 +414,7 @@ public struct RUMActionEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -1076,6 +1083,26 @@ public struct RUMActionEvent: RUMDataModel {
         }
     }
 
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// UUID of the view
@@ -1353,6 +1380,9 @@ public struct RUMErrorEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "error"
 
@@ -1389,6 +1419,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -1421,6 +1452,7 @@ public struct RUMErrorEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -1448,6 +1480,7 @@ public struct RUMErrorEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -1475,6 +1508,7 @@ public struct RUMErrorEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -2231,7 +2265,7 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Resource properties of the error
         public struct Resource: Codable {
             /// GraphQL request parameters
-            public var graphql: Graphql?
+            public var graphql: RUMGraphql?
 
             /// HTTP method of the resource
             public let method: RUMMethod
@@ -2262,7 +2296,7 @@ public struct RUMErrorEvent: RUMDataModel {
             ///   - statusCode: HTTP Status code of the resource
             ///   - url: URL of the resource
             public init(
-                graphql: Graphql? = nil,
+                graphql: RUMGraphql? = nil,
                 method: RUMMethod,
                 provider: Provider? = nil,
                 statusCode: Int64,
@@ -2273,177 +2307,6 @@ public struct RUMErrorEvent: RUMDataModel {
                 self.provider = provider
                 self.statusCode = statusCode
                 self.url = url
-            }
-
-            /// GraphQL request parameters
-            public struct Graphql: Codable {
-                /// Number of GraphQL errors in the response
-                public let errorCount: Int64?
-
-                /// Array of GraphQL errors from the response
-                public let errors: [Errors]?
-
-                /// Name of the GraphQL operation
-                public let operationName: String?
-
-                /// Type of the GraphQL operation
-                public let operationType: OperationType?
-
-                /// Content of the GraphQL operation
-                public var payload: String?
-
-                /// String representation of the operation variables
-                public var variables: String?
-
-                public enum CodingKeys: String, CodingKey {
-                    case errorCount = "error_count"
-                    case errors = "errors"
-                    case operationName = "operationName"
-                    case operationType = "operationType"
-                    case payload = "payload"
-                    case variables = "variables"
-                }
-
-                /// GraphQL request parameters
-                ///
-                /// - Parameters:
-                ///   - errorCount: Number of GraphQL errors in the response
-                ///   - errors: Array of GraphQL errors from the response
-                ///   - operationName: Name of the GraphQL operation
-                ///   - operationType: Type of the GraphQL operation
-                ///   - payload: Content of the GraphQL operation
-                ///   - variables: String representation of the operation variables
-                public init(
-                    errorCount: Int64? = nil,
-                    errors: [Errors]? = nil,
-                    operationName: String? = nil,
-                    operationType: OperationType? = nil,
-                    payload: String? = nil,
-                    variables: String? = nil
-                ) {
-                    self.errorCount = errorCount
-                    self.errors = errors
-                    self.operationName = operationName
-                    self.operationType = operationType
-                    self.payload = payload
-                    self.variables = variables
-                }
-
-                /// GraphQL error details
-                public struct Errors: Codable {
-                    /// Error code (used by some providers)
-                    public let code: String?
-
-                    /// Array of error locations in the GraphQL query
-                    public let locations: [Locations]?
-
-                    /// Error message
-                    public let message: String
-
-                    /// Path to the field that caused the error
-                    public let path: [Path]?
-
-                    public enum CodingKeys: String, CodingKey {
-                        case code = "code"
-                        case locations = "locations"
-                        case message = "message"
-                        case path = "path"
-                    }
-
-                    /// GraphQL error details
-                    ///
-                    /// - Parameters:
-                    ///   - code: Error code (used by some providers)
-                    ///   - locations: Array of error locations in the GraphQL query
-                    ///   - message: Error message
-                    ///   - path: Path to the field that caused the error
-                    public init(
-                        code: String? = nil,
-                        locations: [Locations]? = nil,
-                        message: String,
-                        path: [Path]? = nil
-                    ) {
-                        self.code = code
-                        self.locations = locations
-                        self.message = message
-                        self.path = path
-                    }
-
-                    /// Error location
-                    public struct Locations: Codable {
-                        /// Column number where the error occurred
-                        public let column: Int64
-
-                        /// Line number where the error occurred
-                        public let line: Int64
-
-                        public enum CodingKeys: String, CodingKey {
-                            case column = "column"
-                            case line = "line"
-                        }
-
-                        /// Error location
-                        ///
-                        /// - Parameters:
-                        ///   - column: Column number where the error occurred
-                        ///   - line: Line number where the error occurred
-                        public init(
-                            column: Int64,
-                            line: Int64
-                        ) {
-                            self.column = column
-                            self.line = line
-                        }
-                    }
-
-                    public enum Path: Codable {
-                        case string(value: String)
-                        case integer(value: Int64)
-
-                        // MARK: - Codable
-
-                        public func encode(to encoder: Encoder) throws {
-                            // Encode only the associated value, without encoding enum case
-                            var container = encoder.singleValueContainer()
-
-                            switch self {
-                            case .string(let value):
-                                try container.encode(value)
-                            case .integer(let value):
-                                try container.encode(value)
-                            }
-                        }
-
-                        public init(from decoder: Decoder) throws {
-                            // Decode enum case from associated value
-                            let container = try decoder.singleValueContainer()
-
-                            if let value = try? container.decode(String.self) {
-                                self = .string(value: value)
-                                return
-                            }
-                            if let value = try? container.decode(Int64.self) {
-                                self = .integer(value: value)
-                                return
-                            }
-                            let error = DecodingError.Context(
-                                codingPath: container.codingPath,
-                                debugDescription: """
-                                Failed to decode `Path`.
-                                Ran out of possibilities when trying to decode the value of associated type.
-                                """
-                            )
-                            throw DecodingError.typeMismatch(Path.self, error)
-                        }
-                    }
-                }
-
-                /// Type of the GraphQL operation
-                public enum OperationType: String, Codable {
-                    case query = "query"
-                    case mutation = "mutation"
-                    case subscription = "subscription"
-                }
             }
 
             /// The provider for this resource
@@ -2672,6 +2535,26 @@ public struct RUMErrorEvent: RUMDataModel {
         }
     }
 
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// UUID of the view
@@ -2776,6 +2659,177 @@ extension RUMEventAttributes {
     }
 }
 
+/// GraphQL request parameters
+public struct RUMGraphql: Codable {
+    /// Number of GraphQL errors in the response
+    public let errorCount: Int64?
+
+    /// Array of GraphQL errors from the response
+    public let errors: [Errors]?
+
+    /// Name of the GraphQL operation
+    public let operationName: String?
+
+    /// Type of the GraphQL operation
+    public let operationType: OperationType?
+
+    /// Content of the GraphQL operation
+    public var payload: String?
+
+    /// String representation of the operation variables
+    public var variables: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case errorCount = "error_count"
+        case errors = "errors"
+        case operationName = "operationName"
+        case operationType = "operationType"
+        case payload = "payload"
+        case variables = "variables"
+    }
+
+    /// GraphQL request parameters
+    ///
+    /// - Parameters:
+    ///   - errorCount: Number of GraphQL errors in the response
+    ///   - errors: Array of GraphQL errors from the response
+    ///   - operationName: Name of the GraphQL operation
+    ///   - operationType: Type of the GraphQL operation
+    ///   - payload: Content of the GraphQL operation
+    ///   - variables: String representation of the operation variables
+    public init(
+        errorCount: Int64? = nil,
+        errors: [Errors]? = nil,
+        operationName: String? = nil,
+        operationType: OperationType? = nil,
+        payload: String? = nil,
+        variables: String? = nil
+    ) {
+        self.errorCount = errorCount
+        self.errors = errors
+        self.operationName = operationName
+        self.operationType = operationType
+        self.payload = payload
+        self.variables = variables
+    }
+
+    /// GraphQL error details
+    public struct Errors: Codable {
+        /// Error code (used by some providers)
+        public let code: String?
+
+        /// Array of error locations in the GraphQL query
+        public let locations: [Locations]?
+
+        /// Error message
+        public let message: String
+
+        /// Path to the field that caused the error
+        public let path: [Path]?
+
+        public enum CodingKeys: String, CodingKey {
+            case code = "code"
+            case locations = "locations"
+            case message = "message"
+            case path = "path"
+        }
+
+        /// GraphQL error details
+        ///
+        /// - Parameters:
+        ///   - code: Error code (used by some providers)
+        ///   - locations: Array of error locations in the GraphQL query
+        ///   - message: Error message
+        ///   - path: Path to the field that caused the error
+        public init(
+            code: String? = nil,
+            locations: [Locations]? = nil,
+            message: String,
+            path: [Path]? = nil
+        ) {
+            self.code = code
+            self.locations = locations
+            self.message = message
+            self.path = path
+        }
+
+        /// Error location
+        public struct Locations: Codable {
+            /// Column number where the error occurred
+            public let column: Int64
+
+            /// Line number where the error occurred
+            public let line: Int64
+
+            public enum CodingKeys: String, CodingKey {
+                case column = "column"
+                case line = "line"
+            }
+
+            /// Error location
+            ///
+            /// - Parameters:
+            ///   - column: Column number where the error occurred
+            ///   - line: Line number where the error occurred
+            public init(
+                column: Int64,
+                line: Int64
+            ) {
+                self.column = column
+                self.line = line
+            }
+        }
+
+        public enum Path: Codable {
+            case string(value: String)
+            case integer(value: Int64)
+
+            // MARK: - Codable
+
+            public func encode(to encoder: Encoder) throws {
+                // Encode only the associated value, without encoding enum case
+                var container = encoder.singleValueContainer()
+
+                switch self {
+                case .string(let value):
+                    try container.encode(value)
+                case .integer(let value):
+                    try container.encode(value)
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                // Decode enum case from associated value
+                let container = try decoder.singleValueContainer()
+
+                if let value = try? container.decode(String.self) {
+                    self = .string(value: value)
+                    return
+                }
+                if let value = try? container.decode(Int64.self) {
+                    self = .integer(value: value)
+                    return
+                }
+                let error = DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: """
+                    Failed to decode `Path`.
+                    Ran out of possibilities when trying to decode the value of associated type.
+                    """
+                )
+                throw DecodingError.typeMismatch(Path.self, error)
+            }
+        }
+    }
+
+    /// Type of the GraphQL operation
+    public enum OperationType: String, Codable {
+        case query = "query"
+        case mutation = "mutation"
+        case subscription = "subscription"
+    }
+}
+
 /// Schema of all properties of a Long Task event
 public struct RUMLongTaskEvent: RUMDataModel {
     /// Internal properties
@@ -2841,6 +2895,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "long_task"
 
@@ -2875,6 +2932,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -2905,6 +2963,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -2930,6 +2989,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -2955,6 +3015,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -3585,6 +3646,26 @@ public struct RUMLongTaskEvent: RUMDataModel {
         }
     }
 
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// UUID of the view
@@ -3705,6 +3786,9 @@ public struct RUMResourceEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "resource"
 
@@ -3739,6 +3823,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -3769,6 +3854,7 @@ public struct RUMResourceEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -3794,6 +3880,7 @@ public struct RUMResourceEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -3819,6 +3906,7 @@ public struct RUMResourceEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -4160,7 +4248,7 @@ public struct RUMResourceEvent: RUMDataModel {
         public let firstByte: FirstByte?
 
         /// GraphQL request parameters
-        public var graphql: Graphql?
+        public var graphql: RUMGraphql?
 
         /// UUID of the resource
         public let id: String?
@@ -4270,7 +4358,7 @@ public struct RUMResourceEvent: RUMDataModel {
             duration: Int64? = nil,
             encodedBodySize: Int64? = nil,
             firstByte: FirstByte? = nil,
-            graphql: Graphql? = nil,
+            graphql: RUMGraphql? = nil,
             id: String? = nil,
             method: RUMMethod? = nil,
             `protocol`: String? = nil,
@@ -4425,177 +4513,6 @@ public struct RUMResourceEvent: RUMDataModel {
             ) {
                 self.duration = duration
                 self.start = start
-            }
-        }
-
-        /// GraphQL request parameters
-        public struct Graphql: Codable {
-            /// Number of GraphQL errors in the response
-            public let errorCount: Int64?
-
-            /// Array of GraphQL errors from the response
-            public let errors: [Errors]?
-
-            /// Name of the GraphQL operation
-            public let operationName: String?
-
-            /// Type of the GraphQL operation
-            public let operationType: OperationType?
-
-            /// Content of the GraphQL operation
-            public var payload: String?
-
-            /// String representation of the operation variables
-            public var variables: String?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorCount = "error_count"
-                case errors = "errors"
-                case operationName = "operationName"
-                case operationType = "operationType"
-                case payload = "payload"
-                case variables = "variables"
-            }
-
-            /// GraphQL request parameters
-            ///
-            /// - Parameters:
-            ///   - errorCount: Number of GraphQL errors in the response
-            ///   - errors: Array of GraphQL errors from the response
-            ///   - operationName: Name of the GraphQL operation
-            ///   - operationType: Type of the GraphQL operation
-            ///   - payload: Content of the GraphQL operation
-            ///   - variables: String representation of the operation variables
-            public init(
-                errorCount: Int64? = nil,
-                errors: [Errors]? = nil,
-                operationName: String? = nil,
-                operationType: OperationType? = nil,
-                payload: String? = nil,
-                variables: String? = nil
-            ) {
-                self.errorCount = errorCount
-                self.errors = errors
-                self.operationName = operationName
-                self.operationType = operationType
-                self.payload = payload
-                self.variables = variables
-            }
-
-            /// GraphQL error details
-            public struct Errors: Codable {
-                /// Error code (used by some providers)
-                public let code: String?
-
-                /// Array of error locations in the GraphQL query
-                public let locations: [Locations]?
-
-                /// Error message
-                public let message: String
-
-                /// Path to the field that caused the error
-                public let path: [Path]?
-
-                public enum CodingKeys: String, CodingKey {
-                    case code = "code"
-                    case locations = "locations"
-                    case message = "message"
-                    case path = "path"
-                }
-
-                /// GraphQL error details
-                ///
-                /// - Parameters:
-                ///   - code: Error code (used by some providers)
-                ///   - locations: Array of error locations in the GraphQL query
-                ///   - message: Error message
-                ///   - path: Path to the field that caused the error
-                public init(
-                    code: String? = nil,
-                    locations: [Locations]? = nil,
-                    message: String,
-                    path: [Path]? = nil
-                ) {
-                    self.code = code
-                    self.locations = locations
-                    self.message = message
-                    self.path = path
-                }
-
-                /// Error location
-                public struct Locations: Codable {
-                    /// Column number where the error occurred
-                    public let column: Int64
-
-                    /// Line number where the error occurred
-                    public let line: Int64
-
-                    public enum CodingKeys: String, CodingKey {
-                        case column = "column"
-                        case line = "line"
-                    }
-
-                    /// Error location
-                    ///
-                    /// - Parameters:
-                    ///   - column: Column number where the error occurred
-                    ///   - line: Line number where the error occurred
-                    public init(
-                        column: Int64,
-                        line: Int64
-                    ) {
-                        self.column = column
-                        self.line = line
-                    }
-                }
-
-                public enum Path: Codable {
-                    case string(value: String)
-                    case integer(value: Int64)
-
-                    // MARK: - Codable
-
-                    public func encode(to encoder: Encoder) throws {
-                        // Encode only the associated value, without encoding enum case
-                        var container = encoder.singleValueContainer()
-
-                        switch self {
-                        case .string(let value):
-                            try container.encode(value)
-                        case .integer(let value):
-                            try container.encode(value)
-                        }
-                    }
-
-                    public init(from decoder: Decoder) throws {
-                        // Decode enum case from associated value
-                        let container = try decoder.singleValueContainer()
-
-                        if let value = try? container.decode(String.self) {
-                            self = .string(value: value)
-                            return
-                        }
-                        if let value = try? container.decode(Int64.self) {
-                            self = .integer(value: value)
-                            return
-                        }
-                        let error = DecodingError.Context(
-                            codingPath: container.codingPath,
-                            debugDescription: """
-                            Failed to decode `Path`.
-                            Ran out of possibilities when trying to decode the value of associated type.
-                            """
-                        )
-                        throw DecodingError.typeMismatch(Path.self, error)
-                    }
-                }
-            }
-
-            /// Type of the GraphQL operation
-            public enum OperationType: String, Codable {
-                case query = "query"
-                case mutation = "mutation"
-                case subscription = "subscription"
             }
         }
 
@@ -4899,6 +4816,26 @@ public struct RUMResourceEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
         public init(
             id: String
         ) {
@@ -5313,6 +5250,9 @@ public struct RUMViewEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "view"
 
@@ -5347,6 +5287,7 @@ public struct RUMViewEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -5377,6 +5318,7 @@ public struct RUMViewEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -5402,6 +5344,7 @@ public struct RUMViewEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -5427,6 +5370,7 @@ public struct RUMViewEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -6125,6 +6069,26 @@ public struct RUMViewEvent: RUMDataModel {
             self.resolution = resolution
             self.timestamp = timestamp
             self.watchTime = watchTime
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
         }
     }
 
@@ -6844,7 +6808,7 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the frustrations of the view
         public struct Frustration: Codable {
             /// Number of frustrations that occurred on the view
-            public let count: Int64?
+            public let count: Int64
 
             public enum CodingKeys: String, CodingKey {
                 case count = "count"
@@ -6855,7 +6819,7 @@ public struct RUMViewEvent: RUMDataModel {
             /// - Parameters:
             ///   - count: Number of frustrations that occurred on the view
             public init(
-                count: Int64? = nil
+                count: Int64
             ) {
                 self.count = count
             }
@@ -7268,12 +7232,12 @@ public struct RUMViewEvent: RUMDataModel {
                     public let presentationDelay: Int64
 
                     /// Event handler execution time
-                    public let processingTime: Int64
+                    public let processingDuration: Int64
 
                     public enum CodingKeys: String, CodingKey {
                         case inputDelay = "input_delay"
                         case presentationDelay = "presentation_delay"
-                        case processingTime = "processing_time"
+                        case processingDuration = "processing_duration"
                     }
 
                     /// Sub-parts of the INP
@@ -7281,15 +7245,15 @@ public struct RUMViewEvent: RUMDataModel {
                     /// - Parameters:
                     ///   - inputDelay: Time from the start of the input event to the start of the processing of the event
                     ///   - presentationDelay: Rendering time happening after processing
-                    ///   - processingTime: Event handler execution time
+                    ///   - processingDuration: Event handler execution time
                     public init(
                         inputDelay: Int64,
                         presentationDelay: Int64,
-                        processingTime: Int64
+                        processingDuration: Int64
                     ) {
                         self.inputDelay = inputDelay
                         self.presentationDelay = presentationDelay
-                        self.processingTime = processingTime
+                        self.processingDuration = processingDuration
                     }
                 }
             }
@@ -7524,6 +7488,9 @@ public struct RUMViewUpdateEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "view_update"
 
@@ -7558,6 +7525,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -7588,6 +7556,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -7613,6 +7582,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View
@@ -7638,6 +7608,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -8129,6 +8100,26 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             self.resolution = resolution
             self.timestamp = timestamp
             self.watchTime = watchTime
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
         }
     }
 
@@ -8848,7 +8839,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Properties of the frustrations of the view
         public struct Frustration: Codable {
             /// Number of frustrations that occurred on the view
-            public let count: Int64?
+            public let count: Int64
 
             public enum CodingKeys: String, CodingKey {
                 case count = "count"
@@ -8859,7 +8850,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// - Parameters:
             ///   - count: Number of frustrations that occurred on the view
             public init(
-                count: Int64? = nil
+                count: Int64
             ) {
                 self.count = count
             }
@@ -9272,12 +9263,12 @@ public struct RUMViewUpdateEvent: RUMDataModel {
                     public let presentationDelay: Int64
 
                     /// Event handler execution time
-                    public let processingTime: Int64
+                    public let processingDuration: Int64
 
                     public enum CodingKeys: String, CodingKey {
                         case inputDelay = "input_delay"
                         case presentationDelay = "presentation_delay"
-                        case processingTime = "processing_time"
+                        case processingDuration = "processing_duration"
                     }
 
                     /// Sub-parts of the INP
@@ -9285,15 +9276,15 @@ public struct RUMViewUpdateEvent: RUMDataModel {
                     /// - Parameters:
                     ///   - inputDelay: Time from the start of the input event to the start of the processing of the event
                     ///   - presentationDelay: Rendering time happening after processing
-                    ///   - processingTime: Event handler execution time
+                    ///   - processingDuration: Event handler execution time
                     public init(
                         inputDelay: Int64,
                         presentationDelay: Int64,
-                        processingTime: Int64
+                        processingDuration: Int64
                     ) {
                         self.inputDelay = inputDelay
                         self.presentationDelay = presentationDelay
-                        self.processingTime = processingTime
+                        self.processingDuration = processingDuration
                     }
                 }
             }
@@ -9522,6 +9513,9 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "vital"
 
@@ -9557,6 +9551,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -9586,6 +9581,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -9610,6 +9606,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View,
@@ -9634,6 +9631,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -10044,6 +10042,26 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
         public init(
             id: String
         ) {
@@ -10237,6 +10255,9 @@ public struct RUMVitalDurationEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "vital"
 
@@ -10272,6 +10293,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -10301,6 +10323,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -10325,6 +10348,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View,
@@ -10349,6 +10373,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -10759,6 +10784,26 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
         public init(
             id: String
         ) {
@@ -10912,6 +10957,9 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
     /// Synthetics properties
     public var synthetics: RUMSyntheticsTest?
 
+    /// Tab properties
+    public let tab: TAB?
+
     /// RUM event type
     public let type: String = "vital"
 
@@ -10947,6 +10995,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case source = "source"
         case stream = "stream"
         case synthetics = "synthetics"
+        case tab = "tab"
         case type = "type"
         case usr = "usr"
         case version = "version"
@@ -10976,6 +11025,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
     ///   - source: The source of this event
     ///   - stream: Stream properties
     ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
     ///   - usr: User properties
     ///   - version: The version for this application
     ///   - view: View properties
@@ -11000,6 +11050,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         source: Source? = nil,
         stream: Stream? = nil,
         synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
         usr: RUMUser? = nil,
         version: String? = nil,
         view: View,
@@ -11024,6 +11075,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         self.source = source
         self.stream = stream
         self.synthetics = synthetics
+        self.tab = tab
         self.usr = usr
         self.version = version
         self.view = view
@@ -11434,6 +11486,26 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
         public init(
             id: String
         ) {
@@ -14302,4 +14374,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/0d9435f867237b1cd993324902fe88ec235b9707
+// Generated from https://github.com/DataDog/rum-events-format/tree/ea41a41f19117b04ed9a06977fdeb8f7a90319e3

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -1491,8 +1491,14 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// parent span identifier in decimal format
+        public let parentSpanId: String?
+
         /// Profiling context
         public let profiling: Profiling?
+
+        /// trace sample rate in decimal format
+        public let rulePsr: Double?
 
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
@@ -1500,13 +1506,23 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Session-related internal properties
         public let session: Session?
 
+        /// span identifier in decimal format
+        public let spanId: String?
+
+        /// trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
+        public let traceId: String?
+
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
             case configuration = "configuration"
             case formatVersion = "format_version"
+            case parentSpanId = "parent_span_id"
             case profiling = "profiling"
+            case rulePsr = "rule_psr"
             case sdkName = "sdk_name"
             case session = "session"
+            case spanId = "span_id"
+            case traceId = "trace_id"
         }
 
         /// Internal properties
@@ -1514,21 +1530,33 @@ public struct RUMErrorEvent: RUMDataModel {
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
         ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - parentSpanId: parent span identifier in decimal format
         ///   - profiling: Profiling context
+        ///   - rulePsr: trace sample rate in decimal format
         ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         ///   - session: Session-related internal properties
+        ///   - spanId: span identifier in decimal format
+        ///   - traceId: trace identifier, either a 64 bit decimal number or a 128 bit hexadecimal number padded with 0s
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
+            parentSpanId: String? = nil,
             profiling: Profiling? = nil,
+            rulePsr: Double? = nil,
             sdkName: String? = nil,
-            session: Session? = nil
+            session: Session? = nil,
+            spanId: String? = nil,
+            traceId: String? = nil
         ) {
             self.browserSdkVersion = browserSdkVersion
             self.configuration = configuration
+            self.parentSpanId = parentSpanId
             self.profiling = profiling
+            self.rulePsr = rulePsr
             self.sdkName = sdkName
             self.session = session
+            self.spanId = spanId
+            self.traceId = traceId
         }
 
         /// Subset of the SDK configuration options in use during its execution
@@ -2202,6 +2230,9 @@ public struct RUMErrorEvent: RUMDataModel {
 
         /// Resource properties of the error
         public struct Resource: Codable {
+            /// GraphQL request parameters
+            public var graphql: Graphql?
+
             /// HTTP method of the resource
             public let method: RUMMethod
 
@@ -2215,6 +2246,7 @@ public struct RUMErrorEvent: RUMDataModel {
             public var url: String
 
             public enum CodingKeys: String, CodingKey {
+                case graphql = "graphql"
                 case method = "method"
                 case provider = "provider"
                 case statusCode = "status_code"
@@ -2224,20 +2256,194 @@ public struct RUMErrorEvent: RUMDataModel {
             /// Resource properties of the error
             ///
             /// - Parameters:
+            ///   - graphql: GraphQL request parameters
             ///   - method: HTTP method of the resource
             ///   - provider: The provider for this resource
             ///   - statusCode: HTTP Status code of the resource
             ///   - url: URL of the resource
             public init(
+                graphql: Graphql? = nil,
                 method: RUMMethod,
                 provider: Provider? = nil,
                 statusCode: Int64,
                 url: String
             ) {
+                self.graphql = graphql
                 self.method = method
                 self.provider = provider
                 self.statusCode = statusCode
                 self.url = url
+            }
+
+            /// GraphQL request parameters
+            public struct Graphql: Codable {
+                /// Number of GraphQL errors in the response
+                public let errorCount: Int64?
+
+                /// Array of GraphQL errors from the response
+                public let errors: [Errors]?
+
+                /// Name of the GraphQL operation
+                public let operationName: String?
+
+                /// Type of the GraphQL operation
+                public let operationType: OperationType?
+
+                /// Content of the GraphQL operation
+                public var payload: String?
+
+                /// String representation of the operation variables
+                public var variables: String?
+
+                public enum CodingKeys: String, CodingKey {
+                    case errorCount = "error_count"
+                    case errors = "errors"
+                    case operationName = "operationName"
+                    case operationType = "operationType"
+                    case payload = "payload"
+                    case variables = "variables"
+                }
+
+                /// GraphQL request parameters
+                ///
+                /// - Parameters:
+                ///   - errorCount: Number of GraphQL errors in the response
+                ///   - errors: Array of GraphQL errors from the response
+                ///   - operationName: Name of the GraphQL operation
+                ///   - operationType: Type of the GraphQL operation
+                ///   - payload: Content of the GraphQL operation
+                ///   - variables: String representation of the operation variables
+                public init(
+                    errorCount: Int64? = nil,
+                    errors: [Errors]? = nil,
+                    operationName: String? = nil,
+                    operationType: OperationType? = nil,
+                    payload: String? = nil,
+                    variables: String? = nil
+                ) {
+                    self.errorCount = errorCount
+                    self.errors = errors
+                    self.operationName = operationName
+                    self.operationType = operationType
+                    self.payload = payload
+                    self.variables = variables
+                }
+
+                /// GraphQL error details
+                public struct Errors: Codable {
+                    /// Error code (used by some providers)
+                    public let code: String?
+
+                    /// Array of error locations in the GraphQL query
+                    public let locations: [Locations]?
+
+                    /// Error message
+                    public let message: String
+
+                    /// Path to the field that caused the error
+                    public let path: [Path]?
+
+                    public enum CodingKeys: String, CodingKey {
+                        case code = "code"
+                        case locations = "locations"
+                        case message = "message"
+                        case path = "path"
+                    }
+
+                    /// GraphQL error details
+                    ///
+                    /// - Parameters:
+                    ///   - code: Error code (used by some providers)
+                    ///   - locations: Array of error locations in the GraphQL query
+                    ///   - message: Error message
+                    ///   - path: Path to the field that caused the error
+                    public init(
+                        code: String? = nil,
+                        locations: [Locations]? = nil,
+                        message: String,
+                        path: [Path]? = nil
+                    ) {
+                        self.code = code
+                        self.locations = locations
+                        self.message = message
+                        self.path = path
+                    }
+
+                    /// Error location
+                    public struct Locations: Codable {
+                        /// Column number where the error occurred
+                        public let column: Int64
+
+                        /// Line number where the error occurred
+                        public let line: Int64
+
+                        public enum CodingKeys: String, CodingKey {
+                            case column = "column"
+                            case line = "line"
+                        }
+
+                        /// Error location
+                        ///
+                        /// - Parameters:
+                        ///   - column: Column number where the error occurred
+                        ///   - line: Line number where the error occurred
+                        public init(
+                            column: Int64,
+                            line: Int64
+                        ) {
+                            self.column = column
+                            self.line = line
+                        }
+                    }
+
+                    public enum Path: Codable {
+                        case string(value: String)
+                        case integer(value: Int64)
+
+                        // MARK: - Codable
+
+                        public func encode(to encoder: Encoder) throws {
+                            // Encode only the associated value, without encoding enum case
+                            var container = encoder.singleValueContainer()
+
+                            switch self {
+                            case .string(let value):
+                                try container.encode(value)
+                            case .integer(let value):
+                                try container.encode(value)
+                            }
+                        }
+
+                        public init(from decoder: Decoder) throws {
+                            // Decode enum case from associated value
+                            let container = try decoder.singleValueContainer()
+
+                            if let value = try? container.decode(String.self) {
+                                self = .string(value: value)
+                                return
+                            }
+                            if let value = try? container.decode(Int64.self) {
+                                self = .integer(value: value)
+                                return
+                            }
+                            let error = DecodingError.Context(
+                                codingPath: container.codingPath,
+                                debugDescription: """
+                                Failed to decode `Path`.
+                                Ran out of possibilities when trying to decode the value of associated type.
+                                """
+                            )
+                            throw DecodingError.typeMismatch(Path.self, error)
+                        }
+                    }
+                }
+
+                /// Type of the GraphQL operation
+                public enum OperationType: String, Codable {
+                    case query = "query"
+                    case mutation = "mutation"
+                    case subscription = "subscription"
+                }
             }
 
             /// The provider for this resource
@@ -3953,7 +4159,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// First Byte phase properties
         public let firstByte: FirstByte?
 
-        /// GraphQL requests parameters
+        /// GraphQL request parameters
         public var graphql: Graphql?
 
         /// UUID of the resource
@@ -4039,7 +4245,7 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - duration: Duration of the resource
         ///   - encodedBodySize: Size in octet of the response body before removing any applied content encodings
         ///   - firstByte: First Byte phase properties
-        ///   - graphql: GraphQL requests parameters
+        ///   - graphql: GraphQL request parameters
         ///   - id: UUID of the resource
         ///   - method: HTTP method of the resource
         ///   - `protocol`: Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')
@@ -4222,7 +4428,7 @@ public struct RUMResourceEvent: RUMDataModel {
             }
         }
 
-        /// GraphQL requests parameters
+        /// GraphQL request parameters
         public struct Graphql: Codable {
             /// Number of GraphQL errors in the response
             public let errorCount: Int64?
@@ -4251,7 +4457,7 @@ public struct RUMResourceEvent: RUMDataModel {
                 case variables = "variables"
             }
 
-            /// GraphQL requests parameters
+            /// GraphQL request parameters
             ///
             /// - Parameters:
             ///   - errorCount: Number of GraphQL errors in the response
@@ -6638,7 +6844,7 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the frustrations of the view
         public struct Frustration: Codable {
             /// Number of frustrations that occurred on the view
-            public let count: Int64
+            public let count: Int64?
 
             public enum CodingKeys: String, CodingKey {
                 case count = "count"
@@ -6649,7 +6855,7 @@ public struct RUMViewEvent: RUMDataModel {
             /// - Parameters:
             ///   - count: Number of frustrations that occurred on the view
             public init(
-                count: Int64
+                count: Int64? = nil
             ) {
                 self.count = count
             }
@@ -8642,7 +8848,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Properties of the frustrations of the view
         public struct Frustration: Codable {
             /// Number of frustrations that occurred on the view
-            public let count: Int64
+            public let count: Int64?
 
             public enum CodingKeys: String, CodingKey {
                 case count = "count"
@@ -8653,7 +8859,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// - Parameters:
             ///   - count: Number of frustrations that occurred on the view
             public init(
-                count: Int64
+                count: Int64? = nil
             ) {
                 self.count = count
             }
@@ -14096,4 +14302,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/dc859a26e0d0546e45fac5fa9fd55444359093c1
+// Generated from https://github.com/DataDog/rum-events-format/tree/0d9435f867237b1cd993324902fe88ec235b9707

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -1388,8 +1388,16 @@ public class objc_RUMErrorEventDD: NSObject {
         root.swiftModel.dd.formatVersion as NSNumber
     }
 
+    public var parentSpanId: String? {
+        root.swiftModel.dd.parentSpanId
+    }
+
     public var profiling: objc_RUMErrorEventDDProfiling? {
         root.swiftModel.dd.profiling != nil ? objc_RUMErrorEventDDProfiling(root: root) : nil
+    }
+
+    public var rulePsr: NSNumber? {
+        root.swiftModel.dd.rulePsr as NSNumber?
     }
 
     public var sdkName: String? {
@@ -1398,6 +1406,14 @@ public class objc_RUMErrorEventDD: NSObject {
 
     public var session: objc_RUMErrorEventDDSession? {
         root.swiftModel.dd.session != nil ? objc_RUMErrorEventDDSession(root: root) : nil
+    }
+
+    public var spanId: String? {
+        root.swiftModel.dd.spanId
+    }
+
+    public var traceId: String? {
+        root.swiftModel.dd.traceId
     }
 }
 
@@ -2412,6 +2428,10 @@ public class objc_RUMErrorEventErrorResource: NSObject {
         self.root = root
     }
 
+    public var graphql: objc_RUMErrorEventErrorResourceGraphql? {
+        root.swiftModel.error.resource!.graphql != nil ? objc_RUMErrorEventErrorResourceGraphql(root: root) : nil
+    }
+
     public var method: objc_RUMErrorEventErrorResourceRUMMethod {
         .init(swift: root.swiftModel.error.resource!.method)
     }
@@ -2428,6 +2448,144 @@ public class objc_RUMErrorEventErrorResource: NSObject {
         set { root.swiftModel.error.resource!.url = newValue }
         get { root.swiftModel.error.resource!.url }
     }
+}
+
+@objc(DDRUMErrorEventErrorResourceGraphql)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventErrorResourceGraphql: NSObject {
+    internal let root: objc_RUMErrorEvent
+
+    internal init(root: objc_RUMErrorEvent) {
+        self.root = root
+    }
+
+    public var errorCount: NSNumber? {
+        root.swiftModel.error.resource!.graphql!.errorCount as NSNumber?
+    }
+
+    public var errors: [objc_RUMErrorEventErrorResourceGraphqlErrors]? {
+        root.swiftModel.error.resource!.graphql!.errors?.map { objc_RUMErrorEventErrorResourceGraphqlErrors(swiftModel: $0) }
+    }
+
+    public var operationName: String? {
+        root.swiftModel.error.resource!.graphql!.operationName
+    }
+
+    public var operationType: objc_RUMErrorEventErrorResourceGraphqlOperationType {
+        .init(swift: root.swiftModel.error.resource!.graphql!.operationType)
+    }
+
+    public var payload: String? {
+        set { root.swiftModel.error.resource!.graphql!.payload = newValue }
+        get { root.swiftModel.error.resource!.graphql!.payload }
+    }
+
+    public var variables: String? {
+        set { root.swiftModel.error.resource!.graphql!.variables = newValue }
+        get { root.swiftModel.error.resource!.graphql!.variables }
+    }
+}
+
+@objc(DDRUMErrorEventErrorResourceGraphqlErrors)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventErrorResourceGraphqlErrors: NSObject {
+    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors
+    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrors { self }
+
+    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors) {
+        self.swiftModel = swiftModel
+    }
+
+    public var code: String? {
+        root.swiftModel.code
+    }
+
+    public var locations: [objc_RUMErrorEventErrorResourceGraphqlErrorsLocations]? {
+        root.swiftModel.locations?.map { objc_RUMErrorEventErrorResourceGraphqlErrorsLocations(swiftModel: $0) }
+    }
+
+    public var message: String {
+        root.swiftModel.message
+    }
+
+    public var path: [objc_RUMErrorEventErrorResourceGraphqlErrorsPath]? {
+        root.swiftModel.path?.map { objc_RUMErrorEventErrorResourceGraphqlErrorsPath(swiftModel: $0) }
+    }
+}
+
+@objc(DDRUMErrorEventErrorResourceGraphqlErrorsLocations)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventErrorResourceGraphqlErrorsLocations: NSObject {
+    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Locations
+    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrorsLocations { self }
+
+    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Locations) {
+        self.swiftModel = swiftModel
+    }
+
+    public var column: NSNumber {
+        root.swiftModel.column as NSNumber
+    }
+
+    public var line: NSNumber {
+        root.swiftModel.line as NSNumber
+    }
+}
+
+@objc(DDRUMErrorEventErrorResourceGraphqlErrorsPath)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventErrorResourceGraphqlErrorsPath: NSObject {
+    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Path
+    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrorsPath { self }
+
+    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Path) {
+        self.swiftModel = swiftModel
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel else {
+            return nil
+        }
+        return value
+    }
+
+    public var integer: NSNumber? {
+        guard case .integer(let value) = root.swiftModel else {
+            return nil
+        }
+        return value as NSNumber
+    }
+}
+
+@objc(DDRUMErrorEventErrorResourceGraphqlOperationType)
+@_spi(objc)
+public enum objc_RUMErrorEventErrorResourceGraphqlOperationType: Int {
+    internal init(swift: RUMErrorEvent.Error.Resource.Graphql.OperationType?) {
+        switch swift {
+        case nil: self = .none
+        case .query?: self = .query
+        case .mutation?: self = .mutation
+        case .subscription?: self = .subscription
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.Error.Resource.Graphql.OperationType? {
+        switch self {
+        case .none: return nil
+        case .query: return .query
+        case .mutation: return .mutation
+        case .subscription: return .subscription
+        }
+    }
+
+    case none
+    case query
+    case mutation
+    case subscription
 }
 
 @objc(DDRUMErrorEventErrorResourceRUMMethod)
@@ -7463,8 +7621,8 @@ public class objc_RUMViewEventViewFrustration: NSObject {
         self.root = root
     }
 
-    public var count: NSNumber {
-        root.swiftModel.view.frustration!.count as NSNumber
+    public var count: NSNumber? {
+        root.swiftModel.view.frustration!.count as NSNumber?
     }
 }
 
@@ -9355,8 +9513,8 @@ public class objc_RUMViewUpdateEventViewFrustration: NSObject {
         self.root = root
     }
 
-    public var count: NSNumber {
-        root.swiftModel.view.frustration!.count as NSNumber
+    public var count: NSNumber? {
+        root.swiftModel.view.frustration!.count as NSNumber?
     }
 }
 
@@ -14499,4 +14657,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/dc859a26e0d0546e45fac5fa9fd55444359093c1
+// Generated from https://github.com/DataDog/rum-events-format/tree/0d9435f867237b1cd993324902fe88ec235b9707

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -102,6 +102,10 @@ public class objc_RUMActionEvent: NSObject {
         root.swiftModel.synthetics != nil ? objc_RUMActionEventRUMSyntheticsTest(root: root) : nil
     }
 
+    public var tab: objc_RUMActionEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMActionEventTAB(root: root) : nil
+    }
+
     public var type: String {
         root.swiftModel.type
     }
@@ -1180,6 +1184,21 @@ public class objc_RUMActionEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMActionEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMActionEventTAB: NSObject {
+    internal let root: objc_RUMActionEvent
+
+    internal init(root: objc_RUMActionEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMActionEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -1347,6 +1366,10 @@ public class objc_RUMErrorEvent: NSObject {
 
     public var synthetics: objc_RUMErrorEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMErrorEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMErrorEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMErrorEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -2428,8 +2451,8 @@ public class objc_RUMErrorEventErrorResource: NSObject {
         self.root = root
     }
 
-    public var graphql: objc_RUMErrorEventErrorResourceGraphql? {
-        root.swiftModel.error.resource!.graphql != nil ? objc_RUMErrorEventErrorResourceGraphql(root: root) : nil
+    public var graphql: objc_RUMErrorEventErrorResourceRUMGraphql? {
+        root.swiftModel.error.resource!.graphql != nil ? objc_RUMErrorEventErrorResourceRUMGraphql(root: root) : nil
     }
 
     public var method: objc_RUMErrorEventErrorResourceRUMMethod {
@@ -2450,10 +2473,10 @@ public class objc_RUMErrorEventErrorResource: NSObject {
     }
 }
 
-@objc(DDRUMErrorEventErrorResourceGraphql)
+@objc(DDRUMErrorEventErrorResourceRUMGraphql)
 @objcMembers
 @_spi(objc)
-public class objc_RUMErrorEventErrorResourceGraphql: NSObject {
+public class objc_RUMErrorEventErrorResourceRUMGraphql: NSObject {
     internal let root: objc_RUMErrorEvent
 
     internal init(root: objc_RUMErrorEvent) {
@@ -2464,15 +2487,15 @@ public class objc_RUMErrorEventErrorResourceGraphql: NSObject {
         root.swiftModel.error.resource!.graphql!.errorCount as NSNumber?
     }
 
-    public var errors: [objc_RUMErrorEventErrorResourceGraphqlErrors]? {
-        root.swiftModel.error.resource!.graphql!.errors?.map { objc_RUMErrorEventErrorResourceGraphqlErrors(swiftModel: $0) }
+    public var errors: [objc_RUMErrorEventErrorResourceRUMGraphqlErrors]? {
+        root.swiftModel.error.resource!.graphql!.errors?.map { objc_RUMErrorEventErrorResourceRUMGraphqlErrors(swiftModel: $0) }
     }
 
     public var operationName: String? {
         root.swiftModel.error.resource!.graphql!.operationName
     }
 
-    public var operationType: objc_RUMErrorEventErrorResourceGraphqlOperationType {
+    public var operationType: objc_RUMErrorEventErrorResourceRUMGraphqlOperationType {
         .init(swift: root.swiftModel.error.resource!.graphql!.operationType)
     }
 
@@ -2487,14 +2510,14 @@ public class objc_RUMErrorEventErrorResourceGraphql: NSObject {
     }
 }
 
-@objc(DDRUMErrorEventErrorResourceGraphqlErrors)
+@objc(DDRUMErrorEventErrorResourceRUMGraphqlErrors)
 @objcMembers
 @_spi(objc)
-public class objc_RUMErrorEventErrorResourceGraphqlErrors: NSObject {
-    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors
-    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrors { self }
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrors: NSObject {
+    internal var swiftModel: RUMGraphql.Errors
+    internal var root: objc_RUMErrorEventErrorResourceRUMGraphqlErrors { self }
 
-    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors) {
+    internal init(swiftModel: RUMGraphql.Errors) {
         self.swiftModel = swiftModel
     }
 
@@ -2502,27 +2525,27 @@ public class objc_RUMErrorEventErrorResourceGraphqlErrors: NSObject {
         root.swiftModel.code
     }
 
-    public var locations: [objc_RUMErrorEventErrorResourceGraphqlErrorsLocations]? {
-        root.swiftModel.locations?.map { objc_RUMErrorEventErrorResourceGraphqlErrorsLocations(swiftModel: $0) }
+    public var locations: [objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations]? {
+        root.swiftModel.locations?.map { objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations(swiftModel: $0) }
     }
 
     public var message: String {
         root.swiftModel.message
     }
 
-    public var path: [objc_RUMErrorEventErrorResourceGraphqlErrorsPath]? {
-        root.swiftModel.path?.map { objc_RUMErrorEventErrorResourceGraphqlErrorsPath(swiftModel: $0) }
+    public var path: [objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath]? {
+        root.swiftModel.path?.map { objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath(swiftModel: $0) }
     }
 }
 
-@objc(DDRUMErrorEventErrorResourceGraphqlErrorsLocations)
+@objc(DDRUMErrorEventErrorResourceRUMGraphqlErrorsLocations)
 @objcMembers
 @_spi(objc)
-public class objc_RUMErrorEventErrorResourceGraphqlErrorsLocations: NSObject {
-    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Locations
-    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrorsLocations { self }
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations: NSObject {
+    internal var swiftModel: RUMGraphql.Errors.Locations
+    internal var root: objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations { self }
 
-    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Locations) {
+    internal init(swiftModel: RUMGraphql.Errors.Locations) {
         self.swiftModel = swiftModel
     }
 
@@ -2535,14 +2558,14 @@ public class objc_RUMErrorEventErrorResourceGraphqlErrorsLocations: NSObject {
     }
 }
 
-@objc(DDRUMErrorEventErrorResourceGraphqlErrorsPath)
+@objc(DDRUMErrorEventErrorResourceRUMGraphqlErrorsPath)
 @objcMembers
 @_spi(objc)
-public class objc_RUMErrorEventErrorResourceGraphqlErrorsPath: NSObject {
-    internal var swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Path
-    internal var root: objc_RUMErrorEventErrorResourceGraphqlErrorsPath { self }
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath: NSObject {
+    internal var swiftModel: RUMGraphql.Errors.Path
+    internal var root: objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath { self }
 
-    internal init(swiftModel: RUMErrorEvent.Error.Resource.Graphql.Errors.Path) {
+    internal init(swiftModel: RUMGraphql.Errors.Path) {
         self.swiftModel = swiftModel
     }
 
@@ -2561,10 +2584,10 @@ public class objc_RUMErrorEventErrorResourceGraphqlErrorsPath: NSObject {
     }
 }
 
-@objc(DDRUMErrorEventErrorResourceGraphqlOperationType)
+@objc(DDRUMErrorEventErrorResourceRUMGraphqlOperationType)
 @_spi(objc)
-public enum objc_RUMErrorEventErrorResourceGraphqlOperationType: Int {
-    internal init(swift: RUMErrorEvent.Error.Resource.Graphql.OperationType?) {
+public enum objc_RUMErrorEventErrorResourceRUMGraphqlOperationType: Int {
+    internal init(swift: RUMGraphql.OperationType?) {
         switch swift {
         case nil: self = .none
         case .query?: self = .query
@@ -2573,7 +2596,7 @@ public enum objc_RUMErrorEventErrorResourceGraphqlOperationType: Int {
         }
     }
 
-    internal var toSwift: RUMErrorEvent.Error.Resource.Graphql.OperationType? {
+    internal var toSwift: RUMGraphql.OperationType? {
         switch self {
         case .none: return nil
         case .query: return .query
@@ -3030,6 +3053,21 @@ public class objc_RUMErrorEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMErrorEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventTAB: NSObject {
+    internal let root: objc_RUMErrorEvent
+
+    internal init(root: objc_RUMErrorEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMErrorEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -3189,6 +3227,10 @@ public class objc_RUMLongTaskEvent: NSObject {
 
     public var synthetics: objc_RUMLongTaskEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMLongTaskEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMLongTaskEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMLongTaskEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -4245,6 +4287,21 @@ public class objc_RUMLongTaskEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMLongTaskEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMLongTaskEventTAB: NSObject {
+    internal let root: objc_RUMLongTaskEvent
+
+    internal init(root: objc_RUMLongTaskEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMLongTaskEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -4400,6 +4457,10 @@ public class objc_RUMResourceEvent: NSObject {
 
     public var synthetics: objc_RUMResourceEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMResourceEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMResourceEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMResourceEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -5126,8 +5187,8 @@ public class objc_RUMResourceEventResource: NSObject {
         root.swiftModel.resource.firstByte != nil ? objc_RUMResourceEventResourceFirstByte(root: root) : nil
     }
 
-    public var graphql: objc_RUMResourceEventResourceGraphql? {
-        root.swiftModel.resource.graphql != nil ? objc_RUMResourceEventResourceGraphql(root: root) : nil
+    public var graphql: objc_RUMResourceEventResourceRUMGraphql? {
+        root.swiftModel.resource.graphql != nil ? objc_RUMResourceEventResourceRUMGraphql(root: root) : nil
     }
 
     public var id: String? {
@@ -5295,10 +5356,10 @@ public class objc_RUMResourceEventResourceFirstByte: NSObject {
     }
 }
 
-@objc(DDRUMResourceEventResourceGraphql)
+@objc(DDRUMResourceEventResourceRUMGraphql)
 @objcMembers
 @_spi(objc)
-public class objc_RUMResourceEventResourceGraphql: NSObject {
+public class objc_RUMResourceEventResourceRUMGraphql: NSObject {
     internal let root: objc_RUMResourceEvent
 
     internal init(root: objc_RUMResourceEvent) {
@@ -5309,15 +5370,15 @@ public class objc_RUMResourceEventResourceGraphql: NSObject {
         root.swiftModel.resource.graphql!.errorCount as NSNumber?
     }
 
-    public var errors: [objc_RUMResourceEventResourceGraphqlErrors]? {
-        root.swiftModel.resource.graphql!.errors?.map { objc_RUMResourceEventResourceGraphqlErrors(swiftModel: $0) }
+    public var errors: [objc_RUMResourceEventResourceRUMGraphqlErrors]? {
+        root.swiftModel.resource.graphql!.errors?.map { objc_RUMResourceEventResourceRUMGraphqlErrors(swiftModel: $0) }
     }
 
     public var operationName: String? {
         root.swiftModel.resource.graphql!.operationName
     }
 
-    public var operationType: objc_RUMResourceEventResourceGraphqlOperationType {
+    public var operationType: objc_RUMResourceEventResourceRUMGraphqlOperationType {
         .init(swift: root.swiftModel.resource.graphql!.operationType)
     }
 
@@ -5332,14 +5393,14 @@ public class objc_RUMResourceEventResourceGraphql: NSObject {
     }
 }
 
-@objc(DDRUMResourceEventResourceGraphqlErrors)
+@objc(DDRUMResourceEventResourceRUMGraphqlErrors)
 @objcMembers
 @_spi(objc)
-public class objc_RUMResourceEventResourceGraphqlErrors: NSObject {
-    internal var swiftModel: RUMResourceEvent.Resource.Graphql.Errors
-    internal var root: objc_RUMResourceEventResourceGraphqlErrors { self }
+public class objc_RUMResourceEventResourceRUMGraphqlErrors: NSObject {
+    internal var swiftModel: RUMGraphql.Errors
+    internal var root: objc_RUMResourceEventResourceRUMGraphqlErrors { self }
 
-    internal init(swiftModel: RUMResourceEvent.Resource.Graphql.Errors) {
+    internal init(swiftModel: RUMGraphql.Errors) {
         self.swiftModel = swiftModel
     }
 
@@ -5347,27 +5408,27 @@ public class objc_RUMResourceEventResourceGraphqlErrors: NSObject {
         root.swiftModel.code
     }
 
-    public var locations: [objc_RUMResourceEventResourceGraphqlErrorsLocations]? {
-        root.swiftModel.locations?.map { objc_RUMResourceEventResourceGraphqlErrorsLocations(swiftModel: $0) }
+    public var locations: [objc_RUMResourceEventResourceRUMGraphqlErrorsLocations]? {
+        root.swiftModel.locations?.map { objc_RUMResourceEventResourceRUMGraphqlErrorsLocations(swiftModel: $0) }
     }
 
     public var message: String {
         root.swiftModel.message
     }
 
-    public var path: [objc_RUMResourceEventResourceGraphqlErrorsPath]? {
-        root.swiftModel.path?.map { objc_RUMResourceEventResourceGraphqlErrorsPath(swiftModel: $0) }
+    public var path: [objc_RUMResourceEventResourceRUMGraphqlErrorsPath]? {
+        root.swiftModel.path?.map { objc_RUMResourceEventResourceRUMGraphqlErrorsPath(swiftModel: $0) }
     }
 }
 
-@objc(DDRUMResourceEventResourceGraphqlErrorsLocations)
+@objc(DDRUMResourceEventResourceRUMGraphqlErrorsLocations)
 @objcMembers
 @_spi(objc)
-public class objc_RUMResourceEventResourceGraphqlErrorsLocations: NSObject {
-    internal var swiftModel: RUMResourceEvent.Resource.Graphql.Errors.Locations
-    internal var root: objc_RUMResourceEventResourceGraphqlErrorsLocations { self }
+public class objc_RUMResourceEventResourceRUMGraphqlErrorsLocations: NSObject {
+    internal var swiftModel: RUMGraphql.Errors.Locations
+    internal var root: objc_RUMResourceEventResourceRUMGraphqlErrorsLocations { self }
 
-    internal init(swiftModel: RUMResourceEvent.Resource.Graphql.Errors.Locations) {
+    internal init(swiftModel: RUMGraphql.Errors.Locations) {
         self.swiftModel = swiftModel
     }
 
@@ -5380,14 +5441,14 @@ public class objc_RUMResourceEventResourceGraphqlErrorsLocations: NSObject {
     }
 }
 
-@objc(DDRUMResourceEventResourceGraphqlErrorsPath)
+@objc(DDRUMResourceEventResourceRUMGraphqlErrorsPath)
 @objcMembers
 @_spi(objc)
-public class objc_RUMResourceEventResourceGraphqlErrorsPath: NSObject {
-    internal var swiftModel: RUMResourceEvent.Resource.Graphql.Errors.Path
-    internal var root: objc_RUMResourceEventResourceGraphqlErrorsPath { self }
+public class objc_RUMResourceEventResourceRUMGraphqlErrorsPath: NSObject {
+    internal var swiftModel: RUMGraphql.Errors.Path
+    internal var root: objc_RUMResourceEventResourceRUMGraphqlErrorsPath { self }
 
-    internal init(swiftModel: RUMResourceEvent.Resource.Graphql.Errors.Path) {
+    internal init(swiftModel: RUMGraphql.Errors.Path) {
         self.swiftModel = swiftModel
     }
 
@@ -5406,10 +5467,10 @@ public class objc_RUMResourceEventResourceGraphqlErrorsPath: NSObject {
     }
 }
 
-@objc(DDRUMResourceEventResourceGraphqlOperationType)
+@objc(DDRUMResourceEventResourceRUMGraphqlOperationType)
 @_spi(objc)
-public enum objc_RUMResourceEventResourceGraphqlOperationType: Int {
-    internal init(swift: RUMResourceEvent.Resource.Graphql.OperationType?) {
+public enum objc_RUMResourceEventResourceRUMGraphqlOperationType: Int {
+    internal init(swift: RUMGraphql.OperationType?) {
         switch swift {
         case nil: self = .none
         case .query?: self = .query
@@ -5418,7 +5479,7 @@ public enum objc_RUMResourceEventResourceGraphqlOperationType: Int {
         }
     }
 
-    internal var toSwift: RUMResourceEvent.Resource.Graphql.OperationType? {
+    internal var toSwift: RUMGraphql.OperationType? {
         switch self {
         case .none: return nil
         case .query: return .query
@@ -5898,6 +5959,21 @@ public class objc_RUMResourceEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMResourceEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMResourceEventTAB: NSObject {
+    internal let root: objc_RUMResourceEvent
+
+    internal init(root: objc_RUMResourceEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMResourceEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -6053,6 +6129,10 @@ public class objc_RUMViewEvent: NSObject {
 
     public var synthetics: objc_RUMViewEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMViewEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMViewEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMViewEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -7132,6 +7212,21 @@ public class objc_RUMViewEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMViewEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewEventTAB: NSObject {
+    internal let root: objc_RUMViewEvent
+
+    internal init(root: objc_RUMViewEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMViewEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -7621,8 +7716,8 @@ public class objc_RUMViewEventViewFrustration: NSObject {
         self.root = root
     }
 
-    public var count: NSNumber? {
-        root.swiftModel.view.frustration!.count as NSNumber?
+    public var count: NSNumber {
+        root.swiftModel.view.frustration!.count as NSNumber
     }
 }
 
@@ -7948,8 +8043,8 @@ public class objc_RUMViewEventViewPerformanceINPSubParts: NSObject {
         root.swiftModel.view.performance!.inp!.subParts!.presentationDelay as NSNumber
     }
 
-    public var processingTime: NSNumber {
-        root.swiftModel.view.performance!.inp!.subParts!.processingTime as NSNumber
+    public var processingDuration: NSNumber {
+        root.swiftModel.view.performance!.inp!.subParts!.processingDuration as NSNumber
     }
 }
 
@@ -8132,6 +8227,10 @@ public class objc_RUMViewUpdateEvent: NSObject {
 
     public var synthetics: objc_RUMViewUpdateEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMViewUpdateEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMViewUpdateEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMViewUpdateEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -9024,6 +9123,21 @@ public class objc_RUMViewUpdateEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMViewUpdateEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventTAB: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMViewUpdateEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -9513,8 +9627,8 @@ public class objc_RUMViewUpdateEventViewFrustration: NSObject {
         self.root = root
     }
 
-    public var count: NSNumber? {
-        root.swiftModel.view.frustration!.count as NSNumber?
+    public var count: NSNumber {
+        root.swiftModel.view.frustration!.count as NSNumber
     }
 }
 
@@ -9840,8 +9954,8 @@ public class objc_RUMViewUpdateEventViewPerformanceINPSubParts: NSObject {
         root.swiftModel.view.performance!.inp!.subParts!.presentationDelay as NSNumber
     }
 
-    public var processingTime: NSNumber {
-        root.swiftModel.view.performance!.inp!.subParts!.processingTime as NSNumber
+    public var processingDuration: NSNumber {
+        root.swiftModel.view.performance!.inp!.subParts!.processingDuration as NSNumber
     }
 }
 
@@ -10016,6 +10130,10 @@ public class objc_RUMVitalAppLaunchEvent: NSObject {
 
     public var synthetics: objc_RUMVitalAppLaunchEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMVitalAppLaunchEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMVitalAppLaunchEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMVitalAppLaunchEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -10865,6 +10983,21 @@ public class objc_RUMVitalAppLaunchEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMVitalAppLaunchEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMVitalAppLaunchEventTAB: NSObject {
+    internal let root: objc_RUMVitalAppLaunchEvent
+
+    internal init(root: objc_RUMVitalAppLaunchEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMVitalAppLaunchEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -11104,6 +11237,10 @@ public class objc_RUMVitalDurationEvent: NSObject {
 
     public var synthetics: objc_RUMVitalDurationEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMVitalDurationEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMVitalDurationEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMVitalDurationEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -11953,6 +12090,21 @@ public class objc_RUMVitalDurationEventRUMSyntheticsTest: NSObject {
     }
 }
 
+@objc(DDRUMVitalDurationEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMVitalDurationEventTAB: NSObject {
+    internal let root: objc_RUMVitalDurationEvent
+
+    internal init(root: objc_RUMVitalDurationEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
 @objc(DDRUMVitalDurationEventRUMUser)
 @objcMembers
 @_spi(objc)
@@ -12131,6 +12283,10 @@ public class objc_RUMVitalOperationStepEvent: NSObject {
 
     public var synthetics: objc_RUMVitalOperationStepEventRUMSyntheticsTest? {
         root.swiftModel.synthetics != nil ? objc_RUMVitalOperationStepEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMVitalOperationStepEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMVitalOperationStepEventTAB(root: root) : nil
     }
 
     public var type: String {
@@ -12977,6 +13133,21 @@ public class objc_RUMVitalOperationStepEventRUMSyntheticsTest: NSObject {
     public var syntheticsInfo: [String: Any] {
         set { root.swiftModel.synthetics!.syntheticsInfo = newValue.dd.swiftAttributes }
         get { root.swiftModel.synthetics!.syntheticsInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMVitalOperationStepEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMVitalOperationStepEventTAB: NSObject {
+    internal let root: objc_RUMVitalOperationStepEvent
+
+    internal init(root: objc_RUMVitalOperationStepEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
     }
 }
 
@@ -14657,4 +14828,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/0d9435f867237b1cd993324902fe88ec235b9707
+// Generated from https://github.com/DataDog/rum-events-format/tree/ea41a41f19117b04ed9a06977fdeb8f7a90319e3

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -120,46 +120,28 @@ internal class RUMResourceScope: RUMScope {
         let resourceDuration: TimeInterval
         let size: Int64?
 
-        // Check trace attributes
-        let traceId: TraceID? = attributes.removeValue(forKey: CrossPlatformAttributes.traceID)?
-            .dd.decode()
-            .map { .init($0, representation: .hexadecimal) }
-            ?? spanContext?.traceID
+        // Trace context from cross-platform attributes or spanContext fallback
+        let traceContext = extractTraceAttributes()
 
-        let spanId: SpanID? = attributes.removeValue(forKey: CrossPlatformAttributes.spanID)?
-            .dd.decode()
-            .map { .init($0, representation: .decimal) }
-            ?? spanContext?.spanID
-
-        let parentSpanID: SpanID? = attributes.removeValue(forKey: CrossPlatformAttributes.parentSpanID)?
-            .dd.decode()
-            .map { .init($0, representation: .decimal) }
-            ?? spanContext?.parentSpanID
-
-        let traceSamplingRate = attributes.removeValue(forKey: CrossPlatformAttributes.rulePSR)?.dd.decode() ?? spanContext?.samplingRate
-
-        // Check GraphQL attributes
-        var graphql: RUMResourceEvent.Resource.Graphql? = nil
-        let graphqlOperationName: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationName)?.dd.decode()
-        let graphqlPayload: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlPayload)?.dd.decode()
-        let graphqlVariables: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlVariables)?.dd.decode()
-        let graphqlErrorsString: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlErrors)?.dd.decode()
-
-        // Parse GraphQL errors if present
-        let graphqlErrors = parseGraphQLErrors(from: graphqlErrorsString)
-
-        if
-            let rawGraphqlOperationType: String = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationType)?.dd.decode(),
-            let graphqlOperationType = RUMResourceEvent.Resource.Graphql.OperationType(rawValue: rawGraphqlOperationType) {
-            graphql = .init(
+        // GraphQL attributes from cross-platform attributes
+        let graphqlAttributes = extractGraphQLAttributes()
+        let graphqlErrors = parseGraphQLErrors(from: graphqlAttributes.errorsJSON)
+        let graphql: RUMResourceEvent.Resource.Graphql? = {
+            guard
+                let rawOperationType = graphqlAttributes.operationType,
+                let operationType = RUMResourceEvent.Resource.Graphql.OperationType(rawValue: rawOperationType)
+            else {
+                return nil
+            }
+            return .init(
                 errorCount: graphqlErrors?.count.toInt64,
                 errors: graphqlErrors,
-                operationName: graphqlOperationName,
-                operationType: graphqlOperationType,
-                payload: graphqlPayload,
-                variables: graphqlVariables
+                operationName: graphqlAttributes.operationName,
+                operationType: operationType,
+                payload: graphqlAttributes.payload,
+                variables: graphqlAttributes.variables
             )
-        }
+        }()
 
         // Extract captured HTTP headers
         let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
@@ -209,14 +191,14 @@ internal class RUMResourceScope: RUMScope {
                     sessionSampleRate: Double(dependencies.samplingRate)
                 ),
                 discarded: nil,
-                parentSpanId: parentSpanID?.toString(representation: .decimal),
-                rulePsr: traceSamplingRate,
+                parentSpanId: traceContext.parentSpanID?.toString(representation: .decimal),
+                rulePsr: traceContext.samplingRate,
                 session: .init(
                     plan: .plan1,
                     sessionPrecondition: parent.context.sessionPrecondition
                 ),
-                spanId: spanId?.toString(representation: .decimal),
-                traceId: traceId?.toString(representation: .hexadecimal)
+                spanId: traceContext.spanID?.toString(representation: .decimal),
+                traceId: traceContext.traceID?.toString(representation: .hexadecimal)
             ),
             account: .init(context: context),
             action: parent.context.activeUserActionID.map { rumUUID in
@@ -326,15 +308,39 @@ internal class RUMResourceScope: RUMScope {
         let errorFingerprint: String? = attributes.removeValue(forKey: RUM.Attributes.errorFingerprint)?.dd.decode()
         let timeSinceAppStart = command.time.timeIntervalSince(context.launchInfo.processLaunchDate).dd.toInt64Milliseconds
 
+        // Trace context from cross-platform attributes or spanContext fallback
+        let traceContext = extractTraceAttributes()
+
+        // GraphQL attributes from cross-platform attributes
+        let graphqlAttributes = extractGraphQLAttributes()
+        let graphqlErrors = parseGraphQLErrorsForErrorEvent(from: graphqlAttributes.errorsJSON)
+        let graphql: RUMErrorEvent.Error.Resource.Graphql? = {
+            guard
+                let rawOperationType = graphqlAttributes.operationType,
+                let operationType = RUMErrorEvent.Error.Resource.Graphql.OperationType(rawValue: rawOperationType)
+            else {
+                return nil
+            }
+            return .init(
+                errorCount: graphqlErrors?.count.toInt64,
+                errors: graphqlErrors,
+                operationName: graphqlAttributes.operationName,
+                operationType: operationType,
+                payload: graphqlAttributes.payload,
+                variables: graphqlAttributes.variables
+            )
+        }()
+
         // Write error event
         let errorEvent = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
                 configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.samplingRate)),
-                session: .init(
-                    plan: .plan1,
-                    sessionPrecondition: parent.context.sessionPrecondition
-                )
+                parentSpanId: traceContext.parentSpanID?.toString(representation: .decimal),
+                rulePsr: traceContext.samplingRate,
+                session: .init(plan: .plan1, sessionPrecondition: parent.context.sessionPrecondition),
+                spanId: traceContext.spanID?.toString(representation: .decimal),
+                traceId: traceContext.traceID?.toString(representation: .hexadecimal)
             ),
             account: .init(context: context),
             action: parent.context.activeUserActionID.map { rumUUID in
@@ -363,6 +369,7 @@ internal class RUMResourceScope: RUMScope {
                 message: command.errorMessage,
                 meta: nil,
                 resource: .init(
+                    graphql: graphql,
                     method: resourceHTTPMethod,
                     provider: errorEventProvider,
                     statusCode: command.httpStatusCode?.toInt64 ?? 0,
@@ -454,49 +461,94 @@ internal class RUMResourceScope: RUMScope {
         return duration.dd.toInt64Nanoseconds
     }
 
-    /// Decodes GraphQL errors from JSON string and returns them as RUM event errors
-    private func parseGraphQLErrors(from jsonString: String?) -> [RUMResourceEvent.Resource.Graphql.Errors]? {
+    /// Decodes GraphQL errors JSON string into intermediate response error models.
+    ///
+    /// Note: The cross-platform attribute `_dd.graphql.errors` contains a JSON array of error objects
+    /// (e.g. `[{"message": "...", "locations": [...]}]`), not a full GraphQL response body.
+    /// This is why we decode `[GraphQLResponseError]` directly rather than using the `GraphQLResponse`
+    /// wrapper struct, which is used elsewhere for full response body parsing.
+    private func decodeGraphQLResponseErrors(from jsonString: String?) -> [GraphQLResponseError]? {
         guard let jsonString, !jsonString.isEmpty else {
             return nil
         }
-
         guard let data = jsonString.data(using: .utf8) else {
             DD.logger.debug("Failed to convert GraphQL errors string to UTF-8 data")
             return nil
         }
-
         do {
-            let responseErrors = try JSONDecoder().decode([GraphQLResponseError].self, from: data)
-
-            guard !responseErrors.isEmpty else {
-                return nil
-            }
-
-            let parsedErrors = responseErrors.map { error in
-                RUMResourceEvent.Resource.Graphql.Errors(
-                    code: error.code,
-                    locations: error.locations?.map { location in
-                        RUMResourceEvent.Resource.Graphql.Errors.Locations(
-                            column: Int64(location.column),
-                            line: Int64(location.line)
-                        )
-                    },
-                    message: error.message,
-                    path: error.path?.map { pathElement in
-                        switch pathElement {
-                        case .string(let value):
-                            return .string(value: value)
-                        case .int(let value):
-                            return .integer(value: Int64(value))
-                        }
-                    }
-                )
-            }
-
-            return parsedErrors
+            let errors = try JSONDecoder().decode([GraphQLResponseError].self, from: data)
+            return errors.isEmpty ? nil : errors
         } catch {
             DD.logger.debug("Failed to decode GraphQL errors: \(error)")
             return nil
         }
+    }
+
+    /// Decodes GraphQL errors from JSON string and returns them as RUM resource event errors.
+    private func parseGraphQLErrors(from jsonString: String?) -> [RUMResourceEvent.Resource.Graphql.Errors]? {
+        decodeGraphQLResponseErrors(from: jsonString)?.map { error in
+            RUMResourceEvent.Resource.Graphql.Errors(
+                code: error.code,
+                locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
+                message: error.message,
+                path: error.path?.map { pathElement in
+                    switch pathElement {
+                    case .string(let value): return .string(value: value)
+                    case .int(let value): return .integer(value: Int64(value))
+                    }
+                }
+            )
+        }
+    }
+
+    /// Decodes GraphQL errors from JSON string and returns them as RUM error event errors.
+    private func parseGraphQLErrorsForErrorEvent(from jsonString: String?) -> [RUMErrorEvent.Error.Resource.Graphql.Errors]? {
+        decodeGraphQLResponseErrors(from: jsonString)?.map { error in
+            RUMErrorEvent.Error.Resource.Graphql.Errors(
+                code: error.code,
+                locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
+                message: error.message,
+                path: error.path?.map { pathElement in
+                    switch pathElement {
+                    case .string(let value): return .string(value: value)
+                    case .int(let value): return .integer(value: Int64(value))
+                    }
+                }
+            )
+        }
+    }
+
+    // MARK: - Attribute extraction helpers
+
+    /// Extracts trace attributes from `self.attributes`, consuming them via `removeValue`.
+    /// Must be called at most once per event send — repeated calls return nil for consumed keys.
+    private func extractTraceAttributes() -> (traceID: TraceID?, spanID: SpanID?, parentSpanID: SpanID?, samplingRate: Double?) {
+        let traceID: TraceID? = attributes.removeValue(forKey: CrossPlatformAttributes.traceID)?
+            .dd.decode()
+            .map { .init($0, representation: .hexadecimal) }
+            ?? spanContext?.traceID
+        let spanID: SpanID? = attributes.removeValue(forKey: CrossPlatformAttributes.spanID)?
+            .dd.decode()
+            .map { .init($0, representation: .decimal) }
+            ?? spanContext?.spanID
+        let parentSpanID: SpanID? = attributes.removeValue(forKey: CrossPlatformAttributes.parentSpanID)?
+            .dd.decode()
+            .map { .init($0, representation: .decimal) }
+            ?? spanContext?.parentSpanID
+        let samplingRate = attributes.removeValue(forKey: CrossPlatformAttributes.rulePSR)?.dd.decode() ?? spanContext?.samplingRate
+
+        return (traceID, spanID, parentSpanID, samplingRate)
+    }
+
+    /// Extracts GraphQL attributes from `self.attributes`, consuming them via `removeValue`.
+    /// Must be called at most once per event send — repeated calls return nil for consumed keys.
+    private func extractGraphQLAttributes() -> (operationType: String?, operationName: String?, payload: String?, variables: String?, errorsJSON: String?) {
+        let operationType: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationType)?.dd.decode()
+        let operationName: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationName)?.dd.decode()
+        let payload: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlPayload)?.dd.decode()
+        let variables: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlVariables)?.dd.decode()
+        let errorsJSON: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlErrors)?.dd.decode()
+
+        return (operationType, operationName, payload, variables, errorsJSON)
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -125,23 +125,7 @@ internal class RUMResourceScope: RUMScope {
 
         // GraphQL attributes from cross-platform attributes
         let graphqlAttributes = extractGraphQLAttributes()
-        let graphqlErrors = parseGraphQLErrors(from: graphqlAttributes.errorsJSON)
-        let graphql: RUMResourceEvent.Resource.Graphql? = {
-            guard
-                let rawOperationType = graphqlAttributes.operationType,
-                let operationType = RUMResourceEvent.Resource.Graphql.OperationType(rawValue: rawOperationType)
-            else {
-                return nil
-            }
-            return .init(
-                errorCount: graphqlErrors?.count.toInt64,
-                errors: graphqlErrors,
-                operationName: graphqlAttributes.operationName,
-                operationType: operationType,
-                payload: graphqlAttributes.payload,
-                variables: graphqlAttributes.variables
-            )
-        }()
+        let graphql = buildGraphQL(from: graphqlAttributes)
 
         // Extract captured HTTP headers
         let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
@@ -313,23 +297,7 @@ internal class RUMResourceScope: RUMScope {
 
         // GraphQL attributes from cross-platform attributes
         let graphqlAttributes = extractGraphQLAttributes()
-        let graphqlErrors = parseGraphQLErrorsForErrorEvent(from: graphqlAttributes.errorsJSON)
-        let graphql: RUMErrorEvent.Error.Resource.Graphql? = {
-            guard
-                let rawOperationType = graphqlAttributes.operationType,
-                let operationType = RUMErrorEvent.Error.Resource.Graphql.OperationType(rawValue: rawOperationType)
-            else {
-                return nil
-            }
-            return .init(
-                errorCount: graphqlErrors?.count.toInt64,
-                errors: graphqlErrors,
-                operationName: graphqlAttributes.operationName,
-                operationType: operationType,
-                payload: graphqlAttributes.payload,
-                variables: graphqlAttributes.variables
-            )
-        }()
+        let graphql = buildGraphQL(from: graphqlAttributes)
 
         // Write error event
         let errorEvent = RUMErrorEvent(
@@ -484,10 +452,18 @@ internal class RUMResourceScope: RUMScope {
         }
     }
 
-    /// Decodes GraphQL errors from JSON string and returns them as RUM resource event errors.
-    private func parseGraphQLErrors(from jsonString: String?) -> [RUMResourceEvent.Resource.Graphql.Errors]? {
-        decodeGraphQLResponseErrors(from: jsonString)?.map { error in
-            RUMResourceEvent.Resource.Graphql.Errors(
+    /// Builds a `RUMGraphql` value from extracted GraphQL attributes, or returns `nil` if no valid operation type is found.
+    private func buildGraphQL(
+        from attributes: (operationType: String?, operationName: String?, payload: String?, variables: String?, errorsJSON: String?)
+    ) -> RUMGraphql? {
+        guard
+            let rawOperationType = attributes.operationType,
+            let operationType = RUMGraphql.OperationType(rawValue: rawOperationType)
+        else {
+            return nil
+        }
+        let errors = decodeGraphQLResponseErrors(from: attributes.errorsJSON)?.map { error in
+            RUMGraphql.Errors(
                 code: error.code,
                 locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
                 message: error.message,
@@ -499,23 +475,14 @@ internal class RUMResourceScope: RUMScope {
                 }
             )
         }
-    }
-
-    /// Decodes GraphQL errors from JSON string and returns them as RUM error event errors.
-    private func parseGraphQLErrorsForErrorEvent(from jsonString: String?) -> [RUMErrorEvent.Error.Resource.Graphql.Errors]? {
-        decodeGraphQLResponseErrors(from: jsonString)?.map { error in
-            RUMErrorEvent.Error.Resource.Graphql.Errors(
-                code: error.code,
-                locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
-                message: error.message,
-                path: error.path?.map { pathElement in
-                    switch pathElement {
-                    case .string(let value): return .string(value: value)
-                    case .int(let value): return .integer(value: Int64(value))
-                    }
-                }
-            )
-        }
+        return .init(
+            errorCount: errors?.count.toInt64,
+            errors: errors,
+            operationName: attributes.operationName,
+            operationType: operationType,
+            payload: attributes.payload,
+            variables: attributes.variables
+        )
     }
 
     // MARK: - Attribute extraction helpers

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -124,8 +124,7 @@ internal class RUMResourceScope: RUMScope {
         let traceContext = extractTraceAttributes()
 
         // GraphQL attributes from cross-platform attributes
-        let graphqlAttributes = extractGraphQLAttributes()
-        let graphql = buildGraphQL(from: graphqlAttributes)
+        let graphql = extractGraphQL()
 
         // Extract captured HTTP headers
         let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
@@ -296,8 +295,7 @@ internal class RUMResourceScope: RUMScope {
         let traceContext = extractTraceAttributes()
 
         // GraphQL attributes from cross-platform attributes
-        let graphqlAttributes = extractGraphQLAttributes()
-        let graphql = buildGraphQL(from: graphqlAttributes)
+        let graphql = extractGraphQL()
 
         // Write error event
         let errorEvent = RUMErrorEvent(
@@ -452,39 +450,6 @@ internal class RUMResourceScope: RUMScope {
         }
     }
 
-    /// Builds a `RUMGraphql` value from extracted GraphQL attributes, or returns `nil` if no valid operation type is found.
-    private func buildGraphQL(
-        from attributes: (operationType: String?, operationName: String?, payload: String?, variables: String?, errorsJSON: String?)
-    ) -> RUMGraphql? {
-        guard
-            let rawOperationType = attributes.operationType,
-            let operationType = RUMGraphql.OperationType(rawValue: rawOperationType)
-        else {
-            return nil
-        }
-        let errors = decodeGraphQLResponseErrors(from: attributes.errorsJSON)?.map { error in
-            RUMGraphql.Errors(
-                code: error.code,
-                locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
-                message: error.message,
-                path: error.path?.map { pathElement in
-                    switch pathElement {
-                    case .string(let value): return .string(value: value)
-                    case .int(let value): return .integer(value: Int64(value))
-                    }
-                }
-            )
-        }
-        return .init(
-            errorCount: errors?.count.toInt64,
-            errors: errors,
-            operationName: attributes.operationName,
-            operationType: operationType,
-            payload: attributes.payload,
-            variables: attributes.variables
-        )
-    }
-
     // MARK: - Attribute extraction helpers
 
     /// Extracts trace attributes from `self.attributes`, consuming them via `removeValue`.
@@ -507,15 +472,42 @@ internal class RUMResourceScope: RUMScope {
         return (traceID, spanID, parentSpanID, samplingRate)
     }
 
-    /// Extracts GraphQL attributes from `self.attributes`, consuming them via `removeValue`.
-    /// Must be called at most once per event send — repeated calls return nil for consumed keys.
-    private func extractGraphQLAttributes() -> (operationType: String?, operationName: String?, payload: String?, variables: String?, errorsJSON: String?) {
+    /// Extracts GraphQL attributes from `self.attributes` and builds a `RUMGraphql` value.
+    /// Consumes attributes via `removeValue` — must be called at most once per event send.
+    /// Returns `nil` if no valid operation type is found.
+    private func extractGraphQL() -> RUMGraphql? {
         let operationType: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationType)?.dd.decode()
         let operationName: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlOperationName)?.dd.decode()
         let payload: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlPayload)?.dd.decode()
         let variables: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlVariables)?.dd.decode()
         let errorsJSON: String? = attributes.removeValue(forKey: CrossPlatformAttributes.graphqlErrors)?.dd.decode()
 
-        return (operationType, operationName, payload, variables, errorsJSON)
+        guard
+            let rawOperationType = operationType,
+            let opType = RUMGraphql.OperationType(rawValue: rawOperationType)
+        else {
+            return nil
+        }
+        let errors = decodeGraphQLResponseErrors(from: errorsJSON)?.map { error in
+            RUMGraphql.Errors(
+                code: error.code,
+                locations: error.locations?.map { .init(column: Int64($0.column), line: Int64($0.line)) },
+                message: error.message,
+                path: error.path?.map { pathElement in
+                    switch pathElement {
+                    case .string(let value): return .string(value: value)
+                    case .int(let value): return .integer(value: Int64(value))
+                    }
+                }
+            )
+        }
+        return .init(
+            errorCount: errors?.count.toInt64,
+            errors: errors,
+            operationName: operationName,
+            operationType: opType,
+            payload: payload,
+            variables: variables
+        )
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -10,21 +10,8 @@ import DatadogInternal
 @testable import TestUtilities
 
 // Extension to make Path conform to Equatable for testing
-extension RUMResourceEvent.Resource.Graphql.Errors.Path: Equatable {
-    public static func == (lhs: RUMResourceEvent.Resource.Graphql.Errors.Path, rhs: RUMResourceEvent.Resource.Graphql.Errors.Path) -> Bool {
-        switch (lhs, rhs) {
-        case (.string(let lhsValue), .string(let rhsValue)):
-            return lhsValue == rhsValue
-        case (.integer(let lhsValue), .integer(let rhsValue)):
-            return lhsValue == rhsValue
-        default:
-            return false
-        }
-    }
-}
-
-extension RUMErrorEvent.Error.Resource.Graphql.Errors.Path: Equatable {
-    public static func == (lhs: RUMErrorEvent.Error.Resource.Graphql.Errors.Path, rhs: RUMErrorEvent.Error.Resource.Graphql.Errors.Path) -> Bool {
+extension RUMGraphql.Errors.Path: Equatable {
+    public static func == (lhs: RUMGraphql.Errors.Path, rhs: RUMGraphql.Errors.Path) -> Bool {
         switch (lhs, rhs) {
         case (.string(let lhsValue), .string(let rhsValue)):
             return lhsValue == rhsValue
@@ -1982,7 +1969,7 @@ class RUMResourceScopeTests: XCTestCase {
             spanContext: .init(
                 traceID: .init(idLo: 100),
                 spanID: .init(rawValue: 200),
-                parentSpanID: nil,
+                parentSpanID: .init(rawValue: 300),
                 samplingRate: 0.42
             )
         )
@@ -2008,7 +1995,7 @@ class RUMResourceScopeTests: XCTestCase {
         let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
         XCTAssertEqual(event.dd.traceId, "64") // hex of 100 (idLo: 100)
         XCTAssertEqual(event.dd.spanId, "200")
-        XCTAssertNil(event.dd.parentSpanId)
+        XCTAssertEqual(event.dd.parentSpanId, "300")
         XCTAssertEqual(event.dd.rulePsr, 0.42)
     }
 
@@ -2182,78 +2169,7 @@ class RUMResourceScopeTests: XCTestCase {
             "locations": [{ "line": 10, "column": 3 }],
             "path": ["user", "profile"],
             "extensions": { "code": "UNAUTHORIZED" }
-          }
-        ]
-        """
-
-        // When
-        XCTAssertFalse(
-            scope.process(
-                command: RUMStopResourceWithErrorCommand(
-                    resourceKey: "/graphql",
-                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
-                    error: ErrorMock("graphql error"),
-                    source: .network,
-                    httpStatusCode: 200,
-                    globalAttributes: [:],
-                    attributes: [
-                        CrossPlatformAttributes.graphqlOperationType: "query",
-                        CrossPlatformAttributes.graphqlErrors: graphQLErrorsJSON
-                    ]
-                ),
-                context: context,
-                writer: writer
-            )
-        )
-
-        // Then
-        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
-        let graphql = try XCTUnwrap(event.error.resource?.graphql)
-        XCTAssertEqual(graphql.errorCount, 2)
-
-        let errors = try XCTUnwrap(graphql.errors)
-        XCTAssertEqual(errors.count, 2)
-
-        let error1 = errors[0]
-        XCTAssertEqual(error1.message, "Book not found")
-        XCTAssertEqual(error1.code, "NOT_FOUND")
-        let locations1 = try XCTUnwrap(error1.locations)
-        XCTAssertEqual(locations1.count, 2)
-        XCTAssertEqual(locations1[0].line, 2)
-        XCTAssertEqual(locations1[0].column, 7)
-        XCTAssertEqual(locations1[1].line, 5)
-        XCTAssertEqual(locations1[1].column, 12)
-        let path1 = try XCTUnwrap(error1.path)
-        XCTAssertEqual(path1.count, 2)
-        XCTAssertEqual(path1[0], .string(value: "library"))
-        XCTAssertEqual(path1[1], .string(value: "book"))
-
-        let error2 = errors[1]
-        XCTAssertEqual(error2.message, "Unauthorized access to user profile")
-        XCTAssertEqual(error2.code, "UNAUTHORIZED")
-        let locations2 = try XCTUnwrap(error2.locations)
-        XCTAssertEqual(locations2.count, 1)
-        XCTAssertEqual(locations2[0].line, 10)
-        XCTAssertEqual(locations2[0].column, 3)
-        let path2 = try XCTUnwrap(error2.path)
-        XCTAssertEqual(path2.count, 2)
-        XCTAssertEqual(path2[0], .string(value: "user"))
-        XCTAssertEqual(path2[1], .string(value: "profile"))
-    }
-
-    func testGivenResourceWithIntegerPathInGraphQLError_whenResourceLoadingEndsWithError_itMapsIntegerPathCorrectly() throws {
-        // Given
-        let scope = RUMResourceScope.mockWith(
-            parent: provider,
-            dependencies: dependencies,
-            resourceKey: "/graphql",
-            startTime: .mockDecember15th2019At10AMUTC(),
-            url: "https://api.example.com/graphql",
-            httpMethod: .post
-        )
-
-        let graphQLErrorsJSON = """
-        [
+          },
           {
             "message": "Index out of bounds",
             "path": ["users", 0, "name"]
@@ -2283,12 +2199,46 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Then
         let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
-        let errors = try XCTUnwrap(event.error.resource?.graphql?.errors)
-        let path = try XCTUnwrap(errors[0].path)
-        XCTAssertEqual(path.count, 3)
-        XCTAssertEqual(path[0], .string(value: "users"))
-        XCTAssertEqual(path[1], .integer(value: 0))
-        XCTAssertEqual(path[2], .string(value: "name"))
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertEqual(graphql.errorCount, 3)
+
+        let errors = try XCTUnwrap(graphql.errors)
+        XCTAssertEqual(errors.count, 3)
+
+        let error1 = errors[0]
+        XCTAssertEqual(error1.message, "Book not found")
+        XCTAssertEqual(error1.code, "NOT_FOUND")
+        let locations1 = try XCTUnwrap(error1.locations)
+        XCTAssertEqual(locations1.count, 2)
+        XCTAssertEqual(locations1[0].line, 2)
+        XCTAssertEqual(locations1[0].column, 7)
+        XCTAssertEqual(locations1[1].line, 5)
+        XCTAssertEqual(locations1[1].column, 12)
+        let path1 = try XCTUnwrap(error1.path)
+        XCTAssertEqual(path1.count, 2)
+        XCTAssertEqual(path1[0], .string(value: "library"))
+        XCTAssertEqual(path1[1], .string(value: "book"))
+
+        let error2 = errors[1]
+        XCTAssertEqual(error2.message, "Unauthorized access to user profile")
+        XCTAssertEqual(error2.code, "UNAUTHORIZED")
+        let locations2 = try XCTUnwrap(error2.locations)
+        XCTAssertEqual(locations2.count, 1)
+        XCTAssertEqual(locations2[0].line, 10)
+        XCTAssertEqual(locations2[0].column, 3)
+        let path2 = try XCTUnwrap(error2.path)
+        XCTAssertEqual(path2.count, 2)
+        XCTAssertEqual(path2[0], .string(value: "user"))
+        XCTAssertEqual(path2[1], .string(value: "profile"))
+
+        let error3 = errors[2]
+        XCTAssertEqual(error3.message, "Index out of bounds")
+        XCTAssertNil(error3.code)
+        let path3 = try XCTUnwrap(error3.path)
+        XCTAssertEqual(path3.count, 3)
+        XCTAssertEqual(path3[0], .string(value: "users"))
+        XCTAssertEqual(path3[1], .integer(value: 0))
+        XCTAssertEqual(path3[2], .string(value: "name"))
     }
 
     func testGivenResourceWithCrossPlatformTraceAttributes_whenResourceLoadingEndsWithError_itSendsErrorEventWithTraceContext() throws {
@@ -2313,6 +2263,7 @@ class RUMResourceScopeTests: XCTestCase {
                     attributes: [
                         CrossPlatformAttributes.traceID: "1a2b3c",
                         CrossPlatformAttributes.spanID: "12345678901",
+                        CrossPlatformAttributes.parentSpanID: "9999",
                         CrossPlatformAttributes.rulePSR: 0.5
                     ]
                 ),
@@ -2325,47 +2276,8 @@ class RUMResourceScopeTests: XCTestCase {
         let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
         XCTAssertEqual(event.dd.traceId, "1a2b3c")
         XCTAssertEqual(event.dd.spanId, "12345678901")
-        XCTAssertNil(event.dd.parentSpanId)
+        XCTAssertEqual(event.dd.parentSpanId, "9999")
         XCTAssertEqual(event.dd.rulePsr, 0.5)
-    }
-
-    func testGivenResourceWithParentSpanID_whenResourceLoadingEndsWithError_itSendsErrorEventWithParentSpanId() throws {
-        // Given
-        let scope = RUMResourceScope.mockWith(
-            parent: provider,
-            dependencies: dependencies,
-            resourceKey: "/resource/1",
-            spanContext: .init(
-                traceID: .init(idLo: 100),
-                spanID: .init(rawValue: 200),
-                parentSpanID: .init(rawValue: 300),
-                samplingRate: 0.42
-            )
-        )
-
-        // When
-        XCTAssertFalse(
-            scope.process(
-                command: RUMStopResourceWithErrorCommand(
-                    resourceKey: "/resource/1",
-                    time: .mockDecember15th2019At10AMUTC(),
-                    error: ErrorMock("network issue"),
-                    source: .network,
-                    httpStatusCode: 500,
-                    globalAttributes: [:],
-                    attributes: [:]
-                ),
-                context: context,
-                writer: writer
-            )
-        )
-
-        // Then
-        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
-        XCTAssertEqual(event.dd.traceId, "64") // hex of 100 (idLo: 100)
-        XCTAssertEqual(event.dd.spanId, "200")
-        XCTAssertEqual(event.dd.parentSpanId, "300")
-        XCTAssertEqual(event.dd.rulePsr, 0.42)
     }
 
     func testGivenResourceWithMutationGraphQLOperationType_whenResourceLoadingEndsWithError_itSendsErrorEventWithGraphQL() throws {
@@ -2440,40 +2352,6 @@ class RUMResourceScopeTests: XCTestCase {
         // Then
         let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
         XCTAssertNil(event.error.resource?.graphql)
-    }
-
-    func testGivenResourceWithNoTraceContext_whenResourceLoadingEndsWithError_itSendsErrorEventWithNilTraceFields() throws {
-        // Given
-        let scope = RUMResourceScope.mockWith(
-            parent: provider,
-            dependencies: dependencies,
-            resourceKey: "/resource/1",
-            spanContext: nil
-        )
-
-        // When
-        XCTAssertFalse(
-            scope.process(
-                command: RUMStopResourceWithErrorCommand(
-                    resourceKey: "/resource/1",
-                    time: .mockDecember15th2019At10AMUTC(),
-                    error: ErrorMock("network issue"),
-                    source: .network,
-                    httpStatusCode: 500,
-                    globalAttributes: [:],
-                    attributes: [:]
-                ),
-                context: context,
-                writer: writer
-            )
-        )
-
-        // Then
-        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
-        XCTAssertNil(event.dd.traceId)
-        XCTAssertNil(event.dd.spanId)
-        XCTAssertNil(event.dd.parentSpanId)
-        XCTAssertNil(event.dd.rulePsr)
     }
 
     func testGivenResourceWithNoGraphQLOperationType_whenResourceLoadingEndsWithError_itDoesNotSetGraphQL() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -23,6 +23,19 @@ extension RUMResourceEvent.Resource.Graphql.Errors.Path: Equatable {
     }
 }
 
+extension RUMErrorEvent.Error.Resource.Graphql.Errors.Path: Equatable {
+    public static func == (lhs: RUMErrorEvent.Error.Resource.Graphql.Errors.Path, rhs: RUMErrorEvent.Error.Resource.Graphql.Errors.Path) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhsValue), .string(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.integer(let lhsValue), .integer(let rhsValue)):
+            return lhsValue == rhsValue
+        default:
+            return false
+        }
+    }
+}
+
 class RUMResourceScopeTests: XCTestCase {
     let context: DatadogContext = .mockWith(
         service: "test-service",
@@ -1958,5 +1971,585 @@ class RUMResourceScopeTests: XCTestCase {
         let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
         XCTAssertNil(event.resource.request)
         XCTAssertNil(event.resource.response)
+    }
+
+    func testGivenStartedResourceWithSpanContext_whenResourceLoadingEndsWithError_itSendsErrorEventWithTraceContext() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                parentSpanID: nil,
+                samplingRate: 0.42
+            )
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(),
+                    error: ErrorMock("network issue"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [:]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.dd.traceId, "64") // hex of 100 (idLo: 100)
+        XCTAssertEqual(event.dd.spanId, "200")
+        XCTAssertNil(event.dd.parentSpanId)
+        XCTAssertEqual(event.dd.rulePsr, 0.42)
+    }
+
+    func testGivenResourceWithGraphQLAttributes_whenResourceLoadingEndsWithError_itSendsErrorEventWithGraphQL() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        let graphQLErrorsJSON = """
+        [
+          {
+            "message": "Book not found",
+            "locations": [{ "line": 2, "column": 7 }],
+            "path": ["library", "book"],
+            "extensions": { "code": "NOT_FOUND" }
+          }
+        ]
+        """
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "query",
+                        CrossPlatformAttributes.graphqlOperationName: "GetBook",
+                        CrossPlatformAttributes.graphqlPayload: "{ library { book } }",
+                        CrossPlatformAttributes.graphqlVariables: "{\"bookId\": \"123\"}",
+                        CrossPlatformAttributes.graphqlErrors: graphQLErrorsJSON
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertEqual(graphql.operationType, .query)
+        XCTAssertEqual(graphql.operationName, "GetBook")
+        XCTAssertEqual(graphql.payload, "{ library { book } }")
+        XCTAssertEqual(graphql.variables, "{\"bookId\": \"123\"}")
+        XCTAssertEqual(graphql.errorCount, 1)
+        let errors = try XCTUnwrap(graphql.errors)
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors[0].message, "Book not found")
+        XCTAssertEqual(errors[0].code, "NOT_FOUND")
+        let locations = try XCTUnwrap(errors[0].locations)
+        XCTAssertEqual(locations.count, 1)
+        XCTAssertEqual(locations[0].line, 2)
+        XCTAssertEqual(locations[0].column, 7)
+        let path = try XCTUnwrap(errors[0].path)
+        XCTAssertEqual(path.count, 2)
+        XCTAssertEqual(path[0], .string(value: "library"))
+        XCTAssertEqual(path[1], .string(value: "book"))
+    }
+
+    func testGivenResourceWithInvalidGraphQLJSON_whenResourceLoadingEndsWithError_itHandlesGracefully() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "query",
+                        CrossPlatformAttributes.graphqlErrors: "{ invalid json }"
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertNil(graphql.errors)
+        XCTAssertNil(graphql.errorCount)
+    }
+
+    func testGivenResourceWithEmptyGraphQLErrorsArray_whenResourceLoadingEndsWithError_itDoesNotSetErrors() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "query",
+                        CrossPlatformAttributes.graphqlErrors: "[]"
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertNil(graphql.errors)
+        XCTAssertNil(graphql.errorCount)
+    }
+
+    func testGivenResourceWithMultipleGraphQLErrors_whenResourceLoadingEndsWithError_itParsesAllErrorsCorrectly() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        let graphQLErrorsJSON = """
+        [
+          {
+            "message": "Book not found",
+            "locations": [
+              { "line": 2, "column": 7 },
+              { "line": 5, "column": 12 }
+            ],
+            "path": ["library", "book"],
+            "extensions": { "code": "NOT_FOUND" }
+          },
+          {
+            "message": "Unauthorized access to user profile",
+            "locations": [{ "line": 10, "column": 3 }],
+            "path": ["user", "profile"],
+            "extensions": { "code": "UNAUTHORIZED" }
+          }
+        ]
+        """
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "query",
+                        CrossPlatformAttributes.graphqlErrors: graphQLErrorsJSON
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertEqual(graphql.errorCount, 2)
+
+        let errors = try XCTUnwrap(graphql.errors)
+        XCTAssertEqual(errors.count, 2)
+
+        let error1 = errors[0]
+        XCTAssertEqual(error1.message, "Book not found")
+        XCTAssertEqual(error1.code, "NOT_FOUND")
+        let locations1 = try XCTUnwrap(error1.locations)
+        XCTAssertEqual(locations1.count, 2)
+        XCTAssertEqual(locations1[0].line, 2)
+        XCTAssertEqual(locations1[0].column, 7)
+        XCTAssertEqual(locations1[1].line, 5)
+        XCTAssertEqual(locations1[1].column, 12)
+        let path1 = try XCTUnwrap(error1.path)
+        XCTAssertEqual(path1.count, 2)
+        XCTAssertEqual(path1[0], .string(value: "library"))
+        XCTAssertEqual(path1[1], .string(value: "book"))
+
+        let error2 = errors[1]
+        XCTAssertEqual(error2.message, "Unauthorized access to user profile")
+        XCTAssertEqual(error2.code, "UNAUTHORIZED")
+        let locations2 = try XCTUnwrap(error2.locations)
+        XCTAssertEqual(locations2.count, 1)
+        XCTAssertEqual(locations2[0].line, 10)
+        XCTAssertEqual(locations2[0].column, 3)
+        let path2 = try XCTUnwrap(error2.path)
+        XCTAssertEqual(path2.count, 2)
+        XCTAssertEqual(path2[0], .string(value: "user"))
+        XCTAssertEqual(path2[1], .string(value: "profile"))
+    }
+
+    func testGivenResourceWithIntegerPathInGraphQLError_whenResourceLoadingEndsWithError_itMapsIntegerPathCorrectly() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        let graphQLErrorsJSON = """
+        [
+          {
+            "message": "Index out of bounds",
+            "path": ["users", 0, "name"]
+          }
+        ]
+        """
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "query",
+                        CrossPlatformAttributes.graphqlErrors: graphQLErrorsJSON
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let errors = try XCTUnwrap(event.error.resource?.graphql?.errors)
+        let path = try XCTUnwrap(errors[0].path)
+        XCTAssertEqual(path.count, 3)
+        XCTAssertEqual(path[0], .string(value: "users"))
+        XCTAssertEqual(path[1], .integer(value: 0))
+        XCTAssertEqual(path[2], .string(value: "name"))
+    }
+
+    func testGivenResourceWithCrossPlatformTraceAttributes_whenResourceLoadingEndsWithError_itSendsErrorEventWithTraceContext() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            spanContext: nil
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(),
+                    error: ErrorMock("network issue"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.traceID: "1a2b3c",
+                        CrossPlatformAttributes.spanID: "12345678901",
+                        CrossPlatformAttributes.rulePSR: 0.5
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then - traceId is stored as-is (hex string), spanId is stored as-is (decimal string)
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.dd.traceId, "1a2b3c")
+        XCTAssertEqual(event.dd.spanId, "12345678901")
+        XCTAssertNil(event.dd.parentSpanId)
+        XCTAssertEqual(event.dd.rulePsr, 0.5)
+    }
+
+    func testGivenResourceWithParentSpanID_whenResourceLoadingEndsWithError_itSendsErrorEventWithParentSpanId() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            spanContext: .init(
+                traceID: .init(idLo: 100),
+                spanID: .init(rawValue: 200),
+                parentSpanID: .init(rawValue: 300),
+                samplingRate: 0.42
+            )
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(),
+                    error: ErrorMock("network issue"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [:]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.dd.traceId, "64") // hex of 100 (idLo: 100)
+        XCTAssertEqual(event.dd.spanId, "200")
+        XCTAssertEqual(event.dd.parentSpanId, "300")
+        XCTAssertEqual(event.dd.rulePsr, 0.42)
+    }
+
+    func testGivenResourceWithMutationGraphQLOperationType_whenResourceLoadingEndsWithError_itSendsErrorEventWithGraphQL() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "mutation",
+                        CrossPlatformAttributes.graphqlOperationName: "CreateBook"
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        let graphql = try XCTUnwrap(event.error.resource?.graphql)
+        XCTAssertEqual(graphql.operationType, .mutation)
+        XCTAssertEqual(graphql.operationName, "CreateBook")
+    }
+
+    func testGivenResourceWithUnrecognizedGraphQLOperationType_whenResourceLoadingEndsWithError_itDoesNotSetGraphQL() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationType: "subscribe",
+                        CrossPlatformAttributes.graphqlOperationName: "OnBookAdded"
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertNil(event.error.resource?.graphql)
+    }
+
+    func testGivenResourceWithNoTraceContext_whenResourceLoadingEndsWithError_itSendsErrorEventWithNilTraceFields() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            spanContext: nil
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(),
+                    error: ErrorMock("network issue"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [:]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertNil(event.dd.traceId)
+        XCTAssertNil(event.dd.spanId)
+        XCTAssertNil(event.dd.parentSpanId)
+        XCTAssertNil(event.dd.rulePsr)
+    }
+
+    func testGivenResourceWithNoGraphQLOperationType_whenResourceLoadingEndsWithError_itDoesNotSetGraphQL() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/graphql",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/graphql",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/graphql",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    error: ErrorMock("graphql error"),
+                    source: .network,
+                    httpStatusCode: 200,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.graphqlOperationName: "GetBook"
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertNil(event.error.resource?.graphql)
+    }
+
+    func testGivenResourceWithSpanContextAndCrossPlatformAttributes_whenResourceLoadingEndsWithError_itPrefersAttributesOverSpanContext() throws {
+        // Given - spanContext is set, but cross-platform attributes will also be provided
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            spanContext: .init(
+                traceID: .init(idLo: 999),
+                spanID: .init(rawValue: 888),
+                parentSpanID: nil,
+                samplingRate: 0.1
+            )
+        )
+
+        // When - cross-platform attributes are provided alongside spanContext
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(),
+                    error: ErrorMock("network issue"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [
+                        CrossPlatformAttributes.traceID: "aabbcc",
+                        CrossPlatformAttributes.spanID: "42",
+                        CrossPlatformAttributes.rulePSR: 0.9
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then - cross-platform attributes take precedence over spanContext
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.dd.traceId, "aabbcc")
+        XCTAssertEqual(event.dd.spanId, "42")
+        XCTAssertEqual(event.dd.rulePsr, 0.9)
     }
 }

--- a/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
@@ -28,7 +28,8 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
                 "RUMSessionPrecondition",
                 "RUMTelemetryDevice",
                 "RUMTelemetryOperatingSystem",
-                "RUMAccount"
+                "RUMAccount",
+                "RUMGraphql"
             ]
         )
     }
@@ -149,6 +150,10 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
 
         if fixedName == "Account" {
             fixedName = "RUMAccount"
+        }
+
+        if fixedName == "Graphql" {
+            fixedName = "RUMGraphql"
         }
 
         return fixedName


### PR DESCRIPTION
## What     

Adds trace context (`traceId`, `spanId`, `parentSpanId`, `rulePsr`) and GraphQL fields to `sendErrorEvent` in `RUMResourceScope`, bringing it to parity with `sendResourceEvent`.                                                                                            
   
  ## Why                                                                                                                                                                                                                                                                       
                  
These fields were missing from the error event path, causing trace correlation and GraphQL error data to be lost when a resource load fails.

  ## Changes

  - Regenerated `RUMDataModels` and Obj-C bridge to add the new fields to `RUMErrorEvent`
  - Added trace context and GraphQL extraction to `sendErrorEvent`
  - Extracted shared helpers `extractTraceAttributes()` and `extractGraphQLAttributes()` to eliminate duplication between the two send paths
  - Refactored GraphQL error parsing into a shared `decodeGraphQLResponseErrors` base with two typed wrappers
  - Added 13 tests covering all new fields and edge cases