### PR TITLE
[RUM-15318] Revert SR sampler to random sampling pending retention filter readiness

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/RecordingCoordinator.swift
@@ -102,14 +102,9 @@ internal class RecordingCoordinator {
 
     private func onRUMContextChanged(rumContext: RUMCoreContext?) {
         if currentRUMContext?.sessionID != rumContext?.sessionID || currentRUMContext == nil {
-            if let sampler = rumContext?.sessionSampler {
-                isSampled = sampler.combined(with: replaySampleRate).sample()
-            } else {
-                // No RUM session context means there is no session to correlate a replay to.
-                // Random sampling is intentional here — the replay cannot be linked to a session,
-                // so deterministic Knuth sampling would provide no benefit.
-                isSampled = Sampler(samplingRate: replaySampleRate).sample()
-            }
+            // TODO RUM-15318: Use cross-product deterministic sampling once Session Replay
+            // retention filters are ready
+            isSampled = Sampler(samplingRate: replaySampleRate).sample()
         }
 
         currentRUMContext = rumContext

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -290,19 +290,12 @@ class RecordingCoordinatorTests: XCTestCase {
         XCTAssertFalse(hasReplay.value)
     }
 
-    // MARK: - Deterministic sampling
+    // MARK: - Sampling
 
-    func test_givenSameSessionID_samplingDecisionIsIdentical_acrossMultipleCalls() {
+    func test_samplingDecisionIsRetained_acrossMultipleCallsWithSameSessionID() {
         // Given
         prepareRecordingCoordinator(replaySampleRate: 60.0)
-        let fixedSessionID = "abcdef01-2345-6789-abcd-ef0123456789"
-        let sessionSampler = DeterministicSampler(uuid: .mockWith(fixedSessionID), samplingRate: 70.0)
-        let rumContext = RUMCoreContext(
-            applicationID: "app-id",
-            sessionID: fixedSessionID,
-            sessionSampler: sessionSampler,
-            viewID: "view-id"
-        )
+        let rumContext: RUMCoreContext = .mockRandom()
 
         // When
         rumContextObserver.notify(rumContext: rumContext)
@@ -312,69 +305,25 @@ class RecordingCoordinatorTests: XCTestCase {
         let secondDecision = scheduler.isRunning
 
         // Then
-        XCTAssertEqual(firstDecision, secondDecision, "Knuth sampling must be deterministic for the same session UUID")
+        XCTAssertEqual(firstDecision, secondDecision, "Sampling decision must not change for the same session")
     }
 
-    func test_knownSessionUUID_matchesPrecomputedKnuthResult() throws {
-        // UUID: "abcdef01-2345-6789-abcd-ef0123456789", last segment 0xef0123456789
-        // sessionRate=50, replayRate=80 → effectiveRate=40.0
-        let knownSessionID = "abcdef01-2345-6789-abcd-ef0123456789"
-        let replaySampleRate: SampleRate = 80.0
-        let sessionSampleRate: SampleRate = 50.0
+    func test_samplingDecisionIsReevaluated_whenSessionIDChanges() {
+        // Given - sample rate 100% guarantees sampling
+        prepareRecordingCoordinator(replaySampleRate: 100.0)
+        let firstContext: RUMCoreContext = .mockRandom()
+        let secondContext: RUMCoreContext = .mockRandom()
 
-        // Precompute using combined(with:) — canonical cross-SDK formula
-        let sessionSampler = DeterministicSampler(uuid: .mockWith(knownSessionID), samplingRate: sessionSampleRate)
-        let expectedResult = sessionSampler.combined(with: replaySampleRate).isSampled
+        // When
+        rumContextObserver.notify(rumContext: firstContext)
+        XCTAssertTrue(scheduler.isRunning)
 
-        prepareRecordingCoordinator(replaySampleRate: replaySampleRate)
-        let rumContext = RUMCoreContext(
-            applicationID: "app-id",
-            sessionID: knownSessionID,
-            sessionSampler: sessionSampler,
-            viewID: "view-id"
-        )
-        rumContextObserver.notify(rumContext: rumContext)
+        // Switch to a new session with 0% sample rate
+        prepareRecordingCoordinator(replaySampleRate: 0.0)
+        rumContextObserver.notify(rumContext: secondContext)
 
-        let hasReplay = try XCTUnwrap(core.context.additionalContext(ofType: SessionReplayCoreContext.HasReplay.self))
-        XCTAssertEqual(
-            scheduler.isRunning,
-            expectedResult,
-            "RecordingCoordinator must use sessionSampler.combined(with:).isSampled with the composed effective rate"
-        )
-        XCTAssertEqual(hasReplay.value, expectedResult)
-    }
-
-    func test_childRateCorrectionIsApplied_replay() throws {
-        // seed 0xd860b2b9437a (~68.7% hash): sampled at replay-only 80% but NOT at composed 40% (50*80/100)
-        // This verifies the session rate is not ignored.
-        let knownSessionID = "00000000-0000-0000-0000-d860b2b9437a"
-        let sessionSampleRate: SampleRate = 50.0
-        let replaySampleRate: SampleRate = 80.0
-
-        let sessionSampler = DeterministicSampler(uuid: .mockWith(knownSessionID), samplingRate: sessionSampleRate)
-        let composedResult = sessionSampler.combined(with: replaySampleRate).isSampled
-        let replayOnlyResult = DeterministicSampler(uuid: .mockWith(knownSessionID), samplingRate: replaySampleRate).isSampled
-        guard composedResult != replayOnlyResult else {
-            XCTFail("Precondition: chosen vector must differ between composed and replay-only rate")
-            return
-        }
-
-        prepareRecordingCoordinator(replaySampleRate: replaySampleRate)
-        let rumContext = RUMCoreContext(
-            applicationID: "app",
-            sessionID: knownSessionID,
-            sessionSampler: sessionSampler,
-            viewID: "view"
-        )
-        rumContextObserver.notify(rumContext: rumContext)
-
-        let hasReplay = try XCTUnwrap(core.context.additionalContext(ofType: SessionReplayCoreContext.HasReplay.self))
-        XCTAssertEqual(
-            scheduler.isRunning,
-            composedResult,
-            "RecordingCoordinator must apply child-rate correction via sessionSampler.combined(with:)"
-        )
-        XCTAssertEqual(hasReplay.value, composedResult)
+        // Then
+        XCTAssertFalse(scheduler.isRunning, "Sampling must be re-evaluated when session ID changes")
     }
 
     private func prepareRecordingCoordinator(


### PR DESCRIPTION
### What and why?

Reverts the Session Replay sampler back to random sampling (`Sampler(samplingRate:).sample()`) with a TODO comment for RUM-15318.

The deterministic cross-product sampling (via `sessionSampler.combined(with:)`) was introduced ahead of the Session Replay retention filters being ready. Until those filters are in place, the deterministic approach is premature.

### How?

- Reverts `RecordingCoordinator.onRUMContextChanged` to use `Sampler(samplingRate: replaySampleRate).sample()` with a TODO comment referencing RUM-15318
- Replaces deterministic sampling tests with simpler tests matching the random sampling behaviour: decision is retained for the same session ID, and re-evaluated when the session ID changes

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs