### PR TITLE
Fix Carthage rate limiting on raw.githubusercontent.com

### DIFF
--- a/tools/carthage-shim.sh
+++ b/tools/carthage-shim.sh
@@ -16,8 +16,18 @@ source "${REPO_ROOT:-.}/tools/secrets/get-secret.sh"
 # Ref.: https://github.com/Carthage/Carthage/pull/605
 if [ "$CI" = "true" ]; then
     export GITHUB_ACCESS_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/dd-sdk-ios --policy self.carthage)
-    # Set up trap to always revoke token on script exit (success, failure, or interruption)
-    trap 'dd-octo-sts --disable-tracing revoke --token $GITHUB_ACCESS_TOKEN' EXIT
+
+    # GitHub introduced rate limits for unauthenticated requests to raw.githubusercontent.com
+    # (https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/).
+    # Carthage fetches binary-only framework JSON manifests from raw.githubusercontent.com without
+    # auth by default, causing failures on shared CI runners. Writing a ~/.netrc entry and passing
+    # --use-netrc makes Carthage add an Authorization header for that host.
+    printf "machine raw.githubusercontent.com login x-access-token password %s\n" "${GITHUB_ACCESS_TOKEN}" >> ~/.netrc
+    chmod 600 ~/.netrc
+
+    # Set up a single EXIT trap combining all cleanup: revoke the token and remove the netrc entry.
+    # A single trap is used because each `trap ... EXIT` call in zsh replaces the previous one.
+    trap 'dd-octo-sts --disable-tracing revoke --token $GITHUB_ACCESS_TOKEN; sed -i "" "/machine raw.githubusercontent.com/d" ~/.netrc' EXIT
 fi
 
-carthage "$@"
+carthage "$@" ${CI:+--use-netrc}


### PR DESCRIPTION
### What and why?

GitHub introduced rate limits for unauthenticated requests to `raw.githubusercontent.com`
(https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/).
Carthage fetches binary-only framework JSON manifests (e.g. `OpenTelemetryApi.json`) from
that host without authentication by default, causing frequent failures on shared CI runners
that exhaust the unauthenticated quota.

### How?

In `tools/carthage-shim.sh`, when running on CI:
1. Write the existing `GITHUB_ACCESS_TOKEN` to `~/.netrc` for `raw.githubusercontent.com`
2. Pass `--use-netrc` to Carthage so it adds an `Authorization` header when fetching binary JSON manifests
3. Clean up `~/.netrc` via a trap on exit

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs