### PR TITLE
Fix RUMS-5665: prevent applicationActive latch before view is created in backgroundLaunch path

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1557,6 +1557,7 @@
 		D23F8EB229DDCD38001CFAE8 /* ValuePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611529AD25E3E429004F740E /* ValuePublisherTests.swift */; };
 		D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */; };
 		D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
+		AA001RUMS566501000000001 /* RUMApplicationScopeTests+RUMS5665.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA001RUMS566500000000001 /* RUMApplicationScopeTests+RUMS5665.swift */; };
 		D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
 		D23F8EB829DDCD38001CFAE8 /* RUMActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* RUMActionsHandlerTests.swift */; };
 		D23F8EBA29DDCD38001CFAE8 /* ViewIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C1510C25AC8C1B00362D4B /* ViewIdentifierTests.swift */; };
@@ -1771,6 +1772,7 @@
 		D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BCB12129D34A5F00737A9A /* URLSessionRUMResourcesHandlerTests.swift */; };
 		D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611529AD25E3E429004F740E /* ValuePublisherTests.swift */; };
 		D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
+		AA001RUMS566502000000001 /* RUMApplicationScopeTests+RUMS5665.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA001RUMS566500000000001 /* RUMApplicationScopeTests+RUMS5665.swift */; };
 		D29A9FA229DDB483005C54A4 /* RUMEventSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122EED25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift */; };
 		D29A9FA329DDB483005C54A4 /* RUMDeviceInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FD9FCE28534EBD00214BD9 /* RUMDeviceInfoTests.swift */; };
 		D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E53889B2773C4B300A7DC42 /* WebViewEventReceiverTests.swift */; };
@@ -3363,6 +3365,7 @@
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
 		617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorTests.swift; sourceTree = "<group>"; };
 		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
+		AA001RUMS566500000000001 /* RUMApplicationScopeTests+RUMS5665.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMApplicationScopeTests+RUMS5665.swift"; sourceTree = "<group>"; };
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
 		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
 		618031F72D6DC430007027E3 /* Threading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Threading.swift; sourceTree = "<group>"; };
@@ -6377,6 +6380,7 @@
 				61181CDB2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift */,
 				1124D5312EA6D4050002E053 /* RUMAppLaunchManagerTests.swift */,
 				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
+				AA001RUMS566500000000001 /* RUMApplicationScopeTests+RUMS5665.swift */,
 				61494CB424C864680082C633 /* RUMResourceScopeTests.swift */,
 				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 				617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */,
@@ -10711,6 +10715,7 @@
 				D23F8EB329DDCD38001CFAE8 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C12A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D23F8EB429DDCD38001CFAE8 /* RUMApplicationScopeTests.swift in Sources */,
+				AA001RUMS566501000000001 /* RUMApplicationScopeTests+RUMS5665.swift in Sources */,
 				6105C5152D0C584F00C4C5EE /* INVMetricTests.swift in Sources */,
 				D23F8EB629DDCD38001CFAE8 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CB2A3DC22700FA735A /* RUMTests.swift in Sources */,
@@ -11215,6 +11220,7 @@
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,
+				AA001RUMS566502000000001 /* RUMApplicationScopeTests+RUMS5665.swift in Sources */,
 				6105C5142D0C584F00C4C5EE /* INVMetricTests.swift in Sources */,
 				D29A9FAA29DDB483005C54A4 /* RUMViewsHandlerTests.swift in Sources */,
 				61C713CA2A3DC22700FA735A /* RUMTests.swift in Sources */,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -330,15 +330,25 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// is started on SDK init only when the app is launched by user with no prewarming or when app was prewarmed but SDK was initialized
     /// after it became active.
     private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        applicationActive = true
-
         let isUserLaunch = context.launchInfo.launchReason == .userLaunch
         let isPrewarmed = context.launchInfo.launchReason == .prewarming
         let isBackgroundLaunch = context.launchInfo.launchReason == .backgroundLaunch
         let isStartedInForeground = command is RUMSDKInitCommand && context.applicationStateHistory.currentState != .background
-        guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) else {
+
+        // For backgroundLaunch (task_policy_get returned non-foreground on ~20% of devices or for
+        // UISceneDelegate apps that initialise in background), also allow view creation when a
+        // subsequent command explicitly requests it via canStartApplicationLaunchView. This covers
+        // the case where SDKInit happened in background but the app is now handling user-visible work.
+        let backgroundLaunchWithEligibleCommand = isBackgroundLaunch && command.canStartApplicationLaunchView
+
+        guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) || backgroundLaunchWithEligibleCommand else {
             return
         }
+
+        // Only latch applicationActive after all guards pass — ensures subsequent commands can retry
+        // view creation if the guard condition wasn't met (e.g., backgroundLaunch SDKInit in background
+        // before any canStartApplicationLaunchView command arrives).
+        applicationActive = true
 
         // Immediately start the ApplicationLaunchView for the new session
         _ = process(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests+RUMS5665.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests+RUMS5665.swift
@@ -1,0 +1,289 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+@testable import TestUtilities
+
+// RUMS-5665: Native iOS RUM batches not reaching custom endpoint for subset of users
+// after SDK upgrade from 2.30.2 to 3.x.
+//
+// Root cause: `RUMApplicationScope.startApplicationLaunchView` sets `applicationActive = true`
+// BEFORE the guard that checks `isUserLaunch`. When `launchReason == .backgroundLaunch`
+// (triggered by `task_policy_get` returning KERN_FAILURE or DEFAULTED on ~20% of devices),
+// the guard fails and returns early, but `applicationActive` is permanently latched to `true`.
+// All subsequent commands therefore skip the `startApplicationLaunchView` path entirely,
+// resulting in `handleOffViewCommand` being called with `RUMStopResourceCommand.canStartApplicationLaunchView == false`,
+// which silently drops the event and logs a "no view is active" warning.
+class RUMApplicationScopeTests_RUMS5665: XCTestCase {
+    let writer = FileWriterMock()
+
+    // MARK: - Helper
+
+    /// Creates a `RUMApplicationScope` that has received an `RUMSDKInitCommand` using the given `sdkContext`.
+    private func createScope(
+        sdkContext: DatadogContext,
+        samplingRate: Float = 100,
+        trackBackgroundEvents: Bool = false
+    ) -> RUMApplicationScope {
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                samplingRate: samplingRate,
+                trackBackgroundEvents: trackBackgroundEvents
+            )
+        )
+        let initCommand = RUMSDKInitCommand(time: sdkContext.sdkInitDate, globalAttributes: [:])
+        _ = scope.process(command: initCommand, context: sdkContext, writer: writer)
+        return scope
+    }
+
+    // MARK: - Test 1: backgroundLaunch permanently latches applicationActive without creating a view
+
+    /// Proves the latch bug: after `RUMSDKInitCommand` with `launchReason = .backgroundLaunch` in background,
+    /// `applicationActive` is set to `true` but NO ApplicationLaunch view is created.
+    /// Then `RUMStartResourceCommand` (which has `canStartApplicationLaunchView = true`) arrives —
+    /// because `applicationActive` is already `true`, `startApplicationLaunchView` is never called again,
+    /// and no view scope is ever started.
+    ///
+    /// Expected (correct) behaviour: either `applicationActive` should remain `false` until a view is
+    /// actually created, OR the guard should be evaluated before setting `applicationActive`.
+    ///
+    /// This test FAILS on the buggy code because `applicationActive == true` but `viewScopes.isEmpty == true`.
+    func test_backgroundLaunch_firstResourceCommand_setsApplicationActivePermanentlyWithoutCreatingView() throws {
+        // Given — SDK init in background with backgroundLaunch reason (simulates ~20% of devices where
+        // task_policy_get returns KERN_FAILURE/DEFAULTED)
+        let sdkContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: .mockDecember15th2019At10AMUTC())
+        )
+
+        let scope = createScope(sdkContext: sdkContext)
+
+        // After SDKInitCommand: no view should be created yet (background launch, correct so far)
+        let sessionAfterInit = try XCTUnwrap(scope.activeSession)
+        XCTAssertTrue(
+            sessionAfterInit.viewScopes.isEmpty,
+            "No view should be created on SDK init in background with backgroundLaunch"
+        )
+
+        // When — first non-init command arrives (StartResource, which has canStartApplicationLaunchView = true)
+        let resourceKey = "resources/network-request"
+        _ = scope.process(
+            command: RUMStartResourceCommand.mockWith(resourceKey: resourceKey, time: .mockDecember15th2019At10AMUTC().addingTimeInterval(1)),
+            context: sdkContext,
+            writer: writer
+        )
+
+        // Then — because of the latch bug, applicationActive is true but no view was ever created
+        // The fix should either:
+        //   a) not set applicationActive=true when guard fails, OR
+        //   b) create the ApplicationLaunch view retroactively via handleOffViewCommand
+        //
+        // On buggy code: applicationActive==true AND viewScopes is still empty => this assert FAILS (proving the bug)
+        let sessionAfterResource = try XCTUnwrap(scope.activeSession)
+        XCTAssertFalse(
+            sessionAfterResource.viewScopes.isEmpty,
+            "RUMS-5665: After StartResourceCommand with backgroundLaunch, an ApplicationLaunch view " +
+            "should have been created to host the resource. " +
+            "Bug: applicationActive is permanently latched to true after SDKInitCommand returned early, " +
+            "so startApplicationLaunchView is never called again even for commands with canStartApplicationLaunchView=true."
+        )
+    }
+
+    // MARK: - Test 2: RUMStopResourceCommand silently drops event when no view is active
+
+    /// Proves that `RUMStopResourceCommand` is silently dropped (and a warning logged) when the latch bug
+    /// leaves the session with no active view after `RUMStartResourceCommand` was similarly dropped.
+    ///
+    /// The customer's debug log showed exactly:
+    /// "RUMStopResourceCommand was detected, but no view is active"
+    /// with canStartApplicationLaunchView: false, canStartBackgroundView: false
+    ///
+    /// This test FAILS on the buggy code because no RUMResourceEvent is written to the output.
+    func test_backgroundLaunch_stopResourceCommand_dropsEventDueToNoActiveView() throws {
+        // Given — SDK init in background with backgroundLaunch reason
+        let sdkContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: .mockDecember15th2019At10AMUTC())
+        )
+
+        let scope = createScope(sdkContext: sdkContext)
+        let resourceKey = "resources/network-request"
+        let t0 = Date.mockDecember15th2019At10AMUTC()
+
+        // Start a resource (this itself fails to create a view due to the latch bug)
+        _ = scope.process(
+            command: RUMStartResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(1)),
+            context: sdkContext,
+            writer: writer
+        )
+
+        // When — stop the resource; with canStartApplicationLaunchView=false this falls into the "drop" path
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        _ = scope.process(
+            command: RUMStopResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(2)),
+            context: sdkContext,
+            writer: writer
+        )
+
+        // Then — the resource event must have been written if a view was active
+        // On buggy code: RUMResourceEvent is NOT written because StopResource has canStartApplicationLaunchView=false
+        // and falls into the drop path; this assertion FAILS (proving the bug)
+        let resourceEvents = writer.events(ofType: RUMResourceEvent.self)
+        XCTAssertFalse(
+            resourceEvents.isEmpty,
+            "RUMS-5665: RUMStopResourceCommand should produce a RUMResourceEvent. " +
+            "Bug: because no view was created (applicationActive latch), the event is silently dropped. " +
+            "Customer log: 'RUMStopResourceCommand was detected, but no view is active' with " +
+            "canStartApplicationLaunchView: false, canStartBackgroundView: false."
+        )
+
+        // Also verify: the warning about 'no view is active' should NOT be emitted when things work correctly
+        // (on buggy code the warning IS emitted, meaning events are being silently dropped)
+        XCTAssertNil(
+            dd.logger.warnLog?.message,
+            "RUMS-5665: No 'no view is active' warning should be emitted when resources are properly tracked. " +
+            "Bug: warning IS emitted because applicationActive latch prevents view creation."
+        )
+    }
+
+    // MARK: - Test 3: Regression boundary — userLaunch MUST create ApplicationLaunch view correctly
+
+    /// Regression boundary test: `launchReason = .userLaunch` should continue to create the
+    /// ApplicationLaunch view immediately on SDKInit, and subsequent resources should be tracked.
+    /// This test should PASS on both buggy and fixed code, confirming the fix boundary.
+    func test_userLaunch_createsApplicationLaunchView() throws {
+        // Given — SDK init in foreground with userLaunch reason (normal path, ~80% of devices)
+        let sdkContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .userLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInForeground(since: .mockDecember15th2019At10AMUTC())
+        )
+
+        let scope = createScope(sdkContext: sdkContext)
+
+        // Then — ApplicationLaunch view must be immediately present after SDKInitCommand
+        let session = try XCTUnwrap(scope.activeSession)
+        XCTAssertFalse(
+            session.viewScopes.isEmpty,
+            "With userLaunch, the ApplicationLaunch view must be created immediately on SDKInit."
+        )
+        let firstView = try XCTUnwrap(session.viewScopes.first)
+        XCTAssertEqual(
+            firstView.viewName,
+            RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName,
+            "First view must be the ApplicationLaunch view"
+        )
+
+        // And — resource commands are tracked inside that view
+        let resourceKey = "resources/network-request"
+        let t0 = Date.mockDecember15th2019At10AMUTC()
+
+        _ = scope.process(
+            command: RUMStartResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(1)),
+            context: sdkContext,
+            writer: writer
+        )
+        _ = scope.process(
+            command: RUMStopResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(2)),
+            context: sdkContext,
+            writer: writer
+        )
+
+        let resourceEvents = writer.events(ofType: RUMResourceEvent.self)
+        XCTAssertFalse(
+            resourceEvents.isEmpty,
+            "Resources must be tracked inside the ApplicationLaunch view for userLaunch scenario."
+        )
+    }
+
+    // MARK: - Test 4: Integration — backgroundLaunch then foreground transition then resource cycle
+
+    /// Integration test: SDK initialized with backgroundLaunch, scene transitions to foreground,
+    /// then a view is started and a resource cycle completes. Verifies no events are lost.
+    ///
+    /// This test FAILS on the buggy code because after the scene transitions to foreground,
+    /// if a resource is started before an explicit startView, `applicationActive` is already `true`
+    /// and no ApplicationLaunch or any other view is created to receive the resource.
+    func test_backgroundLaunch_thenForegroundTransition_resourcesAreTracked() throws {
+        // Given — SDK init in background (backgroundLaunch)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: .mockDecember15th2019At10AMUTC())
+        )
+
+        let scope = createScope(sdkContext: backgroundContext)
+
+        // Sanity: no view after background init
+        let sessionAfterInit = try XCTUnwrap(scope.activeSession)
+        XCTAssertTrue(sessionAfterInit.viewScopes.isEmpty, "No view yet in background")
+
+        // When — app transitions to foreground (scene becomes active)
+        let foregroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInForeground(since: .mockDecember15th2019At10AMUTC().addingTimeInterval(2))
+        )
+
+        // User starts a view (simulating UISceneDelegate or SwiftUI navigation)
+        _ = scope.process(
+            command: RUMStartViewCommand.mockWith(
+                time: .mockDecember15th2019At10AMUTC().addingTimeInterval(2),
+                identity: .mockViewIdentifier()
+            ),
+            context: foregroundContext,
+            writer: writer
+        )
+
+        // Then a resource is started and stopped within that view
+        let resourceKey = "resources/api-call"
+        let t0 = Date.mockDecember15th2019At10AMUTC().addingTimeInterval(2)
+
+        _ = scope.process(
+            command: RUMStartResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(1)),
+            context: foregroundContext,
+            writer: writer
+        )
+        _ = scope.process(
+            command: RUMStopResourceCommand.mockWith(resourceKey: resourceKey, time: t0.addingTimeInterval(2)),
+            context: foregroundContext,
+            writer: writer
+        )
+
+        // Then — resource event must be present in output
+        let resourceEvents = writer.events(ofType: RUMResourceEvent.self)
+        XCTAssertFalse(
+            resourceEvents.isEmpty,
+            "RUMS-5665: After transitioning to foreground following a backgroundLaunch, " +
+            "resources started within an explicit view must be tracked and reach the output. " +
+            "Bug: if applicationActive latch prevents any view from being created during the background " +
+            "phase, downstream resource events may also be affected depending on session state."
+        )
+
+        // View events should also be written
+        let viewEvents = writer.events(ofType: RUMViewEvent.self)
+        XCTAssertFalse(
+            viewEvents.isEmpty,
+            "At least one view event must be written after starting a view in foreground."
+        )
+    }
+}


### PR DESCRIPTION
### What and why?

Fixes [RUMS-5665](https://datadoghq.atlassian.net/browse/RUMS-5665): Native iOS RUM batches not reaching custom endpoint for a subset of users (~20%) after upgrading from SDK 2.30.2 to 3.x.

After the upgrade, affected users saw all RUM events silently dropped with the log:
```
RUMStopResourceCommand was detected, but no view is active
canStartApplicationLaunchView: false, canStartBackgroundView: false
```

This affected apps running on devices where `task_policy_get` returns `KERN_FAILURE` or `DEFAULTED`, causing `launchReason` to be set to `.backgroundLaunch` instead of `.userLaunch`.

### How?

**Root cause — two bugs in `RUMApplicationScope.startApplicationLaunchView`:**

**Bug 1 — Premature latch:**
`applicationActive = true` was set at the top of `startApplicationLaunchView`, *before* the guard that checks `isUserLaunch`. When `launchReason == .backgroundLaunch` and `RUMSDKInitCommand` arrives in background, the guard fails and returns early — but `applicationActive` is permanently latched to `true`. All subsequent commands skip the `if !applicationActive` path, meaning no view is ever created.

**Bug 2 — Overly-restrictive guard for backgroundLaunch:**
The guard condition for `backgroundLaunch` required `isStartedInForeground` (which is `true` only when `command is RUMSDKInitCommand`). This meant that once the SDKInit window passed, no subsequent command — not even `RUMStartResourceCommand` with `canStartApplicationLaunchView = true` — could trigger ApplicationLaunch view creation for the `backgroundLaunch` path.

**Call chain on affected devices:**
```
RUM.enable() in background (UISceneDelegate app, task_policy_get → KERN_FAILURE)
  → launchReason = .backgroundLaunch
  → RUMSDKInitCommand: startApplicationLaunchView → applicationActive=true SET (BUG1) → guard fails → early return, no view created
  → RUMStartResourceCommand: applicationActive=true → startApplicationLaunchView skipped entirely
  → RUMStopResourceCommand: handleOffViewCommand → canStartApplicationLaunchView=false → warning + drop
```

**Fix:**
1. Move `applicationActive = true` to *after* all guards pass, so the latch is only set when a view is actually created.
2. Extend the `backgroundLaunch` guard to also allow ApplicationLaunch view creation when a subsequent command arrives with `canStartApplicationLaunchView = true` — covering the case where SDKInit happened in background but the app is now handling user-visible work.

```swift
// Before (buggy):
applicationActive = true  // ← set before guard
guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) else {
    return  // guard fails, but latch already set
}

// After (fixed):
let backgroundLaunchWithEligibleCommand = isBackgroundLaunch && command.canStartApplicationLaunchView
guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) || backgroundLaunchWithEligibleCommand else {
    return
}
applicationActive = true  // ← set only after guard succeeds
```

### Files Changed

- `DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift` — fix latch placement and extend backgroundLaunch guard
- `DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests+RUMS5665.swift` — 4 regression tests proving the fix

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference ([RUMS-5665](https://datadoghq.atlassian.net/browse/RUMS-5665))
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs

### Test Results

- **4 new reproduction tests** in `RUMApplicationScopeTests_RUMS5665` — all pass
- **694 total tests** in `DatadogRUM iOS` scheme — 0 failures
- `test_backgroundLaunch_firstResourceCommand_setsApplicationActivePermanentlyWithoutCreatingView` — was failing, now passes
- `test_backgroundLaunch_stopResourceCommand_dropsEventDueToNoActiveView` — was failing, now passes
- `test_userLaunch_createsApplicationLaunchView` — regression boundary, passes on both buggy and fixed code
- `test_backgroundLaunch_thenForegroundTransition_resourcesAreTracked` — integration test, passes on fixed code

[RUMS-5665]: https://datadoghq.atlassian.net/browse/RUMS-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUMS-5665]: https://datadoghq.atlassian.net/browse/RUMS-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ