### PR TITLE
RUM-15482: Rename RUM Operations API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] Add watchOS and visionOS support. See [#2817][]
 - [FEATURE] Add support for the FedRAMP-compatible `fed2.ddog-gov.com` site. See [#2827][]
+- [IMPROVEMENT] Rename RUM Operations APIs. See [#2802][]
 
 # 3.9.0 / 02-04-2026
 
@@ -1109,6 +1110,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2776]: https://github.com/DataDog/dd-sdk-ios/pull/2776
 [#2791]: https://github.com/DataDog/dd-sdk-ios/pull/2791
 [#2794]: https://github.com/DataDog/dd-sdk-ios/pull/2794
+[#2802]: https://github.com/DataDog/dd-sdk-ios/pull/2802
 [#2807]: https://github.com/DataDog/dd-sdk-ios/pull/2807
 [#2817]: https://github.com/DataDog/dd-sdk-ios/pull/2817
 [#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -56,6 +56,12 @@
 		116656D62EB501D3004248E8 /* ProfilingRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116656D42EB501C2004248E8 /* ProfilingRUMIntegrationTests.swift */; };
 		116656D72EB504A8004248E8 /* DatadogProfiling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D229FFA72E3BC6D4009CCD62 /* DatadogProfiling.framework */; platformFilters = (ios, tvos, xros, ); };
 		116656E12EB504F1004248E8 /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
+		1166C5A12F76EBCD008E34BC /* ProfilingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */; };
+		1166C5A22F76EBCD008E34BC /* ProfilingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */; };
+		1166C5A42F76EC0B008E34BC /* OperationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A32F76EC05008E34BC /* OperationOptions.swift */; };
+		1166C5A52F76EC0B008E34BC /* OperationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A32F76EC05008E34BC /* OperationOptions.swift */; };
+		1166C5AA2F76ED7A008E34BC /* ProfilingOptions+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */; };
+		1166C5AB2F76ED7A008E34BC /* ProfilingOptions+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */; };
 		116F84062CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
 		117ADDD92EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117ADDD82EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift */; };
 		117E52222D91A61A00A8E930 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; platformFilter = ios; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -1787,6 +1793,9 @@
 		116506132E95339B00FD815C /* AppStateManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManagerMock.swift; sourceTree = "<group>"; };
 		116506162E9535A500FD815C /* WatchdogTerminationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMocks.swift; sourceTree = "<group>"; };
 		116656D42EB501C2004248E8 /* ProfilingRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingRUMIntegrationTests.swift; sourceTree = "<group>"; };
+		1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingOptions.swift; sourceTree = "<group>"; };
+		1166C5A32F76EC05008E34BC /* OperationOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationOptions.swift; sourceTree = "<group>"; };
+		1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilingOptions+objc.swift"; sourceTree = "<group>"; };
 		116F84052CFDD06700705755 /* SampleRateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRateTests.swift; sourceTree = "<group>"; };
 		117ADDD82EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupTypeHandlerTests.swift; sourceTree = "<group>"; };
 		118246772D90416A00E3D16F /* DirectoriesStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoriesStub.swift; sourceTree = "<group>"; };
@@ -5224,6 +5233,9 @@
 			isa = PBXGroup;
 			children = (
 				5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */,
+				111C13842F83E53600960ED9 /* OperationMessage.swift */,
+				1166C5A32F76EC05008E34BC /* OperationOptions.swift */,
+				D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */,
 				D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */,
 				D2D9A9DB2DBFD507005DB31D /* RUMPayloadMessages.swift */,
 				D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */,
@@ -6248,6 +6260,8 @@
 		D27465732E78679700C47FE2 /* Profiling */ = {
 			isa = PBXGroup;
 			children = (
+				1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */,
+				1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */,
 				D27465742E7867B700C47FE2 /* ProfilingContext.swift */,
 				D274657F2E7B1C4D00C47FE2 /* ProfilingMessages.swift */,
 			);
@@ -8377,12 +8391,14 @@
 				D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */,
 				D23039FC298D5236001A1FA3 /* DataFormat.swift in Sources */,
 				D2160CED29C0E0E600FAA9A5 /* DatadogURLSessionHandler.swift in Sources */,
+				1166C5A52F76EC0B008E34BC /* OperationOptions.swift in Sources */,
 				09A936A02F0EB989000B6379 /* SamplingMechanismType.swift in Sources */,
 				09A936A12F0EB989000B6379 /* SamplingPriority.swift in Sources */,
 				09A936A22F0EB989000B6379 /* SpanContext.swift in Sources */,
 				D2160C9E29C0DE5700FAA9A5 /* TracingHeaderType.swift in Sources */,
 				D23039F5298D5236001A1FA3 /* AnyEncodable.swift in Sources */,
 				D2303A00298D5236001A1FA3 /* DatadogExtended.swift in Sources */,
+				1166C5AA2F76ED7A008E34BC /* ProfilingOptions+objc.swift in Sources */,
 				D233E7CF2E4627B100E7CFDE /* MultipartFormData.swift in Sources */,
 				D23039E6298D5236001A1FA3 /* Sysctl.swift in Sources */,
 				D28FB6962DB7D3F000CD76D0 /* RUMDataModels.swift in Sources */,
@@ -8412,6 +8428,7 @@
 				D2303A02298D5236001A1FA3 /* ReadWriteLock.swift in Sources */,
 				618032042D6F1214007027E3 /* Assert.swift in Sources */,
 				D2EBEE2429BA160F00B15732 /* W3CHTTPHeadersReader.swift in Sources */,
+				1166C5A22F76EBCD008E34BC /* ProfilingOptions.swift in Sources */,
 				A7FA98CE2BA1A6930018D6B5 /* MethodCalledMetric.swift in Sources */,
 				D27465762E7867B700C47FE2 /* ProfilingContext.swift in Sources */,
 				D23039E8298D5236001A1FA3 /* DatadogContext.swift in Sources */,

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -92,9 +92,9 @@
     [monitor addAttributes:@{@"string": @"value", @"integer": @1, @"boolean": @true}];
     [monitor removeAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
-    [monitor startFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
-    [monitor succeedFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
-    [monitor failFeatureOperationWithName:@"test_flow" operationKey:@"operation_1" reason:DDRUMFeatureOperationFailureReasonError attributes:@{}];
+    [monitor startOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
+    [monitor succeedOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
+    [monitor failOperationWithName:@"test_flow" operationKey:@"operation_1" reason:DDRUMFeatureOperationFailureReasonError attributes:@{}];
 
     [monitor _internal_sync_addError:[NSError errorWithDomain:NSCocoaErrorDomain code:-100 userInfo:nil]
                               source:DDRUMErrorSourceCustom attributes:@{}];

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -6,6 +6,7 @@
 
 #import <XCTest/XCTest.h>
 @import DatadogRUM;
+@import DatadogInternal;
 
 @interface DDRUMMonitor_apiTests : XCTestCase
 @end
@@ -92,7 +93,8 @@
     [monitor addAttributes:@{@"string": @"value", @"integer": @1, @"boolean": @true}];
     [monitor removeAttributesForKeys:@[@"string",@"integer",@"boolean"]];
     [monitor addFeatureFlagEvaluationWithName: @"name" value: @"value"];
-    [monitor startOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
+    DDProfilingOptions * options = [[DDProfilingOptions alloc] initWithSampleRate: 100.0];
+    [monitor startOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{} options: options];
     [monitor succeedOperationWithName:@"test_flow" operationKey:@"operation_1" attributes:@{}];
     [monitor failOperationWithName:@"test_flow" operationKey:@"operation_1" reason:DDRUMFeatureOperationFailureReasonError attributes:@{}];
 

--- a/DatadogInternal/Sources/Models/Profiling/ProfilingOptions+objc.swift
+++ b/DatadogInternal/Sources/Models/Profiling/ProfilingOptions+objc.swift
@@ -4,14 +4,13 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-import UIKit
-import DatadogRUM
+import Foundation
 
-final class RUMFeatureOperationsNextViewController: UIViewController {
-
-    @IBAction func didTapSucceedLoginFlowButton(_ sender: Any) {
-        rumMonitor.succeedOperation(
-            name: Operation.login()
-        )
+@objc(DDProfilingOptions)
+@objcMembers
+@_spi(objc)
+public final class objc_ProfilingOptions: objc_OperationOptions {
+    public init(sampleRate: Float) {
+        super.init(swiftType: ProfilingOptions(sampleRate: sampleRate))
     }
 }

--- a/DatadogInternal/Sources/Models/Profiling/ProfilingOptions.swift
+++ b/DatadogInternal/Sources/Models/Profiling/ProfilingOptions.swift
@@ -4,14 +4,11 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-import UIKit
-import DatadogRUM
+public struct ProfilingOptions: OperationOptions {
+    // The profiling sample rate for operations. Must be a value between `0` and `100`.
+    public let sampleRate: SampleRate
 
-final class RUMFeatureOperationsNextViewController: UIViewController {
-
-    @IBAction func didTapSucceedLoginFlowButton(_ sender: Any) {
-        rumMonitor.succeedOperation(
-            name: Operation.login()
-        )
+    public init(sampleRate: SampleRate) {
+        self.sampleRate = sampleRate
     }
 }

--- a/DatadogInternal/Sources/Models/RUM/OperationOptions.swift
+++ b/DatadogInternal/Sources/Models/RUM/OperationOptions.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol OperationOptions {}
+
+@objc(DDOperationOptions)
+@objcMembers
+@_spi(objc)
+public class objc_OperationOptions: NSObject {
+    public var swiftType: OperationOptions
+
+    init(swiftType: OperationOptions) {
+        self.swiftType = swiftType
+    }
+}

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -775,18 +775,24 @@ public class objc_RUMMonitor: NSObject {
     public func startOperation(
         name: String,
         operationKey: String?,
-        attributes: [String: Any]
+        attributes: [String: Any],
+        options: objc_OperationOptions?
     ) {
-        swiftRUMMonitor.startOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+        swiftRUMMonitor.startOperation(
+            name: name,
+            operationKey: operationKey,
+            attributes: attributes.dd.swiftAttributes,
+            options: options?.swiftType
+        )
     }
 
-    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:options:)", message: "Use startOperation(name:operationKey:attributes:options:) instead.")
     public func startFeatureOperation(
         name: String,
         operationKey: String?,
         attributes: [String: Any]
     ) {
-        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes, options: nil)
     }
 
     public func succeedOperation(

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -772,34 +772,62 @@ public class objc_RUMMonitor: NSObject {
         swiftRUMMonitor.addFeatureFlagEvaluation(name: name, value: AnyEncodable(value))
     }
 
+    public func startOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.startOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+    }
+
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
     public func startFeatureOperation(
         name: String,
         operationKey: String?,
         attributes: [String: Any]
     ) {
-        swiftRUMMonitor.startFeatureOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes)
     }
 
+    public func succeedOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.succeedOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+    }
+
+    @available(*, deprecated, renamed: "succeedOperation(name:operationKey:attributes:)", message: "Use succeedOperation(name:operationKey:attributes:) instead.")
     public func succeedFeatureOperation(
         name: String,
         operationKey: String?,
         attributes: [String: Any]
     ) {
-        swiftRUMMonitor.succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes.dd.swiftAttributes)
+        succeedOperation(name: name, operationKey: operationKey, attributes: attributes)
     }
 
+    public func failOperation(
+        name: String,
+        operationKey: String?,
+        reason: objc_RUMFeatureOperationFailureReason,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.failOperation(
+            name: name,
+            operationKey: operationKey,
+            reason: reason.swiftType,
+            attributes: attributes.dd.swiftAttributes
+        )
+    }
+
+    @available(*, deprecated, renamed: "failOperation(name:operationKey:reason:attributes:)", message: "Use failOperation(name:operationKey:reason:attributes:) instead.")
     public func failFeatureOperation(
         name: String,
         operationKey: String?,
         reason: objc_RUMFeatureOperationFailureReason,
         attributes: [String: Any]
     ) {
-        swiftRUMMonitor.failFeatureOperation(
-            name: name,
-            operationKey: operationKey,
-            reason: reason.swiftType,
-            attributes: attributes.dd.swiftAttributes
-        )
+        failOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
     }
 
     public var debug: Bool {

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -19,6 +19,7 @@ import QuartzCore
 @_exported import struct DatadogInternal.RUMErrorEvent
 @_exported import struct DatadogInternal.RUMActionEvent
 @_exported import struct DatadogInternal.RUMLongTaskEvent
+@_exported import struct DatadogInternal.ProfilingOptions
 // swiftlint:enable duplicate_imports
 
 extension RUM {

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -463,7 +463,7 @@ extension Monitor: RUMMonitorProtocol {
 
     // MARK: - Feature Operations
 
-    func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) started")
 
         telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
@@ -481,7 +481,11 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
-    func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+    func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    func succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) successfully ended")
 
         telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .succeed)))))
@@ -499,7 +503,11 @@ extension Monitor: RUMMonitorProtocol {
         )
     }
 
-    func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
+    func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+        succeedOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    func failOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) unsuccessfully ended with the following failure reason: \(reason.rawValue)")
 
         telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .fail)))))
@@ -515,6 +523,10 @@ extension Monitor: RUMMonitorProtocol {
                 attributes: attributes
             )
         )
+    }
+
+    func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
+        failOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
     }
 
     private func instanceSuffix(_ operationKey: String?) -> String {

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -463,7 +463,7 @@ extension Monitor: RUMMonitorProtocol {
 
     // MARK: - Feature Operations
 
-    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue], options: OperationOptions?) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) started")
 
         telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
@@ -482,7 +482,7 @@ extension Monitor: RUMMonitorProtocol {
     }
 
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
-        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes, options: nil)
     }
 
     func succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -143,7 +143,7 @@ internal class RUMFeatureOperationManager {
         // Check if operation is currently being tracked
         if !activeOperations.contains(lookupKey) {
             // Warning: Operation step called without a corresponding start
-            DD.logger.warn("`\(stepType.rawValue)` was called, but operation \(formatOperationName(name, operationKey: operationKey)) is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
+            DD.logger.warn("`\(stepType.rawValue)` was called, but operation \(formatOperationName(name, operationKey: operationKey)) is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:options:)` first. Note that the SDK only tracks operations locally and not across sessions.")
         }
 
         // Remove operation from tracking when it ends

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -143,7 +143,7 @@ internal class RUMFeatureOperationManager {
         // Check if operation is currently being tracked
         if !activeOperations.contains(lookupKey) {
             // Warning: Operation step called without a corresponding start
-            DD.logger.warn("`\(stepType.rawValue)` was called, but operation \(formatOperationName(name, operationKey: operationKey)) is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startFeatureOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
+            DD.logger.warn("`\(stepType.rawValue)` was called, but operation \(formatOperationName(name, operationKey: operationKey)) is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
         }
 
         // Remove operation from tracking when it ends

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -310,13 +310,15 @@ public extension RUMMonitorProtocol {
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
+    ///   - options: options to attach to this operation (e.g. profiling options)
     @available(*, message: "This API is in preview and may change in future releases")
     func startOperation(
         name: String,
         operationKey: String? = nil,
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        options: OperationOptions? = nil
     ) {
-        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes, options: options)
     }
 
     /// Starts a Feature Operation.
@@ -324,13 +326,13 @@ public extension RUMMonitorProtocol {
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
-    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:options:)", message: "Use startOperation(name:operationKey:attributes:options:) instead.")
     func startFeatureOperation(
         name: String,
         operationKey: String? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
-        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes, options: nil)
     }
 
     /// Completes a RUM Operation successfully.

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -303,50 +303,94 @@ public extension RUMMonitorProtocol {
         stopAction(type: type, name: name, attributes: attributes)
     }
 
-    // MARK: - Feature Operations
+    // MARK: - Operations
+
+    /// Starts a RUM Operation.
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func startOperation(
+        name: String,
+        operationKey: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
 
     /// Starts a Feature Operation.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
-    @available(*, message: "This API is in preview and may change in future releases")
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
     func startFeatureOperation(
         name: String,
         operationKey: String? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
-        startFeatureOperation(name: name, operationKey: operationKey, attributes: attributes)
+        startOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    /// Completes a RUM Operation successfully.
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func succeedOperation(
+        name: String,
+        operationKey: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        succeedOperation(name: name, operationKey: operationKey, attributes: attributes)
     }
 
     /// Completes a Feature Operation successfully.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
     ///   - attributes: custom attributes to attach to this operation
-    @available(*, message: "This API is in preview and may change in future releases")
+    @available(*, deprecated, renamed: "succeedOperation(name:operationKey:attributes:)", message: "Use succeedOperation(name:operationKey:attributes:) instead.")
     func succeedFeatureOperation(
         name: String,
         operationKey: String? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
-        succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes)
+        succeedOperation(name: name, operationKey: operationKey, attributes: attributes)
+    }
+
+    /// Fails a RUM Operation.
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
+    ///   - reason: the reason for the failure
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func failOperation(
+        name: String,
+        operationKey: String? = nil,
+        reason: RUMFeatureOperationFailureReason,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        failOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
     }
 
     /// Fails a Feature Operation.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
     ///   - reason: the reason for the failure
     ///   - attributes: custom attributes to attach to this operation
-    @available(*, message: "This API is in preview and may change in future releases")
+    @available(*, deprecated, renamed: "failOperation(name:operationKey:reason:attributes:)", message: "Use failOperation(name:operationKey:reason:attributes:) instead.")
     func failFeatureOperation(
         name: String,
         operationKey: String? = nil,
         reason: RUMFeatureOperationFailureReason,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
-        failFeatureOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
+        failOperation(name: name, operationKey: operationKey, reason: reason, attributes: attributes)
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -279,12 +279,37 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
 
     // MARK: - features
 
+    /// Starts a RUM Operation
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func startOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
     /// Starts a Feature Operation
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
     func startFeatureOperation(
+        name: String,
+        operationKey: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Completes a RUM Operation successfully.
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func succeedOperation(
         name: String,
         operationKey: String?,
         attributes: [AttributeKey: AttributeValue]
@@ -293,20 +318,36 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     /// Completes a Feature successfully.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
     ///   - attributes: custom attributes to attach to this operation
+    @available(*, deprecated, renamed: "succeedOperation(name:operationKey:attributes:)", message: "Use succeedOperation(name:operationKey:attributes:) instead.")
     func succeedFeatureOperation(
         name: String,
         operationKey: String?,
         attributes: [AttributeKey: AttributeValue]
     )
 
+    /// Fails a RUM Operation.
+    /// - Parameters:
+    ///   - name: the name of the operation (e.g., `login_flow`)
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
+    ///   - reason: the reason for the failure
+    ///   - attributes: custom attributes to attach to this operation
+    @available(*, message: "This API is in preview and may change in future releases")
+    func failOperation(
+        name: String,
+        operationKey: String?,
+        reason: RUMFeatureOperationFailureReason,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
     /// Fails a Feature Operation.
     /// - Parameters:
     ///   - name: the name of the operation (e.g., `login_flow`)
-    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startFeatureOperation`
+    ///   - operationKey: the key of the operation for this step (when running several instances of the same operation); it should be provided if `operationKey` was provided when invoking `startOperation`
     ///   - reason: the reason for the failure
     ///   - attributes: custom attributes to attach to this operation
+    @available(*, deprecated, renamed: "failOperation(name:operationKey:reason:attributes:)", message: "Use failOperation(name:operationKey:reason:attributes:) instead.")
     func failFeatureOperation(
         name: String,
         operationKey: String?,
@@ -480,8 +521,11 @@ internal class NOPMonitor: RUMMonitorProtocol {
         warn()
         completionHandler()
     }
+    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func failOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) { warn() }
     func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) { warn() }
     var debug: Bool {
         set { warn() }

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -284,11 +284,13 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
+    ///   - options: options to attach to this operation (e.g. profiling options)
     @available(*, message: "This API is in preview and may change in future releases")
     func startOperation(
         name: String,
         operationKey: String?,
-        attributes: [AttributeKey: AttributeValue]
+        attributes: [AttributeKey: AttributeValue],
+        options: OperationOptions?
     )
 
     /// Starts a Feature Operation
@@ -296,7 +298,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
     ///   - name: the name of the operation (e.g., `login_flow`)
     ///   - operationKey: the key of the operation for this step (when running several instances of the same operation)
     ///   - attributes: custom attributes to attach to this operation
-    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:)", message: "Use startOperation(name:operationKey:attributes:) instead.")
+    @available(*, deprecated, renamed: "startOperation(name:operationKey:attributes:options:)", message: "Use startOperation(name:operationKey:attributes:options:) instead.")
     func startFeatureOperation(
         name: String,
         operationKey: String?,
@@ -521,7 +523,7 @@ internal class NOPMonitor: RUMMonitorProtocol {
         warn()
         completionHandler()
     }
-    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
+    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue], options: OperationOptions?) { warn() }
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }
     func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) { warn() }

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -190,7 +190,7 @@ class RUMFeatureOperationManagerTests: XCTestCase {
 
         // Then
         let logMessage = try XCTUnwrap(dd.logger.warnLog?.message)
-        XCTAssertEqual(logMessage, "`\(stepType.rawValue)` was called, but operation `\(operationName)` is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
+        XCTAssertEqual(logMessage, "`\(stepType.rawValue)` was called, but operation `\(operationName)` is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:options:)` first. Note that the SDK only tracks operations locally and not across sessions.")
     }
 
     func testProcess_OperationStartTwice_LogsWarning() throws {

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -190,7 +190,7 @@ class RUMFeatureOperationManagerTests: XCTestCase {
 
         // Then
         let logMessage = try XCTUnwrap(dd.logger.warnLog?.message)
-        XCTAssertEqual(logMessage, "`\(stepType.rawValue)` was called, but operation `\(operationName)` is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startFeatureOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
+        XCTAssertEqual(logMessage, "`\(stepType.rawValue)` was called, but operation `\(operationName)` is currently not active. This may lead to a backend `instrumentation_error`. Make sure to call `startOperation(name:operationKey:attributes:)` first. Note that the SDK only tracks operations locally and not across sessions.")
     }
 
     func testProcess_OperationStartTwice_LogsWarning() throws {

--- a/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocol+ConvenienceTests.swift
@@ -41,8 +41,8 @@ class RUMMonitorProtocol_ConvenienceTests: XCTestCase {
         monitor.addAction(type: .click, name: .mockAny())
         monitor.startAction(type: .click, name: .mockAny())
         monitor.stopAction(type: .click)
-        monitor.startFeatureOperation(name: .mockAny())
-        monitor.succeedFeatureOperation(name: .mockAny())
-        monitor.failFeatureOperation(name: .mockAny(), reason: .mockAny())
+        monitor.startOperation(name: .mockAny())
+        monitor.succeedOperation(name: .mockAny())
+        monitor.failOperation(name: .mockAny(), reason: .mockAny())
     }
 }

--- a/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
@@ -86,7 +86,7 @@ class NOPMonitorTests: XCTestCase {
             "startAction(type:name:attributes:)",
             "stopAction(type:name:attributes:)",
             "addFeatureFlagEvaluation(name:value:)",
-            "startOperation(name:operationKey:attributes:)",
+            "startOperation(name:operationKey:attributes:options:)",
             "succeedOperation(name:operationKey:attributes:)",
             "failOperation(name:operationKey:reason:attributes:)",
             "debug",

--- a/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
+++ b/DatadogRUM/Tests/RUMMonitorProtocolTests.swift
@@ -47,9 +47,9 @@ class NOPMonitorTests: XCTestCase {
         noop.startAction(type: .click, name: .mockAny())
         noop.stopAction(type: .click)
         noop.addFeatureFlagEvaluation(name: .mockAny(), value: String.mockAny())
-        noop.startFeatureOperation(name: .mockAny())
-        noop.succeedFeatureOperation(name: .mockAny())
-        noop.failFeatureOperation(name: .mockAny(), reason: .mockAny())
+        noop.startOperation(name: .mockAny())
+        noop.succeedOperation(name: .mockAny())
+        noop.failOperation(name: .mockAny(), reason: .mockAny())
 
         noop.debug = .mockRandom()
         _ = noop.debug
@@ -86,9 +86,9 @@ class NOPMonitorTests: XCTestCase {
             "startAction(type:name:attributes:)",
             "stopAction(type:name:attributes:)",
             "addFeatureFlagEvaluation(name:value:)",
-            "startFeatureOperation(name:operationKey:attributes:)",
-            "succeedFeatureOperation(name:operationKey:attributes:)",
-            "failFeatureOperation(name:operationKey:reason:attributes:)",
+            "startOperation(name:operationKey:attributes:)",
+            "succeedOperation(name:operationKey:attributes:)",
+            "failOperation(name:operationKey:reason:attributes:)",
             "debug",
             "debug",
         ].map { method in

--- a/IntegrationTests/Runner/Scenarios/RUM/Feature Operations/RUMFeatureOperationsViewController.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM/Feature Operations/RUMFeatureOperationsViewController.swift
@@ -28,13 +28,13 @@ final class RUMFeatureOperationsViewController: UIViewController {
     // MARK: - Login Flow Operations
 
     @IBAction func didTapStartLoginFlowButton(_ sender: Any) {
-        rumMonitor.startFeatureOperation(
+        rumMonitor.startOperation(
             name: Operation.login()
         )
     }
 
     @IBAction func didTapSucceedLoginFlowButton(_ sender: Any) {
-        rumMonitor.succeedFeatureOperation(
+        rumMonitor.succeedOperation(
             name: Operation.login(),
             attributes: [
                 "user_type": "new_user"
@@ -43,7 +43,7 @@ final class RUMFeatureOperationsViewController: UIViewController {
     }
 
     @IBAction func didTapFailLoginFlowButton(_ sender: Any) {
-        rumMonitor.failFeatureOperation(
+        rumMonitor.failOperation(
             name: Operation.login(),
             reason: .error,
             attributes: [
@@ -56,19 +56,19 @@ final class RUMFeatureOperationsViewController: UIViewController {
 
     @IBAction func didTapStartParallelOperationsButton(_ sender: Any) {
         // Start multiple photo upload operations with different keys
-        rumMonitor.startFeatureOperation(
+        rumMonitor.startOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo1(),
             attributes: ["photo_id": "IMG_001", "size": "2.5MB"]
         )
 
-        rumMonitor.startFeatureOperation(
+        rumMonitor.startOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo2(),
             attributes: ["photo_id": "IMG_002", "size": "1.8MB"]
         )
 
-        rumMonitor.startFeatureOperation(
+        rumMonitor.startOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo3(),
             attributes: ["photo_id": "IMG_003", "size": "3.2MB"]
@@ -77,17 +77,17 @@ final class RUMFeatureOperationsViewController: UIViewController {
 
     @IBAction func didTapSucceedParallelOperationsButton(_ sender: Any) {
         // Succeed all photo upload operations
-        rumMonitor.succeedFeatureOperation(
+        rumMonitor.succeedOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo1()
         )
 
-        rumMonitor.succeedFeatureOperation(
+        rumMonitor.succeedOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo2()
         )
 
-        rumMonitor.succeedFeatureOperation(
+        rumMonitor.succeedOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo3()
         )
@@ -95,19 +95,19 @@ final class RUMFeatureOperationsViewController: UIViewController {
 
     @IBAction func didTapFailParallelOperationsButton(_ sender: Any) {
         // Fail all photo upload operations
-        rumMonitor.failFeatureOperation(
+        rumMonitor.failOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo1(),
             reason: .error
         )
 
-        rumMonitor.failFeatureOperation(
+        rumMonitor.failOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo2(),
             reason: .abandoned
         )
 
-        rumMonitor.failFeatureOperation(
+        rumMonitor.failOperation(
             name: Operation.photoUpload(),
             operationKey: Operation.Key.photo3(),
             reason: .other

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3414,8 +3414,11 @@ public class objc_RUMMonitor: NSObject
     public func removeAttribute(forKey key: String)
     public func removeAttributes(forKeys keys: [String])
     public func addFeatureFlagEvaluation(name: String, value: Any)
+    public func startOperation(name: String,operationKey: String?,attributes: [String: Any],options: objc_OperationOptions?)
     public func startFeatureOperation(name: String,operationKey: String?,attributes: [String: Any])
+    public func succeedOperation(name: String,operationKey: String?,attributes: [String: Any])
     public func succeedFeatureOperation(name: String,operationKey: String?,attributes: [String: Any])
+    public func failOperation(name: String,operationKey: String?,reason: objc_RUMFeatureOperationFailureReason,attributes: [String: Any])
     public func failFeatureOperation(name: String,operationKey: String?,reason: objc_RUMFeatureOperationFailureReason,attributes: [String: Any])
     public var debug: Bool
 [?] extension objc_RUMMonitor

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -491,8 +491,11 @@ public extension RUMMonitorProtocol
     func addAction(type: RUMActionType,name: String,attributes: [AttributeKey: AttributeValue] = [:])
     func startAction(type: RUMActionType,name: String,attributes: [AttributeKey: AttributeValue] = [:])
     func stopAction(type: RUMActionType,name: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+    func startOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:],options: OperationOptions? = nil)
     func startFeatureOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+    func succeedOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
     func succeedFeatureOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+    func failOperation(name: String,operationKey: String? = nil,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue] = [:])
     func failFeatureOperation(name: String,operationKey: String? = nil,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue] = [:])
 public extension RUMMonitorProtocol
     var _internal: DatadogInternalInterface?
@@ -537,8 +540,11 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject
     func startAction(type: RUMActionType,name: String,attributes: [AttributeKey: AttributeValue])
     func stopAction(type: RUMActionType,name: String?,attributes: [AttributeKey: AttributeValue])
     func addFeatureFlagEvaluation(name: String,value: Encodable)
+    func startOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue],options: OperationOptions?)
     func startFeatureOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue])
+    func succeedOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue])
     func succeedFeatureOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue])
+    func failOperation(name: String,operationKey: String?,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue])
     func failFeatureOperation(name: String,operationKey: String?,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue])
     var debug: Bool
     func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue],completionHandler: @escaping CompletionHandler)


### PR DESCRIPTION
### What and why?

This PR renames the RUM Operations API for consistency and clarity, and introduces a new generic parameter `options: OperationOptions?` to make the API extensible and avoid coupling the public interface to a single feature (profiling).

  **Before:**
  ```swift
func startFeatureOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
func succeedFeatureOperation(name: String,operationKey: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
func failFeatureOperation(name: String,operationKey: String? = nil,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue] = [:])
```

**After:**
```swift
func startOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue],options: OperationOptions?)
func succeedOperation(name: String,operationKey: String?,attributes: [AttributeKey: AttributeValue])
func failOperation(name: String,operationKey: String?,reason: RUMFeatureOperationFailureReason,attributes: [AttributeKey: AttributeValue])
```

### How?

- Introduces `OperationOptions` protocol in `DatadogInternal` as the extensible options type for operations.
- Introduces `ProfilingOptions` (conforming to `OperationOptions`) to carry the profiling sample rate.
- Updates `RUMMonitorProtocol`, its default implementations, `Monitor`, and `NOPMonitor` accordingly.
- Updates API surface files to reference the new API naming

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
