### PR TITLE
[RUM-10349]Add telemetry to track WebView instrumentation usage

### DIFF
--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -120,6 +120,8 @@ public struct UsageTelemetry: SampledTelemetry {
         case addOperationStepVital(TelemetryUsageEvent.Telemetry.Usage.TelemetryCommonFeaturesUsage.AddOperationStepVital)
         /// GraphQL request detected
         case addGraphQLRequest
+        /// trackWebView API
+        case trackWebView
 
         /// Describes the properties of `addViewLoadingTime` usage telemetry.
         public struct ViewLoadingTime {

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -503,6 +503,11 @@ extension Telemetry {
     public func metric(name: String, attributes: [String: Encodable], sampleRate: SampleRate = MetricTelemetry.defaultSampleRate) {
         send(telemetry: .metric(MetricTelemetry(name: name, attributes: attributes, sampleRate: sampleRate)))
     }
+
+    /// Reports WebView tracking API usage.
+    public func trackWebView() {
+        send(telemetry: .usage(.init(event: .trackWebView, sampleRate: UsageTelemetry.defaultSampleRate)))
+    }
 }
 
 public struct NOPTelemetry: Telemetry {

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -504,9 +504,19 @@ extension Telemetry {
         send(telemetry: .metric(MetricTelemetry(name: name, attributes: attributes, sampleRate: sampleRate)))
     }
 
-    /// Reports WebView tracking API usage.
-    public func trackWebView() {
-        send(telemetry: .usage(.init(event: .trackWebView, sampleRate: UsageTelemetry.defaultSampleRate)))
+    /// Collects a usage telemetry event.
+    ///
+    /// - Parameters:
+    ///   - event: The usage event to report.
+    ///   - sampleRate: The sample rate for this event, applied in addition to the telemetry sample rate (15% by default).
+    ///     Must be a value between `0` (reject all) and `100` (keep all).
+    ///
+    ///     Note: This sample rate is compounded with the telemetry sample rate. For example, if the telemetry sample rate is 20% (default)
+    ///     and this event's sample rate is 15%, the effective sample rate for this event will be 3%.
+    ///
+    ///     This sample rate is applied in the telemetry receiver, after the event has been processed by the SDK core (tail-based sampling).
+    public func usage(event: UsageTelemetry.Event, sampleRate: SampleRate = UsageTelemetry.defaultSampleRate) {
+        send(telemetry: .usage(UsageTelemetry(event: event, sampleRate: sampleRate)))
     }
 }
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -107,10 +107,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
         // Check if GraphQL was detected in the captured states
         if let capturedState = capturedStates.compactMap({ $0 as? RUMURLSessionHandlerCapturedState }).first,
            capturedState.hasGraphQLHeaders {
-            telemetry.send(telemetry: .usage(.init(
-                event: .addGraphQLRequest,
-                sampleRate: UsageTelemetry.defaultSampleRate
-            )))
+            telemetry.usage(event: .addGraphQLRequest)
         }
 
         subscriber?.process(

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -377,6 +377,10 @@ private extension TelemetryUsageEvent.Telemetry.Usage {
             )
         case .addGraphQLRequest:
             self = .telemetryCommonFeaturesUsage(value: .graphQLRequest(value: .init()))
+        case .trackWebView:
+            self = .telemetryMobileFeaturesUsage(
+                value: .trackWebView(value: .init())
+            )
         }
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -466,7 +466,7 @@ extension Monitor: RUMMonitorProtocol {
     func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) started")
 
-        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
+        telemetry.usage(event: .addOperationStepVital(.init(actionType: .start)))
 
         process(
             command: RUMOperationStepVitalCommand(
@@ -484,7 +484,7 @@ extension Monitor: RUMMonitorProtocol {
     func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) successfully ended")
 
-        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .succeed)))))
+        telemetry.usage(event: .addOperationStepVital(.init(actionType: .succeed)))
 
         process(
             command: RUMOperationStepVitalCommand(
@@ -502,7 +502,7 @@ extension Monitor: RUMMonitorProtocol {
     func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason, attributes: [AttributeKey: AttributeValue]) {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) unsuccessfully ended with the following failure reason: \(reason.rawValue)")
 
-        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .fail)))))
+        telemetry.usage(event: .addOperationStepVital(.init(actionType: .fail)))
 
         process(
             command: RUMOperationStepVitalCommand(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -301,10 +301,10 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         if let command = command as? RUMAddViewLoadingTime {
             if viewScopes.isEmpty {
                 DD.logger.warn("No view found to add the loading time.")
-                dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: true, overwritten: command.overwrite)))))
+                dependencies.telemetry.usage(event: .addViewLoadingTime(.init(noActiveView: false, noView: true, overwritten: command.overwrite)))
             } else if !hasActiveView {
                 DD.logger.warn("No active view found to add the loading time.")
-                dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: true, noView: false, overwritten: command.overwrite)))))
+                dependencies.telemetry.usage(event: .addViewLoadingTime(.init(noActiveView: true, noView: false, overwritten: command.overwrite)))
             }
         }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -372,13 +372,13 @@ extension RUMViewScope {
             viewLoadingTime = time
             needsViewUpdate = true
             DD.logger.debug("View loading time \(time)ns added to the view \(viewName)")
-            dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: false)))))
+            dependencies.telemetry.usage(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: false)))
         } else if command.overwrite {
             let time = command.time.timeIntervalSince(viewStartTime)
             viewLoadingTime = time
             needsViewUpdate = true
             DD.logger.warn("View loading time already exists for the view \(viewName). Replacing the existing \(String(describing: viewLoadingTime))ns with the new \(time)ns loading time.")
-            dependencies.telemetry.send(telemetry: .usage(.init(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: true)))))
+            dependencies.telemetry.usage(event: .addViewLoadingTime(.init(noActiveView: false, noView: false, overwritten: true)))
         }
     }
 

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -584,10 +584,11 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockKeepAll())
 
         // When
-        receiver.receive(
+        let result = receiver.receive(
             message: .telemetry(.usage(.init(event: .trackWebView, sampleRate: 100))),
             from: NOPDatadogCore()
         )
+        XCTAssertTrue(result)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryUsageEvent.self).first

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -576,4 +576,27 @@ class TelemetryReceiverTests: XCTestCase {
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
         XCTAssertNil(event)
     }
+
+    // MARK: - Usage Telemetry Events
+
+    func testSendTelemetryUsage_trackWebView() {
+        // Given
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockKeepAll())
+
+        // When
+        receiver.receive(
+            message: .telemetry(.usage(.init(event: .trackWebView, sampleRate: 100))),
+            from: NOPDatadogCore()
+        )
+
+        // Then
+        let event = featureScope.eventsWritten(ofType: TelemetryUsageEvent.self).first
+        XCTAssertNotNil(event)
+        XCTAssertEqual(event?.effectiveSampleRate, 100)
+        guard case .telemetryMobileFeaturesUsage(let usage) = event?.telemetry.usage,
+              case .trackWebView = usage else {
+            XCTFail("Expected .telemetryMobileFeaturesUsage(.trackWebView)")
+            return
+        }
+    }
 }

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -581,6 +581,7 @@ class TelemetryReceiverTests: XCTestCase {
 
     func testSendTelemetryUsage_trackWebView() {
         // Given
+        featureScope.contextMock = .mockWith(source: "ios", sdkVersion: "sdk-version")
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockKeepAll())
 
         // When
@@ -594,6 +595,9 @@ class TelemetryReceiverTests: XCTestCase {
         let event = featureScope.eventsWritten(ofType: TelemetryUsageEvent.self).first
         XCTAssertNotNil(event)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
+        XCTAssertEqual(event?.service, "dd-sdk-ios")
+        XCTAssertEqual(event?.source, .ios)
+        XCTAssertEqual(event?.version, "sdk-version")
         guard case .telemetryMobileFeaturesUsage(let usage) = event?.telemetry.usage,
               case .trackWebView = usage else {
             XCTFail("Expected .telemetryMobileFeaturesUsage(.trackWebView)")

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -188,10 +188,7 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
         if interception.origin != "rum",
            let capturedState = capturedState,
            capturedState.hasGraphQLHeaders {
-            telemetry.send(telemetry: .usage(.init(
-                event: .addGraphQLRequest,
-                sampleRate: UsageTelemetry.defaultSampleRate
-            )))
+            telemetry.usage(event: .addGraphQLRequest)
         }
     }
 

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -162,7 +162,7 @@ public enum WebViewTracking {
             )
         )
 
-        core.telemetry.send(telemetry: .usage(.init(event: .trackWebView, sampleRate: UsageTelemetry.defaultSampleRate)))
+        core.telemetry.trackWebView()
     }
 
     /// Conversion matrix from global privacy level to fine-grained privaly levels.

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -161,6 +161,8 @@ public enum WebViewTracking {
                 forMainFrameOnly: false
             )
         )
+
+        core.telemetry.send(telemetry: .usage(.init(event: .trackWebView, sampleRate: UsageTelemetry.defaultSampleRate)))
     }
 
     /// Conversion matrix from global privacy level to fine-grained privaly levels.

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -162,7 +162,7 @@ public enum WebViewTracking {
             )
         )
 
-        core.telemetry.trackWebView()
+        core.telemetry.usage(event: .trackWebView)
     }
 
     /// Conversion matrix from global privacy level to fine-grained privaly levels.

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -250,7 +250,7 @@ class WebViewTrackingTests: XCTestCase {
                     XCTAssertEqual(try? matcher.value("error"), ["origin": "console"])
                     XCTAssertEqual(try? matcher.value("session_id"), "0110cab4-7471-480e-aa4e-7ce039ced355")
                     logMessageExpectation.fulfill()
-                case .context:
+                case .context, .telemetry:
                     break
                 default:
                     XCTFail("Unexpected message received: \(message)")
@@ -302,7 +302,7 @@ class WebViewTrackingTests: XCTestCase {
                     let matcher = JSONObjectMatcher(object: event)
                     XCTAssertEqual(try? matcher.value("view.id"), "64308fd4-83f9-48cb-b3e1-1e91f6721230")
                     rumMessageExpectation.fulfill()
-                case .context:
+                case .context, .telemetry:
                     break
                 default:
                     XCTFail("Unexpected message received: \(message)")
@@ -395,7 +395,7 @@ class WebViewTrackingTests: XCTestCase {
                     XCTAssertEqual(try? matcher.value("date"), 1_635_932_927_012)
                     XCTAssertEqual(try? matcher.value("slotId"), String(webView.hash))
                     recordMessageExpectation.fulfill()
-                case .context:
+                case .context, .telemetry:
                     break
                 default:
                     XCTFail("Unexpected message received: \(message)")
@@ -424,6 +424,89 @@ class WebViewTrackingTests: XCTestCase {
 
         messageHandler?.userContentController(controller, didReceive: webLogMessage)
         waitForExpectations(timeout: 1)
+    }
+
+    func testItSendsTrackWebViewUsageTelemetry() throws {
+        // Given
+        var capturedUsage: UsageTelemetry?
+        let core = PassthroughCoreMock(
+            messageReceiver: FeatureMessageReceiverMock { message in
+                if case .telemetry(.usage(let usage)) = message {
+                    capturedUsage = usage
+                }
+            }
+        )
+        let controller = DDUserContentController()
+
+        // When
+        try WebViewTracking.enableOrThrow(
+            tracking: controller,
+            hosts: [],
+            hostsSanitizer: HostsSanitizerMock(),
+            logsSampleRate: 100,
+            in: core
+        )
+
+        // Then
+        let usage = try XCTUnwrap(capturedUsage, "Expected a usage telemetry event to be sent")
+        XCTAssertEqual(usage.sampleRate, UsageTelemetry.defaultSampleRate)
+        guard case .trackWebView = usage.event else {
+            XCTFail("Expected .trackWebView usage event")
+            return
+        }
+    }
+
+    func testItSendsTrackWebViewUsageTelemetryOnlyOnce() throws {
+        // Given
+        var trackWebViewUsageCount = 0
+        let core = PassthroughCoreMock(
+            messageReceiver: FeatureMessageReceiverMock { message in
+                if case .telemetry(.usage(let usage)) = message, case .trackWebView = usage.event {
+                    trackWebViewUsageCount += 1
+                }
+            }
+        )
+        let controller = DDUserContentController()
+
+        // When - enable is called multiple times on the same controller
+        try (0..<3).forEach { _ in
+            try WebViewTracking.enableOrThrow(
+                tracking: controller,
+                hosts: [],
+                hostsSanitizer: HostsSanitizerMock(),
+                logsSampleRate: 100,
+                in: core
+            )
+        }
+
+        // Then
+        XCTAssertEqual(trackWebViewUsageCount, 1)
+    }
+
+    func testItSendsTrackWebViewUsageTelemetryAgainAfterDisable() throws {
+        // Given
+        var trackWebViewUsageCount = 0
+        let core = PassthroughCoreMock(
+            messageReceiver: FeatureMessageReceiverMock { message in
+                if case .telemetry(.usage(let usage)) = message, case .trackWebView = usage.event {
+                    trackWebViewUsageCount += 1
+                }
+            }
+        )
+        let controller = DDUserContentController()
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = controller
+        let webview = WKWebView(frame: .zero, configuration: configuration)
+
+        // When
+        WebViewTracking.enable(webView: webview, in: core)
+        XCTAssertEqual(trackWebViewUsageCount, 1)
+
+        WebViewTracking.disable(webView: webview)
+        WebViewTracking.enable(webView: webview, in: core)
+
+        // Then - disable clears user scripts so the duplicate guard passes again on re-enable
+        XCTAssertEqual(trackWebViewUsageCount, 2)
     }
 }
 


### PR DESCRIPTION
### What and why?
Adds trackWebView usage telemetry to WebViewTracking.enable(). We currently have no visibility into how many organizations use WebView tracking, since it is lazily initialized at runtime after the initial Configuration Telemetry is sent. This change fires a UsageTelemetry.Event.trackWebView event every time WebView tracking is successfully enabled, giving us the data needed to measure adoption.

### How?
 - Added case trackWebView to UsageTelemetry.Event in DatadogInternal                                                                                                                                               
 - Added the corresponding mapping in TelemetryReceiver (DatadogRUM) to route the event to .telemetryMobileFeaturesUsage(.trackWebView), matching the mobile usage schema
 - Called core.telemetry.send(telemetry: .usage(.init(event: .trackWebView, sampleRate: UsageTelemetry.defaultSampleRate))) at the end of WebViewTracking.enableOrThrow(), after both the NOPDatadogCore guard and  the duplicate-detection guard, so the event fires only on the first successful enable per controller     

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
