### PR TITLE
Fix flaky testBuildingImageWireframe_ItCreatesAResource by constraining CGRect mock size

### DIFF
--- a/DatadogSessionReplay/Tests/Processor/Builders/WireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Builders/WireframesBuilderTests.swift
@@ -64,7 +64,7 @@ class WireframesBuilderTests: XCTestCase {
     func testBuildingImageWireframe_ItCreatesAResource() throws {
         let id: WireframeID = .mockRandom()
         let resource: MockResource = .mockRandom()
-        let frame: CGRect = .mockRandom()
+        let frame: CGRect = .mockRandom(minWidth: 3, minHeight: 3)
         let clip = frame.insetBy(dx: 1, dy: 1)
         let builder = WireframesBuilder()
 


### PR DESCRIPTION
### What and why?
testBuildingImageWireframe_ItCreatesAResource in WireframesBuilderTests was flaky. CGRect.mockRandom() has no minimum size constraint, so it occasionally generates a frame with width < 2 or height < 2. When insetBy(dx: 1, dy: 1) is called on such a frame, it produces an empty or negative rect, causing SRContentClip to take the wrong branch and produce incorrect clip values.

### How?
Constrained the random frame to mockRandom(minWidth: 3, minHeight: 3), ensuring insetBy(dx: 1, dy: 1) always produces a valid non-empty rect. This is the same pattern already used in testContentClip_fromIntersection in the same file.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
