### PR TITLE
RUM-15310: When an active span is not sampled, pass sampling decision to RUM URLSession handler

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -6725,6 +6725,7 @@
 				D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */,
 				61DCC84C2C05D4E500CB59E5 /* SDKMetrics */,
 				D2AB895D2F71780900040F58 /* DeterministicSamplingIntegrationTests.swift */,
+				094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -9604,6 +9605,7 @@
 				118248652D908CE300E3D16F /* AnonymousIdentifierTests.swift in Sources */,
 				118248662D908CF400E3D16F /* RUMViewHitchesIntegrationTests.swift in Sources */,
 				118248672D908CF400E3D16F /* RUMAttributesIntegrationTests.swift in Sources */,
+				094B553F2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift in Sources */,
 				6119DDDE2DD24AB700DA80F9 /* AppRun.swift in Sources */,
 				6119DDDF2DD24AB700DA80F9 /* AppRunStep+Fixtures.swift in Sources */,
 				6119DDE02DD24AB700DA80F9 /* AppRunner.swift in Sources */,
@@ -9641,6 +9643,7 @@
 			files = (
 				118249272D9096B400E3D16F /* CoreTelemetryIntegrationTests.swift in Sources */,
 				118249282D9096B400E3D16F /* CoreMetricsIntegrationTests.swift in Sources */,
+				094B55402F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift in Sources */,
 				118249292D9096B400E3D16F /* WebLogIntegrationTests.swift in Sources */,
 				1182492A2D9096B400E3D16F /* AppHangsMonitoringTests.swift in Sources */,
 				1182492B2D9096B400E3D16F /* Datadog+MultipleInstancesIntegrationTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/RUM/RUMResourceTraceIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMResourceTraceIntegrationTests.swift
@@ -11,8 +11,6 @@ import TestUtilities
 @testable import DatadogRUM
 @testable import DatadogTrace
 
-private class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {}
-
 class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
     private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
 
@@ -28,121 +26,97 @@ class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
     }
 
     func testNoActiveSpan_traceSampled_sessionSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: true)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: false, spanSampled: true, sessionSampled: true, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.rum, span: span)
     }
 
     func testNoActiveSpan_traceSampled_sessionSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: true)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: false, spanSampled: true, sessionSampled: true, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
     }
 
     func testNoActiveSpan_traceSampled_sessionNotSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: true)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: false, spanSampled: true, sessionSampled: false, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testNoActiveSpan_traceSampled_sessionNotSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: true)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: false, spanSampled: true, sessionSampled: false, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testNoActiveSpan_traceNotSampled_sessionSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: false)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: false, spanSampled: false, sessionSampled: true, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.rum, span: span)
     }
 
     func testNoActiveSpan_traceNotSampled_sessionSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: false)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: false, spanSampled: false, sessionSampled: true, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
     }
 
     func testNoActiveSpan_traceNotSampled_sessionNotSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: false)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: false, spanSampled: false, sessionSampled: false, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testNoActiveSpan_traceNotSampled_sessionNotSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: false, sampled: false)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: false, spanSampled: false, sessionSampled: false, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testActiveSpan_traceSampled_sessionSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: true)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: true, spanSampled: true, sessionSampled: true, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.activeSpan, span: span)
     }
 
     func testActiveSpan_traceSampled_sessionSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: true)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: true, spanSampled: true, sessionSampled: true, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.activeSpan, span: span)
     }
 
     func testActiveSpan_traceSampled_sessionNotSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: true)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: true, spanSampled: true, sessionSampled: false, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testActiveSpan_traceSampled_sessionNotSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: true)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: true, spanSampled: true, sessionSampled: false, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testActiveSpan_traceNotSampled_sessionSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: false)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: true, spanSampled: false, sessionSampled: true, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.rum, span: span)
     }
 
     func testActiveSpan_traceNotSampled_sessionSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: false)
-        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: true, spanSampled: false, sessionSampled: true, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
     }
 
     func testActiveSpan_traceNotSampled_sessionNotSampled_requestSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: false)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        let span = prepare(activeSpan: true, spanSampled: false, sessionSampled: false, urlSessionTrackingSampled: true)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
     func testActiveSpan_traceNotSampled_sessionNotSampled_requestNotSampled() throws {
-        let span = initTraceAndMakeSpan(active: true, sampled: false)
-        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        let span = prepare(activeSpan: true, spanSampled: false, sessionSampled: false, urlSessionTrackingSampled: false)
         try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
     }
 
-    private func initTraceAndMakeSpan(active: Bool, sampled: Bool) -> OTSpan {
+    private func prepare(activeSpan: Bool, spanSampled: Bool, sessionSampled: Bool, urlSessionTrackingSampled: Bool) -> OTSpan {
         Trace.enable(
-            with: Trace.Configuration(sampleRate: sampled ? 90 : 5),
+            with: Trace.Configuration(sampleRate: spanSampled ? 90 : 5),
             in: core
         )
 
-        let span = Tracer.shared(in: core).startRootSpan(operationName: "test-op")
-        if active {
-            span.setActive()
-        }
-        return span
-    }
-
-    private func initRUM(sessionSampled: Bool, urlSessionTrackingSampled: Bool) {
         var config = RUM.Configuration(
             applicationID: .mockAny(),
             sessionSampleRate: sessionSampled ? 80 : 20,
             urlSessionTracking: .init(
                 firstPartyHostsTracing: .trace(
-                    hosts: ["example.com"],
+                    hosts: ["www.example.com"],
                     sampleRate: urlSessionTrackingSampled ? 70 : 10
                 )
             )
@@ -150,6 +124,15 @@ class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
         // This session ID is not sampled at 50%, but it is sampled at 60%.
         config.uuidGenerator = RUMUUIDGeneratorMock(uuid: RUMUUID(rawValue: UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!))
         RUM.enable(with: config, in: core)
+
+        // We need to wait for all the messages between features to stabilize so we have everything setup correctly.
+        core.flush()
+
+        let span = Tracer.shared(in: core).startRootSpan(operationName: "test-op")
+        if activeSpan {
+            span.setActive()
+        }
+        return span
     }
 
     enum SamplingExpectation {
@@ -160,7 +143,7 @@ class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
     }
 
     private func performRequestAndVerifyIfSampled(_ expectation: SamplingExpectation, span: OTSpan) throws {
-        let request = try sendURLSessionRequest(to: URL.mockAny(), using: InstrumentedSessionDelegate())
+        let request = try sendURLSessionRequest(to: URL.mockAny())
         let matchers = try core.waitAndReturnRUMEventMatchers()
         let possibleResourceMatcher = try matchers.first(where: { try $0.eventType() == "resource" })
 
@@ -195,7 +178,7 @@ class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
             XCTAssertNotEqual(request.value(forHTTPHeaderField: "x-datadog-trace-id"), spanDD.traceID.toString(representation: .decimal))
             XCTAssertNotNil(request.value(forHTTPHeaderField: "x-datadog-sampling-priority"))
             XCTAssertNotNil(request.value(forHTTPHeaderField: "traceparent"))
-            XCTAssertEqual(sessionSampleRate, 70)
+            XCTAssertEqual(sessionSampleRate, 80)
         } else { // expectation == .activeSpan
             let parentSpanIDString: String = try XCTUnwrap(resourceMatcher.attribute(forKeyPath: "_dd.parent_span_id"))
             let parentSpanID = SpanID(parentSpanIDString, representation: .decimal)
@@ -203,24 +186,7 @@ class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
             XCTAssertEqual(parentSpanID, spanDD.spanID)
             XCTAssertEqual(request.value(forHTTPHeaderField: "x-datadog-trace-id"), spanDD.traceID.toString(representation: .decimal))
             XCTAssertNotNil(request.value(forHTTPHeaderField: "traceparent"))
-            XCTAssertEqual(sessionSampleRate, 90)
+            XCTAssertEqual(sessionSampleRate, 80)
         }
-
-        print(matchers)
-    }
-
-    private func sendURLSessionRequest(to url: URL, using delegate: URLSessionDelegate, completionHandler: (() -> Void)? = nil) throws -> URLRequest {
-        let server = ServerMock(delivery: .success(response: .mockAny(), data: .mockAny()))
-        let session = server.getInterceptedURLSession(delegate: delegate)
-        let taskCompleted = expectation(description: "wait for task completion")
-        let task = session.dataTask(with: .mockWith(url: url)) { _, _, _ in
-            completionHandler?()
-            taskCompleted.fulfill()
-        }
-        task.resume()
-        waitForExpectations(timeout: 5)
-
-        let requests = server.waitAndReturnRequests(count: 1)
-        return try XCTUnwrap(requests.first)
     }
 }

--- a/Datadog/IntegrationUnitTests/RUM/RUMResourceTraceIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMResourceTraceIntegrationTests.swift
@@ -1,0 +1,226 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+@testable import DatadogCore
+@testable import DatadogRUM
+@testable import DatadogTrace
+
+private class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {}
+
+class RUMResourceTraceIntegrationTests: RUMSessionTestsBase {
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = DatadogCoreProxy()
+    }
+
+    override func tearDownWithError() throws {
+        try core.flushAndTearDown()
+        core = nil
+        super.tearDown()
+    }
+
+    func testNoActiveSpan_traceSampled_sessionSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: true)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.rum, span: span)
+    }
+
+    func testNoActiveSpan_traceSampled_sessionSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: true)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
+    }
+
+    func testNoActiveSpan_traceSampled_sessionNotSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: true)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testNoActiveSpan_traceSampled_sessionNotSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: true)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testNoActiveSpan_traceNotSampled_sessionSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: false)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.rum, span: span)
+    }
+
+    func testNoActiveSpan_traceNotSampled_sessionSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: false)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
+    }
+
+    func testNoActiveSpan_traceNotSampled_sessionNotSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: false)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testNoActiveSpan_traceNotSampled_sessionNotSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: false, sampled: false)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testActiveSpan_traceSampled_sessionSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: true)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.activeSpan, span: span)
+    }
+
+    func testActiveSpan_traceSampled_sessionSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: true)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.activeSpan, span: span)
+    }
+
+    func testActiveSpan_traceSampled_sessionNotSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: true)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testActiveSpan_traceSampled_sessionNotSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: true)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testActiveSpan_traceNotSampled_sessionSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: false)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.rum, span: span)
+    }
+
+    func testActiveSpan_traceNotSampled_sessionSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: false)
+        initRUM(sessionSampled: true, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionSampledRequestNotSampled, span: span)
+    }
+
+    func testActiveSpan_traceNotSampled_sessionNotSampled_requestSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: false)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: true)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    func testActiveSpan_traceNotSampled_sessionNotSampled_requestNotSampled() throws {
+        let span = initTraceAndMakeSpan(active: true, sampled: false)
+        initRUM(sessionSampled: false, urlSessionTrackingSampled: false)
+        try performRequestAndVerifyIfSampled(.sessionNotSampled, span: span)
+    }
+
+    private func initTraceAndMakeSpan(active: Bool, sampled: Bool) -> OTSpan {
+        Trace.enable(
+            with: Trace.Configuration(sampleRate: sampled ? 90 : 5),
+            in: core
+        )
+
+        let span = Tracer.shared(in: core).startRootSpan(operationName: "test-op")
+        if active {
+            span.setActive()
+        }
+        return span
+    }
+
+    private func initRUM(sessionSampled: Bool, urlSessionTrackingSampled: Bool) {
+        var config = RUM.Configuration(
+            applicationID: .mockAny(),
+            sessionSampleRate: sessionSampled ? 80 : 20,
+            urlSessionTracking: .init(
+                firstPartyHostsTracing: .trace(
+                    hosts: ["example.com"],
+                    sampleRate: urlSessionTrackingSampled ? 70 : 10
+                )
+            )
+        )
+        // This session ID is not sampled at 50%, but it is sampled at 60%.
+        config.uuidGenerator = RUMUUIDGeneratorMock(uuid: RUMUUID(rawValue: UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!))
+        RUM.enable(with: config, in: core)
+    }
+
+    enum SamplingExpectation {
+        case activeSpan
+        case rum
+        case sessionNotSampled
+        case sessionSampledRequestNotSampled
+    }
+
+    private func performRequestAndVerifyIfSampled(_ expectation: SamplingExpectation, span: OTSpan) throws {
+        let request = try sendURLSessionRequest(to: URL.mockAny(), using: InstrumentedSessionDelegate())
+        let matchers = try core.waitAndReturnRUMEventMatchers()
+        let possibleResourceMatcher = try matchers.first(where: { try $0.eventType() == "resource" })
+
+        if expectation == .sessionNotSampled {
+            XCTAssertNil(possibleResourceMatcher)
+            return
+        }
+
+        let resourceMatcher = try XCTUnwrap(possibleResourceMatcher)
+
+        if expectation == .sessionSampledRequestNotSampled {
+            XCTAssertNil(request.value(forHTTPHeaderField: "x-datadog-parent-id"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "x-datadog-trace-id"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "x-datadog-sampling-priority"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "traceparent"))
+            return
+        }
+
+        let spanIDString: String = try XCTUnwrap(resourceMatcher.attribute(forKeyPath: "_dd.span_id"))
+        let spanID = SpanID(spanIDString, representation: .decimal)
+        let traceIDString: String = try XCTUnwrap(resourceMatcher.attribute(forKeyPath: "_dd.trace_id"))
+        let traceID = TraceID(traceIDString, representation: .hexadecimal)
+        let sessionSampleRate: Float = try XCTUnwrap(resourceMatcher.attribute(forKeyPath: "_dd.configuration.session_sample_rate"))
+        let spanDD = try XCTUnwrap(span.context.dd)
+
+        XCTAssertNotEqual(spanID, spanDD.spanID)
+        XCTAssertNotEqual(request.value(forHTTPHeaderField: "x-datadog-parent-id"), spanDD.spanID.toString(representation: .decimal))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-datadog-sampling-priority"), "1")
+
+        if expectation == .rum {
+            XCTAssertNotEqual(traceID, span.context.dd?.traceID)
+            XCTAssertNotEqual(request.value(forHTTPHeaderField: "x-datadog-trace-id"), spanDD.traceID.toString(representation: .decimal))
+            XCTAssertNotNil(request.value(forHTTPHeaderField: "x-datadog-sampling-priority"))
+            XCTAssertNotNil(request.value(forHTTPHeaderField: "traceparent"))
+            XCTAssertEqual(sessionSampleRate, 70)
+        } else { // expectation == .activeSpan
+            let parentSpanIDString: String = try XCTUnwrap(resourceMatcher.attribute(forKeyPath: "_dd.parent_span_id"))
+            let parentSpanID = SpanID(parentSpanIDString, representation: .decimal)
+            XCTAssertEqual(traceID, spanDD.traceID)
+            XCTAssertEqual(parentSpanID, spanDD.spanID)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "x-datadog-trace-id"), spanDD.traceID.toString(representation: .decimal))
+            XCTAssertNotNil(request.value(forHTTPHeaderField: "traceparent"))
+            XCTAssertEqual(sessionSampleRate, 90)
+        }
+
+        print(matchers)
+    }
+
+    private func sendURLSessionRequest(to url: URL, using delegate: URLSessionDelegate, completionHandler: (() -> Void)? = nil) throws -> URLRequest {
+        let server = ServerMock(delivery: .success(response: .mockAny(), data: .mockAny()))
+        let session = server.getInterceptedURLSession(delegate: delegate)
+        let taskCompleted = expectation(description: "wait for task completion")
+        let task = session.dataTask(with: .mockWith(url: url)) { _, _, _ in
+            completionHandler?()
+            taskCompleted.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 5)
+
+        let requests = server.waitAndReturnRequests(count: 1)
+        return try XCTUnwrap(requests.first)
+    }
+}

--- a/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
+++ b/Datadog/IntegrationUnitTests/Trace/HeadBasedSamplingTests.swift
@@ -10,9 +10,9 @@ import XCTest
 import DatadogInternal
 import TestUtilities
 
-private class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {}
-
 class HeadBasedSamplingTests: XCTestCase {
+    private class InstrumentedSessionDelegate: NSObject, URLSessionDataDelegate {}
+
     private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
     private var traceConfig: Trace.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
 
@@ -234,7 +234,7 @@ class HeadBasedSamplingTests: XCTestCase {
         URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)
 
         // When
-        let request = try sendURLSessionRequest(to: "https://foo.com/request", using: InstrumentedSessionDelegate())
+        let request = try sendURLSessionRequest(to: URL(string: "https://foo.com/request")!, using: InstrumentedSessionDelegate())
 
         // Then
         let span = try XCTUnwrap(core.waitAndReturnSpanEvents().first, "It should send span event")
@@ -273,7 +273,7 @@ class HeadBasedSamplingTests: XCTestCase {
         URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)
 
         // When
-        let request = try sendURLSessionRequest(to: "https://foo.com/request", using: InstrumentedSessionDelegate())
+        let request = try sendURLSessionRequest(to: URL(string: "https://foo.com/request")!, using: InstrumentedSessionDelegate())
 
         // Then
         XCTAssertNil(core.waitAndReturnSpanEvents().first, "It should not send span event")
@@ -306,7 +306,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         let span = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
-        let request = try sendURLSessionRequest(to: "https://foo.com/request", using: InstrumentedSessionDelegate()) {
+        let request = try sendURLSessionRequest(to: URL(string: "https://foo.com/request")!, using: InstrumentedSessionDelegate()) {
             span.finish()
         }
 
@@ -355,7 +355,7 @@ class HeadBasedSamplingTests: XCTestCase {
 
         // When
         let span = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
-        let request = try sendURLSessionRequest(to: "https://foo.com/request", using: InstrumentedSessionDelegate()) {
+        let request = try sendURLSessionRequest(to: URL(string: "https://foo.com/request")!, using: InstrumentedSessionDelegate()) {
             span.finish()
         }
 
@@ -390,12 +390,12 @@ class HeadBasedSamplingTests: XCTestCase {
             firstPartyHostsTracing: .trace(hosts: ["foo.com"], sampleRate: distributedTraceSampling, traceControlInjection: .sampled)
         )
         Trace.enable(with: traceConfig, in: core)
-        URLSessionInstrumentation.enable(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)
+        URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: InstrumentedSessionDelegate.self), in: core)
 
         // When
         let span = Tracer.shared(in: core).startSpan(operationName: "active.span").setActive()
         span.setTag(key: SpanTags.manualDrop, value: true)
-        let request = try sendURLSessionRequest(to: "https://foo.com/request", using: InstrumentedSessionDelegate()) {
+        let request = try sendURLSessionRequest(to: URL(string: "https://foo.com/request")!, using: InstrumentedSessionDelegate()) {
             span.finish()
         }
 
@@ -566,49 +566,5 @@ class HeadBasedSamplingTests: XCTestCase {
         XCTAssertNotNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField))
         XCTAssertNotNil(request.value(forHTTPHeaderField: TracingHTTPHeaders.tagsField))
         XCTAssertEqual(request.value(forHTTPHeaderField: TracingHTTPHeaders.samplingPriorityField), "0")
-    }
-
-    // MARK: - Helpers
-
-    /// Sends request to `url` using real `URLSession` instrumented with provided `delegate`.
-    /// It returns the actual request that was sent to the server which can include additional headers set by the SDK.
-    ///
-    /// # Implementation note
-    /// `completionHandler` runs as part of `session.dataTask`'s completion handler. This is useful to finish
-    /// active (or parent) spans in a more realistic way. Here's a description of problem this solves.
-    ///
-    /// By the end of a request interception, the `DatadogURLSessionHandler.interceptionDidComplete(interception:)`
-    /// method is called. In situations where a span should be created to trace this request, that span is created inside this
-    /// method. This span can be a child of a currently active span, or a root span if no active span is present.
-    ///
-    /// If the SDK users want to trace a process that includes a request, one possibility is setting an active span before
-    /// initiating the request, and finishing it when the request ends, using the `DataTask` completion handler. Given
-    /// how interception implemented, `interceptionDidComplete(interception:)` runs after that completion
-    /// handler, which means if the active span is removed on the completion handler, there would not be an active session
-    /// any more.
-    ///
-    /// The SDK handles this situation (as well as if the SDK users immediately finish the active span after initiating the
-    /// request), so this is not a problem. However, in tests, we want to make sure this happens as we expect.
-    ///
-    /// In this specific method, and unlike most real world code, we block the main thread waiting for test expectations
-    /// after initiating the request. In the previous implementation, any active span would be terminated inside the test,
-    /// after we returned from this method, meaning after the entire request interception finished. This would not test
-    /// if the request interceptors handled correctly the fact the active session is gone by the end of the request, but still
-    /// existed in the beginning. Therefore, `completionHandler` was added, and runs as part of the `DataTask`
-    /// completion handler. This allows tests to finish active spans inside this completion handler, in a more realistic way,
-    /// close to what real world apps would do.
-    private func sendURLSessionRequest(to url: String, using delegate: URLSessionDelegate, completionHandler: (() -> Void)? = nil) throws -> URLRequest {
-        let server = ServerMock(delivery: .success(response: .mockAny(), data: .mockAny()))
-        let session = server.getInterceptedURLSession(delegate: delegate)
-        let taskCompleted = expectation(description: "wait for task completion")
-        let task = session.dataTask(with: .mockWith(url: URL(string: url)!)) { _, _, _ in
-            completionHandler?()
-            taskCompleted.fulfill()
-        }
-        task.resume()
-        waitForExpectations(timeout: 5)
-
-        let requests = server.waitAndReturnRequests(count: 1)
-        return try XCTUnwrap(requests.first)
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -248,7 +248,19 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandler, RU
 
 extension DistributedTracing {
     func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?, URLSessionHandlerCapturedState?) {
-        let activeSpanContext = networkContext?.activeSpanProvider?.activeSpanContext()
+        // Per RUM-15310: If there is an active span, and that span is sampled, we use it as the parent span,
+        // and set everything in the RUM resource span to be consistent with it.
+        // If we don't have an active span, or if we do have one, but it's not sampled, we ignore it. The
+        // latter case is important, as it provides RUM the opportunity to sample this request even if the
+        // trace that would be related to it is not. In that case, the RUM Resource span will be the root.
+        let activeSpanContext: ActiveSpanContext?
+        if let possibleActiveSpanContext = networkContext?.activeSpanProvider?.activeSpanContext(),
+           possibleActiveSpanContext.samplingPriority.isKept {
+            activeSpanContext = possibleActiveSpanContext
+        } else {
+            activeSpanContext = nil
+        }
+
         // When a RUM context is available, its `sessionSampler` is a `DeterministicSampler`
         // seeded from the session ID. Calling `combined(with:)` composes the session rate
         // with the tracing `samplingRate` while preserving the seed, so every resource in

--- a/IntegrationTests/Runner/Scenarios/RUM+TraceScenarios/RUM+TracingScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/RUM+TraceScenarios/RUM+TracingScenarios.swift
@@ -41,7 +41,7 @@ class RUMAndTracingURLSessionBaseScenario: URLSessionBaseScenario, TestScenario 
                     hosts: [
                         customGETResourceURL.host!
                     ],
-                    sampleRate: 100
+                    sampleRate: 0
                 )
             )
         case .delegateWithAdditionalFirstPartyHosts:

--- a/TestUtilities/Sources/Helpers/XCTestCase.swift
+++ b/TestUtilities/Sources/Helpers/XCTestCase.swift
@@ -99,4 +99,46 @@ extension XCTestCase {
         expectation.isInverted = true
         return expectation
     }
+
+    /// Sends request to `url` using real `URLSession` instrumented with provided `delegate`.
+    /// It returns the actual request that was sent to the server which can include additional headers set by the SDK.
+    ///
+    /// # Implementation note
+    /// `completionHandler` runs as part of `session.dataTask`'s completion handler. This is useful to finish
+    /// active (or parent) spans in a more realistic way. Here's a description of problem this solves.
+    ///
+    /// By the end of a request interception, the `DatadogURLSessionHandler.interceptionDidComplete(interception:)`
+    /// method is called. In situations where a span should be created to trace this request, that span is created inside this
+    /// method. This span can be a child of a currently active span, or a root span if no active span is present.
+    ///
+    /// If the SDK users want to trace a process that includes a request, one possibility is setting an active span before
+    /// initiating the request, and finishing it when the request ends, using the `DataTask` completion handler. Given
+    /// how interception implemented, `interceptionDidComplete(interception:)` runs after that completion
+    /// handler, which means if the active span is removed on the completion handler, there would not be an active session
+    /// any more.
+    ///
+    /// The SDK handles this situation (as well as if the SDK users immediately finish the active span after initiating the
+    /// request), so this is not a problem. However, in tests, we want to make sure this happens as we expect.
+    ///
+    /// In this specific method, and unlike most real world code, we block the main thread waiting for test expectations
+    /// after initiating the request. In the previous implementation, any active span would be terminated inside the test,
+    /// after we returned from this method, meaning after the entire request interception finished. This would not test
+    /// if the request interceptors handled correctly the fact the active session is gone by the end of the request, but still
+    /// existed in the beginning. Therefore, `completionHandler` was added, and runs as part of the `DataTask`
+    /// completion handler. This allows tests to finish active spans inside this completion handler, in a more realistic way,
+    /// close to what real world apps would do.
+    public func sendURLSessionRequest(to url: URL, using delegate: URLSessionDelegate? = nil, completionHandler: (() -> Void)? = nil) throws -> URLRequest {
+        let server = ServerMock(delivery: .success(response: .mockAny(), data: .mockAny()))
+        let session = server.getInterceptedURLSession(delegate: delegate)
+        let taskCompleted = expectation(description: "wait for task completion")
+        let task = session.dataTask(with: .mockWith(url: url)) { _, _, _ in
+            completionHandler?()
+            taskCompleted.fulfill()
+        }
+        task.resume()
+        waitForExpectations(timeout: 5)
+
+        let requests = server.waitAndReturnRequests(count: 1)
+        return try XCTUnwrap(requests.first)
+    }
 }


### PR DESCRIPTION
### What and why?

[This PR](https://github.com/DataDog/dd-sdk-ios/pull/2726) changes the behavior of RUM `URLSession` sampling: if there is an active span (APM) when the request happens, the RUM resource span will be attached to it (be a child of it) and uses its sampling decision.

That causes reduction in the number of sampled resource spans compared to before, in the situation where the RUM session is sampled, but the APM span is not.

To fix this, when the span is not sampled, it should not impose its decision, and RUM should still decide based on its own URLSession sampling rate.

### How?

A simple bit of logic was added to `DistributedTracing.modify`: we only consider the active span if it's sampled. Otherwise, we fallback to regular sampling.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
