### PR TITLE
[RUM-11767] Rename last_failure_status ddtag to retry_after

### DIFF
--- a/DatadogProfiling/Sources/RequestBuilder.swift
+++ b/DatadogProfiling/Sources/RequestBuilder.swift
@@ -56,7 +56,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
 
         var tags = ["retry_count:\(execution.attempt + 1)"]
         if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
+            tags.append("retry_after:\(previousResponseCode)")
         }
 
         let builder = URLRequestBuilder(

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -100,6 +100,20 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
     }
 
+    func testItSetsRetryQueryParameters() throws {
+        let randomAttempt: UInt = .mockRandom()
+        let randomStatus: Int = .mockRandom()
+
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When
+        let request = try builder.request(for: [mockEvent()], with: .mockRandom(), execution: .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt))
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+    }
+
     func testItSetsHTTPHeaders() throws {
         let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomVersion: String = .mockRandom(among: .decimalDigits)

--- a/DatadogRUM/Sources/Feature/RequestBuilder.swift
+++ b/DatadogRUM/Sources/Feature/RequestBuilder.swift
@@ -29,7 +29,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
     ) throws -> URLRequest {
         var tags = ["retry_count:\(execution.attempt + 1)"]
         if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
+            tags.append("retry_after:\(previousResponseCode)")
         }
 
         let filteredEvents = eventsFilter.filter(events: events)

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -109,7 +109,7 @@ class RequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: context, execution: execution)
 
         // Then
-        let expextedQuery = "ddsource=\(randomSource)&ddtags=retry_count:\(randomAttempt + 1),last_failure_status:\(randomStatus)"
+        let expextedQuery = "ddsource=\(randomSource)&ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)"
         XCTAssertEqual(request.url?.query, expextedQuery)
     }
 

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -36,7 +36,7 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
         ]
 
         if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
+            tags.append("retry_after:\(previousResponseCode)")
         }
 
         let decoder = JSONDecoder()

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
@@ -38,7 +38,7 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
         ]
 
         if let previousResponseCode = execution.previousResponseCode {
-            tags.append("last_failure_status:\(previousResponseCode)")
+            tags.append("retry_after:\(previousResponseCode)")
         }
 
         guard !events.isEmpty else {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -84,6 +84,20 @@ class ResourceRequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
     }
 
+    func testItSetsRetryQueryParameters() throws {
+        let randomAttempt: UInt = .mockRandom()
+        let randomStatus: Int = .mockRandom()
+
+        // Given
+        let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .init(previousResponseCode: randomStatus, attempt: randomAttempt))
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+    }
+
     func testItSetsHTTPHeaders() throws {
         let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomVersion: String = .mockRandom(among: .decimalDigits)

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -89,6 +89,20 @@ class SegmentRequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
     }
 
+    func testItSetsRetryQueryParameters() throws {
+        let randomAttempt: UInt = .mockRandom()
+        let randomStatus: Int = .mockRandom()
+
+        // Given
+        let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockAny(), execution: .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt))
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+    }
+
     func testItSetsHTTPHeaders() throws {
         let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomVersion: String = .mockRandom(among: .decimalDigits)


### PR DESCRIPTION
### What and why?
Rename the `last_failure_status` ddtag to `retry_after` in the `ddtags` query parameter to align with the RUM intake spec and Browser SDK convention.

### How?
Updated all request builders that previously appended `last_failure_status:<code>` to use `retry_after:<code>` instead:
  - `DatadogRUM/Sources/Feature/RequestBuilder.swift`
  - `DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift`
  - `DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift`
  - `DatadogProfiling/Sources/RequestBuilder.swift`
Added missing test coverage for the `retry_after` code path in the Session Replay and Profiling request builders.

### Review checklist
  - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
  - [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
  - [ ] Add CHANGELOG entry for user facing changes (not needed — internal tag rename)
  - [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
  - [ ] Run `make api-surface` when adding new APIs
