### PR TITLE
[RUM-15258] Enable visionOS and watchOS in SPM and podspecs

### DIFF
--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
   

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
   s.static_framework = true

--- a/DatadogFlags.podspec
+++ b/DatadogFlags.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/DatadogProfiling.podspec
+++ b/DatadogProfiling.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
   

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.9'
   s.ios.deployment_target = '12.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 

--- a/Makefile
+++ b/Makefile
@@ -276,9 +276,7 @@ spm-build-visionos:
 # Builds SPM package for watchOS
 spm-build-watchos:
 	# Build only compatible schemes for watchOS:
-	@$(MAKE) spm-build DESTINATION="generic/platform=watchOS" SCHEME="DatadogCore"
-	@$(MAKE) spm-build DESTINATION="generic/platform=watchOS" SCHEME="DatadogLogs"
-	@$(MAKE) spm-build DESTINATION="generic/platform=watchOS" SCHEME="DatadogTrace"
+	@$(MAKE) spm-build SCHEME="Datadog-Package" DESTINATION="generic/platform=watchOS"
 
 # Builds SPM package for macOS (and Mac Catalyst)
 spm-build-macos:

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,13 @@ let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment[
 
 let package = Package(
     name: "Datadog",
-    platforms: [.iOS(.v12), .tvOS(.v12), .macOS(.v12), .watchOS(.v7)],
+    platforms: [
+        .iOS(.v12),
+        .tvOS(.v12),
+        .macOS(.v12),
+        .watchOS(.v7),
+        .visionOS(.v1)
+    ],
     products: [
         .library(
             name: "DatadogCore",

--- a/TestUtilities/Package.swift
+++ b/TestUtilities/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version: 5.7.1
+// swift-tools-version: 5.10
 
 import PackageDescription
 
 let package = Package(
     name: "TestUtilities",
-    platforms: [.iOS(.v12), .tvOS(.v12), .macOS(.v12), .watchOS(.v7)],
+    platforms: [
+        .iOS(.v12),
+        .tvOS(.v12),
+        .macOS(.v12),
+        .watchOS(.v7),
+        .visionOS(.v1)
+    ],
     products: [
         .library(
             name: "TestUtilities",


### PR DESCRIPTION
### What and why?

Enable visionOS and watchOS platform declarations in all podspecs and `Package.swift` files, so that the Datadog iOS SDK can be consumed via SPM or CocoaPods on those platforms.

### How?

- Added `visionos.deployment_target` and `watchos.deployment_target` entries to each podspec that didn't already have them.
- Updated `Package.swift` and `TestUtilities/Package.swift` to include visionOS and watchOS platform targets.

> [!IMPORTANT]
>  Smoke Tests are intentionally left out for the moment, we need to find a way to cover both platform without drastically increasing our CI pipeline duration.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs