### PR TITLE
Fixes a potential crasher in the `DeterministicSampler` seed generation identified by codex.

### DIFF
--- a/DatadogInternal/Sources/Utils/DeterministicSampler.swift
+++ b/DatadogInternal/Sources/Utils/DeterministicSampler.swift
@@ -85,9 +85,9 @@ extension DeterministicSampler {
     public init(uuid: UUID, samplingRate: SampleRate) {
         assert(MemoryLayout<UUID>.size == 16)
         let seed = withUnsafePointer(to: uuid) { uuidPointer in
-            uuidPointer.withMemoryRebound(to: UInt64.self, capacity: 2) { pointer in
-                UInt64(bigEndian: pointer.successor().pointee) & 0x0000FFFFFFFFFFFF
-            }
+            let buffer = UnsafeRawBufferPointer(start: uuidPointer, count: MemoryLayout<UUID>.size)
+            let last8Bytes = buffer.loadUnaligned(fromByteOffset: 8, as: UInt64.self)
+            return UInt64(bigEndian: last8Bytes) & 0x0000FFFFFFFFFFFF
         }
         self.init(seed: seed, samplingRate: samplingRate)
     }

--- a/DatadogInternal/Sources/Utils/DeterministicSampler.swift
+++ b/DatadogInternal/Sources/Utils/DeterministicSampler.swift
@@ -84,7 +84,7 @@ extension DeterministicSampler {
     ///   - samplingRate: A percentage value between `0.0` and `100.0`.
     public init(uuid: UUID, samplingRate: SampleRate) {
         assert(MemoryLayout<UUID>.size == 16)
-        let seed = withUnsafePointer(to: uuid) { uuidPointer in
+        let seed = withUnsafePointer(to: uuid.uuid) { uuidPointer in
             let buffer = UnsafeRawBufferPointer(start: uuidPointer, count: MemoryLayout<UUID>.size)
             let last8Bytes = buffer.loadUnaligned(fromByteOffset: 8, as: UInt64.self)
             return UInt64(bigEndian: last8Bytes) & 0x0000FFFFFFFFFFFF

--- a/DatadogInternal/Tests/Utils/DeterministicSamplerTests.swift
+++ b/DatadogInternal/Tests/Utils/DeterministicSamplerTests.swift
@@ -38,4 +38,18 @@ final class DeterministicSamplerTests: XCTestCase {
         XCTAssertFalse(DeterministicSampler(seed: 0, samplingRate: 0.0).sample(), "rate=0.0 must never be sampled")
         XCTAssertFalse(DeterministicSampler(seed: UInt64.max, samplingRate: 0.0).sample(), "rate=0.0 must never be sampled regardless of seed")
     }
+
+    /// Tests the fast algorithm for creating a seed.
+    func testFastInit() {
+        func seedUsingReferenceImplementation(for uuid: UUID) -> UInt64 {
+            uuid.uuidString.split(separator: "-").last.flatMap { UInt64($0, radix: 16) } ?? 0
+        }
+
+        for _ in 0..<100 {
+            let uuid = UUID()
+            let fast = DeterministicSampler(uuid: uuid, samplingRate: 50)
+            let ref = DeterministicSampler(seed: seedUsingReferenceImplementation(for: uuid), samplingRate: 50)
+            XCTAssertEqual(fast.seed, ref.seed, "Seeds are different for UUID \(uuid.uuidString)")
+        }
+    }
 }


### PR DESCRIPTION
Calling `withMemoryRebound` on misaligned memory will crash. Although it's unlikely the UUID memory is misaligned in this situation, it may happen. Switched to a new implementation using `loadUnaligned`, allowing the compiler to switch between `LDR` or `LDUR` depending on the actual layout of the resulting code.

This was [identified by Codex](https://github.com/DataDog/dd-sdk-ios/pull/2811#discussion_r3023710556) and **must** be fixed before the release.