### PR TITLE
Client-side stats proof of concept: feature scaffolding + span lifecycle hook

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1909,6 +1909,7 @@
 		F70B4701C2C2A1684F3C15D2 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */; };
 		3B232F5C8965A13E7627237B /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */; };
 		5314C6635972BD3195DFF949 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C95A061626863603998100 /* StatsConcentrator.swift */; };
+		E7F1A2B409C4D5A800FNV1A2 /* FNV1aHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F1A2B309C4D5A800FNV1A1 /* FNV1aHash.swift */; };
 		D2C1A50B29C4C4CB00946C31 /* SpanEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */; };
 		D2C1A50C29C4C4CB00946C31 /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
 		D2C1A50D29C4C4CB00946C31 /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
@@ -1957,6 +1958,7 @@
 		48199DE79B0AB44B90ED6B67 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */; };
 		A9432D701FBDB1B4BFB4FA3A /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */; };
 		CD0D865B184DCEF621175B55 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C95A061626863603998100 /* StatsConcentrator.swift */; };
+		E7F1A2B509C4D5A800FNV1A3 /* FNV1aHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F1A2B309C4D5A800FNV1A1 /* FNV1aHash.swift */; };
 		D2C1A55129C4F2DF00946C31 /* TracingURLSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25BADA029C1EF3000112069 /* TracingURLSessionHandler.swift */; };
 		D2C1A55229C4F2DF00946C31 /* DatadogTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546BF029AF4F550054E00B /* DatadogTracer.swift */; };
 		D2C1A55F29C4F2E800946C31 /* Casting+Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89C24509C1100DA608C /* Casting+Tracing.swift */; };
@@ -3826,6 +3828,7 @@
 		A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
 		825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshot.swift; sourceTree = "<group>"; };
 		84C95A061626863603998100 /* StatsConcentrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentrator.swift; sourceTree = "<group>"; };
+		E7F1A2B309C4D5A800FNV1A1 /* FNV1aHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FNV1aHash.swift; sourceTree = "<group>"; };
 		D2546C0A29AF56270054E00B /* MessageReceivers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivers.swift; sourceTree = "<group>"; };
 		D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEventIntegrationTests.swift; sourceTree = "<group>"; };
 		D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisher.swift; sourceTree = "<group>"; };
@@ -7454,6 +7457,7 @@
 			isa = PBXGroup;
 			children = (
 				84C95A061626863603998100 /* StatsConcentrator.swift */,
+				E7F1A2B309C4D5A800FNV1A1 /* FNV1aHash.swift */,
 			);
 			path = ClientStats;
 			sourceTree = "<group>";
@@ -11078,6 +11082,7 @@
 				F70B4701C2C2A1684F3C15D2 /* StatsRequestBuilder.swift in Sources */,
 				3B232F5C8965A13E7627237B /* SpanSnapshot.swift in Sources */,
 				5314C6635972BD3195DFF949 /* StatsConcentrator.swift in Sources */,
+				E7F1A2B409C4D5A800FNV1A2 /* FNV1aHash.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
 			);
@@ -11396,6 +11401,7 @@
 				48199DE79B0AB44B90ED6B67 /* StatsRequestBuilder.swift in Sources */,
 				A9432D701FBDB1B4BFB4FA3A /* SpanSnapshot.swift in Sources */,
 				CD0D865B184DCEF621175B55 /* StatsConcentrator.swift in Sources */,
+				E7F1A2B509C4D5A800FNV1A3 /* FNV1aHash.swift in Sources */,
 				D2C1A55129C4F2DF00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A55229C4F2DF00946C31 /* DatadogTracer.swift in Sources */,
 			);

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -971,6 +971,12 @@
 		619CE75F2A458CE1005588CB /* TraceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */; };
 		619CE7612A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
 		619CE7622A458D66005588CB /* TraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619CE7602A458D66005588CB /* TraceTests.swift */; };
+		77B87DD6C47BFFE756892D97 /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C09A41496113F22F2EFED /* ClientStatsFeatureTests.swift */; };
+		A33D5A7110557D86938E21EB /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011C09A41496113F22F2EFED /* ClientStatsFeatureTests.swift */; };
+		B1387F34A917DAA40BA2F22B /* StatsConcentratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DFD85BB827459822B0F7DE /* StatsConcentratorTests.swift */; };
+		1EAA603AC42AFFD114B91E8B /* SpanSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10694F96A7279292CFC5B3 /* SpanSnapshotTests.swift */; };
+		1EAA603AC42AFFD114B91E8C /* StatsConcentratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DFD85BB827459822B0F7DE /* StatsConcentratorTests.swift */; };
+		1EAA603AC42AFFD114B91E8D /* SpanSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10694F96A7279292CFC5B3 /* SpanSnapshotTests.swift */; };
 		619F1A242DEE493F003954BD /* LaunchReasonResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */; };
 		619F1A252DEE493F003954BD /* LaunchReasonResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */; };
 		619F1A282DEF0B3F003954BD /* LaunchReasonResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */; };
@@ -1899,6 +1905,10 @@
 		D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25BADA029C1EF3000112069 /* TracingURLSessionHandler.swift */; };
 		D2C1A50929C4C4CB00946C31 /* SpanEventEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEventEncoder.swift */; };
 		D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546C0329AF55AA0054E00B /* TraceFeature.swift */; };
+		2AFE8005124A2C1B751DE1E6 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE1ADFF46DC8B5876CC2F38 /* ClientStatsFeature.swift */; };
+		F70B4701C2C2A1684F3C15D2 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */; };
+		3B232F5C8965A13E7627237B /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */; };
+		5314C6635972BD3195DFF949 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C95A061626863603998100 /* StatsConcentrator.swift */; };
 		D2C1A50B29C4C4CB00946C31 /* SpanEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */; };
 		D2C1A50C29C4C4CB00946C31 /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
 		D2C1A50D29C4C4CB00946C31 /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
@@ -1943,6 +1953,10 @@
 		D2C1A54E29C4F2DF00946C31 /* OTFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E724A24DD3005EA2DE /* OTFormat.swift */; };
 		D2C1A54F29C4F2DF00946C31 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
 		D2C1A55029C4F2DF00946C31 /* TraceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546C0329AF55AA0054E00B /* TraceFeature.swift */; };
+		CC0874DF88B61C036BFEBA58 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE1ADFF46DC8B5876CC2F38 /* ClientStatsFeature.swift */; };
+		48199DE79B0AB44B90ED6B67 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */; };
+		A9432D701FBDB1B4BFB4FA3A /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */; };
+		CD0D865B184DCEF621175B55 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C95A061626863603998100 /* StatsConcentrator.swift */; };
 		D2C1A55129C4F2DF00946C31 /* TracingURLSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25BADA029C1EF3000112069 /* TracingURLSessionHandler.swift */; };
 		D2C1A55229C4F2DF00946C31 /* DatadogTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546BF029AF4F550054E00B /* DatadogTracer.swift */; };
 		D2C1A55F29C4F2E800946C31 /* Casting+Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89C24509C1100DA608C /* Casting+Tracing.swift */; };
@@ -3404,6 +3418,9 @@
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
 		619CE75D2A458CE1005588CB /* TraceConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceConfigurationTests.swift; sourceTree = "<group>"; };
 		619CE7602A458D66005588CB /* TraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTests.swift; sourceTree = "<group>"; };
+		011C09A41496113F22F2EFED /* ClientStatsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeatureTests.swift; sourceTree = "<group>"; };
+		22DFD85BB827459822B0F7DE /* StatsConcentratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentratorTests.swift; sourceTree = "<group>"; };
+		FF10694F96A7279292CFC5B3 /* SpanSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshotTests.swift; sourceTree = "<group>"; };
 		619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReasonResolver.swift; sourceTree = "<group>"; };
 		619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReasonResolverTests.swift; sourceTree = "<group>"; };
 		61A2CC202A443D330000FF25 /* DDRUMConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMConfigurationTests.swift; sourceTree = "<group>"; };
@@ -3805,6 +3822,10 @@
 		D2546BF029AF4F550054E00B /* DatadogTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTracer.swift; sourceTree = "<group>"; };
 		D2546C0329AF55AA0054E00B /* TraceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceFeature.swift; sourceTree = "<group>"; };
 		D2546C0729AF55E90054E00B /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
+		FFE1ADFF46DC8B5876CC2F38 /* ClientStatsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeature.swift; sourceTree = "<group>"; };
+		A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
+		825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshot.swift; sourceTree = "<group>"; };
+		84C95A061626863603998100 /* StatsConcentrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentrator.swift; sourceTree = "<group>"; };
 		D2546C0A29AF56270054E00B /* MessageReceivers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivers.swift; sourceTree = "<group>"; };
 		D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEventIntegrationTests.swift; sourceTree = "<group>"; };
 		D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisher.swift; sourceTree = "<group>"; };
@@ -6596,6 +6617,7 @@
 				61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */,
 				614872762485067300E3EBDB /* SpanTagsReducer.swift */,
 				61CE58592B48174D00479510 /* SpanWriteContext.swift */,
+				825B72534A26D3AB5D458B82 /* SpanSnapshot.swift */,
 			);
 			path = Span;
 			sourceTree = "<group>";
@@ -7405,6 +7427,8 @@
 				D2546C0329AF55AA0054E00B /* TraceFeature.swift */,
 				D2546C0729AF55E90054E00B /* RequestBuilder.swift */,
 				D2546C0A29AF56270054E00B /* MessageReceivers.swift */,
+				FFE1ADFF46DC8B5876CC2F38 /* ClientStatsFeature.swift */,
+				A26A2FA864409C70B0D26CBD /* StatsRequestBuilder.swift */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -7415,6 +7439,23 @@
 				D21A94F12B8397CA00AC4256 /* WebViewMessage.swift */,
 			);
 			path = WebViewTracking;
+			sourceTree = "<group>";
+		};
+		1EAA603AC42AFFD114B91E80 /* ClientStats */ = {
+			isa = PBXGroup;
+			children = (
+				22DFD85BB827459822B0F7DE /* StatsConcentratorTests.swift */,
+				FF10694F96A7279292CFC5B3 /* SpanSnapshotTests.swift */,
+			);
+			path = ClientStats;
+			sourceTree = "<group>";
+		};
+		CBB0732CF4B141BE822BC0CB /* ClientStats */ = {
+			isa = PBXGroup;
+			children = (
+				84C95A061626863603998100 /* StatsConcentrator.swift */,
+			);
+			path = ClientStats;
 			sourceTree = "<group>";
 		};
 		D25EE93529C4C3C300CE3839 /* DatadogTrace */ = {
@@ -7428,6 +7469,7 @@
 				61A2CC382A44B0EA0000FF25 /* Trace.swift */,
 				61A2CC352A44B0A20000FF25 /* TraceConfiguration.swift */,
 				61A2CC3B2A44BED30000FF25 /* Tracer.swift */,
+				CBB0732CF4B141BE822BC0CB /* ClientStats */,
 				D2546C0629AF55CE0054E00B /* Feature */,
 				D21C26E928AF9D22005DD405 /* Integrations */,
 				11F55FEA2DCE501A00DE4944 /* Objc */,
@@ -7457,6 +7499,8 @@
 				61E45BD02450F64100F2C652 /* Span */,
 				61C5A89924509C1100DA608C /* Utils */,
 				619CE7602A458D66005588CB /* TraceTests.swift */,
+				011C09A41496113F22F2EFED /* ClientStatsFeatureTests.swift */,
+				1EAA603AC42AFFD114B91E80 /* ClientStats */,
 			);
 			name = DatadogTraceTests;
 			path = ../DatadogTrace/Tests;
@@ -11030,6 +11074,10 @@
 				3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */,
 				D2C1A4FA29C4C4CB00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
+				2AFE8005124A2C1B751DE1E6 /* ClientStatsFeature.swift in Sources */,
+				F70B4701C2C2A1684F3C15D2 /* StatsRequestBuilder.swift in Sources */,
+				3B232F5C8965A13E7627237B /* SpanSnapshot.swift in Sources */,
+				5314C6635972BD3195DFF949 /* StatsConcentrator.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
 			);
@@ -11051,6 +11099,9 @@
 				D2C1A51C29C4C75700946C31 /* ContextMessageReceiverTests.swift in Sources */,
 				3C6C7FFD2B459AF6006F5CBC /* OTelSpanTests.swift in Sources */,
 				619CE7612A458D66005588CB /* TraceTests.swift in Sources */,
+				77B87DD6C47BFFE756892D97 /* ClientStatsFeatureTests.swift in Sources */,
+				B1387F34A917DAA40BA2F22B /* StatsConcentratorTests.swift in Sources */,
+				1EAA603AC42AFFD114B91E8B /* SpanSnapshotTests.swift in Sources */,
 				615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A52029C4C75700946C31 /* DDSpanTests.swift in Sources */,
 				3C5D636C2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */,
@@ -11341,6 +11392,10 @@
 				3CFF5D4A2B555F4F00FC483A /* OTelTracerProvider.swift in Sources */,
 				D2C1A54F29C4F2DF00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A55029C4F2DF00946C31 /* TraceFeature.swift in Sources */,
+				CC0874DF88B61C036BFEBA58 /* ClientStatsFeature.swift in Sources */,
+				48199DE79B0AB44B90ED6B67 /* StatsRequestBuilder.swift in Sources */,
+				A9432D701FBDB1B4BFB4FA3A /* SpanSnapshot.swift in Sources */,
+				CD0D865B184DCEF621175B55 /* StatsConcentrator.swift in Sources */,
 				D2C1A55129C4F2DF00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A55229C4F2DF00946C31 /* DatadogTracer.swift in Sources */,
 			);
@@ -11362,6 +11417,9 @@
 				D2C1A56529C4F2E800946C31 /* ContextMessageReceiverTests.swift in Sources */,
 				3C6C80002B459AF6006F5CBC /* OTelSpanTests.swift in Sources */,
 				619CE7622A458D66005588CB /* TraceTests.swift in Sources */,
+				A33D5A7110557D86938E21EB /* ClientStatsFeatureTests.swift in Sources */,
+				1EAA603AC42AFFD114B91E8C /* StatsConcentratorTests.swift in Sources */,
+				1EAA603AC42AFFD114B91E8D /* SpanSnapshotTests.swift in Sources */,
 				615192D12BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A56629C4F2E800946C31 /* DDSpanTests.swift in Sources */,
 				3C5D636D2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */,

--- a/DatadogTrace/Sources/ClientStats/FNV1aHash.swift
+++ b/DatadogTrace/Sources/ClientStats/FNV1aHash.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// FNV-1a 64-bit hash utility.
+///
+/// Used to produce a stable hash of peer tag key-value pairs for stats aggregation.
+/// The format matches the Go reference implementation: sorted `"key=value,"` pairs
+/// fed byte-by-byte into FNV-1a.
+internal enum FNV1aHash {
+    private static let offsetBasis: UInt64 = 14_695_981_039_346_656_037
+    private static let prime: UInt64 = 1_099_511_628_211
+
+    /// Hashes the subset of `peerTags` whose keys appear in `keys`.
+    ///
+    /// - Returns: 0 when no matching peer tags are found.
+    static func hash(peerTags tags: [String: String], keys: [String]) -> UInt64 {
+        let pairs = keys
+            .compactMap { key -> (String, String)? in
+                guard let value = tags[key], !value.isEmpty else {
+                    return nil
+                }
+                return (key, value)
+            }
+        let relevant = pairs
+            .sorted { $0.0 < $1.0 }
+
+        guard !relevant.isEmpty else {
+            return 0
+        }
+
+        var hash = offsetBasis
+        for (key, value) in relevant {
+            for byte in "\(key)=\(value),".utf8 {
+                hash ^= UInt64(byte)
+                hash &*= prime
+            }
+        }
+        return hash
+    }
+}

--- a/DatadogTrace/Sources/ClientStats/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/ClientStats/StatsConcentrator.swift
@@ -7,26 +7,32 @@
 import Foundation
 import DatadogInternal
 
+/// Nanosecond-precision timestamp or duration.
+internal typealias Nanoseconds = UInt64
+
 /// Aggregates `SpanSnapshot`s into time-bucketed stats (hit counts, error counts,
 /// duration distributions) keyed by an `AggregationKey`.
 ///
 /// Thread-safety: All public methods dispatch onto a dedicated serial queue
 /// so that `DDSpan.finish()` pays only the cost of enqueuing.
-internal final class StatsConcentrator {
+internal final class StatsConcentrator: @unchecked Sendable {
     /// Default bucket width: 10 seconds (in nanoseconds).
-    static let defaultBucketDuration: UInt64 = 10_000_000_000
+    static let defaultBucketDuration: Nanoseconds = 10_000_000_000
 
-    private let bucketDuration: UInt64
+    /// OTel span kinds that qualify a span for stats, regardless of top-level or measured status.
+    static let eligibleSpanKinds: Set<String> = ["server", "consumer", "client", "producer"]
+
+    private let bucketDuration: Nanoseconds
     private let queue: DispatchQueue
 
     @ReadWriteLock
-    private var buckets: [UInt64: StatsBucket] = [:]
+    private var buckets: [Nanoseconds: StatsBucket] = [:]
 
     /// Peer tag keys considered for downstream-service aggregation.
     private let peerTagKeys: [String]
 
     init(
-        bucketDuration: UInt64 = StatsConcentrator.defaultBucketDuration,
+        bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
     ) {
         self.bucketDuration = bucketDuration
@@ -46,7 +52,7 @@ internal final class StatsConcentrator {
 
     /// Returns all buckets whose start time is strictly older than `cutoff`,
     /// removing them from the internal storage.
-    func flush(olderThan cutoff: UInt64) -> [StatsBucket] {
+    func flush(olderThan cutoff: Nanoseconds) -> [StatsBucket] {
         var flushed: [StatsBucket] = []
         _buckets.mutate { buckets in
             let staleKeys = buckets.keys.filter { $0 < cutoff }
@@ -68,9 +74,9 @@ internal final class StatsConcentrator {
 
         let bucketKey = alignedBucketStart(for: snapshot)
         _buckets.mutate { buckets in
-            var bucket = buckets[bucketKey] ?? StatsBucket(start: bucketKey, duration: self.bucketDuration)
             let key = AggregationKey(snapshot: snapshot, peerTagKeys: self.peerTagKeys)
-            var group = bucket.groups[key] ?? ClientGroupedStats()
+            var group = buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: self.bucketDuration)]
+                .groups[key, default: ClientGroupedStats()]
 
             group.hits += 1
             if snapshot.isError {
@@ -78,14 +84,14 @@ internal final class StatsConcentrator {
             }
             group.duration += snapshot.duration
 
-            bucket.groups[key] = group
-            buckets[bucketKey] = bucket
+            buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: self.bucketDuration)]
+                .groups[key] = group
         }
     }
 
     /// Returns the bucket start time (aligned to `bucketDuration` boundaries)
     /// based on the span's end time.
-    private func alignedBucketStart(for snapshot: SpanSnapshot) -> UInt64 {
+    private func alignedBucketStart(for snapshot: SpanSnapshot) -> Nanoseconds {
         let endTime = snapshot.startTime + snapshot.duration
         return endTime - (endTime % bucketDuration)
     }
@@ -101,8 +107,7 @@ internal final class StatsConcentrator {
         if snapshot.isMeasured {
             return true
         }
-        if let kind = snapshot.spanKind?.lowercased(),
-           ["server", "consumer", "client", "producer"].contains(kind) {
+        if let kind = snapshot.spanKind?.lowercased(), eligibleSpanKinds.contains(kind) {
             return true
         }
         return false
@@ -122,14 +127,14 @@ internal final class StatsConcentrator {
 // MARK: - Supporting Types
 
 /// One time bucket containing grouped stats.
-internal struct StatsBucket {
-    let start: UInt64
-    let duration: UInt64
+internal struct StatsBucket: Sendable {
+    let start: Nanoseconds
+    let duration: Nanoseconds
     var groups: [AggregationKey: ClientGroupedStats] = [:]
 }
 
 /// The unique combination of fields that identifies a stats group within a bucket.
-internal struct AggregationKey: Hashable {
+internal struct AggregationKey: Hashable, Sendable {
     let service: String
     let operationName: String
     let resource: String
@@ -151,38 +156,13 @@ internal struct AggregationKey: Hashable {
         self.isTraceRoot = snapshot.parentSpanID == nil
         self.isSynthetics = snapshot.isSynthetics
         self.serviceSource = snapshot.serviceSource ?? ""
-        self.peerTagsHash = Self.computePeerTagsHash(from: snapshot.peerTags, keys: peerTagKeys)
-    }
-
-    /// FNV-1a 64-bit hash of sorted peer tag key-value pairs.
-    private static func computePeerTagsHash(from tags: [String: String], keys: [String]) -> UInt64 {
-        let relevant = keys
-            .compactMap { key -> (String, String)? in
-                guard let value = tags[key], !value.isEmpty else {
-                    return nil
-                }
-                return (key, value)
-            }
-            .sorted { $0.0 < $1.0 }
-
-        guard !relevant.isEmpty else {
-            return 0
-        }
-
-        var hash: UInt64 = 14_695_981_039_346_656_037 // FNV offset basis
-        for (key, value) in relevant {
-            for byte in "\(key)=\(value),".utf8 {
-                hash ^= UInt64(byte)
-                hash &*= 1_099_511_628_211 // FNV prime
-            }
-        }
-        return hash
+        self.peerTagsHash = FNV1aHash.hash(peerTags: snapshot.peerTags, keys: peerTagKeys)
     }
 }
 
 /// Accumulated stats for one aggregation group within a bucket.
-internal struct ClientGroupedStats {
+internal struct ClientGroupedStats: Sendable {
     var hits: UInt64 = 0
     var errors: UInt64 = 0
-    var duration: UInt64 = 0
+    var duration: Nanoseconds = 0
 }

--- a/DatadogTrace/Sources/ClientStats/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/ClientStats/StatsConcentrator.swift
@@ -1,0 +1,188 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Aggregates `SpanSnapshot`s into time-bucketed stats (hit counts, error counts,
+/// duration distributions) keyed by an `AggregationKey`.
+///
+/// Thread-safety: All public methods dispatch onto a dedicated serial queue
+/// so that `DDSpan.finish()` pays only the cost of enqueuing.
+internal final class StatsConcentrator {
+    /// Default bucket width: 10 seconds (in nanoseconds).
+    static let defaultBucketDuration: UInt64 = 10_000_000_000
+
+    private let bucketDuration: UInt64
+    private let queue: DispatchQueue
+
+    @ReadWriteLock
+    private var buckets: [UInt64: StatsBucket] = [:]
+
+    /// Peer tag keys considered for downstream-service aggregation.
+    private let peerTagKeys: [String]
+
+    init(
+        bucketDuration: UInt64 = StatsConcentrator.defaultBucketDuration,
+        peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
+    ) {
+        self.bucketDuration = bucketDuration
+        self.peerTagKeys = peerTagKeys
+        self.queue = DispatchQueue(label: "com.datadoghq.client-stats.concentrator", qos: .utility)
+    }
+
+    /// Enqueues a span snapshot for stats aggregation.
+    ///
+    /// Called from `DDSpan.finish()` — the actual aggregation runs on a
+    /// background serial queue to keep the caller's thread fast.
+    func add(_ snapshot: SpanSnapshot) {
+        queue.async { [weak self] in
+            self?.aggregate(snapshot)
+        }
+    }
+
+    /// Returns all buckets whose start time is strictly older than `cutoff`,
+    /// removing them from the internal storage.
+    func flush(olderThan cutoff: UInt64) -> [StatsBucket] {
+        var flushed: [StatsBucket] = []
+        _buckets.mutate { buckets in
+            let staleKeys = buckets.keys.filter { $0 < cutoff }
+            for key in staleKeys {
+                if let bucket = buckets.removeValue(forKey: key) {
+                    flushed.append(bucket)
+                }
+            }
+        }
+        return flushed
+    }
+
+    // MARK: - Private
+
+    private func aggregate(_ snapshot: SpanSnapshot) {
+        guard Self.isEligible(snapshot) else {
+            return
+        }
+
+        let bucketKey = alignedBucketStart(for: snapshot)
+        _buckets.mutate { buckets in
+            var bucket = buckets[bucketKey] ?? StatsBucket(start: bucketKey, duration: self.bucketDuration)
+            let key = AggregationKey(snapshot: snapshot, peerTagKeys: self.peerTagKeys)
+            var group = bucket.groups[key] ?? ClientGroupedStats()
+
+            group.hits += 1
+            if snapshot.isError {
+                group.errors += 1
+            }
+            group.duration += snapshot.duration
+
+            bucket.groups[key] = group
+            buckets[bucketKey] = bucket
+        }
+    }
+
+    /// Returns the bucket start time (aligned to `bucketDuration` boundaries)
+    /// based on the span's end time.
+    private func alignedBucketStart(for snapshot: SpanSnapshot) -> UInt64 {
+        let endTime = snapshot.startTime + snapshot.duration
+        return endTime - (endTime % bucketDuration)
+    }
+
+    // MARK: - Eligibility
+
+    /// A span is eligible for stats if it is top-level, measured, or has a
+    /// qualifying `span_kind` (server, consumer, client, producer).
+    static func isEligible(_ snapshot: SpanSnapshot) -> Bool {
+        if snapshot.isTopLevel {
+            return true
+        }
+        if snapshot.isMeasured {
+            return true
+        }
+        if let kind = snapshot.spanKind?.lowercased(),
+           ["server", "consumer", "client", "producer"].contains(kind) {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Constants
+
+    static let defaultPeerTagKeys: [String] = [
+        "peer.service",
+        "out.host",
+        "server.address",
+        "network.destination.name",
+        "peer.hostname",
+    ]
+}
+
+// MARK: - Supporting Types
+
+/// One time bucket containing grouped stats.
+internal struct StatsBucket {
+    let start: UInt64
+    let duration: UInt64
+    var groups: [AggregationKey: ClientGroupedStats] = [:]
+}
+
+/// The unique combination of fields that identifies a stats group within a bucket.
+internal struct AggregationKey: Hashable {
+    let service: String
+    let operationName: String
+    let resource: String
+    let httpStatusCode: UInt32
+    let type: String
+    let spanKind: String
+    let isTraceRoot: Bool
+    let isSynthetics: Bool
+    let peerTagsHash: UInt64
+    let serviceSource: String
+
+    init(snapshot: SpanSnapshot, peerTagKeys: [String]) {
+        self.service = snapshot.service
+        self.operationName = snapshot.operationName
+        self.resource = snapshot.resource
+        self.httpStatusCode = snapshot.httpStatusCode
+        self.type = snapshot.type
+        self.spanKind = snapshot.spanKind ?? ""
+        self.isTraceRoot = snapshot.parentSpanID == nil
+        self.isSynthetics = snapshot.isSynthetics
+        self.serviceSource = snapshot.serviceSource ?? ""
+        self.peerTagsHash = Self.computePeerTagsHash(from: snapshot.peerTags, keys: peerTagKeys)
+    }
+
+    /// FNV-1a 64-bit hash of sorted peer tag key-value pairs.
+    private static func computePeerTagsHash(from tags: [String: String], keys: [String]) -> UInt64 {
+        let relevant = keys
+            .compactMap { key -> (String, String)? in
+                guard let value = tags[key], !value.isEmpty else {
+                    return nil
+                }
+                return (key, value)
+            }
+            .sorted { $0.0 < $1.0 }
+
+        guard !relevant.isEmpty else {
+            return 0
+        }
+
+        var hash: UInt64 = 14_695_981_039_346_656_037 // FNV offset basis
+        for (key, value) in relevant {
+            for byte in "\(key)=\(value),".utf8 {
+                hash ^= UInt64(byte)
+                hash &*= 1_099_511_628_211 // FNV prime
+            }
+        }
+        return hash
+    }
+}
+
+/// Accumulated stats for one aggregation group within a bucket.
+internal struct ClientGroupedStats {
+    var hits: UInt64 = 0
+    var errors: UInt64 = 0
+    var duration: UInt64 = 0
+}

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -35,8 +35,6 @@ internal final class DDSpan: OTSpan {
     private let eventBuilder: SpanEventBuilder
     /// Writes span events to core.
     private let eventWriter: SpanWriteContext
-    /// Called when this span finishes (before sampling check) to feed client-side stats.
-    private let onSpanFinished: ((SpanSnapshot) -> Void)?
 
     init(
         tracer: DatadogTracer,
@@ -45,8 +43,7 @@ internal final class DDSpan: OTSpan {
         startTime: Date,
         tags: [String: Encodable],
         eventBuilder: SpanEventBuilder,
-        eventWriter: SpanWriteContext,
-        onSpanFinished: ((SpanSnapshot) -> Void)? = nil
+        eventWriter: SpanWriteContext
     ) {
         self.ddTracer = tracer
         self.ddContext = context
@@ -58,7 +55,6 @@ internal final class DDSpan: OTSpan {
         self.isFinished = false
         self.eventBuilder = eventBuilder
         self.eventWriter = eventWriter
-        self.onSpanFinished = onSpanFinished
     }
 
     // MARK: - Open Tracing interface
@@ -136,9 +132,9 @@ internal final class DDSpan: OTSpan {
 
         // Client-side stats: create snapshot BEFORE the sampling check
         // so that all spans (including sampled-out) contribute to stats.
-        if let onSpanFinished = onSpanFinished {
+        if ddTracer.onSpanFinished != nil {
             let snapshot = createSnapshot(finishTime: time)
-            onSpanFinished(snapshot)
+            ddTracer.notifySpanFinished(snapshot)
         }
 
         if self.ddContext.samplingDecision.samplingPriority.isKept {

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -35,6 +35,8 @@ internal final class DDSpan: OTSpan {
     private let eventBuilder: SpanEventBuilder
     /// Writes span events to core.
     private let eventWriter: SpanWriteContext
+    /// Called when this span finishes (before sampling check) to feed client-side stats.
+    private let onSpanFinished: ((SpanSnapshot) -> Void)?
 
     init(
         tracer: DatadogTracer,
@@ -43,7 +45,8 @@ internal final class DDSpan: OTSpan {
         startTime: Date,
         tags: [String: Encodable],
         eventBuilder: SpanEventBuilder,
-        eventWriter: SpanWriteContext
+        eventWriter: SpanWriteContext,
+        onSpanFinished: ((SpanSnapshot) -> Void)? = nil
     ) {
         self.ddTracer = tracer
         self.ddContext = context
@@ -55,6 +58,7 @@ internal final class DDSpan: OTSpan {
         self.isFinished = false
         self.eventBuilder = eventBuilder
         self.eventWriter = eventWriter
+        self.onSpanFinished = onSpanFinished
     }
 
     // MARK: - Open Tracing interface
@@ -129,6 +133,14 @@ internal final class DDSpan: OTSpan {
             ddTracer.removeSpan(span: self)
             activity.leave()
         }
+
+        // Client-side stats: create snapshot BEFORE the sampling check
+        // so that all spans (including sampled-out) contribute to stats.
+        if let onSpanFinished = onSpanFinished {
+            let snapshot = createSnapshot(finishTime: time)
+            onSpanFinished(snapshot)
+        }
+
         if self.ddContext.samplingDecision.samplingPriority.isKept {
             sendSpan(finishTime: time)
         }
@@ -164,6 +176,65 @@ internal final class DDSpan: OTSpan {
         loggingIntegration.writeLog(withSpanContext: ddContext, message: message, fields: fields, date: date, else: {
             DD.logger.warn("The log for span \"\(self.operationName)\" will not be send, because the Logs feature is not enabled.")
         })
+    }
+
+    // MARK: - Snapshot
+
+    /// Creates a lightweight, immutable snapshot of this span for client-side stats.
+    private func createSnapshot(finishTime: Date) -> SpanSnapshot {
+        let currentTags = tags
+        let tagsReducer = SpanTagsReducer(spanTags: currentTags, logFields: logFields)
+
+        let resolvedService = tagsReducer.extractedServiceName
+            ?? eventBuilder.service
+            ?? "unnamed-service"
+        let resolvedResource = tagsReducer.extractedResourceName ?? operationName
+        let resolvedOperationName = tagsReducer.extractedOperationName ?? operationName
+
+        let startNanos = startTime.timeIntervalSince1970.dd.toNanoseconds
+        let durationNanos = finishTime.timeIntervalSince(startTime).dd.toNanoseconds
+
+        let httpStatusCode: UInt32 = {
+            if let code = currentTags[OTTags.httpStatusCode] as? Int {
+                return UInt32(code)
+            }
+            return 0
+        }()
+
+        let isError = tagsReducer.extractedIsError ?? false
+        let spanKind = currentTags[SpanTags.kind] as? String
+            ?? currentTags[OTTags.spanKind] as? String
+        let isMeasured = (currentTags["_dd.measured"] as? Int == 1)
+            || (currentTags["_dd.measured"] as? Bool == true)
+
+        var peerTags: [String: String] = [:]
+        for key in StatsConcentrator.defaultPeerTagKeys {
+            if let value = currentTags[key] as? String, !value.isEmpty {
+                peerTags[key] = value
+            }
+        }
+
+        let serviceSource = currentTags["_dd.svc_src"] as? String
+
+        return SpanSnapshot(
+            traceID: ddContext.traceID,
+            spanID: ddContext.spanID,
+            parentSpanID: ddContext.parentSpanID,
+            service: resolvedService,
+            operationName: resolvedOperationName,
+            resource: resolvedResource,
+            type: "custom",
+            spanKind: spanKind,
+            httpStatusCode: httpStatusCode,
+            isError: isError,
+            startTime: startNanos,
+            duration: durationNanos,
+            isTopLevel: ddContext.parentSpanID == nil,
+            isMeasured: isMeasured,
+            peerTags: peerTags,
+            isSynthetics: false,
+            serviceSource: serviceSource
+        )
     }
 
     // MARK: - Private

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -35,6 +35,10 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
     /// Creates span events.
     let spanEventBuilder: SpanEventBuilder
 
+    /// Called when any span finishes (before sampling), for client-side stats.
+    /// Set after initialization when `ClientStatsFeature` is enabled.
+    var onSpanFinished: ((SpanSnapshot) -> Void)?
+
     // MARK: - Initialization
 
     convenience init(
@@ -160,7 +164,8 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
             startTime: startTime ?? dateProvider.now,
             tags: combinedTags,
             eventBuilder: spanEventBuilder,
-            eventWriter: writer
+            eventWriter: writer,
+            onSpanFinished: onSpanFinished
         )
         return span
     }

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -39,6 +39,12 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
     /// Set after initialization when `ClientStatsFeature` is enabled.
     var onSpanFinished: ((SpanSnapshot) -> Void)?
 
+    /// Notifies the tracer that a span has finished, forwarding its snapshot
+    /// to the client-side stats pipeline (if enabled).
+    func notifySpanFinished(_ snapshot: SpanSnapshot) {
+        onSpanFinished?(snapshot)
+    }
+
     // MARK: - Initialization
 
     convenience init(
@@ -164,8 +170,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
             startTime: startTime ?? dateProvider.now,
             tags: combinedTags,
             eventBuilder: spanEventBuilder,
-            eventWriter: writer,
-            onSpanFinished: onSpanFinished
+            eventWriter: writer
         )
         return span
     }

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Computes client-side APM stats (hit counts, error rates, latency distributions)
+/// on all eligible finished spans — including sampled-out ones — and uploads them
+/// as a separate payload to `/api/v0.2/stats`.
+///
+/// Registered as a companion `DatadogRemoteFeature` alongside `TraceFeature`
+/// when `Trace.Configuration.statsComputationEnabled` is `true`.
+internal final class ClientStatsFeature: DatadogRemoteFeature {
+    static let name = "client-stats"
+
+    let requestBuilder: FeatureRequestBuilder
+    let messageReceiver: FeatureMessageReceiver
+    let performanceOverride: PerformancePresetOverride?
+
+    /// The concentrator that aggregates span snapshots into time-bucketed stats.
+    let concentrator: StatsConcentrator
+
+    init(
+        core: DatadogCoreProtocol,
+        configuration: Trace.Configuration
+    ) {
+        self.requestBuilder = StatsRequestBuilder(
+            customIntakeURL: configuration.customEndpoint,
+            telemetry: core.telemetry
+        )
+        self.messageReceiver = NOPFeatureMessageReceiver()
+        self.performanceOverride = nil
+        self.concentrator = StatsConcentrator()
+    }
+}

--- a/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Builds URL requests for uploading client-side stats payloads to `/api/v0.2/stats`.
+///
+/// The final implementation will encode payloads as MessagePack. For now the stub
+/// uses JSON so we can validate the pipeline end-to-end.
+internal struct StatsRequestBuilder: FeatureRequestBuilder {
+    let customIntakeURL: URL?
+    let telemetry: Telemetry
+
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) throws -> URLRequest {
+        let builder = URLRequestBuilder(
+            url: url(with: context),
+            queryItems: [],
+            headers: [
+                .contentTypeHeader(contentType: .applicationJSON),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device,
+                    os: context.os
+                ),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.ciAppOrigin ?? context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader(),
+            ],
+            telemetry: telemetry
+        )
+
+        let data = events.reduce(Data()) { $0 + $1.data }
+        return builder.uploadRequest(with: data)
+    }
+
+    private func url(with context: DatadogContext) -> URL {
+        customIntakeURL ?? context.site.endpoint.appendingPathComponent("api/v0.2/stats")
+    }
+}

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -15,7 +15,7 @@ import DatadogInternal
 ///
 /// The snapshot captures only the data needed for stats aggregation, avoiding
 /// any reference back to the mutable `DDSpan`.
-internal struct SpanSnapshot {
+internal struct SpanSnapshot: Sendable {
     let traceID: TraceID
     let spanID: SpanID
     let parentSpanID: SpanID?
@@ -27,9 +27,9 @@ internal struct SpanSnapshot {
     let httpStatusCode: UInt32
     let isError: Bool
     /// Span start time in nanoseconds since Unix epoch.
-    let startTime: UInt64
+    let startTime: Nanoseconds
     /// Span duration in nanoseconds.
-    let duration: UInt64
+    let duration: Nanoseconds
     let isTopLevel: Bool
     let isMeasured: Bool
     /// Peer tag values for downstream-service aggregation (e.g., `peer.service`, `out.host`).

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// A lightweight, immutable snapshot of a `DDSpan` at the moment it finishes.
+///
+/// Created in `DDSpan.finish(at:)` **before** the sampling decision so that
+/// every finished span — including sampled-out ones — can be forwarded to the
+/// `StatsConcentrator` for client-side stats computation.
+///
+/// The snapshot captures only the data needed for stats aggregation, avoiding
+/// any reference back to the mutable `DDSpan`.
+internal struct SpanSnapshot {
+    let traceID: TraceID
+    let spanID: SpanID
+    let parentSpanID: SpanID?
+    let service: String
+    let operationName: String
+    let resource: String
+    let type: String
+    let spanKind: String?
+    let httpStatusCode: UInt32
+    let isError: Bool
+    /// Span start time in nanoseconds since Unix epoch.
+    let startTime: UInt64
+    /// Span duration in nanoseconds.
+    let duration: UInt64
+    let isTopLevel: Bool
+    let isMeasured: Bool
+    /// Peer tag values for downstream-service aggregation (e.g., `peer.service`, `out.host`).
+    let peerTags: [String: String]
+    let isSynthetics: Bool
+    /// Value of `_dd.svc_src` meta tag, if present. Tracks the origin of the service name.
+    let serviceSource: String?
+}

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -48,6 +48,10 @@ public enum Trace {
         if configuration.statsComputationEnabled {
             let stats = ClientStatsFeature(core: core, configuration: configuration)
             try core.register(feature: stats)
+
+            trace.tracer.onSpanFinished = { [weak concentrator = stats.concentrator] snapshot in
+                concentrator?.add(snapshot)
+            }
         }
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -44,6 +44,12 @@ public enum Trace {
         let trace = TraceFeature(in: core, configuration: configuration)
         try core.register(feature: trace)
 
+        // Register Client-Side Stats feature if enabled:
+        if configuration.statsComputationEnabled {
+            let stats = ClientStatsFeature(core: core, configuration: configuration)
+            try core.register(feature: stats)
+        }
+
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:
         if let firstPartyHostsTracing = configuration.urlSessionTracking?.firstPartyHostsTracing {
             let firstPartyHosts: FirstPartyHosts

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -76,6 +76,16 @@ extension Trace {
         /// Default: `nil`.
         public var customEndpoint: URL?
 
+        /// Enables client-side computation of APM stats (hit count, error rate,
+        /// latency distribution) on all eligible spans, including sampled-out ones.
+        ///
+        /// When enabled, the SDK computes RED (Rate, Error, Duration) metrics locally
+        /// and uploads them to the Datadog stats intake, providing accurate metrics
+        /// regardless of the trace sampling rate.
+        ///
+        /// Default: `false`.
+        public var statsComputationEnabled: Bool
+
         // MARK: - Nested Types
 
         /// Configuration of automatic network requests tracing.
@@ -145,6 +155,7 @@ extension Trace {
         ///   - networkInfoEnabled: Determines if traces should be enriched with network connection information.
         ///   - eventMapper: Custom mapper for span events.
         ///   - customEndpoint: Custom server url for sending traces.
+        ///   - statsComputationEnabled: Determines if client-side APM stats should be computed.
         public init(
             sampleRate: SampleRate = .maxSampleRate,
             service: String? = nil,
@@ -153,7 +164,8 @@ extension Trace {
             bundleWithRumEnabled: Bool = true,
             networkInfoEnabled: Bool = false,
             eventMapper: EventMapper? = nil,
-            customEndpoint: URL? = nil
+            customEndpoint: URL? = nil,
+            statsComputationEnabled: Bool = false
         ) {
             self.sampleRate = sampleRate
             self.service = service
@@ -163,6 +175,7 @@ extension Trace {
             self.networkInfoEnabled = networkInfoEnabled
             self.eventMapper = eventMapper
             self.customEndpoint = customEndpoint
+            self.statsComputationEnabled = statsComputationEnabled
         }
     }
 }

--- a/DatadogTrace/Tests/ClientStats/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/ClientStats/SpanSnapshotTests.swift
@@ -1,0 +1,178 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogTrace
+
+class SpanSnapshotTests: XCTestCase {
+    func testWhenSpanFinishes_onSpanFinishedCallbackReceivesSnapshot() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        // Given
+        let span = tracer.startSpan(operationName: "test.operation")
+
+        // When
+        span.finish()
+
+        // Then
+        waitForExpectations(timeout: 0.5)
+        XCTAssertNotNil(receivedSnapshot)
+        XCTAssertEqual(receivedSnapshot?.operationName, "test.operation")
+    }
+
+    func testSnapshotCapturesServiceFromTag() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "op")
+        span.setTag(key: SpanTags.service, value: "custom-service")
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.service, "custom-service")
+    }
+
+    func testSnapshotCapturesResourceFromTag() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "op")
+        span.setTag(key: SpanTags.resource, value: "GET /users")
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.resource, "GET /users")
+    }
+
+    func testSnapshotCapturesErrorStatus() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "op")
+        span.setTag(key: OTTags.error, value: true)
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.isError, true)
+    }
+
+    func testSnapshotCapturesSpanKind() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "op")
+        span.setTag(key: SpanTags.kind, value: "client")
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.spanKind, "client")
+    }
+
+    func testSnapshotCapturesHTTPStatusCode() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "op")
+        span.setTag(key: OTTags.httpStatusCode, value: 404)
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.httpStatusCode, 404)
+    }
+
+    func testSnapshotIsTopLevelWhenNoParent() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+        var receivedSnapshot: SpanSnapshot?
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        tracer.onSpanFinished = { snapshot in
+            receivedSnapshot = snapshot
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startRootSpan(operationName: "root")
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+        XCTAssertEqual(receivedSnapshot?.isTopLevel, true)
+        XCTAssertNil(receivedSnapshot?.parentSpanID)
+    }
+
+    func testSnapshotIsCalledBeforeSamplingCheck() {
+        let snapshotExpectation = expectation(description: "snapshot received")
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockRejectAll()
+        )
+        tracer.onSpanFinished = { _ in
+            snapshotExpectation.fulfill()
+        }
+
+        let span = tracer.startSpan(operationName: "sampled-out")
+        span.finish()
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testWhenOnSpanFinishedIsNil_noSnapshotIsCreated() {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+        // onSpanFinished is nil by default
+
+        let span = tracer.startSpan(operationName: "op")
+        span.finish()
+
+        // No crash, no snapshot - this is a no-op path
+    }
+}

--- a/DatadogTrace/Tests/ClientStats/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/ClientStats/StatsConcentratorTests.swift
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogTrace
+
+class StatsConcentratorTests: XCTestCase {
+    // MARK: - Eligibility
+
+    func testIsEligible_whenTopLevel() {
+        let snapshot = SpanSnapshot.mock(spanKind: nil, isTopLevel: true, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsEligible_whenMeasured() {
+        let snapshot = SpanSnapshot.mock(spanKind: nil, isTopLevel: false, isMeasured: true)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsEligible_whenSpanKindIsServer() {
+        let snapshot = SpanSnapshot.mock(spanKind: "server", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsEligible_whenSpanKindIsClient() {
+        let snapshot = SpanSnapshot.mock(spanKind: "client", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsEligible_whenSpanKindIsConsumer() {
+        let snapshot = SpanSnapshot.mock(spanKind: "consumer", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsEligible_whenSpanKindIsProducer() {
+        let snapshot = SpanSnapshot.mock(spanKind: "producer", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsNotEligible_whenNotTopLevelNotMeasuredInternalKind() {
+        let snapshot = SpanSnapshot.mock(spanKind: "internal", isTopLevel: false, isMeasured: false)
+        XCTAssertFalse(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testIsNotEligible_whenNotTopLevelNotMeasuredNoKind() {
+        let snapshot = SpanSnapshot.mock(spanKind: nil, isTopLevel: false, isMeasured: false)
+        XCTAssertFalse(StatsConcentrator.isEligible(snapshot))
+    }
+
+    // MARK: - Aggregation
+
+    func testAdd_aggregatesHitsForEligibleSpans() {
+        let concentrator = StatsConcentrator(bucketDuration: 10_000_000_000)
+        let snapshot = SpanSnapshot.mock(
+            operationName: "http.request",
+            startTime: 1_000_000_000,
+            duration: 500_000_000,
+            isTopLevel: true
+        )
+
+        concentrator.add(snapshot)
+        concentrator.add(snapshot)
+
+        // Wait for async aggregation
+        let expectation = expectation(description: "aggregation completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let buckets = concentrator.flush(olderThan: UInt64.max)
+        XCTAssertEqual(buckets.count, 1)
+
+        let bucket = buckets[0]
+        let groupValues = Array(bucket.groups.values)
+        XCTAssertEqual(groupValues.count, 1)
+        XCTAssertEqual(groupValues[0].hits, 2)
+        XCTAssertEqual(groupValues[0].duration, 1_000_000_000)
+    }
+
+    func testAdd_countsErrors() {
+        let concentrator = StatsConcentrator(bucketDuration: 10_000_000_000)
+        let errorSnapshot = SpanSnapshot.mock(isError: true, isTopLevel: true)
+        let okSnapshot = SpanSnapshot.mock(isError: false, isTopLevel: true)
+
+        concentrator.add(errorSnapshot)
+        concentrator.add(okSnapshot)
+
+        let expectation = expectation(description: "aggregation completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let buckets = concentrator.flush(olderThan: UInt64.max)
+        let group = buckets.flatMap { Array($0.groups.values) }.first!
+        XCTAssertEqual(group.hits, 2)
+        XCTAssertEqual(group.errors, 1)
+    }
+
+    func testAdd_doesNotAggregateIneligibleSpans() {
+        let concentrator = StatsConcentrator(bucketDuration: 10_000_000_000)
+        let ineligible = SpanSnapshot.mock(spanKind: nil, isTopLevel: false, isMeasured: false)
+
+        concentrator.add(ineligible)
+
+        let expectation = expectation(description: "aggregation completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let buckets = concentrator.flush(olderThan: UInt64.max)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    // MARK: - Flushing
+
+    func testFlush_onlyReturnsBucketsOlderThanCutoff() {
+        let bucketDuration: UInt64 = 10_000_000_000
+        let concentrator = StatsConcentrator(bucketDuration: bucketDuration)
+
+        let earlySpan = SpanSnapshot.mock(startTime: 5_000_000_000, duration: 1_000_000_000, isTopLevel: true)
+        let lateSpan = SpanSnapshot.mock(startTime: 50_000_000_000, duration: 1_000_000_000, isTopLevel: true)
+
+        concentrator.add(earlySpan)
+        concentrator.add(lateSpan)
+
+        let expectation = expectation(description: "aggregation completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        // Only flush buckets older than 20s mark
+        let flushed = concentrator.flush(olderThan: 20_000_000_000)
+        XCTAssertEqual(flushed.count, 1)
+
+        // The late span bucket should still be there
+        let remaining = concentrator.flush(olderThan: UInt64.max)
+        XCTAssertEqual(remaining.count, 1)
+    }
+
+    // MARK: - Aggregation Key
+
+    func testAggregationKey_differsByService() {
+        let concentrator = StatsConcentrator(bucketDuration: 10_000_000_000)
+        let s1 = SpanSnapshot.mock(service: "service-a", isTopLevel: true)
+        let s2 = SpanSnapshot.mock(service: "service-b", isTopLevel: true)
+
+        concentrator.add(s1)
+        concentrator.add(s2)
+
+        let expectation = expectation(description: "aggregation completes")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let buckets = concentrator.flush(olderThan: UInt64.max)
+        let totalGroups = buckets.reduce(0) { $0 + $1.groups.count }
+        XCTAssertEqual(totalGroups, 2)
+    }
+}
+
+// MARK: - SpanSnapshot Test Helpers
+
+extension SpanSnapshot {
+    static func mock(
+        traceID: TraceID = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentSpanID: SpanID? = nil,
+        service: String = "test-service",
+        operationName: String = "test.operation",
+        resource: String = "test-resource",
+        type: String = "custom",
+        spanKind: String? = nil,
+        httpStatusCode: UInt32 = 0,
+        isError: Bool = false,
+        startTime: UInt64 = 1_000_000_000,
+        duration: UInt64 = 100_000_000,
+        isTopLevel: Bool = true,
+        isMeasured: Bool = false,
+        peerTags: [String: String] = [:],
+        isSynthetics: Bool = false,
+        serviceSource: String? = nil
+    ) -> SpanSnapshot {
+        SpanSnapshot(
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentSpanID,
+            service: service,
+            operationName: operationName,
+            resource: resource,
+            type: type,
+            spanKind: spanKind,
+            httpStatusCode: httpStatusCode,
+            isError: isError,
+            startTime: startTime,
+            duration: duration,
+            isTopLevel: isTopLevel,
+            isMeasured: isMeasured,
+            peerTags: peerTags,
+            isSynthetics: isSynthetics,
+            serviceSource: serviceSource
+        )
+    }
+}

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+@testable import DatadogTrace
+
+class ClientStatsFeatureTests: XCTestCase {
+    private var core: FeatureRegistrationCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var config: Trace.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        core = FeatureRegistrationCoreMock()
+        config = Trace.Configuration()
+    }
+
+    override func tearDown() {
+        core = nil
+        config = nil
+        XCTAssertEqual(FeatureRegistrationCoreMock.referenceCount, 0)
+    }
+
+    // MARK: - Registration
+
+    func testWhenStatsComputationDisabled_thenClientStatsFeatureIsNotRegistered() {
+        // Given
+        config.statsComputationEnabled = false
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenStatsComputationEnabled_thenClientStatsFeatureIsRegistered() {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenStatsComputationEnabled_thenTraceFeatureIsAlsoRegistered() {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(core.get(feature: TraceFeature.self))
+        XCTAssertNotNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenDefaultConfiguration_thenStatsComputationIsDisabled() {
+        // Given
+        let defaultConfig = Trace.Configuration()
+
+        // Then
+        XCTAssertFalse(defaultConfig.statsComputationEnabled)
+    }
+
+    // MARK: - Request Builder
+
+    func testWhenStatsComputationEnabled_thenRequestBuilderUsesStatsEndpoint() throws {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        XCTAssertTrue(stats.requestBuilder is StatsRequestBuilder)
+    }
+
+    func testWhenStatsComputationEnabledWithCustomEndpoint_thenRequestBuilderUsesCustomURL() throws {
+        // Given
+        let customURL: URL = .mockRandom()
+        config.statsComputationEnabled = true
+        config.customEndpoint = customURL
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        let requestBuilder = try XCTUnwrap(stats.requestBuilder as? StatsRequestBuilder)
+        XCTAssertEqual(requestBuilder.customIntakeURL, customURL)
+    }
+
+    // MARK: - Feature Name
+
+    func testFeatureName() {
+        XCTAssertEqual(ClientStatsFeature.name, "client-stats")
+    }
+}


### PR DESCRIPTION
### What and why?

Proof-of-concept for client-side stats (CSS) for APM on the iOS SDK. This is the first agent-less CSS implementation across Datadog tracers. Client-side stats compute trace metrics (hits, errors, duration) locally on all eligible spans — including those sampled out — so that RED metrics remain accurate regardless of client-side sampling rates.

This is a throwaway PoC validating the architecture. Remaining work (DDSketch, MessagePack encoding, flush-to-storage pipeline) will follow in subsequent PRs.

### How?

- Introduces `ClientStatsFeature` as a separate `DatadogRemoteFeature` alongside `TraceFeature`, with its own storage/upload pipeline targeting `/api/v0.2/stats`
- Hooks into `DDSpan.finish()` to create lightweight `SpanSnapshot` value types **before** the sampling decision, ensuring all spans (including sampled-out) contribute to stats
- Adds `StatsConcentrator` that aggregates snapshots into time-bucketed stats on a dedicated background queue, with span eligibility filtering per the Client-Side Stats v1.2.0 spec (top-level, measured, or OTel span_kind of server/consumer/client/producer)
- Gated behind `Trace.Configuration.statsComputationEnabled` (default `false`)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - `ClientStatsFeatureTests` — registration, config defaults, request builder wiring (7 tests)
  - `SpanSnapshotTests` — snapshot creation, tag extraction, sampled-out spans (9 tests)
  - `StatsConcentratorTests` — eligibility, aggregation, flushing, key differentiation (12 tests)
  - Existing `TraceTests` and `DDSpanTests` pass with zero regressions
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs