### PR TITLE
Fixes flaky NetworkInstrumentationFeatureTests tests.

### DIFF
--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -24,7 +24,15 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     override func tearDown() {
+        // Flush the feature's serial queue before releasing the core to ensure
+        // all pending async blocks (especially from the concurrent test) complete
+        // before the feature is deallocated. Without this, a block executing past
+        // `guard let self = self` holds the feature alive, causing deallocation
+        // on a background thread — which can race with the next test's swizzles
+        // via `_unswizzle`'s transient IMP resets.
+        core?.get(feature: NetworkInstrumentationFeature.self)?.flush()
         core = nil
+        handler = nil
         super.tearDown()
     }
 


### PR DESCRIPTION
### What and why?

There are multiple tests failing randomly, including causing crashes, in `NetworkInstrumentationFeatureTests`.

### How?

The problem was tearing down the core might happen too late, causing conflicts between the previous core unswizzling and the new one swizzling the necessary framework functions. This commit adds feature flushing to the `tearDown` function to force proper core and feature tear down before proceeding.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
