### PR TITLE
RUM-8113 Align retry_count request tag with other SDKs

### DIFF
--- a/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMFeatureTests.swift
@@ -91,7 +91,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(
             requestURL.query,
             """
-            ddsource=\(randomSource)&ddtags=retry_count:1
+            ddsource=\(randomSource)
             """
         )
         XCTAssertEqual(

--- a/DatadogInternal/Sources/Upload/FeatureRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/FeatureRequestBuilder.swift
@@ -40,6 +40,25 @@ public struct ExecutionContext {
     /// The current attempt number.
     public let attempt: UInt
 
+    /// Tags to include in the request when this is a retry attempt.
+    /// Returns `nil` on the first request (`attempt == 0`).
+    private var retryTags: [String]? {
+        guard attempt > 0 else {
+            return nil
+        }
+        var tags = ["retry_count:\(attempt)"]
+        if let code = previousResponseCode {
+            tags.append("retry_after:\(code)")
+        }
+        return tags
+    }
+
+    /// Query items to include in the request when this is a retry attempt.
+    /// Returns an empty array on the first request (`attempt == 0`).
+    public var retryQueryItems: [URLRequestBuilder.QueryItem] {
+        retryTags.map { [.ddtags(tags: $0)] } ?? []
+    }
+
     /// Initializes the execution context.
     /// - Parameters:
     ///   - previousResponseCode: Previous HTTP status code, if available.

--- a/DatadogProfiling/Sources/RequestBuilder.swift
+++ b/DatadogProfiling/Sources/RequestBuilder.swift
@@ -54,16 +54,9 @@ internal struct RequestBuilder: FeatureRequestBuilder {
             mimeType: "application/octet-stream"
         )
 
-        var tags = ["retry_count:\(execution.attempt + 1)"]
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("retry_after:\(previousResponseCode)")
-        }
-
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [
-                .ddtags(tags: tags)
-            ],
+            queryItems: execution.retryQueryItems,
             headers: [
                 .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
                 .userAgentHeader(

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -202,5 +202,17 @@ class RequestBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
+
+    func testItSetsRetryQueryParametersOnNetworkErrorRetry() throws {
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: nil, attempt: 1) // network error retry has no response code
+
+        // When
+        let request = try builder.request(for: [mockEvent()], with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+    }
 }
 #endif // !os(watchOS)

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -97,21 +97,7 @@ class RequestBuilderTests: XCTestCase {
         let request = try builder.request(for: [mockEvent()], with: context, execution: .mockWith(previousResponseCode: nil, attempt: 0))
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
-    }
-
-    func testItSetsRetryQueryParameters() throws {
-        let randomAttempt: UInt = .mockRandom()
-        let randomStatus: Int = .mockRandom()
-
-        // Given
-        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
-
-        // When
-        let request = try builder.request(for: [mockEvent()], with: .mockRandom(), execution: .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt))
-
-        // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+        XCTAssertNil(request.url!.query)
     }
 
     func testItSetsHTTPHeaders() throws {
@@ -201,6 +187,20 @@ class RequestBuilderTests: XCTestCase {
             with: .mockAny(),
             execution: .mockAny()
         ))
+    }
+
+    func testItSetsRetryQueryParameters() throws {
+        // Given
+        let randomAttempt: UInt = .mockRandom(min: 1, max: 10)
+        let randomStatus: Int = .mockRandom()
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt)
+
+        // When
+        let request = try builder.request(for: [mockEvent()], with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
 }
 #endif // !os(watchOS)

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -212,7 +212,7 @@ class RequestBuilderTests: XCTestCase {
         let request = try builder.request(for: [mockEvent()], with: .mockRandom(), execution: execution)
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no retry_after without response code
     }
 }
 #endif // !os(watchOS)

--- a/DatadogRUM/Sources/Feature/RequestBuilder.swift
+++ b/DatadogRUM/Sources/Feature/RequestBuilder.swift
@@ -27,11 +27,6 @@ internal struct RequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) throws -> URLRequest {
-        var tags = ["retry_count:\(execution.attempt + 1)"]
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("retry_after:\(previousResponseCode)")
-        }
-
         let filteredEvents = eventsFilter.filter(events: events)
 
         guard !filteredEvents.isEmpty else {
@@ -42,10 +37,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
 
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [
-                .ddsource(source: context.source),
-                .ddtags(tags: tags)
-            ],
+            queryItems: [.ddsource(source: context.source)] + execution.retryQueryItems,
             headers: [
                 .contentTypeHeader(contentType: .textPlainUTF8),
                 .userAgentHeader(

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -109,7 +109,7 @@ class RequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: context, execution: execution)
 
         // Then
-        let expextedQuery = "ddsource=\(randomSource)&ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)"
+        let expextedQuery = "ddsource=\(randomSource)&ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)"
         XCTAssertEqual(request.url?.query, expextedQuery)
     }
 
@@ -186,5 +186,19 @@ class RequestBuilderTests: XCTestCase {
         event 3
         """
         XCTAssertEqual(expected, actual, "It must separate each event with newline character")
+    }
+
+    func testItSetsNoRetryQueryParametersOnFirstRequest() throws {
+        // Given
+        let randomSource: String = .mockRandom(among: .alphanumerics)
+        let builder = RequestBuilder(customIntakeURL: nil, eventsFilter: .init(telemetry: TelemetryMock()), telemetry: NOPTelemetry())
+        let context: DatadogContext = .mockWith(source: randomSource)
+        let execution: ExecutionContext = .mockWith(previousResponseCode: nil, attempt: 0)
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context, execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url?.query, "ddsource=\(randomSource)") // no ddtags on first request
     }
 }

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -213,6 +213,6 @@ class RequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: context, execution: execution)
 
         // Then
-        XCTAssertEqual(request.url?.query, "ddsource=\(randomSource)&ddtags=retry_count:1") // no last_failure_status without response code
+        XCTAssertEqual(request.url?.query, "ddsource=\(randomSource)&ddtags=retry_count:1") // no retry_after without response code
     }
 }

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -201,4 +201,18 @@ class RequestBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(request.url?.query, "ddsource=\(randomSource)") // no ddtags on first request
     }
+
+    func testItSetsRetryQueryParametersOnNetworkErrorRetry() throws {
+        // Given
+        let randomSource: String = .mockRandom(among: .alphanumerics)
+        let builder = RequestBuilder(customIntakeURL: nil, eventsFilter: .init(telemetry: TelemetryMock()), telemetry: NOPTelemetry())
+        let context: DatadogContext = .mockWith(source: randomSource)
+        let execution: ExecutionContext = .mockWith(previousResponseCode: nil, attempt: 1) // network error retry has no response code
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context, execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url?.query, "ddsource=\(randomSource)&ddtags=retry_count:1") // no last_failure_status without response code
+    }
 }

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/ResourceRequestBuilder.swift
@@ -31,29 +31,19 @@ internal struct ResourceRequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) throws -> URLRequest {
-        var tags = [
-            "retry_count:\(execution.attempt + 1)"
-        ]
-
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("retry_after:\(previousResponseCode)")
-        }
-
         let decoder = JSONDecoder()
         let resources = try events.map { event in
             try decoder.decode(EnrichedResource.self, from: event.data)
         }
-        return try createRequest(resources: resources, context: context, tags: tags)
+        return try createRequest(resources: resources, context: context, execution: execution)
     }
 
-    private func createRequest(resources: [EnrichedResource], context: DatadogContext, tags: [String]) throws -> URLRequest {
+    private func createRequest(resources: [EnrichedResource], context: DatadogContext, execution: ExecutionContext) throws -> URLRequest {
         var multipart = multipartBuilder
 
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [
-                .ddtags(tags: tags)
-            ],
+            queryItems: execution.retryQueryItems,
             headers: [
                 .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
                 .userAgentHeader(

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift
@@ -33,14 +33,6 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
         with context: DatadogContext,
         execution: ExecutionContext
     ) throws -> URLRequest {
-        var tags = [
-            "retry_count:\(execution.attempt + 1)"
-        ]
-
-        if let previousResponseCode = execution.previousResponseCode {
-            tags.append("retry_after:\(previousResponseCode)")
-        }
-
         guard !events.isEmpty else {
             throw InternalError(description: "[SR] batch events must not be empty.")
         }
@@ -56,17 +48,15 @@ internal struct SegmentRequestBuilder: FeatureRequestBuilder {
             .map { try SegmentJSON($0.data, source: source) }
             .merge()
 
-        return try createRequest(segments: segments, context: context, tags: tags)
+        return try createRequest(segments: segments, context: context, execution: execution)
     }
 
-    private func createRequest(segments: [SegmentJSON], context: DatadogContext, tags: [String]) throws -> URLRequest {
+    private func createRequest(segments: [SegmentJSON], context: DatadogContext, execution: ExecutionContext) throws -> URLRequest {
         var multipart = multipartBuilder
 
         let builder = URLRequestBuilder(
             url: url(with: context),
-            queryItems: [
-                .ddtags(tags: tags)
-            ],
+            queryItems: execution.retryQueryItems,
             headers: [
                 .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
                 .userAgentHeader(

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -182,7 +182,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no retry_after without response code
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -81,21 +81,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .init(previousResponseCode: nil, attempt: 0))
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
-    }
-
-    func testItSetsRetryQueryParameters() throws {
-        let randomAttempt: UInt = .mockRandom()
-        let randomStatus: Int = .mockRandom()
-
-        // Given
-        let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
-
-        // When
-        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: .init(previousResponseCode: randomStatus, attempt: randomAttempt))
-
-        // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+        XCTAssertNil(request.url!.query)
     }
 
     func testItSetsHTTPHeaders() throws {
@@ -171,6 +157,20 @@ class ResourceRequestBuilderTests: XCTestCase {
 
         // When, Then
         XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockRandom(), execution: .mockAny()))
+    }
+
+    func testItSetsRetryQueryParameters() throws {
+        // Given
+        let randomAttempt: UInt = .mockRandom(min: 1, max: 10)
+        let randomStatus: Int = .mockRandom()
+        let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt)
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -172,5 +172,17 @@ class ResourceRequestBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
+
+    func testItSetsRetryQueryParametersOnNetworkErrorRetry() throws {
+        // Given
+        let builder = ResourceRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: nil, attempt: 1) // network error retry has no response code
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -86,21 +86,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: context, execution: .mockWith(previousResponseCode: nil, attempt: 0))
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1")
-    }
-
-    func testItSetsRetryQueryParameters() throws {
-        let randomAttempt: UInt = .mockRandom()
-        let randomStatus: Int = .mockRandom()
-
-        // Given
-        let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
-
-        // When
-        let request = try builder.request(for: mockEvents, with: .mockAny(), execution: .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt))
-
-        // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt + 1),retry_after:\(randomStatus)")
+        XCTAssertNil(request.url!.query)
     }
 
     func testItSetsHTTPHeaders() throws {
@@ -272,6 +258,20 @@ class SegmentRequestBuilderTests: XCTestCase {
                 """
             )
         )
+    }
+
+    func testItSetsRetryQueryParameters() throws {
+        // Given
+        let randomAttempt: UInt = .mockRandom(min: 1, max: 10)
+        let randomStatus: Int = .mockRandom()
+        let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: randomStatus, attempt: randomAttempt)
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -283,7 +283,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
 
         // Then
-        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no retry_after without response code
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -273,5 +273,17 @@ class SegmentRequestBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(request.url!.query, "ddtags=retry_count:\(randomAttempt),retry_after:\(randomStatus)")
     }
+
+    func testItSetsRetryQueryParametersOnNetworkErrorRetry() throws {
+        // Given
+        let builder = SegmentRequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let execution: ExecutionContext = .mockWith(previousResponseCode: nil, attempt: 1) // network error retry has no response code
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockRandom(), execution: execution)
+
+        // Then
+        XCTAssertEqual(request.url!.query, "ddtags=retry_count:1") // no last_failure_status without response code
+    }
 }
 #endif

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Logging/LoggingCommonAsserts.swift
@@ -22,7 +22,7 @@ extension LoggingCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios&ddtags=retry_count:1`
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios`
             XCTAssertNotNil(request.path, file: file, line: line)
             XCTAssertNotNil(request.queryItems)
             XCTAssertEqual(request.queryItems!.count, 1)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMCommonAsserts.swift
@@ -22,16 +22,11 @@ extension RUMCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios&&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:1.3.0-beta3,env:integration,retry_count:1`
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddsource=ios`
             XCTAssertNotNil(request.path, file: file, line: line)
             XCTAssertNotNil(request.queryItems)
-            XCTAssertEqual(request.queryItems!.count, 2)
+            XCTAssertEqual(request.queryItems!.count, 1)
             XCTAssertEqual(request.queryItems?.value(name: "ddsource"), "ios", file: file, line: line)
-
-            let ddtags = request.queryItems?.ddtags()
-            XCTAssertNotNil(ddtags, file: file, line: line)
-            XCTAssertEqual(ddtags?.count, 1, file: file, line: line)
-            XCTAssertEqual(ddtags?["retry_count"], "1", file: file, line: line)
 
             XCTAssertEqual(request.httpHeaders["Content-Type"], "text/plain;charset=UTF-8", file: file, line: line)
             XCTAssertEqual(request.httpHeaders["User-Agent"]?.matches(regex: userAgentRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/SessionReplay/SRCommonAsserts.swift
@@ -22,15 +22,8 @@ extension SRCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddtags=retry_count:1`
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309`
             XCTAssertNotNil(request.path, file: file, line: line)
-            XCTAssertNotNil(request.queryItems)
-            XCTAssertEqual(request.queryItems!.count, 1)
-
-            let ddtags = request.queryItems?.ddtags()
-            XCTAssertNotNil(ddtags, file: file, line: line)
-            XCTAssertEqual(ddtags?.count, 1, file: file, line: line)
-            XCTAssertEqual(ddtags?["retry_count"], "1", file: file, line: line)
 
             let contentTypeRegex = #"^multipart/form-data; boundary=.*$"#
             XCTAssertEqual(request.httpHeaders["Content-Type"]?.matches(regex: contentTypeRegex), true, file: file, line: line)

--- a/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/Tracing/TracingCommonAsserts.swift
@@ -34,7 +34,7 @@ extension TracingCommonAsserts {
         requests.forEach { request in
             XCTAssertEqual(request.httpMethod, "POST")
 
-            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309?ddtags=retry_count:1`
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309`
             XCTAssertFalse(request.path.isEmpty)
             XCTAssertNil(request.queryItems)
 


### PR DESCRIPTION
  ### What and why?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
The iOS SDK was incorrectly emitting `retry_count:1` on every request including the first one.                                                                                                                                                                               
Unlike Android and Browser SDKs, which only set `retry_count` after an initial failure, iOS was                                                                                                                                                                            
setting it unconditionally. This PR fixes the behaviour to align with other SDKs.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                               
  ### How?                                                                                                                                                                                                                                                                                                                                                               

Extracted shared retry tag logic into two computed properties on `ExecutionContext` in `DatadogInternal`:                                                                                                                                                                  
  - `retryTags` (private) — returns `nil` on the first request (`attempt == 0`), otherwise builds `["retry_count:<n>"]` plus `"retry_after:<status>"` when an HTTP response code is available
  - `retryQueryItems` (public) — returns `[]` on first request or `[.ddtags(tags: retryTags)]` on retries                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  This correctly handles both retry scenarios:                                                                                                                                                                                                                                 
  - **HTTP error retry** (`attempt > 0`, `previousResponseCode != nil`): emits `retry_count` + `retry_after`                                                                                                                                                           
  - **Network error retry** (`attempt > 0`, `previousResponseCode == nil`): emits `retry_count` only
  
Updated RUM, SessionReplay (Segment + Resource), and Profiling request builders to use `execution.retryQueryItems` instead of their own inline tag construction.

Logs and Trace builders are unaffected as they do not use retry tags.
                                                                                                                                                                                                                                                                                                                                                                                                              
  ### Review checklist                                                                                                                                                                                                                                                         
  - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)                                                                                                                                                                                                    
  - [ ] Make sure each commit and the PR mention the Issue number or JIRA reference                                                                                                                                                                                          
  - [ ] Add CHANGELOG entry for user facing changes — not needed                                                                                                                                                                                                               
  - [ ] Add Objective-C interface for public APIs — no customer-facing public APIs added
  - [ ] Run `make api-surface` when adding new APIs — verified, no surface changes   

