### PR TITLE
[RUM-14721] Add missing CHANGELOG entry for deterministic sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 3.9.0 / 02-04-2026
 
 - [IMPROVEMENT] Add `NWPath.linkQuality` to network info attached to Logs and Traces on supported platforms. See [#2751][]
+- [IMPROVEMENT] RUM sessions, distributed traces, and Session Replay now use Knuth deterministic sampling seeded from the session UUID, maximizing the probability that a sampled session retains its traces and replay for full observability correlation. See [#2714][]
 - [IMPROVEMENT] Trace now uses deterministic sampling for custom spans, based on the RUM session ID when available. See [#2794][]
 - [FIX] Fix stack overflow crash when RUM scroll tracking is used alongside third-party delegate proxy libraries (e.g. RxSwift). See [#2791][]
 - [FIX] When there is an active span, RUM session tracking uses it as the basis for the resource parent span and sampling decision. Starting in this release, if the active span is not sampled, session tracking falls back to making its own sampling decision based on the RUM session tracking sampling rate. See [#2807][]
@@ -1099,6 +1100,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2761]: https://github.com/DataDog/dd-sdk-ios/pull/2761
 [#2740]: https://github.com/DataDog/dd-sdk-ios/pull/2740
 [#2750]: https://github.com/DataDog/dd-sdk-ios/pull/2750
+[#2714]: https://github.com/DataDog/dd-sdk-ios/pull/2714
 [#2751]: https://github.com/DataDog/dd-sdk-ios/pull/2751
 [#2773]: https://github.com/DataDog/dd-sdk-ios/pull/2773
 [#2776]: https://github.com/DataDog/dd-sdk-ios/pull/2776


### PR DESCRIPTION
### What and why?

Add the missing CHANGELOG entry for [#2714](https://github.com/DataDog/dd-sdk-ios/pull/2714) which introduced Knuth deterministic sampling seeded from the RUM session UUID for RUM sessions, distributed traces, and Session Replay.

### How?

Added the changelog entry and its PR link reference to `CHANGELOG.md` under the 3.9.0 section.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs