### PR TITLE
MOB-6385: Add fed2 endpoint to `DatadogSite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add watchOS and visionOS support. See [#2817][]
+- [FEATURE] Add support for the FedRAMP-compatible `fed2.ddog-gov.com` site. See [#2827][]
 
 # 3.9.0 / 02-04-2026
 
@@ -1110,6 +1111,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2794]: https://github.com/DataDog/dd-sdk-ios/pull/2794
 [#2807]: https://github.com/DataDog/dd-sdk-ios/pull/2807
 [#2817]: https://github.com/DataDog/dd-sdk-ios/pull/2817
+[#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogCore/Sources/DatadogConfiguration+objc.swift
@@ -32,6 +32,8 @@ public final class objc_DatadogSite: NSObject {
     public static func ap2() -> objc_DatadogSite { .init(sdkSite: .ap2) }
 
     public static func us1_fed() -> objc_DatadogSite { .init(sdkSite: .us1_fed) }
+
+    public static func us2_fed() -> objc_DatadogSite { .init(sdkSite: .us2_fed) }
 }
 
 @objc(DDBatchSize)

--- a/DatadogCore/Tests/Datadog/Core/DirectoriesTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/DirectoriesTests.swift
@@ -32,6 +32,7 @@ class DirectoriesTests: XCTestCase {
             ("abcdef", .ap1, "e7f8dbbceb3cb6c93d74a8fc6ba9c6a43c05c00b792b65b183f62edb98709c79"),
             ("abcdef", .ap2, "2ec0ea56fdf0f78ddfdfc8bc1e03e8ea28814817e0dae3433f2da5038ccad17c"),
             ("abcdef", .us1_fed, "2a69100a36ae68ad3b081daa4c254fcade6b804ec71eda9109b7ec4b8317940b"),
+            ("abcdef", .us2_fed, "4d781adc6d7c642064e0d1bdba5b565ff6a90785f6838928bfd01d99cf948df2"),
             ("ghijkl", .us1, "158931c9e9576ef6ed1576721227d29e641e3f0ec2083e4bff280684f6b7ca94"),
             ("ghijkl", .us3, "e098808a9b0e3695f6b876ff677e50aaf98034606369abeabd5df45bbe8bb739"),
             ("ghijkl", .us5, "6212ba431e02e4da2da2f36a5fe9d26b4c33641a63be75c22e81196acfde7d91"),
@@ -39,6 +40,7 @@ class DirectoriesTests: XCTestCase {
             ("ghijkl", .ap1, "396717396bd53c4019640e9b6f6f1848f10fa95752c497d3a93de88e2600d550"),
             ("ghijkl", .ap2, "904bd45213241e69c07b3918f39b1330f08cbbd2c828eeeff53fd4ed189a4a08"),
             ("ghijkl", .us1_fed, "1585291b515c607624ed20935382bde4438ffac64f190b20a064eb6c1b734c6b"),
+            ("ghijkl", .us2_fed, "319adab00cc08408ac1ee87f72297595797d17ba95f1c2865f249770e4780f3c"),
         ]
 
         // When

--- a/DatadogCore/Tests/Objc/DDConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDConfigurationTests.swift
@@ -50,6 +50,9 @@ class DDConfigurationTests: XCTestCase {
         objcConfig.site = .us1_fed()
         XCTAssertEqual(objcConfig.sdkConfiguration.site, .us1_fed)
 
+        objcConfig.site = .us2_fed()
+        XCTAssertEqual(objcConfig.sdkConfiguration.site, .us2_fed)
+
         objcConfig.service = "service-name"
         XCTAssertEqual(objcConfig.sdkConfiguration.service, "service-name")
 

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -43,6 +43,7 @@
     [DDSite us1];
     [DDSite us1];
     [DDSite us1_fed];
+    [DDSite us2_fed];
     [DDSite us3];
     [DDSite us5];
 }

--- a/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
@@ -130,10 +130,10 @@ extension DatadogSite {
         case .eu1: return URL(string: "https://\(subdomain).ff-cdn.datadoghq.eu")!
         case .ap1: return URL(string: "https://\(subdomain).ff-cdn.ap1.datadoghq.com")!
         case .ap2: return URL(string: "https://\(subdomain).ff-cdn.ap2.datadoghq.com")!
-        case .us1_fed:
+        case .us1_fed, .us2_fed:
             DD.logger.warn(
                 """
-                Government sites (us1_fed) are not officially supported for feature flags. \
+                Government sites (us1_fed, us2_fed) are not officially supported for feature flags. \
                 Falling back to us1 endpoint.
                 """
             )

--- a/DatadogFlags/Tests/Client/EvaluationLoggingTests.swift
+++ b/DatadogFlags/Tests/Client/EvaluationLoggingTests.swift
@@ -90,6 +90,7 @@ class EvaluationLoggingTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/flagevaluation")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/flagevaluation")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/flagevaluation")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/flagevaluation")
 
         // Then - Verify Content-Type and batched schema
         let contextWithRUM = DatadogContext.mockWith(

--- a/DatadogFlags/Tests/Client/ExposureRequestBuilderTests.swift
+++ b/DatadogFlags/Tests/Client/ExposureRequestBuilderTests.swift
@@ -52,6 +52,7 @@ final class ExposureRequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/exposures")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/exposures")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/exposures")
     }
 
     func testItSetsCustomIntakeURL() throws {
@@ -77,6 +78,7 @@ final class ExposureRequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), expectedURL)
         XCTAssertEqual(url(for: .ap2), expectedURL)
         XCTAssertEqual(url(for: .us1_fed), expectedURL)
+        XCTAssertEqual(url(for: .us2_fed), expectedURL)
     }
 
     func testItSetsExposureQueryParameters() throws {

--- a/DatadogInternal/Sources/Context/DatadogSite.swift
+++ b/DatadogInternal/Sources/Context/DatadogSite.swift
@@ -28,6 +28,9 @@ public enum DatadogSite: String {
     /// US based servers, FedRAMP compatible.
     /// Sends data to [app.ddog-gov.com](https://app.ddog-gov.com/).
     case us1_fed
+    /// US based servers, FedRAMP compatible.
+    /// Sends data to [fed2.ddog-gov.com](https://fed2.ddog-gov.com/).
+    case us2_fed
 }
 
 extension DatadogSite {
@@ -41,6 +44,7 @@ extension DatadogSite {
         case .ap1: return URL(string: "https://browser-intake-ap1-datadoghq.com/")!
         case .ap2: return URL(string: "https://browser-intake-ap2-datadoghq.com/")!
         case .us1_fed: return URL(string: "https://browser-intake-ddog-gov.com/")!
+        case .us2_fed: return URL(string: "https://browser-intake-fed2-ddog-gov.com/")!
         // swiftlint:enable force_unwrapping
         }
     }

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -64,6 +64,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/profile")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/profile")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/profile")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/profile")
     }
 
     func testItSetsCustomIntakeURL() {
@@ -86,6 +87,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), expectedURL)
         XCTAssertEqual(try url(for: .ap2), expectedURL)
         XCTAssertEqual(try url(for: .us1_fed), expectedURL)
+        XCTAssertEqual(try url(for: .us2_fed), expectedURL)
     }
 
     func testItSetsQueryParameters() throws {

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -53,6 +53,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/rum")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/rum")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/rum")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/rum")
     }
 
     func testItSetsCustomIntakeURL() throws {
@@ -79,6 +80,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), expectedURL)
         XCTAssertEqual(url(for: .ap2), expectedURL)
         XCTAssertEqual(url(for: .us1_fed), expectedURL)
+        XCTAssertEqual(url(for: .us2_fed), expectedURL)
     }
 
     func testItSetsRUMQueryParameters() throws {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -49,6 +49,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/replay")
     }
 
     func testItSetsCustomIntakeURL() {
@@ -71,6 +72,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), expectedURL)
         XCTAssertEqual(try url(for: .ap2), expectedURL)
         XCTAssertEqual(try url(for: .us1_fed), expectedURL)
+        XCTAssertEqual(try url(for: .us2_fed), expectedURL)
     }
 
     func testItSetsQueryParameters() throws {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -53,6 +53,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/replay")
     }
 
     func testItSetsCustomIntakeURL() {
@@ -75,6 +76,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), expectedURL)
         XCTAssertEqual(try url(for: .ap2), expectedURL)
         XCTAssertEqual(try url(for: .us1_fed), expectedURL)
+        XCTAssertEqual(try url(for: .us2_fed), expectedURL)
     }
 
     func testItSetsQueryParameters() throws {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
@@ -120,7 +120,7 @@ extension DatadogSite: AnyMockable, RandomMockable {
     }
 
     public static func mockRandom() -> Self {
-        return [.us1, .us3, .us5, .eu1, .ap1, .ap2, .us1_fed].randomElement()!
+        return [.us1, .us3, .us5, .eu1, .ap1, .ap2, .us1_fed, .us2_fed].randomElement()!
     }
 }
 

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -28,6 +28,7 @@ public final class objc_DatadogSite: NSObject
     public static func ap1() -> objc_DatadogSite
     public static func ap2() -> objc_DatadogSite
     public static func us1_fed() -> objc_DatadogSite
+    public static func us2_fed() -> objc_DatadogSite
 public enum objc_BatchSize: Int
     case small
     case medium
@@ -369,6 +370,7 @@ public class objc_RUMActionEvent: NSObject
     public var source: objc_RUMActionEventSource
     public var stream: objc_RUMActionEventStream?
     public var synthetics: objc_RUMActionEventRUMSyntheticsTest?
+    public var tab: objc_RUMActionEventTAB?
     public var type: String
     public var usr: objc_RUMActionEventRUMUser?
     public var version: String?
@@ -575,6 +577,8 @@ public class objc_RUMActionEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMActionEventTAB: NSObject
+    public var id: String
 public class objc_RUMActionEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -613,6 +617,7 @@ public class objc_RUMErrorEvent: NSObject
     public var source: objc_RUMErrorEventSource
     public var stream: objc_RUMErrorEventStream?
     public var synthetics: objc_RUMErrorEventRUMSyntheticsTest?
+    public var tab: objc_RUMErrorEventTAB?
     public var type: String
     public var usr: objc_RUMErrorEventRUMUser?
     public var version: String?
@@ -621,9 +626,13 @@ public class objc_RUMErrorEventDD: NSObject
     public var browserSdkVersion: String?
     public var configuration: objc_RUMErrorEventDDConfiguration?
     public var formatVersion: NSNumber
+    public var parentSpanId: String?
     public var profiling: objc_RUMErrorEventDDProfiling?
+    public var rulePsr: NSNumber?
     public var sdkName: String?
     public var session: objc_RUMErrorEventDDSession?
+    public var spanId: String?
+    public var traceId: String?
 public class objc_RUMErrorEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
     public var sessionReplaySampleRate: NSNumber?
@@ -818,10 +827,34 @@ public class objc_RUMErrorEventErrorMeta: NSObject
     public var path: String?
     public var process: String?
 public class objc_RUMErrorEventErrorResource: NSObject
+    public var graphql: objc_RUMErrorEventErrorResourceRUMGraphql?
     public var method: objc_RUMErrorEventErrorResourceRUMMethod
     public var provider: objc_RUMErrorEventErrorResourceProvider?
     public var statusCode: NSNumber
     public var url: String
+public class objc_RUMErrorEventErrorResourceRUMGraphql: NSObject
+    public var errorCount: NSNumber?
+    public var errors: [objc_RUMErrorEventErrorResourceRUMGraphqlErrors]?
+    public var operationName: String?
+    public var operationType: objc_RUMErrorEventErrorResourceRUMGraphqlOperationType
+    public var payload: String?
+    public var variables: String?
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrors: NSObject
+    public var code: String?
+    public var locations: [objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations]?
+    public var message: String
+    public var path: [objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath]?
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrorsLocations: NSObject
+    public var column: NSNumber
+    public var line: NSNumber
+public class objc_RUMErrorEventErrorResourceRUMGraphqlErrorsPath: NSObject
+    public var string: String?
+    public var integer: NSNumber?
+public enum objc_RUMErrorEventErrorResourceRUMGraphqlOperationType: Int
+    case none
+    case query
+    case mutation
+    case subscription
 public enum objc_RUMErrorEventErrorResourceRUMMethod: Int
     case post
     case get
@@ -916,6 +949,8 @@ public class objc_RUMErrorEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMErrorEventTAB: NSObject
+    public var id: String
 public class objc_RUMErrorEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -952,6 +987,7 @@ public class objc_RUMLongTaskEvent: NSObject
     public var source: objc_RUMLongTaskEventSource
     public var stream: objc_RUMLongTaskEventStream?
     public var synthetics: objc_RUMLongTaskEventRUMSyntheticsTest?
+    public var tab: objc_RUMLongTaskEventTAB?
     public var type: String
     public var usr: objc_RUMLongTaskEventRUMUser?
     public var version: String?
@@ -1157,6 +1193,8 @@ public class objc_RUMLongTaskEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMLongTaskEventTAB: NSObject
+    public var id: String
 public class objc_RUMLongTaskEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -1192,6 +1230,7 @@ public class objc_RUMResourceEvent: NSObject
     public var source: objc_RUMResourceEventSource
     public var stream: objc_RUMResourceEventStream?
     public var synthetics: objc_RUMResourceEventRUMSyntheticsTest?
+    public var tab: objc_RUMResourceEventTAB?
     public var type: String
     public var usr: objc_RUMResourceEventRUMUser?
     public var version: String?
@@ -1332,7 +1371,7 @@ public class objc_RUMResourceEventResource: NSObject
     public var duration: NSNumber?
     public var encodedBodySize: NSNumber?
     public var firstByte: objc_RUMResourceEventResourceFirstByte?
-    public var graphql: objc_RUMResourceEventResourceGraphql?
+    public var graphql: objc_RUMResourceEventResourceRUMGraphql?
     public var id: String?
     public var method: objc_RUMResourceEventResourceRUMMethod
     public var `protocol`: String?
@@ -1365,25 +1404,25 @@ public class objc_RUMResourceEventResourceDownload: NSObject
 public class objc_RUMResourceEventResourceFirstByte: NSObject
     public var duration: NSNumber
     public var start: NSNumber
-public class objc_RUMResourceEventResourceGraphql: NSObject
+public class objc_RUMResourceEventResourceRUMGraphql: NSObject
     public var errorCount: NSNumber?
-    public var errors: [objc_RUMResourceEventResourceGraphqlErrors]?
+    public var errors: [objc_RUMResourceEventResourceRUMGraphqlErrors]?
     public var operationName: String?
-    public var operationType: objc_RUMResourceEventResourceGraphqlOperationType
+    public var operationType: objc_RUMResourceEventResourceRUMGraphqlOperationType
     public var payload: String?
     public var variables: String?
-public class objc_RUMResourceEventResourceGraphqlErrors: NSObject
+public class objc_RUMResourceEventResourceRUMGraphqlErrors: NSObject
     public var code: String?
-    public var locations: [objc_RUMResourceEventResourceGraphqlErrorsLocations]?
+    public var locations: [objc_RUMResourceEventResourceRUMGraphqlErrorsLocations]?
     public var message: String
-    public var path: [objc_RUMResourceEventResourceGraphqlErrorsPath]?
-public class objc_RUMResourceEventResourceGraphqlErrorsLocations: NSObject
+    public var path: [objc_RUMResourceEventResourceRUMGraphqlErrorsPath]?
+public class objc_RUMResourceEventResourceRUMGraphqlErrorsLocations: NSObject
     public var column: NSNumber
     public var line: NSNumber
-public class objc_RUMResourceEventResourceGraphqlErrorsPath: NSObject
+public class objc_RUMResourceEventResourceRUMGraphqlErrorsPath: NSObject
     public var string: String?
     public var integer: NSNumber?
-public enum objc_RUMResourceEventResourceGraphqlOperationType: Int
+public enum objc_RUMResourceEventResourceRUMGraphqlOperationType: Int
     case none
     case query
     case mutation
@@ -1481,6 +1520,8 @@ public class objc_RUMResourceEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMResourceEventTAB: NSObject
+    public var id: String
 public class objc_RUMResourceEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -1516,6 +1557,7 @@ public class objc_RUMViewEvent: NSObject
     public var source: objc_RUMViewEventSource
     public var stream: objc_RUMViewEventStream?
     public var synthetics: objc_RUMViewEventRUMSyntheticsTest?
+    public var tab: objc_RUMViewEventTAB?
     public var type: String
     public var usr: objc_RUMViewEventRUMUser?
     public var version: String?
@@ -1724,6 +1766,8 @@ public class objc_RUMViewEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMViewEventTAB: NSObject
+    public var id: String
 public class objc_RUMViewEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -1886,7 +1930,7 @@ public class objc_RUMViewEventViewPerformanceINP: NSObject
 public class objc_RUMViewEventViewPerformanceINPSubParts: NSObject
     public var inputDelay: NSNumber
     public var presentationDelay: NSNumber
-    public var processingTime: NSNumber
+    public var processingDuration: NSNumber
 public class objc_RUMViewEventViewPerformanceLCP: NSObject
     public var resourceUrl: String?
     public var subParts: objc_RUMViewEventViewPerformanceLCPSubParts?
@@ -1925,6 +1969,7 @@ public class objc_RUMViewUpdateEvent: NSObject
     public var source: objc_RUMViewUpdateEventSource
     public var stream: objc_RUMViewUpdateEventStream?
     public var synthetics: objc_RUMViewUpdateEventRUMSyntheticsTest?
+    public var tab: objc_RUMViewUpdateEventTAB?
     public var type: String
     public var usr: objc_RUMViewUpdateEventRUMUser?
     public var version: String?
@@ -2098,6 +2143,8 @@ public class objc_RUMViewUpdateEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMViewUpdateEventTAB: NSObject
+    public var id: String
 public class objc_RUMViewUpdateEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -2260,7 +2307,7 @@ public class objc_RUMViewUpdateEventViewPerformanceINP: NSObject
 public class objc_RUMViewUpdateEventViewPerformanceINPSubParts: NSObject
     public var inputDelay: NSNumber
     public var presentationDelay: NSNumber
-    public var processingTime: NSNumber
+    public var processingDuration: NSNumber
 public class objc_RUMViewUpdateEventViewPerformanceLCP: NSObject
     public var resourceUrl: String?
     public var subParts: objc_RUMViewUpdateEventViewPerformanceLCPSubParts?
@@ -2297,6 +2344,7 @@ public class objc_RUMVitalAppLaunchEvent: NSObject
     public var source: objc_RUMVitalAppLaunchEventSource
     public var stream: objc_RUMVitalAppLaunchEventStream?
     public var synthetics: objc_RUMVitalAppLaunchEventRUMSyntheticsTest?
+    public var tab: objc_RUMVitalAppLaunchEventTAB?
     public var type: String
     public var usr: objc_RUMVitalAppLaunchEventRUMUser?
     public var version: String?
@@ -2462,6 +2510,8 @@ public class objc_RUMVitalAppLaunchEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMVitalAppLaunchEventTAB: NSObject
+    public var id: String
 public class objc_RUMVitalAppLaunchEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -2512,6 +2562,7 @@ public class objc_RUMVitalDurationEvent: NSObject
     public var source: objc_RUMVitalDurationEventSource
     public var stream: objc_RUMVitalDurationEventStream?
     public var synthetics: objc_RUMVitalDurationEventRUMSyntheticsTest?
+    public var tab: objc_RUMVitalDurationEventTAB?
     public var type: String
     public var usr: objc_RUMVitalDurationEventRUMUser?
     public var version: String?
@@ -2677,6 +2728,8 @@ public class objc_RUMVitalDurationEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMVitalDurationEventTAB: NSObject
+    public var id: String
 public class objc_RUMVitalDurationEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -2716,6 +2769,7 @@ public class objc_RUMVitalOperationStepEvent: NSObject
     public var source: objc_RUMVitalOperationStepEventSource
     public var stream: objc_RUMVitalOperationStepEventStream?
     public var synthetics: objc_RUMVitalOperationStepEventRUMSyntheticsTest?
+    public var tab: objc_RUMVitalOperationStepEventTAB?
     public var type: String
     public var usr: objc_RUMVitalOperationStepEventRUMUser?
     public var version: String?
@@ -2881,6 +2935,8 @@ public class objc_RUMVitalOperationStepEventRUMSyntheticsTest: NSObject
     public var resultId: String
     public var testId: String
     public var syntheticsInfo: [String: Any]
+public class objc_RUMVitalOperationStepEventTAB: NSObject
+    public var id: String
 public class objc_RUMVitalOperationStepEventRUMUser: NSObject
     public var anonymousId: String?
     public var email: String?
@@ -3307,6 +3363,7 @@ public class objc_RUMConfiguration: NSObject
     public var uiKitActionsPredicate: objc_UIKitRUMActionsPredicate?
     public var swiftUIViewsPredicate: objc_SwiftUIRUMViewsPredicate?
     public var swiftUIActionsPredicate: objc_SwiftUIRUMActionsPredicate?
+    public var trackMemoryWarnings: Bool
     public func setURLSessionTracking(_ tracking: objc_URLSessionTracking)
     public var trackFrustrations: Bool
     public var trackBackgroundEvents: Bool
@@ -3322,7 +3379,6 @@ public class objc_RUMConfiguration: NSObject
     public var onSessionStart: ((String, Bool) -> Void)?
     public var customEndpoint: URL?
     public var trackAnonymousUser: Bool
-    public var trackMemoryWarnings: Bool
 public class objc_RUM: NSObject
     public static func enable(with configuration: objc_RUMConfiguration)
 public class objc_RUMMonitor: NSObject


### PR DESCRIPTION
### What and why?

This PR adds support for a new `DatadogSite` case, `us2_fed`, for the FedRAMP-compatible `fed2.ddog-gov.com` site.

### How?

It adds a new case `us2_fed` to `DatadogSite` with documentation aligned with the `us1_fed` case and maps it to its intake endpoint. 
It also updates the Objective-C `DDSite` bridge.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
