### PR TITLE
chore: Update dogfooding branch on `gitlab-ci`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ stages:
 variables:
   MAIN_BRANCH: "master"
   DEVELOP_BRANCH: "develop"
+  DOGFOODING_BRANCH: "dogfooding"
   # Default Xcode and runtime versions for all jobs:
   DEFAULT_XCODE: "26.0.0"
   DEFAULT_IOS_OS: "26.0.1"
@@ -378,7 +379,7 @@ Benchmark Test (upload to s8s):
 Dogfood (Shopist):
   stage: dogfood
   rules:
-    - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH'
+    - if: '$CI_COMMIT_BRANCH == $DOGFOODING_BRANCH'
       when: manual
       allow_failure: true
   id_tokens:
@@ -390,7 +391,7 @@ Dogfood (Shopist):
 Dogfood (Datadog app):
   stage: dogfood
   rules:
-    - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH'
+    - if: '$CI_COMMIT_BRANCH == $DOGFOODING_BRANCH'
       when: manual
       allow_failure: true
   id_tokens:

--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -32,10 +32,11 @@ DOGFOODED_BRANCH="$(current_git_branch)"
 DOGFOODED_COMMIT="$(current_git_commit)"
 DOGFOODED_COMMIT_SHORT="$(current_git_commit_short)"
 DOGFOODING_BRANCH_NAME="dogfooding-$DOGFOODED_COMMIT_SHORT" # the name of the branch to create in dependent repo
+EXPECTED_DOGFOODED_BRANCH="dogfooding"
 
-if [[ "$DOGFOODED_BRANCH" != "develop" ]]; then
+if [[ "$DOGFOODED_BRANCH" != "$EXPECTED_DOGFOODED_BRANCH" ]]; then
     DRY_RUN=1
-    echo_warn "DOGFOODED_BRANCH is not 'develop'. Enforcing DRY_RUN=1."
+    echo_warn "DOGFOODED_BRANCH is not '$EXPECTED_DOGFOODED_BRANCH'. Enforcing DRY_RUN=1."
 fi
 
 echo_info "▸ PWD = '$(pwd)'"


### PR DESCRIPTION
### What and why?

This PR updates the dogfooding workflow so `dogfood-shopist` and `dogfood-datadog-app` consume `dd-sdk-ios` from the `dogfooding` branch instead of `develop`.

The goal is to align the dogfooding jobs with the new SDK branch used for dogfooding.

### How?

The dogfooding script now expects `dogfooding` as the source branch for `dd-sdk-ios` when preparing dogfooding updates.
The GitLab rules for the manual dogfooding jobs were also updated so those jobs are exposed on `dogfooding` branch pipelines instead of `develop`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
