### PR TITLE
[RUM-14354] Enable SwiftUI manual instrumentation on watchOS

### DIFF
--- a/DatadogInternal/Sources/Context/AppState.swift
+++ b/DatadogInternal/Sources/Context/AppState.swift
@@ -158,8 +158,7 @@ public struct DefaultAppStateProvider: AppStateProvider {
     ///
     /// **Note**: Must be called on the main thread.
     public var current: AppState {
-        let wkState = WKExtension.dd.shared.applicationState
-        return AppState(wkState)
+        return AppState(WKApplication.shared().applicationState)
     }
 }
 

--- a/DatadogRUM/Sources/Instrumentation/Actions/RUMActionsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/RUMActionsHandler.swift
@@ -4,24 +4,30 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(watchOS)
-import UIKit
 import DatadogInternal
 
+#if !os(watchOS)
+import UIKit
+#endif
+
 internal protocol RUMActionsHandling: RUMCommandPublisher {
+    #if !os(watchOS)
     /// Tracks RUM actions automatically for UIKit and SwiftUI by responding to `UIApplication.sendEvent(application:event:)` being called.
     func notify_sendEvent(application: UIApplication, event: UIEvent)
-    /// Tracks RUM actions manually with SwiftUI view modifers by being notified from `RUMTapActionModifier`.
+    #endif
+    /// Tracks RUM actions manually with SwiftUI view modifiers by being notified from `RUMTapActionModifier`.
     func notify_viewModifierTapped(actionName: String, actionAttributes: [String: Encodable])
 }
 
 internal final class RUMActionsHandler: RUMActionsHandling {
-    /// Factory that processes `UIEvents` and creates RUM action commands.
-    /// It is `nil` when both UIKit and SwiftUI automatic instrumentations are not enabled.
-    private let eventCommandsFactory: UIEventCommandFactory?
     private let dateProvider: DateProvider
 
     weak var subscriber: RUMCommandSubscriber?
+
+    #if !os(watchOS)
+    /// Factory that processes `UIEvents` and creates RUM action commands.
+    /// It is `nil` when both UIKit and SwiftUI automatic instrumentations are not enabled.
+    private let eventCommandsFactory: UIEventCommandFactory?
 
     /// Convenience initializer for iOS
     convenience init(
@@ -70,18 +76,21 @@ internal final class RUMActionsHandler: RUMActionsHandling {
         )
     }
 
-    init(
-        dateProvider: DateProvider,
-        eventCommandsFactory: UIEventCommandFactory?
-    ) {
+    init(dateProvider: DateProvider, eventCommandsFactory: UIEventCommandFactory?) {
         self.eventCommandsFactory = eventCommandsFactory
         self.dateProvider = dateProvider
     }
+    #else
+    init(dateProvider: DateProvider) {
+        self.dateProvider = dateProvider
+    }
+    #endif
 
     func publish(to subscriber: RUMCommandSubscriber) {
         self.subscriber = subscriber
     }
 
+    #if !os(watchOS)
     /// Tracks RUM actions automatically for UIKit and SwiftUI in response to `UIApplication.sendEvent(application:event:)` event.
     func notify_sendEvent(application: UIApplication, event: UIEvent) {
         guard let command = eventCommandsFactory?.command(from: event) else {
@@ -100,6 +109,7 @@ internal final class RUMActionsHandler: RUMActionsHandling {
 
         subscriber.process(command: command)
     }
+    #endif
 
     /// Tracks manually instrumented SwiftUI actions via `.trackRUMTapAction()` view modifier,
     /// in response to `SwiftUI.TapGesture.onEnded` event.
@@ -125,4 +135,3 @@ internal final class RUMActionsHandler: RUMActionsHandling {
         subscriber.process(command: command)
     }
 }
-#endif

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -4,12 +4,10 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(watchOS)
-#if canImport(SwiftUI)
+#if !os(tvOS) && canImport(SwiftUI)
+
 import SwiftUI
 import DatadogInternal
-
-#if !os(tvOS)
 
 /// `SwiftUI.ViewModifier` which notifies RUM instrumentation when the modified view is tapped.
 /// It serves as an entry point to RUM actions instrumentation in SwiftUI.
@@ -21,7 +19,7 @@ import DatadogInternal
 /// - If tracking taps inside a `List` is required, consider logging actions manually via `RUMMonitor.shared().addAction(...)`
 ///   instead of using this modifier.
 /// - We consider this a bug in SwiftUI and have reported it to Apple: [FB16488816](https://openradar.appspot.com/FB16488816).
-@available(iOS 13, *)
+@available(iOS 13, watchOS 7, *)
 internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     /// The SDK core instance.
     weak var core: DatadogCoreProtocol?
@@ -51,7 +49,7 @@ internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     }
 }
 
-@available(iOS 13, *)
+@available(iOS 13, watchOS 7, *)
 public extension SwiftUI.View {
     /// Monitor tap actions on this view with Datadog RUM. An Action event will be logged after the required number of taps.
     ///
@@ -83,6 +81,4 @@ public extension SwiftUI.View {
     }
 }
 
-#endif
-#endif
 #endif

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -20,6 +20,10 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     /// It is non-optional as we can't know if SwiftUI manual instrumentation will be used or not.
     let viewsHandler: RUMViewsHandler
 
+    /// Receives interceptions of both automatic and manual instrumentations.
+    /// It is non-optional as we can't know if SwiftUI manual instrumentation will be used or not.
+    let actionsHandler: RUMActionsHandling
+
     #if !os(watchOS)
     /// Swizzles `UIViewController` for intercepting its lifecycle callbacks.
     /// It is `nil` (no swizzling) if RUM View automatic instrumentation is not enabled.
@@ -28,9 +32,6 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     /// Swizzles `UIApplication` for intercepting `UIEvents` passed to the app.
     /// It is `nil` (no swizzling) if RUM Action automatic instrumentation is not enabled.
     let uiApplicationSwizzler: UIApplicationSwizzler?
-    /// Receives interceptions of both automatic and manual instrumentations.
-    /// It is non-optional as we can't know if SwiftUI manual instrumentation will be used or not.
-    let actionsHandler: RUMActionsHandling
 
     #if !os(tvOS)
     /// Swizzles `UIScrollView.delegate` setter for intercepting scroll gestures.
@@ -159,8 +160,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         #endif
 
         self.viewsHandler = viewsHandler
-        self.viewControllerSwizzler = viewControllerSwizzler
         self.actionsHandler = actionsHandler
+        self.viewControllerSwizzler = viewControllerSwizzler
         self.uiApplicationSwizzler = uiApplicationSwizzler
         #if !os(tvOS)
         self.scrollHandler = scrollHandler
@@ -211,6 +212,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     ) {
         // Always create views handler (we can't know if it will be used by manual instrumentation)
         self.viewsHandler = RUMViewsHandler(dateProvider: dateProvider, notificationCenter: notificationCenter)
+        // Always create the actions handler (we can't know if it will be used by SwiftUI manual instrumentation)
+        self.actionsHandler = RUMActionsHandler(dateProvider: dateProvider)
         self.longTasks = LongTaskObserver(threshold: longTaskThreshold, dateProvider: dateProvider)
         self.appHangs = AppHangsMonitor(
             featureScope: featureScope,
@@ -251,11 +254,9 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
 
     func publish(to subscriber: RUMCommandSubscriber) {
         viewsHandler.publish(to: subscriber)
-        #if !os(watchOS)
         actionsHandler.publish(to: subscriber)
-        #if !os(tvOS)
+        #if !os(watchOS) && !os(tvOS)
         scrollHandler?.publish(to: subscriber)
-        #endif
         #endif
         longTasks?.publish(to: subscriber)
         appHangs?.nonFatalHangsHandler.publish(to: subscriber)

--- a/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
@@ -4,13 +4,13 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(watchOS) && canImport(SwiftUI)
+#if canImport(SwiftUI)
 import SwiftUI
 import DatadogInternal
 
 /// `SwiftUI.ViewModifier` which notifes RUM instrumentation when modified view appears and disappears.
 /// It makes an entry point to RUM views instrumentation in SwiftUI.
-@available(iOS 13, tvOS 13, *)
+@available(iOS 13, tvOS 13, watchOS 7, *)
 internal struct RUMViewModifier: SwiftUI.ViewModifier {
     /// Datadog RUM instrumentation instance
     let instrumentation: RUMInstrumentation?
@@ -45,7 +45,7 @@ internal struct RUMViewModifier: SwiftUI.ViewModifier {
     }
 }
 
-@available(iOS 13, tvOS 13, *)
+@available(iOS 13, tvOS 13, watchOS 7, *)
 public extension SwiftUI.View {
     /// Monitor this view with Datadog RUM. A start and stop events will be logged when this view appears
     /// and disappears.

--- a/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
@@ -4,24 +4,21 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if !os(watchOS)
-
 import XCTest
 import TestUtilities
 import DatadogInternal
-import SwiftUI
 @testable import DatadogRUM
 
 class RUMActionsHandlerTests: XCTestCase {
     private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
     private let commandSubscriber = RUMCommandSubscriberMock()
 
+    #if !os(watchOS)
     private func touchHandler(
         with uiKitPredicate: UITouchRUMActionsPredicate = DefaultUIKitRUMActionsPredicate(),
         swiftUIPredicate: SwiftUIRUMActionsPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
     ) -> RUMActionsHandler {
-        let handler =
-        RUMActionsHandler(
+        let handler = RUMActionsHandler(
             dateProvider: dateProvider,
             uiKitPredicate: uiKitPredicate,
             swiftUIPredicate: swiftUIPredicate,
@@ -51,8 +48,17 @@ class RUMActionsHandlerTests: XCTestCase {
         mockAppWindow = nil
         super.tearDown()
     }
+    #else
+    private func watchHandler() -> RUMActionsHandler {
+        let handler = RUMActionsHandler(dateProvider: dateProvider)
+        handler.publish(to: commandSubscriber)
+        return handler
+    }
+    #endif
 
-    // MARK: - Scenarios For Accepting Tap Events
+    // MARK: - UIKit Automatic Action Tracking
+
+    #if !os(watchOS)
 
     func testGivenUIKitViewWithAccessibilityIdentifier_whenSingleTouchEnds_itSendsRUMAction() {
         // Given
@@ -447,14 +453,20 @@ class RUMActionsHandlerTests: XCTestCase {
         XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
+    #endif // !os(watchOS)
+
     // MARK: - SwiftUI View Modifier Actions
 
     func testWhenSwiftUIViewModifierIsTapped_itSendsRUMAction() throws {
         // Given
+        #if os(watchOS)
+        let handler = watchHandler()
+        #else
         let handler = oneOf([
             { self.touchHandler() },
             { self.pressHandler() }
         ])
+        #endif
 
         // When
         let actionName: String = .mockRandom()
@@ -472,6 +484,8 @@ class RUMActionsHandlerTests: XCTestCase {
 }
 
 // MARK: - Helpers
+
+#if !os(watchOS)
 
 private extension UIView {
     func attached(to parent: UIView) -> UIView {
@@ -508,4 +522,4 @@ private class MockUIKitRUMActionsPredicate: UITouchRUMActionsPredicate & UIPress
     }
 }
 
-#endif
+#endif // !os(watchOS)


### PR DESCRIPTION
### What and why?

watchOS doesn't have `UIApplication` but it supports SwiftUI. This PR partially enables RUM instrumentation on watchOS by making the SwiftUI manual modifiers (`.trackRUMTapAction()` and `.trackRUMView()`) available on watchOS 7+.

Automatic instrumentation (UIKit swizzling) remains unavailable on watchOS.

Additionally, this PR fixes a crash when initializing the SDK in a SwiftUI lifecycle watchOS app (using `@main App`). The root cause was `WKExtension.shared()` being called during SDK init — this API only works in the legacy WatchKit Extension lifecycle and aborts when called from a SwiftUI `@main` app. The fix replaces it with `WKApplication.shared()`, which works across both lifecycles.

### How?

The SwiftUI manual view and action modifiers are now compiled for watchOS 7+. UIKit-based automatic instrumentation is unchanged and continues to be excluded on watchOS.

`DefaultAppStateProvider` on watchOS now uses `WKApplication.shared().applicationState` instead of `WKExtension.shared().applicationState` to safely support both the legacy WatchKit Extension and the modern SwiftUI `@main` app lifecycle.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs