### PR TITLE
Fix duplicate assertion in testPresetsConsistency

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
@@ -132,9 +132,9 @@ class PerformancePresetTests: XCTestCase {
                 "Upload delay boundaries must be consistent."
             )
             XCTAssertGreaterThan(
-                preset.maxUploadDelay,
-                preset.minUploadDelay,
-                "Upload delay boundaries must be consistent."
+                preset.maxBatchesPerUpload,
+                0,
+                "At least one batch must be processed per upload."
             )
             XCTAssertLessThanOrEqual(
                 preset.uploadDelayChangeRate,


### PR DESCRIPTION
 ### What and why?                   
Remove a duplicate assertion in testPresetsConsistency that was testing the same condition twice (maxUploadDelay > minUploadDelay), and replace the duplicate with a missing invariant check: maxBatchesPerUpload > 0.                                                       
                  
 ### How?                                                                                                                                                                                                                                                                         
Single assertion change in PerformancePresetTests.swift : removed the redundant XCTAssertGreaterThan(preset.maxUploadDelay, preset.minUploadDelay, ...) and added XCTAssertGreaterThan(preset.maxBatchesPerUpload, 0, "At least one batch must be processed per upload.").
                                                                                                                                                                                                                                                                               
 ### Review checklist:
  - Feature or bugfix MUST have appropriate tests — this is a test fix, no new code changed                                                                                                                                                                                    
  - Make sure each commit and the PR mention the Issue number or JIRA reference — no ticket for this one                                                                                                                                                              
  - CHANGELOG — not needed, no user-facing change                                                               
  - Objective-C interface — not applicable                                                                                                                                                                                                                                     
  - make api-surface — not applicable   
