### PR TITLE
RUMS-5762: Fix blank SwiftUI TabView when Session Replay is enabled

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0904F9F42EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
 		0904F9F62EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
+		09F8A1B12F88000100DDBEEF /* UIKitExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F8A1B02F88000100DDBEEF /* UIKitExtensionTests.swift */; };
 		093AC32A2F56F8AA00267CE1 /* ActiveSpanProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */; };
 		094B553F2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */; };
 		095AE9552F7D4E9F00C332AE /* TracerSamplerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095AE9542F7D4E9F00C332AE /* TracerSamplerProvider.swift */; };
@@ -1748,6 +1749,7 @@
 
 /* Begin PBXFileReference section */
 		0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
+		09F8A1B02F88000100DDBEEF /* UIKitExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionTests.swift; sourceTree = "<group>"; };
 		093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpanProvider.swift; sourceTree = "<group>"; };
 		094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceTraceIntegrationTests.swift; sourceTree = "<group>"; };
 		095AE9522F7D4E9F00C332AE /* SamplingDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingDecision.swift; sourceTree = "<group>"; };
@@ -6377,6 +6379,7 @@
 			isa = PBXGroup;
 			children = (
 				115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */,
+				09F8A1B02F88000100DDBEEF /* UIKitExtensionTests.swift */,
 				D284C73F2C2059F3005142CC /* ObjcExceptionTests.swift */,
 				116F84052CFDD06700705755 /* SampleRateTests.swift */,
 				613C6B912768FF3100870CBF /* SamplerTests.swift */,
@@ -8911,7 +8914,7 @@
 				615192CD2BD6948B0005A782 /* HTTPHeadersWriterTests.swift in Sources */,
 				6156A9072BF75A7C00DF66C3 /* ImmutableRequestTests.swift in Sources */,
 				D2F44FB8299AA1DA0074B0D9 /* DataCompressionTests.swift in Sources */,
-				0904F9F42EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */,
+				09F8A1B12F88000100DDBEEF /* UIKitExtensionTests.swift in Sources */,
 				D2EBEE3B29BA163E00B15732 /* B3HTTPHeadersReaderTests.swift in Sources */,
 				D2BEEDB82B3360F50065F3AC /* URLSessionTaskDelegateSwizzlerTests.swift in Sources */,
 				3CCECDB22BC68A0A0013C125 /* SpanIDTests.swift in Sources */,

--- a/DatadogInternal/Sources/Utils/UIKitExtensions.swift
+++ b/DatadogInternal/Sources/Utils/UIKitExtensions.swift
@@ -23,9 +23,20 @@ extension DatadogExtension where ExtendedType == UIApplication {
 }
 
 extension DatadogExtension where ExtendedType: UIView {
+    /// Returns `true` when the class name matches SwiftUI runtime naming patterns.
+    static func isSwiftUIRuntimeClassName(_ className: String) -> Bool {
+        className.hasPrefix("SwiftUI.")
+            || className.hasPrefix("_TtC7SwiftUI")
+            || className.hasPrefix("_TtGC7SwiftUI")
+            || className.hasPrefix("_TtCV7SwiftUI")
+    }
+
     /// Whether this view is owned by SwiftUI.
     public var isSwiftUIView: Bool {
-        Bundle(for: Swift.type(of: type)).dd.isSwiftUI || NSStringFromClass(Swift.type(of: type)).contains("SwiftUI")
+        let viewType = Swift.type(of: type)
+        let className = NSStringFromClass(viewType)
+
+        return Bundle(for: viewType).dd.isSwiftUI || Self.isSwiftUIRuntimeClassName(className)
     }
 }
 

--- a/DatadogInternal/Sources/Utils/UIKitExtensions.swift
+++ b/DatadogInternal/Sources/Utils/UIKitExtensions.swift
@@ -9,6 +9,8 @@ import Foundation
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 
+extension UIView: DatadogExtended { }
+
 extension DatadogExtension where ExtendedType == UIApplication {
     /// `UIApplication.shared` does not compile in some environments (e.g. notification service app extension), resulting with:
     /// _"shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead"_.
@@ -17,6 +19,13 @@ extension DatadogExtension where ExtendedType == UIApplication {
     public static var managedShared: UIApplication? {
         return UIApplication
             .value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication // swiftlint:disable:this unsafe_uiapplication_shared
+    }
+}
+
+extension DatadogExtension where ExtendedType: UIView {
+    /// Whether this view is owned by SwiftUI.
+    public var isSwiftUIView: Bool {
+        Bundle(for: Swift.type(of: type)).dd.isSwiftUI || NSStringFromClass(Swift.type(of: type)).contains("SwiftUI")
     }
 }
 

--- a/DatadogInternal/Tests/Utils/UIKitExtensionTests.swift
+++ b/DatadogInternal/Tests/Utils/UIKitExtensionTests.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+@testable import DatadogInternal
+
+final class UIKitExtensionTests: XCTestCase {
+    func testItRecognizesSwiftUIRuntimeClassNames() {
+        XCTAssertTrue(UIView.dd.isSwiftUIRuntimeClassName("SwiftUI.UIKitTabBarController"))
+        XCTAssertTrue(UIView.dd.isSwiftUIRuntimeClassName("_TtGC7SwiftUI19UIHostingControllerVVS_7TabItem8RootView_"))
+        XCTAssertTrue(UIView.dd.isSwiftUIRuntimeClassName("_TtCV7SwiftUIP33_D74FE142C3C5A6C2CEA4987A69AEBD7522SystemSegmentedControl18UISegmentedControl"))
+    }
+
+    func testItDoesNotTreatAppClassNamesContainingSwiftUIAsSwiftUIRuntimeClasses() {
+        XCTAssertFalse(UIView.dd.isSwiftUIRuntimeClassName("DatadogTests.MySwiftUIView"))
+    }
+}
+#endif

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/LegacySwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/LegacySwiftUIComponentDetector.swift
@@ -22,7 +22,7 @@ internal final class LegacySwiftUIComponentDetector: SwiftUIComponentDetector {
         }
 
         if let view = touch.view,
-           view.isSwiftUIView,
+           view.dd.isSwiftUIView,
            // For iOS 17 and below, we can't reliably distinguish SwiftUI component types (e.g., Button vs Label).
            // We exclude hosting views and track other SwiftUI elements with a generic name.
            !SwiftUIContainerViews.shouldIgnore(view.typeDescription) {

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/ModernSwiftUIComponentDetector.swift
@@ -59,7 +59,7 @@ internal final class ModernSwiftUIComponentDetector: SwiftUIComponentDetector {
     /// which is when we can detect the Button gesture.
     private func handleTouchBegan(_ touch: UITouch, dateProvider: DateProvider) -> Bool {
         guard let view = touch.view,
-              view.isSwiftUIView else {
+              view.dd.isSwiftUIView else {
             return false
         }
 

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
@@ -52,7 +52,7 @@ public struct DefaultUIKitRUMActionsPredicate {
         // Some SwiftUI components are UIKit under the hood,
         // but need to clean up tangled SwiftUI name
         // e.g., _TtCV7SwiftUIP33_D74FE142C3C5A6C2CEA4987A69AEBD7522SystemSegmentedControl18UISegmentedControl
-        } else if view.isSwiftUIView {
+        } else if view.dd.isSwiftUIView {
             return view.swiftUIViewName
         } else {
             return className

--- a/DatadogRUM/Sources/Utils/UIKitExtensions.swift
+++ b/DatadogRUM/Sources/Utils/UIKitExtensions.swift
@@ -45,10 +45,6 @@ internal extension UIView {
         return true
     }
 
-    @objc var isSwiftUIView: Bool {
-        return NSStringFromClass(type(of: self)).contains("SwiftUI")
-    }
-
     /// `true` if this view is a button in a `UIAlertController`, `false` otherwise.
     var isUIAlertActionView: Bool {
         guard let actionViewClass = NSClassFromString("_UIAlertControllerActionView"),

--- a/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
@@ -613,6 +613,7 @@ private class MockGestureRecognizer: UIGestureRecognizer {
     }
 }
 
+@objc(_TtC7SwiftUI17SwiftUIViewMock)
 private class SwiftUIViewMock: UIView {
     var mockTypeDescription: String?
 

--- a/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/SwiftUIComponentDetectorTests.swift
@@ -615,15 +615,10 @@ private class MockGestureRecognizer: UIGestureRecognizer {
 
 private class SwiftUIViewMock: UIView {
     var mockTypeDescription: String?
-    var overrideIsSwiftUIView: Bool?
 
     // Implement TypeDescribing protocol
     override var typeDescription: String {
         return mockTypeDescription ?? "_TtCV7SwiftUI9EmptyView"
-    }
-
-    @objc override var isSwiftUIView: Bool {
-        return overrideIsSwiftUIView ?? true
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIView+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIView+SessionReplay.swift
@@ -8,8 +8,6 @@
 import UIKit
 import DatadogInternal
 
-extension UIView: DatadogExtended { }
-
 /// Sensitive text content types as defined in Session Replay.
 private let UITextContentSensitiveTypes: Set<UITextContentType> = [
     .password,
@@ -62,6 +60,17 @@ internal extension DatadogExtension where ExtendedType: UITextInputTraits {
 
 internal extension DatadogExtension where ExtendedType: UITraitEnvironment {
     var usesDarkMode: Bool { type.traitCollection.userInterfaceStyle == .dark }
+}
+
+internal extension DatadogExtension where ExtendedType: UIView {
+    /// Returns a layout-safe size snapshot for views whose intrinsic size can trigger SwiftUI layout work.
+    var safeIntrinsicContentSize: CGSize {
+        guard type.dd.isSwiftUIView, type.layer.needsLayout() else {
+            return type.intrinsicContentSize
+        }
+
+        return type.bounds.size
+    }
 }
 
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -129,7 +129,7 @@ extension ViewAttributes {
         self.layerCornerRadius = view.layer.cornerRadius
         self.alpha = view.alpha
         self.isHidden = view.isHidden
-        self.intrinsicContentSize = view.intrinsicContentSize
+        self.intrinsicContentSize = view.dd.safeIntrinsicContentSize
         self.textAndInputPrivacy = overrides?.textAndInputPrivacy
         self.imagePrivacy = overrides?.imagePrivacy
         self.touchPrivacy = overrides?.touchPrivacy

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -50,6 +50,19 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.intrinsicContentSize, view.bounds.size)
     }
 
+    func testItStillReadsIntrinsicContentSizeForCustomUIViewNamedLikeSwiftUI() {
+        // Given
+        let view = MySwiftUIView(frame: CGRect(x: 0, y: 0, width: 123, height: 45))
+        view.setNeedsLayout()
+
+        // When
+        let attributes = createViewAttributes(with: view)
+
+        // Then
+        XCTAssertEqual(view.intrinsicContentSizeReadCount, 1)
+        XCTAssertEqual(attributes.intrinsicContentSize, CGSize(width: 300, height: 200))
+    }
+
     func testWhenViewIsVisible() {
         // Given
         let view: UIView = .mockRandom()
@@ -243,7 +256,18 @@ class ViewAttributesTests: XCTestCase {
 }
 // swiftlint:enable opening_brace
 
+// Give the spy a SwiftUI-like runtime name so the test exercises the same classifier path as real hosting views.
+@objc(_TtC7SwiftUI20SwiftUIHostingViewSpy)
 private final class SwiftUIHostingViewSpy: UIView {
+    private(set) var intrinsicContentSizeReadCount = 0
+
+    override var intrinsicContentSize: CGSize {
+        intrinsicContentSizeReadCount += 1
+        return CGSize(width: 300, height: 200)
+    }
+}
+
+private final class MySwiftUIView: UIView {
     private(set) var intrinsicContentSizeReadCount = 0
 
     override var intrinsicContentSize: CGSize {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -37,6 +37,19 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertNil(attributes.hide)
     }
 
+    func testItAvoidsIntrinsicContentSizeReadForSwiftUIViewWithPendingLayout() {
+        // Given
+        let view = SwiftUIHostingViewSpy(frame: CGRect(x: 0, y: 0, width: 123, height: 45))
+        view.setNeedsLayout()
+
+        // When
+        let attributes = createViewAttributes(with: view)
+
+        // Then
+        XCTAssertEqual(view.intrinsicContentSizeReadCount, 0)
+        XCTAssertEqual(attributes.intrinsicContentSize, view.bounds.size)
+    }
+
     func testWhenViewIsVisible() {
         // Given
         let view: UIView = .mockRandom()
@@ -229,6 +242,15 @@ class ViewAttributesTests: XCTestCase {
     }
 }
 // swiftlint:enable opening_brace
+
+private final class SwiftUIHostingViewSpy: UIView {
+    private(set) var intrinsicContentSizeReadCount = 0
+
+    override var intrinsicContentSize: CGSize {
+        intrinsicContentSizeReadCount += 1
+        return CGSize(width: 300, height: 200)
+    }
+}
 
 class NodeSemanticsTests: XCTestCase {
     func testImportance() {


### PR DESCRIPTION
### What and why?

This PR fixes a Session Replay issue introduced in [3.7.0](https://github.com/DataDog/dd-sdk-ios/releases/tag/3.7.0) where `SwiftUI` `TabView` could fail to render if it appeared after Session Replay was enabled. The root cause was reading `intrinsicContentSize` on `SwiftUI` owned views while they still had pending layout, which could trigger an `AttributeGraph` cycle.

### How?

Session Replay now avoids reading `intrinsicContentSize` for `SwiftUI` owned views with pending layout and uses the current bounds size instead during snapshot capture. 
Additionally, the `SwiftUI` view detection helper was centralized in `DatadogInternal`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
