### PR TITLE
Add ClientStatsFeature scaffolding with statsComputationEnabled config

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1154,6 +1154,9 @@
 		D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25BADA029C1EF3000112069 /* TracingURLSessionHandler.swift */; };
 		D2C1A50929C4C4CB00946C31 /* SpanEventEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEventEncoder.swift */; };
 		D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546C0329AF55AA0054E00B /* TraceFeature.swift */; };
+		E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */; };
+		E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */; };
+		E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */; };
 		D2C1A50B29C4C4CB00946C31 /* SpanEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */; };
 		D2C1A50C29C4C4CB00946C31 /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
 		D2C1A50D29C4C4CB00946C31 /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
@@ -2789,6 +2792,9 @@
 		D253EE982B98B3690010B589 /* ViewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCacheTests.swift; sourceTree = "<group>"; };
 		D2546BF029AF4F550054E00B /* DatadogTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTracer.swift; sourceTree = "<group>"; };
 		D2546C0329AF55AA0054E00B /* TraceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceFeature.swift; sourceTree = "<group>"; };
+		E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeature.swift; sourceTree = "<group>"; };
+		E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
+		E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeatureTests.swift; sourceTree = "<group>"; };
 		D2546C0729AF55E90054E00B /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		D2546C0A29AF56270054E00B /* MessageReceivers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivers.swift; sourceTree = "<group>"; };
 		D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEventIntegrationTests.swift; sourceTree = "<group>"; };
@@ -6206,6 +6212,8 @@
 				D2546C0329AF55AA0054E00B /* TraceFeature.swift */,
 				D2546C0729AF55E90054E00B /* RequestBuilder.swift */,
 				D2546C0A29AF56270054E00B /* MessageReceivers.swift */,
+				E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */,
+				E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -6258,6 +6266,7 @@
 				61E45BD02450F64100F2C652 /* Span */,
 				61C5A89924509C1100DA608C /* Utils */,
 				619CE7602A458D66005588CB /* TraceTests.swift */,
+				E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */,
 			);
 			name = DatadogTraceTests;
 			path = ../DatadogTrace/Tests;
@@ -8689,6 +8698,8 @@
 				3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */,
 				D2C1A4FA29C4C4CB00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
+				E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */,
+				E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
 			);
@@ -8710,6 +8721,7 @@
 				D2C1A51C29C4C75700946C31 /* ContextMessageReceiverTests.swift in Sources */,
 				3C6C7FFD2B459AF6006F5CBC /* OTelSpanTests.swift in Sources */,
 				619CE7612A458D66005588CB /* TraceTests.swift in Sources */,
+				E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */,
 				615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A52029C4C75700946C31 /* DDSpanTests.swift in Sources */,
 				3C5D636C2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */,

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Computes client-side APM stats (hit counts, error rates, latency distributions)
+/// on all finished spans and uploads them to the Datadog stats intake.
+///
+/// Registered as a separate `DatadogRemoteFeature` alongside `TraceFeature`
+/// so that it has its own storage and upload pipeline.
+internal final class ClientStatsFeature: DatadogRemoteFeature {
+    static let name = "client-stats"
+
+    let requestBuilder: FeatureRequestBuilder
+    let messageReceiver: FeatureMessageReceiver
+    let performanceOverride: PerformancePresetOverride?
+
+    init(core: DatadogCoreProtocol, configuration: Trace.Configuration) {
+        self.requestBuilder = StatsRequestBuilder(
+            customIntakeURL: configuration.customEndpoint,
+            telemetry: core.telemetry
+        )
+        self.messageReceiver = NOPFeatureMessageReceiver()
+        self.performanceOverride = nil
+    }
+}

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -13,7 +13,7 @@ import DatadogInternal
 /// Registered as a separate `DatadogRemoteFeature` alongside `TraceFeature`
 /// so that it has its own storage and upload pipeline.
 internal final class ClientStatsFeature: DatadogRemoteFeature {
-    static let name = "client-stats"
+    static let name = "tracing-client-stats"
 
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver

--- a/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Builds HTTP requests for uploading client-side stats to the `/api/v0.2/stats` intake.
+internal struct StatsRequestBuilder: FeatureRequestBuilder {
+    let customIntakeURL: URL?
+    let telemetry: Telemetry
+
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: ExecutionContext
+    ) -> URLRequest {
+        let builder = URLRequestBuilder(
+            url: url(with: context),
+            queryItems: [],
+            headers: [
+                .contentTypeHeader(contentType: .applicationJSON),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device,
+                    os: context.os
+                ),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.ciAppOrigin ?? context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader(),
+            ],
+            telemetry: telemetry
+        )
+
+        let data = events.reduce(Data()) { $0 + $1.data }
+        return builder.uploadRequest(with: data)
+    }
+
+    func url(with context: DatadogContext) -> URL {
+        customIntakeURL ?? context.site.endpoint.appendingPathComponent("api/v0.2/stats")
+    }
+}

--- a/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
+++ b/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
@@ -51,6 +51,11 @@ public final class objc_TraceConfiguration: NSObject {
         set { swiftConfig.customEndpoint = newValue }
         get { swiftConfig.customEndpoint }
     }
+
+    public var statsComputationEnabled: Bool {
+        set { swiftConfig.statsComputationEnabled = newValue }
+        get { swiftConfig.statsComputationEnabled }
+    }
 }
 
 @objc(DDTraceFirstPartyHostsTracing)

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -44,6 +44,12 @@ public enum Trace {
         let trace = TraceFeature(in: core, configuration: configuration)
         try core.register(feature: trace)
 
+        // Register Client-Side Stats feature if enabled:
+        if configuration.statsComputationEnabled {
+            let stats = ClientStatsFeature(core: core, configuration: configuration)
+            try core.register(feature: stats)
+        }
+
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:
         if let firstPartyHostsTracing = configuration.urlSessionTracking?.firstPartyHostsTracing {
             let firstPartyHosts: FirstPartyHosts

--- a/DatadogTrace/Sources/TraceConfiguration.swift
+++ b/DatadogTrace/Sources/TraceConfiguration.swift
@@ -76,6 +76,15 @@ extension Trace {
         /// Default: `nil`.
         public var customEndpoint: URL?
 
+        /// Enables client-side stats computation for APM.
+        ///
+        /// When enabled, the SDK computes trace statistics (hit counts, error rates, latency distributions)
+        /// locally on all finished spans — including sampled-out ones — and uploads them to the Datadog
+        /// stats intake. This provides accurate RED metrics regardless of the trace sampling rate.
+        ///
+        /// Default: `false`.
+        public var statsComputationEnabled: Bool
+
         // MARK: - Nested Types
 
         /// Configuration of automatic network requests tracing.
@@ -145,6 +154,7 @@ extension Trace {
         ///   - networkInfoEnabled: Determines if traces should be enriched with network connection information.
         ///   - eventMapper: Custom mapper for span events.
         ///   - customEndpoint: Custom server url for sending traces.
+        ///   - statsComputationEnabled: Enables client-side stats computation for APM.
         public init(
             sampleRate: SampleRate = .maxSampleRate,
             service: String? = nil,
@@ -153,7 +163,8 @@ extension Trace {
             bundleWithRumEnabled: Bool = true,
             networkInfoEnabled: Bool = false,
             eventMapper: EventMapper? = nil,
-            customEndpoint: URL? = nil
+            customEndpoint: URL? = nil,
+            statsComputationEnabled: Bool = false
         ) {
             self.sampleRate = sampleRate
             self.service = service
@@ -163,6 +174,7 @@ extension Trace {
             self.networkInfoEnabled = networkInfoEnabled
             self.eventMapper = eventMapper
             self.customEndpoint = customEndpoint
+            self.statsComputationEnabled = statsComputationEnabled
         }
     }
 }

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+@testable import DatadogTrace
+
+class ClientStatsFeatureTests: XCTestCase {
+    private var core: FeatureRegistrationCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var config: Trace.Configuration! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        core = FeatureRegistrationCoreMock()
+        config = Trace.Configuration()
+    }
+
+    override func tearDown() {
+        core = nil
+        config = nil
+        XCTAssertEqual(FeatureRegistrationCoreMock.referenceCount, 0)
+    }
+
+    // MARK: - Registration
+
+    func testWhenStatsComputationDisabled_thenClientStatsFeatureIsNotRegistered() {
+        // Given
+        config.statsComputationEnabled = false
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenStatsComputationEnabled_thenClientStatsFeatureIsRegistered() {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenStatsComputationEnabled_thenTraceFeatureIsAlsoRegistered() {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(core.get(feature: TraceFeature.self))
+        XCTAssertNotNil(core.get(feature: ClientStatsFeature.self))
+    }
+
+    func testWhenDefaultConfiguration_thenStatsComputationIsDisabled() {
+        // Given
+        let defaultConfig = Trace.Configuration()
+
+        // Then
+        XCTAssertFalse(defaultConfig.statsComputationEnabled)
+    }
+
+    // MARK: - Request Builder
+
+    func testWhenStatsComputationEnabled_thenRequestBuilderUsesStatsEndpoint() throws {
+        // Given
+        config.statsComputationEnabled = true
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        XCTAssertTrue(stats.requestBuilder is StatsRequestBuilder)
+    }
+
+    func testWhenStatsComputationEnabledWithCustomEndpoint_thenRequestBuilderUsesCustomURL() throws {
+        // Given
+        let customURL: URL = .mockRandom()
+        config.statsComputationEnabled = true
+        config.customEndpoint = customURL
+
+        // When
+        Trace.enable(with: config, in: core)
+
+        // Then
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        let requestBuilder = try XCTUnwrap(stats.requestBuilder as? StatsRequestBuilder)
+        XCTAssertEqual(requestBuilder.customIntakeURL, customURL)
+    }
+
+    // MARK: - Feature Name
+
+    func testFeatureName() {
+        XCTAssertEqual(ClientStatsFeature.name, "client-stats")
+    }
+}

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -100,6 +100,6 @@ class ClientStatsFeatureTests: XCTestCase {
     // MARK: - Feature Name
 
     func testFeatureName() {
-        XCTAssertEqual(ClientStatsFeature.name, "client-stats")
+        XCTAssertEqual(ClientStatsFeature.name, "tracing-client-stats")
     }
 }


### PR DESCRIPTION
### What and why?

First PR in the client-side stats (CSS) implementation series. This introduces the feature scaffolding — the empty `ClientStatsFeature` shell that registers alongside the existing `TraceFeature`, with its own storage and upload pipeline targeting the `/api/v0.2/stats` intake endpoint.

The feature is gated behind `Trace.Configuration.statsComputationEnabled` (default `false`).

### How?

- Added `statsComputationEnabled` property to `Trace.Configuration` with ObjC bridge
- Created `ClientStatsFeature` as a `DatadogRemoteFeature` with a NOP message receiver
- Created `StatsRequestBuilder` targeting `/api/v0.2/stats` (mirrors `TracingRequestBuilder` pattern)
- Conditional registration in `Trace.enableOrThrow()` — only when `statsComputationEnabled` is `true`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - `ClientStatsFeatureTests` — 7 tests covering registration, config defaults, request builder wiring, custom endpoint, feature name
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs