### PR TITLE
[PANA-6952] Defer `CALayer` change delivery off the swizzled call stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Prevent Session Replay capture from running on the swizzled `CALayer` layout call stack, avoiding AttributeGraph cycles and other errors. See [#2840][]
+
 # 3.9.0 / 02-04-2026
 
 - [IMPROVEMENT] Add `NWPath.linkQuality` to network info attached to Logs and Traces on supported platforms. See [#2751][]
@@ -1105,6 +1107,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2791]: https://github.com/DataDog/dd-sdk-ios/pull/2791
 [#2794]: https://github.com/DataDog/dd-sdk-ios/pull/2794
 [#2807]: https://github.com/DataDog/dd-sdk-ios/pull/2807
+[#2840]: https://github.com/DataDog/dd-sdk-ios/pull/2840
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
@@ -80,22 +80,26 @@ internal final class CALayerChangeAggregator {
     private func scheduleDeliveryIfNeeded() {
         let now = timerScheduler.now
 
-        // This should not happen with the current start()/stop() semantics, it is purely defensive.
         guard let last = lastDeliveryTime else {
             lastDeliveryTime = now
-            scheduleDelivery(after: minimumDeliveryInterval)
+            if scheduledDelivery == nil {
+                scheduleDelivery(after: minimumDeliveryInterval)
+            }
+            return
+        }
+
+        // Always defer delivery off the layer callback stack. If the throttle window
+        // already elapsed, schedule a zero-delay one-shot delivery. Otherwise schedule
+        // for the remaining time. Keep at most one pending delivery so subsequent
+        // changes are coalesced into the same snapshot
+
+        guard scheduledDelivery == nil else {
             return
         }
 
         let elapsed = now - last
-
-        // If the window elapsed, deliver immediately. Otherwise schedule a one-shot
-        // delivery for the remaining time (if not already scheduled).
-        if elapsed >= minimumDeliveryInterval {
-            deliverPendingChanges(now)
-        } else if scheduledDelivery == nil {
-            scheduleDelivery(after: minimumDeliveryInterval - elapsed)
-        }
+        let delay = max(0, minimumDeliveryInterval - elapsed)
+        scheduleDelivery(after: delay)
     }
 
     private func scheduleDelivery(after delay: TimeInterval) {

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
@@ -72,7 +72,7 @@ final class CALayerChangeAggregatorTests: XCTestCase {
         )
     }
 
-    func testDeliversImmediatelyWhenOutsideThrottleWindow() {
+    func testDefersDeliveryWhenOutsideThrottleWindow() {
         // given
         let layer = CALayer()
 
@@ -96,6 +96,12 @@ final class CALayerChangeAggregatorTests: XCTestCase {
         layerChangeAggregator.layerDidLayoutSublayers(layer)
 
         // then
+        XCTAssertEqual(snapshots.count, 1, "Should not deliver synchronously from the layer callback")
+
+        // when
+        testTimerScheduler.advance(to: 0.5)
+
+        // then
         XCTAssertEqual(snapshots.count, 2)
         XCTAssertEqual(
             snapshots,
@@ -106,6 +112,34 @@ final class CALayerChangeAggregatorTests: XCTestCase {
                 .init(
                     [ObjectIdentifier(layer): CALayerChange(layer: layer, aspects: .layout)]
                 ),
+            ]
+        )
+    }
+
+    func testMergesChangesRecordedBeforeDeferredDeliveryRuns() {
+        // given
+        let layer = CALayer()
+
+        // when
+        layerChangeAggregator.start()
+
+        testTimerScheduler.advance(to: 0.5)
+        layerChangeAggregator.layerDidDisplay(layer)
+        layerChangeAggregator.layerDidLayoutSublayers(layer)
+
+        // then
+        XCTAssertTrue(snapshots.isEmpty, "Should defer delivery until the scheduled task runs")
+
+        // when
+        testTimerScheduler.advance(to: 0.5)
+
+        // then
+        XCTAssertEqual(
+            snapshots,
+            [
+                .init(
+                    [ObjectIdentifier(layer): CALayerChange(layer: layer, aspects: [.display, .layout])]
+                )
             ]
         )
     }


### PR DESCRIPTION
### What and why?

The `ScreenChangeMonitor` uses a process-wide `CALayer` swizzle to detect screen changes. When the minimum delivery interval had already elapsed, `CALayerChangeAggregator` delivered changes synchronously on the same call stack as the swizzled `layoutSublayers`. This meant snapshot capture could run inside an active layout pass, causing:

- An infinite loop where snapshot reads triggered new layer changes, re-entering the delivery path (fixed in 3.8.2)
- Blank SwiftUI `TabView` when reading `intrinsicContentSize` re-entered SwiftUI's `AttributeGraph` during an active layout pass (RUMS-5762)

### How?

`CALayerChangeAggregator.scheduleDeliveryIfNeeded()` now always delivers through a scheduled timer, even when the minimum interval has elapsed. When the interval is already past, the timer fires with zero delay, which defers delivery to the next run loop turn. This guarantees snapshot capture never runs on the same call stack as the swizzled layout pass.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
