### PR TITLE
RUM-15513: Add deterministic sampling based on session id to Profiling

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
 		116232382F866ACF00F20ABC /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848522F6C4E0C008D2919 /* OperationMessage.swift */; };
 		1162323A2F866B4000F20ABC /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
+		1162323E2F87D8FC00F20ABC /* ProfilingContextMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */; };
+		116232402F87FA6F00F20ABC /* ProfilingSamplerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */; };
 		116506142E9533A700FD815C /* AppStateManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116506132E95339B00FD815C /* AppStateManagerMock.swift */; };
 		116506172E9535A500FD815C /* WatchdogTerminationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116506162E9535A500FD815C /* WatchdogTerminationMocks.swift */; };
 		116656D62EB501D3004248E8 /* ProfilingRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116656D42EB501C2004248E8 /* ProfilingRUMIntegrationTests.swift */; };
@@ -189,6 +191,7 @@
 		1188485A2F6C50EC008D2919 /* ProfilingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848592F6C50EC008D2919 /* ProfilingHandler.swift */; };
 		118848602F6C5122008D2919 /* ProfilingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188485E2F6C5122008D2919 /* ProfilingOperation.swift */; };
 		1188486C2F717DDE008D2919 /* DatadogProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188486A2F717DD8008D2919 /* DatadogProfiler.swift */; };
+		1188486C2F717DDE008D2919 /* ContinuousProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188486A2F717DD8008D2919 /* ContinuousProfiler.swift */; };
 		1188486F2F717EEF008D2919 /* ProfilingConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188486D2F717EE5008D2919 /* ProfilingConditions.swift */; };
 		118AAE082EBBB7F10018E745 /* dd_profiler_testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 118AAE052EBBB74D0018E745 /* dd_profiler_testing.h */; };
 		118ACA3C2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118ACA3A2EEED247004E7F20 /* AppLaunchMetricController.swift */; };
@@ -1820,6 +1823,8 @@
 		115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageResolverTests.swift; sourceTree = "<group>"; };
 		115793092F51F05100AEE829 /* binary_image_resolver_testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver_testing.h; sourceTree = "<group>"; };
 		115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
+		1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextMessageReceiver.swift; sourceTree = "<group>"; };
+		1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingSamplerProvider.swift; sourceTree = "<group>"; };
 		116506132E95339B00FD815C /* AppStateManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManagerMock.swift; sourceTree = "<group>"; };
 		116506162E9535A500FD815C /* WatchdogTerminationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMocks.swift; sourceTree = "<group>"; };
 		116656D42EB501C2004248E8 /* ProfilingRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingRUMIntegrationTests.swift; sourceTree = "<group>"; };
@@ -5551,25 +5556,25 @@
 		61E8C5062B28896100E709B4 /* RUM */ = {
 			isa = PBXGroup;
 			children = (
-				D26152332F433BBA0054EB7D /* UIApplicationSwizzlerTests.swift */,
-				6119DDC52DD24A9600DA80F9 /* RUMSessionTestsBase.swift */,
-				6119DDC32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift */,
-				6119DDC22DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift */,
-				6119DDC62DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift */,
-				6119DDC42DD24A9600DA80F9 /* RUMSessionStopTests.swift */,
-				6119DDC72DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift */,
-				61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */,
 				A757AE8F2D3815AC00C772FA /* AnonymousIdentifierTests.swift */,
 				6167E6DC2B811A8300C3CA2D /* AppHangsMonitoringTests.swift */,
+				D2AB895D2F71780900040F58 /* DeterministicSamplingIntegrationTests.swift */,
 				1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */,
+				D26152302F432C990054EB7D /* RUMDebuggingTests.swift */,
+				094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */,
+				6119DDC22DD24A9600DA80F9 /* RUMSessionStartInBackgroundTests.swift */,
+				6119DDC32DD24A9600DA80F9 /* RUMSessionStartInForegroundTests.swift */,
+				6119DDC42DD24A9600DA80F9 /* RUMSessionStopTests.swift */,
+				6119DDC52DD24A9600DA80F9 /* RUMSessionTestsBase.swift */,
+				6119DDC62DD24A9600DA80F9 /* RUMSessionTimeOutTests.swift */,
+				61536ABD2DF0A0D100B06D7D /* RUMSessionTrackingTests.swift */,
+				6119DDC72DD24A9600DA80F9 /* RUMSessionWithNoViewTests.swift */,
 				11BA765C2D7F0EE40058C21C /* RUMViewHitchesIntegrationTests.swift */,
+				D26152332F433BBA0054EB7D /* UIApplicationSwizzlerTests.swift */,
 				6105C5022CF8D5AB00C4C5EE /* ViewLoadingMetricsTests.swift */,
 				3CA00B062C2AE52400E6FE01 /* WatchdogTerminationsMonitoringTests.swift */,
 				D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */,
-				D26152302F432C990054EB7D /* RUMDebuggingTests.swift */,
 				61DCC84C2C05D4E500CB59E5 /* SDKMetrics */,
-				D2AB895D2F71780900040F58 /* DeterministicSamplingIntegrationTests.swift */,
-				094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -6576,11 +6581,15 @@
 			children = (
 				D274657A2E7B199A00C47FE2 /* AppLaunchProfiler.swift */,
 				1188486A2F717DD8008D2919 /* DatadogProfiler.swift */,
+				1188486A2F717DD8008D2919 /* ContinuousProfiler.swift */,
 				D233E7C22E4625D400E7CFDE /* ProfileEvent.swift */,
 				D233E7CA2E46264500E7CFDE /* ProfilerFeature.swift */,
 				D233E7C12E4625D400E7CFDE /* Profiling.swift */,
 				110DD1B02EEB6BB5002F3B8B /* ProfilingConfiguration.swift */,
 				118848592F6C50EC008D2919 /* ProfilingHandler.swift */,
+				1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */,
+				118848592F6C50EC008D2919 /* ProfilingHandler.swift */,
+				1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */,
 				D233E7C32E4625D400E7CFDE /* RequestBuilder.swift */,
 				1126B2512EBAB22600A74226 /* PrivacyInfo.xcprivacy */,
 				D229FF5B2E3BA298009CCD62 /* Mach */,
@@ -8444,6 +8453,8 @@
 				D233E8022E4B653F00E7CFDE /* dd_pprof.cpp in Sources */,
 				D233E7C62E4625D400E7CFDE /* Profiling.swift in Sources */,
 				11C4E5922F571F86002196F4 /* ProfileAttachments.swift in Sources */,
+				1162323E2F87D8FC00F20ABC /* ProfilingContextMessageReceiver.swift in Sources */,
+				116232402F87FA6F00F20ABC /* ProfilingSamplerProvider.swift in Sources */,
 				1121FD022EE33B3400297156 /* ConfigurationMetric.swift in Sources */,
 				D2D0E1F22E3CE59700BA4113 /* dd_profiler.cpp in Sources */,
 				D233E7EE2E4B588000E7CFDE /* profile.pb-c.c in Sources */,
@@ -9032,6 +9043,7 @@
 				D2E937352E535B6400FECA76 /* ProfileMocks.swift in Sources */,
 				1166C5952F748138008E34BC /* DDProfilerTests.swift in Sources */,
 				D2E937322E53368E00FECA76 /* ProfileCxxTests.swift in Sources */,
+				D261523B2F43872A0054EB7D /* MockThread.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
@@ -19,6 +19,15 @@ import TestUtilities
 @testable import DatadogRUM
 
 final class ProfilingRUMIntegrationTests: XCTestCase {
+    private enum Fixtures {
+        static let deterministicSessionUUID = UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!
+        static let sampledInRUMSessionRate: SampleRate = 60
+        static let unsampledRUMSessionRate: SampleRate = 50
+        static let continuousSampledInRate: SampleRate = 85
+        static let continuousSampledOutRate: SampleRate = 50
+        static let minProfileDuration: TimeInterval = 0.1
+    }
+
     private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
@@ -45,99 +54,395 @@ final class ProfilingRUMIntegrationTests: XCTestCase {
         super.tearDown()
     }
 
-    func testProfilingWithoutRUM_itDoesNotSendAProfileEvent() throws {
-        // Given
-        var frameInfoProvider: FrameInfoProviderMock? = nil
-        var config = RUM.Configuration(applicationID: "mock-application-id")
-        config.dateProvider = DateProviderMock()
-        config.mediaTimeProvider = MediaTimeProviderMock(current: 0)
-        config.frameInfoProviderFactory = {
-            frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
-            return frameInfoProvider!
-        }
-
+    func testProfilingWithoutRUM_itDoesNotSendAProfileEvent() {
         // When
-        Profiling.enable(in: self.core)
+        enableProfiling()
 
         // Then
-        let pprofData = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: ProfilerFeature.name, ofType: Data.self))
-        XCTAssertTrue(pprofData.isEmpty)
-        let profilingEvents = try XCTUnwrap(core.waitAndReturnEventsMetadata(ofFeature: ProfilerFeature.name, ofType: ProfileEvent.self))
-        XCTAssertTrue(profilingEvents.isEmpty)
+        // No passive output should be produced when profiling is enabled without RUM.
+        assertNoProfileOutput()
 
+        // No output should be produced even after forcing a profile flush.
+        triggerProfileFlush()
+        assertNoProfileOutput(timeout: timeout(after: 1.0))
         XCTAssertTrue(dd_is_profiling_enabled())
     }
 
     func testWhenRUMSendsTTIDMessage_itSendsAProfileEvent() throws {
-        // Given
         var frameInfoProvider: FrameInfoProviderMock? = nil
-        var config = RUM.Configuration(applicationID: "mock-application-id")
-        config.dateProvider = DateProviderMock()
-        config.mediaTimeProvider = MediaTimeProviderMock(current: 0)
-        config.frameInfoProviderFactory = {
-            frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
-            return frameInfoProvider!
-        }
 
         // When
-        RUM.enable(with: config, in: self.core)
-        Profiling.enable(in: self.core)
+        enableRUM(
+            sessionSampleRate: .maxSampleRate,
+            sessionUUID: Fixtures.deterministicSessionUUID,
+            frameInfoProviderFactory: {
+                frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
+                return frameInfoProvider!
+            }
+        )
+        enableProfiling()
+        startRUMView()
 
         frameInfoProvider?.triggerCallback(interval: 1)
 
         // Then
-        let rumVitalEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMVitalAppLaunchEvent.self)
-
-        XCTAssertEqual(rumVitalEvents.count, 1)
-        let ttidVitalEvent = try XCTUnwrap(rumVitalEvents.first)
-        XCTAssertEqual(ttidVitalEvent.dd.profiling?.status, .running)
-        XCTAssertEqual(ttidVitalEvent.vital.appLaunchMetric, .ttid)
-
-        let attachments = try XCTUnwrap(core.waitAndReturnEventsMetadata(ofFeature: ProfilerFeature.name, ofType: ProfileAttachments.self))
-        XCTAssertEqual(attachments.count, 1)
-        XCTAssertNotNil(attachments.first?.pprof)
-        XCTAssertNotNil(attachments.first?.rumEvents)
-
-        let profilingEvents = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: ProfilerFeature.name, ofType: ProfileEvent.self))
-        XCTAssertEqual(profilingEvents.count, 1)
-        let profilingEvent = try XCTUnwrap(profilingEvents.first)
-        XCTAssertEqual(profilingEvent.family, "ios")
-        XCTAssertEqual(profilingEvent.runtime, "ios")
-        XCTAssertEqual(profilingEvent.attachments, [
-            ProfileAttachments.Constants.wallFilename,
-            ProfileAttachments.Constants.rumEventsFilename
-        ])
-        XCTAssertFalse(profilingEvent.tags.isEmpty)
-        XCTAssertFalse(profilingEvent.additionalAttributes!.isEmpty)
+        waitAndAssertRUMViewEvents()
+        waitAndAssertRUMAppLaunchVitalEvents(count: 1)
+        try waitAndAssertProfileOutput(count: 1)
 
         XCTAssertTrue(dd_is_profiling_enabled())
     }
 
     func testWhenRUMDoesNotSendTTIDMessage_itDoesNotSendAProfileEvent() throws {
-        // Given
         var frameInfoProvider: FrameInfoProviderMock? = nil
-        var config = RUM.Configuration(applicationID: "mock-application-id")
-        config.dateProvider = DateProviderMock()
-        config.mediaTimeProvider = MediaTimeProviderMock(current: 0)
-        config.frameInfoProviderFactory = {
-            frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
-            return frameInfoProvider!
-        }
 
         // When
-        RUM.enable(with: config, in: self.core)
-        Profiling.enable(in: self.core)
+        enableRUM(
+            sessionSampleRate: .maxSampleRate,
+            sessionUUID: Fixtures.deterministicSessionUUID,
+            frameInfoProviderFactory: {
+                frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
+                return frameInfoProvider!
+            }
+        )
+        enableProfiling()
+        startRUMView()
 
         // Then
-        let rumVitalEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMVitalAppLaunchEvent.self)
-        XCTAssertTrue(rumVitalEvents.isEmpty)
-
-        let pprofData = try XCTUnwrap(core.waitAndReturnEvents(ofFeature: ProfilerFeature.name, ofType: Data.self))
-        XCTAssertTrue(pprofData.isEmpty)
-        let profilingEvents = try XCTUnwrap(core.waitAndReturnEventsMetadata(ofFeature: ProfilerFeature.name, ofType: ProfileEvent.self))
-        XCTAssertTrue(profilingEvents.isEmpty)
+        waitAndAssertRUMViewEvents()
+        waitAndAssertRUMAppLaunchVitalEvents(count: 0)
+        try waitAndAssertProfileOutput(count: 0)
 
         XCTAssertTrue(dd_is_profiling_enabled())
+    }
+
+    func testContinuousProfilingWithSampledInRUMSession_itSamplesContinuousProfilingIn() throws {
+        // Given
+        let sessionUUID = Fixtures.deterministicSessionUUID
+        let sessionSampler = DeterministicSampler(uuid: sessionUUID, samplingRate: Fixtures.sampledInRUMSessionRate)
+        try XCTSkipUnless(sessionSampler.isSampled, "Precondition: UUID must be sampled at 60%")
+        try XCTSkipUnless(
+            sessionSampler.combined(with: Fixtures.continuousSampledInRate).isSampled,
+            "Precondition: UUID must be sampled at the combined 51% rate"
+        )
+
+        // When
+        enableRUM(sessionSampleRate: Fixtures.sampledInRUMSessionRate, sessionUUID: sessionUUID)
+        enableProfiling(continuousSampleRate: Fixtures.continuousSampledInRate)
+
+        startRUMView()
+
+        // Then
+        waitAndAssertRUMViewEvents()
+        waitUntilContinuousProfilingSampled(true)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+    }
+
+    func testContinuousProfilingWithSampledOutRUMSession_itDoesNotSendAProfileEvent() throws {
+        // Given
+        let sessionUUID = Fixtures.deterministicSessionUUID
+        let sessionSampler = DeterministicSampler(uuid: sessionUUID, samplingRate: Fixtures.sampledInRUMSessionRate)
+        try XCTSkipUnless(sessionSampler.isSampled, "Precondition: UUID must be sampled at 60%")
+        try XCTSkipUnless(
+            !sessionSampler.combined(with: Fixtures.continuousSampledOutRate).isSampled,
+            "Precondition: UUID must NOT be sampled at the combined 30% rate"
+        )
+
+        // When
+        enableRUM(sessionSampleRate: Fixtures.sampledInRUMSessionRate, sessionUUID: sessionUUID)
+        enableProfiling(continuousSampleRate: Fixtures.continuousSampledOutRate)
+
+        startRUMView()
+
+        // Then
+        waitAndAssertRUMViewEvents()
+        waitUntilContinuousProfilingSampled(false)
+        triggerProfileFlush()
+        assertNoProfileOutput(timeout: timeout(after: 0.1))
+    }
+
+    func testCustomProfilingWithSampledInRUMSession_itDoesNotWriteProfileBeforeAVitalStarts() throws {
+        // Given
+        let sessionUUID = Fixtures.deterministicSessionUUID
+        try XCTSkipUnless(
+            DeterministicSampler(uuid: sessionUUID, samplingRate: Fixtures.sampledInRUMSessionRate).isSampled,
+            "Precondition: UUID must be sampled at 60%"
+        )
+
+        // When
+        enableRUM(sessionSampleRate: Fixtures.sampledInRUMSessionRate, sessionUUID: sessionUUID)
+        enableProfiling(applicationLaunchSampleRate: 0, continuousSampleRate: 0) // custom profiling
+
+        startRUMView()
+
+        // Then
+        waitAndAssertRUMViewEvents()
+        assertNoProfileOutput(timeout: timeout(after: 0.5))
+    }
+
+    func testCustomProfilingWithSampledOutRUMSession_itDoesNotSendAProfileEvent() throws {
+        // Given
+        let sessionUUID = Fixtures.deterministicSessionUUID
+        let vitalName = "vital-name"
+        try XCTSkipUnless(
+            !DeterministicSampler(uuid: sessionUUID, samplingRate: Fixtures.unsampledRUMSessionRate).isSampled,
+            "Precondition: UUID must NOT be sampled at 50%"
+        )
+
+        // When
+        enableRUM(sessionSampleRate: Fixtures.unsampledRUMSessionRate, sessionUUID: sessionUUID)
+        enableProfiling(applicationLaunchSampleRate: 0, continuousSampleRate: 0) // custom profiling
+
+        startRUMView()
+        startVital(name: vitalName)
+        finishVital(name: vitalName)
+
+        // Then
+        triggerProfileFlush()
+
+        let rumViews = core.waitAndReturnEvents(
+            ofFeature: RUMFeature.name,
+            ofType: RUMViewEvent.self,
+            timeout: timeout(after: 0.1)
+        )
+        XCTAssertTrue(rumViews.isEmpty)
+        assertNoProfileOutput(timeout: timeout(after: 0.1))
+    }
+
+    func testContinuousProfilingSamplesOut_customVitalStillSendsProfileEvent() throws {
+        // Given
+        let sessionUUID = Fixtures.deterministicSessionUUID
+        let vitalName = "vital-name"
+        let operationKey = "vital-key"
+        let sessionSampler = DeterministicSampler(uuid: sessionUUID, samplingRate: Fixtures.sampledInRUMSessionRate)
+        try XCTSkipUnless(sessionSampler.isSampled, "Precondition: UUID must be sampled at 60%")
+        try XCTSkipUnless(
+            !sessionSampler.combined(with: Fixtures.continuousSampledOutRate).isSampled,
+            "Precondition: UUID must NOT be sampled at the combined 30% rate"
+        )
+
+        // When
+        enableRUM(sessionSampleRate: Fixtures.sampledInRUMSessionRate, sessionUUID: sessionUUID)
+        enableProfiling(continuousSampleRate: Fixtures.continuousSampledOutRate)
+
+        startRUMView()
+
+        // Then
+        waitAndAssertRUMViewEvents()
+        waitUntilContinuousProfilingSampled(false)
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "continuous profiling is stopped")
+
+        startVital(name: vitalName, operationKey: operationKey)
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_RUNNING, description: "profiler is running for the custom vital")
+
+        finishVital(name: vitalName, operationKey: operationKey)
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "profiler is stopped after the custom vital")
+
+        let attachments = try XCTUnwrap(waitForProfileAttachments().last)
+        let rumVitals = try rumVitals(from: attachments)
+        XCTAssertEqual(rumVitals.count, 1)
+        XCTAssertEqual(rumVitals.first?["name"] as? String, vitalName)
+    }
+}
+
+private extension ProfilingRUMIntegrationTests {
+    func enableRUM(
+        sessionSampleRate: SampleRate,
+        sessionUUID: UUID,
+        dateProvider: DateProvider = DateProviderMock(),
+        mediaTimeProvider: CACurrentMediaTimeProvider = MediaTimeProviderMock(current: 0),
+        frameInfoProviderFactory: ((Any, Selector) -> FrameInfoProvider)? = nil
+    ) {
+        var configuration = RUM.Configuration(applicationID: "test-app-id")
+        configuration.sessionSampleRate = sessionSampleRate
+        configuration.uuidGenerator = RUMUUIDGeneratorMock(uuid: RUMUUID(rawValue: sessionUUID))
+        configuration.dateProvider = dateProvider
+        configuration.mediaTimeProvider = mediaTimeProvider
+        configuration.frameInfoProviderFactory = frameInfoProviderFactory ?? {
+            FrameInfoProviderMock(target: $0, selector: $1)
+        }
+
+        RUM.enable(with: configuration, in: core)
+    }
+
+    func enableProfiling(applicationLaunchSampleRate: SampleRate = .maxSampleRate, continuousSampleRate: SampleRate = .maxSampleRate) {
+        var configuration = Profiling.Configuration(
+            applicationLaunchSampleRate: applicationLaunchSampleRate,
+            continuousSampleRate: continuousSampleRate
+        )
+        configuration.minProfileDuration = Fixtures.minProfileDuration
+
+        Profiling.enable(
+            with: configuration,
+            in: core
+        )
+    }
+
+    func startRUMView() {
+        RUMMonitor.shared(in: core).startView(key: "test-view", name: "Test View")
+    }
+
+    func startVital(name: String, operationKey: String? = nil) {
+        RUMMonitor.shared(in: core).startOperation(
+            name: name,
+            operationKey: operationKey,
+            options: ProfilingOptions(sampleRate: .maxSampleRate)
+        )
+    }
+
+    func finishVital(name: String, operationKey: String? = nil) {
+        RUMMonitor.shared(in: core).succeedOperation(
+            name: name,
+            operationKey: operationKey
+        )
+    }
+
+    func triggerProfileFlush() {
+        let expectation = expectation(description: "read latest profiler context")
+        var currentContext: DatadogContext?
+        core.scope(for: ProfilerFeature.self).context {
+            currentContext = $0
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        guard var backgroundContext = currentContext else {
+            XCTFail("Expected to read the latest profiler context before triggering a background flush")
+            return
+        }
+        backgroundContext.applicationStateHistory.append(state: .background, at: Date())
+        core.context = backgroundContext
+        core.send(message: .context(backgroundContext), else: {})
+        // Wait until all the pieces injected in the context and shared between modules are in place.
+        core.flush()
+    }
+
+    func timeout(after interval: TimeInterval) -> DispatchTime {
+        .now() + interval
+    }
+
+    func rumVitals(from attachments: ProfileAttachments) throws -> [[String: Any]] {
+        let rumEventsData = try XCTUnwrap(attachments.rumEvents)
+        let rumEvents = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
+        return rumEvents.filter { $0["type"] as? String == "vital" }
+    }
+
+    func waitAndAssertRUMViewEvents(expectedViewName: String = "Test View") {
+        let rumViews = core.waitAndReturnEvents(
+            ofFeature: RUMFeature.name,
+            ofType: RUMViewEvent.self,
+            timeout: timeout(after: 1.0)
+        )
+
+        XCTAssertFalse(rumViews.isEmpty)
+        XCTAssertTrue(rumViews.allSatisfy { $0.type == "view" })
+        XCTAssertTrue(rumViews.contains { $0.view.name == "ApplicationLaunch" })
+        XCTAssertTrue(rumViews.contains { $0.view.name == expectedViewName })
+
+        let matchingView = rumViews.last { $0.view.name == expectedViewName }
+        XCTAssertTrue(matchingView.map { $0.view.id.isEmpty == false } ?? false)
+    }
+
+    func waitAndAssertRUMAppLaunchVitalEvents(count expectedCount: Int) {
+        let rumVitalEvents = core.waitAndReturnEvents(
+            ofFeature: RUMFeature.name,
+            ofType: RUMVitalAppLaunchEvent.self,
+            timeout: timeout(after: 1.0)
+        )
+
+        XCTAssertEqual(rumVitalEvents.count, expectedCount)
+
+        if let ttidVitalEvent = rumVitalEvents.first {
+            XCTAssertEqual(ttidVitalEvent.dd.profiling?.status, .running)
+            XCTAssertEqual(ttidVitalEvent.vital.appLaunchMetric, .ttid)
+        }
+    }
+
+    func waitAndAssertProfileOutput(count expectedCount: Int) throws {
+        let attachments = try XCTUnwrap(core.waitAndReturnEventsMetadata(
+            ofFeature: ProfilerFeature.name,
+            ofType: ProfileAttachments.self
+        ))
+
+        XCTAssertEqual(attachments.count, expectedCount)
+
+        if let attachment = attachments.first {
+            XCTAssertNotNil(attachment.pprof)
+            XCTAssertNotNil(attachment.rumEvents)
+        }
+
+        let profilingEvents = try XCTUnwrap(core.waitAndReturnEvents(
+            ofFeature: ProfilerFeature.name,
+            ofType: ProfileEvent.self
+        ))
+        XCTAssertEqual(profilingEvents.count, expectedCount)
+
+        if let profilingEvent = profilingEvents.first {
+            XCTAssertEqual(profilingEvent.family, "ios")
+            XCTAssertEqual(profilingEvent.runtime, "ios")
+            XCTAssertEqual(profilingEvent.attachments, [
+                ProfileAttachments.Constants.wallFilename,
+                ProfileAttachments.Constants.rumEventsFilename
+            ])
+            XCTAssertFalse(profilingEvent.tags.isEmpty)
+            XCTAssertFalse(profilingEvent.additionalAttributes!.isEmpty)
+        }
+    }
+
+    func assertNoProfileOutput(timeout: DispatchTime = .now() + 0.1) {
+        XCTAssertTrue(core.waitAndReturnEvents(
+            ofFeature: ProfilerFeature.name,
+            ofType: ProfileEvent.self,
+            timeout: timeout
+        ).isEmpty)
+        XCTAssertTrue(core.waitAndReturnEventsMetadata(
+            ofFeature: ProfilerFeature.name,
+            ofType: ProfileAttachments.self,
+            timeout: timeout
+        ).isEmpty)
+    }
+
+    func waitForProfileAttachments(timeout: TimeInterval = 1.0) -> [ProfileAttachments] {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            core.flush()
+            let attachments = core.waitAndReturnEventsMetadata(
+                ofFeature: ProfilerFeature.name,
+                ofType: ProfileAttachments.self,
+                timeout: .now()
+            )
+            if attachments.isEmpty == false {
+                return attachments
+            }
+
+            let remaining = deadline.timeIntervalSinceNow
+            if remaining > 0 {
+                wait(during: min(0.05, remaining)) {}
+            }
+        } while Date() < deadline
+
+        return []
+    }
+
+    func waitUntilContinuousProfilingSampled(_ expected: Bool) {
+        let expectation = expectation(description: "continuous profiling sampled is \(expected)")
+        wait(until: {
+            self.core.flush()
+            return self.core
+                .feature(named: ProfilerFeature.name, type: ProfilerFeature.self)?
+                .profilingSamplerProvider
+                .continuousProfilingSampled == expected
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func waitUntilProfilerStatus(_ expected: dd_profiler_status_t, description: String) {
+        let expectation = expectation(description: description)
+        wait(until: {
+            dd_profiler_get_status() == expected
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 1.0)
     }
 }
 

--- a/DatadogInternal/Sources/Utils/DeterministicSampler.swift
+++ b/DatadogInternal/Sources/Utils/DeterministicSampler.swift
@@ -34,7 +34,7 @@ public struct DeterministicSampler: Sampling, Equatable, Sendable {
     ///     - `0.0` disables sampling entirely (no data is sampled).
     ///     - `100.0` enables full sampling (all data is sampled).
     public init(seed: UInt64, samplingRate: SampleRate) {
-        let normalizedSampleRate = samplingRate.normalized
+        let normalizedSampleRate = samplingRate.normalizedSampleRate
         self.seed = seed
         self.samplingRate = normalizedSampleRate
         if normalizedSampleRate == 100.0 {
@@ -65,7 +65,7 @@ public struct DeterministicSampler: Sampling, Equatable, Sendable {
     /// - Parameter childRate: The child feature's sampling rate (0.0–100.0).
     /// - Returns: A new sampler with `samplingRate.composed(with: childRate)` as its rate.
     public func combined(with childRate: SampleRate) -> DeterministicSampler {
-        DeterministicSampler(seed: seed, samplingRate: samplingRate.composed(with: childRate.normalized))
+        DeterministicSampler(seed: seed, samplingRate: samplingRate.composed(with: childRate.normalizedSampleRate))
     }
 }
 

--- a/DatadogInternal/Sources/Utils/Sampler.swift
+++ b/DatadogInternal/Sources/Utils/Sampler.swift
@@ -51,7 +51,7 @@ extension SampleRate {
     }
 
     /// Clamps the value between 0 and 100
-    internal var normalized: Self {
+    public var normalized: Self {
         max(0, min(100, self))
     }
 }

--- a/DatadogInternal/Sources/Utils/Sampler.swift
+++ b/DatadogInternal/Sources/Utils/Sampler.swift
@@ -28,7 +28,7 @@ public struct Sampler: Sampling {
     public let samplingRate: SampleRate
 
     public init(samplingRate: SampleRate) {
-        self.samplingRate = samplingRate.normalized
+        self.samplingRate = samplingRate.normalizedSampleRate
     }
 
     /// Based on the sampling rate, it returns random value deciding if an event should be "sampled" or not.
@@ -51,7 +51,7 @@ extension SampleRate {
     }
 
     /// Clamps the value between 0 and 100
-    public var normalized: Self {
+    public var normalizedSampleRate: Self {
         max(0, min(100, self))
     }
 }

--- a/DatadogInternal/Tests/Utils/SampleRateTests.swift
+++ b/DatadogInternal/Tests/Utils/SampleRateTests.swift
@@ -81,10 +81,10 @@ final class SampleRateTests: XCTestCase {
     }
 
     func testNormalization() {
-        XCTAssertEqual(SampleRate(42).normalized, 42)
-        XCTAssertEqual(SampleRate(0).normalized, 0)
-        XCTAssertEqual(SampleRate(100).normalized, 100)
-        XCTAssertEqual(SampleRate(-10).normalized, 0)
-        XCTAssertEqual(SampleRate(298).normalized, 100)
+        XCTAssertEqual(SampleRate(42).normalizedSampleRate, 42)
+        XCTAssertEqual(SampleRate(0).normalizedSampleRate, 0)
+        XCTAssertEqual(SampleRate(100).normalizedSampleRate, 100)
+        XCTAssertEqual(SampleRate(-10).normalizedSampleRate, 0)
+        XCTAssertEqual(SampleRate(298).normalizedSampleRate, 100)
     }
 }

--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -24,7 +24,7 @@ internal final class AppLaunchProfiler: ProfilingHandler {
     private static var appLaunchProfile: OpaquePointer?
     private static let lock = NSLock()
 
-    private let isContinuousProfiling: Bool
+    private let profilingSamplerProvider: ProfilingSamplerProvider
 
     let featureScope: FeatureScope
     let telemetryController: ProfilingTelemetryController
@@ -38,14 +38,14 @@ internal final class AppLaunchProfiler: ProfilingHandler {
 
     init(
         core: DatadogCoreProtocol,
-        isContinuousProfiling: Bool,
+        profilingSamplerProvider: ProfilingSamplerProvider,
         telemetryController: ProfilingTelemetryController = .init(),
         encoder: JSONEncoder = JSONEncoder()
     ) {
         Self.registerInstance()
 
         self.featureScope = core.scope(for: ProfilerFeature.self)
-        self.isContinuousProfiling = isContinuousProfiling
+        self.profilingSamplerProvider = profilingSamplerProvider
         self.telemetryController = telemetryController
         self.encoder = encoder
     }
@@ -67,7 +67,8 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
             hasProcessedAppLaunch = true
             attributes = message.attributes
 
-            if isContinuousProfiling == false && self.currentRUMVitals.didCompleteOperations() {
+            if profilingSamplerProvider.isContinuousProfilingConfigured == false
+                && self.currentRUMVitals.didCompleteOperations() {
                 dd_profiler_stop()
                 self.updateProfilingContext()
             }

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -327,9 +327,9 @@ private extension DatadogProfiler {
     func shouldKeepProfilerRunning() -> Bool {
         if profilingSamplerProvider.isContinuousProfilingConfigured {
             switch profilingSamplerProvider.continuousProfilingSampled {
-            case true: // It is Continuous Profiling running
+            case .some(true): // It is Continuous Profiling running
                 return hasConditionsToProfile
-            case false: // It is Custom Profiling running
+            case .some(false): // It is Custom Profiling running
                 return hasConditionsToProfile && currentRUMVitals.ongoingOperations().isEmpty == false
             case .none: // Waiting for RUM context info
                 return hasConditionsToProfile && isContinuousProfilingGraceAvailable

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -38,7 +38,7 @@ internal final class DatadogProfiler: ProfilingHandler {
 
     /// The queue used to synchronize the profiling data and the writes.
     private let queue: DispatchQueue
-    private let isContinuousProfiling: Bool
+    private let profilingSamplerProvider: ProfilingSamplerProvider
     private let profilingConditions: ProfilingConditions
     private let profilingInterval: TimeInterval
     private var timer: DispatchSourceTimer?
@@ -61,11 +61,12 @@ internal final class DatadogProfiler: ProfilingHandler {
     private var longTasks: [DurationEvent] = []
     private var previousCustomProfilingStartDate: Date
     private var hasConditionsToProfile = true
+    private var previousAppState: AppState?
 
     init?(
         core: DatadogCoreProtocol,
+        profilingSamplerProvider: ProfilingSamplerProvider,
         queue: DispatchQueue = DatadogProfiler.defaultQueue,
-        isContinuousProfiling: Bool = true,
         operation: ProfilingOperation = .continuousProfiling,
         telemetryController: ProfilingTelemetryController = .init(),
         profilingConditions: ProfilingConditions = .init(),
@@ -84,7 +85,7 @@ internal final class DatadogProfiler: ProfilingHandler {
 
         self.featureScope = core.scope(for: ProfilerFeature.self)
         self.queue = queue
-        self.isContinuousProfiling = isContinuousProfiling
+        self.profilingSamplerProvider = profilingSamplerProvider
         self.operation = operation
         self.telemetryController = telemetryController
         self.profilingConditions = profilingConditions
@@ -93,7 +94,7 @@ internal final class DatadogProfiler: ProfilingHandler {
         self.dateProvider = dateProvider
         self.previousCustomProfilingStartDate = dateProvider.now
 
-        if isContinuousProfiling {
+        if profilingSamplerProvider.isContinuousProfilingConfigured {
             startTimer()
         }
     }
@@ -175,22 +176,27 @@ private extension DatadogProfiler {
             guard let self else {
                 return
             }
-            // Check, based on the context, if the profiler has conditions to profile
-            hasConditionsToProfile = profilingConditions.canProfileApplication(with: context)
 
-            if context.applicationStateHistory.currentState == .background {
+            let previousConditions = hasConditionsToProfile
+            hasConditionsToProfile = profilingConditions.canProfileApplication(with: context)
+            let currentAppState = context.applicationStateHistory.currentState
+            defer { previousAppState = currentAppState }
+
+            if currentAppState == .background {
                 // Updates the profiler state if the app was or is about to have foreground time
                 guard context.applicationStateHistory
                     .containsState(during: context.launchInfo.processLaunchDate...dateProvider.now, where: { $0 == .active }) else {
                     return
                 }
 
-                updateProfilerState(canProfile: hasConditionsToProfile && (isContinuousProfiling || canExtendCustomProfiling()))
                 sendProfile()
-            } else {
+                updateProfilerState(canProfile: shouldKeepProfilerRunning())
+            }
+            // If the conditions are the same, ignore the update profiler state
+            else if currentAppState != previousAppState || hasConditionsToProfile != previousConditions {
                 switch ProfilingContext.Status.current {
                 case .running, .stopped:
-                    updateProfilerState(canProfile: hasConditionsToProfile && (isContinuousProfiling || canExtendCustomProfiling()))
+                    updateProfilerState(canProfile: shouldKeepProfilerRunning())
                 default:
                     break
                 }
@@ -209,7 +215,7 @@ private extension DatadogProfiler {
             currentRUMVitals = currentRUMVitals.ongoingOperations()
             hangs.removeAll()
             longTasks.removeAll()
-            updateProfilerState(canProfile: hasConditionsToProfile && (isContinuousProfiling || canExtendCustomProfiling()))
+            updateProfilerState(canProfile: shouldKeepProfilerRunning())
         }
     }
 
@@ -222,13 +228,8 @@ private extension DatadogProfiler {
 
             switch message.operation.stepType {
             case .start:
-                // Start profiler if it is a custom profiler and the operations have started
-                if currentRUMVitals.isEmpty && isContinuousProfiling == false {
-                    startTimer()
-                    updateProfilerState(canProfile: hasConditionsToProfile)
-                }
-
                 currentRUMVitals[message.operation.key] = message.operation
+                updateProfilerState(canProfile: shouldKeepProfilerRunning())
             case .end:
                 if var startVital = currentRUMVitals[message.operation.key] {
                     // Add duration to vital to help Profiling backend label correctly the samples of this vital
@@ -237,7 +238,7 @@ private extension DatadogProfiler {
                     currentRUMVitals[message.operation.key] = startVital
 
                     // Stop profiler if it is a custom profiler and the operations have completed
-                    if currentRUMVitals.didCompleteOperations() && isContinuousProfiling == false {
+                    if currentRUMVitals.didCompleteOperations() && profilingSamplerProvider.isContinuousProfilingConfigured == false {
                         let customProfilingDuration = dateProvider.now.timeIntervalSince(previousCustomProfilingStartDate)
                         let fireInterval = customProfilingDuration < Constants.minProfileDuration ? Constants.minProfileDuration - customProfilingDuration : 0
                         fireTimer(after: fireInterval)
@@ -261,14 +262,12 @@ private extension DatadogProfiler {
     }
 
     func updateProfilerAndSendProfile() {
-        updateProfilerState(canProfile: hasConditionsToProfile && (isContinuousProfiling || canExtendCustomProfiling()))
+        updateProfilerState(canProfile: shouldKeepProfilerRunning())
         sendProfile()
     }
 
     func updateProfilerState(canProfile: Bool) {
-        let profilingContext = updateProfilingContext()
-
-        switch profilingContext.status {
+        switch ProfilingContext.Status.current {
         case .stopped:
             if canProfile {
                 dd_profiler_start()
@@ -294,7 +293,7 @@ private extension DatadogProfiler {
         }
 
         defer { dd_pprof_destroy(profile) }
-        if canWriteProfile() {
+        if canWriteProfile {
             write(
                 profile: profile,
                 rumVitals: Array(self.currentRUMVitals.values),
@@ -305,14 +304,30 @@ private extension DatadogProfiler {
         }
     }
 
-    func canWriteProfile() -> Bool {
-        currentRUMVitals.count > 0
-        || hangs.isEmpty == false
-        || longTasks.isEmpty == false
+    var canWriteProfile: Bool {
+        // At least Custom Profiling is running
+        self.currentRUMVitals.count > 0
+        // Continuous Profiling is sampled in and there are events of interest
+        || (profilingSamplerProvider.continuousProfilingSampled == true && (hangs.count > 0 || longTasks.count > 0))
+    }
+
+    func shouldKeepProfilerRunning() -> Bool {
+        if profilingSamplerProvider.isContinuousProfilingConfigured {
+            switch profilingSamplerProvider.continuousProfilingSampled {
+            case true?: // It is Continuous Profiling running
+                return hasConditionsToProfile
+            case false?: // It is Custom Profiling running
+                return hasConditionsToProfile && currentRUMVitals.ongoingOperations().isEmpty == false
+            case .none: // Waiting for RUM context info
+                return hasConditionsToProfile
+            }
+        } else { // It is Custom Profiling running
+            return hasConditionsToProfile && canExtendCustomProfiling()
+        }
     }
 
     func canExtendCustomProfiling() -> Bool {
-        currentRUMVitals.contains {
+        currentRUMVitals.ongoingOperations().contains {
             dateProvider.now.timeIntervalSince($1.date) < Constants.customProfilingCutOffTime
         }
     }

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -41,6 +41,7 @@ internal final class DatadogProfiler: ProfilingHandler {
     private let profilingSamplerProvider: ProfilingSamplerProvider
     private let profilingConditions: ProfilingConditions
     private let profilingInterval: TimeInterval
+    private let minProfileDuration: TimeInterval
     private var timer: DispatchSourceTimer?
 
     let operation: ProfilingOperation
@@ -62,6 +63,10 @@ internal final class DatadogProfiler: ProfilingHandler {
     private var previousCustomProfilingStartDate: Date
     private var hasConditionsToProfile = true
     private var previousAppState: AppState?
+    /// Allows continuous profiling to temporarily run while waiting for the first
+    /// RUM-linked sampling decision. The grace is consumed on the first timer cycle
+    /// or when the app backgrounds before a decision is received.
+    private var isContinuousProfilingGraceAvailable: Bool
 
     init?(
         core: DatadogCoreProtocol,
@@ -71,6 +76,7 @@ internal final class DatadogProfiler: ProfilingHandler {
         telemetryController: ProfilingTelemetryController = .init(),
         profilingConditions: ProfilingConditions = .init(),
         profilingInterval: TimeInterval = Constants.maxProfileDuration,
+        minProfileDuration: TimeInterval = Constants.minProfileDuration,
         encoder: JSONEncoder = JSONEncoder(),
         dateProvider: DateProvider = SystemDateProvider()
     ) {
@@ -90,9 +96,11 @@ internal final class DatadogProfiler: ProfilingHandler {
         self.telemetryController = telemetryController
         self.profilingConditions = profilingConditions
         self.profilingInterval = profilingInterval
+        self.minProfileDuration = minProfileDuration
         self.encoder = encoder
         self.dateProvider = dateProvider
         self.previousCustomProfilingStartDate = dateProvider.now
+        self.isContinuousProfilingGraceAvailable = profilingSamplerProvider.isContinuousProfilingConfigured
 
         if profilingSamplerProvider.isContinuousProfilingConfigured {
             startTimer()
@@ -189,13 +197,17 @@ private extension DatadogProfiler {
                     return
                 }
 
+                if profilingSamplerProvider.continuousProfilingSampled == nil {
+                    isContinuousProfilingGraceAvailable = false
+                }
+
                 sendProfile()
                 updateProfilerState(canProfile: shouldKeepProfilerRunning())
             }
             // If the conditions are the same, ignore the update profiler state
             else if currentAppState != previousAppState || hasConditionsToProfile != previousConditions {
                 switch ProfilingContext.Status.current {
-                case .running, .stopped:
+                case .running, .stopped, .unknown:
                     updateProfilerState(canProfile: shouldKeepProfilerRunning())
                 default:
                     break
@@ -237,10 +249,10 @@ private extension DatadogProfiler {
                     startVital.duration = duration.dd.toInt64Nanoseconds
                     currentRUMVitals[message.operation.key] = startVital
 
-                    // Stop profiler if it is a custom profiler and the operations have completed
-                    if currentRUMVitals.didCompleteOperations() && profilingSamplerProvider.isContinuousProfilingConfigured == false {
+                    // If profiling is effectively running in custom mode, trigger timer when the last operation completes.
+                    if currentRUMVitals.didCompleteOperations() && isCustomProfiling {
                         let customProfilingDuration = dateProvider.now.timeIntervalSince(previousCustomProfilingStartDate)
-                        let fireInterval = customProfilingDuration < Constants.minProfileDuration ? Constants.minProfileDuration - customProfilingDuration : 0
+                        let fireInterval = customProfilingDuration < minProfileDuration ? minProfileDuration - customProfilingDuration : 0
                         fireTimer(after: fireInterval)
                     }
                 }
@@ -262,13 +274,14 @@ private extension DatadogProfiler {
     }
 
     func updateProfilerAndSendProfile() {
+        isContinuousProfilingGraceAvailable = false
         updateProfilerState(canProfile: shouldKeepProfilerRunning())
         sendProfile()
     }
 
     func updateProfilerState(canProfile: Bool) {
         switch ProfilingContext.Status.current {
-        case .stopped:
+        case .stopped, .unknown: // When `.unknown` status, mostly profiler NOT_CREATED, it will try to start the profiler
             if canProfile {
                 dd_profiler_start()
                 previousCustomProfilingStartDate = dateProvider.now
@@ -314,16 +327,21 @@ private extension DatadogProfiler {
     func shouldKeepProfilerRunning() -> Bool {
         if profilingSamplerProvider.isContinuousProfilingConfigured {
             switch profilingSamplerProvider.continuousProfilingSampled {
-            case true?: // It is Continuous Profiling running
+            case true: // It is Continuous Profiling running
                 return hasConditionsToProfile
-            case false?: // It is Custom Profiling running
+            case false: // It is Custom Profiling running
                 return hasConditionsToProfile && currentRUMVitals.ongoingOperations().isEmpty == false
             case .none: // Waiting for RUM context info
-                return hasConditionsToProfile
+                return hasConditionsToProfile && isContinuousProfilingGraceAvailable
             }
         } else { // It is Custom Profiling running
             return hasConditionsToProfile && canExtendCustomProfiling()
         }
+    }
+
+    var isCustomProfiling: Bool {
+        profilingSamplerProvider.isContinuousProfilingConfigured == false
+            || profilingSamplerProvider.continuousProfilingSampled == false
     }
 
     func canExtendCustomProfiling() -> Bool {

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -63,7 +63,8 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
         if let datadogProfiler = DatadogProfiler(
             core: core,
             profilingSamplerProvider: profilingSamplerProvider,
-            telemetryController: telemetryController
+            telemetryController: telemetryController,
+            minProfileDuration: configuration.minProfileDuration
         ) {
             messageReceivers.append(datadogProfiler)
         }

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -25,13 +25,10 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
     }
     static let name = "profiler"
 
-    let requestBuilder: FeatureRequestBuilder
-
-    let messageReceiver: FeatureMessageReceiver
-
-    let isContinuousProfiling: Bool
-
+    let profilingSamplerProvider: ProfilingSamplerProvider
     let telemetryController: ProfilingTelemetryController
+    let requestBuilder: FeatureRequestBuilder
+    let messageReceiver: FeatureMessageReceiver
 
     /// Setting max-file-age to minimum will force creating a batch per profile.
     /// It is necessary as the profiling intake only accepts one profile per request.
@@ -51,19 +48,23 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
         self.requestBuilder = requestBuilder
         self.telemetryController = telemetryController
 
-        self.isContinuousProfiling = Sampler(
-            samplingRate: configuration.debugSDK ? .maxSampleRate : configuration.continuousSampleRate
-        ).sample()
+        let continuousSampleRate = configuration.debugSDK ? .maxSampleRate : configuration.continuousSampleRate
+        self.profilingSamplerProvider = ProfilingSamplerProvider(continuousSampleRate: continuousSampleRate)
 
         var messageReceivers: [FeatureMessageReceiver] = [
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
             AppLaunchProfiler(
                 core: core,
-                isContinuousProfiling: isContinuousProfiling,
+                profilingSamplerProvider: profilingSamplerProvider,
                 telemetryController: telemetryController
             )
         ]
 
-        if let datadogProfiler = DatadogProfiler(core: core, isContinuousProfiling: isContinuousProfiling, telemetryController: telemetryController) {
+        if let datadogProfiler = DatadogProfiler(
+            core: core,
+            profilingSamplerProvider: profilingSamplerProvider,
+            telemetryController: telemetryController
+        ) {
             messageReceivers.append(datadogProfiler)
         }
 

--- a/DatadogProfiling/Sources/ProfilingConfiguration.swift
+++ b/DatadogProfiling/Sources/ProfilingConfiguration.swift
@@ -33,6 +33,7 @@ extension Profiling {
         // MARK: - Internal
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
+        internal var minProfileDuration: TimeInterval = DatadogProfiler.Constants.minProfileDuration
 
         /// Creates the Profiling configuration.
         /// - Parameters:

--- a/DatadogProfiling/Sources/ProfilingContextMessageReceiver.swift
+++ b/DatadogProfiling/Sources/ProfilingContextMessageReceiver.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+internal final class ProfilingContextMessageReceiver: FeatureMessageReceiver {
+    let profilingSamplerProvider: ProfilingSamplerProvider
+
+    init(profilingSamplerProvider: ProfilingSamplerProvider) {
+        self.profilingSamplerProvider = profilingSamplerProvider
+    }
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message,
+              let deterministicSampler = context.additionalContext(ofType: RUMCoreContext.self)?.sessionSampler else {
+            return false
+        }
+
+        profilingSamplerProvider.updateWith(deterministicSampler: deterministicSampler)
+
+        return false
+    }
+}

--- a/DatadogProfiling/Sources/ProfilingSamplerProvider.swift
+++ b/DatadogProfiling/Sources/ProfilingSamplerProvider.swift
@@ -32,7 +32,7 @@ internal final class ProfilingSamplerProvider: @unchecked Sendable {
     let isContinuousProfilingConfigured: Bool
 
     init(continuousSampleRate: SampleRate) {
-        self.continuousSampleRate = continuousSampleRate.normalized
+        self.continuousSampleRate = continuousSampleRate.normalizedSampleRate
         self.continuousProfilingSampled = nil
         self.isContinuousProfilingConfigured = continuousSampleRate > 0
     }

--- a/DatadogProfiling/Sources/ProfilingSamplerProvider.swift
+++ b/DatadogProfiling/Sources/ProfilingSamplerProvider.swift
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+/// Stores the continuous profiling sampling state derived from the current RUM session.
+///
+/// This type separates static SDK configuration from the dynamic, session-linked sampling decision:
+/// - `isContinuousProfilingConfigured` reflects the configured `continuousSampleRate`
+/// - `continuousProfilingSampled` reflects the current RUM-linked sampling result
+///
+/// The provider intentionally stores only the resolved sampling result, not the deterministic sampler
+/// itself. This keeps all profiling sampling reads contextualized in one place and allows other
+/// components to react to three distinct states:
+/// - `nil`: no RUM sampling decision received yet
+/// - `true`: the current RUM session samples continuous profiling in
+/// - `false`: the current RUM session samples continuous profiling out
+internal final class ProfilingSamplerProvider: @unchecked Sendable {
+    private let continuousSampleRate: SampleRate
+
+    /// Session-linked sampling result for continuous profiling.
+    ///
+    /// The value is `nil` until a RUM context provides a `sessionSampler`. Once a context is received,
+    /// the value becomes the result of composing the RUM session sampler with `continuousSampleRate`.
+    @ReadWriteLock
+    private(set) var continuousProfilingSampled: Bool?
+
+    /// `true` when continuous profiling is configured with a sample rate greater than zero.
+    let isContinuousProfilingConfigured: Bool
+
+    init(continuousSampleRate: SampleRate) {
+        self.continuousSampleRate = continuousSampleRate.normalized
+        self.continuousProfilingSampled = nil
+        self.isContinuousProfilingConfigured = continuousSampleRate > 0
+    }
+
+    /// Updates the session-linked sampling result from the current RUM session sampler.
+    func updateWith(deterministicSampler: DeterministicSampler) {
+        continuousProfilingSampled = deterministicSampler.combined(with: continuousSampleRate).sample()
+    }
+}

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -54,7 +54,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testReceiveTTIDMessage_afterIncompleteOperationMessage() {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: true)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: true)
         XCTAssertEqual(dd_profiler_start(), 1)
 
         XCTAssertFalse(
@@ -104,7 +104,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testReceiveVitalMessageWhenContinuousProfiling_doesNotStopProfiler() {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: true)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: true)
 
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
         XCTAssertEqual(dd_profiler_start(), 1)
@@ -168,7 +168,7 @@ final class AppLaunchProfilerTests: XCTestCase {
                 telemetryController: .init()
             )
         )
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: false)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
 
         XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.1) // allow few samples
@@ -319,7 +319,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testReceiveCompleteRumOperation() {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: false)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
         let startVital = startOperationVital
         let endVital = Vital.mockWith(name: startVital.name, operationKey: startVital.operationKey, stepType: .end)
 
@@ -334,7 +334,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testReceiveApplicationLaunchAndOperations() {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: false)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
         XCTAssertEqual(dd_profiler_start(), 1)
 
         // When
@@ -352,7 +352,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testApplicationLaunchWithRumOperations_includesVitalsInProfile() throws {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: false)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
         let startVital = Vital.mockWith(id: "start-id", name: "operation", stepType: .start)
         let endVital = Vital.mockWith(id: "end-id", name: "operation", operationKey: startVital.operationKey, stepType: .end)
 
@@ -373,7 +373,7 @@ final class AppLaunchProfilerTests: XCTestCase {
     func testApplicationLaunchWithOrphanedEndVital_excludesOrphanedFromProfile() throws {
         // Given
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: false)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
         let startVital: Vital = .mockWith(id: "start-id", name: "operation1", stepType: .start)
         let orphanedEnd: Vital = .mockWith(id: "orphan-id", name: "operation2", stepType: .end)
 
@@ -394,7 +394,7 @@ final class AppLaunchProfilerTests: XCTestCase {
 
     func testReceiveMessages_afterTTIDMessage() throws {
         let core = PassthroughCoreMock()
-        let profiler = AppLaunchProfiler(core: core, isContinuousProfiling: true)
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: true)
         XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.05)
 
@@ -461,7 +461,21 @@ final class AppLaunchProfilerTests: XCTestCase {
     }
 
     private var appLaunchProfiler: AppLaunchProfiler {
-        AppLaunchProfiler(core: PassthroughCoreMock(), isContinuousProfiling: false)
+        appLaunchProfiler()
+    }
+
+    private func appLaunchProfiler(
+        core: DatadogCoreProtocol = PassthroughCoreMock(),
+        isContinuousProfiling: Bool = false
+    ) -> AppLaunchProfiler {
+        let profilingSamplerProvider = ProfilingSamplerProvider(
+            continuousSampleRate: isContinuousProfiling ? .maxSampleRate : 0
+        )
+
+        return AppLaunchProfiler(
+            core: core,
+            profilingSamplerProvider: profilingSamplerProvider
+        )
     }
 
     private var startOperationVital: Vital {

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -247,7 +247,11 @@ extension DatadogProfilerTests {
     func testApplicationDidEnterBackground_includesLongTasksInProfile() throws {
         // Given
         let dateProvider = DateProviderMock()
-        let profiler = continuousProfiler(dateProvider: dateProvider)
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
@@ -274,7 +278,11 @@ extension DatadogProfilerTests {
     func testApplicationDidEnterBackground_includesAppHangsInProfile() throws {
         // Given
         let dateProvider = DateProviderMock()
-        let profiler = continuousProfiler(dateProvider: dateProvider)
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
@@ -297,6 +305,124 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 }
+
+// MARK: - Sampling Decisions
+
+extension DatadogProfilerTests {
+    func testReceiveContextWhenContinuousProfilingSamplesOut_andNoVitalIsOngoing() {
+        // Given
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
+        core.messageReceiver = CombinedFeatureMessageReceiver(
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
+            profiler
+        )
+        XCTAssertEqual(dd_profiler_start(), 1)
+
+        // When
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContextWhenContinuousProfilingSamplesOut_andVitalIsOngoing() {
+        // Given
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
+        core.messageReceiver = CombinedFeatureMessageReceiver(
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
+            profiler
+        )
+        let startOperation = Vital.mockWith(stepType: .start)
+        XCTAssertEqual(dd_profiler_start(), 1)
+        _ = profiler.receive(
+            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
+            from: core
+        )
+
+        // When
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveOperationStartWhenContinuousProfilingSamplesOut_andVitalStarts() {
+        // Given
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
+        core.messageReceiver = CombinedFeatureMessageReceiver(
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
+            profiler
+        )
+        XCTAssertEqual(dd_profiler_start(), 1)
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+
+        let startOperation = Vital.mockWith(stepType: .start)
+
+        // When
+        _ = profiler.receive(
+            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
+            from: core
+        )
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testWritesProfileInCustomProfiling_evenIfContinuousProfileIsNotSampled() {
+        // Given
+        let dateProvider = DateProviderMock()
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: 0)
+        )
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
+        let startOperation = Vital.mockWith(name: "operation")
+        let endOperation = Vital.mockWith(
+            name: startOperation.name,
+            operationKey: startOperation.operationKey,
+            stepType: .end
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then
+        XCTAssertFalse(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+}
+
 // MARK: - Write Decisions
 
 extension DatadogProfilerTests {
@@ -347,7 +473,7 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testWritesProfile_whenLongTasksAccumulated() {
+    func testDoesNotWriteProfile_whenOnlyLongTasksAccumulated() {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
@@ -355,7 +481,6 @@ extension DatadogProfilerTests {
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
-        flushQueue()
 
         // When
         core.context = .mockWith(applicationStateHistory: .mockWith(
@@ -363,16 +488,16 @@ extension DatadogProfilerTests {
             date: dateProvider.now.addingTimeInterval(-1),
             transitions: [(state: .background, date: dateProvider.now)]
         ))
-        waitForProfileWrite {
+        waitForProfileWrite(expectingWrite: false) {
             _ = profiler.receive(message: .context(core.context), from: core)
         }
 
         // Then
-        XCTAssertFalse(core.metadata.isEmpty)
+        XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
 
-    func testWritesProfile_whenAppHangsAccumulated() {
+    func testDoesNotWriteProfile_whenOnlyAppHangsAccumulated() {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
@@ -388,12 +513,12 @@ extension DatadogProfilerTests {
             date: dateProvider.now.addingTimeInterval(-1),
             transitions: [(state: .background, date: dateProvider.now)]
         ))
-        waitForProfileWrite {
+        waitForProfileWrite(expectingWrite: false) {
             _ = profiler.receive(message: .context(core.context), from: core)
         }
 
         // Then
-        XCTAssertFalse(core.metadata.isEmpty)
+        XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
 
@@ -453,10 +578,19 @@ extension DatadogProfilerTests {
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
-        let profiler = customProfiler()
+        let dateProvider = DateProviderMock()
+        let profiler = customProfiler(dateProvider: dateProvider)
 
         // When
-        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: .mockWith(stepType: .start))), from: core)
+        _ = profiler.receive(
+            message: .payload(
+                OperationMessage(
+                    attributes: mockRandomAttributes(),
+                    operation: .mockWith(stepType: .start, date: dateProvider.now + 1)
+                )
+            ),
+            from: core
+        )
         flushQueue()
 
         // Then
@@ -469,10 +603,19 @@ extension DatadogProfilerTests {
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
-        let profiler = customProfiler()
+        let dateProvider = DateProviderMock()
+        let profiler = customProfiler(dateProvider: dateProvider)
 
         // When
-        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: .mockWith(stepType: .start))), from: core)
+        _ = profiler.receive(
+            message: .payload(
+                OperationMessage(
+                    attributes: mockRandomAttributes(),
+                    operation: .mockWith(stepType: .start, date: dateProvider.now + 1)
+                )
+            ),
+            from: core
+        )
         flushQueue()
 
         // Then - profiler stays running without error
@@ -528,7 +671,7 @@ extension DatadogProfilerTests {
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
-        let startOp: Vital = .mockWith(stepType: .start)
+        let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         // Custom profiler auto-starts on first .start operation
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
@@ -559,7 +702,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let startOp = Vital.mockWith(id: "start-id", name: "operation", stepType: .start)
+        let startOp = Vital.mockWith(id: "start-id", name: "operation", stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
 
@@ -604,7 +747,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let startOp: Vital = .mockWith(stepType: .start)
+        let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
@@ -644,7 +787,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let startOp: Vital = .mockWith(stepType: .start)
+        let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
 
@@ -688,7 +831,15 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
+        let startOperation = Vital.mockWith(name: "operation", date: dateProvider.now)
+        let endOperation = Vital.mockWith(
+            name: startOperation.name,
+            operationKey: startOperation.operationKey,
+            stepType: .end
+        )
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
         flushQueue()
 
@@ -715,7 +866,15 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
+        let startOperation = Vital.mockWith(name: "operation", date: dateProvider.now)
+        let endOperation = Vital.mockWith(
+            name: startOperation.name,
+            operationKey: startOperation.operationKey,
+            stepType: .end
+        )
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
         _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
         flushQueue()
 
@@ -789,7 +948,10 @@ extension DatadogProfilerTests {
         XCTAssertTrue(DatadogProfiler.isInstantiated)
 
         // When
-        let second = DatadogProfiler(core: core, isContinuousProfiling: true)
+        let second = DatadogProfiler(
+            core: core,
+            profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true)
+        )
         XCTAssertNil(second)
 
         // Then - first still processes messages normally
@@ -828,7 +990,10 @@ extension DatadogProfilerTests {
 
         // When - many instances created concurrently
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
-            let profiler = DatadogProfiler(core: core, isContinuousProfiling: true)
+            let profiler = DatadogProfiler(
+                core: core,
+                profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true)
+            )
             lock.lock()
             profilers.append(profiler)
             lock.unlock()
@@ -877,14 +1042,15 @@ private extension DatadogProfilerTests {
     }
 
     func continuousProfiler(
+        profilingSamplerProvider: ProfilingSamplerProvider = ProfilingSamplerProvider(continuousSampleRate: .maxSampleRate),
         profilingConditions: ProfilingConditions = ProfilingConditions(),
         profilingInterval: TimeInterval = .infinity,
         dateProvider: DateProvider = DateProviderMock()
     ) -> DatadogProfiler {
         DatadogProfiler(
             core: core,
+            profilingSamplerProvider: profilingSamplerProvider,
             queue: profilerQueue,
-            isContinuousProfiling: true,
             profilingConditions: profilingConditions,
             profilingInterval: profilingInterval,
             dateProvider: dateProvider
@@ -898,12 +1064,16 @@ private extension DatadogProfilerTests {
     ) -> DatadogProfiler {
         DatadogProfiler(
             core: core,
+            profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: false),
             queue: profilerQueue,
-            isContinuousProfiling: false,
             profilingConditions: profilingConditions,
             profilingInterval: profilingInterval,
             dateProvider: dateProvider
         )! // swiftlint:disable:this force_unwrapping
+    }
+
+    func profilingSamplerProvider(isContinuousProfiling: Bool) -> ProfilingSamplerProvider {
+        ProfilingSamplerProvider(continuousSampleRate: isContinuousProfiling ? .maxSampleRate : 0)
     }
 }
 #endif // !os(watchOS)

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -309,38 +309,61 @@ extension DatadogProfilerTests {
 // MARK: - Sampling Decisions
 
 extension DatadogProfilerTests {
-    func testReceiveContextWhenContinuousProfilingSamplesOut_andNoVitalIsOngoing() {
+    func testContinuousProfiler_doesNotStartProfilerAtInit_whenWaitingForInitialContext() {
         // Given
-        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
-        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
-        core.messageReceiver = CombinedFeatureMessageReceiver(
-            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
-            profiler
-        )
-        XCTAssertEqual(dd_profiler_start(), 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
 
         // When
-        core.context = .mockWith(
-            applicationStateHistory: .mockAppInForeground(),
-            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
-        )
+        let profiler = continuousProfiler()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testContinuousProfiler_doesNotStartProfilerAtInit_whenInitialConditionsPreventProfiling() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // When
+        let profiler = continuousProfiler()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_startsContinuousProfiler_whenSamplingDecisionIsNotReceived() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
         flushQueue()
 
         // Then
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
         withExtendedLifetime(profiler) {}
     }
 
     func testReceiveContextWhenContinuousProfilingSamplesOut_andVitalIsOngoing() {
         // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
-        core.messageReceiver = CombinedFeatureMessageReceiver(
-            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
-            profiler
-        )
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
         let startOperation = Vital.mockWith(stepType: .start)
-        XCTAssertEqual(dd_profiler_start(), 1)
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
         _ = profiler.receive(
             message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
             from: core
@@ -361,18 +384,11 @@ extension DatadogProfilerTests {
     func testReceiveOperationStartWhenContinuousProfilingSamplesOut_andVitalStarts() {
         // Given
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: 0)
+        )
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
-        core.messageReceiver = CombinedFeatureMessageReceiver(
-            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
-            profiler
-        )
-        XCTAssertEqual(dd_profiler_start(), 1)
-        core.context = .mockWith(
-            applicationStateHistory: .mockAppInForeground(),
-            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
-        )
-        flushQueue()
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
 
         let startOperation = Vital.mockWith(stepType: .start)
 
@@ -385,6 +401,28 @@ extension DatadogProfilerTests {
 
         // Then
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testTimer_stopsContinuousProfiler_whenSamplingDecisionIsNotReceived_andGraceExpires() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            profilingInterval: 0.05
+        )
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
     }
 
@@ -421,6 +459,58 @@ extension DatadogProfilerTests {
         XCTAssertFalse(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
+
+    func testWritesProfileOnTimer_whenContinuousProfileIsNotSampled_andOperationsComplete() {
+        // Given
+        let initialDate = Date().addingTimeInterval(-(DatadogProfiler.Constants.minProfileDuration + 3))
+        let dateProvider = DateProviderMock(now: initialDate)
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
+
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: 0)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider
+        )
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        shareCurrentContext(with: profiler)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
+
+        let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
+        _ = profiler.receive(
+            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
+            from: core
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.minProfileDuration + 1)
+
+        let endOperation = Vital.mockWith(
+            name: startOperation.name,
+            operationKey: startOperation.operationKey,
+            stepType: .end
+        )
+
+        // When - operations complete, sampled-out continuous profiling should use the custom timer path.
+        waitForProfileWrite {
+            _ = profiler.receive(
+                message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)),
+                from: core
+            )
+        }
+
+        // Then
+        XCTAssertFalse(core.metadata.isEmpty)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
 }
 
 // MARK: - Write Decisions
@@ -444,6 +534,27 @@ extension DatadogProfilerTests {
 
         // Then
         XCTAssertTrue(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testDoesNotWriteProfile_whenNoEventsAccumulated_onTimerCycle() {
+        // Given
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            profilingInterval: 0.05
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+
+        // When
+        waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
+
+        // Then
+        XCTAssertTrue(core.metadata.isEmpty)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
         withExtendedLifetime(profiler) {}
     }
 
@@ -522,13 +633,50 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testApplicationWillEnterForeground_restartsProfilerAfterBackground() {
+    func testDoesNotWriteProfile_whenAppHangsAndLongTasksAccumulated_butContinuousProfilingIsSampledOut() {
         // Given
         let dateProvider = DateProviderMock()
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: 0)
+        )
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+
+        _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
+        _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
+        flushQueue()
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite(expectingWrite: false) {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then
+        XCTAssertTrue(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testApplicationWillEnterForeground_restartsProfilerAfterBackground_whenContinuousProfilingIsSampledIn() {
+        // Given
+        let dateProvider = DateProviderMock()
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider
+        )
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
-
-        let profiler = continuousProfiler(dateProvider: dateProvider)
 
         // Send background context to stop the profiler and record the state transition
         core.context = .mockWith(applicationStateHistory: .mockWith(
@@ -556,6 +704,39 @@ extension DatadogProfilerTests {
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
         withExtendedLifetime(profiler) {}
     }
+
+    func testApplicationWillEnterForeground_doesNotRestartProfilerAfterBackground_whenContinuousProfilingSamplingDecisionIsNotReceived() {
+        // Given
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(dateProvider: dateProvider)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // Send background context to record the state transition
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // When - enter foreground with no sampling decision and no ongoing operation
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-2),
+            transitions: [
+                (state: .background, date: dateProvider.now.addingTimeInterval(-1)),
+                (state: .inactive, date: dateProvider.now)
+            ]
+        ))
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+        withExtendedLifetime(profiler) {}
+    }
 }
 
 // MARK: - Custom Profiling
@@ -580,6 +761,7 @@ extension DatadogProfilerTests {
 
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
 
         // When
         _ = profiler.receive(
@@ -605,6 +787,7 @@ extension DatadogProfilerTests {
 
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
 
         // When
         _ = profiler.receive(
@@ -667,6 +850,7 @@ extension DatadogProfilerTests {
         // Ensure core.context has an active state that falls within dateProvider.now's range
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
         // Put profiler in NOT_STARTED state (fresh instance, never started) so the custom profiler can start it
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
@@ -700,6 +884,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: initialDate)
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let startOp = Vital.mockWith(id: "start-id", name: "operation", stepType: .start, date: dateProvider.now)
@@ -745,6 +930,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
@@ -766,6 +952,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let startOp: Vital = .mockWith(date: dateProvider.now.addingTimeInterval(1))
@@ -785,6 +972,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
+        shareCurrentContext(with: profiler)
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
@@ -946,6 +1134,7 @@ extension DatadogProfilerTests {
         // Given
         let first = continuousProfiler()
         XCTAssertTrue(DatadogProfiler.isInstantiated)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
 
         // When
         let second = DatadogProfiler(
@@ -955,7 +1144,6 @@ extension DatadogProfilerTests {
         XCTAssertNil(second)
 
         // Then - first still processes messages normally
-        XCTAssertEqual(dd_profiler_start(), 1)
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(first.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
         XCTAssertNotNil(first)
@@ -974,7 +1162,7 @@ extension DatadogProfilerTests {
 
         // Then
         XCTAssertTrue(DatadogProfiler.isInstantiated)
-        XCTAssertEqual(dd_profiler_start(), 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(second.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
         XCTAssertNotNil(second)
@@ -1074,6 +1262,24 @@ private extension DatadogProfilerTests {
 
     func profilingSamplerProvider(isContinuousProfiling: Bool) -> ProfilingSamplerProvider {
         ProfilingSamplerProvider(continuousSampleRate: isContinuousProfiling ? .maxSampleRate : 0)
+    }
+
+    func shareCurrentContext(with profiler: DatadogProfiler) {
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+    }
+
+    func connectMessageReceiver(
+        to profiler: DatadogProfiler,
+        profilingSamplerProvider: ProfilingSamplerProvider
+    ) {
+        let messageReceiver = CombinedFeatureMessageReceiver(
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
+            profiler
+        )
+        core.messageReceiver = messageReceiver
+        _ = messageReceiver.receive(message: .context(core.context), from: core)
+        flushQueue()
     }
 }
 #endif // !os(watchOS)

--- a/DatadogProfiling/Tests/ProfilerFeatureTests.swift
+++ b/DatadogProfiling/Tests/ProfilerFeatureTests.swift
@@ -15,7 +15,6 @@ import TestUtilities
 final class ProfilerFeatureTests: XCTestCase {
     private let core: DatadogCoreProtocol = PassthroughCoreMock()
     private let requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
-    private let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     private let telemetryController = ProfilingTelemetryController()
 
     private var userDefaults: UserDefaults! //swiftlint:disable:this implicitly_unwrapped_optional
@@ -108,6 +107,110 @@ final class ProfilerFeatureTests: XCTestCase {
 
         // Then
         XCTAssertEqual(userDefaults.value(forKey: DD_PROFILING_APP_LAUNCH_SAMPLE_RATE_KEY) as? SampleRate, previousSampleRate)
+    }
+
+    func testProfilingSamplerProvider_isDeterministicForSameSessionID() {
+        // Given
+        let continuousSampleRate: SampleRate = 80
+        let sessionUUID = "abcdef01-2345-6789-abcd-ef0123456789"
+        let sessionSampler = DeterministicSampler(uuid: .mockWith(sessionUUID), samplingRate: 100)
+
+        let firstProvider = ProfilingSamplerProvider(continuousSampleRate: continuousSampleRate)
+        let secondProvider = ProfilingSamplerProvider(continuousSampleRate: continuousSampleRate)
+
+        // When
+        firstProvider.updateWith(deterministicSampler: sessionSampler)
+        secondProvider.updateWith(deterministicSampler: sessionSampler)
+        let firstDecision = firstProvider.continuousProfilingSampled
+        let secondDecision = secondProvider.continuousProfilingSampled
+
+        // Then
+        XCTAssertEqual(firstDecision, firstProvider.continuousProfilingSampled)
+        XCTAssertEqual(firstDecision, secondDecision)
+    }
+
+    func testProfilingSamplerProvider_hasNoContinuousProfilingDecision_withoutDeterministicSampler() {
+        XCTAssertNil(ProfilingSamplerProvider(continuousSampleRate: 100).continuousProfilingSampled)
+    }
+
+    func testProfilingSamplerProvider_appliesChildRateCorrection() {
+        // Given
+        // seed 0xd860b2b9437a (~68.7% hash): NOT sampled at composed 40%, but sampled at profiling-only 80%.
+        let sessionUUID = "a1b2c3d4-e5f6-7890-abcd-d860b2b9437a"
+        let sessionSampleRate: SampleRate = 50
+        let continuousSampleRate: SampleRate = 80
+        let sessionSampler = DeterministicSampler(uuid: .mockWith(sessionUUID), samplingRate: sessionSampleRate)
+        let expectedSampled = sessionSampler.combined(with: continuousSampleRate).isSampled
+        let oldBehavior = DeterministicSampler(uuid: .mockWith(sessionUUID), samplingRate: continuousSampleRate).isSampled
+
+        let provider = ProfilingSamplerProvider(continuousSampleRate: continuousSampleRate)
+
+        // When
+        provider.updateWith(deterministicSampler: sessionSampler)
+
+        // Then
+        XCTAssertNotEqual(expectedSampled, oldBehavior, "Chosen vector must differ between composed and profiling-only rate")
+        XCTAssertEqual(provider.continuousProfilingSampled, expectedSampled)
+    }
+
+    func testMessageReceiver_updatesContinuousProfileSamplingWhenRUMContextChanges() {
+        // Given
+        let core = PassthroughCoreMock()
+        let feature = ProfilerFeature(
+            core: core,
+            configuration: .init(continuousSampleRate: 100),
+            requestBuilder: requestBuilder,
+            telemetryController: telemetryController,
+            userDefaults: userDefaults
+        )
+
+        let unsampledContext: DatadogContext = .mockWith(
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        let sampledContext: DatadogContext = .mockWith(
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 100)]
+        )
+
+        // When
+        _ = feature.messageReceiver.receive(message: .context(unsampledContext), from: core)
+
+        // Then
+        XCTAssertEqual(feature.profilingSamplerProvider.continuousProfilingSampled, false)
+
+        // When
+        _ = feature.messageReceiver.receive(message: .context(sampledContext), from: core)
+
+        // Then
+        XCTAssertEqual(feature.profilingSamplerProvider.continuousProfilingSampled, true)
+    }
+
+    func testMessageReceiver_keepsPreviousContinuousProfileSampling_whenContextHasNoRUM() {
+        // Given
+        let core = PassthroughCoreMock()
+        let feature = ProfilerFeature(
+            core: core,
+            configuration: .init(continuousSampleRate: 100),
+            requestBuilder: requestBuilder,
+            telemetryController: telemetryController,
+            userDefaults: userDefaults
+        )
+
+        let unsampledContext: DatadogContext = .mockWith(
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        let contextWithoutRUM: DatadogContext = .mockWith(additionalContext: [])
+
+        // When
+        _ = feature.messageReceiver.receive(message: .context(unsampledContext), from: core)
+
+        // Then
+        XCTAssertEqual(feature.profilingSamplerProvider.continuousProfilingSampled, false)
+
+        // When
+        _ = feature.messageReceiver.receive(message: .context(contextWithoutRUM), from: core)
+
+        // Then
+        XCTAssertEqual(feature.profilingSamplerProvider.continuousProfilingSampled, false)
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -474,8 +474,8 @@ extension Monitor: RUMMonitorProtocol {
             date: dateProvider.now
         )
 
-        // RUM-15482: Update sample rate decision
-        if applicationScope.activeSession?.sampler.combined(with: .maxSampleRate).sample() ?? false {
+        if let options = options as? ProfilingOptions,
+           applicationScope.activeSession?.sampler.combined(with: options.sampleRate).sample() ?? false {
             let attributes = applicationScope.activeSession?.rumContextAttributes ?? applicationScope.rumContextAttributes
             featureScope.send(message: .payload(OperationMessage(attributes: attributes, operation: vital)))
         }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -79,7 +79,7 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
     }
 
     public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
-        self.context.set(additionalContext: context())
+        _context.mutate { $0.set(additionalContext: context()) }
     }
 
     public func send(message: FeatureMessage, else fallback: () -> Void) {


### PR DESCRIPTION
### What and why?

This PR aligns `DatadogProfiling` continuous profiling sampling with the RUM session sampling decision, so profiling follows the same cross-feature deterministic strategy already used in tracing.

The goal is to make profiling behavior more consistent across features where sampling is impacted by RUM configurations.

### How?

It introduces a dedicated `ProfilingSamplerProvider` updated by a `ProfilingContextMessageReceiver`, so profiling sampling state is derived from the RUM session sampler instead of making a one-off local sampling decision when the profiler feature starts.

`ContinuousProfiler` and `AppLaunchProfiler` now consume that shared provider, which centralizes the sampling logic and keeps the profiler components focused on lifecycle and writing behavior. Continuous profiling can start normally, but continuous profile writes are gated by the RUM-linked sampling result.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
