### PR TITLE
[RUM-13731] Skip malformed RUM attributes instead of dropping the entire event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [IMPROVEMENT] Skip malformed RUM attributes individually instead of dropping the entire event, and log clear error messages. See [#xxx][]
+- [IMPROVEMENT] Skip malformed RUM attributes individually instead of dropping the entire event, and log clear error messages. See [#2844][]
 - [FEATURE] Add Mobile Heatmaps support. See [#2829][]
 - [FEATURE] Add watchOS and visionOS support. See [#2817][]
 - [FEATURE] Add support for the FedRAMP-compatible `fed2.ddog-gov.com` site. See [#2827][]
@@ -1117,7 +1117,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2817]: https://github.com/DataDog/dd-sdk-ios/pull/2817
 [#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827
 [#2829]: https://github.com/DataDog/dd-sdk-ios/pull/2829
-[#xxx]: https://github.com/DataDog/dd-sdk-ios/pull/xxx
+[#2844]: https://github.com/DataDog/dd-sdk-ios/pull/2844
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVEMENT] Skip malformed RUM attributes individually instead of dropping the entire event, and log clear error messages. See [#xxx][]
 - [FEATURE] Add Mobile Heatmaps support. See [#2829][]
 - [FEATURE] Add watchOS and visionOS support. See [#2817][]
 - [FEATURE] Add support for the FedRAMP-compatible `fed2.ddog-gov.com` site. See [#2827][]
@@ -1115,6 +1116,8 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2807]: https://github.com/DataDog/dd-sdk-ios/pull/2807
 [#2817]: https://github.com/DataDog/dd-sdk-ios/pull/2817
 [#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827
+[#2829]: https://github.com/DataDog/dd-sdk-ios/pull/2829
+[#xxx]: https://github.com/DataDog/dd-sdk-ios/pull/xxx
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -51,12 +51,9 @@
 		116656D62EB501D3004248E8 /* ProfilingRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116656D42EB501C2004248E8 /* ProfilingRUMIntegrationTests.swift */; };
 		116656D72EB504A8004248E8 /* DatadogProfiling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D229FFA72E3BC6D4009CCD62 /* DatadogProfiling.framework */; platformFilters = (ios, tvos, xros, ); };
 		116656E12EB504F1004248E8 /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
-		1166C5A12F76EBCD008E34BC /* ProfilingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */; };
 		1166C5A22F76EBCD008E34BC /* ProfilingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A02F76EBC1008E34BC /* ProfilingOptions.swift */; };
-		1166C5A42F76EC0B008E34BC /* OperationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A32F76EC05008E34BC /* OperationOptions.swift */; };
 		1166C5A52F76EC0B008E34BC /* OperationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A32F76EC05008E34BC /* OperationOptions.swift */; };
 		1166C5AA2F76ED7A008E34BC /* ProfilingOptions+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */; };
-		1166C5AB2F76ED7A008E34BC /* ProfilingOptions+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1166C5A92F76ED6F008E34BC /* ProfilingOptions+objc.swift */; };
 		116F84062CFDD06700705755 /* SampleRateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116F84052CFDD06700705755 /* SampleRateTests.swift */; };
 		117ADDD92EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117ADDD82EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift */; };
 		117E52222D91A61A00A8E930 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; platformFilter = ios; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -723,6 +720,7 @@
 		965497022D761EA3006428EE /* SwiftUIRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965497012D761E9E006428EE /* SwiftUIRUMViewsPredicate.swift */; };
 		965497052D761FCB006428EE /* SwiftUIViewNameExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965497042D761FC2006428EE /* SwiftUIViewNameExtractor.swift */; };
 		9654971D2D774060006428EE /* SwiftUIViewNameExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9654971C2D77404E006428EE /* SwiftUIViewNameExtractorTests.swift */; };
+		965A1B282F8E6402006A4B4E /* Monitor+AttributeEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965A1B272F8E6402006A4B4E /* Monitor+AttributeEncodingTests.swift */; };
 		9678E2772E55CD200094B106 /* RUMFeatureOperationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E2752E55CD200094B106 /* RUMFeatureOperationManagerTests.swift */; };
 		96867B992D08826B004AE0BC /* TextReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96867B982D08826B004AE0BC /* TextReflectionTests.swift */; };
 		96867B9B2D0883DD004AE0BC /* ColorReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96867B9A2D0883DD004AE0BC /* ColorReflectionTests.swift */; };
@@ -2547,6 +2545,7 @@
 		965497012D761E9E006428EE /* SwiftUIRUMViewsPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIRUMViewsPredicate.swift; sourceTree = "<group>"; };
 		965497042D761FC2006428EE /* SwiftUIViewNameExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewNameExtractor.swift; sourceTree = "<group>"; };
 		9654971C2D77404E006428EE /* SwiftUIViewNameExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewNameExtractorTests.swift; sourceTree = "<group>"; };
+		965A1B272F8E6402006A4B4E /* Monitor+AttributeEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Monitor+AttributeEncodingTests.swift"; sourceTree = "<group>"; };
 		966253B52C98807400B90B63 /* SessionReplayPrivacyOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyOverrides.swift; sourceTree = "<group>"; };
 		9678E2752E55CD200094B106 /* RUMFeatureOperationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureOperationManagerTests.swift; sourceTree = "<group>"; };
 		96867B982D08826B004AE0BC /* TextReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReflectionTests.swift; sourceTree = "<group>"; };
@@ -5161,6 +5160,7 @@
 		617B953B24BF4D7300E6F443 /* RUMMonitor */ = {
 			isa = PBXGroup;
 			children = (
+				965A1B272F8E6402006A4B4E /* Monitor+AttributeEncodingTests.swift */,
 				61CE2E5E2BF2177100EC7D42 /* Monitor+GlobalAttributesTests.swift */,
 				6176C1712ABDBA2E00131A70 /* MonitorTests.swift */,
 				618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */,
@@ -5259,9 +5259,7 @@
 			isa = PBXGroup;
 			children = (
 				5BFDD7A82E28FDC9009A2CEE /* RUMWebViewContext.swift */,
-				111C13842F83E53600960ED9 /* OperationMessage.swift */,
 				1166C5A32F76EC05008E34BC /* OperationOptions.swift */,
-				D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */,
 				D28FB6952DB7D3F000CD76D0 /* RUMDataModels.swift */,
 				D2D9A9DB2DBFD507005DB31D /* RUMPayloadMessages.swift */,
 				D2E8A8E62DCBBA5100CF7C63 /* RUMCoreContext.swift */,
@@ -8885,6 +8883,7 @@
 				A7E6EA852D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B62A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,
+				965A1B282F8E6402006A4B4E /* Monitor+AttributeEncodingTests.swift in Sources */,
 				D29A9FB829DDB483005C54A4 /* RUMViewScopeTests.swift in Sources */,
 				D224430F29E9779F00274EC7 /* TelemetryReceiverTests.swift in Sources */,
 				96155A292D79A4E50029034E /* SwiftUIViewNameExtractorIntegrationTests.swift in Sources */,

--- a/DatadogInternal/Sources/Context/AccountInfo.swift
+++ b/DatadogInternal/Sources/Context/AccountInfo.swift
@@ -37,9 +37,8 @@ public struct AccountInfo: Codable {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try extraInfo.forEach {
-            let key = DynamicCodingKey($0)
-            try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+        extraInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .accountInfo)
         }
     }
 

--- a/DatadogInternal/Sources/Context/UserInfo.swift
+++ b/DatadogInternal/Sources/Context/UserInfo.swift
@@ -49,9 +49,8 @@ public struct UserInfo: Codable {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try extraInfo.forEach {
-            let key = DynamicCodingKey($0)
-            try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+        extraInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .userInfo)
         }
     }
 

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -214,8 +214,8 @@ extension RUMAccount {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try accountInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        accountInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .accountInfo)
         }
     }
 
@@ -2608,8 +2608,8 @@ extension RUMErrorEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try featureFlagsInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        featureFlagsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -2643,8 +2643,8 @@ extension RUMEventAttributes {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try contextInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        contextInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -4889,8 +4889,8 @@ extension RUMResourceEvent.Resource.Request.Headers {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try headersInfo.forEach {
-            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        headersInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -4909,8 +4909,8 @@ extension RUMResourceEvent.Resource.Response.Headers {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try headersInfo.forEach {
-            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        headersInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -4992,8 +4992,8 @@ extension RUMSyntheticsTest {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try syntheticsInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        syntheticsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
         }
     }
 
@@ -5161,8 +5161,8 @@ extension RUMUser {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try usrInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        usrInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .userInfo)
         }
     }
 
@@ -7387,8 +7387,8 @@ extension RUMViewEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try featureFlagsInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        featureFlagsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -7407,8 +7407,8 @@ extension RUMViewEvent.View.CustomTimings {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try customTimingsInfo.forEach {
-            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        customTimingsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -9418,8 +9418,8 @@ extension RUMViewUpdateEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try featureFlagsInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        featureFlagsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -9438,8 +9438,8 @@ extension RUMViewUpdateEvent.View.CustomTimings {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try customTimingsInfo.forEach {
-            try dynamicContainer.encode($1, forKey: DynamicCodingKey($0))
+        customTimingsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -12710,8 +12710,8 @@ extension TelemetryConfigurationEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try telemetryInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        telemetryInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
         }
     }
 
@@ -12741,8 +12741,8 @@ extension TelemetryConfigurationEvent.Telemetry.Configuration.Plugins {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try pluginsInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        pluginsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
         }
     }
 
@@ -13028,8 +13028,8 @@ extension TelemetryDebugEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try telemetryInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        telemetryInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
         }
     }
 
@@ -13352,8 +13352,8 @@ extension TelemetryErrorEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try telemetryInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        telemetryInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
         }
     }
 
@@ -14351,8 +14351,8 @@ extension TelemetryUsageEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try telemetryInfo.forEach {
-            try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+        telemetryInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
         }
     }
 
@@ -14374,4 +14374,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ea41a41f19117b04ed9a06977fdeb8f7a90319e3
+// Generated from https://github.com/DataDog/rum-events-format/tree/0ca44bb75f6d0d02df73ecdfb0e71ea8eeb3e2e4

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -14828,4 +14828,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ea41a41f19117b04ed9a06977fdeb8f7a90319e3
+// Generated from https://github.com/DataDog/rum-events-format/tree/0ca44bb75f6d0d02df73ecdfb0e71ea8eeb3e2e4

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
@@ -1,0 +1,183 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+@testable import TestUtilities
+
+/// Tests that verify attribute encoding error handling in RUM events.
+/// These tests use `AnyEncodable` to wrap non-`Encodable` types, simulating real production scenarios:
+/// - **ObjC APIs** (primary production path): Customers use ObjC APIs like `addAttribute(forKey:value:)` which accepts `Any`.
+///   SDK automatically wraps values in `AnyEncodable`, losing type safety. Telemetry shows this is the dominant error path.
+/// - **Swift APIs with manual wrapping**: Swift API requires `Encodable`, but customers can explicitly wrap non-encodable
+///   types using `AnyEncodable(value)` to bypass compile-time checks, e.g. passing closures/blocks, `NSObject`, custom classes.
+class Monitor_AttributeEncodingTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+    private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope),
+            dateProvider: SystemDateProvider()
+        )
+    }
+
+    override func tearDown() {
+        monitor = nil
+    }
+
+    // MARK: - Custom attributes (context.*)
+
+    func testWhenCustomAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When
+        monitor.addAttribute(forKey: "valid", value: "test")
+        monitor.addAttribute(forKey: "invalid", value: AnyEncodable(NSObject()))
+        monitor.notifySDKInit()
+
+        // Then
+        let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let jsonData = try JSONEncoder().encode(viewEvent)
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let context = json["context"] as? [String: Any]
+
+        XCTAssertEqual(context?["valid"] as? String, "test", "Valid attribute should be present in the event")
+        XCTAssertNil(context?["invalid"], "Non-encodable attribute should be dropped")
+
+        XCTAssertEqual(
+            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute 'invalid'") }.count,
+            1,
+            "One error should be logged for the dropped attribute"
+        )
+    }
+
+    func testWhenOnlyMalformedCustomAttributesAdded_itSendsEventWithoutCustomAttributes() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When
+        monitor.addAttribute(forKey: "invalid1", value: AnyEncodable(NSObject()))
+        let closure: (NSArray) -> Void = { _ in }
+        monitor.addAttribute(forKey: "invalid2", value: AnyEncodable(closure))
+        monitor.notifySDKInit()
+
+        // Then - event is sent even though all custom attributes are malformed
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        XCTAssertEqual(viewEvents.count, 1)
+
+        let viewEvent = try XCTUnwrap(viewEvents.first)
+        let jsonData = try JSONEncoder().encode(viewEvent)
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+
+        XCTAssertNil((json["context"] as? [String: Any])?["invalid1"])
+        XCTAssertNil((json["context"] as? [String: Any])?["invalid2"])
+
+        XCTAssertEqual(
+            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
+            2
+        )
+    }
+
+    // MARK: - User info extra attributes (usr.*)
+
+    func testWhenUserInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        featureScope.contextMock = .mockWith(userInfo: UserInfo(
+            id: "user-id",
+            extraInfo: [
+                "valid_info": "test",
+                "invalid_info": AnyEncodable(NSObject())
+            ]
+        ))
+
+        // When
+        monitor.notifySDKInit()
+
+        // Then
+        let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let jsonData = try JSONEncoder().encode(viewEvent)
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let usr = json["usr"] as? [String: Any]
+
+        XCTAssertEqual(usr?["valid_info"] as? String, "test", "Valid user info attribute should be present")
+        XCTAssertNil(usr?["invalid_info"], "Non-encodable user info attribute should be dropped")
+
+        XCTAssertEqual(
+            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_info") }.count,
+            1
+        )
+    }
+
+    // MARK: - Account info extra attributes (account.*)
+
+    func testWhenAccountInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        featureScope.contextMock = .mockWith(accountInfo: AccountInfo(
+            id: "acc-id",
+            extraInfo: [
+                "valid_plan": "enterprise",
+                "invalid_plan": AnyEncodable(NSObject())
+            ]
+        ))
+
+        // When
+        monitor.notifySDKInit()
+
+        // Then
+        let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let jsonData = try JSONEncoder().encode(viewEvent)
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let account = json["account"] as? [String: Any]
+
+        XCTAssertEqual(account?["valid_plan"] as? String, "enterprise", "Valid account info attribute should be present")
+        XCTAssertNil(account?["invalid_plan"], "Non-encodable account info attribute should be dropped")
+
+        XCTAssertEqual(
+            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_plan") }.count,
+            1
+        )
+    }
+
+    // MARK: - Feature flag values (feature_flags.*)
+
+    func testWhenFeatureFlagValueFailsToEncode_itIsDroppedAndEventIsSent() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // When
+        monitor.notifySDKInit()
+        monitor.startView(key: "TestView")
+        monitor.addFeatureFlagEvaluation(name: "valid_flag", value: "enabled")
+        monitor.addFeatureFlagEvaluation(name: "invalid_flag", value: AnyEncodable(NSObject()))
+
+        // Then
+        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
+        let viewWithFlags = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "TestView" }))
+        let jsonData = try JSONEncoder().encode(viewWithFlags)
+        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let featureFlags = json["feature_flags"] as? [String: Any]
+
+        XCTAssertEqual(featureFlags?["valid_flag"] as? String, "enabled", "Valid feature flag should be present")
+        XCTAssertNil(featureFlags?["invalid_flag"], "Non-encodable feature flag should be dropped")
+
+        XCTAssertEqual(
+            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_flag") }.count,
+            1
+        )
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
@@ -45,7 +45,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let context = json["context"] as? [String: Any]
 
         XCTAssertEqual(context?["valid"] as? String, "test", "Valid attribute should be present in the event")
@@ -75,7 +75,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
         let viewEvent = try XCTUnwrap(viewEvents.first)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
 
         XCTAssertNil((json["context"] as? [String: Any])?["invalid1"])
         XCTAssertNil((json["context"] as? [String: Any])?["invalid2"])
@@ -107,7 +107,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let usr = json["usr"] as? [String: Any]
 
         XCTAssertEqual(usr?["valid_info"] as? String, "test", "Valid user info attribute should be present")
@@ -140,7 +140,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let account = json["account"] as? [String: Any]
 
         XCTAssertEqual(account?["valid_plan"] as? String, "enterprise", "Valid account info attribute should be present")
@@ -169,7 +169,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
         let viewWithFlags = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "TestView" }))
         let jsonData = try JSONEncoder().encode(viewWithFlags)
-        let json = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let featureFlags = json["feature_flags"] as? [String: Any]
 
         XCTAssertEqual(featureFlags?["valid_flag"] as? String, "enabled", "Valid feature flag should be present")

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
@@ -249,9 +249,17 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
                     value = "$1"
                 }
 
-                writeLine("try \(dynamicProperty.backtickName).forEach {") // dynamic properties are dictionaries
+                let context: String
+                switch dynamicProperty.name {
+                case "usrInfo":     context = ".userInfo"
+                case "accountInfo": context = ".accountInfo"
+                case "telemetryInfo", "syntheticsInfo": context = ".internal"
+                default:            context = ".custom"
+                }
+                let encodedValue = value.replacingOccurrences(of: "$1", with: "value")
+                writeLine("\(dynamicProperty.backtickName).forEach { name, value in") // dynamic properties are dictionaries
                 indentRight()
-                    writeLine("try dynamicContainer.encode(\(value), forKey: DynamicCodingKey($0))") // encode `value` (dictionary `key` is used as coding key)
+                    writeLine("dynamicContainer.encodeAttribute(\(encodedValue), forKey: DynamicCodingKey(name), attributeName: name, context: \(context))")
                 indentLeft()
                 writeLine("}")
             }

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
@@ -355,8 +355,8 @@ final class SwiftPrinterTests: XCTestCase {
             public func encode(to encoder: Encoder) throws {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                try context.forEach {
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+                context.forEach { name, value in
+                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
                 }
             }
 
@@ -469,8 +469,8 @@ final class SwiftPrinterTests: XCTestCase {
 
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                try context.forEach {
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+                context.forEach { name, value in
+                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
                 }
             }
 
@@ -713,8 +713,8 @@ final class SwiftPrinterTests: XCTestCase {
             public func encode(to encoder: Encoder) throws {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                try context.forEach {
-                    try dynamicContainer.encode(AnyEncodable($1), forKey: DynamicCodingKey($0))
+                context.forEach { name, value in
+                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
                 }
             }
 
@@ -740,6 +740,40 @@ final class SwiftPrinterTests: XCTestCase {
         """
 
         XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingSwiftStructWithDynamicCodingKeys_usesCorrectAttributeEncodingContext() throws {
+        func makeStruct(propertyName: String) throws -> String {
+            let `struct` = SwiftStruct(
+                name: "Foo",
+                comment: nil,
+                properties: [
+                    SwiftStruct.Property(
+                        name: propertyName,
+                        comment: nil,
+                        type: SwiftDictionary(value: SwiftEncodable()),
+                        isOptional: false,
+                        mutability: .immutable,
+                        defaultValue: nil,
+                        codingKey: .dynamic
+                    ),
+                ],
+                conformance: [codableProtocol]
+            )
+            return try SwiftPrinter().print(swiftTypes: [`struct`])
+        }
+
+        // usrInfo → .userInfo
+        XCTAssertTrue(try makeStruct(propertyName: "usrInfo").contains("context: .userInfo"))
+        // accountInfo → .accountInfo
+        XCTAssertTrue(try makeStruct(propertyName: "accountInfo").contains("context: .accountInfo"))
+        // telemetryInfo → .internal
+        XCTAssertTrue(try makeStruct(propertyName: "telemetryInfo").contains("context: .internal"))
+        // syntheticsInfo → .internal
+        XCTAssertTrue(try makeStruct(propertyName: "syntheticsInfo").contains("context: .internal"))
+        // anything else → .custom
+        XCTAssertTrue(try makeStruct(propertyName: "contextInfo").contains("context: .custom"))
+        XCTAssertTrue(try makeStruct(propertyName: "featureFlagsInfo").contains("context: .custom"))
     }
 
     func testPrintingSwiftStructWithMultiLineComments() throws {


### PR DESCRIPTION
### What and why?

When a customer passes a non-encodable value as a RUM attribute — most commonly via the ObjC bridge, where `addAttribute(forKey:value:)` accepts `Any` and the SDK wraps it in `AnyEncodable` — the entire RUM event is dropped instead of just skipping the bad attribute.

This is the same issue fixed for Logs in #2665 and Trace in #2676. This PR closes the gap for RUM.

### How?

RUM event models are auto-generated from the `rum-events-format` schema via `tools/rum-models-generator`. Patching `RUMDataModels.swift` directly would be overwritten on the next schema update, so the fix goes into `SwiftPrinter.swift` (the code generator): the `forEach { try encode() }` pattern is replaced with `forEach { encodeAttribute() }`, using the `KeyedEncodingContainer` extension introduced in #2665. It catches encoding errors internally, logs a clear message naming the specific attribute, and skips only that key — the event is always sent.

Property names are mapped to `AttributeEncodingContext` for precise error messages:
- `usrInfo` → `.userInfo` — "Failed to encode user info attribute 'X'"
- `accountInfo` → `.accountInfo` — "Failed to encode account attribute 'X'"
- `telemetryInfo`, `syntheticsInfo` → `.internal` — "Failed to encode internal attribute 'X'"
- `contextInfo`, `featureFlagsInfo`, others → `.custom` — "Failed to encode attribute 'X'"

The same fix is applied to the hand-written `encode(to:)` in `UserInfo.swift` and `AccountInfo.swift`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
