### PR TITLE
[PANA-7031] Gate heatmap identifier computation behind a Session Replay feature flag

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -91,7 +91,8 @@ public class Recorder: Recording {
                     nodeRecorders: createDefaultNodeRecorders(featureFlags: featureFlags) + additionalNodeRecorders
                 ),
                 idsGenerator: NodeIDGenerator(),
-                core: core
+                core: core,
+                featureFlags: featureFlags
             )
         )
         let touchSnapshotProducer = WindowTouchSnapshotProducer(windowObserver: windowObserver)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -59,8 +59,9 @@ internal struct ViewTreeRecorder {
             context.clip = frame.intersection(context.clip)
         }
 
-        // Compute the heatmap identifier
-        let heatmapIdentifier = context.recorder.viewPath.map { viewPath in
+        // Compute the heatmap identifier when heatmaps are enabled
+        let heatmapIdentifier: HeatmapIdentifier?
+        if let heatmapCache = context.heatmapCache, let viewPath = context.recorder.viewPath {
             let component: String
             if let accessibilityIdentifier = view.accessibilityIdentifier, !accessibilityIdentifier.isEmpty {
                 component = accessibilityIdentifier
@@ -69,14 +70,15 @@ internal struct ViewTreeRecorder {
             }
             context.nodePath.append(component)
 
-            let heatmapIdentifier = HeatmapIdentifier(
+            let identifier = HeatmapIdentifier(
                 elementPath: context.nodePath,
                 screenName: viewPath,
                 bundleIdentifier: bundleIdentifier() ?? "unknown"
             )
-
-            context.heatmapCache.identifiers[ObjectIdentifier(view)] = heatmapIdentifier
-            return heatmapIdentifier
+            heatmapCache.identifiers[ObjectIdentifier(view)] = identifier
+            heatmapIdentifier = identifier
+        } else {
+            heatmapIdentifier = nil
         }
 
         let attributes = ViewAttributes(view: view, frame: frame, clip: context.clip, overrides: overrides)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -26,8 +26,8 @@ public struct SessionReplayViewTreeRecordingContext {
     var viewControllerContext: ViewControllerContext = .init()
     /// Webviews caching.
     let webViewCache: NSHashTable<WKWebView>
-    /// Heatmaps caching
-    let heatmapCache: HeatmapCache
+    /// Heatmaps caching. When `nil`, heatmap identifier computation is skipped.
+    let heatmapCache: HeatmapCache?
     /// The clipping rect to apply to wireframes.
     var clip: CGRect
     /// The path components from the root to the current node, used for heatmap identifier computation.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -21,6 +21,8 @@ internal struct ViewTreeSnapshotBuilder {
     let idsGenerator: NodeIDGenerator
     /// A weak core reference.
     weak var core: DatadogCoreProtocol?
+    /// Feature flags for Session Replay.
+    let featureFlags: SessionReplay.Configuration.FeatureFlags
     /// The webviews cache.
     let webViewCache: NSHashTable<WKWebView> = .weakObjects()
 
@@ -32,7 +34,7 @@ internal struct ViewTreeSnapshotBuilder {
     /// are computed relatively to the `rootView` (e.g. the `x` and `y` position of all descendant nodes  is given
     /// as its position in the root, no matter of nesting level).
     func createSnapshot(of rootView: UIView, with recorderContext: Recorder.Context) -> ViewTreeSnapshot {
-        let heatmapCache = HeatmapCache()
+        let heatmapCache: HeatmapCache? = featureFlags[.heatmaps] ? HeatmapCache() : nil
         let context = ViewTreeRecordingContext(
             recorder: recorderContext,
             coordinateSpace: rootView,
@@ -49,7 +51,9 @@ internal struct ViewTreeSnapshotBuilder {
             nodes: nodes,
             webViewSlotIDs: Set(webViewCache.allObjects.map(\.hash))
         )
-        core?.heatmapIdentifierRegistry?.setHeatmapIdentifiers(heatmapCache.identifiers)
+        if let heatmapCache {
+            core?.heatmapIdentifierRegistry?.setHeatmapIdentifiers(heatmapCache.identifiers)
+        }
         return snapshot
     }
 }
@@ -65,7 +69,8 @@ extension ViewTreeSnapshotBuilder {
                 nodeRecorders: createDefaultNodeRecorders(featureFlags: featureFlags) + additionalNodeRecorders
             ),
             idsGenerator: NodeIDGenerator(),
-            core: core
+            core: core,
+            featureFlags: featureFlags
         )
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -103,9 +103,10 @@ public final class objc_SessionReplayConfiguration: NSObject {
     }
 
     /// Feature flags to preview features in Session Replay.
-    /// 
+    ///
     /// Available flags:
     /// - `swiftui`: `false` by default.
+    /// - `heatmaps`: `false` by default.
     @objc public var featureFlags: [String: Bool] {
         set { _swift.featureFlags = newValue.dd.featureFlags }
         get { _swift.featureFlags.dd.featureFlags }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -108,6 +108,9 @@ extension SessionReplay.Configuration {
         /// SwiftUI Recording
         case swiftui
 
+        /// Heatmap identifier computation
+        case heatmaps
+
         @available(*, deprecated, message: "Screen change scheduling is now the default and always enabled. This flag has no effect.")
         case screenChangeScheduling
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
@@ -216,6 +216,29 @@ struct HeatmapIdentifierComputationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips heatmap computation when heatmapCache is nil")
+    func heatmapsDisabled() {
+        // Given
+        let view = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+
+        let recorder = ViewTreeRecorder(
+            nodeRecorders: [UIViewRecorder(identifier: UUID())],
+            bundleIdentifier: "com.example.app"
+        )
+        let context = ViewTreeRecordingContext.mockWith(
+            recorder: .mockWith(rumContext: .mockWith(viewPath: "Home")),
+            coordinateSpace: view,
+            heatmapCache: nil
+        )
+
+        // When
+        let nodes = recorder.record(view, in: context)
+
+        // Then
+        #expect(nodes.first?.heatmapIdentifier == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframes have nil permanentId when no heatmap identifier")
     func wireframeNoPermanentId() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -21,7 +21,8 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let builder = ViewTreeSnapshotBuilder(
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
-            core: PassthroughCoreMock()
+            core: PassthroughCoreMock(),
+            featureFlags: .allEnabled
         )
 
         // When
@@ -51,7 +52,8 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let builder = ViewTreeSnapshotBuilder(
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
-            core: PassthroughCoreMock()
+            core: PassthroughCoreMock(),
+            featureFlags: .allEnabled
         )
 
         // When
@@ -126,6 +128,28 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         )
         let context = Recorder.Context.mockWith(
             rumContext: .mockWith(viewPath: nil)
+        )
+
+        // When
+        _ = builder.createSnapshot(of: view, with: context)
+
+        // Then
+        XCTAssertTrue(registry.identifiers.isEmpty)
+    }
+
+    func testWhenCreatingSnapshot_withHeatmapsFlagDisabled_itDoesNotWriteToRegistry() throws {
+        // Given
+        let view = UIView.mock(withFixture: .visible(.someAppearance))
+        let core = FeatureRegistrationCoreMock()
+        let registry = HeatmapIdentifierRegistryMock()
+        try core.register(heatmapIdentifierRegistry: registry)
+        let builder = ViewTreeSnapshotBuilder(
+            additionalNodeRecorders: [],
+            core: core,
+            featureFlags: .defaults
+        )
+        let context = Recorder.Context.mockWith(
+            rumContext: .mockWith(viewPath: "Home")
         )
 
         // When

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
@@ -13,7 +13,8 @@ import Foundation
 extension SessionReplay.Configuration.FeatureFlags {
     public static var allEnabled: Self {
         [
-            .swiftui: true
+            .swiftui: true,
+            .heatmaps: true,
         ]
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
@@ -383,7 +383,7 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator(),
         webViewCache: NSHashTable<WKWebView> = .weakObjects(),
-        heatmapCache: HeatmapCache = .init(),
+        heatmapCache: HeatmapCache? = .init(),
         clip: CGRect? = nil
     ) -> ViewTreeRecordingContext {
         return .init(


### PR DESCRIPTION
 ### What and why?

The heatmaps feature computes a heatmap identifier for every view in the UIKit hierarchy on every Session Replay recording tick. Since heatmaps is shipping as a preview feature, this computation should be opt-in.

### How?

Added a `.heatmaps` case to `SessionReplay.Configuration.FeatureFlag` (defaults to `false`) and used it to gate the heatmap computation:

- `ViewTreeSnapshotBuilder` stores `featureFlags` and only creates a `HeatmapCache` when `.heatmaps` is enabled. When disabled, `nil` is passed to the recording context and the registry is not updated.
- `ViewTreeRecorder` skips the heatmap identifier computation (MD5 hashing, path accumulation, cache writes) when `heatmapCache` is `nil`.
- `HeatmapCache` in `ViewTreeRecordingContext` is now optional, acting as the signal for whether heatmap computation should run.

When the flag is off, `permanentId` is omitted from wireframes and `dd.action.target.permanent_id` is absent from RUM action events. Both fields are already optional, so backends handle this gracefully.

Users opt in with:
```swift
SessionReplay.Configuration(featureFlags: [.heatmaps: true])
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
