### PR TITLE
RUM-15279: Propagate native anonymous_id to webview events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FEATURE] Add watchOS and visionOS support. See [#2817][]
 - [FEATURE] Add support for the FedRAMP-compatible `fed2.ddog-gov.com` site. See [#2827][]
 - [IMPROVEMENT] Rename RUM Operations APIs. See [#2802][]
+- [FIX] Propagate native `anonymous_id` to WebView RUM and Log events. See [#2847][]
 
 # 3.9.0 / 02-04-2026
 
@@ -1115,6 +1116,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2807]: https://github.com/DataDog/dd-sdk-ios/pull/2807
 [#2817]: https://github.com/DataDog/dd-sdk-ios/pull/2817
 [#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827
+[#2847]: https://github.com/DataDog/dd-sdk-ios/pull/2847
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/WebLogIntegrationTests.swift
@@ -98,6 +98,10 @@ class WebLogIntegrationTests: XCTestCase {
             $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
         }, in: core)
 
+        // Flush to ensure the AnonymousIdentifierManager has generated
+        // and propagated the anonymous ID to the context
+        core.flush()
+
         let body = """
         {
             "eventType": "log",
@@ -136,6 +140,9 @@ class WebLogIntegrationTests: XCTestCase {
                 "referrer": "",
                 "url": "https://datadoghq.dev/browser-sdk-test-playground"
             },
+            "usr": {
+                "anonymous_id": "\(expectedUUID)"
+            }
         }
         """
         )

--- a/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/WebEventIntegrationTests.swift
@@ -53,6 +53,10 @@ class WebEventIntegrationTests: XCTestCase {
             $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: randomUUID)
         }, in: core)
 
+        // Flush to ensure the AnonymousIdentifierManager has generated
+        // and propagated the anonymous ID to the context
+        core.flush()
+
         let body = """
         {
           "eventType": "view",
@@ -168,6 +172,9 @@ class WebEventIntegrationTests: XCTestCase {
               "document_version": 2,
               "drift": 0,
               "format_version": 2
+            },
+            "usr": {
+              "anonymous_id": "\(expectedUUID)"
             }
         }
         """

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -96,6 +96,13 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
                 event[LogEvent.Attributes.RUM.actionID] = rum.userActionID
             }
 
+            // Add native anonymous_id to the event's usr object
+            if let anonymousId = context.userInfo?.anonymousId {
+                var usr = event[LogEvent.Attributes.User.key] as? [String: Any] ?? [:]
+                usr[LogEvent.Attributes.User.anonymousId] = anonymousId
+                event[LogEvent.Attributes.User.key] = usr
+            }
+
             writer.write(value: AnyEncodable(event))
         }
 

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -45,6 +45,14 @@ public struct LogEvent: Encodable {
             static let spanID = "dd.span_id"
         }
 
+        /// User attribute keys propagated from the native SDK to webview events.
+        internal enum User {
+            /// Key referencing the usr object.
+            static let key = "usr"
+            /// Key referencing the anonymous user ID.
+            static let anonymousId = "anonymous_id"
+        }
+
         /// Log custom attributes, They are subject for sanitization.
         public var userAttributes: [String: Encodable]
         /// Log attributes added internally by the SDK. They are not a subject for sanitization.

--- a/DatadogLogs/Tests/WebViewLogReceiverTests.swift
+++ b/DatadogLogs/Tests/WebViewLogReceiverTests.swift
@@ -260,4 +260,102 @@ class WebViewLogReceiverTests: XCTestCase {
         XCTAssertNil(log["user_action.id"])
         XCTAssertTrue(telemetryReceiver.messages.isEmpty)
     }
+
+    // MARK: - Anonymous ID Propagation
+
+    func testWhenAnonymousIdIsAvailable_itAddsAnonymousIdAndPreservesExistingWebUsrFields() throws {
+        // Given
+        let messageReceiver = WebViewLogReceiver()
+        let fakeAnonymousId: String = .mockRandom()
+        let webUsrId: String = .mockRandom()
+        let webUsrName: String = .mockRandom()
+
+        let expectation = expectation(description: "Send log")
+        let core = PassthroughCoreMock(
+            context: .mockWith(
+                userInfo: UserInfo(anonymousId: fakeAnonymousId)
+            )
+        )
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        // When
+        XCTAssert(
+            messageReceiver.receive(
+                message: .webview(.log([
+                    "test": "value",
+                    "usr": ["id": webUsrId, "name": webUsrName]
+                ])),
+                from: core
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        let log = try XCTUnwrap(core.events(ofType: AnyEncodable.self).first?.value as? [String: Any])
+        let usr = try XCTUnwrap(log["usr"] as? [String: Any])
+        XCTAssertEqual(usr["id"] as? String, webUsrId)
+        XCTAssertEqual(usr["name"] as? String, webUsrName)
+        XCTAssertEqual(usr["anonymous_id"] as? String, fakeAnonymousId)
+    }
+
+    func testWhenBrowserAlreadySetAnonymousId_itOverwritesWithNativeValue() throws {
+        // Given
+        let messageReceiver = WebViewLogReceiver()
+        let nativeAnonymousId: String = .mockRandom()
+        let browserAnonymousId: String = .mockRandom()
+
+        let expectation = expectation(description: "Send log")
+        let core = PassthroughCoreMock(
+            context: .mockWith(
+                userInfo: UserInfo(anonymousId: nativeAnonymousId)
+            )
+        )
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        // When
+        XCTAssert(
+            messageReceiver.receive(
+                message: .webview(.log([
+                    "test": "value",
+                    "usr": ["anonymous_id": browserAnonymousId]
+                ])),
+                from: core
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        let log = try XCTUnwrap(core.events(ofType: AnyEncodable.self).first?.value as? [String: Any])
+        let usr = try XCTUnwrap(log["usr"] as? [String: Any])
+        XCTAssertEqual(usr["anonymous_id"] as? String, nativeAnonymousId)
+    }
+
+    func testWhenAnonymousIdIsAvailable_andNoUsrSet_itAddsAnonymousId() throws {
+        // Given
+        let messageReceiver = WebViewLogReceiver()
+        let fakeAnonymousId: String = .mockRandom()
+
+        let expectation = expectation(description: "Send log")
+        let core = PassthroughCoreMock(
+            context: .mockWith(
+                userInfo: UserInfo(anonymousId: fakeAnonymousId)
+            )
+        )
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        // When
+        XCTAssert(
+            messageReceiver.receive(
+                message: .webview(.log(["test": "value"])),
+                from: core
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        let log = try XCTUnwrap(core.events(ofType: AnyEncodable.self).first?.value as? [String: Any])
+        let usr = try XCTUnwrap(log["usr"] as? [String: Any])
+        XCTAssertEqual(usr["anonymous_id"] as? String, fakeAnonymousId)
+        XCTAssertEqual(usr.count, 1, "usr should only contain anonymous_id")
+    }
 }

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -123,6 +123,13 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                 event["_dd"] = dd
             }
 
+            // Add native anonymous_id to the event's usr object
+            if let anonymousId = context.userInfo?.anonymousId {
+                var usr = event["usr"] as? JSON ?? [:]
+                usr["anonymous_id"] = anonymousId
+                event["usr"] = usr
+            }
+
             writer.write(value: AnyEncodable(event))
         }
     }

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -456,4 +456,147 @@ class WebViewEventReceiverTests: XCTestCase {
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
     }
+
+    // MARK: - Anonymous ID Propagation
+
+    func testGivenAnonymousIdAvailable_whenReceivingWebEventWithExistingUsr_itAddsAnonymousIdAndPreservesWebFields() throws {
+        // Given
+        let dateProvider = RelativeDateProvider()
+        let fakeAnonymousId: String = .mockRandom()
+        let webUsrId: String = .mockRandom()
+        let webUsrName: String = .mockRandom()
+        let rumContext: RUMCoreContext = .mockRandom()
+        featureScope.contextMock = .mockWith(
+            userInfo: UserInfo(anonymousId: fakeAnonymousId),
+            additionalContext: [rumContext]
+        )
+
+        let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
+            dateProvider: DateProviderMock(),
+            commandSubscriber: RUMCommandSubscriberMock(),
+            viewCache: ViewCache(dateProvider: dateProvider)
+        )
+
+        dateProvider.advance(bySeconds: 1)
+        let date = dateProvider.now.timeIntervalSince1970.dd.toInt64Milliseconds
+        let webEventMock: JSON = [
+            "application": ["id": String.mockRandom()],
+            "session": ["id": String.mockRandom()],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": Int(date),
+            "usr": [
+                "id": webUsrId,
+                "name": webUsrName
+            ]
+        ]
+
+        // When
+        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
+        let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
+        let expectedWebEventWritten: JSON = [
+            "application": ["id": rumContext.applicationID],
+            "session": ["id": rumContext.sessionID],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
+            "usr": [
+                "id": webUsrId,
+                "name": webUsrName,
+                "anonymous_id": fakeAnonymousId
+            ]
+        ]
+        DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
+    }
+
+    func testGivenAnonymousIdAlreadySetByBrowser_whenReceivingWebEvent_itOverwritesWithNativeValue() throws {
+        // Given
+        let dateProvider = RelativeDateProvider()
+        let nativeAnonymousId: String = .mockRandom()
+        let browserAnonymousId: String = .mockRandom()
+        let rumContext: RUMCoreContext = .mockRandom()
+        featureScope.contextMock = .mockWith(
+            userInfo: UserInfo(anonymousId: nativeAnonymousId),
+            additionalContext: [rumContext]
+        )
+
+        let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
+            dateProvider: DateProviderMock(),
+            commandSubscriber: RUMCommandSubscriberMock(),
+            viewCache: ViewCache(dateProvider: dateProvider)
+        )
+
+        dateProvider.advance(bySeconds: 1)
+        let date = dateProvider.now.timeIntervalSince1970.dd.toInt64Milliseconds
+        let webEventMock: JSON = [
+            "application": ["id": String.mockRandom()],
+            "session": ["id": String.mockRandom()],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": Int(date),
+            "usr": ["anonymous_id": browserAnonymousId]
+        ]
+
+        // When
+        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(featureScope.eventsWritten.count, 1)
+        let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
+        let expectedWebEventWritten: JSON = [
+            "application": ["id": rumContext.applicationID],
+            "session": ["id": rumContext.sessionID],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
+            "usr": ["anonymous_id": nativeAnonymousId]
+        ]
+        DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
+    }
+
+    func testGivenAnonymousIdAvailable_whenReceivingWebEventWithNoUsr_itAddsAnonymousId() throws {
+        // Given
+        let dateProvider = RelativeDateProvider()
+        let fakeAnonymousId: String = .mockRandom()
+        let rumContext: RUMCoreContext = .mockRandom()
+        featureScope.contextMock = .mockWith(
+            userInfo: UserInfo(anonymousId: fakeAnonymousId),
+            additionalContext: [rumContext]
+        )
+
+        let receiver = WebViewEventReceiver(
+            featureScope: featureScope,
+            dateProvider: DateProviderMock(),
+            commandSubscriber: RUMCommandSubscriberMock(),
+            viewCache: ViewCache(dateProvider: dateProvider)
+        )
+
+        dateProvider.advance(bySeconds: 1)
+        let date = dateProvider.now.timeIntervalSince1970.dd.toInt64Milliseconds
+        let webEventMock: JSON = [
+            "application": ["id": String.mockRandom()],
+            "session": ["id": String.mockRandom()],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": Int(date)
+        ]
+
+        // When
+        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(featureScope.eventsWritten.count, 1)
+        let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
+        let expectedWebEventWritten: JSON = [
+            "application": ["id": rumContext.applicationID],
+            "session": ["id": rumContext.sessionID],
+            "view": ["id": "00000000-aaaa-0000-aaaa-000000000000"],
+            "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
+            "usr": ["anonymous_id": fakeAnonymousId]
+        ]
+        DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
+    }
 }


### PR DESCRIPTION
### What and why?

- Propagate the native `anonymousId` into webview RUM and Log events (overriding browser one).
- Why: [RUMS-5561](https://datadoghq.atlassian.net/browse/RUMS-5661)
- dd-sdk-android counterpart: [3306](https://github.com/DataDog/dd-sdk-android/pull/3306)

Tested on Shopist, here is an [example session](https://mobile-integration.datadoghq.com/rum/sessions?query=%40type%3Asession%20%40application.id%3A88ac1787-811c-467d-98d5-48247d1d11d7&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZ2WRZGuqYDrOAAAABhBWjJXUlpHdUFBQXp3d3hwS1l4QVVQVGgAAAAkMDE5ZDk2NGYtNzBkYy00YmNmLWJiNDktZDNiZmJjNGEwYzRiAAAAAA&fromUser=false&graphType=flamegraph&shouldShowLegend=true&spanID=6532790809895426692&traceQuery=&from_ts=1775737865662&to_ts=1776342665662&live=true):
<img width="493" height="138" alt="image" src="https://github.com/user-attachments/assets/71b8e9eb-19bd-40fc-bece-40df50a14ffb" />


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs


[RUMS-5561]: https://datadoghq.atlassian.net/browse/RUMS-5561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ