### PR TITLE
Install datadog-ci for Build Artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -429,7 +429,7 @@ Build Artifacts:
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --ssh
+    - ./tools/runner-setup.sh --datadog-ci --xcode "$XCODE" --ssh
     - make env-check
     - make clean
     - make release-build release-validate


### PR DESCRIPTION
### What and why?

Fix `Build Artifacts` job

### How?

Install `datadog-ci` during setup.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
