### PR TITLE
RUM-15697: Update `rum-mobile-events.json` attachment format in DatadogProfiling

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/DurationEvent.swift
+++ b/DatadogInternal/Sources/Models/RUM/DurationEvent.swift
@@ -7,13 +7,20 @@
 import Foundation
 
 public struct DurationEvent: Encodable, Equatable {
+    public enum EventType: String, Encodable {
+        case longTask = "long_task"
+        case error
+    }
     enum CodingKeys: String, CodingKey {
-        case id = "id"
+        case id
+        case type
         case start = "start_ns"
         case duration = "duration_ns"
     }
     /// UUID of the event
     public let id: String
+    /// Type of the event
+    public let type: EventType
     /// Start of the event from epoch in nanoseconds
     public let start: Int64
     /// Duration of the event in nanoseconds
@@ -21,10 +28,12 @@ public struct DurationEvent: Encodable, Equatable {
 
     public init(
         id: String,
+        type: EventType,
         start: Int64,
         duration: Int64
     ) {
         self.id = id
+        self.type = type
         self.start = start
         self.duration = duration
     }

--- a/DatadogInternal/Sources/Models/RUM/Vital.swift
+++ b/DatadogInternal/Sources/Models/RUM/Vital.swift
@@ -8,13 +8,16 @@ import Foundation
 
 public struct Vital: Encodable, Equatable {
     enum CodingKeys: String, CodingKey {
-        case id = "id"
-        case name = "name"
+        case id
+        case type
+        case name
         case start = "start_ns"
         case duration = "duration_ns"
     }
     /// UUID of the vital
     public let id: String
+    /// Type of the vital
+    public let type: String = "vital"
     /// Name of the vital
     public let name: String
     /// Operation key of the vital
@@ -48,6 +51,7 @@ public struct Vital: Encodable, Equatable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
+        try container.encode(type, forKey: .type)
         try container.encode(name, forKey: .name)
         let start = date.timeIntervalSince1970.dd.toInt64Nanoseconds
         try container.encode(start, forKey: .start)

--- a/DatadogProfiling/Sources/Models/ProfileAttachments.swift
+++ b/DatadogProfiling/Sources/Models/ProfileAttachments.swift
@@ -19,15 +19,22 @@ internal struct ProfileAttachments: Codable {
     let rumEvents: Data?
 }
 
-/// Bundles all RUM events that are part of a profile event.
-internal struct RUMEvents: Encodable, Equatable {
-    enum CodingKeys: String, CodingKey {
-        case vitals
-        case hangs
-        case longTasks = "long_tasks"
-    }
+/// Bundles individually all RUM events that are part of a profile event.
+internal enum RUMEvent {
+    case vital(Vital)
+    case hang(DurationEvent)
+    case longTask(DurationEvent)
+}
 
-    let vitals: [Vital]
-    let hangs: [DurationEvent]?
-    let longTasks: [DurationEvent]?
+extension RUMEvent: Encodable {
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .vital(let value):
+            try value.encode(to: encoder)
+        case .hang(let value):
+            try value.encode(to: encoder)
+        case .longTask(let value):
+            try value.encode(to: encoder)
+        }
+    }
 }

--- a/DatadogProfiling/Sources/ProfilingHandler.swift
+++ b/DatadogProfiling/Sources/ProfilingHandler.swift
@@ -56,16 +56,20 @@ extension ProfilingHandler {
             attributes[RUMCoreContext.IDs.longTaskID] = longTasks.map { $0.id }
         }
 
+        let rumEvents: [RUMEvent] = rumVitals.map(RUMEvent.vital)
+        + (hangs?.map(RUMEvent.hang) ?? [])
+        + (longTasks?.map(RUMEvent.longTask) ?? [])
+
         self.writeProfilingEvent(
             with: profile,
-            rumEvents: RUMEvents(vitals: rumVitals, hangs: hangs, longTasks: longTasks),
+            rumEvents: rumEvents,
             attributes: attributes
         )
     }
 
     private func writeProfilingEvent(
         with profile: OpaquePointer,
-        rumEvents: RUMEvents,
+        rumEvents: [RUMEvent],
         attributes: [AttributeKey: AttributeValue]
     ) {
         var data: UnsafeMutablePointer<UInt8>?

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -365,10 +365,7 @@ final class AppLaunchProfilerTests: XCTestCase {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
-        let vitalIDs = vitals.compactMap { $0["id"] as? String }
+        let vitalIDs = try eventIDs(ofType: "vital", from: metadata)
         XCTAssertEqual(vitalIDs.count, 2)
         XCTAssertTrue(vitalIDs.contains("start-id"))
     }
@@ -389,10 +386,7 @@ final class AppLaunchProfilerTests: XCTestCase {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
-        let vitalIDs = vitals.compactMap { $0["id"] as? String }
+        let vitalIDs = try eventIDs(ofType: "vital", from: metadata)
         XCTAssertEqual(vitalIDs.count, 2)
         XCTAssertTrue(vitalIDs.contains("start-id"))
         XCTAssertFalse(vitalIDs.contains("orphan-id"))
@@ -476,6 +470,15 @@ final class AppLaunchProfilerTests: XCTestCase {
 
     private var appLaunchVital: Vital {
         .mockWith(stepType: nil)
+    }
+
+    private func eventIDs(ofType type: String, from metadata: ProfileAttachments) throws -> [String] {
+        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
+        let rumEvents = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
+
+        return rumEvents
+            .filter { $0["type"] as? String == type }
+            .compactMap { $0["id"] as? String }
     }
 }
 

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -76,7 +76,7 @@ final class DatadogProfilerTests: XCTestCase {
     func testReceiveLongTask() {
         // Given
         let profiler = continuousProfiler()
-        let longTask = DurationEvent(id: .mockRandom(), start: 0, duration: 100)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
 
         // When
         let result = profiler.receive(
@@ -91,7 +91,7 @@ final class DatadogProfilerTests: XCTestCase {
     func testReceiveAppHang() {
         // Given
         let profiler = continuousProfiler()
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
 
         // When
         let result = profiler.receive(
@@ -114,8 +114,8 @@ final class DatadogProfilerTests: XCTestCase {
             stepType: .end
         )
         let ongoingOperationStart = Vital.mockWith(name: "ongoing-operation", stepType: .start)
-        let hang = DurationEvent(id: "hang-id", start: 0, duration: 500)
-        let longTask = DurationEvent(id: "long-task-id", start: 0, duration: 100)
+        let hang = DurationEvent(id: "hang-id", type: .error, start: 0, duration: 500)
+        let longTask = DurationEvent(id: "long-task-id", type: .longTask, start: 0, duration: 100)
         let launchVital: Vital = .mockWith(stepType: nil)
 
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
@@ -159,15 +159,17 @@ final class DatadogProfilerTests: XCTestCase {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
-        let hangs = try XCTUnwrap(json["hangs"] as? [[String: Any]])
-        let longTasks = try XCTUnwrap(json["long_tasks"] as? [[String: Any]])
-        let vitalIDs = vitals.compactMap { $0["id"] as? String }
+        let rumEvents = try typedRUMEvents(from: metadata)
+        let vitalIDs = eventIDs(ofType: "vital", in: rumEvents)
         XCTAssertEqual(vitalIDs, [ongoingOperationStart.id], "Only ongoing operations should remain after TTID")
-        XCTAssertTrue(hangs.isEmpty, "App hangs handled by AppLaunchProfiler should not be re-attached")
-        XCTAssertTrue(longTasks.isEmpty, "Long tasks handled by AppLaunchProfiler should not be re-attached")
+        XCTAssertTrue(
+            eventIDs(ofType: "error", in: rumEvents).isEmpty,
+            "App hangs handled by AppLaunchProfiler should not be re-attached"
+        )
+        XCTAssertTrue(
+            eventIDs(ofType: "long_task", in: rumEvents).isEmpty,
+            "Long tasks handled by AppLaunchProfiler should not be re-attached"
+        )
     }
 }
 
@@ -236,10 +238,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
-        let vitalIDs = vitals.compactMap { $0["id"] as? String }
+        let rumEvents = try typedRUMEvents(from: metadata)
+        let vitalIDs = eventIDs(ofType: "vital", in: rumEvents)
         XCTAssertTrue(vitalIDs.contains(startOperation.id))
         withExtendedLifetime(profiler) {}
     }
@@ -250,7 +250,7 @@ extension DatadogProfilerTests {
         let profiler = continuousProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let longTask = DurationEvent(id: .mockRandom(), start: 0, duration: 100)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
         flushQueue()
 
@@ -266,10 +266,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let longTasks = try XCTUnwrap(json["long_tasks"] as? [[String: Any]])
-        XCTAssertEqual(longTasks.compactMap { $0["id"] as? String }, [longTask.id])
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(eventIDs(ofType: "long_task", in: rumEvents), [longTask.id])
         withExtendedLifetime(profiler) {}
     }
 
@@ -279,7 +277,7 @@ extension DatadogProfilerTests {
         let profiler = continuousProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
 
         // When
@@ -294,10 +292,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let hangs = try XCTUnwrap(json["hangs"] as? [[String: Any]])
-        XCTAssertEqual(hangs.compactMap { $0["id"] as? String }, [hang.id])
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(eventIDs(ofType: "error", in: rumEvents), [hang.id])
         withExtendedLifetime(profiler) {}
     }
 }
@@ -355,7 +351,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        let longTask = DurationEvent(id: .mockRandom(), start: 0, duration: 100)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
@@ -380,7 +376,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
         _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
@@ -487,8 +483,8 @@ extension DatadogProfilerTests {
     func testCustomProfiler_beforeReceivingAppLaunchVital() {
         // Given
         let profiler = customProfiler()
-        let longTask = DurationEvent(id: .mockRandom(), start: 0, duration: 100)
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         let operation: Vital = .mockWith(stepType: .start)
 
         // Then
@@ -578,10 +574,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
-        let vitalIDs = vitals.compactMap { $0["id"] as? String }
+        let rumEvents = try typedRUMEvents(from: metadata)
+        let vitalIDs = eventIDs(ofType: "vital", in: rumEvents)
         XCTAssertTrue(vitalIDs.contains("start-id"))
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
@@ -694,7 +688,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let longTask = DurationEvent(id: .mockRandom(), start: 0, duration: 100)
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
         flushQueue()
 
@@ -710,10 +704,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let longTasks = try XCTUnwrap(json["long_tasks"] as? [[String: Any]])
-        XCTAssertEqual(longTasks.compactMap { $0["id"] as? String }, [longTask.id])
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(eventIDs(ofType: "long_task", in: rumEvents), [longTask.id])
         withExtendedLifetime(profiler) {}
     }
 
@@ -723,7 +715,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
 
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
         flushQueue()
 
@@ -739,10 +731,8 @@ extension DatadogProfilerTests {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let hangs = try XCTUnwrap(json["hangs"] as? [[String: Any]])
-        XCTAssertEqual(hangs.compactMap { $0["id"] as? String }, [hang.id])
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(eventIDs(ofType: "error", in: rumEvents), [hang.id])
         withExtendedLifetime(profiler) {}
     }
 
@@ -804,7 +794,7 @@ extension DatadogProfilerTests {
 
         // Then - first still processes messages normally
         XCTAssertEqual(dd_profiler_start(), 1)
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(first.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
         XCTAssertNotNil(first)
     }
@@ -823,7 +813,7 @@ extension DatadogProfilerTests {
         // Then
         XCTAssertTrue(DatadogProfiler.isInstantiated)
         XCTAssertEqual(dd_profiler_start(), 1)
-        let hang = DurationEvent(id: .mockRandom(), start: 0, duration: 500)
+        let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(second.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
         XCTAssertNotNil(second)
     }
@@ -873,6 +863,17 @@ private extension DatadogProfilerTests {
 
     func flushQueue() {
         profilerQueue.sync {}
+    }
+
+    func typedRUMEvents(from metadata: ProfileAttachments) throws -> [[String: Any]] {
+        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
+    }
+
+    func eventIDs(ofType type: String, in rumEvents: [[String: Any]]) -> [String] {
+        rumEvents
+            .filter { $0["type"] as? String == type }
+            .compactMap { $0["id"] as? String }
     }
 
     func continuousProfiler(

--- a/DatadogProfiling/Tests/ProfilingHandlerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingHandlerTests.swift
@@ -184,13 +184,52 @@ final class ProfilingHandlerTests: XCTestCase {
 
         // Then
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [String: Any])
-        let vitalsFromJson = try XCTUnwrap(json["vitals"] as? [[String: Any]])
+        let vitalsFromJson = try typedRUMEvents(from: metadata)
+            .filter { $0["type"] as? String == "vital" }
         let vitalIDs = vitalsFromJson.compactMap { $0["id"] as? String }
         let vitalNames = vitalsFromJson.compactMap { $0["name"] as? String }
         XCTAssertEqual(vitalIDs, ["id1", "id2"])
         XCTAssertEqual(vitalNames, ["operation1", "operation2"])
+    }
+
+    func testWriteProfileAttachments_encodeTypedRumEventsForAllSupportedTypes() throws {
+        // Given
+        XCTAssertEqual(dd_profiler_start(), 1)
+        let profile = try XCTUnwrap(dd_profiler_flush_and_get_profile())
+        let vital = Vital.mockWith(id: "vital-id", name: "operation", duration: 60)
+        let longTask = DurationEvent(id: "long-task-id", type: .longTask, start: 20, duration: 30)
+        let hang = DurationEvent(id: "hang-id", type: .error, start: 40, duration: 50)
+
+        // When
+        handler.write(profile: profile, rumVitals: [vital], hangs: [hang], longTasks: [longTask])
+
+        // Then
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(rumEvents.count, 3)
+
+        let vitalEvent = try XCTUnwrap(rumEvents.first { $0["type"] as? String == "vital" })
+        XCTAssertEqual(vitalEvent["id"] as? String, vital.id)
+        XCTAssertEqual(vitalEvent["name"] as? String, vital.name)
+        XCTAssertNotNil(vitalEvent["start_ns"] as? NSNumber)
+        XCTAssertNotNil(vitalEvent["duration_ns"] as? NSNumber)
+
+        let longTaskEvent = try XCTUnwrap(rumEvents.first { $0["type"] as? String == "long_task" })
+        XCTAssertEqual(longTaskEvent["id"] as? String, longTask.id)
+        XCTAssertNil(longTaskEvent["name"])
+        XCTAssertEqual(longTaskEvent["start_ns"] as? NSNumber, NSNumber(value: longTask.start))
+        XCTAssertEqual(longTaskEvent["duration_ns"] as? NSNumber, NSNumber(value: longTask.duration))
+
+        let errorEvent = try XCTUnwrap(rumEvents.first { $0["type"] as? String == "error" })
+        XCTAssertEqual(errorEvent["id"] as? String, hang.id)
+        XCTAssertNil(errorEvent["name"])
+        XCTAssertEqual(errorEvent["start_ns"] as? NSNumber, NSNumber(value: hang.start))
+        XCTAssertEqual(errorEvent["duration_ns"] as? NSNumber, NSNumber(value: hang.duration))
+    }
+
+    private func typedRUMEvents(from metadata: ProfileAttachments) throws -> [[String: Any]] {
+        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
     }
 }
 

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -25,7 +25,7 @@ class RequestBuilderTests: XCTestCase {
         additionalAttributes: mockRandomAttributes()
     )
 
-    let rumEvents: RUMEvents = .init(vitals: [.mockWith(operationKey: nil, stepType: nil)], hangs: nil, longTasks: nil)
+    let rumEvents: [RUMEvent] = [.vital(.mockWith(operationKey: nil, stepType: nil))]
     let pprof: Data = .mockRandom()
 
     private func mockEvent() throws -> Event {
@@ -177,13 +177,25 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(rumEventsFile.filename, "rum-mobile-events.json")
         XCTAssertEqual(rumEventsFile.mimeType, "application/json")
 
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsFile.data) as? [String: Any])
-        let vitals = try XCTUnwrap(json["vitals"] as? [[String: Any]])
+        let encodedRUMEvents = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsFile.data) as? [[String: Any]])
+        let vitals = encodedRUMEvents.filter { $0["type"] as? String == "vital" }
         let vitalIDs = vitals.compactMap { $0["id"] as? String }
         let vitalNames = vitals.compactMap { $0["name"] as? String }
+        let expectedVitalIDs = rumEvents.compactMap { event -> String? in
+            guard case .vital(let vital) = event else {
+                return nil
+            }
+            return vital.id
+        }
+        let expectedVitalNames = rumEvents.compactMap { event -> String? in
+            guard case .vital(let vital) = event else {
+                return nil
+            }
+            return vital.name
+        }
 
-        XCTAssertEqual(vitalIDs, rumEvents.vitals.map(\.id))
-        XCTAssertEqual(vitalNames, rumEvents.vitals.map(\.name))
+        XCTAssertEqual(vitalIDs, expectedVitalIDs)
+        XCTAssertEqual(vitalNames, expectedVitalNames)
     }
 
     func testWhenBatchDataHasMoreThanOneProfile() {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -716,6 +716,7 @@ extension RUMViewScope {
         if let appHangCommand = command as? RUMAddCurrentViewAppHangCommand {
             let appHang = DurationEvent(
                 id: errorId,
+                type: .error,
                 start: command.time.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.dd.toInt64Nanoseconds,
                 duration: appHangCommand.hangDuration.dd.toInt64Nanoseconds
             )
@@ -835,6 +836,7 @@ extension RUMViewScope {
 
         let longTask = DurationEvent(
             id: longTaskId,
+            type: .longTask,
             start: start.dd.toInt64Nanoseconds,
             duration: taskDurationInNs
         )


### PR DESCRIPTION
### What and why?

This PR updates the `rum-mobile-events.json` profiling attachment in `DatadogProfiling` to use the new typed event array format expected by the profiling backend.

The attachment previously grouped events under separate top-level keys `vitals`, `hangs` and `long_tasks`. With this change, each entry is serialized as a typed event carrying its own parameters.

### How?

- `rum-mobile-events.json` is now serialized as a top-level array of typed events.
- `ProfilingHandler` now builds the attachment as a flat list of `RUMEvent` values.

The new `rum-mobile-events.json` format is:

```json
[
  {
    "type": "vital",
    "id": "abcd-efgh",
    "name": "time_to_initial_display",
    "start_ns": 1500000000,
    "duration_ns": 250000000
  },
  {
    "type": "long_task",
    "id": "lt-1234",
    "start_ns": 2000000000,
    "duration_ns": 500000000
  },
  {
    "type": "error",
    "id": "err-5678",
    "start_ns": 3000000000,
    "duration_ns": 100000000
  }
]
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
