### PR TITLE
Add SpanSnapshot type and span finish notification hook

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1154,6 +1154,8 @@
 		D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25BADA029C1EF3000112069 /* TracingURLSessionHandler.swift */; };
 		D2C1A50929C4C4CB00946C31 /* SpanEventEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEventEncoder.swift */; };
 		D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2546C0329AF55AA0054E00B /* TraceFeature.swift */; };
+		E7CSS01129C4D5A800000011 /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS01429C4D5A800000014 /* SpanSnapshot.swift */; };
+		E7CSS01329C4D5A800000013 /* SpanSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS01629C4D5A800000016 /* SpanSnapshotTests.swift */; };
 		E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */; };
 		E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */; };
 		E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */; };
@@ -2792,6 +2794,8 @@
 		D253EE982B98B3690010B589 /* ViewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCacheTests.swift; sourceTree = "<group>"; };
 		D2546BF029AF4F550054E00B /* DatadogTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTracer.swift; sourceTree = "<group>"; };
 		D2546C0329AF55AA0054E00B /* TraceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceFeature.swift; sourceTree = "<group>"; };
+		E7CSS01429C4D5A800000014 /* SpanSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshot.swift; sourceTree = "<group>"; };
+		E7CSS01629C4D5A800000016 /* SpanSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshotTests.swift; sourceTree = "<group>"; };
 		E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeature.swift; sourceTree = "<group>"; };
 		E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
 		E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeatureTests.swift; sourceTree = "<group>"; };
@@ -5386,6 +5390,7 @@
 				61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */,
 				614872762485067300E3EBDB /* SpanTagsReducer.swift */,
 				61CE58592B48174D00479510 /* SpanWriteContext.swift */,
+				E7CSS01429C4D5A800000014 /* SpanSnapshot.swift */,
 			);
 			path = Span;
 			sourceTree = "<group>";
@@ -5449,6 +5454,7 @@
 				61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */,
 				61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */,
 				618C0FBF2B482F6800266B38 /* SpanWriteContextTests.swift */,
+				E7CSS01629C4D5A800000016 /* SpanSnapshotTests.swift */,
 			);
 			path = Span;
 			sourceTree = "<group>";
@@ -8700,6 +8706,7 @@
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
 				E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */,
 				E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */,
+				E7CSS01129C4D5A800000011 /* SpanSnapshot.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
 			);
@@ -8722,6 +8729,7 @@
 				3C6C7FFD2B459AF6006F5CBC /* OTelSpanTests.swift in Sources */,
 				619CE7612A458D66005588CB /* TraceTests.swift in Sources */,
 				E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */,
+				E7CSS01329C4D5A800000013 /* SpanSnapshotTests.swift in Sources */,
 				615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A52029C4C75700946C31 /* DDSpanTests.swift in Sources */,
 				3C5D636C2B55513500FEB4BA /* OTelTraceState+DatadogTests.swift in Sources */,

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -129,9 +129,62 @@ internal final class DDSpan: OTSpan {
             ddTracer.removeSpan(span: self)
             activity.leave()
         }
+
+        ddTracer.onSpanFinished?(createSnapshot(finishTime: time))
+
         if self.ddContext.samplingDecision.samplingPriority.isKept {
             sendSpan(finishTime: time)
         }
+    }
+
+    // MARK: - Snapshot
+
+    /// Creates a lightweight `SpanSnapshot` capturing the data needed for client-side stats.
+    /// Called before the sampling decision so that all spans contribute to stats.
+    private func createSnapshot(finishTime: Date) -> SpanSnapshot {
+        let tagsReducer = SpanTagsReducer(spanTags: tags, logFields: logFields)
+        let resolvedService = tagsReducer.extractedServiceName ?? eventBuilder.service ?? ""
+        let resolvedResource = tagsReducer.extractedResourceName ?? operationName
+        let resolvedOperationName = tagsReducer.extractedOperationName ?? operationName
+
+        let spanKind: String? = tags[SpanTags.kind] as? String ?? tags[OTTags.spanKind] as? String
+        let httpStatusCode = (tags[OTTags.httpStatusCode] as? Int).flatMap { UInt32(exactly: $0) } ?? 0
+        let isError = tagsReducer.extractedIsError ?? false
+        let isTopLevel = ddContext.parentSpanID == nil || (tags["_dd.top_level"] as? Int == 1)
+        let isMeasured = tags["_dd.measured"] as? Int == 1
+        let serviceSource: String = tags["_dd.svc_src"] as? String ?? ""
+
+        let peerTagKeys = [
+            "peer.service", "db.instance", "db.system",
+            "out.host", "net.peer.name", "server.address"
+        ]
+        var peerTags: [String: String] = [:]
+        for key in peerTagKeys {
+            if let value = tags[key] as? String, !value.isEmpty {
+                peerTags[key] = value
+            }
+        }
+
+        let startNanos = startTime.timeIntervalSince1970.toNanoseconds
+        let durationNanos = finishTime.timeIntervalSince(startTime).toNanoseconds
+
+        return SpanSnapshot(
+            traceID: ddContext.traceID,
+            spanID: ddContext.spanID,
+            parentSpanID: ddContext.parentSpanID,
+            service: resolvedService,
+            operationName: resolvedOperationName,
+            resource: resolvedResource,
+            spanKind: spanKind,
+            httpStatusCode: httpStatusCode,
+            isError: isError,
+            startTime: startNanos,
+            duration: durationNanos,
+            isTopLevel: isTopLevel,
+            isMeasured: isMeasured,
+            peerTags: peerTags,
+            serviceSource: serviceSource
+        )
     }
 
     // MARK: - Writing SpanEvent

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -35,6 +35,11 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
     /// Creates span events.
     let spanEventBuilder: SpanEventBuilder
 
+    /// Optional callback invoked when any span finishes, regardless of sampling.
+    /// Set by `Trace.enableOrThrow()` when client-side stats is enabled.
+    @ReadWriteLock
+    var onSpanFinished: ((SpanSnapshot) -> Void)?
+
     // MARK: - Initialization
 
     convenience init(
@@ -187,6 +192,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
             }
         )
     }
+
     // MARK: - OpenTelemetry
 
     func spanBuilder(spanName: String) -> OpenTelemetryApi.SpanBuilder {

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Nanosecond-precision time value used across client-side stats.
+internal typealias Nanoseconds = UInt64
+
+/// A lightweight, immutable snapshot of span data needed for client-side stats computation.
+///
+/// Created in `DDSpan.finish()` **before** the sampling decision, so that all spans
+/// (including sampled-out ones) contribute to accurate aggregate metrics.
+internal struct SpanSnapshot: Encodable, Sendable {
+    let traceID: TraceID
+    let spanID: SpanID
+    let parentSpanID: SpanID?
+    var service: String
+    let operationName: String
+    let resource: String
+    let spanKind: String?
+    let httpStatusCode: UInt32
+    let isError: Bool
+    /// Span start time in nanoseconds since Unix epoch.
+    let startTime: Nanoseconds
+    /// Span duration in nanoseconds.
+    let duration: Nanoseconds
+    let isTopLevel: Bool
+    let isMeasured: Bool
+    /// Peer tag values for downstream-service aggregation (e.g. `peer.service`, `out.host`).
+    let peerTags: [String: String]
+    /// The source of the service name override, from `_dd.svc_src` span meta tag.
+    let serviceSource: String
+}

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -48,6 +48,9 @@ public enum Trace {
         if configuration.statsComputationEnabled {
             let stats = ClientStatsFeature(core: core, configuration: configuration)
             try core.register(feature: stats)
+
+            // [CSS] Wire StatsConcentrator here to aggregate snapshots into
+            // time-bucketed stats payloads before writing to the stats feature scope.
         }
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -1,0 +1,320 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogTrace
+
+class SpanSnapshotTests: XCTestCase {
+    // MARK: - Snapshot Creation
+
+    func testSnapshotCapturesBasicSpanData() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "network.request",
+            tags: [
+                SpanTags.resource: "GET /api/users",
+                SpanTags.service: "my-service"
+            ]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { snapshot in
+            capturedSnapshot = snapshot
+        }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.operationName, "network.request")
+        XCTAssertEqual(snapshot.resource, "GET /api/users")
+        XCTAssertEqual(snapshot.service, "my-service")
+    }
+
+    func testSnapshotCapturesSpanKind() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "rpc.call",
+            tags: [SpanTags.kind: "client"]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.spanKind, "client")
+    }
+
+    func testSnapshotCapturesHTTPStatusCode() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "http.request",
+            tags: [OTTags.httpStatusCode: 404]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.httpStatusCode, 404)
+    }
+
+    func testSnapshotCapturesErrorFromTag() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "failing.op",
+            tags: [OTTags.error: true]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertTrue(snapshot.isError)
+    }
+
+    func testSnapshotCapturesErrorFromLogFields() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(operationName: "error.op") as! DDSpan
+        span.log(
+            fields: [
+                OTLogFields.event: "error",
+                OTLogFields.errorKind: "NetworkError"
+            ]
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertTrue(snapshot.isError)
+    }
+
+    func testSnapshotDefaultsToNoError() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(operationName: "ok.op") as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertFalse(snapshot.isError)
+    }
+
+    // MARK: - Top-Level and Measured
+
+    func testSnapshotIsTopLevel_whenRootSpan() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(operationName: "root.span") as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertTrue(snapshot.isTopLevel)
+        XCTAssertNil(snapshot.parentSpanID)
+    }
+
+    func testSnapshotIsNotTopLevel_whenChildSpan() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let parent = tracer.startSpan(operationName: "parent")
+        let child = tracer.startSpan(
+            operationName: "child",
+            references: [OTReference.child(of: parent.context)]
+        )
+
+        var snapshots: [SpanSnapshot] = []
+        tracer.onSpanFinished = { snapshots.append($0) }
+
+        child.finish()
+        parent.finish()
+
+        XCTAssertEqual(snapshots.count, 2)
+        let childSnapshot = try XCTUnwrap(snapshots.first { $0.operationName == "child" })
+        XCTAssertFalse(childSnapshot.isTopLevel)
+        XCTAssertNotNil(childSnapshot.parentSpanID)
+    }
+
+    func testSnapshotIsMeasured_whenTagSet() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "measured.op",
+            tags: ["_dd.measured": 1]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertTrue(snapshot.isMeasured)
+    }
+
+    // MARK: - Peer Tags
+
+    func testSnapshotCapturesPeerTags() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "db.call",
+            tags: [
+                "peer.service": "postgres-primary",
+                "db.instance": "users_db",
+                "out.host": "db.internal.io",
+                "unrelated.tag": "should-be-ignored"
+            ]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.peerTags["peer.service"], "postgres-primary")
+        XCTAssertEqual(snapshot.peerTags["db.instance"], "users_db")
+        XCTAssertEqual(snapshot.peerTags["out.host"], "db.internal.io")
+        XCTAssertNil(snapshot.peerTags["unrelated.tag"])
+    }
+
+    // MARK: - Service Source
+
+    func testSnapshotCapturesServiceSource() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(
+            operationName: "op",
+            tags: ["_dd.svc_src": "m"]
+        ) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.serviceSource, "m")
+    }
+
+    func testSnapshotDefaultsToEmptyServiceSource() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(operationName: "op") as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.serviceSource, "")
+    }
+
+    // MARK: - Duration and Timing
+
+    func testSnapshotCapturesNonZeroDuration() throws {
+        let startDate = Date(timeIntervalSince1970: 1_000)
+        let finishDate = Date(timeIntervalSince1970: 1_000.5)
+
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 0)
+        )
+
+        let span = tracer.startSpan(operationName: "timed.op", startTime: startDate) as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish(at: finishDate)
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.duration, 500_000_000)
+        XCTAssertEqual(snapshot.startTime, 1_000_000_000_000)
+    }
+
+    // MARK: - Resource Fallback
+
+    func testSnapshotUsesOperationNameAsResourceFallback() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        let span = tracer.startSpan(operationName: "fallback.op") as! DDSpan
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.resource, "fallback.op")
+    }
+
+    // MARK: - Callback Wiring
+
+    func testCallbackIsNotInvoked_whenNotSet() {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(core: core)
+
+        XCTAssertNil(tracer.onSpanFinished)
+
+        let span = tracer.startSpan(operationName: "no-callback")
+        span.finish()
+    }
+
+    func testSnapshotIsCapturedEvenForSampledOutSpans() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockRejectAll()
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(operationName: "sampled.out")
+        span.finish()
+
+        XCTAssertNotNil(capturedSnapshot, "Snapshot must be captured regardless of sampling decision")
+    }
+}


### PR DESCRIPTION
### What and why?

Introduces the `SpanSnapshot` value type and wires a notification hook into the span finish lifecycle. This is the second building block for client-side stats (CSS): it captures lightweight, immutable span data needed for stats computation before the sampling decision, ensuring all spans (including sampled-out ones) contribute to accurate metrics.

### How?

- **`SpanSnapshot`**: New `Sendable` + `Encodable` struct capturing span fields relevant to stats: service, resource, operation, duration, error, span kind, top-level, measured, peer tags, and service source. Also introduces a `Nanoseconds` typealias for clarity.
- **`DDSpan.createSnapshot()`**: Private method called in `finish()` before the sampling check. Resolves service/resource/operation using the same `SpanTagsReducer` logic as `SpanEventBuilder`.
- **`DatadogTracer.onSpanFinished`**: Optional callback property (not stored per-span). Set once during `Trace.enableOrThrow()` when stats is enabled; writes snapshots to the `ClientStatsFeature` scope.
- **16 unit tests** covering snapshot creation, tag extraction, peer tags, service source, sampling-independent capture, and callback wiring.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs