### PR TITLE
Add device properties `isLowRam`, `logicalCpuCount`, `totalRam` to the `LogEvent` Objective-C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Propagate native `anonymous_id` to WebView RUM and Log events. See [#2847][]
+- [IMPROVEMENT] Add device properties `isLowRam`, `logicalCpuCount`, `totalRam` to the `LogEvent` Objective-C API. See [#2854][]
 
 # 3.10.0 / 16-04-2026
 
@@ -1127,6 +1128,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2827]: https://github.com/DataDog/dd-sdk-ios/pull/2827
 [#2829]: https://github.com/DataDog/dd-sdk-ios/pull/2829
 [#2847]: https://github.com/DataDog/dd-sdk-ios/pull/2847
+[#2854]: https://github.com/DataDog/dd-sdk-ios/pull/2854
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogLogs/Sources/LogsDataModels+objc.swift
+++ b/DatadogLogs/Sources/LogsDataModels+objc.swift
@@ -395,12 +395,20 @@ public class objc_LogEventDevice: NSObject {
         root.swiftModel.device.brightnessLevel
     }
 
+    public var isLowRam: Bool? {
+        root.swiftModel.device.isLowRam
+    }
+
     public var locale: String? {
         root.swiftModel.device.locale
     }
 
     public var locales: [String]? {
         root.swiftModel.device.locales
+    }
+
+    public var logicalCpuCount: Double? {
+        root.swiftModel.device.logicalCpuCount
     }
 
     public var model: String? {
@@ -417,6 +425,10 @@ public class objc_LogEventDevice: NSObject {
 
     public var timeZone: String? {
         root.swiftModel.device.timeZone
+    }
+
+    public var totalRam: Double? {
+        root.swiftModel.device.totalRam
     }
 
     public var type: objc_LogEventDeviceDeviceType {

--- a/DatadogLogs/Tests/LogsDataModels+objcTests.swift
+++ b/DatadogLogs/Tests/LogsDataModels+objcTests.swift
@@ -33,12 +33,15 @@ class LogsDataModels_objcTests: XCTestCase {
         XCTAssertEqual(swiftDevice.batteryLevel, objcDevice.batteryLevel)
         XCTAssertEqual(swiftDevice.brand, objcDevice.brand)
         XCTAssertEqual(swiftDevice.brightnessLevel, objcDevice.brightnessLevel)
+        XCTAssertEqual(swiftDevice.isLowRam, objcDevice.isLowRam)
         XCTAssertEqual(swiftDevice.locale, objcDevice.locale)
         XCTAssertEqual(swiftDevice.locales, objcDevice.locales)
+        XCTAssertEqual(swiftDevice.logicalCpuCount, objcDevice.logicalCpuCount)
         XCTAssertEqual(swiftDevice.model, objcDevice.model)
         XCTAssertEqual(swiftDevice.name, objcDevice.name)
         XCTAssertEqual(swiftDevice.powerSavingMode, objcDevice.powerSavingMode)
         XCTAssertEqual(swiftDevice.timeZone, objcDevice.timeZone)
+        XCTAssertEqual(swiftDevice.totalRam, objcDevice.totalRam)
         XCTAssertEqual(swiftDevice.type, objcDevice.type.toSwift)
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -204,12 +204,15 @@ public class objc_LogEventDevice: NSObject
     public var batteryLevel: Double?
     public var brand: String?
     public var brightnessLevel: Double?
+    public var isLowRam: Bool?
     public var locale: String?
     public var locales: [String]?
+    public var logicalCpuCount: Double?
     public var model: String?
     public var name: String?
     public var powerSavingMode: Bool?
     public var timeZone: String?
+    public var totalRam: Double?
     public var type: objc_LogEventDeviceDeviceType
 public enum objc_LogEventDeviceDeviceType: Int
     case none


### PR DESCRIPTION
### What and why?

Follow-up for https://github.com/DataDog/dd-sdk-ios/pull/2591, update Objective-C API.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
