### PR TITLE
RUM-15863: Add `collectAccessibility` property to the Objective-C API of RUM configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Propagate native `anonymous_id` to WebView RUM and Log events. See [#2847][]
 - [IMPROVEMENT] Add device properties `isLowRam`, `logicalCpuCount`, `totalRam` to the `LogEvent` Objective-C API. See [#2854][]
+- [IMPROVEMENT] Add `collectAccessibility` property to the Objective-C API of RUM configuration. See [#2855][]
 
 # 3.10.0 / 16-04-2026
 
@@ -1129,6 +1130,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2829]: https://github.com/DataDog/dd-sdk-ios/pull/2829
 [#2847]: https://github.com/DataDog/dd-sdk-ios/pull/2847
 [#2854]: https://github.com/DataDog/dd-sdk-ios/pull/2854
+[#2855]: https://github.com/DataDog/dd-sdk-ios/pull/2855
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -32,6 +32,13 @@ class DDRUMConfigurationTests: XCTestCase {
     }
 
 #if !os(watchOS)
+    func testCollectAccessibility() {
+        let random: Bool = .mockRandom()
+        objc.collectAccessibility = random
+        XCTAssertEqual(objc.collectAccessibility, random)
+        XCTAssertEqual(swift.collectAccessibility, random)
+    }
+
     func testUIKitViewsPredicate() {
         class ObjcPredicate: objc_UIKitRUMViewsPredicate {
             func rumView(for viewController: UIViewController) -> objc_RUMView? { nil }

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
@@ -160,6 +160,10 @@
     XCTAssertTrue(config.trackMemoryWarnings);
     config.trackMemoryWarnings = NO;
     XCTAssertFalse(config.trackMemoryWarnings);
+
+    XCTAssertFalse(config.collectAccessibility);
+    config.collectAccessibility = YES;
+    XCTAssertTrue(config.collectAccessibility);
 #endif
 }
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -449,6 +449,11 @@ public class objc_RUMConfiguration: NSObject {
         set { swiftConfig.trackMemoryWarnings = newValue }
         get { swiftConfig.trackMemoryWarnings }
     }
+
+    public var collectAccessibility: Bool {
+        set { swiftConfig.collectAccessibility = newValue }
+        get { swiftConfig.collectAccessibility }
+    }
     #endif
 
     public func setURLSessionTracking(_ tracking: objc_URLSessionTracking) {

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3367,6 +3367,7 @@ public class objc_RUMConfiguration: NSObject
     public var swiftUIViewsPredicate: objc_SwiftUIRUMViewsPredicate?
     public var swiftUIActionsPredicate: objc_SwiftUIRUMActionsPredicate?
     public var trackMemoryWarnings: Bool
+    public var collectAccessibility: Bool
     public func setURLSessionTracking(_ tracking: objc_URLSessionTracking)
     public var trackFrustrations: Bool
     public var trackBackgroundEvents: Bool


### PR DESCRIPTION
### What and why?

Accessibility collection was initially behind a feature flag, so it wasn't exposed in Objective-C API, but the feature flag was removed in https://github.com/DataDog/dd-sdk-ios/commit/4d67c2c2cc0baa6b37e4c1619b7ea1b55a3e950d.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
