### PR TITLE
RUM-15866: Add Objective-C APIs for `networkSettledResourcePredicate` and `nextViewActionPredicate` of RUM configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FIX] Propagate native `anonymous_id` to WebView RUM and Log events. See [#2847][]
 - [IMPROVEMENT] Add device properties `isLowRam`, `logicalCpuCount`, `totalRam` to the `LogEvent` Objective-C API. See [#2854][]
 - [IMPROVEMENT] Add `collectAccessibility` property to the Objective-C API of RUM configuration. See [#2855][]
+- [IMPROVEMENT] Add Objective-C APIs for `networkSettledResourcePredicate` and `nextViewActionPredicate` of RUM configuration. See [#2856][]
 
 # 3.10.0 / 16-04-2026
 
@@ -1131,6 +1132,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2847]: https://github.com/DataDog/dd-sdk-ios/pull/2847
 [#2854]: https://github.com/DataDog/dd-sdk-ios/pull/2854
 [#2855]: https://github.com/DataDog/dd-sdk-ios/pull/2855
+[#2856]: https://github.com/DataDog/dd-sdk-ios/pull/2856
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -31,6 +31,38 @@ class DDRUMConfigurationTests: XCTestCase {
         XCTAssertEqual(swift.telemetrySampleRate, 30)
     }
 
+    func testNetworkSettledResourcePredicate() {
+        class ObjcPredicate: objc_NetworkSettledResourcePredicate {
+            func isInitialResource(from resourceParams: objc_TNSResourceParams) -> Bool { return true }
+        }
+        let predicate = ObjcPredicate()
+        objc.networkSettledResourcePredicate = predicate
+        XCTAssertIdentical(objc.networkSettledResourcePredicate, predicate)
+        XCTAssertTrue(swift.networkSettledResourcePredicate is NetworkSettledResourcePredicateBridge)
+    }
+
+    func testNextViewActionPredicate() {
+        class ObjcPredicate: objc_NextViewActionPredicate {
+            func isLastAction(from actionParams: objc_INVActionParams) -> Bool { return true }
+        }
+        let predicate = ObjcPredicate()
+        objc.nextViewActionPredicate = predicate
+        XCTAssertIdentical(objc.nextViewActionPredicate, predicate)
+        XCTAssertTrue(swift.nextViewActionPredicate is NextViewActionPredicateBridge)
+    }
+
+    func testNextViewActionPredicateDisable() {
+        class ObjcPredicate: objc_NextViewActionPredicate {
+            func isLastAction(from actionParams: objc_INVActionParams) -> Bool { return true }
+        }
+        objc.nextViewActionPredicate = ObjcPredicate()
+        XCTAssertNotNil(objc.nextViewActionPredicate)
+
+        objc.nextViewActionPredicate = nil
+        XCTAssertNil(objc.nextViewActionPredicate)
+        XCTAssertNil(swift.nextViewActionPredicate)
+    }
+
 #if !os(watchOS)
     func testCollectAccessibility() {
         let random: Bool = .mockRandom()

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
@@ -8,6 +8,30 @@
 @import DatadogRUM;
 @import DatadogInternal;
 
+// MARK: - DDNetworkSettledResourcePredicate
+
+@interface CustomDDNetworkSettledResourcePredicate: NSObject
+@end
+
+@interface CustomDDNetworkSettledResourcePredicate () <DDNetworkSettledResourcePredicate>
+@end
+
+@implementation CustomDDNetworkSettledResourcePredicate
+- (BOOL)isInitialResourceFrom:(DDTNSResourceParams * _Nonnull)resourceParams { return YES; }
+@end
+
+// MARK: - DDNextViewActionPredicate
+
+@interface CustomDDNextViewActionPredicate: NSObject
+@end
+
+@interface CustomDDNextViewActionPredicate () <DDNextViewActionPredicate>
+@end
+
+@implementation CustomDDNextViewActionPredicate
+- (BOOL)isLastActionFrom:(DDINVActionParams * _Nonnull)actionParams { return YES; }
+@end
+
 #if !TARGET_OS_WATCH
 
 // MARK: - DDUIKitRUMViewsPredicate
@@ -67,6 +91,24 @@
     XCTAssertEqual(config.telemetrySampleRate, 20);
     config.telemetrySampleRate = 30;
     XCTAssertEqual(config.telemetrySampleRate, 30);
+
+    XCTAssertNotNil(config.networkSettledResourcePredicate);
+    CustomDDNetworkSettledResourcePredicate *tnsPredicate = [CustomDDNetworkSettledResourcePredicate new];
+    config.networkSettledResourcePredicate = tnsPredicate;
+    XCTAssertIdentical(config.networkSettledResourcePredicate, tnsPredicate);
+
+    DDTimeBasedTNSResourcePredicate *defaultTNSPredicate = [[DDTimeBasedTNSResourcePredicate alloc] initWithThreshold:0.2];
+    config.networkSettledResourcePredicate = defaultTNSPredicate;
+    XCTAssertNotNil(config.networkSettledResourcePredicate);
+
+    XCTAssertNotNil(config.nextViewActionPredicate);
+    CustomDDNextViewActionPredicate *invPredicate = [CustomDDNextViewActionPredicate new];
+    config.nextViewActionPredicate = invPredicate;
+    XCTAssertIdentical(config.nextViewActionPredicate, invPredicate);
+
+    DDTimeBasedINVActionPredicate *defaultINVPredicate = [[DDTimeBasedINVActionPredicate alloc] initWithMaxTimeToNextView:5.0];
+    config.nextViewActionPredicate = defaultINVPredicate;
+    XCTAssertNotNil(config.nextViewActionPredicate);
 
 #if !TARGET_OS_WATCH
     XCTAssertNil(config.uiKitViewsPredicate);

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -323,11 +323,11 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
         core.telemetry.configuration(
             appHangThreshold: configuration.appHangThreshold?.dd.toInt64Milliseconds,
-            invTimeThresholdMs: (configuration.nextViewActionPredicate as? TimeBasedINVActionPredicate)?.maxTimeToNextView.dd.toInt64Milliseconds,
+            invTimeThresholdMs: configuration.nextViewActionPredicate?.invTimeThresholdMs,
             mobileVitalsUpdatePeriod: configuration.vitalsUpdateFrequency?.timeInterval.dd.toInt64Milliseconds,
             sessionSampleRate: Int64.ddWithNoOverflow(configuration.debugSDK ? 100 : configuration.sessionSampleRate),
             telemetrySampleRate: Int64.ddWithNoOverflow(configuration.debugSDK ? 100 : configuration.telemetrySampleRate),
-            tnsTimeThresholdMs: (configuration.networkSettledResourcePredicate as? TimeBasedTNSResourcePredicate)?.threshold.dd.toInt64Milliseconds,
+            tnsTimeThresholdMs: configuration.networkSettledResourcePredicate.tnsTimeThresholdMs,
             traceSampleRate: configuration.urlSessionTracking?.firstPartyHostsTracing.map { Int64.ddWithNoOverflow($0.sampleRate) },
             swiftUIViewTrackingEnabled: swiftUIViewTrackingEnabled,
             swiftUIActionTrackingEnabled: swiftUIActionTrackingEnabled,
@@ -343,6 +343,34 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
         // Manage anonymous identifier depending on the configuration.
         anonymousIdentifierManager.manageAnonymousIdentifier(shouldTrack: configuration.trackAnonymousUser)
+    }
+}
+
+private extension NetworkSettledResourcePredicate {
+    var tnsTimeThresholdMs: Int64? {
+        switch self {
+        case let timeBased as TimeBasedTNSResourcePredicate:
+            return timeBased.threshold.dd.toInt64Milliseconds
+        case let objcBridge as NetworkSettledResourcePredicateBridge:
+            return (objcBridge.objcPredicate as? objc_TimeBasedTNSResourcePredicate)?
+                .swiftPredicate.tnsTimeThresholdMs
+        default:
+            return nil
+        }
+    }
+}
+
+private extension NextViewActionPredicate {
+    var invTimeThresholdMs: Int64? {
+        switch self {
+        case let timeBased as TimeBasedINVActionPredicate:
+            return timeBased.maxTimeToNextView.dd.toInt64Milliseconds
+        case let objcBridge as NextViewActionPredicateBridge:
+            return (objcBridge.objcPredicate as? objc_TimeBasedINVActionPredicate)?
+                .swiftPredicate.invTimeThresholdMs
+        default:
+            return nil
+        }
     }
 }
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -159,6 +159,141 @@ public protocol objc_UIPressRUMActionsPredicate: AnyObject {
 }
 #endif
 
+// MARK: - NetworkSettledResourcePredicate
+
+@objc(DDTNSResourceParams)
+@objcMembers
+@_spi(objc)
+public class objc_TNSResourceParams: NSObject {
+    /// The URL of the resource.
+    public let url: String
+
+    /// The time elapsed from when the view started to when the resource started.
+    public let timeSinceViewStart: TimeInterval
+
+    /// The name of the view in which the resource is tracked.
+    public let viewName: String
+
+    internal init(swiftParams: TNSResourceParams) {
+        self.url = swiftParams.url
+        self.timeSinceViewStart = swiftParams.timeSinceViewStart
+        self.viewName = swiftParams.viewName
+    }
+}
+
+@objc(DDNetworkSettledResourcePredicate)
+@_spi(objc)
+public protocol objc_NetworkSettledResourcePredicate: AnyObject {
+    /// Determines if the provided resource should be included in the TNS metric calculation.
+    ///
+    /// - Parameter resourceParams: The parameters of the resource.
+    /// - Returns: `true` if the resource qualifies for TNS metric calculation, `false` otherwise.
+    func isInitialResource(from resourceParams: objc_TNSResourceParams) -> Bool
+}
+
+internal struct NetworkSettledResourcePredicateBridge: NetworkSettledResourcePredicate {
+    let objcPredicate: objc_NetworkSettledResourcePredicate
+
+    func isInitialResource(from resourceParams: TNSResourceParams) -> Bool {
+        objcPredicate.isInitialResource(from: objc_TNSResourceParams(swiftParams: resourceParams))
+    }
+}
+
+@objc(DDTimeBasedTNSResourcePredicate)
+@objcMembers
+@_spi(objc)
+public class objc_TimeBasedTNSResourcePredicate: NSObject, objc_NetworkSettledResourcePredicate {
+    /// The default value of the threshold.
+    public static let defaultThreshold: TimeInterval = 0.1 // aligned with TimeBasedTNSResourcePredicate
+
+    internal let swiftPredicate: TimeBasedTNSResourcePredicate
+
+    /// Initializes a new predicate with a specified time threshold.
+    ///
+    /// - Parameter threshold: The time threshold (in seconds) used to classify resources. The default value is 0.1 seconds.
+    public init(threshold: TimeInterval = objc_TimeBasedTNSResourcePredicate.defaultThreshold) {
+        swiftPredicate = TimeBasedTNSResourcePredicate(threshold: threshold)
+    }
+
+    public func isInitialResource(from resourceParams: objc_TNSResourceParams) -> Bool {
+        swiftPredicate.isInitialResource(from: TNSResourceParams(
+            url: resourceParams.url,
+            timeSinceViewStart: resourceParams.timeSinceViewStart,
+            viewName: resourceParams.viewName
+        ))
+    }
+}
+
+// MARK: - NextViewActionPredicate
+
+@objc(DDINVActionParams)
+@objcMembers
+@_spi(objc)
+public class objc_INVActionParams: NSObject {
+    /// The type of the action (e.g., tap, swipe, click).
+    public let type: objc_RUMActionType
+
+    /// The name of the action.
+    public let name: String
+
+    /// The time elapsed between this action and the start of the next view.
+    public let timeToNextView: TimeInterval
+
+    /// The name of the next view.
+    public let nextViewName: String
+
+    internal init(swiftParams: INVActionParams) {
+        self.type = objc_RUMActionType(swiftType: swiftParams.type)
+        self.name = swiftParams.name
+        self.timeToNextView = swiftParams.timeToNextView
+        self.nextViewName = swiftParams.nextViewName
+    }
+}
+
+@objc(DDNextViewActionPredicate)
+@_spi(objc)
+public protocol objc_NextViewActionPredicate: AnyObject {
+    /// Determines whether the provided action should be classified as the "last interaction" in the previous view for INV calculation.
+    ///
+    /// - Parameter actionParams: The parameters of the action (type, name, time to next view, and next view name).
+    /// - Returns: `true` if this action is the "last interaction" for INV, `false` otherwise.
+    func isLastAction(from actionParams: objc_INVActionParams) -> Bool
+}
+
+internal struct NextViewActionPredicateBridge: NextViewActionPredicate {
+    let objcPredicate: objc_NextViewActionPredicate
+
+    func isLastAction(from actionParams: INVActionParams) -> Bool {
+        objcPredicate.isLastAction(from: objc_INVActionParams(swiftParams: actionParams))
+    }
+}
+
+@objc(DDTimeBasedINVActionPredicate)
+@objcMembers
+@_spi(objc)
+public class objc_TimeBasedINVActionPredicate: NSObject, objc_NextViewActionPredicate {
+    /// The default maximum time interval for considering an action as the "last interaction."
+    public static let defaultMaxTimeToNextView: TimeInterval = 3 // aligned with TimeBasedINVActionPredicate
+
+    internal let swiftPredicate: TimeBasedINVActionPredicate
+
+    /// Initializes a new predicate with a specified maximum time interval.
+    ///
+    /// - Parameter maxTimeToNextView: The maximum time interval (in seconds) from the action to the next view's start. The default value is 3 seconds.
+    public init(maxTimeToNextView: TimeInterval = objc_TimeBasedINVActionPredicate.defaultMaxTimeToNextView) {
+        swiftPredicate = TimeBasedINVActionPredicate(maxTimeToNextView: maxTimeToNextView)
+    }
+
+    public func isLastAction(from actionParams: objc_INVActionParams) -> Bool {
+        swiftPredicate.isLastAction(from: INVActionParams(
+            type: actionParams.type.swiftType,
+            name: actionParams.name,
+            timeToNextView: actionParams.timeToNextView,
+            nextViewName: actionParams.nextViewName
+        ))
+    }
+}
+
 @objc(DDRUMErrorSource)
 @_spi(objc)
 public enum objc_RUMErrorSource: Int {
@@ -192,6 +327,7 @@ public enum objc_RUMActionType: Int {
     case scroll
     case swipe
     case custom
+    case click
 
     internal var swiftType: RUMActionType {
         switch self {
@@ -199,7 +335,18 @@ public enum objc_RUMActionType: Int {
         case .scroll: return .scroll
         case .swipe: return .swipe
         case .custom: return .custom
+        case .click: return .click
         default: return .custom
+        }
+    }
+
+    internal init(swiftType: RUMActionType) {
+        switch swiftType {
+        case .tap: self = .tap
+        case .click: self = .click
+        case .scroll: self = .scroll
+        case .swipe: self = .swipe
+        case .custom: self = .custom
         }
     }
 }
@@ -407,7 +554,11 @@ public class objc_RUMConfiguration: NSObject {
     internal var swiftConfig: DatadogRUM.RUM.Configuration
 
     public init(applicationID: String) {
-        swiftConfig = .init(applicationID: applicationID)
+        swiftConfig = .init(
+            applicationID: applicationID,
+            networkSettledResourcePredicate: NetworkSettledResourcePredicateBridge(objcPredicate: objc_TimeBasedTNSResourcePredicate()),
+            nextViewActionPredicate: NextViewActionPredicateBridge(objcPredicate: objc_TimeBasedINVActionPredicate())
+        )
     }
 
     public var applicationID: String {
@@ -455,6 +606,16 @@ public class objc_RUMConfiguration: NSObject {
         get { swiftConfig.collectAccessibility }
     }
     #endif
+
+    public var networkSettledResourcePredicate: objc_NetworkSettledResourcePredicate {
+        set { swiftConfig.networkSettledResourcePredicate = NetworkSettledResourcePredicateBridge(objcPredicate: newValue) }
+        get { (swiftConfig.networkSettledResourcePredicate as? NetworkSettledResourcePredicateBridge)?.objcPredicate ?? objc_TimeBasedTNSResourcePredicate() }
+    }
+
+    public var nextViewActionPredicate: objc_NextViewActionPredicate? {
+        set { swiftConfig.nextViewActionPredicate = newValue.map { NextViewActionPredicateBridge(objcPredicate: $0) } }
+        get { (swiftConfig.nextViewActionPredicate as? NextViewActionPredicateBridge)?.objcPredicate }
+    }
 
     public func setURLSessionTracking(_ tracking: objc_URLSessionTracking) {
         swiftConfig.urlSessionTracking = tracking.swiftConfig

--- a/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/ViewEndedMetric.swift
@@ -160,6 +160,13 @@ internal extension NetworkSettledResourcePredicate {
         switch self {
         case let timeBased as TimeBasedTNSResourcePredicate:
             return timeBased.threshold == TimeBasedTNSResourcePredicate.defaultThreshold ? .timeBasedDefault : .timeBasedCustom
+        case let objcBridge as NetworkSettledResourcePredicateBridge:
+            switch objcBridge.objcPredicate {
+            case let timeBased as objc_TimeBasedTNSResourcePredicate:
+                return timeBased.swiftPredicate.metricPredicateType
+            default:
+                return .custom
+            }
         default:
             return .custom
         }
@@ -171,6 +178,13 @@ internal extension NextViewActionPredicate {
         switch self {
         case let timeBased as TimeBasedINVActionPredicate:
             return timeBased.maxTimeToNextView == TimeBasedINVActionPredicate.defaultMaxTimeToNextView ? .timeBasedDefault : .timeBasedCustom
+        case let objcBridge as NextViewActionPredicateBridge:
+            switch objcBridge.objcPredicate {
+            case let timeBased as objc_TimeBasedINVActionPredicate:
+                return timeBased.swiftPredicate.metricPredicateType
+            default:
+                return .custom
+            }
         default:
             return .custom
         }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3298,6 +3298,27 @@ public protocol objc_UITouchRUMActionsPredicate: AnyObject
     func rumAction(targetView: UIView) -> objc_RUMAction?
 public protocol objc_UIPressRUMActionsPredicate: AnyObject
     func rumAction(press type: UIPress.PressType, targetView: UIView) -> objc_RUMAction?
+public class objc_TNSResourceParams: NSObject
+    public let url: String
+    public let timeSinceViewStart: TimeInterval
+    public let viewName: String
+public protocol objc_NetworkSettledResourcePredicate: AnyObject
+    func isInitialResource(from resourceParams: objc_TNSResourceParams) -> Bool
+public class objc_TimeBasedTNSResourcePredicate: NSObject, objc_NetworkSettledResourcePredicate
+    public static let defaultThreshold: TimeInterval = 0.1
+    public init(threshold: TimeInterval = objc_TimeBasedTNSResourcePredicate.defaultThreshold)
+    public func isInitialResource(from resourceParams: objc_TNSResourceParams) -> Bool
+public class objc_INVActionParams: NSObject
+    public let type: objc_RUMActionType
+    public let name: String
+    public let timeToNextView: TimeInterval
+    public let nextViewName: String
+public protocol objc_NextViewActionPredicate: AnyObject
+    func isLastAction(from actionParams: objc_INVActionParams) -> Bool
+public class objc_TimeBasedINVActionPredicate: NSObject, objc_NextViewActionPredicate
+    public static let defaultMaxTimeToNextView: TimeInterval = 3
+    public init(maxTimeToNextView: TimeInterval = objc_TimeBasedINVActionPredicate.defaultMaxTimeToNextView)
+    public func isLastAction(from actionParams: objc_INVActionParams) -> Bool
 public enum objc_RUMErrorSource: Int
     case source
     case network
@@ -3309,6 +3330,7 @@ public enum objc_RUMActionType: Int
     case scroll
     case swipe
     case custom
+    case click
 public enum objc_ResourceType: Int
     case image
     case xhr
@@ -3368,6 +3390,8 @@ public class objc_RUMConfiguration: NSObject
     public var swiftUIActionsPredicate: objc_SwiftUIRUMActionsPredicate?
     public var trackMemoryWarnings: Bool
     public var collectAccessibility: Bool
+    public var networkSettledResourcePredicate: objc_NetworkSettledResourcePredicate
+    public var nextViewActionPredicate: objc_NextViewActionPredicate?
     public func setURLSessionTracking(_ tracking: objc_URLSessionTracking)
     public var trackFrustrations: Bool
     public var trackBackgroundEvents: Bool


### PR DESCRIPTION
### What and why?

Adding missing APIs.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
