### PR TITLE
Enable heatmaps feature flag on Session Replay benchmark scenarios

### DIFF
--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
@@ -40,7 +40,7 @@ struct SessionReplaySwiftUIScenario: Scenario {
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
                 touchPrivacyLevel: .show,
-                featureFlags: [.swiftui: true]
+                featureFlags: [.swiftui: true, .heatmaps: true]
             )
         )
 

--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
@@ -38,7 +38,8 @@ struct SessionReplayScenario: Scenario {
                 replaySampleRate: 100,
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
-                touchPrivacyLevel: .show
+                touchPrivacyLevel: .show,
+                featureFlags: [.heatmaps: true]
             )
         )
 


### PR DESCRIPTION
### What and why?

Enable heatmaps feature flag on Session Replay benchmark scenarios to detect any performance regressions.