### PR TITLE
Update confluence workflow to run only on master branch

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -2,7 +2,7 @@ name: Publish Changelog and Feature Docs to Confluence
 on:
     push:
         branches:
-            - develop
+            - master
         paths:
             - 'CHANGELOG.md'
             - '/DatadogRUM/RUM_FEATURE.md'


### PR DESCRIPTION
### What and why?

This workflow updates the changelog (and features descriptions) on each merge to `develop`, which is unnecessary. It only needs to run for new releases.

### How?

Update workflow to run on merges to `master` branch.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
