### PR TITLE
Enforce schema character set on vital.name in Feature Operation APIs

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -176,8 +176,9 @@ internal class RUMFeatureOperationManager {
     /// (which `CharacterSet.alphanumerics` would pull in) do not mask
     /// non-conforming names — e.g. `ログイン` is all Unicode "Letter, other"
     /// and must still trigger the warning.
-    private static let validOperationNameCharacters: CharacterSet =
-        CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.@$-")
+    private static let validOperationNameCharacters = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.@$-"
+    )
 
     /// Validates the operation name.
     ///

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -157,30 +157,61 @@ internal class RUMFeatureOperationManager {
     /// Validates the `name` and `operationKey` of the command
     private func validateCommand(_ command: RUMOperationStepVitalCommand) -> Bool {
         // Validate name (required)
-        guard validateString(command.name, stepType: command.stepType) else {
+        guard validateName(command.name, stepType: command.stepType) else {
             return false
         }
 
         // Validate operationKey if present (optional)
         if let operationKey = command.operationKey,
-           !validateString(operationKey, stepType: command.stepType) {
+           !validateOperationKey(operationKey, stepType: command.stepType) {
             return false
         }
 
         return true
     }
 
-    /// Validates the string is not empty
-    // or contains only whitespace/line breaks
-    private func validateString(_ value: String, stepType: RUMVitalOperationStepEvent.Vital.StepType) -> Bool {
+    /// ASCII character set accepted by the backend for `vital.name`, matching
+    /// the server-side regex `[\w.@$-]` (letters, digits, `_`, `.`, `@`, `$`,
+    /// `-`). Built explicitly from ASCII so that Unicode-aware categories
+    /// (which `CharacterSet.alphanumerics` would pull in) do not mask
+    /// non-conforming names — e.g. `ログイン` is all Unicode "Letter, other"
+    /// and must still trigger the warning.
+    private static let validOperationNameCharacters: CharacterSet =
+        CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.@$-")
+
+    /// Validates the operation name.
+    ///
+    /// Blank / empty names are rejected (the backend rejects them with its
+    /// own non-empty precondition before evaluating the character-set regex).
+    /// Names that fail the backend's `[\w.@$-]*` character-set regex trigger
+    /// a developer warning but the event is still emitted — the backend is
+    /// the source of truth on character-set policy, so client-side drop
+    /// would force an SDK bump if that policy is ever relaxed.
+    private func validateName(_ value: String, stepType: RUMVitalOperationStepEvent.Vital.StepType) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmed.isEmpty else {
-            DD.logger.error("Operation `name` and `operationKey` cannot be empty or contain only whitespace/line breaks. \(stepType) command will be ignored.")
+            DD.logger.error("Operation `name` cannot be empty or contain only whitespace/line breaks. \(stepType) command will be ignored.")
             return false
         }
 
-        // Backend takes care of sanitizing user inputs
+        if !value.unicodeScalars.allSatisfy(Self.validOperationNameCharacters.contains) {
+            DD.logger.warn("Operation `name` '\(value)' does not match the backend-accepted pattern [\\w.@$-]* (letters, digits, _ . @ $ -). The \(stepType) command will still be emitted and may be rejected by the backend.")
+        }
+
+        return true
+    }
+
+    /// Validates the operation key: non-blank. The schema does not restrict
+    /// the character set for `operation_key`.
+    private func validateOperationKey(_ value: String, stepType: RUMVitalOperationStepEvent.Vital.StepType) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else {
+            DD.logger.error("Operation `operationKey`, when provided, cannot be empty or contain only whitespace/line breaks. \(stepType) command will be ignored.")
+            return false
+        }
+
         return true
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -205,12 +205,13 @@ internal class RUMFeatureOperationManager {
 
     /// Validates the operation key: non-blank. The schema does not restrict
     /// the character set for `operation_key`.
+    /// A blank value is warned about but the event is still emitted — `operationKey`
+    /// is optional, so a blank value should not discard the entire operation step.
     private func validateOperationKey(_ value: String, stepType: RUMVitalOperationStepEvent.Vital.StepType) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard !trimmed.isEmpty else {
-            DD.logger.error("Operation `operationKey`, when provided, cannot be empty or contain only whitespace/line breaks. \(stepType) command will be ignored.")
-            return false
+        if trimmed.isEmpty {
+            DD.logger.warn("Operation `operationKey`, when provided, cannot be empty or contain only whitespace/line breaks. The \(stepType) command will still be emitted.")
         }
 
         return true

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -128,6 +128,8 @@ class RUMFeatureOperationManagerTests: XCTestCase {
 
     // MARK: - Edge Cases Tests
 
+    // Blank / empty names are rejected: the backend rejects them with its
+    // own non-empty precondition, so the SDK drops client-side to match.
     private let invalidNames = ["", " ", "\n", "\t", "   \n\t  "]
     func testProcess_OperationWithInvalidName_DoesNotCreateVitalEvent() {
         // Given
@@ -146,6 +148,81 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         // Then
         let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
         XCTAssertEqual(vitalEvents.count, 0)
+    }
+
+    // Names containing characters outside the schema facet-path set
+    // (letters / digits / - _ . @ $). All must be rejected at the API boundary.
+    private let invalidCharacterSetNames = [
+        "user login",     // space
+        "api/v1",         // slash
+        "checkout:step",  // colon
+        "a,b",            // comma
+        "a+b",            // plus
+        "login!",         // bang
+        "login\ttwo",     // tab
+        "ログイン",         // Unicode
+        "login🔐",         // emoji
+    ]
+
+    func testProcess_OperationWithNameOutsideSchemaCharacterSet_StillCreatesVitalEvent() {
+        // Names outside the schema facet-path set are warned about but still
+        // emitted — the backend is the source of truth on character-set policy,
+        // so client-side drop would force an SDK bump if the rule were relaxed.
+        for invalidName in invalidCharacterSetNames {
+            let command = RUMOperationStepVitalCommand.mockWith(name: invalidName)
+
+            // When
+            manager.process(
+                command,
+                context: mockContext,
+                writer: mockWriter,
+                activeView: .mockAny()
+            )
+        }
+
+        // Then — every event is emitted; the name is preserved verbatim.
+        let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
+        XCTAssertEqual(vitalEvents.count, invalidCharacterSetNames.count)
+        for (emitted, expected) in zip(vitalEvents, invalidCharacterSetNames) {
+            XCTAssertEqual(emitted.vital.name, expected)
+        }
+    }
+
+    func testProcess_OperationWithNameInSchemaCharacterSet_CreatesVitalEvent() {
+        // Given — exercises every allowed character class
+        let validNames = ["login", "step42", "login-v2", "user_login", "login.v2", "login@prod", "login$1", "LoginV2"]
+        for validName in validNames {
+            let command = RUMOperationStepVitalCommand.mockWith(name: validName)
+
+            // When
+            manager.process(
+                command,
+                context: mockContext,
+                writer: mockWriter,
+                activeView: .mockAny()
+            )
+        }
+
+        // Then
+        let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
+        XCTAssertEqual(vitalEvents.count, validNames.count)
+    }
+
+    func testProcess_OperationKeyOutsideNameCharacterSet_CreatesVitalEvent() {
+        // operation_key has no character-set restriction in the schema.
+        let command = RUMOperationStepVitalCommand.mockWith(name: "login", operationKey: "user foo / bar")
+
+        // When
+        manager.process(
+            command,
+            context: mockContext,
+            writer: mockWriter,
+            activeView: .mockAny()
+        )
+
+        // Then
+        let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
+        XCTAssertEqual(vitalEvents.count, 1)
     }
 
     func testProcess_OperationWithInvalidOperationKey_DoesNotCreateVitalEvent() {

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -168,6 +168,9 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         // Names outside the schema facet-path set are warned about but still
         // emitted — the backend is the source of truth on character-set policy,
         // so client-side drop would force an SDK bump if the rule were relaxed.
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
         for invalidName in invalidCharacterSetNames {
             let command = RUMOperationStepVitalCommand.mockWith(name: invalidName)
 
@@ -186,10 +189,19 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         for (emitted, expected) in zip(vitalEvents, invalidCharacterSetNames) {
             XCTAssertEqual(emitted.vital.name, expected)
         }
+
+        // A warning is logged for each non-conforming name.
+        XCTAssertEqual(dd.logger.warnMessages.count, invalidCharacterSetNames.count)
+        for (message, name) in zip(dd.logger.warnMessages, invalidCharacterSetNames) {
+            XCTAssertTrue(message.contains(name), "Expected warning to mention '\(name)', got: \(message)")
+        }
     }
 
     func testProcess_OperationWithNameInSchemaCharacterSet_CreatesVitalEvent() {
         // Given — exercises every allowed character class
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
         let validNames = ["login", "step42", "login-v2", "user_login", "login.v2", "login@prod", "login$1", "LoginV2"]
         for validName in validNames {
             let command = RUMOperationStepVitalCommand.mockWith(name: validName)
@@ -203,9 +215,10 @@ class RUMFeatureOperationManagerTests: XCTestCase {
             )
         }
 
-        // Then
+        // Then — every event is emitted and no warnings are produced.
         let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
         XCTAssertEqual(vitalEvents.count, validNames.count)
+        XCTAssertNil(dd.logger.warnLog)
     }
 
     func testProcess_OperationKeyOutsideNameCharacterSet_CreatesVitalEvent() {
@@ -225,8 +238,11 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         XCTAssertEqual(vitalEvents.count, 1)
     }
 
-    func testProcess_OperationWithInvalidOperationKey_DoesNotCreateVitalEvent() {
-        // Given
+    func testProcess_OperationWithBlankOperationKey_LogsWarningAndCreatesVitalEvent() throws {
+        // operationKey is optional — a blank value warns but does not discard the event.
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
         for invalidOpKey in invalidNames {
             let command = RUMOperationStepVitalCommand.mockWith(name: .mockAny(), operationKey: invalidOpKey)
 
@@ -239,9 +255,12 @@ class RUMFeatureOperationManagerTests: XCTestCase {
             )
         }
 
-        // Then
+        // Then — events are emitted and a warning is logged for each blank key.
         let vitalEvents = mockWriter.events(ofType: RUMVitalOperationStepEvent.self)
-        XCTAssertEqual(vitalEvents.count, 0)
+        XCTAssertEqual(vitalEvents.count, invalidNames.count)
+        XCTAssertEqual(dd.logger.warnMessages.count, invalidNames.count)
+        let warnMessage = try XCTUnwrap(dd.logger.warnLog?.message)
+        XCTAssertTrue(warnMessage.contains("operationKey"), "Expected warning to mention 'operationKey', got: \(warnMessage)")
     }
 
     // MARK: Warning Logs Tests

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -932,7 +932,10 @@ extension RUMOperationStepVitalCommand: AnyMockable, RandomMockable {
     public static func mockRandom() -> RUMOperationStepVitalCommand {
         return mockWith(
             vitalId: .mockRandom(),
-            name: .mockRandom(),
+            // vital.name must match the schema facet-path character set
+            // (letters, digits, - _ . @ $). Use alphanumerics to avoid
+            // generating whitespace and tripping the API-boundary validator.
+            name: .mockRandom(among: .alphanumerics),
             operationKey: .mockRandom(),
             stepType: .mockRandom(),
             failureReason: .mockRandom(),


### PR DESCRIPTION
### What and why?

The authoritative `_vital-common-schema.json` restricts `vital.name` to the character set `[\w.@$-]*` (letters, digits, `_`, `.`, `@`, `$`, `-`) and the backend enforces this as a server-side regex on the facet path. Until now the iOS SDK only rejected blank names; non-conforming values (e.g. `"user login"`, `"api/v1"`, `"ログイン"`) were silently accepted and shipped to intake.

This PR validates the character set at the API boundary so developers catch the problem at dev time instead of discovering it only after events are dropped at intake.

### How?

Split `RUMFeatureOperationManager`'s single `validateString` helper into:

- `validateName` — rejects blank names with `DD.logger.error` (drops the event), then checks each unicode scalar against an explicit ASCII `CharacterSet(charactersIn: "A-Za-z0-9_.@$-")`. Using `.alphanumerics` would have been wrong — it is Unicode-aware and would accept Japanese/Cyrillic/etc.
- `validateOperationKey` — blank-check only (schema does not restrict `operation_key`).

When `name` contains characters outside the allowed set, `DD.logger.warn` is emitted quoting the exact backend pattern `[\w.@$-]*`, but the event is still emitted. The rationale: the backend is the source of truth on the policy, so a client-side drop would force customers to bump the SDK if the server rule is ever relaxed.

Updated `RUMFeatureMocks.mockRandom()` to use `.alphanumerics` so existing forgery-based tests stay within the allowed set.

Tests cover:

- blank / whitespace-only name → dropped + error
- invalid ASCII chars (space, slash, colon, comma, plus, tab) → warn + emitted
- non-ASCII name `"ログイン"` and emoji `"login🔐"` → warn + emitted (pins ASCII-only semantics against future `.alphanumerics` regressions)
- every allowed-character class → silent emit
- `operationKey` with space/slash/etc. → silent emit (no char-set rule)
- applies to all three methods: start/succeed/fail

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs — not applicable, change is internal
- [x] Run `make api-surface` when adding new APIs — not applicable, no new public API