### PR TITLE
MOB-6385: Fix `us2_fed` intake hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [IMPROVEMENT] Add device properties `isLowRam`, `logicalCpuCount`, `totalRam` to the `LogEvent` Objective-C API. See [#2854][]
 - [IMPROVEMENT] Add `collectAccessibility` property to the Objective-C API of RUM configuration. See [#2855][]
 - [IMPROVEMENT] Add Objective-C APIs for `networkSettledResourcePredicate` and `nextViewActionPredicate` of RUM configuration. See [#2856][]
+- [FIX] Fix `us2_fed` intake hostname. See [#2866][]
 
 # 3.10.0 / 16-04-2026
 
@@ -1135,6 +1136,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2854]: https://github.com/DataDog/dd-sdk-ios/pull/2854
 [#2855]: https://github.com/DataDog/dd-sdk-ios/pull/2855
 [#2856]: https://github.com/DataDog/dd-sdk-ios/pull/2856
+[#2866]: https://github.com/DataDog/dd-sdk-ios/pull/2866
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogFlags/Tests/Client/EvaluationLoggingTests.swift
+++ b/DatadogFlags/Tests/Client/EvaluationLoggingTests.swift
@@ -90,7 +90,7 @@ class EvaluationLoggingTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/flagevaluation")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/flagevaluation")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/flagevaluation")
-        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/flagevaluation")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/flagevaluation")
 
         // Then - Verify Content-Type and batched schema
         let contextWithRUM = DatadogContext.mockWith(

--- a/DatadogFlags/Tests/Client/ExposureRequestBuilderTests.swift
+++ b/DatadogFlags/Tests/Client/ExposureRequestBuilderTests.swift
@@ -52,7 +52,7 @@ final class ExposureRequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/exposures")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/exposures")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/exposures")
-        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/exposures")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/exposures")
     }
 
     func testItSetsCustomIntakeURL() throws {

--- a/DatadogInternal/Sources/Context/DatadogSite.swift
+++ b/DatadogInternal/Sources/Context/DatadogSite.swift
@@ -29,7 +29,7 @@ public enum DatadogSite: String {
     /// Sends data to [app.ddog-gov.com](https://app.ddog-gov.com/).
     case us1_fed
     /// US based servers, FedRAMP compatible.
-    /// Sends data to [fed2.ddog-gov.com](https://fed2.ddog-gov.com/).
+    /// Sends data to [us2.ddog-gov.com](https://us2.ddog-gov.com/).
     case us2_fed
 }
 
@@ -44,7 +44,7 @@ extension DatadogSite {
         case .ap1: return URL(string: "https://browser-intake-ap1-datadoghq.com/")!
         case .ap2: return URL(string: "https://browser-intake-ap2-datadoghq.com/")!
         case .us1_fed: return URL(string: "https://browser-intake-ddog-gov.com/")!
-        case .us2_fed: return URL(string: "https://browser-intake-fed2-ddog-gov.com/")!
+        case .us2_fed: return URL(string: "https://browser-intake-us2-ddog-gov.com/")!
         // swiftlint:enable force_unwrapping
         }
     }

--- a/DatadogProfiling/Tests/RequestBuilderTests.swift
+++ b/DatadogProfiling/Tests/RequestBuilderTests.swift
@@ -64,7 +64,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/profile")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/profile")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/profile")
-        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/profile")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/profile")
     }
 
     func testItSetsCustomIntakeURL() {

--- a/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
+++ b/DatadogRUM/Tests/Feature/RequestBuilderTests.swift
@@ -53,7 +53,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/rum")
         XCTAssertEqual(url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/rum")
         XCTAssertEqual(url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/rum")
-        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/rum")
+        XCTAssertEqual(url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/rum")
     }
 
     func testItSetsCustomIntakeURL() throws {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/ResourceRequestBuilderTests.swift
@@ -49,7 +49,7 @@ class ResourceRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/replay")
-        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/replay")
     }
 
     func testItSetsCustomIntakeURL() {

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/SegmentRequestBuilderTests.swift
@@ -53,7 +53,7 @@ class SegmentRequestBuilderTests: XCTestCase {
         XCTAssertEqual(try url(for: .ap1), "https://browser-intake-ap1-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .ap2), "https://browser-intake-ap2-datadoghq.com/api/v2/replay")
         XCTAssertEqual(try url(for: .us1_fed), "https://browser-intake-ddog-gov.com/api/v2/replay")
-        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-fed2-ddog-gov.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us2_fed), "https://browser-intake-us2-ddog-gov.com/api/v2/replay")
     }
 
     func testItSetsCustomIntakeURL() {


### PR DESCRIPTION
### What and why?

This PR corrects the `us2_fed` site configuration by updating the intake hostname to `browser-intake-us2-ddog-gov.com`. This change aligns the SDK with the internal intake source of truth for `us2.fed.dog`: [Intake+releases#us2.fed.dog](https://datadoghq.atlassian.net/wiki/spaces/EP/pages/652018344/Intake+releases#us2.fed.dog)

### How?

The implementation updates the `DatadogSite.us2_fed` documentation comment and fixes the endpoint mapping used for intake requests.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
