### PR TITLE
RUM-14274: Create continuous Benchmarks for continuous Profiling

### DIFF
--- a/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		111BAB552F12E89F00B4B492 /* ProfilingScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111BAB542F12E89200B4B492 /* ProfilingScenario.swift */; };
+		111BAB582F12E95200B4B492 /* ProfilingContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111BAB572F12E94D00B4B492 /* ProfilingContentView.swift */; };
+		111BAB5A2F12EAA500B4B492 /* DatadogProfiling in Frameworks */ = {isa = PBXBuildFile; productRef = 111BAB592F12EAA500B4B492 /* DatadogProfiling */; };
 		86252B1B2D818E360098FAEF /* TraceScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86252B1A2D818E360098FAEF /* TraceScenario.swift */; };
 		86252B1D2D8190DA0098FAEF /* TraceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86252B1C2D8190DA0098FAEF /* TraceContentView.swift */; };
 		8649177D2D8875C300761363 /* RUMManualContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8649177C2D8875C300761363 /* RUMManualContentView.swift */; };
@@ -268,6 +271,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		111BAB542F12E89200B4B492 /* ProfilingScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingScenario.swift; sourceTree = "<group>"; };
+		111BAB572F12E94D00B4B492 /* ProfilingContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContentView.swift; sourceTree = "<group>"; };
 		86252B1A2D818E360098FAEF /* TraceScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceScenario.swift; sourceTree = "<group>"; };
 		86252B1C2D8190DA0098FAEF /* TraceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceContentView.swift; sourceTree = "<group>"; };
 		8649177C2D8875C300761363 /* RUMManualContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMManualContentView.swift; sourceTree = "<group>"; };
@@ -517,6 +522,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				111BAB5A2F12EAA500B4B492 /* DatadogProfiling in Frameworks */,
 				D27606A92C514F77002D2A14 /* DatadogLogs in Frameworks */,
 				D27606AF2C514F77002D2A14 /* DatadogTrace in Frameworks */,
 				D294E9402D0880EB009582F3 /* CatalogSwiftUI.framework in Frameworks */,
@@ -531,6 +537,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		111BAB532F12E85900B4B492 /* Profiling */ = {
+			isa = PBXGroup;
+			children = (
+				111BAB562F12E92B00B4B492 /* UI */,
+				111BAB542F12E89200B4B492 /* ProfilingScenario.swift */,
+			);
+			path = Profiling;
+			sourceTree = "<group>";
+		};
+		111BAB562F12E92B00B4B492 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				111BAB572F12E94D00B4B492 /* ProfilingContentView.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		86252B182D818DFB0098FAEF /* Trace */ = {
 			isa = PBXGroup;
 			children = (
@@ -828,10 +851,11 @@
 			children = (
 				D276069B2C514F37002D2A14 /* Scenario.swift */,
 				D24BFD462C6B916B00AB9604 /* SyntheticScenario.swift */,
-				D27606992C514F37002D2A14 /* SessionReplay */,
 				86FBEDB72D8C24A9005CFCC4 /* Logs */,
-				86252B182D818DFB0098FAEF /* Trace */,
+				111BAB532F12E85900B4B492 /* Profiling */,
 				86FBEDB32D8C248A005CFCC4 /* RUM */,
+				D27606992C514F37002D2A14 /* SessionReplay */,
+				86252B182D818DFB0098FAEF /* Trace */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -1254,6 +1278,7 @@
 				D27606AC2C514F77002D2A14 /* DatadogSessionReplay */,
 				D27606AE2C514F77002D2A14 /* DatadogTrace */,
 				D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */,
+				111BAB592F12EAA500B4B492 /* DatadogProfiling */,
 			);
 			productName = Runner;
 			productReference = D29F754D2C4AA07E00288638 /* Runner.app */;
@@ -1528,6 +1553,7 @@
 				86FBEDDD2D8C491E005CFCC4 /* EpisodeDetailViewController.swift in Sources */,
 				86252B1D2D8190DA0098FAEF /* TraceContentView.swift in Sources */,
 				86FBEDD12D8C2B04005CFCC4 /* LocationCollectionViewCell.swift in Sources */,
+				111BAB552F12E89F00B4B492 /* ProfilingScenario.swift in Sources */,
 				86FA743B2D8AC3C900F69130 /* Utils.swift in Sources */,
 				86FA74332D89CC1500F69130 /* EpisodesView.swift in Sources */,
 				868DA2F72D71DD8A007D20D5 /* LogsHeavyTrafficContentView.swift in Sources */,
@@ -1553,6 +1579,7 @@
 				86FBEDCE2D8C29C3005CFCC4 /* CharacterDetailView.swift in Sources */,
 				86FBEDCF2D8C29C3005CFCC4 /* InfoRow.swift in Sources */,
 				86FA743F2D8AE85B00F69130 /* LocationsViewController.swift in Sources */,
+				111BAB582F12E95200B4B492 /* ProfilingContentView.swift in Sources */,
 				86FA74312D89CC0400F69130 /* LocationsView.swift in Sources */,
 				D24E15F32C776956005AE4E8 /* BenchmarkProfiler.swift in Sources */,
 				D24BFD472C6B916B00AB9604 /* SyntheticScenario.swift in Sources */,
@@ -2332,6 +2359,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		111BAB592F12EAA500B4B492 /* DatadogProfiling */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DatadogProfiling;
+		};
 		D23DD32C2C58D80C00B90C4C /* DatadogBenchmarks */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DatadogBenchmarks;

--- a/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BENCHMARK_SCENARIO"
-            value = "logsHeavyTraffic"
+            value = "profiling"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/BenchmarkTests/BenchmarkTests.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -58,7 +58,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BENCHMARK_SCENARIO"
-            value = "profiling"
+            value = "continuousProfiling"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/BenchmarkTests/Runner/AppDelegate.swift
+++ b/BenchmarkTests/Runner/AppDelegate.swift
@@ -86,7 +86,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func stop() {
         vitals = nil // stop collecting vitals
         Datadog.stopInstance() // stop runner instrumentation
+#if DD_BENCHMARK
         DatadogInternal.bench = (NOPBench(), NOPBench()) // stop profiling the sdk
+#endif
         window?.rootViewController = UIViewController()
     }
 
@@ -145,8 +147,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 )
             )
         )
-
+#if DD_BENCHMARK
         DatadogInternal.bench = (profiler, meter) // Inject profiler and meter to collect telemetry
+#endif
     }
 }
 

--- a/BenchmarkTests/Runner/Scenarios/Profiling/ProfilingScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/Profiling/ProfilingScenario.swift
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import SwiftUI
+
+import DatadogCore
+import DatadogRUM
+import DatadogProfiling
+
+struct ProfilingScenario: Scenario {
+    var initialViewController: UIViewController {
+        UIHostingController(rootView: ProfilingContentView())
+    }
+
+    func instrument(with info: AppInfo) {
+        Datadog.initialize(
+            with: .benchmark(info: info),
+            trackingConsent: .granted
+        )
+
+        RUM.enable(
+            with: RUM.Configuration(
+                applicationID: info.applicationID,
+                longTaskThreshold: 0.1,
+                appHangThreshold: 0.4
+            )
+        )
+
+        RUMMonitor.shared().addAttribute(forKey: "scenario", value: "Profiling")
+
+        Profiling.enable(with: .init(applicationLaunchSampleRate: .maxSampleRate, continuousSampleRate: .maxSampleRate))
+    }
+}

--- a/BenchmarkTests/Runner/Scenarios/Profiling/ProfilingScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/Profiling/ProfilingScenario.swift
@@ -30,7 +30,7 @@ struct ProfilingScenario: Scenario {
             )
         )
 
-        RUMMonitor.shared().addAttribute(forKey: "scenario", value: "Profiling")
+        RUMMonitor.shared().addAttribute(forKey: "scenario", value: "ContinuousProfiling")
 
         Profiling.enable(with: .init(applicationLaunchSampleRate: .maxSampleRate, continuousSampleRate: .maxSampleRate))
     }

--- a/BenchmarkTests/Runner/Scenarios/Profiling/UI/ProfilingContentView.swift
+++ b/BenchmarkTests/Runner/Scenarios/Profiling/UI/ProfilingContentView.swift
@@ -222,24 +222,20 @@ private extension ProfilingContentView {
     func sendOperation(using configuration: ProfilingConfiguration) async {
         let trimmedName = configuration.operationName.trimmingCharacters(in: .whitespacesAndNewlines)
         let name = trimmedName.isEmpty ? "benchmark.operation" : trimmedName
-        let attributes: [String: Encodable] = [
-            "scenario": "Profiling"
-        ]
 
         rumMonitor.startOperation(
             name: name,
-            attributes: attributes,
             options: ProfilingOptions(sampleRate: .maxSampleRate)
         )
 
-        await Task.detached(priority: .userInitiated) {
-            runHighProcessingBlock(for: configuration.operationDuration)
+        _ = await Task.detached(priority: .userInitiated) {
+            await runHighProcessingBlock(for: configuration.operationDuration)
         }.value
 
         if configuration.shouldFailOperation {
-            rumMonitor.failOperation(name: name, reason: .other, attributes: attributes)
+            rumMonitor.failOperation(name: name, reason: .other)
         } else {
-            rumMonitor.succeedOperation(name: name, attributes: attributes)
+            rumMonitor.succeedOperation(name: name)
         }
 
         recordSignal(

--- a/BenchmarkTests/Runner/Scenarios/Profiling/UI/ProfilingContentView.swift
+++ b/BenchmarkTests/Runner/Scenarios/Profiling/UI/ProfilingContentView.swift
@@ -1,0 +1,307 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogRUM
+import SwiftUI
+
+struct ProfilingContentView: View {
+    private static let durationFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+
+    @State private var signal: ProfilingSignal = .longTask
+    @State private var longTaskDuration: TimeInterval = 0.2
+    @State private var appHangDuration: TimeInterval = 1.0
+    @State private var operationName: String = "benchmark.operation"
+    @State private var operationDuration: TimeInterval = 2.0
+    @State private var shouldFailOperation: Bool = false
+
+    @State private var isSending: Bool = false
+    @State private var eventsCount: Int = 0
+    @State private var lastSignalSummary: String = ""
+    @State private var sendTask: Task<Void, Never>?
+
+    private var rumMonitor: RUMMonitorProtocol { RUMMonitor.shared() }
+
+    init() {
+        // Block TTID for 1 second to have App launch profiling data.
+        Thread.sleep(forTimeInterval: 1)
+    }
+
+    var body: some View {
+        Form {
+            Section(header: Text("Profiling signal")) {
+                Picker("Select signal", selection: $signal) {
+                    ForEach(ProfilingSignal.allCases, id: \.self) { signal in
+                        Text(signal.rawValue)
+                    }
+                }
+            }
+
+            signalConfiguration()
+
+            Button(action: startSending) {
+                Text("Send")
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Constants.contentPadding)
+                    .background(isSending ? Color.purple.opacity(0.8) : Color.purple)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(isSending)
+            .padding(.horizontal, Constants.contentPadding)
+            .padding(.vertical, 8)
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
+
+            VStack(alignment: .center, spacing: 12) {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .opacity(isSending ? 1 : 0)
+
+                Text("Signals sent: \(eventsCount)")
+
+                Text(lastSignalSummary)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, Constants.contentPadding)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 12)
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+        }
+        .trackRUMView(name: Constants.viewName)
+        .onDisappear {
+            sendTask?.cancel()
+            sendTask = nil
+        }
+    }
+
+    @ViewBuilder
+    private func signalConfiguration() -> some View {
+        switch signal {
+        case .longTask:
+            Section(header: Text("Long task configuration")) {
+                durationRow(
+                    title: "Main thread work (sec)",
+                    placeholder: "Duration",
+                    value: $longTaskDuration,
+                    range: 0.1 ... 5.0,
+                    step: 0.1
+                )
+
+                Text("Runs a CPU-heavy block on the main thread so Profiling can capture a long task.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+        case .appHang:
+            Section(header: Text("App hang configuration")) {
+                durationRow(
+                    title: "Blocked main thread (sec)",
+                    placeholder: "Duration",
+                    value: $appHangDuration,
+                    range: 0.5 ... 10.0,
+                    step: 0.25
+                )
+
+                Text("Uses a longer CPU-heavy block on the main thread to cross the app hang threshold.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+        case .operation:
+            Section(header: Text("Operation configuration")) {
+                TextField("Operation name", text: $operationName)
+
+                durationRow(
+                    title: "Background work (sec)",
+                    placeholder: "Duration",
+                    value: $operationDuration,
+                    range: 0.25 ... 15.0,
+                    step: 0.25
+                )
+
+                Toggle("Fail operation at the end", isOn: $shouldFailOperation)
+                    .tint(Color.purple)
+
+                Text("Starts a sampled RUM operation and keeps a CPU-heavy block running in a background task while the operation is active.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func durationRow(
+        title: String,
+        placeholder: String,
+        value: Binding<TimeInterval>,
+        range: ClosedRange<TimeInterval>,
+        step: TimeInterval
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+
+            HStack(spacing: 12) {
+                TextField(placeholder, value: value, formatter: Self.durationFormatter)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .frame(maxWidth: .infinity)
+                    .keyboardType(.decimalPad)
+
+                Stepper("", value: value, in: range, step: step)
+                    .frame(maxWidth: .infinity)
+                    .labelsHidden()
+            }
+        }
+    }
+}
+
+private extension ProfilingContentView {
+    func startSending() {
+        guard isSending == false else {
+            return
+        }
+
+        isSending = true
+        let configuration = ProfilingConfiguration(
+            signal: signal,
+            longTaskDuration: longTaskDuration,
+            appHangDuration: appHangDuration,
+            operationName: operationName,
+            operationDuration: operationDuration,
+            shouldFailOperation: shouldFailOperation
+        )
+
+        sendTask = Task(priority: .userInitiated) {
+            if configuration.signal.blocksMainThread {
+                try? await Task.sleep(nanoseconds: Constants.progressViewLeadTime)
+            }
+
+            await send(configuration)
+
+            await MainActor.run {
+                isSending = false
+                sendTask = nil
+            }
+        }
+    }
+
+    func send(_ configuration: ProfilingConfiguration) async {
+        switch configuration.signal {
+        case .longTask:
+            sendLongTask(using: configuration)
+        case .appHang:
+            sendAppHang(using: configuration)
+        case .operation:
+            await sendOperation(using: configuration)
+        }
+    }
+
+    func sendLongTask(using configuration: ProfilingConfiguration) {
+        runHighProcessingBlock(for: configuration.longTaskDuration)
+        recordSignal(label: "Long task", duration: configuration.longTaskDuration)
+    }
+
+    func sendAppHang(using configuration: ProfilingConfiguration) {
+        runHighProcessingBlock(for: configuration.appHangDuration)
+        recordSignal(label: "App hang", duration: configuration.appHangDuration)
+    }
+
+    func sendOperation(using configuration: ProfilingConfiguration) async {
+        let trimmedName = configuration.operationName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = trimmedName.isEmpty ? "benchmark.operation" : trimmedName
+        let attributes: [String: Encodable] = [
+            "scenario": "Profiling"
+        ]
+
+        rumMonitor.startOperation(
+            name: name,
+            attributes: attributes,
+            options: ProfilingOptions(sampleRate: .maxSampleRate)
+        )
+
+        await Task.detached(priority: .userInitiated) {
+            runHighProcessingBlock(for: configuration.operationDuration)
+        }.value
+
+        if configuration.shouldFailOperation {
+            rumMonitor.failOperation(name: name, reason: .other, attributes: attributes)
+        } else {
+            rumMonitor.succeedOperation(name: name, attributes: attributes)
+        }
+
+        recordSignal(
+            label: configuration.shouldFailOperation ? "Failed operation" : "Operation",
+            duration: configuration.operationDuration
+        )
+    }
+
+    @discardableResult
+    func runHighProcessingBlock(for duration: TimeInterval) -> Double {
+        let deadline = ProcessInfo.processInfo.systemUptime + max(duration, Constants.minimumWorkDuration)
+        var accumulator = 0.0
+        var current = 1.0
+
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            for _ in 0 ..< Constants.workChunkSize {
+                accumulator += sin(current) * cos(current / 3)
+                current += 0.0001
+            }
+        }
+
+        return accumulator
+    }
+
+    func recordSignal(label: String, duration: TimeInterval) {
+        eventsCount += 1
+        lastSignalSummary = "\(label) finished in \(String(format: "%.2f", duration))s."
+    }
+}
+
+private enum ProfilingSignal: String, CaseIterable {
+    case longTask = "Long Task"
+    case appHang = "App Hang"
+    case operation = "Operation"
+
+    var blocksMainThread: Bool {
+        switch self {
+        case .longTask, .appHang:
+            true
+        case .operation:
+            false
+        }
+    }
+}
+
+private struct ProfilingConfiguration {
+    let signal: ProfilingSignal
+    let longTaskDuration: TimeInterval
+    let appHangDuration: TimeInterval
+    let operationName: String
+    let operationDuration: TimeInterval
+    let shouldFailOperation: Bool
+}
+
+private enum Constants {
+    static let viewName = "ProfilingBenchmarkView"
+    static let minimumWorkDuration: TimeInterval = 0.05
+    static let workChunkSize = 2_000
+    static let contentPadding: CGFloat = 16
+    static let progressViewLeadTime: UInt64 = 100_000_000
+}
+
+#Preview {
+    ProfilingContentView()
+}

--- a/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
@@ -19,6 +19,7 @@ internal struct SyntheticScenario: Scenario {
         case trace
         case rumManual
         case rumAuto
+        case profiling
     }
     /// The scenario's name.
     let name: Name
@@ -81,6 +82,8 @@ internal struct SyntheticScenario: Scenario {
             _scenario = RUMManualScenario()
         case .rumAuto:
             _scenario = RUMAutoScenario()
+        case .profiling:
+            _scenario = ProfilingScenario()
         }
 
         self.name = name

--- a/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
@@ -19,7 +19,7 @@ internal struct SyntheticScenario: Scenario {
         case trace
         case rumManual
         case rumAuto
-        case profiling
+        case continuousProfiling
     }
     /// The scenario's name.
     let name: Name
@@ -82,7 +82,7 @@ internal struct SyntheticScenario: Scenario {
             _scenario = RUMManualScenario()
         case .rumAuto:
             _scenario = RUMAutoScenario()
-        case .profiling:
+        case .continuousProfiling:
             _scenario = ProfilingScenario()
         }
 


### PR DESCRIPTION
### What and why?

This PR adds an interactive Profiling benchmark scenario to `BenchmarkTests` so we can generate deterministic profiling signals on demand. The scenario lets us explicitly trigger long tasks, app hangs and RUM operations from the UI, which makes continuous profiling behavior easier to benchmark and compare across runs.

### How?

`ProfilingScenario` now enables RUM with explicit long-task and app-hang thresholds, tags data with the `Profiling` scenario attribute, and enables Profiling with max sample rates for both app launch and continuous profiling. `ProfilingContentView` was expanded into a small control panel where the user can select a signal type, configure durations and operation settings, and send one signal per tap.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
