### PR TITLE
RUM-15698: Align profiling timestamps with RUM server time offset

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/Vital.swift
+++ b/DatadogInternal/Sources/Models/RUM/Vital.swift
@@ -27,7 +27,7 @@ public struct Vital: Encodable, Equatable {
     /// Date when the vital was created
     public let date: Date
     /// Interval between device and server time.
-    public var serverTimeOffset: TimeInterval
+    public let serverTimeOffset: TimeInterval
     /// Duration of the vital in nanoseconds
     public var duration: Int64?
     /// Key identifier of the vital

--- a/DatadogInternal/Sources/Models/RUM/Vital.swift
+++ b/DatadogInternal/Sources/Models/RUM/Vital.swift
@@ -26,6 +26,8 @@ public struct Vital: Encodable, Equatable {
     public let stepType: RUMVitalOperationStepEvent.Vital.StepType?
     /// Date when the vital was created
     public let date: Date
+    /// Interval between device and server time.
+    public var serverTimeOffset: TimeInterval
     /// Duration of the vital in nanoseconds
     public var duration: Int64?
     /// Key identifier of the vital
@@ -37,6 +39,7 @@ public struct Vital: Encodable, Equatable {
         operationKey: String? = nil,
         stepType: RUMVitalOperationStepEvent.Vital.StepType? = nil,
         date: Date = Date(),
+        serverTimeOffset: TimeInterval = .zero,
         duration: Int64? = nil
     ) {
         self.id = id
@@ -44,6 +47,7 @@ public struct Vital: Encodable, Equatable {
         self.operationKey = operationKey
         self.stepType = stepType
         self.date = date
+        self.serverTimeOffset = serverTimeOffset
         self.duration = duration
         self.key = "\(name)-\(operationKey ?? "")"
     }
@@ -53,7 +57,7 @@ public struct Vital: Encodable, Equatable {
         try container.encode(id, forKey: .id)
         try container.encode(type, forKey: .type)
         try container.encode(name, forKey: .name)
-        let start = date.timeIntervalSince1970.dd.toInt64Nanoseconds
+        let start = date.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.dd.toInt64Nanoseconds
         try container.encode(start, forKey: .start)
         try container.encodeIfPresent(duration, forKey: .duration)
     }

--- a/DatadogProfiling/Mach/dd_pprof.cpp
+++ b/DatadogProfiling/Mach/dd_pprof.cpp
@@ -74,6 +74,11 @@ double dd_pprof_get_end_timestamp_s(dd_pprof_t* profile) {
     return static_cast<double>(timestamp) / 1e9; // to seconds
 }
 
+void dd_pprof_set_server_time_offset_ns(dd_pprof_t* profile, int64_t offset_ns) {
+    if (!profile) return;
+    reinterpret_cast<dd::profiler::profile*>(profile)->set_server_time_offset_ns(offset_ns);
+}
+
 size_t dd_pprof_sample_count(dd_pprof_t* profile) {
     if (!profile) return 0;
     return reinterpret_cast<dd::profiler::profile*>(profile)->samples().size();

--- a/DatadogProfiling/Mach/dd_profiler.cpp
+++ b/DatadogProfiling/Mach/dd_profiler.cpp
@@ -234,6 +234,18 @@ public:
     }
 
     /**
+     * Sets the server time offset on the active profile and stores it for
+     * profiles created after future flushes.
+     */
+    void set_server_time_offset_ns(int64_t offset_ns) {
+        std::lock_guard<std::mutex> lock(profile_mutex);
+        server_time_offset_ns = offset_ns;
+        if (profile) {
+            profile->set_server_time_offset_ns(offset_ns);
+        }
+    }
+
+    /**
      * Flushes the sampling buffer and returns the profile, swapping in a fresh one.
      *
      * @return The harvested profile, or nullptr if no profile exists.
@@ -246,6 +258,7 @@ public:
 
         dd::profiler::profile* harvested = profile;
         profile = new dd::profiler::profile(sampling_interval_ns);
+        profile->set_server_time_offset_ns(server_time_offset_ns);
         return harvested;
     }
 
@@ -269,6 +282,7 @@ private:
             status = DD_PROFILER_STATUS_ALLOCATION_FAILED;
             return false;
         }
+        profile->set_server_time_offset_ns(server_time_offset_ns);
 
         sampling_config_t config = SAMPLING_CONFIG_DEFAULT;
         config.sampling_interval_nanos = sampling_interval_ns;
@@ -291,6 +305,7 @@ private:
     bool is_prewarming = false;
     int64_t timeout_ns = DD_PROFILER_TIMEOUT_NS;
     uint64_t sampling_interval_ns = SAMPLING_CONFIG_DEFAULT_INTERVAL_NANOS;
+    int64_t server_time_offset_ns = 0;
 
     /**
      * Mutex protecting the profile pointer.
@@ -385,6 +400,11 @@ dd_profile_t* dd_profiler_get_profile(void) {
 dd_profile_t* dd_profiler_flush_and_get_profile(void) {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
     return g_dd_profiler ? reinterpret_cast<dd_profile_t*>(g_dd_profiler->flush_and_get_profile()) : nullptr;
+}
+
+void dd_profiler_set_server_time_offset_ns(int64_t offset_ns) {
+    std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
+    if (g_dd_profiler) g_dd_profiler->set_server_time_offset_ns(offset_ns);
 }
 
 void dd_profiler_destroy(void) {

--- a/DatadogProfiling/Mach/include/dd_pprof.h
+++ b/DatadogProfiling/Mach/include/dd_pprof.h
@@ -98,6 +98,14 @@ double dd_pprof_get_start_timestamp_s(dd_pprof_t* profile);
  */
 double dd_pprof_get_end_timestamp_s(dd_pprof_t* profile);
 
+/**
+ * Set the server time correction used for exported timestamps.
+ *
+ * @param profile Pointer to the profile
+ * @param offset_ns Server time offset in nanoseconds
+ */
+void dd_pprof_set_server_time_offset_ns(dd_pprof_t* profile, int64_t offset_ns);
+
 #ifdef __cplusplus
 }
 #endif

--- a/DatadogProfiling/Mach/include/dd_profiler.h
+++ b/DatadogProfiling/Mach/include/dd_profiler.h
@@ -244,6 +244,16 @@ dd_profile_t* dd_profiler_get_profile(void);
 dd_profile_t* dd_profiler_flush_and_get_profile(void);
 
 /**
+ * @brief Sets the server time correction used for exported profile timestamps.
+ *
+ * The latest value is applied to the active profile and to future profiles
+ * created after flushing.
+ *
+ * @param offset_ns Server time offset in nanoseconds
+ */
+void dd_profiler_set_server_time_offset_ns(int64_t offset_ns);
+
+/**
  * @brief Destroys the dd profiler data and frees all associated memory
  *
  * This function should be called when the profile data is no longer needed

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -88,7 +88,8 @@ struct label_t {
  * 
  * Represents a single profiling sample containing:
  * - Stack trace as a sequence of location IDs (leaf-to-root order)
- * - Associated labels (e.g., timestamps, thread info)
+ * - Sample timestamp as uptime nanoseconds
+ * - Associated labels (e.g., thread info)
  * - Sample values (e.g., CPU time, wall time, memory allocation)
  * 
  * Samples are not aggregated at this level - aggregation happens during
@@ -96,6 +97,7 @@ struct label_t {
  */
 struct sample_t {
     std::vector<uint32_t> location_ids;
+    uint64_t timestamp_uptime_ns;
     std::vector<label_t> labels;
     std::vector<int64_t> values;
 };
@@ -177,11 +179,23 @@ public:
     /** @brief Get cached string ID for "nanoseconds" */
     uint32_t nanoseconds_str_id() const { return _nanoseconds_str_id; }
 
+    /** @brief Get cached string ID for "end_timestamp_ns" */
+    uint32_t end_timestamp_ns_str_id() const { return _end_timestamp_ns_str_id; }
+
+    /** @brief Convert uptime nanoseconds to server-corrected epoch nanoseconds */
+    int64_t epoch_timestamp_ns(uint64_t uptime_ns) const { return uptime_ns_to_epoch_ns(uptime_ns); }
+
     /** @brief Get profile start timestamp (uptime nanoseconds converted to epoch) */
     int64_t start_timestamp() const { return uptime_ns_to_epoch_ns(_start_timestamp); };
 
     /** @brief Get profile end timestamp (uptime nanoseconds converted to epoch) */
     int64_t end_timestamp() const { return uptime_ns_to_epoch_ns(_end_timestamp); };
+
+    /**
+     * @brief Set the server time correction used for exported timestamps.
+     * @param offset_ns Server time offset in nanoseconds
+     */
+    void set_server_time_offset_ns(int64_t offset_ns);
 
 private:
     /** @brief Deduplicated string table (index 0 is always empty string) */
@@ -219,6 +233,9 @@ private:
 
     /** @brief Offset to convert uptime nanoseconds to epoch time */
     int64_t _epoch_offset;
+
+    /** @brief Offset to convert device epoch timestamps to server epoch timestamps */
+    int64_t _server_time_offset_ns;
 
     /** @brief Profile start timestamp (uptime nanoseconds, 0 if no samples) */
     uint64_t _start_timestamp;

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -179,11 +179,23 @@ public:
     /** @brief Get cached string ID for "nanoseconds" */
     uint32_t nanoseconds_str_id() const { return _nanoseconds_str_id; }
 
-    /** @brief Get cached string ID for "end_timestamp_ns" */
-    uint32_t end_timestamp_ns_str_id() const { return _end_timestamp_ns_str_id; }
+    /** @brief Number of labels exported for the sample */
+    size_t label_count(const sample_t& sample) const { return sample.labels.size() + 1; }
 
-    /** @brief Convert uptime nanoseconds to server-corrected epoch nanoseconds */
-    int64_t epoch_timestamp_ns(uint64_t uptime_ns) const { return uptime_ns_to_epoch_ns(uptime_ns); }
+    /** @brief Visit labels exported for the sample */
+    template <typename LabelVisitor>
+    void for_each_label(const sample_t& sample, LabelVisitor&& visitor) const {
+        label_t timestamp_label{};
+        timestamp_label.key_id = _end_timestamp_ns_str_id;
+        timestamp_label.str_id = 0;
+        timestamp_label.num = uptime_ns_to_epoch_ns(sample.timestamp_uptime_ns);
+        timestamp_label.num_unit_id = _nanoseconds_str_id;
+        visitor(timestamp_label);
+
+        for (const auto& label : sample.labels) {
+            visitor(label);
+        }
+    }
 
     /** @brief Get profile start timestamp (uptime nanoseconds converted to epoch) */
     int64_t start_timestamp() const { return uptime_ns_to_epoch_ns(_start_timestamp); };
@@ -195,7 +207,7 @@ public:
      * @brief Set the server time correction used for exported timestamps.
      * @param offset_ns Server time offset in nanoseconds
      */
-    void set_server_time_offset_ns(int64_t offset_ns);
+    void set_server_time_offset_ns(int64_t offset_ns) { _server_time_offset_ns = offset_ns; };
 
 private:
     /** @brief Deduplicated string table (index 0 is always empty string) */

--- a/DatadogProfiling/Mach/profile.cpp
+++ b/DatadogProfiling/Mach/profile.cpp
@@ -83,6 +83,7 @@ std::string uuid_string(const uuid_t uuid) {
 profile::profile(uint64_t sampling_interval_ns) 
     : _sampling_interval_ns(sampling_interval_ns)
     , _epoch_offset(uptime_epoch_offset())
+    , _server_time_offset_ns(0)
     , _start_timestamp(0)
     , _end_timestamp(0) {
     
@@ -106,7 +107,11 @@ profile::profile(uint64_t sampling_interval_ns)
  * @return Epoch time in nanoseconds
  */
 int64_t profile::uptime_ns_to_epoch_ns(uint64_t uptime_ns) const {
-    return static_cast<int64_t>(uptime_ns) + _epoch_offset;
+    return static_cast<int64_t>(uptime_ns) + _epoch_offset + _server_time_offset_ns;
+}
+
+void profile::set_server_time_offset_ns(int64_t offset_ns) {
+    _server_time_offset_ns = offset_ns;
 }
 
 /**
@@ -121,7 +126,7 @@ int64_t profile::uptime_ns_to_epoch_ns(uint64_t uptime_ns) const {
  * 
  * **Processing Steps:**
  * 1. Convert stack frames to deduplicated location IDs
- * 2. Create timestamp labels for each sample
+ * 2. Create labels for each sample
  * 3. Store sample values (sampling intervals)
  * 4. Add completed samples to the profile
  */
@@ -140,17 +145,9 @@ void profile::add_samples(const stack_trace_t* traces, size_t count) {
             location_ids.push_back(location_id);
         }
         
-        // Create labels with timestamp, tid, and thread name
+        // Create labels with tid and thread name. Timestamp label is written during serialization.
         std::vector<label_t> labels;
-        labels.reserve(3);
-        
-        // Add timestamp label (convert uptime nanoseconds to epoch)
-        label_t timestamp_label{};
-        timestamp_label.key_id = _end_timestamp_ns_str_id;
-        timestamp_label.str_id = 0;
-        timestamp_label.num = uptime_ns_to_epoch_ns(trace.timestamp);
-        timestamp_label.num_unit_id = _nanoseconds_str_id;
-        labels.push_back(timestamp_label);
+        labels.reserve(2);
         
         // Add thread ID label
         label_t thread_label{};
@@ -173,6 +170,7 @@ void profile::add_samples(const stack_trace_t* traces, size_t count) {
         // Create sample
         sample_t sample;
         sample.location_ids = std::move(location_ids);
+        sample.timestamp_uptime_ns = trace.timestamp;
         sample.labels = std::move(labels);
         sample.values = {static_cast<int64_t>(trace.sampling_interval_nanos)};
         
@@ -274,4 +272,3 @@ uint32_t profile::intern_location(const location_t& location) {
 } // namespace dd::profiler
 
 #endif // __APPLE__ && !TARGET_OS_WATCH
-

--- a/DatadogProfiling/Mach/profile.cpp
+++ b/DatadogProfiling/Mach/profile.cpp
@@ -110,10 +110,6 @@ int64_t profile::uptime_ns_to_epoch_ns(uint64_t uptime_ns) const {
     return static_cast<int64_t>(uptime_ns) + _epoch_offset + _server_time_offset_ns;
 }
 
-void profile::set_server_time_offset_ns(int64_t offset_ns) {
-    _server_time_offset_ns = offset_ns;
-}
-
 /**
  * @brief Process multiple stack traces into deduplicated samples
  * 
@@ -145,7 +141,7 @@ void profile::add_samples(const stack_trace_t* traces, size_t count) {
             location_ids.push_back(location_id);
         }
         
-        // Create labels with tid and thread name. Timestamp label is written during serialization.
+        // Create labels with tid and thread name. Timestamp labels are derived during serialization.
         std::vector<label_t> labels;
         labels.reserve(2);
         

--- a/DatadogProfiling/Mach/profile_pprof_packer.cpp
+++ b/DatadogProfiling/Mach/profile_pprof_packer.cpp
@@ -86,7 +86,7 @@ void perftools_profiles_profile_add_mappings(const std::vector<mapping_t>& mappi
 void perftools_profiles_profile_add_locations(const std::vector<location_t>& locations, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
 
 /** @brief Convert sample data to protobuf format */
-void perftools_profiles_profile_add_samples(const std::vector<sample_t>& samples, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
+void perftools_profiles_profile_add_samples(const profile& prof, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator);
 
 /**
  * @brief Pack profile data into pprof protobuf binary format
@@ -121,7 +121,7 @@ size_t profile_pprof_pack(const profile& prof, uint8_t** data) {
     perftools_profiles_profile_set_period(prof.wall_time_str_id(), prof.nanoseconds_str_id(), static_cast<int64_t>(prof.sampling_interval_ns()), pprof, &profile_allocator);
     perftools_profiles_profile_add_mappings(prof.mappings(), pprof, &profile_allocator);
     perftools_profiles_profile_add_locations(prof.locations(), pprof, &profile_allocator);
-    perftools_profiles_profile_add_samples(prof.samples(), pprof, &profile_allocator);
+    perftools_profiles_profile_add_samples(prof, pprof, &profile_allocator);
     
     // Calculate required buffer size and serialize to binary format
     size_t packed_size = perftools__profiles__profile__get_packed_size(pprof);
@@ -248,7 +248,8 @@ void perftools_profiles_profile_add_locations(const std::vector<location_t>& loc
     }
 }
 
-void perftools_profiles_profile_add_samples(const std::vector<sample_t>& samples, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+void perftools_profiles_profile_add_samples(const profile& prof, Perftools__Profiles__Profile* pprof, ProtobufCAllocator* allocator) {
+    const auto& samples = prof.samples();
     pprof->n_sample = samples.size();
     if (pprof->n_sample == 0) return;
     
@@ -282,22 +283,31 @@ void perftools_profiles_profile_add_samples(const std::vector<sample_t>& samples
         }
         
         // Set labels
-        sample->n_label = src_sample.labels.size();
-        if (sample->n_label > 0) {
-            sample->label = static_cast<Perftools__Profiles__Label**>(
-                pb_alloc(allocator, sample->n_label * sizeof(Perftools__Profiles__Label*))
+        sample->n_label = src_sample.labels.size() + 1;
+        sample->label = static_cast<Perftools__Profiles__Label**>(
+            pb_alloc(allocator, sample->n_label * sizeof(Perftools__Profiles__Label*))
+        );
+
+        auto* timestamp_label = static_cast<Perftools__Profiles__Label*>(
+            pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
+        );
+        perftools__profiles__label__init(timestamp_label);
+        timestamp_label->key = prof.end_timestamp_ns_str_id();
+        timestamp_label->str = 0;
+        timestamp_label->num = prof.epoch_timestamp_ns(src_sample.timestamp_uptime_ns);
+        timestamp_label->num_unit = prof.nanoseconds_str_id();
+        sample->label[0] = timestamp_label;
+
+        for (size_t i = 0; i < src_sample.labels.size(); ++i) {
+            auto* label = static_cast<Perftools__Profiles__Label*>(
+                pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
             );
-            for (size_t i = 0; i < src_sample.labels.size(); ++i) {
-                auto* label = static_cast<Perftools__Profiles__Label*>(
-                    pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
-                );
-                perftools__profiles__label__init(label);
-                label->key = src_sample.labels[i].key_id;
-                label->str = src_sample.labels[i].str_id;
-                label->num = src_sample.labels[i].num;
-                label->num_unit = src_sample.labels[i].num_unit_id;
-                sample->label[i] = label;
-            }
+            perftools__profiles__label__init(label);
+            label->key = src_sample.labels[i].key_id;
+            label->str = src_sample.labels[i].str_id;
+            label->num = src_sample.labels[i].num;
+            label->num_unit = src_sample.labels[i].num_unit_id;
+            sample->label[i + 1] = label;
         }
         
         pprof->sample[sample_idx] = sample;

--- a/DatadogProfiling/Mach/profile_pprof_packer.cpp
+++ b/DatadogProfiling/Mach/profile_pprof_packer.cpp
@@ -283,32 +283,24 @@ void perftools_profiles_profile_add_samples(const profile& prof, Perftools__Prof
         }
         
         // Set labels
-        sample->n_label = src_sample.labels.size() + 1;
+        sample->n_label = prof.label_count(src_sample);
         sample->label = static_cast<Perftools__Profiles__Label**>(
             pb_alloc(allocator, sample->n_label * sizeof(Perftools__Profiles__Label*))
         );
 
-        auto* timestamp_label = static_cast<Perftools__Profiles__Label*>(
-            pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
-        );
-        perftools__profiles__label__init(timestamp_label);
-        timestamp_label->key = prof.end_timestamp_ns_str_id();
-        timestamp_label->str = 0;
-        timestamp_label->num = prof.epoch_timestamp_ns(src_sample.timestamp_uptime_ns);
-        timestamp_label->num_unit = prof.nanoseconds_str_id();
-        sample->label[0] = timestamp_label;
-
-        for (size_t i = 0; i < src_sample.labels.size(); ++i) {
+        size_t label_idx = 0;
+        prof.for_each_label(src_sample, [&](const label_t& src_label) {
             auto* label = static_cast<Perftools__Profiles__Label*>(
                 pb_alloc(allocator, sizeof(Perftools__Profiles__Label))
             );
             perftools__profiles__label__init(label);
-            label->key = src_sample.labels[i].key_id;
-            label->str = src_sample.labels[i].str_id;
-            label->num = src_sample.labels[i].num;
-            label->num_unit = src_sample.labels[i].num_unit_id;
-            sample->label[i + 1] = label;
-        }
+            label->key = src_label.key_id;
+            label->str = src_label.str_id;
+            label->num = src_label.num;
+            label->num_unit = src_label.num_unit_id;
+            sample->label[label_idx] = label;
+            label_idx += 1;
+        });
         
         pprof->sample[sample_idx] = sample;
     }

--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -33,6 +33,8 @@ internal final class AppLaunchProfiler: ProfilingHandler {
 
     @ReadWriteLock
     private(set) var attributes: [AttributeKey: AttributeValue] = [:]
+    // Interval between device and server time.
+    private(set) var currentServerTimeOffset: TimeInterval = .zero
     private var currentRUMVitals: [String: Vital] = [:]
     private var hasProcessedAppLaunch: Bool = false
 
@@ -66,6 +68,8 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
         if case let .payload(message as TTIDMessage) = message {
             hasProcessedAppLaunch = true
             attributes = message.attributes
+            currentServerTimeOffset = message.ttid.serverTimeOffset
+            dd_profiler_set_server_time_offset_ns(message.ttid.serverTimeOffset.dd.toInt64Nanoseconds)
 
             if profilingSamplerProvider.isContinuousProfilingConfigured == false
                 && self.currentRUMVitals.didCompleteOperations() {

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -54,6 +54,8 @@ internal final class DatadogProfiler: ProfilingHandler {
     private(set) var attributes: [String: AttributeValue] = [:]
     @ReadWriteLock
     private var hasReceivedAppLaunchVital = false
+    // Interval between device and server time.
+    private(set) var currentServerTimeOffset: TimeInterval = .zero
     // Ongoing RUM Operations to attach to profiles.
     private var currentRUMVitals: [String: Vital] = [:]
     // App hangs to attach to profiles.
@@ -180,11 +182,14 @@ private extension DatadogProfiler {
 
 private extension DatadogProfiler {
     func handle(context: DatadogContext) {
+        dd_profiler_set_server_time_offset_ns(context.serverTimeOffset.dd.toInt64Nanoseconds)
+
         queue.async { [weak self] in
             guard let self else {
                 return
             }
 
+            currentServerTimeOffset = context.serverTimeOffset
             let previousConditions = hasConditionsToProfile
             hasConditionsToProfile = profilingConditions.canProfileApplication(with: context)
             let currentAppState = context.applicationStateHistory.currentState

--- a/DatadogProfiling/Sources/ProfilingHandler.swift
+++ b/DatadogProfiling/Sources/ProfilingHandler.swift
@@ -19,6 +19,7 @@ internal import DatadogMachProfiler
 
 internal protocol ProfilingHandler {
     var attributes: [AttributeKey: AttributeValue] { get }
+    var currentServerTimeOffset: TimeInterval { get }
     var operation: ProfilingOperation { get }
 
     var featureScope: FeatureScope { get }
@@ -44,8 +45,8 @@ extension ProfilingHandler {
         var attributes = self.attributes
 
         if rumVitals.isEmpty == false {
-            attributes[RUMCoreContext.IDs.vitalID] = rumVitals.map { $0.id }
-            attributes[RUMCoreContext.IDs.vitalLabel] = rumVitals.map { $0.name }
+            attributes[RUMCoreContext.IDs.vitalID] = rumVitals.map(\.id)
+            attributes[RUMCoreContext.IDs.vitalLabel] = rumVitals.map(\.name)
         }
 
         if let hangs {
@@ -72,6 +73,9 @@ extension ProfilingHandler {
         rumEvents: [RUMEvent],
         attributes: [AttributeKey: AttributeValue]
     ) {
+        let timeOffsetInNanoseconds = currentServerTimeOffset.dd.toInt64Nanoseconds
+        dd_pprof_set_server_time_offset_ns(profile, timeOffsetInNanoseconds)
+
         var data: UnsafeMutablePointer<UInt8>?
         let start = dd_pprof_get_start_timestamp_s(profile)
         let end = dd_pprof_get_end_timestamp_s(profile)

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -212,6 +212,42 @@ final class AppLaunchProfilerTests: XCTestCase {
         XCTAssertTrue(event.end >= event.start, "End timestamp should be >= start timestamp")
     }
 
+    func testReceive_withTTIDMessage_correctsAttachedVitalTimestampWithServerTimeOffset() throws {
+        // Given
+        let core = PassthroughCoreMock()
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
+        let serverTimeOffset: TimeInterval = 2
+        let launchDate = Date(timeIntervalSince1970: 10)
+        let launchVital = Vital.mockWith(
+            id: "launch-vital-id",
+            name: "launch-vital-name",
+            operationKey: nil,
+            stepType: nil,
+            date: launchDate,
+            serverTimeOffset: serverTimeOffset
+        )
+
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // When
+        _ = profiler.receive(
+            message: .payload(
+                TTIDMessage(
+                    attributes: mockRandomAttributes(),
+                    ttid: launchVital
+                )
+            ),
+            from: core
+        )
+
+        // Then
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let vitals = try rumEvents(from: metadata).filter { $0["type"] as? String == "vital" }
+        let start = try XCTUnwrap(vitals.first?["start_ns"] as? Int64)
+        XCTAssertEqual(start, launchDate.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.dd.toInt64Nanoseconds)
+    }
+
     // MARK: - Status Mapping Tests
 
     func testProfilingContextStatus_mapsCorrectlyFromDDProfilerStatus() {
@@ -487,12 +523,16 @@ final class AppLaunchProfilerTests: XCTestCase {
     }
 
     private func eventIDs(ofType type: String, from metadata: ProfileAttachments) throws -> [String] {
-        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
-        let rumEvents = try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
+        let rumEvents = try rumEvents(from: metadata)
 
         return rumEvents
             .filter { $0["type"] as? String == type }
             .compactMap { $0["id"] as? String }
+    }
+
+    private func rumEvents(from metadata: ProfileAttachments) throws -> [[String: Any]] {
+        let rumEventsData = try XCTUnwrap(metadata.rumEvents)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
     }
 }
 

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -244,6 +244,71 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
+    func testApplicationDidEnterBackground_correctsAttachedVitalTimestampWithServerTimeOffset() throws {
+        // Given
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(dateProvider: dateProvider)
+        let serverTimeOffset: TimeInterval = 2
+        let startDate = Date(timeIntervalSince1970: 10)
+        let startOperation = Vital.mockWith(
+            id: "operation-id",
+            name: "operation",
+            operationKey: "key",
+            stepType: .start,
+            date: startDate,
+            serverTimeOffset: serverTimeOffset
+        )
+        let endOperation = Vital.mockWith(
+            id: "operation-end-id",
+            name: "operation",
+            operationKey: startOperation.operationKey,
+            stepType: .end,
+            date: startDate.addingTimeInterval(1),
+            serverTimeOffset: serverTimeOffset
+        )
+
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+
+        _ = profiler.receive(
+            message: .payload(
+                OperationMessage(
+                    attributes: mockRandomAttributes(),
+                    operation: startOperation
+                )
+            ),
+            from: core
+        )
+        _ = profiler.receive(
+            message: .payload(
+                OperationMessage(
+                    attributes: mockRandomAttributes(),
+                    operation: endOperation
+                )
+            ),
+            from: core
+        )
+
+        // When
+        core.context = .mockWith(
+            serverTimeOffset: serverTimeOffset,
+            applicationStateHistory: .mockWith(
+                initialState: .active,
+                date: dateProvider.now.addingTimeInterval(-1),
+                transitions: [(state: .background, date: dateProvider.now)]
+            )
+        )
+        waitForProfileWrite {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let vitals = try typedRUMEvents(from: metadata).filter { $0["type"] as? String == "vital" }
+        let start = try XCTUnwrap(vitals.first?["start_ns"] as? Int64)
+        XCTAssertEqual(start, startDate.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.dd.toInt64Nanoseconds)
+        withExtendedLifetime(profiler) {}
+    }
+
     func testApplicationDidEnterBackground_includesLongTasksInProfile() throws {
         // Given
         let dateProvider = DateProviderMock()

--- a/DatadogProfiling/Tests/ProfileCxxTests.swift
+++ b/DatadogProfiling/Tests/ProfileCxxTests.swift
@@ -276,6 +276,36 @@ final class ProfileCxxTests: XCTestCase {
         perftools__profiles__profile__free_unpacked(unpackedProfile, nil)
     }
 
+    func testProfileSerialization_withServerTimeOffset_appliesOffsetWithoutMutatingSamples() throws {
+        // Given
+        let profile = dd_pprof_create(10_000_000)
+        defer { dd_pprof_destroy(profile) }
+        XCTAssertNotNil(profile)
+
+        let stackTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        stackTrace.pointee = .mockWith(
+            tid: 1,
+            addresses: [0x100001000],
+            timestamp: 1_000_000_000
+        )
+        defer { dd_free(stackTrace) }
+
+        dd_pprof_add_samples(profile, stackTrace, 1)
+        let originalStart = dd_pprof_get_start_timestamp_s(profile)
+
+        // When
+        dd_pprof_set_server_time_offset_ns(profile, 2_000_000_000)
+        let firstTimestamp = try firstSerializedSampleEndTimestampSeconds(from: profile)
+
+        dd_pprof_set_server_time_offset_ns(profile, 3_000_000_000)
+        let secondTimestamp = try firstSerializedSampleEndTimestampSeconds(from: profile)
+
+        // Then
+        XCTAssertEqual(dd_pprof_get_start_timestamp_s(profile), originalStart + 3, accuracy: 0.001)
+        XCTAssertEqual(firstTimestamp, originalStart + 2, accuracy: 0.001)
+        XCTAssertEqual(secondTimestamp, originalStart + 3, accuracy: 0.001)
+    }
+
     func testProfileSerialization_withNilProfile_returnsZero() {
         // When
         var data: UnsafeMutablePointer<UInt8>?
@@ -341,6 +371,33 @@ final class ProfileCxxTests: XCTestCase {
         XCTAssertGreaterThan(unpackedProfile.pointee.n_location, 0, "Should have locations")
         XCTAssertGreaterThan(unpackedProfile.pointee.n_mapping, 0, "Should have mappings")
         XCTAssertEqual(unpackedProfile.pointee.n_sample_type, 1, "Should have one sample type")
+    }
+
+    private func firstSerializedSampleEndTimestampSeconds(from profile: OpaquePointer?) throws -> TimeInterval {
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        let sample = try XCTUnwrap(unpackedProfile.pointee.sample[0])
+        var timestamp: TimeInterval?
+
+        for index in 0..<sample.pointee.n_label {
+            guard let label = sample.pointee.label?[index],
+                  let key = unpackedProfile.pointee.string_table[Int(label.pointee.key)]
+            else {
+                continue
+            }
+
+            if String(cString: key) == "end_timestamp_ns" {
+                timestamp = TimeInterval(label.pointee.num) / 1_000_000_000
+                break
+            }
+        }
+
+        return try XCTUnwrap(timestamp)
     }
 }
 ///  Deallocates a stack_trace_t and its subsequent frames

--- a/DatadogProfiling/Tests/ProfilingHandlerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingHandlerTests.swift
@@ -24,6 +24,7 @@ final class ProfilingHandlerTests: XCTestCase {
         core = PassthroughCoreMock()
         handler = ProfilingHandlerMock(
             attributes: [:],
+            currentServerTimeOffset: .zero,
             operation: .appLaunch,
             featureScope: core.scope(for: ProfilerFeature.self),
             telemetryController: .init(),
@@ -227,6 +228,40 @@ final class ProfilingHandlerTests: XCTestCase {
         XCTAssertEqual(errorEvent["duration_ns"] as? NSNumber, NSNumber(value: hang.duration))
     }
 
+    func testWrite_withServerTimeOffset_updatesExportedProfileDatesAndRumVitalTimestamps() throws {
+        // Given
+        let serverTimeOffset: TimeInterval = 2
+        let vitalDate = Date(timeIntervalSince1970: 10)
+        handler.currentServerTimeOffset = serverTimeOffset
+        let vital = Vital.mockWith(
+            id: "vital-id",
+            name: "vital-name",
+            operationKey: nil,
+            stepType: nil,
+            date: vitalDate,
+            serverTimeOffset: serverTimeOffset
+        )
+
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        Thread.sleep(forTimeInterval: 0.05)
+        let profile = try XCTUnwrap(dd_profiler_flush_and_get_profile())
+        let originalStart = dd_pprof_get_start_timestamp_s(profile)
+        let originalEnd = dd_pprof_get_end_timestamp_s(profile)
+
+        // When
+        handler.write(profile: profile, rumVitals: [vital])
+
+        // Then
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        XCTAssertEqual(event.start.timeIntervalSince1970, originalStart + serverTimeOffset, accuracy: 0.001)
+        XCTAssertEqual(event.end.timeIntervalSince1970, originalEnd + serverTimeOffset, accuracy: 0.001)
+
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let vitalsFromJson = try typedRUMEvents(from: metadata).filter { $0["type"] as? String == "vital" }
+        let start = try XCTUnwrap(vitalsFromJson.first?["start_ns"] as? Int64)
+        XCTAssertEqual(start, vitalDate.addingTimeInterval(serverTimeOffset).timeIntervalSince1970.dd.toInt64Nanoseconds)
+    }
+
     private func typedRUMEvents(from metadata: ProfileAttachments) throws -> [[String: Any]] {
         let rumEventsData = try XCTUnwrap(metadata.rumEvents)
         return try XCTUnwrap(JSONSerialization.jsonObject(with: rumEventsData) as? [[String: Any]])
@@ -235,6 +270,7 @@ final class ProfilingHandlerTests: XCTestCase {
 
 private struct ProfilingHandlerMock: ProfilingHandler {
     var attributes: [AttributeKey: AttributeValue]
+    var currentServerTimeOffset: TimeInterval
     var operation: ProfilingOperation
     var featureScope: FeatureScope
     var telemetryController: ProfilingTelemetryController

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -467,12 +467,18 @@ extension Monitor: RUMMonitorProtocol {
 
         telemetry.usage(event: .addOperationStepVital(.init(actionType: .start)))
         telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
+
+        var serverTimeOffset: TimeInterval = .zero
+        if let viewScope = self.applicationScope.activeSession?.viewScopes.last {
+            serverTimeOffset = viewScope.serverTimeOffset
+        }
         let vital = Vital(
             id: rumUUIDGenerator.generateUnique().toRUMDataFormat,
             name: name,
             operationKey: operationKey,
             stepType: .start,
-            date: dateProvider.now
+            date: dateProvider.now,
+            serverTimeOffset: serverTimeOffset
         )
 
         if let options = options as? ProfilingOptions,

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -466,35 +466,16 @@ extension Monitor: RUMMonitorProtocol {
         DD.logger.debug("Feature Operation `\(name)`\(instanceSuffix(operationKey)) started")
 
         telemetry.usage(event: .addOperationStepVital(.init(actionType: .start)))
-        telemetry.send(telemetry: .usage(.init(event: .addOperationStepVital(.init(actionType: .start)))))
-
-        var serverTimeOffset: TimeInterval = .zero
-        if let viewScope = self.applicationScope.activeSession?.viewScopes.last {
-            serverTimeOffset = viewScope.serverTimeOffset
-        }
-        let vital = Vital(
-            id: rumUUIDGenerator.generateUnique().toRUMDataFormat,
-            name: name,
-            operationKey: operationKey,
-            stepType: .start,
-            date: dateProvider.now,
-            serverTimeOffset: serverTimeOffset
-        )
-
-        if let options = options as? ProfilingOptions,
-           applicationScope.activeSession?.sampler.combined(with: options.sampleRate).sample() ?? false {
-            let attributes = applicationScope.activeSession?.rumContextAttributes ?? applicationScope.rumContextAttributes
-            featureScope.send(message: .payload(OperationMessage(attributes: attributes, operation: vital)))
-        }
 
         process(
             command: RUMOperationStepVitalCommand(
-                vitalId: vital.id,
-                name: vital.name,
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
                 operationKey: operationKey,
                 stepType: .start,
                 failureReason: nil,
-                time: vital.date,
+                options: options,
+                time: dateProvider.now,
                 attributes: attributes
             )
         )
@@ -509,25 +490,14 @@ extension Monitor: RUMMonitorProtocol {
 
         telemetry.usage(event: .addOperationStepVital(.init(actionType: .succeed)))
 
-        let vital = Vital(
-            id: rumUUIDGenerator.generateUnique().toRUMDataFormat,
-            name: name,
-            operationKey: operationKey,
-            stepType: .end,
-            date: dateProvider.now
-        )
-
-        let attributes = applicationScope.activeSession?.rumContextAttributes ?? applicationScope.rumContextAttributes
-        featureScope.send(message: .payload(OperationMessage(attributes: attributes, operation: vital)))
-
         process(
             command: RUMOperationStepVitalCommand(
-                vitalId: vital.id,
-                name: vital.name,
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
                 operationKey: operationKey,
                 stepType: .end,
                 failureReason: nil,
-                time: vital.date,
+                time: dateProvider.now,
                 attributes: attributes
             )
         )
@@ -542,25 +512,14 @@ extension Monitor: RUMMonitorProtocol {
 
         telemetry.usage(event: .addOperationStepVital(.init(actionType: .fail)))
 
-        let vital = Vital(
-            id: rumUUIDGenerator.generateUnique().toRUMDataFormat,
-            name: name,
-            operationKey: operationKey,
-            stepType: .end,
-            date: dateProvider.now
-        )
-
-        let attributes = applicationScope.activeSession?.rumContextAttributes ?? applicationScope.rumContextAttributes
-        featureScope.send(message: .payload(OperationMessage(attributes: attributes, operation: vital)))
-
         process(
             command: RUMOperationStepVitalCommand(
-                vitalId: vital.id,
-                name: vital.name,
+                vitalId: rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: name,
                 operationKey: operationKey,
                 stepType: .end,
                 failureReason: reason,
-                time: vital.date,
+                time: dateProvider.now,
                 attributes: attributes
             )
         )

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -756,6 +756,8 @@ internal struct RUMOperationStepVitalCommand: RUMCommand {
     var stepType: RUMVitalOperationStepEvent.Vital.StepType
     /// The reason for failure, if applicable
     var failureReason: RUMVitalOperationStepEvent.Vital.FailureReason?
+    /// Additional options for this operation.
+    var options: OperationOptions? = nil
     // Common properties
     var time: Date
     var globalAttributes: [AttributeKey: AttributeValue] = [:]

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -74,6 +74,7 @@ private extension RUMAppLaunchManager {
                 id: ttidVitalId,
                 name: RUMVitalAppLaunchEvent.Vital.AppLaunchMetric.ttid.name,
                 date: context.launchInfo.processLaunchDate,
+                serverTimeOffset: context.serverTimeOffset,
                 duration: ttid.dd.toInt64Nanoseconds
             ),
             activeView: activeView
@@ -199,7 +200,9 @@ private extension RUMAppLaunchManager {
             ciTest: dependencies.ciTest,
             connectivity: .init(context: context),
             context: RUMEventAttributes(contextInfo: attributes),
-            date: context.launchInfo.processLaunchDate.timeIntervalSince1970.dd.toInt64Milliseconds,
+            date: context.launchInfo.processLaunchDate
+                .addingTimeInterval(context.serverTimeOffset)
+                .timeIntervalSince1970.dd.toInt64Milliseconds,
             ddtags: context.ddTags,
             device: context.normalizedDevice(),
             os: context.os,

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -35,12 +35,14 @@ internal class RUMFeatureOperationManager {
 
     private unowned let parent: RUMContextProvider
     private let dependencies: RUMScopeDependencies
+    private let sessionSampler: DeterministicSampler
 
     // MARK: - Initialization
 
-    init(parent: RUMContextProvider, dependencies: RUMScopeDependencies) {
+    init(parent: RUMContextProvider, dependencies: RUMScopeDependencies, sessionSampler: DeterministicSampler) {
         self.parent = parent
         self.dependencies = dependencies
+        self.sessionSampler = sessionSampler
     }
 
     // MARK: - Public Interface
@@ -96,6 +98,21 @@ internal class RUMFeatureOperationManager {
             profiling = .init(errorReason: profilingContext.error, status: profilingContext.profilingStatus)
         }
 
+        if shouldSendOperationMessage(for: command) {
+            let message = OperationMessage(
+                attributes: parent.rumContextAttributes,
+                operation: Vital(
+                    id: command.vitalId,
+                    name: command.name,
+                    operationKey: command.operationKey,
+                    stepType: command.stepType,
+                    date: command.time,
+                    serverTimeOffset: context.serverTimeOffset
+                )
+            )
+            dependencies.featureScope.send(message: .payload(message))
+        }
+
         let vitalEvent = RUMVitalOperationStepEvent(
             dd: .init(profiling: profiling),
             account: .init(context: context),
@@ -129,6 +146,20 @@ internal class RUMFeatureOperationManager {
         )
 
         writer.write(value: vitalEvent)
+    }
+
+    private func shouldSendOperationMessage(for command: RUMOperationStepVitalCommand) -> Bool {
+        switch command.stepType {
+        case .start:
+            guard let options = command.options as? ProfilingOptions else {
+                return false
+            }
+            return sessionSampler.combined(with: options.sampleRate).sample()
+        case .end:
+            return true
+        case .update, .retry:
+            return false
+        }
     }
 
     private func trackOperationStart(name: String, operationKey: String?, lookupKey: String) {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -55,7 +55,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private let applicationState: RUMApplicationState
     /// Feature Operation manager for processing Feature Operation commands.
     private lazy var featureOperationManager: RUMFeatureOperationManager = {
-        RUMFeatureOperationManager(parent: self, dependencies: dependencies)
+        RUMFeatureOperationManager(parent: self, dependencies: dependencies, sessionSampler: sampler)
     }()
     /// App launch manager to process TTID and TTFD commands.
     private lazy var appLaunchManager: RUMAppLaunchManager = {

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -25,7 +25,8 @@ class RUMFeatureOperationManagerTests: XCTestCase {
 
         manager = RUMFeatureOperationManager(
             parent: mockParent,
-            dependencies: mockDependencies
+            dependencies: mockDependencies,
+            sessionSampler: .mockKeepAll()
         )
     }
 
@@ -89,6 +90,41 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         XCTAssertEqual(vital.stepType, command.stepType)
         XCTAssertEqual(vital.failureReason, command.failureReason)
         XCTAssertNil(vital.vitalDescription)
+    }
+
+    func testFeatureOperationCommand_sendsOperationMessageWithServerTimeOffset() throws {
+        // Given
+        let featureScope = FeatureScopeMock()
+        mockDependencies = .mockWith(featureScope: featureScope)
+        manager = RUMFeatureOperationManager(
+            parent: mockParent,
+            dependencies: mockDependencies,
+            sessionSampler: .mockKeepAll()
+        )
+        mockContext.serverTimeOffset = 2
+        let command: RUMOperationStepVitalCommand = .mockWith(
+            stepType: .start,
+            options: ProfilingOptions(sampleRate: .maxSampleRate),
+            time: Date()
+        )
+
+        // When
+        manager.process(command, context: mockContext, writer: mockWriter, activeView: .mockAny())
+
+        // Then
+        let message = try XCTUnwrap(
+            featureScope.messagesSent().compactMap { $0.asPayload as? OperationMessage }.first
+        )
+        XCTAssertEqual(message.operation.serverTimeOffset, mockContext.serverTimeOffset)
+        XCTAssertEqual(message.operation.date, command.time)
+
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalOperationStepEvent.self).first)
+        XCTAssertEqual(
+            event.date,
+            command.time
+                .addingTimeInterval(mockContext.serverTimeOffset)
+                .timeIntervalSince1970.dd.toInt64Milliseconds
+        )
     }
 
     func testProcess_MultipleOperations_CreatesCorrectNumberOfEvents() {
@@ -250,7 +286,8 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         mockDependencies = RUMScopeDependencies.mockWith(syntheticsTest: syntheticsTest)
         manager = RUMFeatureOperationManager(
             parent: mockParent,
-            dependencies: mockDependencies
+            dependencies: mockDependencies,
+            sessionSampler: .mockKeepAll()
         )
 
         let command = RUMOperationStepVitalCommand.mockRandom()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -92,6 +92,40 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertNotNil(event.version)
     }
 
+    func testTTIDCommand_appliesServerTimeOffsetToAppLaunchEventAndProfilerMessage() throws {
+        // Given
+        let featureScope = FeatureScopeMock()
+        mockDependencies = .mockWith(featureScope: featureScope, appStateManager: appStateManager)
+        manager = RUMAppLaunchManager(
+            parent: mockParent,
+            dependencies: mockDependencies,
+            telemetryController: .init()
+        )
+        mockContext.serverTimeOffset = 2
+        let command: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(1)
+        )
+
+        // When
+        manager.process(command, context: mockContext, writer: mockWriter)
+
+        // Then
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalAppLaunchEvent.self).first)
+        XCTAssertEqual(
+            event.date,
+            mockContext.launchInfo.processLaunchDate
+                .addingTimeInterval(mockContext.serverTimeOffset)
+                .timeIntervalSince1970
+                .dd
+                .toInt64Milliseconds
+        )
+
+        let message = try XCTUnwrap(
+            featureScope.messagesSent().compactMap { $0.asPayload as? TTIDMessage }.first
+        )
+        XCTAssertEqual(message.ttid.serverTimeOffset, mockContext.serverTimeOffset)
+    }
+
     func testTTIDCommand_createsAppLaunchVitalEventForPreWarmingLaunches() throws {
         // Given
         let processLaunchDate = Date()

--- a/TestUtilities/Sources/Mocks/DatadogProfiling/VitalMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogProfiling/VitalMock.swift
@@ -29,8 +29,17 @@ extension Vital: AnyMockable, RandomMockable {
         operationKey: String? = .mockAny(),
         stepType: RUMVitalOperationStepEvent.Vital.StepType? = .start,
         date: Date = .mockAny(),
+        serverTimeOffset: TimeInterval = .zero,
         duration: Int64? = nil
     ) -> Self {
-        .init(id: id, name: name, operationKey: operationKey, stepType: stepType, date: date, duration: duration)
+        .init(
+            id: id,
+            name: name,
+            operationKey: operationKey,
+            stepType: stepType,
+            date: date,
+            serverTimeOffset: serverTimeOffset,
+            duration: duration
+        )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -947,6 +947,7 @@ extension RUMOperationStepVitalCommand: AnyMockable, RandomMockable {
         operationKey: String? = .mockAny(),
         stepType: RUMVitalOperationStepEvent.Vital.StepType = .mockAny(),
         failureReason: RUMFeatureOperationFailureReason = .mockAny(),
+        options: OperationOptions? = nil,
         time: Date = .mockAny(),
         globalAttributes: [AttributeKey: AttributeValue] = [:],
         attributes: [AttributeKey: AttributeValue] = [:]
@@ -957,6 +958,7 @@ extension RUMOperationStepVitalCommand: AnyMockable, RandomMockable {
             operationKey: operationKey,
             stepType: stepType,
             failureReason: failureReason,
+            options: options,
             time: time,
             globalAttributes: globalAttributes,
             attributes: attributes


### PR DESCRIPTION
### What and why?

This PR aligns Datadog Profiling timestamps with the SDK server time offset used by RUM, so profiles and attached RUM events use consistent wall-clock dates when device time drifts from server time.

### How?

Profiling samples now keep their raw uptime timestamp and the C++ profiler stores the latest server time offset. During `pprof` serialization, each sample's `end_timestamp_ns` label is computed from raw uptime plus the epoch offset and server time offset.

Swift propagates the server time offset to the C++ profiler when context updates are received and applies the current offset again before profile export as a final guard. App launch profiling uses the offset carried by the TTID vital so the harvested profile and attached RUM vital are aligned. RUM app launch vital and RUM operation vitals now carry the server offset when encoding their start timestamps.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
