### PR TITLE
Add StatsConcentrator for time-bucketed span aggregation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1160,6 +1160,8 @@
 		E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */; };
 		E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */; };
 		E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */; };
+		E7CSS02129C4D5A800000021 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */; };
+		E7CSS02329C4D5A800000023 /* StatsConcentratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS02629C4D5A800000026 /* StatsConcentratorTests.swift */; };
 		D2C1A50B29C4C4CB00946C31 /* SpanEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */; };
 		D2C1A50C29C4C4CB00946C31 /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
 		D2C1A50D29C4C4CB00946C31 /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
@@ -2804,6 +2806,8 @@
 		E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeature.swift; sourceTree = "<group>"; };
 		E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
 		E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeatureTests.swift; sourceTree = "<group>"; };
+		E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentrator.swift; sourceTree = "<group>"; };
+		E7CSS02629C4D5A800000026 /* StatsConcentratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentratorTests.swift; sourceTree = "<group>"; };
 		D2546C0729AF55E90054E00B /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		D2546C0A29AF56270054E00B /* MessageReceivers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceivers.swift; sourceTree = "<group>"; };
 		D2552AF42BBC47D900A45725 /* WebEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEventIntegrationTests.swift; sourceTree = "<group>"; };
@@ -6227,6 +6231,7 @@
 				D2546C0A29AF56270054E00B /* MessageReceivers.swift */,
 				E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */,
 				E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */,
+				E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -6280,6 +6285,7 @@
 				61C5A89924509C1100DA608C /* Utils */,
 				619CE7602A458D66005588CB /* TraceTests.swift */,
 				E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */,
+				E7CSS02629C4D5A800000026 /* StatsConcentratorTests.swift */,
 			);
 			name = DatadogTraceTests;
 			path = ../DatadogTrace/Tests;
@@ -8716,6 +8722,7 @@
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
 				E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */,
 				E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */,
+				E7CSS02129C4D5A800000021 /* StatsConcentrator.swift in Sources */,
 				E7CSS01129C4D5A800000011 /* SpanSnapshot.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
@@ -8739,6 +8746,7 @@
 				3C6C7FFD2B459AF6006F5CBC /* OTelSpanTests.swift in Sources */,
 				619CE7612A458D66005588CB /* TraceTests.swift in Sources */,
 				E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */,
+				E7CSS02329C4D5A800000023 /* StatsConcentratorTests.swift in Sources */,
 				E7CSS01329C4D5A800000013 /* SpanSnapshotTests.swift in Sources */,
 				615192D02BD6B7C90005A782 /* DatadogTracer+InjectAndExtract.swift in Sources */,
 				D2C1A52029C4C75700946C31 /* DDSpanTests.swift in Sources */,

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -165,8 +165,10 @@ internal final class DDSpan: OTSpan {
             }
         }
 
-        let startNanos = startTime.timeIntervalSince1970.toNanoseconds
-        let durationNanos = finishTime.timeIntervalSince(startTime).toNanoseconds
+        let startNanos = startTime.timeIntervalSince1970.dd.toNanoseconds
+        let durationNanos = finishTime.timeIntervalSince(startTime).dd.toNanoseconds
+
+        let spanType = tags["span.type"] as? String ?? "custom"
 
         return SpanSnapshot(
             traceID: ddContext.traceID,
@@ -175,6 +177,7 @@ internal final class DDSpan: OTSpan {
             service: resolvedService,
             operationName: resolvedOperationName,
             resource: resolvedResource,
+            type: spanType,
             spanKind: spanKind,
             httpStatusCode: httpStatusCode,
             isError: isError,

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -19,12 +19,68 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
     let messageReceiver: FeatureMessageReceiver
     let performanceOverride: PerformancePresetOverride?
 
-    init(core: DatadogCoreProtocol, configuration: Trace.Configuration) {
+    let concentrator: StatsConcentrator
+    private let featureScope: FeatureScope
+    private let dateProvider: DateProvider
+    private var flushTimer: Timer?
+
+    /// Interval between periodic flushes (default: 30 seconds).
+    let flushInterval: TimeInterval
+
+    init(
+        core: DatadogCoreProtocol,
+        configuration: Trace.Configuration,
+        dateProvider: DateProvider,
+        flushInterval: TimeInterval = 30
+    ) {
         self.requestBuilder = StatsRequestBuilder(
             customIntakeURL: configuration.customEndpoint,
             telemetry: core.telemetry
         )
         self.messageReceiver = NOPFeatureMessageReceiver()
         self.performanceOverride = nil
+        self.dateProvider = dateProvider
+        self.flushInterval = flushInterval
+        self.featureScope = core.scope(for: ClientStatsFeature.self)
+
+        let now = dateProvider.now.timeIntervalSince1970.dd.toNanoseconds
+        self.concentrator = StatsConcentrator(now: now)
+
+        startFlushTimer()
+    }
+
+    deinit {
+        flushTimer?.invalidate()
+    }
+
+    /// Flushes completed buckets and writes them to the feature storage for upload.
+    func flushStats(force: Bool = false) {
+        let now = dateProvider.now.timeIntervalSince1970.dd.toNanoseconds
+        let exportedBuckets = concentrator.flush(now: now, force: force)
+
+        guard !exportedBuckets.isEmpty else {
+            return
+        }
+
+        featureScope.eventWriteContext { _, writer in
+            for bucket in exportedBuckets {
+                writer.write(value: bucket)
+            }
+        }
+    }
+
+    private func startFlushTimer() {
+        flushTimer = Timer.scheduledTimer(
+            withTimeInterval: flushInterval,
+            repeats: true
+        ) { [weak self] _ in
+            self?.flushStats()
+        }
+    }
+}
+
+extension ClientStatsFeature: Flushable {
+    func flush() {
+        flushStats(force: true)
     }
 }

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -54,6 +54,10 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
     }
 
     /// Flushes completed buckets and writes them to the feature storage for upload.
+    ///
+    /// - Parameter force: When `true`, flushes all buckets regardless of age (used during
+    ///   SDK teardown via `Flushable`). When `false`, only buckets older than the buffer
+    ///   window are flushed (normal periodic flush).
     func flushStats(force: Bool = false) {
         let now = dateProvider.now.timeIntervalSince1970.dd.toNanoseconds
         let exportedBuckets = concentrator.flush(now: now, force: force)

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -1,0 +1,349 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+// MARK: - Trilean
+
+/// Matches the protobuf `Trilean` enum used in `ClientGroupedStats.is_trace_root`.
+internal enum Trilean: Int, Encodable, Hashable, Sendable {
+    case notSet = 0
+    case `true` = 1
+    case `false` = 2
+}
+
+// MARK: - Aggregation Key
+
+/// The set of dimensions by which spans are grouped within a time bucket.
+/// Matches the Go reference `BucketsAggregationKey` in `aggregation.go`.
+internal struct AggregationKey: Hashable, Sendable {
+    let service: String
+    let operationName: String
+    let resource: String
+    let httpStatusCode: UInt32
+    let type: String
+    let spanKind: String
+    let isTraceRoot: Trilean
+    let synthetics: Bool
+    let peerTagsHash: UInt64
+    let serviceSource: String
+}
+
+// MARK: - Grouped Stats
+
+/// Running counters for a single aggregation key within a time bucket.
+internal final class GroupedStats {
+    var hits: Double = 0
+    var topLevelHits: Double = 0
+    var errors: Double = 0
+    var duration: Double = 0
+    /// Peer tags stored as `"key:value"` pairs for export, matching Go's `matchingPeerTags`.
+    let peerTags: [String]
+
+    init(peerTags: [String]) {
+        self.peerTags = peerTags
+    }
+}
+
+// MARK: - Stats Bucket
+
+/// A single time bucket holding grouped stats keyed by aggregation dimensions.
+internal final class StatsBucket {
+    let start: UInt64
+    let duration: UInt64
+    var groups: [AggregationKey: GroupedStats] = [:]
+
+    init(start: UInt64, duration: UInt64) {
+        self.start = start
+        self.duration = duration
+    }
+}
+
+// MARK: - Exportable Bucket
+
+/// A flushed bucket ready for serialization and upload.
+internal struct ExportedBucket: Encodable, Sendable {
+    let start: UInt64
+    let duration: UInt64
+    let stats: [ExportedGroupedStats]
+}
+
+/// A single grouped stats entry ready for serialization.
+internal struct ExportedGroupedStats: Encodable, Sendable {
+    let service: String
+    let name: String
+    let resource: String
+    let httpStatusCode: UInt32
+    let type: String
+    let spanKind: String
+    let isTraceRoot: Trilean
+    let synthetics: Bool
+    let hits: UInt64
+    let errors: UInt64
+    let duration: UInt64
+    let topLevelHits: UInt64
+    let okSummary: Data
+    let errorSummary: Data
+    let peerTags: [String]
+    let serviceSource: String
+}
+
+// MARK: - Eligible Span Kinds
+
+/// Span kinds eligible for stats computation per the v1.2.0 spec.
+private let eligibleSpanKinds: Set<String> = ["server", "consumer", "client", "producer"]
+
+/// Span kinds for which peer tags should be included in the aggregation key.
+private let peerTagSpanKinds: Set<String> = ["client", "producer", "consumer"]
+
+// MARK: - FNV-64a Hash
+
+/// Computes an FNV-64a hash of sorted tag strings, matching Go's `tagsFnvHash`.
+internal func fnv64a(_ tags: [String]) -> UInt64 {
+    if tags.isEmpty {
+        return 0
+    }
+    let sorted = tags.sorted()
+    var hash: UInt64 = 14_695_981_039_346_656_037 // FNV offset basis
+    let prime: UInt64 = 1_099_511_628_211
+
+    for (i, tag) in sorted.enumerated() {
+        if i > 0 {
+            hash ^= 0 // null separator byte
+            hash = hash &* prime
+        }
+        for byte in tag.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* prime
+        }
+    }
+    return hash
+}
+
+// MARK: - Stochastic Rounding
+
+/// Converts a floating-point count to UInt64 using stochastic rounding.
+/// When weight is always 1.0, this is effectively a truncation to integer.
+internal func stochasticRound(_ value: Double) -> UInt64 {
+    let truncated = UInt64(value)
+    let fractional = value - Double(truncated)
+    if Double.random(in: 0..<1) < fractional {
+        return truncated + 1
+    }
+    return truncated
+}
+
+// MARK: - Stats Concentrator
+
+/// Aggregates `SpanSnapshot`s into time-bucketed stats (hit counts, error counts,
+/// duration totals) keyed by aggregation dimensions.
+///
+/// Thread-safety: Access to `buckets` and `oldestTs` is protected by a `ReadWriteLock`.
+/// `add()` and `flush()` can be called from any thread.
+internal final class StatsConcentrator: @unchecked Sendable {
+    /// Default bucket duration: 10 seconds in nanoseconds.
+    static let defaultBucketDuration: Nanoseconds = 10_000_000_000
+
+    /// Number of bucket-duration windows to keep before flushing.
+    /// Matches Go's `defaultBufferLen = 2` (current + previous bucket).
+    static let defaultBufferLen = 2
+
+    /// Configured peer tag keys to extract from spans.
+    static let defaultPeerTagKeys: [String] = [
+        "peer.service",
+        "db.instance",
+        "db.system",
+        "out.host",
+        "net.peer.name",
+        "server.address"
+    ]
+
+    private let bucketDuration: Nanoseconds
+    private let bufferLen: Int
+    private let peerTagKeys: [String]
+
+    @ReadWriteLock
+    private var buckets: [UInt64: StatsBucket] = [:]
+
+    @ReadWriteLock
+    private var oldestTs: UInt64
+
+    init(
+        bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
+        bufferLen: Int = StatsConcentrator.defaultBufferLen,
+        peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys,
+        now: Nanoseconds
+    ) {
+        self.bucketDuration = bucketDuration
+        self.bufferLen = bufferLen
+        self.peerTagKeys = peerTagKeys
+        self.oldestTs = StatsConcentrator.alignTimestamp(now, bucketDuration: bucketDuration)
+    }
+
+    // MARK: - Add
+
+    /// Records a span snapshot into the appropriate time bucket.
+    /// Ineligible spans are silently discarded.
+    func add(_ snapshot: SpanSnapshot) {
+        guard Self.isEligible(snapshot) else {
+            return
+        }
+
+        let endTime = snapshot.startTime + snapshot.duration
+        let matchingPeerTags = self.matchingPeerTags(for: snapshot)
+        let aggregationKey = makeAggregationKey(from: snapshot, peerTags: matchingPeerTags)
+        let peerTagStrings = matchingPeerTags.map { "\($0.key):\($0.value)" }
+
+        _buckets.mutate { buckets in
+            let bucketKey = max(
+                Self.alignTimestamp(endTime, bucketDuration: self.bucketDuration),
+                self.oldestTs
+            )
+            let bucket = buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: self.bucketDuration)]
+
+            let group = bucket.groups[aggregationKey, default: GroupedStats(peerTags: peerTagStrings)]
+
+            group.hits += 1
+            if snapshot.isError {
+                group.errors += 1
+            }
+            group.duration += Double(snapshot.duration)
+            if snapshot.isTopLevel {
+                group.topLevelHits += 1
+            }
+
+            bucket.groups[aggregationKey] = group
+            buckets[bucketKey] = bucket
+        }
+    }
+
+    // MARK: - Flush
+
+    /// Flushes completed buckets and returns them for export.
+    ///
+    /// - Parameter force: When `true`, flushes all buckets regardless of age.
+    ///   Used during SDK teardown.
+    /// - Parameter now: Current time in nanoseconds.
+    /// - Returns: Array of exported buckets ready for serialization.
+    func flush(now: Nanoseconds, force: Bool) -> [ExportedBucket] {
+        var flushed: [ExportedBucket] = []
+
+        _buckets.mutate { buckets in
+            let cutoff = Int64(now) - Int64(self.bufferLen) * Int64(self.bucketDuration)
+            var keysToRemove: [UInt64] = []
+
+            for (ts, bucket) in buckets {
+                if !force && Int64(ts) > cutoff {
+                    continue
+                }
+                keysToRemove.append(ts)
+
+                let exportedStats: [ExportedGroupedStats] = bucket.groups.map { key, group in
+                    ExportedGroupedStats(
+                        service: key.service,
+                        name: key.operationName,
+                        resource: key.resource,
+                        httpStatusCode: key.httpStatusCode,
+                        type: key.type,
+                        spanKind: key.spanKind,
+                        isTraceRoot: key.isTraceRoot,
+                        synthetics: key.synthetics,
+                        hits: stochasticRound(group.hits),
+                        errors: stochasticRound(group.errors),
+                        duration: stochasticRound(group.duration),
+                        topLevelHits: stochasticRound(group.topLevelHits),
+                        okSummary: Data(),
+                        errorSummary: Data(),
+                        peerTags: group.peerTags,
+                        serviceSource: key.serviceSource
+                    )
+                }
+
+                if !exportedStats.isEmpty {
+                    flushed.append(ExportedBucket(
+                        start: bucket.start,
+                        duration: bucket.duration,
+                        stats: exportedStats
+                    ))
+                }
+            }
+
+            for key in keysToRemove {
+                buckets.removeValue(forKey: key)
+            }
+        }
+
+        let aligned = Self.alignTimestamp(now, bucketDuration: bucketDuration)
+        let offset = UInt64(bufferLen - 1) * bucketDuration
+        let newOldestTs = aligned >= offset ? aligned - offset : 0
+        _oldestTs.mutate { oldest in
+            if newOldestTs > oldest {
+                oldest = newOldestTs
+            }
+        }
+
+        return flushed
+    }
+
+    // MARK: - Eligibility
+
+    /// A span is eligible for stats if it is top-level, measured, or has a
+    /// qualifying `span_kind` (server, consumer, client, producer).
+    static func isEligible(_ snapshot: SpanSnapshot) -> Bool {
+        if snapshot.isTopLevel {
+            return true
+        }
+        if snapshot.isMeasured {
+            return true
+        }
+        if let kind = snapshot.spanKind?.lowercased(), eligibleSpanKinds.contains(kind) {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Private
+
+    /// Aligns a nanosecond timestamp to the bucket boundary.
+    static func alignTimestamp(_ ts: UInt64, bucketDuration: UInt64) -> UInt64 {
+        return ts - ts % bucketDuration
+    }
+
+    /// Extracts matching peer tags from the snapshot based on span kind rules.
+    private func matchingPeerTags(for snapshot: SpanSnapshot) -> [String: String] {
+        let kind = snapshot.spanKind?.lowercased() ?? ""
+        guard peerTagSpanKinds.contains(kind) else {
+            return [:]
+        }
+        var result: [String: String] = [:]
+        for key in peerTagKeys {
+            if let value = snapshot.peerTags[key], !value.isEmpty {
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    /// Builds an `AggregationKey` from a span snapshot and its matching peer tags.
+    private func makeAggregationKey(from snapshot: SpanSnapshot, peerTags: [String: String]) -> AggregationKey {
+        let isTraceRoot: Trilean = snapshot.parentSpanID == nil ? .true : .false
+        let peerTagStrings = peerTags.map { "\($0.key):\($0.value)" }
+
+        return AggregationKey(
+            service: snapshot.service,
+            operationName: snapshot.operationName,
+            resource: snapshot.resource,
+            httpStatusCode: snapshot.httpStatusCode,
+            type: snapshot.type,
+            spanKind: snapshot.spanKind ?? "",
+            isTraceRoot: isTraceRoot,
+            synthetics: false,
+            peerTagsHash: fnv64a(peerTagStrings),
+            serviceSource: snapshot.serviceSource
+        )
+    }
+}

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -36,6 +36,8 @@ internal struct AggregationKey: Hashable, Sendable {
 // MARK: - Grouped Stats
 
 /// Running counters for a single aggregation key within a time bucket.
+/// Counters use `Double` to support fractional weighted sampling (weight per span).
+/// Currently weight is always 1.0, so these are effectively integers.
 internal final class GroupedStats {
     var hits: Double = 0
     var topLevelHits: Double = 0
@@ -100,41 +102,47 @@ private let eligibleSpanKinds: Set<String> = ["server", "consumer", "client", "p
 /// Span kinds for which peer tags should be included in the aggregation key.
 private let peerTagSpanKinds: Set<String> = ["client", "producer", "consumer"]
 
-// MARK: - FNV-64a Hash
+// MARK: - Stats Utilities
 
-/// Computes an FNV-64a hash of sorted tag strings, matching Go's `tagsFnvHash`.
-internal func fnv64a(_ tags: [String]) -> UInt64 {
-    if tags.isEmpty {
-        return 0
-    }
-    let sorted = tags.sorted()
-    var hash: UInt64 = 14_695_981_039_346_656_037 // FNV offset basis
-    let prime: UInt64 = 1_099_511_628_211
-
-    for (i, tag) in sorted.enumerated() {
-        if i > 0 {
-            hash ^= 0 // null separator byte
-            hash = hash &* prime
+/// Utility functions for stats computation.
+internal enum StatsUtils {
+    /// Computes an FNV-64a hash of sorted tag strings, matching Go's `tagsFnvHash`.
+    static func fnv64a(_ tags: [String]) -> UInt64 {
+        if tags.isEmpty {
+            return 0
         }
-        for byte in tag.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* prime
+        let sorted = tags.sorted()
+        var hash: UInt64 = 14_695_981_039_346_656_037 // FNV offset basis
+        let prime: UInt64 = 1_099_511_628_211
+
+        for (i, tag) in sorted.enumerated() {
+            if i > 0 {
+                hash ^= 0 // null separator byte
+                hash = hash &* prime
+            }
+            for byte in tag.utf8 {
+                hash ^= UInt64(byte)
+                hash = hash &* prime
+            }
         }
+        return hash
     }
-    return hash
-}
 
-// MARK: - Stochastic Rounding
-
-/// Converts a floating-point count to UInt64 using stochastic rounding.
-/// When weight is always 1.0, this is effectively a truncation to integer.
-internal func stochasticRound(_ value: Double) -> UInt64 {
-    let truncated = UInt64(value)
-    let fractional = value - Double(truncated)
-    if Double.random(in: 0..<1) < fractional {
-        return truncated + 1
+    /// Converts a floating-point count to `UInt64` using stochastic rounding.
+    ///
+    /// In the Go reference, each span contributes a fractional sampling weight to its
+    /// group counters. When exporting, the float totals are rounded to integers with
+    /// probabilistic correction so that expected values remain unbiased. Currently
+    /// the iOS SDK always uses weight 1.0 (no weighted sampling), so this reduces
+    /// to simple truncation.
+    static func stochasticRound(_ value: Double) -> UInt64 {
+        let truncated = UInt64(value)
+        let fractional = value - Double(truncated)
+        if Double.random(in: 0..<1) < fractional {
+            return truncated + 1
+        }
+        return truncated
     }
-    return truncated
 }
 
 // MARK: - Stats Concentrator
@@ -142,14 +150,16 @@ internal func stochasticRound(_ value: Double) -> UInt64 {
 /// Aggregates `SpanSnapshot`s into time-bucketed stats (hit counts, error counts,
 /// duration totals) keyed by aggregation dimensions.
 ///
-/// Thread-safety: Access to `buckets` and `oldestTs` is protected by a `ReadWriteLock`.
-/// `add()` and `flush()` can be called from any thread.
+/// Thread-safety: All mutations are dispatched onto a dedicated serial queue.
+/// `add()` dispatches asynchronously so the caller's thread is never blocked.
+/// `flush()` dispatches synchronously to drain pending adds before collecting results.
 internal final class StatsConcentrator: @unchecked Sendable {
     /// Default bucket duration: 10 seconds in nanoseconds.
     static let defaultBucketDuration: Nanoseconds = 10_000_000_000
 
-    /// Number of bucket-duration windows to keep before flushing.
-    /// Matches Go's `defaultBufferLen = 2` (current + previous bucket).
+    /// How many recent bucket windows to keep before flushing. A value of 2 means
+    /// the current and previous buckets are retained; older buckets become eligible
+    /// for flush. Matches Go's `defaultBufferLen`.
     static let defaultBufferLen = 2
 
     /// Configured peer tag keys to extract from spans.
@@ -166,10 +176,10 @@ internal final class StatsConcentrator: @unchecked Sendable {
     private let bufferLen: Int
     private let peerTagKeys: [String]
 
-    @ReadWriteLock
-    private var buckets: [UInt64: StatsBucket] = [:]
+    /// Serial queue protecting `buckets` and `oldestTs`.
+    private let queue = DispatchQueue(label: "com.datadoghq.stats-concentrator", qos: .utility)
 
-    @ReadWriteLock
+    private var buckets: [UInt64: StatsBucket] = [:]
     private var oldestTs: UInt64
 
     init(
@@ -187,7 +197,8 @@ internal final class StatsConcentrator: @unchecked Sendable {
     // MARK: - Add
 
     /// Records a span snapshot into the appropriate time bucket.
-    /// Ineligible spans are silently discarded.
+    /// Ineligible spans are silently discarded. This method dispatches
+    /// asynchronously and returns immediately without blocking the caller.
     func add(_ snapshot: SpanSnapshot) {
         guard Self.isEligible(snapshot) else {
             return
@@ -198,12 +209,12 @@ internal final class StatsConcentrator: @unchecked Sendable {
         let aggregationKey = makeAggregationKey(from: snapshot, peerTags: matchingPeerTags)
         let peerTagStrings = matchingPeerTags.map { "\($0.key):\($0.value)" }
 
-        _buckets.mutate { buckets in
+        queue.async { [self] in
             let bucketKey = max(
-                Self.alignTimestamp(endTime, bucketDuration: self.bucketDuration),
-                self.oldestTs
+                Self.alignTimestamp(endTime, bucketDuration: bucketDuration),
+                oldestTs
             )
-            let bucket = buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: self.bucketDuration)]
+            let bucket = buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: bucketDuration)]
 
             let group = bucket.groups[aggregationKey, default: GroupedStats(peerTags: peerTagStrings)]
 
@@ -225,19 +236,18 @@ internal final class StatsConcentrator: @unchecked Sendable {
 
     /// Flushes completed buckets and returns them for export.
     ///
+    /// - Parameter now: Current time in nanoseconds.
     /// - Parameter force: When `true`, flushes all buckets regardless of age.
     ///   Used during SDK teardown.
-    /// - Parameter now: Current time in nanoseconds.
     /// - Returns: Array of exported buckets ready for serialization.
     func flush(now: Nanoseconds, force: Bool) -> [ExportedBucket] {
-        var flushed: [ExportedBucket] = []
-
-        _buckets.mutate { buckets in
-            let cutoff = Int64(now) - Int64(self.bufferLen) * Int64(self.bucketDuration)
+        return queue.sync {
+            let cutoff = force ? Int64.max : Int64(now) - Int64(bufferLen) * Int64(bucketDuration)
+            var flushed: [ExportedBucket] = []
             var keysToRemove: [UInt64] = []
 
             for (ts, bucket) in buckets {
-                if !force && Int64(ts) > cutoff {
+                if Int64(ts) > cutoff {
                     continue
                 }
                 keysToRemove.append(ts)
@@ -252,10 +262,10 @@ internal final class StatsConcentrator: @unchecked Sendable {
                         spanKind: key.spanKind,
                         isTraceRoot: key.isTraceRoot,
                         synthetics: key.synthetics,
-                        hits: stochasticRound(group.hits),
-                        errors: stochasticRound(group.errors),
-                        duration: stochasticRound(group.duration),
-                        topLevelHits: stochasticRound(group.topLevelHits),
+                        hits: StatsUtils.stochasticRound(group.hits),
+                        errors: StatsUtils.stochasticRound(group.errors),
+                        duration: StatsUtils.stochasticRound(group.duration),
+                        topLevelHits: StatsUtils.stochasticRound(group.topLevelHits),
                         okSummary: Data(),
                         errorSummary: Data(),
                         peerTags: group.peerTags,
@@ -276,17 +286,15 @@ internal final class StatsConcentrator: @unchecked Sendable {
                 buckets.removeValue(forKey: key)
             }
 
-            let aligned = Self.alignTimestamp(now, bucketDuration: self.bucketDuration)
-            let offset = UInt64(self.bufferLen - 1) * self.bucketDuration
+            let aligned = Self.alignTimestamp(now, bucketDuration: bucketDuration)
+            let offset = UInt64(bufferLen - 1) * bucketDuration
             let newOldestTs = aligned >= offset ? aligned - offset : 0
-            self._oldestTs.mutate { oldest in
-                if newOldestTs > oldest {
-                    oldest = newOldestTs
-                }
+            if newOldestTs > oldestTs {
+                oldestTs = newOldestTs
             }
-        }
 
-        return flushed
+            return flushed
+        }
     }
 
     // MARK: - Eligibility
@@ -342,7 +350,7 @@ internal final class StatsConcentrator: @unchecked Sendable {
             spanKind: snapshot.spanKind ?? "",
             isTraceRoot: isTraceRoot,
             synthetics: false,
-            peerTagsHash: fnv64a(peerTagStrings),
+            peerTagsHash: StatsUtils.fnv64a(peerTagStrings),
             serviceSource: snapshot.serviceSource
         )
     }

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -275,14 +275,14 @@ internal final class StatsConcentrator: @unchecked Sendable {
             for key in keysToRemove {
                 buckets.removeValue(forKey: key)
             }
-        }
 
-        let aligned = Self.alignTimestamp(now, bucketDuration: bucketDuration)
-        let offset = UInt64(bufferLen - 1) * bucketDuration
-        let newOldestTs = aligned >= offset ? aligned - offset : 0
-        _oldestTs.mutate { oldest in
-            if newOldestTs > oldest {
-                oldest = newOldestTs
+            let aligned = Self.alignTimestamp(now, bucketDuration: self.bucketDuration)
+            let offset = UInt64(self.bufferLen - 1) * self.bucketDuration
+            let newOldestTs = aligned >= offset ? aligned - offset : 0
+            self._oldestTs.mutate { oldest in
+                if newOldestTs > oldest {
+                    oldest = newOldestTs
+                }
             }
         }
 

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -173,10 +173,10 @@ internal final class StatsConcentrator: @unchecked Sendable {
     private var oldestTs: UInt64
 
     init(
+        now: Nanoseconds,
         bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
         bufferLen: Int = StatsConcentrator.defaultBufferLen,
-        peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys,
-        now: Nanoseconds
+        peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
     ) {
         self.bucketDuration = bucketDuration
         self.bufferLen = bufferLen

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -21,6 +21,8 @@ internal struct SpanSnapshot: Encodable, Sendable {
     var service: String
     let operationName: String
     let resource: String
+    /// Span type (e.g. `"custom"`, `"http"`, `"web"`).
+    let type: String
     let spanKind: String?
     let httpStatusCode: UInt32
     let isError: Bool

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -46,11 +46,15 @@ public enum Trace {
 
         // Register Client-Side Stats feature if enabled:
         if configuration.statsComputationEnabled {
-            let stats = ClientStatsFeature(core: core, configuration: configuration)
+            let stats = ClientStatsFeature(core: core, configuration: configuration, dateProvider: configuration.dateProvider)
             try core.register(feature: stats)
 
-            // [CSS] Wire StatsConcentrator here to aggregate snapshots into
-            // time-bucketed stats payloads before writing to the stats feature scope.
+            trace.tracer.onSpanFinished = { [weak core] snapshot in
+                guard core != nil else {
+                    return
+                }
+                stats.concentrator.add(snapshot)
+            }
         }
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -49,11 +49,8 @@ public enum Trace {
             let stats = ClientStatsFeature(core: core, configuration: configuration, dateProvider: configuration.dateProvider)
             try core.register(feature: stats)
 
-            trace.tracer.onSpanFinished = { [weak core] snapshot in
-                guard core != nil else {
-                    return
-                }
-                stats.concentrator.add(snapshot)
+            trace.tracer.onSpanFinished = { [weak stats] snapshot in
+                stats?.concentrator.add(snapshot)
             }
         }
 

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -102,4 +102,72 @@ class ClientStatsFeatureTests: XCTestCase {
     func testFeatureName() {
         XCTAssertEqual(ClientStatsFeature.name, "tracing-client-stats")
     }
+
+    func testWhenStatsComputationEnabledWithCustomDateProvider_thenStatsFeatureUsesItForFlushTiming() throws {
+        let core = FeatureRegistrationPassthroughCoreMock()
+        let dateProvider = RelativeDateProvider(using: Date(timeIntervalSince1970: 0))
+
+        config.statsComputationEnabled = true
+        config.dateProvider = dateProvider
+
+        Trace.enable(with: config, in: core)
+
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        stats.concentrator.add(SpanSnapshot.mockWith(
+            startTime: 20_000_000_000,
+            duration: 5_000_000_000,
+            isTopLevel: true
+        ))
+
+        stats.flushStats(force: false)
+
+        XCTAssertTrue(core.exportedBuckets.isEmpty)
+    }
+}
+
+private final class FeatureRegistrationPassthroughCoreMock: DatadogCoreProtocol, FeatureScope {
+    private let writer = FileWriterMock()
+    private let contextValue: DatadogContext
+    private var registeredFeatures: [DatadogFeature] = []
+
+    init(context: DatadogContext = .mockAny()) {
+        self.contextValue = context
+    }
+
+    func register<T>(feature: T) throws where T: DatadogFeature {
+        registeredFeatures.append(feature)
+    }
+
+    func feature<T>(named name: String, type: T.Type) -> T? {
+        registeredFeatures.first { $0 is T } as? T
+    }
+
+    func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature {
+        self
+    }
+
+    func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext { }
+
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
+
+    func mostRecentModifiedFileAt(before: Date) throws -> Date? {
+        nil
+    }
+
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+        block(contextValue, writer)
+    }
+
+    func context(_ block: @escaping (DatadogContext) -> Void) {
+        block(contextValue)
+    }
+
+    var dataStore: DataStore { NOPDataStore() }
+    var telemetry: Telemetry { NOPTelemetry() }
+
+    func set(anonymousId: String?) { }
+
+    var exportedBuckets: [ExportedBucket] {
+        writer.events(ofType: ExportedBucket.self)
+    }
 }

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -501,34 +501,34 @@ class StatsConcentratorTests: XCTestCase {
     // MARK: - FNV-64a Hash
 
     func testFNV64aEmptyReturnsZero() {
-        XCTAssertEqual(fnv64a([]), 0)
+        XCTAssertEqual(StatsUtils.fnv64a([]), 0)
     }
 
     func testFNV64aDeterministic() {
         let tags = ["peer.service:web", "out.host:db.local"]
-        let hash1 = fnv64a(tags)
-        let hash2 = fnv64a(tags)
+        let hash1 = StatsUtils.fnv64a(tags)
+        let hash2 = StatsUtils.fnv64a(tags)
         XCTAssertEqual(hash1, hash2)
     }
 
     func testFNV64aSortsTags() {
-        let hash1 = fnv64a(["b:2", "a:1"])
-        let hash2 = fnv64a(["a:1", "b:2"])
+        let hash1 = StatsUtils.fnv64a(["b:2", "a:1"])
+        let hash2 = StatsUtils.fnv64a(["a:1", "b:2"])
         XCTAssertEqual(hash1, hash2)
     }
 
     func testFNV64aDifferentTagsProduceDifferentHash() {
-        let hash1 = fnv64a(["a:1"])
-        let hash2 = fnv64a(["b:2"])
+        let hash1 = StatsUtils.fnv64a(["a:1"])
+        let hash2 = StatsUtils.fnv64a(["b:2"])
         XCTAssertNotEqual(hash1, hash2)
     }
 
     // MARK: - Stochastic Rounding
 
     func testStochasticRoundIntegerValues() {
-        XCTAssertEqual(stochasticRound(5.0), 5)
-        XCTAssertEqual(stochasticRound(0.0), 0)
-        XCTAssertEqual(stochasticRound(100.0), 100)
+        XCTAssertEqual(StatsUtils.stochasticRound(5.0), 5)
+        XCTAssertEqual(StatsUtils.stochasticRound(0.0), 0)
+        XCTAssertEqual(StatsUtils.stochasticRound(100.0), 100)
     }
 
     // MARK: - Exported Bucket Structure

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -1,0 +1,638 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogTrace
+
+class StatsConcentratorTests: XCTestCase {
+    private let bucketDuration: Nanoseconds = 10_000_000_000 // 10s
+
+    private func makeConcentrator(
+        now: Nanoseconds = 100_000_000_000,
+        bufferLen: Int = StatsConcentrator.defaultBufferLen,
+        peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
+    ) -> StatsConcentrator {
+        return StatsConcentrator(
+            bucketDuration: bucketDuration,
+            bufferLen: bufferLen,
+            peerTagKeys: peerTagKeys,
+            now: now
+        )
+    }
+
+    // MARK: - Eligibility
+
+    func testTopLevelSpanIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: nil, isTopLevel: true, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testMeasuredSpanIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: nil, isTopLevel: false, isMeasured: true)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testServerSpanKindIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "server", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testConsumerSpanKindIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "consumer", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testClientSpanKindIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "client", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testProducerSpanKindIsEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "producer", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testSpanKindIsCaseInsensitive() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "SERVER", isTopLevel: false, isMeasured: false)
+        XCTAssertTrue(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testInternalSpanKindIsNotEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: "internal", isTopLevel: false, isMeasured: false)
+        XCTAssertFalse(StatsConcentrator.isEligible(snapshot))
+    }
+
+    func testNilSpanKindAndNotTopLevelOrMeasuredIsNotEligible() {
+        let snapshot = SpanSnapshot.mockWith(spanKind: nil, isTopLevel: false, isMeasured: false)
+        XCTAssertFalse(StatsConcentrator.isEligible(snapshot))
+    }
+
+    // MARK: - Aggregation
+
+    func testIneligibleSpansAreDiscarded() {
+        let concentrator = makeConcentrator(now: 0)
+        let snapshot = SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 5_000_000_000,
+            isTopLevel: false,
+            isMeasured: false
+        )
+
+        concentrator.add(snapshot)
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    func testSingleSpanProducesOneGroupInOneBucket() {
+        let concentrator = makeConcentrator(now: 0)
+
+        let snapshot = SpanSnapshot.mockWith(
+            service: "web",
+            operationName: "http.request",
+            resource: "GET /api",
+            startTime: 1_000_000_000,
+            duration: 2_000_000_000,
+            isTopLevel: true
+        )
+
+        concentrator.add(snapshot)
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+
+        XCTAssertEqual(buckets.count, 1)
+        let bucket = buckets[0]
+        XCTAssertEqual(bucket.stats.count, 1)
+
+        let stats = bucket.stats[0]
+        XCTAssertEqual(stats.service, "web")
+        XCTAssertEqual(stats.name, "http.request")
+        XCTAssertEqual(stats.resource, "GET /api")
+        XCTAssertEqual(stats.hits, 1)
+        XCTAssertEqual(stats.errors, 0)
+        XCTAssertEqual(stats.topLevelHits, 1)
+    }
+
+    func testMultipleSpansWithSameKeyAggregateIntoOneGroup() {
+        let concentrator = makeConcentrator(now: 0)
+
+        for i in 0..<5 {
+            let snapshot = SpanSnapshot.mockWith(
+                spanID: SpanID(rawValue: UInt64(i + 1)),
+                service: "web",
+                operationName: "http.request",
+                resource: "GET /api",
+                startTime: UInt64(i) * 1_000_000_000,
+                duration: 500_000_000,
+                isTopLevel: true
+            )
+            concentrator.add(snapshot)
+        }
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.hits, 5)
+        XCTAssertEqual(stats.topLevelHits, 5)
+    }
+
+    func testDifferentServicesProduceSeparateGroups() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            service: "web",
+            operationName: "request",
+            resource: "GET /",
+            startTime: 1_000_000_000,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            service: "api",
+            operationName: "request",
+            resource: "GET /",
+            startTime: 1_000_000_000,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets[0].stats.count, 2)
+    }
+
+    func testErrorSpansIncrementErrorCount() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            isError: true,
+            startTime: 1_000_000_000,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            isError: false,
+            startTime: 1_000_000_000,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.hits, 2)
+        XCTAssertEqual(stats.errors, 1)
+    }
+
+    func testDurationIsAccumulatedAcrossSpans() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 3_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            startTime: 0,
+            duration: 7_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.duration, 10_000_000_000)
+    }
+
+    func testNonTopLevelSpanDoesNotIncrementTopLevelHits() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            parentSpanID: SpanID(rawValue: 99),
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: false,
+            isMeasured: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.hits, 1)
+        XCTAssertEqual(stats.topLevelHits, 0)
+    }
+
+    // MARK: - Time Bucketing
+
+    func testSpansAreAssignedToBucketByEndTime() {
+        let concentrator = makeConcentrator(now: 0)
+
+        // End time = 5s (bucket 0s)
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            startTime: 0,
+            duration: 5_000_000_000,
+            isTopLevel: true
+        ))
+        // End time = 15s (bucket 10s)
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            startTime: 5_000_000_000,
+            duration: 10_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 2)
+
+        let sortedBuckets = buckets.sorted { $0.start < $1.start }
+        XCTAssertEqual(sortedBuckets[0].start, 0)
+        XCTAssertEqual(sortedBuckets[1].start, 10_000_000_000)
+    }
+
+    func testBucketAlignment() {
+        XCTAssertEqual(
+            StatsConcentrator.alignTimestamp(15_500_000_000, bucketDuration: 10_000_000_000),
+            10_000_000_000
+        )
+        XCTAssertEqual(
+            StatsConcentrator.alignTimestamp(10_000_000_000, bucketDuration: 10_000_000_000),
+            10_000_000_000
+        )
+        XCTAssertEqual(
+            StatsConcentrator.alignTimestamp(9_999_999_999, bucketDuration: 10_000_000_000),
+            0
+        )
+    }
+
+    // MARK: - Flushing
+
+    func testFlushOnlyReturnsCompletedBuckets() {
+        let concentrator = makeConcentrator(now: 0)
+
+        // Span ending at 5s goes into bucket 0s
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            startTime: 0,
+            duration: 5_000_000_000,
+            isTopLevel: true
+        ))
+
+        // Span ending at 25s goes into bucket 20s
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            startTime: 20_000_000_000,
+            duration: 5_000_000_000,
+            isTopLevel: true
+        ))
+
+        // At t=15s, cutoff = 15 - 20 = -5 (negative). No buckets are old enough.
+        let earlyBuckets = concentrator.flush(now: 15_000_000_000, force: false)
+        XCTAssertEqual(earlyBuckets.count, 0)
+
+        // At t=25s, cutoff = 25 - 20 = 5. Bucket 0s (ts=0 <= 5) is flushed.
+        // Bucket 20s (ts=20 > 5) stays.
+        let midBuckets = concentrator.flush(now: 25_000_000_000, force: false)
+        XCTAssertEqual(midBuckets.count, 1)
+        XCTAssertEqual(midBuckets[0].start, 0)
+
+        // At t=45s, cutoff = 45 - 20 = 25. Bucket 20s (ts=20 <= 25) is flushed.
+        let lateBuckets = concentrator.flush(now: 45_000_000_000, force: false)
+        XCTAssertEqual(lateBuckets.count, 1)
+        XCTAssertEqual(lateBuckets[0].start, 20_000_000_000)
+    }
+
+    func testForceFlushReturnsAllBuckets() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            startTime: 90_000_000_000,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 91_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 2)
+    }
+
+    func testFlushRemovesBucketsFromConcentrator() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let first = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(first.count, 1)
+
+        let second = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(second.isEmpty)
+    }
+
+    func testFlushWithNoSpansReturnsEmpty() {
+        let concentrator = makeConcentrator(now: 0)
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    // MARK: - Oldest Timestamp
+
+    func testSpansOlderThanOldestTsGoToOldestBucket() {
+        let now: Nanoseconds = 50_000_000_000
+        let concentrator = makeConcentrator(now: now)
+
+        // Flush to advance oldestTs
+        _ = concentrator.flush(now: 80_000_000_000, force: false)
+
+        // Add a span with end time well in the past
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 200_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+    }
+
+    // MARK: - Aggregation Key
+
+    func testDifferentResourcesProduceSeparateGroups() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            resource: "GET /users",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            resource: "POST /users",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].stats.count, 2)
+    }
+
+    func testDifferentHTTPStatusCodesProduceSeparateGroups() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            httpStatusCode: 200,
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            httpStatusCode: 404,
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].stats.count, 2)
+    }
+
+    func testIsTraceRootDerivedFromParentSpanID() {
+        let concentrator = makeConcentrator(now: 0)
+
+        // Root span (no parent)
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 1),
+            parentSpanID: nil,
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+        // Child span (has parent)
+        concentrator.add(SpanSnapshot.mockWith(
+            spanID: SpanID(rawValue: 2),
+            parentSpanID: SpanID(rawValue: 1),
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].stats.count, 2)
+
+        let root = buckets[0].stats.first { $0.isTraceRoot == .true }
+        let child = buckets[0].stats.first { $0.isTraceRoot == .false }
+        XCTAssertNotNil(root)
+        XCTAssertNotNil(child)
+    }
+
+    // MARK: - Peer Tags
+
+    func testPeerTagsIncludedForClientSpanKind() {
+        let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service", "out.host"])
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanKind: "client",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: false,
+            isMeasured: false,
+            peerTags: ["peer.service": "downstream-svc", "out.host": "db.example.com"]
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.peerTags.count, 2)
+        XCTAssertTrue(stats.peerTags.contains("peer.service:downstream-svc"))
+        XCTAssertTrue(stats.peerTags.contains("out.host:db.example.com"))
+    }
+
+    func testPeerTagsNotIncludedForServerSpanKind() {
+        let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service"])
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanKind: "server",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: false,
+            isMeasured: false,
+            peerTags: ["peer.service": "downstream-svc"]
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertTrue(stats.peerTags.isEmpty)
+    }
+
+    func testPeerTagsIncludedForProducerSpanKind() {
+        let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service"])
+
+        concentrator.add(SpanSnapshot.mockWith(
+            spanKind: "producer",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: false,
+            isMeasured: false,
+            peerTags: ["peer.service": "msg-queue"]
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertTrue(stats.peerTags.contains("peer.service:msg-queue"))
+    }
+
+    // MARK: - FNV-64a Hash
+
+    func testFNV64aEmptyReturnsZero() {
+        XCTAssertEqual(fnv64a([]), 0)
+    }
+
+    func testFNV64aDeterministic() {
+        let tags = ["peer.service:web", "out.host:db.local"]
+        let hash1 = fnv64a(tags)
+        let hash2 = fnv64a(tags)
+        XCTAssertEqual(hash1, hash2)
+    }
+
+    func testFNV64aSortsTags() {
+        let hash1 = fnv64a(["b:2", "a:1"])
+        let hash2 = fnv64a(["a:1", "b:2"])
+        XCTAssertEqual(hash1, hash2)
+    }
+
+    func testFNV64aDifferentTagsProduceDifferentHash() {
+        let hash1 = fnv64a(["a:1"])
+        let hash2 = fnv64a(["b:2"])
+        XCTAssertNotEqual(hash1, hash2)
+    }
+
+    // MARK: - Stochastic Rounding
+
+    func testStochasticRoundIntegerValues() {
+        XCTAssertEqual(stochasticRound(5.0), 5)
+        XCTAssertEqual(stochasticRound(0.0), 0)
+        XCTAssertEqual(stochasticRound(100.0), 100)
+    }
+
+    // MARK: - Exported Bucket Structure
+
+    func testExportedBucketContainsBucketDuration() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].duration, bucketDuration)
+    }
+
+    func testExportedGroupedStatsHasEmptySketchPlaceholders() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.okSummary, Data())
+        XCTAssertEqual(stats.errorSummary, Data())
+    }
+
+    // MARK: - Thread Safety
+
+    func testConcurrentAddAndFlush() {
+        let concentrator = makeConcentrator(now: 0)
+        let iterations = 1_000
+        let expectation = XCTestExpectation(description: "concurrent operations")
+        expectation.expectedFulfillmentCount = iterations + 1
+
+        for i in 0..<iterations {
+            DispatchQueue.global().async {
+                concentrator.add(SpanSnapshot.mockWith(
+                    spanID: SpanID(rawValue: UInt64(i + 1)),
+                    startTime: UInt64(i) * 1_000_000,
+                    duration: 500_000,
+                    isTopLevel: true
+                ))
+                expectation.fulfill()
+            }
+        }
+
+        DispatchQueue.global().async {
+            _ = concentrator.flush(now: 100_000_000_000, force: true)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    // MARK: - Service Source Passthrough
+
+    func testServiceSourceIncludedInExportedStats() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true,
+            serviceSource: "m"
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].stats[0].serviceSource, "m")
+    }
+
+    // MARK: - Synthetics
+
+    func testSyntheticsAlwaysFalseForMobile() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertFalse(buckets[0].stats[0].synthetics)
+    }
+
+    // MARK: - Span Type Passthrough
+
+    func testSpanTypeIncludedInExportedStats() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            type: "http",
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets[0].stats[0].type, "http")
+    }
+}

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -19,10 +19,10 @@ class StatsConcentratorTests: XCTestCase {
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
     ) -> StatsConcentrator {
         return StatsConcentrator(
+            now: now,
             bucketDuration: bucketDuration,
             bufferLen: bufferLen,
-            peerTagKeys: peerTagKeys,
-            now: now
+            peerTagKeys: peerTagKeys
         )
     }
 

--- a/TestUtilities/Sources/Mocks/DatadogTrace/TracingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/TracingFeatureMocks.swift
@@ -418,3 +418,49 @@ public struct TracerSamplerProviderMock: TracerSamplerProvider {
         return TracerSamplerProviderMock(sampler: Sampler(samplingRate: 0))
     }
 }
+
+// MARK: - SpanSnapshot Mocks
+
+extension SpanSnapshot {
+    public static func mockAny() -> SpanSnapshot {
+        return mockWith()
+    }
+
+    public static func mockWith(
+        traceID: TraceID = .mockAny(),
+        spanID: SpanID = .mockAny(),
+        parentSpanID: SpanID? = nil,
+        service: String = "test-service",
+        operationName: String = "test.operation",
+        resource: String = "test-resource",
+        type: String = "custom",
+        spanKind: String? = nil,
+        httpStatusCode: UInt32 = 200,
+        isError: Bool = false,
+        startTime: Nanoseconds = 1_000_000_000,
+        duration: Nanoseconds = 500_000_000,
+        isTopLevel: Bool = true,
+        isMeasured: Bool = false,
+        peerTags: [String: String] = [:],
+        serviceSource: String = ""
+    ) -> SpanSnapshot {
+        return SpanSnapshot(
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentSpanID,
+            service: service,
+            operationName: operationName,
+            resource: resource,
+            type: type,
+            spanKind: spanKind,
+            httpStatusCode: httpStatusCode,
+            isError: isError,
+            startTime: startTime,
+            duration: duration,
+            isTopLevel: isTopLevel,
+            isMeasured: isMeasured,
+            peerTags: peerTags,
+            serviceSource: serviceSource
+        )
+    }
+}


### PR DESCRIPTION
### What and why?

Implements the `StatsConcentrator`, the core aggregation engine for client-side stats. This is the component that receives span snapshots from the `onSpanFinished` callback and groups them into time-bucketed stats (hit counts, error counts, duration totals) keyed by aggregation dimensions (service, operation, resource, HTTP status, span kind, etc.).

This PR also wires the concentrator into the existing `ClientStatsFeature` with periodic timer-based flushing and `Flushable` conformance for SDK teardown.

### How?

**New types** (`StatsConcentrator.swift`):
- `StatsConcentrator`: aggregates `SpanSnapshot`s into 10-second time buckets, matching the Go reference implementation. Uses `@ReadWriteLock` for thread safety. Supports eligibility filtering (top-level, measured, or qualifying span kind), `oldestTs` tracking to prevent late-arriving spans from creating already-flushed buckets, and periodic + force flush.
- `AggregationKey`: the set of dimensions by which spans are grouped (service, operation, resource, HTTP status, type, span kind, is_trace_root, peer tags hash, service source).
- `Trilean`: matches the protobuf enum for `is_trace_root` (notSet / true / false).
- `GroupedStats`, `StatsBucket`: internal mutable types for running counters within a bucket.
- `ExportedBucket`, `ExportedGroupedStats`: immutable `Encodable` + `Sendable` structs for serialization.
- `fnv64a()`: FNV-64a hash for peer tag aggregation keys, matching Go's `tagsFnvHash`.
- `stochasticRound()`: converts floating-point counts to UInt64 (effectively truncation since weight is always 1.0 for now).

**Wiring changes**:
- `ClientStatsFeature` now holds a `StatsConcentrator`, runs a 30-second flush timer, conforms to `Flushable`, and writes exported buckets to feature storage via `eventWriteContext`.
- `Trace.enableOrThrow()` wires `trace.tracer.onSpanFinished` to `stats.concentrator.add(snapshot)` and passes `configuration.dateProvider` to ensure the stats pipeline shares the same clock as the tracer.
- `SpanSnapshot` gains a `type` field (populated from `tags["span.type"]` or defaulting to `"custom"` in `DDSpan.createSnapshot()`).
- `SpanSnapshot.mockAny()` / `.mockWith()` helpers added to `TestUtilities`.

**Known limitations** (to be addressed in subsequent PRs):
- `okSummary` / `errorSummary` are `Data()` placeholders; DDSketch implementation is next.
- `StatsRequestBuilder` still concatenates raw event bytes with `application/json` content type. Multi-bucket uploads will produce invalid JSON. The real MessagePack encoder replaces this in a later PR.
- When `Trace.Configuration.service` is nil, `snapshot.service` resolves to `""` instead of falling back to `DatadogContext.service` (which is only available asynchronously via `eventWriteContext`). This means stats may be grouped under an empty service name for default-config users. A proper fix requires resolving the core context service at snapshot creation or aggregation time, tracked for a follow-up PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs
- [x] Run `make api-surface` when adding new APIs