### PR TITLE
RUM-8054: Fix background session precondition for refresh and new session flows

### DIFF
--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionStopTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionStopTests.swift
@@ -762,7 +762,7 @@ class RUMSessionStopTests: RUMSessionTestsBase {
             XCTAssertNil(session2.timeToInitialDisplay)
             DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + dt4, accuracy: accuracy)
             DDAssertEqual(session2.duration, dt5, accuracy: accuracy)
-            XCTAssertEqual(session2.sessionPrecondition, .explicitStop)
+            XCTAssertEqual(session2.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
             XCTAssertEqual(session2.views.count, 1)
             XCTAssertEqual(session2.views[0].name, backgroundViewName)
             DDAssertEqual(session2.views[0].duration, dt5, accuracy: accuracy)

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
@@ -750,7 +750,7 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
                 XCTAssertNil(session2.timeToInitialDisplay)
                 DDAssertEqual(session2.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3, accuracy: accuracy)
                 DDAssertEqual(session2.duration, dt4, accuracy: accuracy)
-                XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
+                XCTAssertEqual(session2.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
                 XCTAssertEqual(session2.views.count, 1)
                 XCTAssertEqual(session2.views[0].name, backgroundViewName)
                 DDAssertEqual(session2.views[0].duration, dt4, accuracy: accuracy)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -360,7 +360,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             writer: writer
         )
     }
-    
+
     private func preconditionForNewBackgroundSession(context: DatadogContext) -> RUMSessionPrecondition? {
         switch context.launchInfo.launchReason {
         case .backgroundLaunch:

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -247,7 +247,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        // If no background-session precondition can be derived for the current context, fall through to the end-reason logic.
+        // If the app is in background, use the background-aware precondition; otherwise fall through to the end-reason logic.
         if context.applicationStateHistory.currentState == .background,
            let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
             startPrecondition = backgroundPrecondition
@@ -283,7 +283,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        // If no background-session precondition can be derived for the current context, fall through to the end-reason logic.
+        // If the app is in background, use the background-aware precondition; otherwise fall through to the end-reason logic.
         if context.applicationStateHistory.currentState == .background,
            let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
             startPrecondition = backgroundPrecondition

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -221,7 +221,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
                 startPrecondition = .userAppLaunch // UISceneDelegate-based apps always start in background
             case .backgroundLaunch, .prewarming:
                 startPrecondition = preconditionForNewBackgroundSession(context: context)
-            default:
+            @unknown default:
                 dependencies.telemetry.error("Creating initial session in background with unexpected launch reason: \(context.launchInfo.launchReason)")
             }
         } else {
@@ -247,7 +247,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        // If the launch reason is uncertain (e.g. on tvOS), the background check falls through to the end-reason logic.
+        // If no background-session precondition can be derived for the current context, fall through to the end-reason logic.
         if context.applicationStateHistory.currentState == .background,
            let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
             startPrecondition = backgroundPrecondition
@@ -283,7 +283,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        // If the launch reason is uncertain (e.g. on tvOS), the background check falls through to the end-reason logic.
+        // If no background-session precondition can be derived for the current context, fall through to the end-reason logic.
         if context.applicationStateHistory.currentState == .background,
            let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
             startPrecondition = backgroundPrecondition
@@ -370,7 +370,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         case .userLaunch:
             // Normal: a user-launched process went to background. Caller uses end-reason-based precondition.
             return nil
-        default:
+        @unknown default:
             dependencies.telemetry.error(
                 "Starting session in background with unexpected launch reason: \(context.launchInfo.launchReason)"
             )

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -217,9 +217,10 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
         if context.applicationStateHistory.currentState == .background {
             switch context.launchInfo.launchReason {
-            case .userLaunch:       startPrecondition = .userAppLaunch // UISceneDelegate-based apps always start in background
-            case .backgroundLaunch: startPrecondition = .backgroundLaunch
-            case .prewarming:       startPrecondition = .prewarm
+            case .userLaunch:
+                startPrecondition = .userAppLaunch // UISceneDelegate-based apps always start in background
+            case .backgroundLaunch, .prewarming:
+                startPrecondition = preconditionForNewBackgroundSession(context: context)
             default:
                 dependencies.telemetry.error("Creating initial session in background with unexpected launch reason: \(context.launchInfo.launchReason)")
             }
@@ -246,12 +247,16 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        if lastSessionEndReason == .timeOut {
+        // If the launch reason is uncertain (e.g. on tvOS), the background check falls through to the end-reason logic.
+        if context.applicationStateHistory.currentState == .background,
+           let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
+            startPrecondition = backgroundPrecondition
+        } else if lastSessionEndReason == .timeOut {
             startPrecondition = .inactivityTimeout
         } else if lastSessionEndReason == .maxDuration {
             startPrecondition = .maxDuration
         } else {
-            dependencies.telemetry.error("Failed to determine session precondition for REFRESHED session with end reason: \(lastSessionEndReason?.rawValue ?? "unknown"))")
+            dependencies.telemetry.error("Failed to determine session precondition for REFRESHED session with end reason: \(lastSessionEndReason?.rawValue ?? "unknown")")
         }
 
         let refreshingInForeground = context.applicationStateHistory.currentState == .active
@@ -278,14 +283,18 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         var startPrecondition: RUMSessionPrecondition? = nil
 
-        if lastSessionEndReason == .stopAPI {
+        // If the launch reason is uncertain (e.g. on tvOS), the background check falls through to the end-reason logic.
+        if context.applicationStateHistory.currentState == .background,
+           let backgroundPrecondition = preconditionForNewBackgroundSession(context: context) {
+            startPrecondition = backgroundPrecondition
+        } else if lastSessionEndReason == .stopAPI {
             startPrecondition = .explicitStop
         } else if lastSessionEndReason == .timeOut {
             startPrecondition = .inactivityTimeout
         } else if lastSessionEndReason == .maxDuration {
             startPrecondition = .maxDuration
         } else {
-            dependencies.telemetry.error("Failed to determine session precondition for NEW session with end reason: \(lastSessionEndReason?.rawValue ?? "unknown"))")
+            dependencies.telemetry.error("Failed to determine session precondition for NEW session with end reason: \(lastSessionEndReason?.rawValue ?? "unknown")")
         }
 
         if didCreateInitialSessionCount > 0 { // Sanity check
@@ -350,5 +359,22 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             context: context,
             writer: writer
         )
+    }
+    
+    private func preconditionForNewBackgroundSession(context: DatadogContext) -> RUMSessionPrecondition? {
+        switch context.launchInfo.launchReason {
+        case .backgroundLaunch:
+            return .backgroundLaunch
+        case .prewarming:
+            return .prewarm
+        case .userLaunch:
+            // Normal: a user-launched process went to background. Caller uses end-reason-based precondition.
+            return nil
+        default:
+            dependencies.telemetry.error(
+                "Starting session in background with unexpected launch reason: \(context.launchInfo.launchReason)"
+            )
+            return nil
+        }
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -497,6 +497,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .backgroundLaunch,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()
@@ -536,6 +537,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When - advance past maxDuration without triggering inactivity timeout, then send in background
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .backgroundLaunch,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()
@@ -567,6 +569,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When
         currentTime.addTimeInterval(1)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .backgroundLaunch,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()
@@ -595,6 +598,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .prewarming,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()
@@ -626,6 +630,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When
         currentTime.addTimeInterval(1)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .prewarming,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()
@@ -658,6 +663,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // When - session times out while app is in background
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
         let backgroundContext: DatadogContext = .mockWith(
+            sdkInitDate: .mockDecember15th2019At10AMUTC(),
             launchInfo: .mockWith(
                 launchReason: .userLaunch,
                 processLaunchDate: .mockDecember15th2019At10AMUTC()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -484,4 +484,195 @@ class RUMApplicationScopeTests: XCTestCase {
         // Then
         XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .explicitStop)
     }
+
+    func testGivenInactiveSession_whenNewOneIsStartedInBackground_itSetsBackgroundLaunchPrecondition() {
+        // Given
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(sdkInitDate: currentTime)
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        // When
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMCommandMock(time: currentTime, isUserInteraction: true),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .backgroundLaunch)
+    }
+
+    func testGivenExpiredSession_whenNewOneIsStartedInBackground_itSetsBackgroundLaunchPrecondition() {
+        // Given
+        let initialTime: Date = .mockDecember15th2019At10AMUTC()
+        var currentTime: Date = initialTime
+        let sdkContext: DatadogContext = .mockWith(sdkInitDate: currentTime)
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        // Keep session active without exceeding maxDuration — stop one step before it would expire
+        while currentTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1) < initialTime.addingTimeInterval(RUMSessionScope.Constants.sessionMaxDuration) {
+            currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+            _ = scope.process(
+                command: RUMCommandMock(time: currentTime, isUserInteraction: true),
+                context: sdkContext,
+                writer: writer
+            )
+        }
+
+        // When - advance past maxDuration without triggering inactivity timeout, then send in background
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMCommandMock(time: currentTime, isUserInteraction: true),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .backgroundLaunch)
+    }
+
+    func testGivenStoppedSession_whenNewOneIsStartedInBackground_itSetsBackgroundLaunchPrecondition() {
+        // Given
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(sdkInitDate: currentTime)
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        currentTime.addTimeInterval(1)
+        _ = scope.process(command: RUMStopSessionCommand(time: currentTime), context: sdkContext, writer: writer)
+
+        // When
+        currentTime.addTimeInterval(1)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .backgroundLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMAddUserActionCommand.mockWith(time: currentTime),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .backgroundLaunch)
+    }
+
+    func testGivenInactiveSession_whenNewOneIsStartedInBackgroundWithPrewarming_itSetsPrewarmPrecondition() {
+        // Given
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(sdkInitDate: currentTime)
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        // When
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMCommandMock(time: currentTime, isUserInteraction: true),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .prewarm)
+    }
+
+    func testGivenStoppedSession_whenNewOneIsStartedInBackgroundWithPrewarming_itSetsPrewarmPrecondition() {
+        // Given
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(sdkInitDate: currentTime)
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        currentTime.addTimeInterval(1)
+        _ = scope.process(command: RUMStopSessionCommand(time: currentTime), context: sdkContext, writer: writer)
+
+        // When
+        currentTime.addTimeInterval(1)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMAddUserActionCommand.mockWith(time: currentTime),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .prewarm)
+    }
+
+    func testGivenUserLaunchedApp_whenSessionTimesOutInBackground_itSetsInactivityTimeoutPrecondition() {
+        // Given - app launched by user, session becomes inactive
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(launchReason: .userLaunch)
+        )
+        let featureScope = FeatureScopeMock()
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(featureScope: featureScope, samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        // When - session times out while app is in background
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let backgroundContext: DatadogContext = .mockWith(
+            launchInfo: .mockWith(
+                launchReason: .userLaunch,
+                processLaunchDate: .mockDecember15th2019At10AMUTC()
+            ),
+            applicationStateHistory: .mockAppInBackground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMCommandMock(time: currentTime, isUserInteraction: true),
+            context: backgroundContext,
+            writer: writer
+        )
+
+        // Then - end-reason-based precondition is used, not backgroundLaunch
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .inactivityTimeout)
+        // And no error telemetry is fired for .userLaunch in background (it is a valid scenario)
+        XCTAssertNil(featureScope.telemetryMock.messages.firstError())
+    }
 }


### PR DESCRIPTION
### What and why?

When a new RUM session starts while the app is in the background, it should be tagged with background_launch or prewarm as its session_precondition. The two session renewal paths (refresh(expiredSession:) and startNewSession()) were ignoring app state and always deriving the precondition from the previous session's end reason, so background sessions were incorrectly labelled inactivity_timeout, max_duration, or explicit_stop.                                                                                                     

### How?

Extracted a private helper preconditionForNewBackgroundSession(context:) that maps launchInfo.launchReason to the correct background precondition (.backgroundLaunch → .backgroundLaunch, .prewarming → .prewarm, .userLaunch → nil to fall through to end-reason logic).    
Applied a background-first check in both refresh(expiredSession:) and startNewSession(), mirroring the existing behaviour in createInitialSession(). Also refactored createInitialSession() to use the same shared helper.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
