### PR TITLE
fix dogfooding: sync `project.pbxproj` branch with `Package.resolved` for Shopist

### DIFF
--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -204,6 +204,12 @@ update_dependent_package_resolved() {
         --dogfooded-commit '$DOGFOODED_COMMIT'"
 }
 
+# Updates dd-sdk-ios branch requirement in dependent project's project.pbxproj.
+update_dependent_pbxproj_branch() {
+    local pbxproj_path="$1"
+    echo_subtitle "Update dd-sdk-ios branch to '$DOGFOODED_BRANCH' in '$pbxproj_path'"
+    sed -i '' -E "s/(branch = )develop(;)/\1$DOGFOODED_BRANCH\2/" "$pbxproj_path"
+}
 # Updates 'sdk_version' in dependent project to DOGFOODED_SDK_VERSION.
 update_dependent_sdk_version() {
     local version_file="$1"
@@ -246,6 +252,7 @@ if [ "$shopist" = "true" ]; then
     # Update dd-sdk-ios version:
     update_dependent_package_resolved "$CLONE_PATH/Shopist/Shopist.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
     update_dependent_sdk_version "$CLONE_PATH/Shopist/Shopist/DogfoodingConfig.swift"
+    update_dependent_pbxproj_branch "$CLONE_PATH/Shopist/Shopist.xcodeproj/project.pbxproj"
 
     echo_info "▸ Exporting 'GITHUB_TOKEN' for CI"
     export GITHUB_TOKEN=$(dd-octo-sts --disable-tracing token --scope DataDog/shopist-ios --policy dd-sdk-ios.gitlab.pr)


### PR DESCRIPTION
### What and why?

The dogfooding automation updates `Package.resolved` to pin a specific `dogfooding` commit and updates `DogfoodingConfig.swift` with the version, but it never updated the XCRemoteSwiftPackageReference branch requirement in `project.pbxproj` (which stayed on `develop`).

This mismatch is benign in local development where Xcode respects the lock file, but in a clean GitHub Actions checkout xcodebuild can see the inconsistency between the project requirement (`develop`) and the resolved pin (`dogfooding` commit) and re-resolve from `develop` — meaning the build silently uses a `develop` commit instead of the intended `dogfooding` one.

This was flagged in an [automated comment](https://github.com/DataDog/shopist-ios/pull/212#discussion_r3131641375) on Shopist but dismissed at the time. The branch has since been [manually corrected](https://github.com/DataDog/shopist-ios/pull/216) in Shopist; this change makes the automation keep it correct going forward.

### How?

Adds `update_dependent_pbxproj_branch` to `dogfood.sh`, called alongside the existing `Package.resolved` and version file updates in the Shopist dogfooding flow.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
