### PR TITLE
RUM-15735: Offload Mach profile aggregation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		1121FD002EE319F000297156 /* ProfilingTelemetryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1121FCFE2EE319E600297156 /* ProfilingTelemetryController.swift */; };
 		1121FD022EE33B3400297156 /* ConfigurationMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1121FD012EE33B2E00297156 /* ConfigurationMetric.swift */; };
 		1121FD052F00000000297156 /* ProfilingSessionMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1121FD042F00000000297156 /* ProfilingSessionMetric.swift */; };
+		1121FD072F00000100297156 /* AggregationDiagnosticsMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1121FD062F00000100297156 /* AggregationDiagnosticsMetric.swift */; };
 		1124D5302EA6D23C0002E053 /* StartupTypeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1124D52E2EA6D2370002E053 /* StartupTypeHandler.swift */; };
 		1124D5322EA6D4050002E053 /* RUMAppLaunchManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1124D5312EA6D4050002E053 /* RUMAppLaunchManagerTests.swift */; };
 		1124D5382EA6D4390002E053 /* RUMAppLaunchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1124D5342EA6D4390002E053 /* RUMAppLaunchManager.swift */; };
@@ -1803,6 +1804,7 @@
 		1121FCFE2EE319E600297156 /* ProfilingTelemetryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingTelemetryController.swift; sourceTree = "<group>"; };
 		1121FD012EE33B2E00297156 /* ConfigurationMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationMetric.swift; sourceTree = "<group>"; };
 		1121FD042F00000000297156 /* ProfilingSessionMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingSessionMetric.swift; sourceTree = "<group>"; };
+		1121FD062F00000100297156 /* AggregationDiagnosticsMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregationDiagnosticsMetric.swift; sourceTree = "<group>"; };
 		1124D52E2EA6D2370002E053 /* StartupTypeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupTypeHandler.swift; sourceTree = "<group>"; };
 		1124D5312EA6D4050002E053 /* RUMAppLaunchManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAppLaunchManagerTests.swift; sourceTree = "<group>"; };
 		1124D5342EA6D4390002E053 /* RUMAppLaunchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAppLaunchManager.swift; sourceTree = "<group>"; };
@@ -3262,6 +3264,7 @@
 		1121FCFA2EE305D900297156 /* SDKMetrics */ = {
 			isa = PBXGroup;
 			children = (
+				1121FD062F00000100297156 /* AggregationDiagnosticsMetric.swift */,
 				1121FD012EE33B2E00297156 /* ConfigurationMetric.swift */,
 				1121FD042F00000000297156 /* ProfilingSessionMetric.swift */,
 				1121FCFE2EE319E600297156 /* ProfilingTelemetryController.swift */,
@@ -8459,6 +8462,7 @@
 				110DD1B22EEB6BBD002F3B8B /* ProfilingConfiguration.swift in Sources */,
 				D233E7C42E4625D400E7CFDE /* RequestBuilder.swift in Sources */,
 				D233E7C52E4625D400E7CFDE /* ProfileEvent.swift in Sources */,
+				1121FD072F00000100297156 /* AggregationDiagnosticsMetric.swift in Sources */,
 				1121FD002EE319F000297156 /* ProfilingTelemetryController.swift in Sources */,
 				1121FD052F00000000297156 /* ProfilingSessionMetric.swift in Sources */,
 				D233E8022E4B653F00E7CFDE /* dd_pprof.cpp in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		115792E62F4504F700AEE829 /* binary_image_resolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 115792E42F4504F700AEE829 /* binary_image_resolver.h */; };
 		115792EC2F4608A200AEE829 /* BinaryImageResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */; };
 		1157930A2F51F05100AEE829 /* binary_image_resolver_testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 115793092F51F05100AEE829 /* binary_image_resolver_testing.h */; };
+		A1B2C3D42F90000100ABCDEF /* aggregation_worker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D22F90000100ABCDEF /* aggregation_worker.cpp */; };
+		A1B2C3D52F90000100ABCDEF /* aggregation_worker.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F90000100ABCDEF /* aggregation_worker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
 		116232382F866ACF00F20ABC /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848522F6C4E0C008D2919 /* OperationMessage.swift */; };
 		1162323A2F866B4000F20ABC /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
@@ -1818,6 +1820,8 @@
 		115792E42F4504F700AEE829 /* binary_image_resolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver.h; sourceTree = "<group>"; };
 		115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageResolverTests.swift; sourceTree = "<group>"; };
 		115793092F51F05100AEE829 /* binary_image_resolver_testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver_testing.h; sourceTree = "<group>"; };
+		A1B2C3D22F90000100ABCDEF /* aggregation_worker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = aggregation_worker.cpp; sourceTree = "<group>"; };
+		A1B2C3D32F90000100ABCDEF /* aggregation_worker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = aggregation_worker.h; sourceTree = "<group>"; };
 		115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
 		1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextMessageReceiver.swift; sourceTree = "<group>"; };
 		1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingSamplerProvider.swift; sourceTree = "<group>"; };
@@ -6034,6 +6038,7 @@
 				D2E937242E53324100FECA76 /* profile.h */,
 				D2E9372A2E53325200FECA76 /* profile.pb-c.h */,
 				D2E9372D2E53325900FECA76 /* protobuf-c.h */,
+				A1B2C3D32F90000100ABCDEF /* aggregation_worker.h */,
 				110DD1B92EEC3EE7002F3B8B /* safe_read_testing.h */,
 				D2355B262E4E05CE000DDF5F /* module.modulemap */,
 			);
@@ -6051,6 +6056,7 @@
 				D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */,
 				D233E7E92E4B588000E7CFDE /* profile_pprof_packer.cpp */,
 				D233E7E72E4B588000E7CFDE /* profile.cpp */,
+				A1B2C3D22F90000100ABCDEF /* aggregation_worker.cpp */,
 				D229FF5A2E3BA298009CCD62 /* include */,
 			);
 			name = Mach;
@@ -6864,6 +6870,7 @@
 				D2E9372B2E53325200FECA76 /* profile.pb-c.h in Headers */,
 				115792E62F4504F700AEE829 /* binary_image_resolver.h in Headers */,
 				D2E9371A2E4E25E800FECA76 /* mach_sampling_profiler.h in Headers */,
+				A1B2C3D52F90000100ABCDEF /* aggregation_worker.h in Headers */,
 				D229FFA92E3BCA9B009CCD62 /* dd_profiler.h in Headers */,
 				D233E8002E4B588B00E7CFDE /* dd_pprof.h in Headers */,
 				D2F0E8A52F5C000100E7CFDE /* dd_pprof_testing.h in Headers */,
@@ -8455,6 +8462,7 @@
 				1121FD002EE319F000297156 /* ProfilingTelemetryController.swift in Sources */,
 				1121FD052F00000000297156 /* ProfilingSessionMetric.swift in Sources */,
 				D233E8022E4B653F00E7CFDE /* dd_pprof.cpp in Sources */,
+				A1B2C3D42F90000100ABCDEF /* aggregation_worker.cpp in Sources */,
 				D233E7C62E4625D400E7CFDE /* Profiling.swift in Sources */,
 				11C4E5922F571F86002196F4 /* ProfileAttachments.swift in Sources */,
 				1162323E2F87D8FC00F20ABC /* ProfilingContextMessageReceiver.swift in Sources */,

--- a/DatadogProfiling/Mach/aggregation_worker.cpp
+++ b/DatadogProfiling/Mach/aggregation_worker.cpp
@@ -1,0 +1,385 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#include "aggregation_worker.h"
+
+#if defined(__APPLE__) && !TARGET_OS_WATCH
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+
+namespace dd::profiler {
+
+static void destroy_stack_trace_payload(stack_trace_t* trace) {
+    if (!trace) return;
+
+    if (trace->thread_name) {
+        std::free((void*)trace->thread_name);
+        trace->thread_name = nullptr;
+    }
+
+    if (trace->frames) {
+        std::free(trace->frames);
+        trace->frames = nullptr;
+    }
+}
+
+aggregation_worker::aggregation_worker(
+    size_t buffer_capacity,
+    uint32_t max_stack_depth,
+    stack_trace_callback_t callback,
+    void* ctx,
+    uint64_t hard_limit_bytes,
+    qos_class_t worker_qos)
+    : buffer_capacity(buffer_capacity)
+    , max_stack_depth(max_stack_depth)
+    , worker_qos(worker_qos)
+    , callback(callback)
+    , ctx(ctx)
+    , hard_limit_bytes(hard_limit_bytes) {
+}
+
+aggregation_worker::~aggregation_worker() {
+    stop();
+}
+
+void* aggregation_worker::worker_thread_entry(void* arg) {
+    pthread_setname_np("com.datadoghq.profiler.aggregate");
+    static_cast<aggregation_worker*>(arg)->worker_main();
+    return nullptr;
+}
+
+bool aggregation_worker::start() {
+    std::lock_guard<std::mutex> lock(work_mutex);
+
+    if (worker_thread_started) {
+        return false;
+    }
+
+    clear_pending_work_locked();
+    reusable_buffers.clear();
+    next_flush_id = 0;
+    completed_flush_id = 0;
+    pending_bytes = 0;
+    dropped_batch_count = 0;
+    dropped_sample_count = 0;
+    max_pending_bytes = 0;
+    producer_finished = false;
+    worker_finished = false;
+    worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
+
+    pthread_attr_t worker_attr;
+    pthread_attr_init(&worker_attr);
+    pthread_attr_set_qos_class_np(&worker_attr, worker_qos, 0);
+
+    int result = pthread_create(&worker_thread, &worker_attr, worker_thread_entry, this);
+    pthread_attr_destroy(&worker_attr);
+    if (result != 0) {
+        producer_finished = true;
+        worker_finished = true;
+        flush_cv.notify_all();
+        return false;
+    }
+
+    worker_mach_thread.store(pthread_mach_thread_np(worker_thread), std::memory_order_relaxed);
+    worker_thread_started = true;
+    return true;
+}
+
+void aggregation_worker::stop() {
+    if (is_worker_thread()) {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        producer_finished = true;
+        work_cv.notify_all();
+        flush_cv.notify_all();
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        if (!worker_thread_started && worker_finished) {
+            clear_pending_work_locked();
+            reusable_buffers.clear();
+            worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
+            return;
+        }
+
+        producer_finished = true;
+        work_cv.notify_all();
+        flush_cv.notify_all();
+    }
+
+    if (worker_thread_started) {
+        pthread_join(worker_thread, nullptr);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        worker_thread_started = false;
+        worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
+        clear_pending_work_locked();
+        reusable_buffers.clear();
+        worker_finished = true;
+        producer_finished = true;
+    }
+}
+
+void aggregation_worker::request_flush(flush_action_t action, void* action_ctx) {
+    std::unique_lock<std::mutex> lock(work_mutex);
+    bool execute_inline = false;
+
+    const uint64_t flush_id = ++next_flush_id;
+    if (worker_finished) {
+        completed_flush_id = flush_id;
+        execute_inline = true;
+    } else {
+        work_item barrier{
+            work_item::kind::flush_barrier,
+            {},
+            flush_id,
+            action,
+            action_ctx
+        };
+
+        if (producer_finished) {
+            pending_work.push_back(std::move(barrier));
+            work_cv.notify_one();
+        } else {
+            requested_flushes.push_back(std::move(barrier));
+        }
+
+        flush_cv.wait(lock, [this, flush_id] {
+            return completed_flush_id >= flush_id || worker_finished;
+        });
+
+        if (completed_flush_id < flush_id && worker_finished) {
+            completed_flush_id = flush_id;
+            execute_inline = true;
+        }
+    }
+
+    lock.unlock();
+    if (execute_inline && action) {
+        action(action_ctx);
+    }
+}
+
+void aggregation_worker::enqueue_active_buffer(std::vector<stack_trace_t>& active_buffer) {
+    if (active_buffer.empty()) {
+        return;
+    }
+
+    std::vector<stack_trace_t> dropped_batch;
+    bool did_drop = false;
+
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        std::vector<stack_trace_t> batch;
+        batch.swap(active_buffer);
+
+        if (!reusable_buffers.empty()) {
+            active_buffer = std::move(reusable_buffers.back());
+            reusable_buffers.pop_back();
+        }
+
+        const uint64_t batch_bytes = batch_footprint_bytes(batch);
+        if (pending_bytes + batch_bytes > hard_limit_bytes) {
+            dropped_batch_count += 1;
+            dropped_sample_count += batch.size();
+            max_pending_bytes = std::max(max_pending_bytes, pending_bytes + batch_bytes);
+            dropped_batch = std::move(batch);
+            did_drop = true;
+        } else {
+            pending_bytes += batch_bytes;
+            max_pending_bytes = std::max(max_pending_bytes, pending_bytes);
+            pending_work.push_back({
+                work_item::kind::batch,
+                std::move(batch),
+                0,
+                nullptr,
+                nullptr,
+                batch_bytes
+            });
+        }
+    }
+
+    if (did_drop) {
+        destroy_batch(dropped_batch);
+    }
+
+    if (!did_drop) {
+        work_cv.notify_one();
+    }
+
+    if (active_buffer.capacity() == 0) {
+        try {
+            // Best effort: overflow handoff keeps sampling moving even if we
+            // cannot immediately reserve the next full-capacity buffer.
+            active_buffer.reserve(buffer_capacity);
+        } catch (const std::bad_alloc&) {
+            return;
+        }
+    }
+}
+
+void aggregation_worker::service_pending_flush_request(std::vector<stack_trace_t>& active_buffer) {
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        if (requested_flushes.empty()) {
+            return;
+        }
+    }
+
+    enqueue_active_buffer(active_buffer);
+
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        while (!requested_flushes.empty()) {
+            pending_work.push_back(std::move(requested_flushes.front()));
+            requested_flushes.pop_front();
+        }
+    }
+
+    work_cv.notify_one();
+}
+
+void aggregation_worker::finish_producer(std::vector<stack_trace_t>& active_buffer) {
+    service_pending_flush_request(active_buffer);
+    enqueue_active_buffer(active_buffer);
+
+    {
+        std::lock_guard<std::mutex> lock(work_mutex);
+        while (!requested_flushes.empty()) {
+            pending_work.push_back(std::move(requested_flushes.front()));
+            requested_flushes.pop_front();
+        }
+
+        producer_finished = true;
+    }
+
+    work_cv.notify_all();
+    flush_cv.notify_all();
+}
+
+bool aggregation_worker::is_worker_thread() {
+    std::lock_guard<std::mutex> lock(work_mutex);
+    return worker_thread_started && pthread_equal(pthread_self(), worker_thread);
+}
+
+bool aggregation_worker::is_worker_thread(thread_t thread) {
+    const thread_t worker_thread_id = worker_mach_thread.load(std::memory_order_relaxed);
+    return worker_thread_id != MACH_PORT_NULL && thread == worker_thread_id;
+}
+
+void aggregation_worker::consume_diagnostics(dd_profiler_diagnostics_t* out) {
+    if (!out) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(work_mutex);
+    out->dropped_batch_count = dropped_batch_count;
+    out->dropped_sample_count = dropped_sample_count;
+    out->max_pending_bytes = max_pending_bytes;
+
+    dropped_batch_count = 0;
+    dropped_sample_count = 0;
+    max_pending_bytes = pending_bytes;
+}
+
+void aggregation_worker::worker_main() {
+    while (true) {
+        work_item item{work_item::kind::flush_barrier, {}, 0};
+
+        {
+            std::unique_lock<std::mutex> lock(work_mutex);
+            work_cv.wait(lock, [this] {
+                return !pending_work.empty() || producer_finished;
+            });
+
+            if (pending_work.empty()) {
+                if (producer_finished) {
+                    worker_finished = true;
+                    flush_cv.notify_all();
+                    return;
+                }
+
+                continue;
+            }
+
+            item = std::move(pending_work.front());
+            pending_work.pop_front();
+        }
+
+        if (item.item_kind == work_item::kind::batch) {
+            if (callback && !item.traces.empty()) {
+                callback(item.traces.data(), item.traces.size(), ctx);
+            }
+
+            destroy_batch(item.traces);
+            recycle_batch(std::move(item.traces), item.footprint_bytes);
+            continue;
+        }
+
+        if (item.action) {
+            item.action(item.action_ctx);
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(work_mutex);
+            completed_flush_id = std::max(completed_flush_id, item.flush_id);
+        }
+
+        flush_cv.notify_all();
+    }
+}
+
+void aggregation_worker::recycle_batch(std::vector<stack_trace_t>&& batch, uint64_t footprint_bytes) {
+    batch.clear();
+
+    std::lock_guard<std::mutex> lock(work_mutex);
+    pending_bytes = pending_bytes > footprint_bytes ? pending_bytes - footprint_bytes : 0;
+    if (reusable_buffers.size() < max_reusable_buffers) {
+        reusable_buffers.push_back(std::move(batch));
+    }
+}
+
+void aggregation_worker::destroy_batch(std::vector<stack_trace_t>& batch) {
+    for (auto& trace : batch) {
+        destroy_stack_trace_payload(&trace);
+    }
+}
+
+void aggregation_worker::clear_pending_work_locked() {
+    for (auto& item : pending_work) {
+        if (item.item_kind == work_item::kind::batch) {
+            destroy_batch(item.traces);
+        }
+    }
+
+    pending_work.clear();
+    requested_flushes.clear();
+    pending_bytes = 0;
+}
+
+uint64_t aggregation_worker::batch_footprint_bytes(const std::vector<stack_trace_t>& batch) const {
+    const uint64_t trace_storage_bytes = static_cast<uint64_t>(batch.capacity()) * sizeof(stack_trace_t);
+    const uint64_t frame_storage_bytes = static_cast<uint64_t>(batch.size()) * max_stack_depth * sizeof(stack_frame_t);
+    uint64_t thread_name_bytes = 0;
+
+    for (const auto& trace : batch) {
+        if (trace.thread_name) {
+            thread_name_bytes += sampled_thread_name_capacity;
+        }
+    }
+
+    return trace_storage_bytes + frame_storage_bytes + thread_name_bytes;
+}
+
+} // namespace dd::profiler
+
+#endif // __APPLE__ && !TARGET_OS_WATCH

--- a/DatadogProfiling/Mach/aggregation_worker.cpp
+++ b/DatadogProfiling/Mach/aggregation_worker.cpp
@@ -9,39 +9,25 @@
 #if defined(__APPLE__) && !TARGET_OS_WATCH
 
 #include <algorithm>
-#include <cstdio>
-#include <cstdlib>
 #include <new>
 
 namespace dd::profiler {
 
-static void destroy_stack_trace_payload(stack_trace_t* trace) {
-    if (!trace) return;
-
-    if (trace->thread_name) {
-        std::free((void*)trace->thread_name);
-        trace->thread_name = nullptr;
-    }
-
-    if (trace->frames) {
-        std::free(trace->frames);
-        trace->frames = nullptr;
-    }
-}
-
 aggregation_worker::aggregation_worker(
-    size_t buffer_capacity,
+    size_t initial_buffer_size,
     uint32_t max_stack_depth,
     stack_trace_callback_t callback,
     void* ctx,
     uint64_t hard_limit_bytes,
     qos_class_t worker_qos)
-    : buffer_capacity(buffer_capacity)
-    , max_stack_depth(max_stack_depth)
-    , worker_qos(worker_qos)
-    , callback(callback)
-    , ctx(ctx)
-    , hard_limit_bytes(hard_limit_bytes) {
+    : config{
+        initial_buffer_size,
+        max_stack_depth,
+        worker_qos,
+        callback,
+        ctx,
+        hard_limit_bytes
+    } {
 }
 
 aggregation_worker::~aggregation_worker() {
@@ -57,25 +43,22 @@ void* aggregation_worker::worker_thread_entry(void* arg) {
 bool aggregation_worker::start() {
     std::lock_guard<std::mutex> lock(work_mutex);
 
-    if (worker_thread_started) {
+    if (has_worker_thread) {
         return false;
     }
 
     clear_pending_work_locked();
-    reusable_buffers.clear();
     next_flush_id = 0;
     completed_flush_id = 0;
     pending_bytes = 0;
-    dropped_batch_count = 0;
-    dropped_sample_count = 0;
-    max_pending_bytes = 0;
+    diagnostics = dd_profiler_diagnostics_t{};
     producer_finished = false;
     worker_finished = false;
     worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
 
     pthread_attr_t worker_attr;
     pthread_attr_init(&worker_attr);
-    pthread_attr_set_qos_class_np(&worker_attr, worker_qos, 0);
+    pthread_attr_set_qos_class_np(&worker_attr, config.worker_qos, 0);
 
     int result = pthread_create(&worker_thread, &worker_attr, worker_thread_entry, this);
     pthread_attr_destroy(&worker_attr);
@@ -87,24 +70,15 @@ bool aggregation_worker::start() {
     }
 
     worker_mach_thread.store(pthread_mach_thread_np(worker_thread), std::memory_order_relaxed);
-    worker_thread_started = true;
+    has_worker_thread = true;
     return true;
 }
 
 void aggregation_worker::stop() {
-    if (is_worker_thread()) {
-        std::lock_guard<std::mutex> lock(work_mutex);
-        producer_finished = true;
-        work_cv.notify_all();
-        flush_cv.notify_all();
-        return;
-    }
-
     {
         std::lock_guard<std::mutex> lock(work_mutex);
-        if (!worker_thread_started && worker_finished) {
+        if (!has_worker_thread && worker_finished) {
             clear_pending_work_locked();
-            reusable_buffers.clear();
             worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
             return;
         }
@@ -114,59 +88,46 @@ void aggregation_worker::stop() {
         flush_cv.notify_all();
     }
 
-    if (worker_thread_started) {
+    if (has_worker_thread) {
         pthread_join(worker_thread, nullptr);
     }
 
     {
         std::lock_guard<std::mutex> lock(work_mutex);
-        worker_thread_started = false;
+        has_worker_thread = false;
         worker_mach_thread.store(MACH_PORT_NULL, std::memory_order_relaxed);
         clear_pending_work_locked();
-        reusable_buffers.clear();
         worker_finished = true;
         producer_finished = true;
     }
 }
 
-void aggregation_worker::request_flush(flush_action_t action, void* action_ctx) {
+bool aggregation_worker::request_flush(flush_action_t action) {
     std::unique_lock<std::mutex> lock(work_mutex);
-    bool execute_inline = false;
+
+    if (worker_finished) {
+        return false;
+    }
 
     const uint64_t flush_id = ++next_flush_id;
-    if (worker_finished) {
-        completed_flush_id = flush_id;
-        execute_inline = true;
+
+    flush_barrier barrier{
+        flush_id,
+        std::move(action)
+    };
+
+    if (producer_finished) {
+        pending_work.emplace_back(std::move(barrier));
+        work_cv.notify_one();
     } else {
-        work_item barrier{
-            work_item::kind::flush_barrier,
-            {},
-            flush_id,
-            action,
-            action_ctx
-        };
-
-        if (producer_finished) {
-            pending_work.push_back(std::move(barrier));
-            work_cv.notify_one();
-        } else {
-            requested_flushes.push_back(std::move(barrier));
-        }
-
-        flush_cv.wait(lock, [this, flush_id] {
-            return completed_flush_id >= flush_id || worker_finished;
-        });
-
-        if (completed_flush_id < flush_id && worker_finished) {
-            completed_flush_id = flush_id;
-            execute_inline = true;
-        }
+        requested_flushes.push_back(std::move(barrier));
     }
 
-    lock.unlock();
-    if (execute_inline && action) {
-        action(action_ctx);
-    }
+    flush_cv.wait(lock, [this, flush_id] {
+        return completed_flush_id >= flush_id || worker_finished;
+    });
+
+    return completed_flush_id >= flush_id;
 }
 
 void aggregation_worker::enqueue_active_buffer(std::vector<stack_trace_t>& active_buffer) {
@@ -180,36 +141,34 @@ void aggregation_worker::enqueue_active_buffer(std::vector<stack_trace_t>& activ
     {
         std::lock_guard<std::mutex> lock(work_mutex);
         std::vector<stack_trace_t> batch;
+
+        // Transfer ownership of captured traces to the worker queue. The
+        // sampler keeps using `active_buffer` after this call returns.
         batch.swap(active_buffer);
 
-        if (!reusable_buffers.empty()) {
-            active_buffer = std::move(reusable_buffers.back());
-            reusable_buffers.pop_back();
-        }
-
         const uint64_t batch_bytes = batch_footprint_bytes(batch);
-        if (pending_bytes + batch_bytes > hard_limit_bytes) {
-            dropped_batch_count += 1;
-            dropped_sample_count += batch.size();
-            max_pending_bytes = std::max(max_pending_bytes, pending_bytes + batch_bytes);
+        if (pending_bytes + batch_bytes > config.hard_limit_bytes) {
+            // Enforce a hard queue-memory limit without blocking the sampling
+            // loop. Dropped samples are reported through diagnostics.
+            diagnostics.dropped_batch_count += 1;
+            diagnostics.dropped_sample_count += batch.size();
+            diagnostics.max_pending_bytes = std::max(diagnostics.max_pending_bytes, pending_bytes + batch_bytes);
             dropped_batch = std::move(batch);
             did_drop = true;
         } else {
             pending_bytes += batch_bytes;
-            max_pending_bytes = std::max(max_pending_bytes, pending_bytes);
-            pending_work.push_back({
-                work_item::kind::batch,
+            diagnostics.max_pending_bytes = std::max(diagnostics.max_pending_bytes, pending_bytes);
+            pending_work.emplace_back(batch_item{
                 std::move(batch),
-                0,
-                nullptr,
-                nullptr,
                 batch_bytes
             });
         }
     }
 
     if (did_drop) {
-        destroy_batch(dropped_batch);
+        // Destroy trace payloads outside the queue lock; cleanup can release
+        // frame and thread-name allocations.
+        free_batch_payloads(dropped_batch);
     }
 
     if (!did_drop) {
@@ -218,9 +177,9 @@ void aggregation_worker::enqueue_active_buffer(std::vector<stack_trace_t>& activ
 
     if (active_buffer.capacity() == 0) {
         try {
-            // Best effort: overflow handoff keeps sampling moving even if we
-            // cannot immediately reserve the next full-capacity buffer.
-            active_buffer.reserve(buffer_capacity);
+            // Best effort: restore the sampler's expected batch capacity after
+            // handing off the previous buffer.
+            active_buffer.reserve(config.initial_buffer_size);
         } catch (const std::bad_alloc&) {
             return;
         }
@@ -240,7 +199,7 @@ void aggregation_worker::service_pending_flush_request(std::vector<stack_trace_t
     {
         std::lock_guard<std::mutex> lock(work_mutex);
         while (!requested_flushes.empty()) {
-            pending_work.push_back(std::move(requested_flushes.front()));
+            pending_work.emplace_back(std::move(requested_flushes.front()));
             requested_flushes.pop_front();
         }
     }
@@ -255,7 +214,7 @@ void aggregation_worker::finish_producer(std::vector<stack_trace_t>& active_buff
     {
         std::lock_guard<std::mutex> lock(work_mutex);
         while (!requested_flushes.empty()) {
-            pending_work.push_back(std::move(requested_flushes.front()));
+            pending_work.emplace_back(std::move(requested_flushes.front()));
             requested_flushes.pop_front();
         }
 
@@ -268,7 +227,7 @@ void aggregation_worker::finish_producer(std::vector<stack_trace_t>& active_buff
 
 bool aggregation_worker::is_worker_thread() {
     std::lock_guard<std::mutex> lock(work_mutex);
-    return worker_thread_started && pthread_equal(pthread_self(), worker_thread);
+    return has_worker_thread && pthread_equal(pthread_self(), worker_thread);
 }
 
 bool aggregation_worker::is_worker_thread(thread_t thread) {
@@ -276,24 +235,15 @@ bool aggregation_worker::is_worker_thread(thread_t thread) {
     return worker_thread_id != MACH_PORT_NULL && thread == worker_thread_id;
 }
 
-void aggregation_worker::consume_diagnostics(dd_profiler_diagnostics_t* out) {
-    if (!out) {
-        return;
-    }
-
+void aggregation_worker::consume_diagnostics(dd_profiler_diagnostics_t& out) {
     std::lock_guard<std::mutex> lock(work_mutex);
-    out->dropped_batch_count = dropped_batch_count;
-    out->dropped_sample_count = dropped_sample_count;
-    out->max_pending_bytes = max_pending_bytes;
-
-    dropped_batch_count = 0;
-    dropped_sample_count = 0;
-    max_pending_bytes = pending_bytes;
+    out = diagnostics;
+    diagnostics = dd_profiler_diagnostics_t{0, 0, pending_bytes};
 }
 
 void aggregation_worker::worker_main() {
     while (true) {
-        work_item item{work_item::kind::flush_barrier, {}, 0};
+        work_item item{flush_barrier{}};
 
         {
             std::unique_lock<std::mutex> lock(work_mutex);
@@ -315,49 +265,45 @@ void aggregation_worker::worker_main() {
             pending_work.pop_front();
         }
 
-        if (item.item_kind == work_item::kind::batch) {
-            if (callback && !item.traces.empty()) {
-                callback(item.traces.data(), item.traces.size(), ctx);
+        if (auto* batch = std::get_if<batch_item>(&item)) {
+            if (config.callback && !batch->traces.empty()) {
+                config.callback(batch->traces.data(), batch->traces.size(), config.ctx);
             }
 
-            destroy_batch(item.traces);
-            recycle_batch(std::move(item.traces), item.footprint_bytes);
+            free_batch_payloads(batch->traces);
+            complete_batch(batch->footprint_bytes);
             continue;
         }
 
-        if (item.action) {
-            item.action(item.action_ctx);
+        auto& barrier = std::get<flush_barrier>(item);
+        if (barrier.action) {
+            barrier.action();
         }
 
         {
             std::lock_guard<std::mutex> lock(work_mutex);
-            completed_flush_id = std::max(completed_flush_id, item.flush_id);
+            completed_flush_id = std::max(completed_flush_id, barrier.flush_id);
         }
 
         flush_cv.notify_all();
     }
 }
 
-void aggregation_worker::recycle_batch(std::vector<stack_trace_t>&& batch, uint64_t footprint_bytes) {
-    batch.clear();
-
+void aggregation_worker::complete_batch(uint64_t footprint_bytes) {
     std::lock_guard<std::mutex> lock(work_mutex);
     pending_bytes = pending_bytes > footprint_bytes ? pending_bytes - footprint_bytes : 0;
-    if (reusable_buffers.size() < max_reusable_buffers) {
-        reusable_buffers.push_back(std::move(batch));
-    }
 }
 
-void aggregation_worker::destroy_batch(std::vector<stack_trace_t>& batch) {
+void aggregation_worker::free_batch_payloads(std::vector<stack_trace_t>& batch) {
     for (auto& trace : batch) {
-        destroy_stack_trace_payload(&trace);
+        stack_trace_destroy(&trace);
     }
 }
 
 void aggregation_worker::clear_pending_work_locked() {
     for (auto& item : pending_work) {
-        if (item.item_kind == work_item::kind::batch) {
-            destroy_batch(item.traces);
+        if (auto* batch = std::get_if<batch_item>(&item)) {
+            free_batch_payloads(batch->traces);
         }
     }
 
@@ -368,7 +314,7 @@ void aggregation_worker::clear_pending_work_locked() {
 
 uint64_t aggregation_worker::batch_footprint_bytes(const std::vector<stack_trace_t>& batch) const {
     const uint64_t trace_storage_bytes = static_cast<uint64_t>(batch.capacity()) * sizeof(stack_trace_t);
-    const uint64_t frame_storage_bytes = static_cast<uint64_t>(batch.size()) * max_stack_depth * sizeof(stack_frame_t);
+    const uint64_t frame_storage_bytes = static_cast<uint64_t>(batch.size()) * config.max_stack_depth * sizeof(stack_frame_t);
     uint64_t thread_name_bytes = 0;
 
     for (const auto& trace : batch) {

--- a/DatadogProfiling/Mach/dd_profiler.cpp
+++ b/DatadogProfiling/Mach/dd_profiler.cpp
@@ -15,14 +15,17 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <cstdlib>
 #include <cstring>
-#include <random>
 #include <mutex>
+#include <new>
+#include <random>
 
 // Profiling sampling backstop (see `callback`).
 // Typical profile span is ~1 minute; this cutoff includes additional slack beyond that.
 // The extra time avoids stopping sampling while the profile is still being processed.
 static constexpr int64_t DD_PROFILER_TIMEOUT_NS = 90000000000ULL; // 1:30 minutes
 static constexpr double DD_PROFILER_MAX_SAMPLE_RATE = 100.0;
+// Maximum queued aggregation batch memory before new batches are dropped.
+static constexpr uint64_t DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES = 64ULL * 1024ULL * 1024ULL;
 
 namespace dd::profiler { class dd_profiler; }
 
@@ -160,8 +163,9 @@ public:
     explicit dd_profiler(
         double sample_rate = DD_PROFILER_MAX_SAMPLE_RATE,
         bool is_prewarming = false,
-        int64_t timeout_ns = DD_PROFILER_TIMEOUT_NS
-    ) : sample_rate(sample_rate), is_prewarming(is_prewarming), timeout_ns(timeout_ns) {}
+        int64_t timeout_ns = DD_PROFILER_TIMEOUT_NS,
+        uint64_t hard_limit_bytes = DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES
+    ) : sample_rate(sample_rate), is_prewarming(is_prewarming), timeout_ns(timeout_ns), hard_limit_bytes(hard_limit_bytes) {}
 
     // Non-copyable, non-movable (prevents double-free of raw pointers)
     dd_profiler(const dd_profiler&) = delete;
@@ -182,7 +186,7 @@ public:
         // Create and populate the binary image cache early, before sampling starts.
         // This pre-loads binary image metadata (UUID, filename) for all currently
         // loaded images and watches for new ones via dyld notifications.
-        image_cache = new binary_image_cache();
+        image_cache = new (std::nothrow) binary_image_cache();
         // if cache allocation/start fails, keep profiling running
         if (!image_cache || !image_cache->load()) {
             delete image_cache;
@@ -209,17 +213,19 @@ public:
         if (!create_profile_and_profiler()) return 0;
         if (status == DD_PROFILER_STATUS_RUNNING) return 1;
 
-        status = DD_PROFILER_STATUS_RUNNING;
         if (!profiler->start_sampling()) {
-            status = DD_PROFILER_STATUS_ALREADY_STARTED;
+            status = DD_PROFILER_STATUS_NOT_STARTED;
+            return 0;
         }
 
+        status = DD_PROFILER_STATUS_RUNNING;
         return 1;
     }
 
     void stop() {
         if (!profiler) return;
         status = DD_PROFILER_STATUS_STOPPED;
+        profiler->request_stop();
         profiler->stop_sampling();
     }
 
@@ -247,22 +253,82 @@ public:
 
     /**
      * Flushes the sampling buffer and returns the profile, swapping in a fresh one.
+     * The swap runs in the aggregation worker's ordered stream, giving this
+     * flush a deterministic profile boundary.
      *
      * @return The harvested profile, or nullptr if no profile exists.
      */
     profile* flush_and_get_profile() {
-        if (profiler) profiler->request_flush();
+        profile_swap_context swap_context{
+            this,
+            new (std::nothrow) dd::profiler::profile(sampling_interval_ns),
+            nullptr
+        };
 
-        std::lock_guard<std::mutex> lock(profile_mutex);
-        if (!profile) return nullptr;
+        if (profiler) {
+            profiler->request_flush(swap_profile_action, &swap_context);
+        } else {
+            swap_profile_action(&swap_context);
+        }
 
-        dd::profiler::profile* harvested = profile;
-        profile = new dd::profiler::profile(sampling_interval_ns);
-        profile->set_server_time_offset_ns(server_time_offset_ns);
-        return harvested;
+        {
+            std::lock_guard<std::mutex> lock(profile_mutex);
+            if (profile) {
+                profile->set_server_time_offset_ns(server_time_offset_ns);
+            }
+        }
+
+        return swap_context.flushed_profile;
+    }
+
+    void consume_diagnostics(dd_profiler_diagnostics_t* out) {
+        if (!out) {
+            return;
+        }
+
+        out->dropped_batch_count = 0;
+        out->dropped_sample_count = 0;
+        out->max_pending_bytes = 0;
+
+        if (profiler) {
+            profiler->consume_diagnostics(out);
+        }
     }
 
 private:
+    struct profile_swap_context {
+        dd_profiler* profiler;
+        dd::profiler::profile* next_profile;
+        dd::profiler::profile* flushed_profile;
+    };
+
+    /**
+     * @brief Swaps the active profile at a flush boundary.
+     *
+     * Moves the current active profile into `flushed_profile` and installs
+     * `next_profile` as the new active profile under `profile_mutex`.
+     *
+     * @param ctx Pointer to `profile_swap_context`
+     */
+    static void swap_profile_action(void* ctx) {
+        if (!ctx) return;
+
+        auto* swap_context = static_cast<profile_swap_context*>(ctx);
+        dd_profiler* profiler = swap_context->profiler;
+        if (!profiler) return;
+
+        std::lock_guard<std::mutex> lock(profiler->profile_mutex);
+
+        swap_context->flushed_profile = profiler->profile;
+        profiler->profile = swap_context->next_profile;
+        swap_context->next_profile = nullptr;
+
+        if (!profiler->profile) {
+            profiler->status = DD_PROFILER_STATUS_ALLOCATION_FAILED;
+            if (profiler->profiler) profiler->profiler->request_stop();
+        }
+    }
+
     /**
      * Creates the profile aggregator and sampling profiler.
      * No-op if already created.
@@ -277,7 +343,7 @@ private:
 
         if (profiler) return true;
 
-        profile = new dd::profiler::profile(sampling_interval_ns);
+        profile = new (std::nothrow) dd::profiler::profile(sampling_interval_ns);
         if (!profile) {
             status = DD_PROFILER_STATUS_ALLOCATION_FAILED;
             return false;
@@ -287,7 +353,7 @@ private:
         sampling_config_t config = SAMPLING_CONFIG_DEFAULT;
         config.sampling_interval_nanos = sampling_interval_ns;
 
-        profiler = new mach_sampling_profiler(&config, callback, this);
+        profiler = new (std::nothrow) mach_sampling_profiler(&config, callback, this, hard_limit_bytes);
         if (!profiler) {
             delete profile;
             profile = nullptr;
@@ -304,6 +370,7 @@ private:
     double sample_rate = 0.0;
     bool is_prewarming = false;
     int64_t timeout_ns = DD_PROFILER_TIMEOUT_NS;
+    uint64_t hard_limit_bytes = DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES;
     uint64_t sampling_interval_ns = SAMPLING_CONFIG_DEFAULT_INTERVAL_NANOS;
     int64_t server_time_offset_ns = 0;
 
@@ -315,8 +382,8 @@ private:
     /**
      * Static callback function to handle collected stack traces.
      *
-     * Resolves binary image information for each frame using the
-     * cached image data, then adds the samples to the profile.
+     * Lazily resolves binary image information for first-seen locations and
+     * adds the samples to the profile.
      *
      * @param traces Array of captured stack traces
      * @param count Number of traces in the array
@@ -327,21 +394,18 @@ private:
 
         dd_profiler* profiler = static_cast<dd_profiler*>(ctx);
 
-        // Resolve binary images in-place before adding to the profile
-        resolve_stack_trace_frames(traces, count, profiler->image_cache);
-
         std::lock_guard<std::mutex> lock(profiler->profile_mutex);
 
         dd::profiler::profile* profile = profiler->profile;
 
         if (!profile) return;
 
-        profile->add_samples(traces, count);
+        profile->add_samples(traces, count, profiler->image_cache);
 
         // Check for timeout after adding samples
         int64_t duration_ns = profile->end_timestamp() - profile->start_timestamp();
         if (duration_ns > profiler->timeout_ns) {
-            profiler->stop();
+            profiler->profiler->request_stop();
             profiler->status = DD_PROFILER_STATUS_TIMEOUT;
         }
     }
@@ -360,8 +424,15 @@ static void dd_profiler_auto_start() {
     set_main_thread(pthread_self());
 
     double sample_rate = dd_is_profiling_enabled() ? read_profiling_sample_rate() : 0;
-    g_dd_profiler = new dd::profiler::dd_profiler(sample_rate, is_active_prewarm());
-    g_dd_profiler->auto_start();
+    g_dd_profiler = new (std::nothrow) dd::profiler::dd_profiler(
+        sample_rate,
+        is_active_prewarm(),
+        DD_PROFILER_TIMEOUT_NS,
+        DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES
+    );
+    if (g_dd_profiler) {
+        g_dd_profiler->auto_start();
+    }
 
     // Reset profiling defaults to be re-evaluated again
     dd_delete_profiling_defaults();
@@ -372,7 +443,15 @@ static void dd_profiler_auto_start() {
 int dd_profiler_start(void) {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
     if (!g_dd_profiler) {
-        g_dd_profiler = new dd::profiler::dd_profiler();
+        g_dd_profiler = new (std::nothrow) dd::profiler::dd_profiler(
+            DD_PROFILER_MAX_SAMPLE_RATE,
+            false,
+            DD_PROFILER_TIMEOUT_NS,
+            DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES
+        );
+        if (!g_dd_profiler) {
+            return 0;
+        }
     }
     return g_dd_profiler->start();
 }
@@ -385,6 +464,18 @@ void dd_profiler_stop(void) {
 dd_profiler_status_t dd_profiler_get_status(void) {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
     return g_dd_profiler ? g_dd_profiler->status : DD_PROFILER_STATUS_NOT_CREATED;
+}
+
+void dd_profiler_consume_diagnostics(dd_profiler_diagnostics_t* out) {
+    std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
+    if (out) {
+        out->dropped_batch_count = 0;
+        out->dropped_sample_count = 0;
+        out->max_pending_bytes = 0;
+    }
+    if (g_dd_profiler) {
+        g_dd_profiler->consume_diagnostics(out);
+    }
 }
 
 bool dd_profiler_is_running() {
@@ -417,11 +508,23 @@ void dd_profiler_destroy(void) {
 extern "C" {
 #endif
 
-void dd_profiler_start_testing(double sample_rate, bool is_prewarming, int64_t timeout_ns) {
+void dd_profiler_start_testing(
+    double sample_rate,
+    bool is_prewarming,
+    int64_t timeout_ns,
+    uint64_t hard_limit_bytes
+) {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
     delete g_dd_profiler;
-    g_dd_profiler = new dd::profiler::dd_profiler(sample_rate, is_prewarming, timeout_ns);
-    g_dd_profiler->auto_start();
+    g_dd_profiler = new (std::nothrow) dd::profiler::dd_profiler(
+        sample_rate,
+        is_prewarming,
+        timeout_ns,
+        hard_limit_bytes == 0 ? DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES : hard_limit_bytes
+    );
+    if (g_dd_profiler) {
+        g_dd_profiler->auto_start();
+    }
 }
 
 #ifdef __cplusplus

--- a/DatadogProfiling/Mach/dd_profiler.cpp
+++ b/DatadogProfiling/Mach/dd_profiler.cpp
@@ -27,6 +27,10 @@ static constexpr double DD_PROFILER_MAX_SAMPLE_RATE = 100.0;
 // Maximum queued aggregation batch memory before new batches are dropped.
 static constexpr uint64_t DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES = 64ULL * 1024ULL * 1024ULL;
 
+static dd_profiler_diagnostics_t empty_diagnostics() {
+    return {0, 0, 0};
+}
+
 namespace dd::profiler { class dd_profiler; }
 
 static dd::profiler::dd_profiler* g_dd_profiler = nullptr;
@@ -281,18 +285,14 @@ public:
         return swap_context.flushed_profile;
     }
 
-    void consume_diagnostics(dd_profiler_diagnostics_t* out) {
-        if (!out) {
-            return;
-        }
-
-        out->dropped_batch_count = 0;
-        out->dropped_sample_count = 0;
-        out->max_pending_bytes = 0;
+    dd_profiler_diagnostics_t diagnostics() {
+        dd_profiler_diagnostics_t result = empty_diagnostics();
 
         if (profiler) {
-            profiler->consume_diagnostics(out);
+            profiler->consume_diagnostics(&result);
         }
+
+        return result;
     }
 
 private:
@@ -466,16 +466,12 @@ dd_profiler_status_t dd_profiler_get_status(void) {
     return g_dd_profiler ? g_dd_profiler->status : DD_PROFILER_STATUS_NOT_CREATED;
 }
 
-void dd_profiler_consume_diagnostics(dd_profiler_diagnostics_t* out) {
+dd_profiler_diagnostics_t dd_profiler_diagnostics(void) {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
-    if (out) {
-        out->dropped_batch_count = 0;
-        out->dropped_sample_count = 0;
-        out->max_pending_bytes = 0;
-    }
     if (g_dd_profiler) {
-        g_dd_profiler->consume_diagnostics(out);
+        return g_dd_profiler->diagnostics();
     }
+    return empty_diagnostics();
 }
 
 bool dd_profiler_is_running() {

--- a/DatadogProfiling/Mach/dd_profiler.cpp
+++ b/DatadogProfiling/Mach/dd_profiler.cpp
@@ -18,14 +18,32 @@
 #include <mutex>
 #include <new>
 #include <random>
+#include <utility>
 
 // Profiling sampling backstop (see `callback`).
 // Typical profile span is ~1 minute; this cutoff includes additional slack beyond that.
 // The extra time avoids stopping sampling while the profile is still being processed.
-static constexpr int64_t DD_PROFILER_TIMEOUT_NS = 90000000000ULL; // 1:30 minutes
+static constexpr int64_t DD_PROFILER_TIMEOUT_NS = 90000000000LL; // 1:30 minutes
 static constexpr double DD_PROFILER_MAX_SAMPLE_RATE = 100.0;
 // Maximum queued aggregation batch memory before new batches are dropped.
 static constexpr uint64_t DD_PROFILER_DEFAULT_HARD_LIMIT_BYTES = 64ULL * 1024ULL * 1024ULL;
+
+/*
+ * Architecture note
+ *
+ * The Swift profiling feature coordinates the C++ Mach profiler layer through
+ * the public C API below. The Mach profiler state is backed by a process-wide
+ * singleton (`g_dd_profiler`).
+ *
+ * The C++ profiler owns two long-lived profiler threads while running:
+ * - `mach_sampling_profiler` owns the sampling thread, which captures raw
+ *   stack traces and hands off completed buffers.
+ * - `aggregation_worker` owns the aggregation thread, which drains buffers,
+ *   runs profile aggregation and executes flush barriers in order.
+ *
+ * Public C API calls such as start, stop and flush run on external caller
+ * threads and are serialized by `g_dd_profiler_mutex`.
+ */
 
 static dd_profiler_diagnostics_t empty_diagnostics() {
     return {0, 0, 0};
@@ -229,7 +247,6 @@ public:
     void stop() {
         if (!profiler) return;
         status = DD_PROFILER_STATUS_STOPPED;
-        profiler->request_stop();
         profiler->stop_sampling();
     }
 
@@ -263,16 +280,18 @@ public:
      * @return The harvested profile, or nullptr if no profile exists.
      */
     profile* flush_and_get_profile() {
-        profile_swap_context swap_context{
-            this,
-            new (std::nothrow) dd::profiler::profile(sampling_interval_ns),
-            nullptr
+        if (!profiler) {
+            return nullptr;
+        }
+
+        dd::profiler::profile* next_profile = new (std::nothrow) dd::profiler::profile(sampling_interval_ns);
+        dd::profiler::profile* flushed_profile = nullptr;
+        auto swap_profile = [this, next_profile, &flushed_profile] {
+            swap_profile_at_flush_boundary(next_profile, flushed_profile);
         };
 
-        if (profiler) {
-            profiler->request_flush(swap_profile_action, &swap_context);
-        } else {
-            swap_profile_action(&swap_context);
+        if (!profiler->request_flush(swap_profile)) {
+            swap_profile();
         }
 
         {
@@ -282,50 +301,41 @@ public:
             }
         }
 
-        return swap_context.flushed_profile;
+        return flushed_profile;
     }
 
     dd_profiler_diagnostics_t diagnostics() {
         dd_profiler_diagnostics_t result = empty_diagnostics();
 
         if (profiler) {
-            profiler->consume_diagnostics(&result);
+            profiler->consume_diagnostics(result);
         }
 
         return result;
     }
 
 private:
-    struct profile_swap_context {
-        dd_profiler* profiler;
-        dd::profiler::profile* next_profile;
-        dd::profiler::profile* flushed_profile;
-    };
-
     /**
      * @brief Swaps the active profile at a flush boundary.
      *
-     * Moves the current active profile into `flushed_profile` and installs
-     * `next_profile` as the new active profile under `profile_mutex`.
+     * Moves the current active profile into `flushed_profile` and installs the
+     * `next_profile` under `profile_mutex`.
      *
-     * @param ctx Pointer to `profile_swap_context`
+     * @param next_profile Profile to install as the active profile.
+     * @param flushed_profile Set to the previously active profile.
      */
-    static void swap_profile_action(void* ctx) {
-        if (!ctx) return;
+    void swap_profile_at_flush_boundary(
+        dd::profiler::profile* next_profile,
+        dd::profiler::profile*& flushed_profile
+    ) {
+        std::lock_guard<std::mutex> lock(profile_mutex);
 
-        auto* swap_context = static_cast<profile_swap_context*>(ctx);
-        dd_profiler* profiler = swap_context->profiler;
-        if (!profiler) return;
+        flushed_profile = profile;
+        profile = next_profile;
 
-        std::lock_guard<std::mutex> lock(profiler->profile_mutex);
-
-        swap_context->flushed_profile = profiler->profile;
-        profiler->profile = swap_context->next_profile;
-        swap_context->next_profile = nullptr;
-
-        if (!profiler->profile) {
-            profiler->status = DD_PROFILER_STATUS_ALLOCATION_FAILED;
-            if (profiler->profiler) profiler->profiler->request_stop();
+        if (!profile) {
+            status = DD_PROFILER_STATUS_ALLOCATION_FAILED;
+            if (profiler) profiler->request_stop();
         }
     }
 

--- a/DatadogProfiling/Mach/include/aggregation_worker.h
+++ b/DatadogProfiling/Mach/include/aggregation_worker.h
@@ -1,0 +1,159 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#ifndef DD_PROFILER_AGGREGATION_WORKER_H_
+#define DD_PROFILER_AGGREGATION_WORKER_H_
+
+#include "dd_profiler.h"
+
+#if defined(__APPLE__) && !TARGET_OS_WATCH
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <pthread.h>
+#include <vector>
+
+namespace dd::profiler {
+
+/**
+ * @brief Serialized worker that drains sampled stack-trace batches in-order.
+ *
+ * The aggregation worker owns the aggregation thread, flush barriers, and a
+ * small reusable buffer pool used to decouple sample capture from heavy
+ * callback work. Under bursty load it can temporarily accept additional
+ * overflow buffers, then shrink back to the reusable pool as the worker
+ * catches up.
+ */
+class aggregation_worker {
+public:
+    using flush_action_t = void (*)(void* ctx);
+
+    aggregation_worker(
+        size_t buffer_capacity,
+        uint32_t max_stack_depth,
+        stack_trace_callback_t callback,
+        void* ctx,
+        uint64_t hard_limit_bytes,
+        qos_class_t worker_qos = QOS_CLASS_UTILITY);
+
+    ~aggregation_worker();
+
+    aggregation_worker(const aggregation_worker&) = delete;
+    aggregation_worker& operator=(const aggregation_worker&) = delete;
+
+    bool start();
+    void stop();
+
+    /**
+     * @brief Blocks until all queued work before this request has been processed.
+     *
+     * If provided, `action` runs on the aggregation worker after all earlier
+     * work has completed and before later batches are processed.
+     */
+    void request_flush(flush_action_t action = nullptr, void* action_ctx = nullptr);
+
+    /**
+     * @brief Hands off the active sampling buffer without blocking the sampler.
+     *
+     * When no reusable buffer is immediately available, the sampler rotates
+     * into a temporary overflow buffer instead of waiting or dropping work.
+     */
+    void enqueue_active_buffer(std::vector<stack_trace_t>& active_buffer);
+
+    /**
+     * @brief Completes a pending flush request from a producer safe point.
+     */
+    void service_pending_flush_request(std::vector<stack_trace_t>& active_buffer);
+
+    /**
+     * @brief Flushes the final producer buffer and marks that no more batches will arrive.
+     */
+    void finish_producer(std::vector<stack_trace_t>& active_buffer);
+
+    /**
+     * @brief Returns true when called from the worker thread itself.
+     */
+    bool is_worker_thread();
+
+    /**
+     * @brief Returns true when the given Mach thread belongs to this processor.
+     */
+    bool is_worker_thread(thread_t thread);
+
+    /**
+     * @brief Returns and resets diagnostics accumulated since the last consume.
+     */
+    void consume_diagnostics(dd_profiler_diagnostics_t* out);
+
+private:
+    struct work_item {
+        enum class kind {
+            batch,
+            flush_barrier
+        };
+
+        kind item_kind;
+        std::vector<stack_trace_t> traces;
+        uint64_t flush_id = 0;
+        flush_action_t action = nullptr;
+        void* action_ctx = nullptr;
+        uint64_t footprint_bytes = 0;
+    };
+
+    size_t buffer_capacity;
+    uint32_t max_stack_depth;
+    qos_class_t worker_qos;
+    stack_trace_callback_t callback;
+    void* ctx;
+    uint64_t hard_limit_bytes;
+
+    pthread_t worker_thread{};
+    bool worker_thread_started = false;
+    /// Cached Mach thread id for hot-path internal-thread filtering.
+    std::atomic<thread_t> worker_mach_thread{MACH_PORT_NULL};
+
+    /// Ordered stream consumed by the worker thread.
+    std::deque<work_item> pending_work;
+    /// Flush barriers requested by external callers and awaiting a producer safe point.
+    std::deque<work_item> requested_flushes;
+    /// Recycled buffers retained for future producer handoff.
+    std::vector<std::vector<stack_trace_t>> reusable_buffers;
+
+    std::mutex work_mutex;
+    /// Wakes the aggregation thread when new batches or flush barriers are queued.
+    std::condition_variable work_cv;
+    /// Wakes flush callers when their requested flush barrier has been completed.
+    std::condition_variable flush_cv;
+    uint64_t next_flush_id = 0;
+    uint64_t completed_flush_id = 0;
+    uint64_t pending_bytes = 0;
+    uint64_t dropped_batch_count = 0;
+    uint64_t dropped_sample_count = 0;
+    uint64_t max_pending_bytes = 0;
+    /// Set once the producer has handed off its final buffer.
+    bool producer_finished = true;
+    /// Set once the worker has drained all queued work and exited.
+    bool worker_finished = true;
+
+    // Keep a small hot pool of reusable buffers; extra overflow buffers are
+    // released once the worker drains them so bursty growth stays temporary.
+    static constexpr size_t max_reusable_buffers = 4;
+    static constexpr size_t sampled_thread_name_capacity = 64;
+
+    static void* worker_thread_entry(void* arg);
+    void worker_main();
+    void recycle_batch(std::vector<stack_trace_t>&& batch, uint64_t footprint_bytes);
+    static void destroy_batch(std::vector<stack_trace_t>& batch);
+    void clear_pending_work_locked();
+    uint64_t batch_footprint_bytes(const std::vector<stack_trace_t>& batch) const;
+};
+
+} // namespace dd::profiler
+
+#endif // __APPLE__ && !TARGET_OS_WATCH
+#endif // DD_PROFILER_AGGREGATION_WORKER_H_

--- a/DatadogProfiling/Mach/include/aggregation_worker.h
+++ b/DatadogProfiling/Mach/include/aggregation_worker.h
@@ -14,8 +14,10 @@
 #include <atomic>
 #include <condition_variable>
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <pthread.h>
+#include <variant>
 #include <vector>
 
 namespace dd::profiler {
@@ -23,18 +25,23 @@ namespace dd::profiler {
 /**
  * @brief Serialized worker that drains sampled stack-trace batches in-order.
  *
- * The aggregation worker owns the aggregation thread, flush barriers, and a
- * small reusable buffer pool used to decouple sample capture from heavy
- * callback work. Under bursty load it can temporarily accept additional
- * overflow buffers, then shrink back to the reusable pool as the worker
- * catches up.
+ * The aggregation worker owns the aggregation thread and flush barriers used
+ * to decouple sample capture from heavy callback work while preserving ordered
+ * profile boundaries.
+ *
+ * ## Flush Ordering
+ * Flush requests are first stored in `requested_flushes`. The producer moves
+ * them into `pending_work` only at a safe point, after handing off the active
+ * sampling buffer. This places each flush barrier after the in-progress batch
+ * in the worker's ordered stream, so the flush action observes a complete
+ * sample boundary.
  */
 class aggregation_worker {
 public:
-    using flush_action_t = void (*)(void* ctx);
+    using flush_action_t = std::function<void()>;
 
     aggregation_worker(
-        size_t buffer_capacity,
+        size_t initial_buffer_size,
         uint32_t max_stack_depth,
         stack_trace_callback_t callback,
         void* ctx,
@@ -46,7 +53,25 @@ public:
     aggregation_worker(const aggregation_worker&) = delete;
     aggregation_worker& operator=(const aggregation_worker&) = delete;
 
+    /**
+     * @brief Starts the aggregation thread.
+     *
+     * Resets queued work, diagnostics and lifecycle state before creating a new
+     * worker thread. Returns false if the worker is already running or if the
+     * thread cannot be created.
+     */
     bool start();
+
+    /**
+     * @brief Stops the aggregation thread.
+     *
+     * Marks the producer as finished, wakes the worker, waits for queued work to
+     * drain, then joins the worker thread and resets its state.
+     *
+     * Must be called from a non-worker thread because the stop path joins the
+     * worker thread. Profiler-owned callback paths should request an
+     * asynchronous stop at the profiler lifecycle layer instead.
+     */
     void stop();
 
     /**
@@ -54,14 +79,18 @@ public:
      *
      * If provided, `action` runs on the aggregation worker after all earlier
      * work has completed and before later batches are processed.
+     *
+     * @return true when the flush barrier was processed by the worker.
      */
-    void request_flush(flush_action_t action = nullptr, void* action_ctx = nullptr);
+    bool request_flush(flush_action_t action = {});
 
     /**
      * @brief Hands off the active sampling buffer without blocking the sampler.
      *
-     * When no reusable buffer is immediately available, the sampler rotates
-     * into a temporary overflow buffer instead of waiting or dropping work.
+     * Moves the buffer contents into the worker queue and leaves
+     * `active_buffer` empty for continued sampling. If queuing the batch would
+     * exceed the configured memory limit, the batch is dropped and recorded in
+     * diagnostics.
      */
     void enqueue_active_buffer(std::vector<stack_trace_t>& active_buffer);
 
@@ -88,42 +117,43 @@ public:
     /**
      * @brief Returns and resets diagnostics accumulated since the last consume.
      */
-    void consume_diagnostics(dd_profiler_diagnostics_t* out);
+    void consume_diagnostics(dd_profiler_diagnostics_t& out);
 
 private:
-    struct work_item {
-        enum class kind {
-            batch,
-            flush_barrier
-        };
+    struct configuration {
+        size_t initial_buffer_size;
+        uint32_t max_stack_depth;
+        qos_class_t worker_qos;
+        stack_trace_callback_t callback;
+        void* ctx;
+        uint64_t hard_limit_bytes;
+    };
 
-        kind item_kind;
+    struct batch_item {
         std::vector<stack_trace_t> traces;
-        uint64_t flush_id = 0;
-        flush_action_t action = nullptr;
-        void* action_ctx = nullptr;
         uint64_t footprint_bytes = 0;
     };
 
-    size_t buffer_capacity;
-    uint32_t max_stack_depth;
-    qos_class_t worker_qos;
-    stack_trace_callback_t callback;
-    void* ctx;
-    uint64_t hard_limit_bytes;
+    struct flush_barrier {
+        uint64_t flush_id = 0;
+        flush_action_t action;
+    };
+
+    using work_item = std::variant<batch_item, flush_barrier>;
+
+    const configuration config;
 
     pthread_t worker_thread{};
-    bool worker_thread_started = false;
+    bool has_worker_thread = false;
     /// Cached Mach thread id for hot-path internal-thread filtering.
     std::atomic<thread_t> worker_mach_thread{MACH_PORT_NULL};
 
     /// Ordered stream consumed by the worker thread.
     std::deque<work_item> pending_work;
     /// Flush barriers requested by external callers and awaiting a producer safe point.
-    std::deque<work_item> requested_flushes;
-    /// Recycled buffers retained for future producer handoff.
-    std::vector<std::vector<stack_trace_t>> reusable_buffers;
+    std::deque<flush_barrier> requested_flushes;
 
+    /// Protects queued work, flush progress, worker lifecycle flags and diagnostics counters.
     std::mutex work_mutex;
     /// Wakes the aggregation thread when new batches or flush barriers are queued.
     std::condition_variable work_cv;
@@ -132,23 +162,18 @@ private:
     uint64_t next_flush_id = 0;
     uint64_t completed_flush_id = 0;
     uint64_t pending_bytes = 0;
-    uint64_t dropped_batch_count = 0;
-    uint64_t dropped_sample_count = 0;
-    uint64_t max_pending_bytes = 0;
+    dd_profiler_diagnostics_t diagnostics{};
     /// Set once the producer has handed off its final buffer.
     bool producer_finished = true;
     /// Set once the worker has drained all queued work and exited.
     bool worker_finished = true;
 
-    // Keep a small hot pool of reusable buffers; extra overflow buffers are
-    // released once the worker drains them so bursty growth stays temporary.
-    static constexpr size_t max_reusable_buffers = 4;
     static constexpr size_t sampled_thread_name_capacity = 64;
 
     static void* worker_thread_entry(void* arg);
     void worker_main();
-    void recycle_batch(std::vector<stack_trace_t>&& batch, uint64_t footprint_bytes);
-    static void destroy_batch(std::vector<stack_trace_t>& batch);
+    void complete_batch(uint64_t footprint_bytes);
+    static void free_batch_payloads(std::vector<stack_trace_t>& batch);
     void clear_pending_work_locked();
     uint64_t batch_footprint_bytes(const std::vector<stack_trace_t>& batch) const;
 };

--- a/DatadogProfiling/Mach/include/dd_profiler.h
+++ b/DatadogProfiling/Mach/include/dd_profiler.h
@@ -213,13 +213,11 @@ typedef struct profile dd_profile_t;
 dd_profiler_status_t dd_profiler_get_status(void);
 
 /**
- * @brief Returns and resets profiling diagnostics accumulated since the last consume.
+ * @brief Returns and resets profiling diagnostics accumulated since the last call.
  *
- * If `out` is null, this function is a no-op.
- *
- * @param out Output diagnostics structure
+ * @return Profiling diagnostics, or zeroed diagnostics if the profiler does not exist.
  */
-void dd_profiler_consume_diagnostics(dd_profiler_diagnostics_t* out);
+dd_profiler_diagnostics_t dd_profiler_diagnostics(void);
 
 /**
  * @brief Stops profiling if it's currently running

--- a/DatadogProfiling/Mach/include/dd_profiler.h
+++ b/DatadogProfiling/Mach/include/dd_profiler.h
@@ -182,6 +182,18 @@ typedef enum {
 } dd_profiler_status_t;
 
 /**
+ * Diagnostics for profiling aggregation pressure.
+ */
+typedef struct dd_profiler_diagnostics {
+    /** Number of sampled batches dropped since the last consume. */
+    uint64_t dropped_batch_count;
+    /** Number of sampled stack traces dropped since the last consume. */
+    uint64_t dropped_sample_count;
+    /** Maximum queued batch memory observed since the last consume. */
+    uint64_t max_pending_bytes;
+} dd_profiler_diagnostics_t;
+
+/**
  * Opaque handle to a dd profiler profile instance
  */
 #ifdef __cplusplus
@@ -199,6 +211,15 @@ typedef struct profile dd_profile_t;
  * @return Current profiler status code
  */
 dd_profiler_status_t dd_profiler_get_status(void);
+
+/**
+ * @brief Returns and resets profiling diagnostics accumulated since the last consume.
+ *
+ * If `out` is null, this function is a no-op.
+ *
+ * @param out Output diagnostics structure
+ */
+void dd_profiler_consume_diagnostics(dd_profiler_diagnostics_t* out);
 
 /**
  * @brief Stops profiling if it's currently running
@@ -234,8 +255,8 @@ dd_profile_t* dd_profiler_get_profile(void);
  * @brief Flushes the sampling buffer and retrieves the profile
  *
  * Requests a flush of pending samples, then atomically swaps the internal
- * profile with a fresh empty one. Sampling continues uninterrupted into the
- * new profile.
+ * profile with a fresh empty one in the aggregation stream. Sampling continues
+ * uninterrupted into the new profile.
  *
  * @return Typed handle to profile data, or NULL if:
  *         - Profiling was never started

--- a/DatadogProfiling/Mach/include/dd_profiler.h
+++ b/DatadogProfiling/Mach/include/dd_profiler.h
@@ -131,6 +131,13 @@ namespace dd::profiler {
     class profile;
 }
 
+/**
+ * Releases heap-backed memory owned by a stack trace.
+ *
+ * @param trace Pointer to stack trace to clean up (can be nullptr).
+ */
+void stack_trace_destroy(stack_trace_t* trace);
+
 extern "C" {
 #endif
 
@@ -178,7 +185,6 @@ typedef enum {
     DD_PROFILER_STATUS_TIMEOUT = 4,           ///< Profiler was stopped due to timeout
     DD_PROFILER_STATUS_PREWARMED = 5,         ///< Profiler was not started due to prewarming
     DD_PROFILER_STATUS_ALLOCATION_FAILED = 6, ///< Memory allocation failed
-    DD_PROFILER_STATUS_ALREADY_STARTED = 7,   ///< Failed to start profiler because it is already started
 } dd_profiler_status_t;
 
 /**

--- a/DatadogProfiling/Mach/include/dd_profiler_testing.h
+++ b/DatadogProfiling/Mach/include/dd_profiler_testing.h
@@ -49,6 +49,9 @@ void dd_delete_profiling_defaults(void);
  *                   - Default: 5000000000ULL (5 seconds)
  *                   - Timeout checking occurs during sample processing
  *
+ * @param hard_limit_bytes Maximum queued batch memory before new batches are dropped
+ *                         - 0 uses the default production limit
+ *
  * @note Safe to call multiple times - destroys existing instance before creating new one
  * @note Check `dd_profiler_get_status()` for detailed status after calling
  * @note Designed for unit tests, integration tests, and development builds
@@ -58,7 +61,7 @@ void dd_delete_profiling_defaults(void);
  *
  * @see `dd_profiler_get_status()`, `dd_profiler_stop()`, `dd_profiler_get_profile()`
  */
-void dd_profiler_start_testing(double sample_rate, bool is_prewarming, int64_t timeout_ns);
+void dd_profiler_start_testing(double sample_rate, bool is_prewarming, int64_t timeout_ns, uint64_t hard_limit_bytes);
 
 #ifdef __cplusplus
 }

--- a/DatadogProfiling/Mach/include/dd_profiler_testing.h
+++ b/DatadogProfiling/Mach/include/dd_profiler_testing.h
@@ -48,7 +48,6 @@ void dd_delete_profiling_defaults(void);
  * @param timeout_ns Timeout in nanoseconds after which profiling automatically stops
  *                   - Default: 5000000000ULL (5 seconds)
  *                   - Timeout checking occurs during sample processing
- *
  * @param hard_limit_bytes Maximum queued batch memory before new batches are dropped
  *                         - 0 uses the default production limit
  *

--- a/DatadogProfiling/Mach/include/mach_sampling_profiler.h
+++ b/DatadogProfiling/Mach/include/mach_sampling_profiler.h
@@ -14,13 +14,13 @@
 #if !TARGET_OS_WATCH
 
 #include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include <mach/mach.h>
 #include <mach/thread_act.h>
 #include <mach/thread_info.h>
-#include <vector>
+#include <memory>
+#include <mutex>
 #include <pthread.h>
+#include <vector>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,15 +41,19 @@ void set_main_thread(pthread_t thread);
 
 namespace dd::profiler {
 
+class aggregation_worker;
+
 /**
  * @brief Mach-based sampling profiler
  * 
- * A pure sampling engine. Collects raw stack frames at a configured interval
- * and delivers them to the callback. Binary image resolution is the
- * responsibility of the callback consumer.
+ * A sampling engine. Collects raw stack frames at a configured interval and
+ * delivers them to the callback. Binary image resolution is the responsibility
+ * of the callback consumer.
  */
 class mach_sampling_profiler {
 public:
+    using flush_action_t = void (*)(void* ctx);
+
     /**
      * @brief Constructs a new profiler instance
      * 
@@ -60,7 +64,8 @@ public:
     mach_sampling_profiler(
         const sampling_config_t* config,
         stack_trace_callback_t callback,
-        void* ctx);
+        void* ctx,
+        uint64_t hard_limit_bytes);
 
     /**
      * @brief Destructor that ensures profiling is stopped
@@ -75,20 +80,38 @@ public:
     bool start_sampling();
 
     /**
-     * @brief Stops the sampling process
+     * @brief Stops the sampling process.
+     *
+     * If called from a thread owned by this profiler, this requests an
+     * asynchronous stop and returns immediately. Full join and reset are
+     * performed only when called from another thread.
      */
     void stop_sampling();
 
     /**
-     * @brief Requests a flush of the sample buffer and blocks until complete.
-     * The sampling thread flushes at its next safe point (start of loop iteration).
+     * @brief Requests a flush of buffered samples and blocks until complete.
+     *
+     * If provided, `action` runs after all work before this request has
+     * completed and before later buffered work is processed.
      */
-    void request_flush();
+    void request_flush(flush_action_t action = nullptr, void* action_ctx = nullptr);
 
     /**
-     * @brief Atomic flag indicating if profiling is currently running
+     * @brief Requests that sampling stop at the next safe point.
+     *
+     * This does not join threads or reset internal state.
      */
-    std::atomic<bool> running;
+    void request_stop();
+
+    /**
+     * @brief Returns and resets diagnostics accumulated since the last consume.
+     */
+    void consume_diagnostics(dd_profiler_diagnostics_t* out);
+
+    /**
+     * @brief Atomic flag indicating whether the sampling loop should keep running.
+     */
+    std::atomic<bool> should_sample;
 
 protected:
     /**
@@ -110,6 +133,8 @@ protected:
      * @brief Thread handle for the sampling thread
      */
     pthread_t sampling_thread{};
+    /// Cached Mach thread id for hot-path internal-thread filtering.
+    std::atomic<thread_t> sampling_thread_mach{MACH_PORT_NULL};
 
     /**
      * @brief Thread to profile when in single-thread mode
@@ -120,6 +145,11 @@ protected:
      * @brief Buffer for collecting stack traces
      */
     std::vector<stack_trace_t> sample_buffer;
+
+    /**
+     * @brief Serialized aggregation worker used to drain sampled traces off-thread.
+     */
+    std::unique_ptr<aggregation_worker> worker;
 
     /**
      * @brief Main sampling loop that collects stack traces from threads
@@ -135,9 +165,9 @@ protected:
     void sample_thread(thread_t thread, uint64_t interval_nanos);
 
     /**
-     * @brief Flushes the sample buffer (common implementation)
+     * @brief Returns true when the thread is owned by the profiler itself.
      */
-    void flush_buffer();
+    bool is_profiler_internal_thread(thread_t thread) const;
 
 private:
     /**
@@ -149,13 +179,8 @@ private:
      * @brief Mutex to protect start/stop operations from concurrent access
      */
     std::mutex state_mutex;
-
-    /**
-     * @brief Synchronization for flush request
-     */
-    std::atomic<bool> flush_requested{false};
-    std::mutex flush_mutex;
-    std::condition_variable flush_cv;
+    /// Indicates whether `sampling_thread` currently refers to a live session thread.
+    std::atomic<bool> has_sampling_thread{false};
 };
 
 } // namespace dd::profiler

--- a/DatadogProfiling/Mach/include/mach_sampling_profiler.h
+++ b/DatadogProfiling/Mach/include/mach_sampling_profiler.h
@@ -14,6 +14,7 @@
 #if !TARGET_OS_WATCH
 
 #include <atomic>
+#include <functional>
 #include <mach/mach.h>
 #include <mach/thread_act.h>
 #include <mach/thread_info.h>
@@ -52,7 +53,7 @@ class aggregation_worker;
  */
 class mach_sampling_profiler {
 public:
-    using flush_action_t = void (*)(void* ctx);
+    using flush_action_t = std::function<void()>;
 
     /**
      * @brief Constructs a new profiler instance
@@ -93,8 +94,10 @@ public:
      *
      * If provided, `action` runs after all work before this request has
      * completed and before later buffered work is processed.
+     *
+     * @return true when the flush barrier was processed by the aggregation worker.
      */
-    void request_flush(flush_action_t action = nullptr, void* action_ctx = nullptr);
+    bool request_flush(flush_action_t action = {});
 
     /**
      * @brief Requests that sampling stop at the next safe point.
@@ -106,7 +109,7 @@ public:
     /**
      * @brief Returns and resets diagnostics accumulated since the last consume.
      */
-    void consume_diagnostics(dd_profiler_diagnostics_t* out);
+    void consume_diagnostics(dd_profiler_diagnostics_t& out);
 
     /**
      * @brief Atomic flag indicating whether the sampling loop should keep running.

--- a/DatadogProfiling/Mach/include/profile.h
+++ b/DatadogProfiling/Mach/include/profile.h
@@ -36,6 +36,8 @@
 
 namespace dd::profiler {
 
+class binary_image_cache;
+
 /**
  * @brief Represents a deduplicated binary mapping in the profile
  * 
@@ -158,6 +160,18 @@ public:
      */
     void add_samples(const stack_trace_t* traces, size_t count);
 
+    /**
+     * @brief Process multiple stack traces and lazily resolve first-seen locations.
+     *
+     * Existing locations reuse their interned mapping and location IDs without
+     * re-resolving binary image data.
+     *
+     * @param traces Array of stack traces to process
+     * @param count Number of traces in the array
+     * @param image_cache Optional binary image cache used to resolve first-seen locations
+     */
+    void add_samples(const stack_trace_t* traces, size_t count, binary_image_cache* image_cache);
+
     /** @brief Get read-only access to deduplicated string table */
     const std::vector<std::string>& strings() const { return _strings; }
     
@@ -270,6 +284,8 @@ private:
     // Helper methods
     uint32_t intern_string(const std::string& str);
     uint32_t intern_frame(const stack_frame_t& frame);
+    // Resolves binary image data for first-seen locations before interning.
+    uint32_t intern_frame(const stack_frame_t& frame, binary_image_cache* image_cache);
     uint32_t intern_binary(const binary_image_t& image);
     uint32_t intern_location(const location_t& location);
 };

--- a/DatadogProfiling/Mach/mach_sampling_profiler.cpp
+++ b/DatadogProfiling/Mach/mach_sampling_profiler.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "mach_sampling_profiler.h"
+#include "aggregation_worker.h"
 
 #if defined(__APPLE__) && !TARGET_OS_WATCH
 
@@ -19,6 +20,7 @@
 #include <mach/thread_act.h>
 #include <mach/thread_status.h>
 #include <mach/machine/thread_state.h>
+#include <new>
 
 // Address validation constants and macros
 //
@@ -336,13 +338,22 @@ namespace dd::profiler {
 mach_sampling_profiler::mach_sampling_profiler(
     const sampling_config_t* config,
     stack_trace_callback_t callback,
-    void* ctx)
-    : running(false)
+    void* ctx,
+    uint64_t hard_limit_bytes)
+    : should_sample(false)
     , config(SAMPLING_CONFIG_DEFAULT)
     , callback(callback)
     , ctx(ctx) {
     if (config) this->config = *config;
     sample_buffer.reserve(this->config.max_buffer_size);
+    worker.reset(new (std::nothrow) aggregation_worker(
+        this->config.max_buffer_size,
+        this->config.max_stack_depth,
+        callback,
+        ctx,
+        hard_limit_bytes,
+        this->config.qos_class
+    ));
 }
 
 /**
@@ -357,7 +368,12 @@ mach_sampling_profiler::~mach_sampling_profiler() {
  */
 void* mach_sampling_profiler::sampling_thread_entry(void* arg) {
     pthread_setname_np("com.datadoghq.profiler.sampling");
-    static_cast<mach_sampling_profiler*>(arg)->main();
+    auto* profiler = static_cast<mach_sampling_profiler*>(arg);
+    profiler->sampling_thread_mach.store(
+        pthread_mach_thread_np(pthread_self()),
+        std::memory_order_relaxed
+    );
+    profiler->main();
     return nullptr;
 }
 
@@ -369,8 +385,9 @@ void* mach_sampling_profiler::sampling_thread_entry(void* arg) {
  */
 bool mach_sampling_profiler::start_sampling() {
     std::lock_guard<std::mutex> lock(state_mutex);
-    
-    if (running) return false;
+
+    if (should_sample.load(std::memory_order_relaxed)
+        || has_sampling_thread.load(std::memory_order_relaxed)) return false;
 
     if (config.profile_current_thread_only) {
         target_thread = pthread_self();
@@ -378,48 +395,91 @@ bool mach_sampling_profiler::start_sampling() {
 
     // Clear any leftover data from previous runs
     sample_buffer.clear();
+    if (sample_buffer.capacity() < config.max_buffer_size) {
+        sample_buffer.reserve(config.max_buffer_size);
+    }
+    sampling_thread_mach.store(MACH_PORT_NULL, std::memory_order_relaxed);
 
     init_safe_read_handlers();
+    if (!worker || !worker->start()) {
+        return false;
+    }
 
-    running = true;
+    should_sample.store(true, std::memory_order_relaxed);
 
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_set_qos_class_np(&attr, config.qos_class, 0);
+    pthread_attr_t sampling_attr;
+    pthread_attr_init(&sampling_attr);
+    pthread_attr_set_qos_class_np(&sampling_attr, config.qos_class, 0);
 
-    pthread_create(&sampling_thread, &attr, sampling_thread_entry, this);
-    
-    pthread_attr_destroy(&attr);
-    return running;
+    int sampling_result = pthread_create(&sampling_thread, &sampling_attr, sampling_thread_entry, this);
+    pthread_attr_destroy(&sampling_attr);
+    if (sampling_result != 0) {
+        should_sample.store(false, std::memory_order_relaxed);
+        worker->stop();
+        return false;
+    }
+
+    has_sampling_thread.store(true, std::memory_order_release);
+    return true;
 }
 
 /**
  * Stops the sampling process.
  *
+ * If called from a thread owned by this profiler, this only requests an
+ * asynchronous stop. Full join and reset are performed later by another thread.
+ *
  */
 void mach_sampling_profiler::stop_sampling() {
-    // Avoid deadlock if the sampling thread triggers the stop when it reaches the timeout.
-    if (pthread_equal(pthread_self(), sampling_thread)) {
-        running = false;
+    if ((has_sampling_thread.load(std::memory_order_acquire) && pthread_equal(pthread_self(), sampling_thread))
+        || (worker && worker->is_worker_thread())) {
+        request_stop();
         return;
     }
 
     std::lock_guard<std::mutex> lock(state_mutex);
-    
-    if (!running) return;
-    running = false;
+    request_stop();
 
-    // Join while holding the lock to ensure the sampling thread
-    // completes its flush_buffer() before any new session can start
-    pthread_join(sampling_thread, nullptr);
+    // Join while holding the lock to ensure the previous session is fully drained
+    // before any new session can start.
+    if (has_sampling_thread.load(std::memory_order_acquire)) {
+        pthread_join(sampling_thread, nullptr);
+        sampling_thread_mach.store(MACH_PORT_NULL, std::memory_order_relaxed);
+        has_sampling_thread.store(false, std::memory_order_release);
+    }
+
+    if (worker) {
+        worker->stop();
+    }
 }
 
-void mach_sampling_profiler::request_flush() {
-    if (!running) return;
+void mach_sampling_profiler::request_flush(flush_action_t action, void* action_ctx) {
+    if (worker) {
+        worker->request_flush(action, action_ctx);
+    }
+}
 
-    std::unique_lock<std::mutex> lock(flush_mutex);
-    flush_requested = true;
-    flush_cv.wait(lock, [this] { return !flush_requested; });
+void mach_sampling_profiler::request_stop() {
+    should_sample.store(false, std::memory_order_relaxed);
+}
+
+void mach_sampling_profiler::consume_diagnostics(dd_profiler_diagnostics_t* out) {
+    if (worker) {
+        worker->consume_diagnostics(out);
+    } else if (out) {
+        out->dropped_batch_count = 0;
+        out->dropped_sample_count = 0;
+        out->max_pending_bytes = 0;
+    }
+}
+
+bool mach_sampling_profiler::is_profiler_internal_thread(thread_t thread) const {
+    const thread_t sampling_thread_id = sampling_thread_mach.load(std::memory_order_relaxed);
+    if (sampling_thread_id != MACH_PORT_NULL && thread == sampling_thread_id) {
+        return true;
+    }
+
+    return worker && worker->is_worker_thread(thread);
 }
 
 /**
@@ -451,9 +511,6 @@ void mach_sampling_profiler::sample_thread(thread_t thread, uint64_t interval_na
 
     if (trace.frame_count > 0) {
         sample_buffer.push_back(trace);
-        if (sample_buffer.size() >= config.max_buffer_size) {
-            flush_buffer();
-        }
     } else {
         stack_trace_destroy(&trace);
     }
@@ -463,22 +520,22 @@ void mach_sampling_profiler::sample_thread(thread_t thread, uint64_t interval_na
  * Main sampling loop that collects stack traces from threads.
  */
 void mach_sampling_profiler::main() {
-    while (running) {
-        // Check for flush request at safe point (no threads suspended)
-        if (flush_requested) {
-            flush_buffer();
-            {
-                std::lock_guard<std::mutex> lock(flush_mutex);
-                flush_requested = false;
-            }
-            flush_cv.notify_one();
-        }
+    while (should_sample.load(std::memory_order_relaxed)) {
+        // Check for flush request at a safe point (no threads suspended).
+        worker->service_pending_flush_request(sample_buffer);
 
         // Sampling interval in nanoseconds
         uint64_t interval_nanos = config.sampling_interval_nanos;
 
+        if (sample_buffer.size() >= config.max_buffer_size) {
+            worker->enqueue_active_buffer(sample_buffer);
+        }
+
         if (config.profile_current_thread_only) {
             sample_thread(pthread_mach_thread_np(target_thread), interval_nanos);
+            if (sample_buffer.size() >= config.max_buffer_size) {
+                worker->enqueue_active_buffer(sample_buffer);
+            }
         } else {
             thread_act_array_t threads = nullptr;
             mach_msg_type_number_t count = 0;
@@ -489,15 +546,19 @@ void mach_sampling_profiler::main() {
             }
 
             for (mach_msg_type_number_t i = 0; i < count; i++) {
-                if (!running) break;
+                if (!should_sample.load(std::memory_order_relaxed)) break;
 
                 // Stop sampling if we've reached the configured thread limit
                 if (config.max_thread_count != 0 && i > config.max_thread_count) break;
-                
-                // Skip the sampling thread itself
-                if (threads[i] == pthread_mach_thread_np(pthread_self())) continue;
+
+                // Skip profiler-owned threads to avoid self-noise in customer profiles.
+                if (is_profiler_internal_thread(threads[i])) continue;
                 
                 sample_thread(threads[i], interval_nanos);
+
+                if (sample_buffer.size() >= config.max_buffer_size) {
+                    worker->enqueue_active_buffer(sample_buffer);
+                }
             }
 
             // Clean up thread references
@@ -511,33 +572,9 @@ void mach_sampling_profiler::main() {
         // Sleep for the same interval we recorded
         std::this_thread::sleep_for(std::chrono::nanoseconds(interval_nanos));
     }
-    
-    // Flush any remaining samples
-    flush_buffer();
 
-    // Unblock waiters if sampling stops before servicing a pending flush request.
-    {
-        std::lock_guard<std::mutex> lock(flush_mutex);
-        flush_requested = false;
-    }
-    flush_cv.notify_all();
-}
-
-/**
- * Flushes the sample buffer by calling the callback with collected traces.
- */
-void mach_sampling_profiler::flush_buffer() {
-    if (sample_buffer.empty()) return;
-
-    // Deliver raw traces to the callback. Binary image resolution is the consumer's responsibility
-    callback(sample_buffer.data(), sample_buffer.size(), ctx);
-
-    // Free allocated frame memory and binary image data
-    for (auto& trace : sample_buffer) {
-        stack_trace_destroy(&trace);
-    }
-    
-    sample_buffer.clear();
+    // Final safe point: hand off any remaining samples and complete a pending flush.
+    worker->finish_producer(sample_buffer);
 }
 
 } // namespace dd::profiler

--- a/DatadogProfiling/Mach/mach_sampling_profiler.cpp
+++ b/DatadogProfiling/Mach/mach_sampling_profiler.cpp
@@ -21,6 +21,7 @@
 #include <mach/thread_status.h>
 #include <mach/machine/thread_state.h>
 #include <new>
+#include <utility>
 
 // Address validation constants and macros
 //
@@ -453,23 +454,25 @@ void mach_sampling_profiler::stop_sampling() {
     }
 }
 
-void mach_sampling_profiler::request_flush(flush_action_t action, void* action_ctx) {
+bool mach_sampling_profiler::request_flush(flush_action_t action) {
     if (worker) {
-        worker->request_flush(action, action_ctx);
+        return worker->request_flush(std::move(action));
     }
+
+    return false;
 }
 
 void mach_sampling_profiler::request_stop() {
     should_sample.store(false, std::memory_order_relaxed);
 }
 
-void mach_sampling_profiler::consume_diagnostics(dd_profiler_diagnostics_t* out) {
+void mach_sampling_profiler::consume_diagnostics(dd_profiler_diagnostics_t& out) {
     if (worker) {
         worker->consume_diagnostics(out);
-    } else if (out) {
-        out->dropped_batch_count = 0;
-        out->dropped_sample_count = 0;
-        out->max_pending_bytes = 0;
+    } else {
+        out.dropped_batch_count = 0;
+        out.dropped_sample_count = 0;
+        out.max_pending_bytes = 0;
     }
 }
 

--- a/DatadogProfiling/Mach/profile.cpp
+++ b/DatadogProfiling/Mach/profile.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "profile.h"
+#include "binary_image_resolver.h"
 
 #if defined(__APPLE__) && !TARGET_OS_WATCH
 
@@ -127,9 +128,15 @@ int64_t profile::uptime_ns_to_epoch_ns(uint64_t uptime_ns) const {
  * 4. Add completed samples to the profile
  */
 void profile::add_samples(const stack_trace_t* traces, size_t count) {
+    add_samples(traces, count, nullptr);
+}
+
+void profile::add_samples(const stack_trace_t* traces, size_t count, binary_image_cache* image_cache) {
     if (!traces) return;
-    
-    for (int i = 0; i < count; ++i) {
+
+    _samples.reserve(_samples.size() + count);
+
+    for (size_t i = 0; i < count; ++i) {
         const auto& trace = traces[i];
         
         // Build location IDs from stack frames
@@ -137,7 +144,7 @@ void profile::add_samples(const stack_trace_t* traces, size_t count) {
         location_ids.reserve(trace.frame_count);
         for (uint32_t j = 0; j < trace.frame_count; ++j) {
             const auto& frame = trace.frames[j];
-            uint32_t location_id = intern_frame(frame);
+            uint32_t location_id = intern_frame(frame, image_cache);
             location_ids.push_back(location_id);
         }
         
@@ -212,7 +219,34 @@ uint32_t profile::intern_string(const std::string& str) {
  * @return Location ID (1-based) for the frame's instruction address
  */
 uint32_t profile::intern_frame(const stack_frame_t& frame) {
-    uint32_t mapping_id = intern_binary(frame.image);
+    return intern_frame(frame, nullptr);
+}
+
+uint32_t profile::intern_frame(const stack_frame_t& frame, binary_image_cache* image_cache) {
+    // Resolve binary image data only when the instruction pointer is first seen.
+    auto existing_location = _location_lookup.find(frame.instruction_ptr);
+    if (existing_location != _location_lookup.end()) {
+        return existing_location->second;
+    }
+
+    binary_image_t resolved_image{};
+    const binary_image_t* image = &frame.image;
+    bool destroy_resolved_image = false;
+
+    if (frame.image.load_address == 0) {
+        if (image_cache && image_cache->lookup(frame.instruction_ptr, &resolved_image)) {
+            image = &resolved_image;
+        } else if (binary_image_lookup_pc(&resolved_image, reinterpret_cast<void*>(frame.instruction_ptr))) {
+            image = &resolved_image;
+            destroy_resolved_image = true;
+        }
+    }
+
+    uint32_t mapping_id = intern_binary(*image);
+    if (destroy_resolved_image) {
+        binary_image_destroy(&resolved_image);
+    }
+
     location_t location{};
     location.mapping_id = mapping_id;
     location.address = frame.instruction_ptr;

--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -180,8 +180,6 @@ extension ProfilingContext.Status {
             self = .stopped(reason: .prewarmed)
         case DD_PROFILER_STATUS_ALLOCATION_FAILED:
             self = .error(reason: .memoryAllocationFailed)
-        case DD_PROFILER_STATUS_ALREADY_STARTED:
-            self = .error(reason: .alreadyStarted)
         default:
             self = .unknown
         }

--- a/DatadogProfiling/Sources/SDKMetrics/AggregationDiagnosticsMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/AggregationDiagnosticsMetric.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if !os(watchOS)
+
+// swiftlint:disable duplicate_imports
+#if swift(>=6.0)
+internal import DatadogMachProfiler
+#else
+@_implementationOnly import DatadogMachProfiler
+#endif
+// swiftlint:enable duplicate_imports
+
+/// Tracks profiling aggregation diagnostics to be added to telemetry metrics.
+internal final class AggregationDiagnosticsMetric {
+    internal enum Constants {
+        /// Namespace for bundling profiling diagnostics.
+        static let diagnosticsKey = "profiling_diagnostics"
+    }
+
+    /// Number of sampled batches dropped during aggregation.
+    let droppedBatchCount: UInt64
+    /// Number of sampled stack traces contained in dropped batches.
+    let droppedSampleCount: UInt64
+    /// Maximum queued aggregation memory observed, in bytes.
+    let maxPendingBytes: UInt64
+
+    init(
+        droppedBatchCount: UInt64 = 0,
+        droppedSampleCount: UInt64 = 0,
+        maxPendingBytes: UInt64 = 0
+    ) {
+        self.droppedBatchCount = droppedBatchCount
+        self.droppedSampleCount = droppedSampleCount
+        self.maxPendingBytes = maxPendingBytes
+    }
+
+    func asMetricAttributes() -> [String: Encodable]? {
+        [Constants.diagnosticsKey: Attributes(aggregation: self)]
+    }
+}
+
+extension AggregationDiagnosticsMetric: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case droppedBatchCount = "dropped_batch_count"
+        case droppedSampleCount = "dropped_sample_count"
+        case maxPendingBytes = "max_pending_bytes"
+    }
+}
+
+extension AggregationDiagnosticsMetric {
+    static func consumeDiagnostics() -> AggregationDiagnosticsMetric {
+        let diagnostics = dd_profiler_diagnostics()
+
+        return AggregationDiagnosticsMetric(
+            droppedBatchCount: diagnostics.dropped_batch_count,
+            droppedSampleCount: diagnostics.dropped_sample_count,
+            maxPendingBytes: diagnostics.max_pending_bytes
+        )
+    }
+
+    /// Container to encode Profiling diagnostics according to the spec.
+    internal struct Attributes: Encodable {
+        /// Diagnostics for the serialized aggregation worker.
+        let aggregation: AggregationDiagnosticsMetric
+    }
+}
+
+#endif

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
@@ -107,6 +107,7 @@ internal final class ProfilingTelemetryController {
             telemetry.debug("Failed to compute attributes for '\(metric.metricName)'")
             return
         }
+        metricAttributes.merge(AggregationDiagnosticsMetric.consumeDiagnostics().asMetricAttributes() ?? [:]) { $1 }
         metricAttributes.merge(configMetric.asMetricAttributes() ?? [:]) { $1 }
 
         telemetry.metric(name: metric.metricName, attributes: metricAttributes, sampleRate: sampleRate)

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -123,7 +123,7 @@ final class AppLaunchProfilerTests: XCTestCase {
         let core = PassthroughCoreMock()
         let profiler = appLaunchProfiler
 
-        dd_profiler_start_testing(0.0, false, 5.seconds.dd.toInt64Nanoseconds) // 0% sample rate
+        dd_profiler_start_testing(0.0, false, 5.seconds.dd.toInt64Nanoseconds, 0) // 0% sample rate
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED, "Profiler should be sampled out")
 
         // When
@@ -138,7 +138,7 @@ final class AppLaunchProfilerTests: XCTestCase {
         let core = PassthroughCoreMock()
         let profiler = appLaunchProfiler
 
-        dd_profiler_start_testing(100.0, true, 5.seconds.dd.toInt64Nanoseconds) // prewarming = true
+        dd_profiler_start_testing(100.0, true, 5.seconds.dd.toInt64Nanoseconds, 0) // prewarming = true
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_PREWARMED, "Profiler should be prewarmed")
 
         // When
@@ -227,7 +227,7 @@ final class AppLaunchProfilerTests: XCTestCase {
             serverTimeOffset: serverTimeOffset
         )
 
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         Thread.sleep(forTimeInterval: 0.05)
 
         // When

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -258,7 +258,6 @@ final class AppLaunchProfilerTests: XCTestCase {
             (DD_PROFILER_STATUS_TIMEOUT, .stopped(reason: .timeout)),
             (DD_PROFILER_STATUS_PREWARMED, .stopped(reason: .prewarmed)),
             (DD_PROFILER_STATUS_ALLOCATION_FAILED, .error(reason: .memoryAllocationFailed)),
-            (DD_PROFILER_STATUS_ALREADY_STARTED, .error(reason: .alreadyStarted))
         ]
 
         for (cStatus, swiftStatus) in cases {

--- a/DatadogProfiling/Tests/DDProfilerTests.swift
+++ b/DatadogProfiling/Tests/DDProfilerTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import DatadogInternal
 // swiftlint:disable duplicate_imports
 import DatadogMachProfiler
+import DatadogMachProfiler.Pprof
 import DatadogMachProfiler.Testing
 // swiftlint:enable duplicate_imports
 
@@ -18,7 +19,7 @@ final class DDProfilerTests: XCTestCase {
         // `tearDown` leaves `g_dd_profiler` nil; without this, only the first test would match the
         // static constructor's state. Recreate with 0% sample rate so `auto_start` leaves `NOT_STARTED`.
         dd_profiler_destroy()
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
     }
 
     override func tearDown() {
@@ -39,22 +40,116 @@ final class DDProfilerTests: XCTestCase {
     }
 
     func testDDProfiler_startTesting_withZeroSampleRate_doesNotStart() {
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED, "Profiler should not start with zero sample rate")
     }
 
     func testDDProfiler_startTesting_withSampleRateAbove100_startsSuccessfully() {
-        dd_profiler_start_testing(150, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(150, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING, "Profiler should start successfully with sample rate above 100")
     }
 
     func testDDProfiler_startTesting_withCustomTimeout() {
-        dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds) // 1 second timeout
+        dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds, 0) // 1 second timeout
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING, "Profiler should start with custom timeout")
     }
 
+    func testDDProfiler_flushHarvestsPartialBatch() {
+        dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds, 0)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        for i in 0..<2_000 {
+            _ = sqrt(Double(i))
+            if i % 100 == 0 {
+                Thread.sleep(forTimeInterval: 0.002)
+            }
+        }
+
+        let profile = dd_profiler_flush_and_get_profile()
+        XCTAssertNotNil(profile, "Flush should harvest samples even when the active batch is not full")
+        if let profile {
+            XCTAssertGreaterThan(dd_pprof_sample_count(profile), 0, "Partial-batch flush should still return collected samples")
+            dd_pprof_destroy(profile)
+        }
+    }
+
+    func testDDProfiler_consumeDiagnostics_reportsDroppedBatchesAtHardLimit() {
+        dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds, 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        for i in 0..<2_000 {
+            _ = sqrt(Double(i))
+            if i % 100 == 0 {
+                Thread.sleep(forTimeInterval: 0.002)
+            }
+        }
+
+        let profile = dd_profiler_flush_and_get_profile()
+        if let profile {
+            dd_pprof_destroy(profile)
+        }
+
+        var diagnostics = dd_profiler_diagnostics_t()
+        dd_profiler_consume_diagnostics(&diagnostics)
+
+        XCTAssertGreaterThan(diagnostics.dropped_batch_count, 0, "Hard-limit drops should be reported")
+        XCTAssertGreaterThan(diagnostics.dropped_sample_count, 0, "Dropped samples should be counted")
+        XCTAssertGreaterThan(diagnostics.max_pending_bytes, 0, "Pending-byte high-water mark should be reported")
+
+        var secondRead = dd_profiler_diagnostics_t()
+        dd_profiler_consume_diagnostics(&secondRead)
+        XCTAssertEqual(secondRead.dropped_batch_count, 0, "Consuming diagnostics should reset batch drops")
+        XCTAssertEqual(secondRead.dropped_sample_count, 0, "Consuming diagnostics should reset sample drops")
+    }
+
+    func testDDProfiler_doesNotIncludeProfilerInternalThreadsInProfile() throws {
+        dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds, 0)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        for i in 0..<10_000 {
+            _ = sqrt(Double(i))
+            if i % 500 == 0 {
+                Thread.sleep(forTimeInterval: 0.002)
+            }
+        }
+
+        let profile = try XCTUnwrap(dd_profiler_flush_and_get_profile())
+        defer { dd_pprof_destroy(profile) }
+
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        var threadNames: Set<String> = []
+        for i in 0..<unpackedProfile.pointee.n_sample {
+            let sample = try XCTUnwrap(unpackedProfile.pointee.sample[i])
+
+            for j in 0..<sample.pointee.n_label {
+                guard let label = sample.pointee.label?[j] else { continue }
+
+                let keyString = try XCTUnwrap(unpackedProfile.pointee.string_table[Int(label.pointee.key)])
+                if String(cString: keyString) != "thread name" {
+                    continue
+                }
+
+                let valueString = try XCTUnwrap(unpackedProfile.pointee.string_table[Int(label.pointee.str)])
+                threadNames.insert(String(cString: valueString))
+            }
+        }
+
+        XCTAssertFalse(
+            threadNames.contains(where: { $0.hasPrefix("com.datadoghq.profiler.") }),
+            "Profiler-owned threads should not appear in the harvested profile"
+        )
+    }
+
     func testDDProfiler_startTesting_withPrewarming_doesNotStart() {
-        dd_profiler_start_testing(100, true, 5.seconds.dd.toInt64Nanoseconds) // prewarming = true
+        dd_profiler_start_testing(100, true, 5.seconds.dd.toInt64Nanoseconds, 0) // prewarming = true
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_PREWARMED, "Profiler should not start when prewarming is active")
     }
 
@@ -183,7 +278,7 @@ final class DDProfilerTests: XCTestCase {
     }
 
     func testDDProfiler_statusCodes_prewarmed() {
-        dd_profiler_start_testing(100, true, 5.seconds.dd.toInt64Nanoseconds) // prewarming = true
+        dd_profiler_start_testing(100, true, 5.seconds.dd.toInt64Nanoseconds, 0) // prewarming = true
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_PREWARMED, "Should return PREWARMED status when prewarming is true")
     }
 

--- a/DatadogProfiling/Tests/DDProfilerTests.swift
+++ b/DatadogProfiling/Tests/DDProfilerTests.swift
@@ -89,17 +89,15 @@ final class DDProfilerTests: XCTestCase {
             dd_pprof_destroy(profile)
         }
 
-        var diagnostics = dd_profiler_diagnostics_t()
-        dd_profiler_consume_diagnostics(&diagnostics)
+        let diagnostics = dd_profiler_diagnostics()
 
         XCTAssertGreaterThan(diagnostics.dropped_batch_count, 0, "Hard-limit drops should be reported")
         XCTAssertGreaterThan(diagnostics.dropped_sample_count, 0, "Dropped samples should be counted")
         XCTAssertGreaterThan(diagnostics.max_pending_bytes, 0, "Pending-byte high-water mark should be reported")
 
-        var secondRead = dd_profiler_diagnostics_t()
-        dd_profiler_consume_diagnostics(&secondRead)
-        XCTAssertEqual(secondRead.dropped_batch_count, 0, "Consuming diagnostics should reset batch drops")
-        XCTAssertEqual(secondRead.dropped_sample_count, 0, "Consuming diagnostics should reset sample drops")
+        let secondRead = dd_profiler_diagnostics()
+        XCTAssertEqual(secondRead.dropped_batch_count, 0, "Reading diagnostics should reset batch drops")
+        XCTAssertEqual(secondRead.dropped_sample_count, 0, "Reading diagnostics should reset sample drops")
     }
 
     func testDDProfiler_doesNotIncludeProfilerInternalThreadsInProfile() throws {

--- a/DatadogProfiling/Tests/DDProfilerTests.swift
+++ b/DatadogProfiling/Tests/DDProfilerTests.swift
@@ -194,6 +194,18 @@ final class DDProfilerTests: XCTestCase {
         XCTAssertNil(dd_profiler_get_profile(), "Profile should be nil when profiler was never started")
     }
 
+    func testDDProfiler_flushProfile_whenNotStarted_returnsNil() {
+        // Given
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED, "Precondition: profiler should not be started")
+
+        // When
+        let profile = dd_profiler_flush_and_get_profile()
+
+        // Then
+        XCTAssertNil(profile, "Flush should not create a profile when profiler was never started")
+        XCTAssertNil(dd_profiler_get_profile(), "Profile should remain nil")
+    }
+
     func testDDProfiler_getProfile_whenRunning_returnsValidProfile() {
         // Given
         XCTAssertEqual(dd_profiler_start(), 1)
@@ -225,6 +237,33 @@ final class DDProfilerTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(profile, "Profile should still be available after stopping")
+    }
+
+    func testDDProfiler_flushProfileAfterStopping_returnsStoppedProfile() {
+        // Given
+        XCTAssertEqual(dd_profiler_start(), 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING, "Profiler should be running")
+
+        for i in 0..<2_000 {
+            _ = sqrt(Double(i))
+            if i % 100 == 0 {
+                Thread.sleep(forTimeInterval: 0.002)
+            }
+        }
+
+        dd_profiler_stop()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED, "Profiler should be stopped")
+
+        // When
+        let profile = dd_profiler_flush_and_get_profile()
+
+        // Then
+        XCTAssertNotNil(profile, "Flush should return the stopped profile")
+        if let profile {
+            XCTAssertGreaterThan(dd_pprof_sample_count(profile), 0, "Stopped profile should contain harvested samples")
+            dd_pprof_destroy(profile)
+        }
+        XCTAssertNotNil(dd_profiler_get_profile(), "Flush should rotate to a fresh active profile")
     }
 
     func testDDProfiler_destroy_clearsAllData() {
@@ -302,12 +341,12 @@ final class DDProfilerTests: XCTestCase {
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
     }
 
-    func testStop_unblocksPendingFlushRequest() {
+    func testConcurrentStopAndFlush_completeWithoutDeadlock() {
         // Given
         XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.05) // Allow sampling to begin
 
-        let flushReturned = expectation(description: "Flush returns after stop")
+        let flushReturned = expectation(description: "Concurrent flush returns")
 
         // When
         DispatchQueue.global().async {

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -118,7 +118,7 @@ final class DatadogProfilerTests: XCTestCase {
         let longTask = DurationEvent(id: "long-task-id", type: .longTask, start: 0, duration: 100)
         let launchVital: Vital = .mockWith(stepType: nil)
 
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(
             message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: completedOperationStart)),
@@ -180,7 +180,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         // When - transition context to background while retaining foreground history
@@ -200,7 +200,7 @@ extension DatadogProfilerTests {
     func testApplicationDidEnterBackground_doesNothing_whenAppWasNeverInForeground() {
         // Given
         let profiler = continuousProfiler()
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // App was only ever in background (e.g. UIScene based app)
         core.context = .mockWith(applicationStateHistory: .mockAppInBackground())
@@ -219,7 +219,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(id: .mockRandom(), name: "operation")
         let endOperation = Vital.mockWith(id: .mockRandom(), name: "operation", operationKey: startOperation.operationKey, stepType: .end)
@@ -267,7 +267,7 @@ extension DatadogProfilerTests {
             serverTimeOffset: serverTimeOffset
         )
 
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(
             message: .payload(
@@ -317,7 +317,7 @@ extension DatadogProfilerTests {
             deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
         )
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
@@ -348,7 +348,7 @@ extension DatadogProfilerTests {
             deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
         )
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         XCTAssertTrue(profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
@@ -505,7 +505,7 @@ extension DatadogProfilerTests {
             operationKey: startOperation.operationKey,
             stepType: .end
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
@@ -544,7 +544,7 @@ extension DatadogProfilerTests {
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
         )
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
@@ -585,7 +585,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When
         core.context = .mockWith(applicationStateHistory: .mockWith(
@@ -612,7 +612,7 @@ extension DatadogProfilerTests {
             profilingSamplerProvider: profilingSamplerProvider,
             profilingInterval: 0.05
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When
         waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
@@ -627,7 +627,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(name: "operation")
         let endOperation = Vital.mockWith(name: "operation", operationKey: startOperation.operationKey, stepType: .end)
@@ -654,7 +654,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
 
@@ -678,7 +678,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(dateProvider: dateProvider)
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
         flushQueue()
@@ -708,7 +708,7 @@ extension DatadogProfilerTests {
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
@@ -740,7 +740,7 @@ extension DatadogProfilerTests {
             profilingSamplerProvider: profilingSamplerProvider,
             dateProvider: dateProvider
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         // Send background context to stop the profiler and record the state transition
@@ -821,7 +821,7 @@ extension DatadogProfilerTests {
 
     func testCustomProfiler_startsProfilerOnFirstRUMOperationStart() {
         // Given
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let dateProvider = DateProviderMock()
@@ -847,7 +847,7 @@ extension DatadogProfilerTests {
 
     func testCustomProfiler_doesNotRestartRunningProfilerOnOperation() {
         // Given
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         let dateProvider = DateProviderMock()
@@ -889,7 +889,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When - background context with no accumulated events
         core.context = .mockWith(applicationStateHistory: .mockWith(
@@ -917,7 +917,7 @@ extension DatadogProfilerTests {
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
         // Put profiler in NOT_STARTED state (fresh instance, never started) so the custom profiler can start it
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
@@ -950,7 +950,7 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp = Vital.mockWith(id: "start-id", name: "operation", stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -977,7 +977,7 @@ extension DatadogProfilerTests {
     func testCustomProfiler_doesNotStartProfiler_onEndOperationWithoutMatchingStart() {
         // Given
         let profiler = customProfiler()
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let orphanEnd: Vital = .mockWith(stepType: .end)
@@ -996,7 +996,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1018,7 +1018,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(date: dateProvider.now.addingTimeInterval(1))
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1038,7 +1038,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1061,7 +1061,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         // When
@@ -1082,7 +1082,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(name: "operation", date: dateProvider.now)
         let endOperation = Vital.mockWith(
@@ -1117,7 +1117,7 @@ extension DatadogProfilerTests {
         // Given
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(name: "operation", date: dateProvider.now)
         let endOperation = Vital.mockWith(
@@ -1151,7 +1151,7 @@ extension DatadogProfilerTests {
     func testCustomProfiler_applicationWillEnterForeground_doesNotRestartProfiler() {
         // Given
         let dateProvider = DateProviderMock()
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let profiler = customProfiler(dateProvider: dateProvider)
@@ -1278,7 +1278,7 @@ extension DatadogProfilerTests {
             dateProvider: dateProvider
         )
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
         flushQueue()
 
@@ -1319,7 +1319,7 @@ extension DatadogProfilerTests {
             profilingInterval: 0.05,
             telemetryController: telemetryController
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When
         waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
@@ -1345,7 +1345,7 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(telemetryController: telemetryController, dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)

--- a/DatadogProfiling/Tests/ProfileCxxTests.swift
+++ b/DatadogProfiling/Tests/ProfileCxxTests.swift
@@ -373,6 +373,48 @@ final class ProfileCxxTests: XCTestCase {
         XCTAssertEqual(unpackedProfile.pointee.n_sample_type, 1, "Should have one sample type")
     }
 
+    func testProfileAggregation_withMissingImageCache_fallsBackToBinaryLookup() throws {
+        // Given
+        let profile = try XCTUnwrap(dd_pprof_create(10_000_000))
+        defer { dd_pprof_destroy(profile) }
+
+        let validPC = try XCTUnwrap(anyKnownProgramCounter())
+        let trace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        trace.pointee = .mockWith(
+            tid: 1,
+            addresses: [UInt64(UInt(bitPattern: validPC))],
+            binaryImage: binary_image_t(load_address: 0, uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), filename: nil)
+        )
+        defer { dd_free(trace) }
+
+        // When
+        dd_pprof_add_samples(profile, trace, 1)
+        var data: UnsafeMutablePointer<UInt8>?
+        let size = dd_pprof_serialize(profile, &data)
+        defer { dd_pprof_free_serialized_data(data) }
+
+        // Then
+        XCTAssertGreaterThan(size, 0, "Serialized profile should not be empty")
+
+        let unpackedProfile = try XCTUnwrap(perftools__profiles__profile__unpack(nil, size, data))
+        defer { perftools__profiles__profile__free_unpacked(unpackedProfile, nil) }
+
+        XCTAssertEqual(unpackedProfile.pointee.n_mapping, 1, "Resolved frame should create one concrete mapping")
+
+        let mapping = try XCTUnwrap(unpackedProfile.pointee.mapping[0])
+        XCTAssertGreaterThan(mapping.pointee.memory_start, 0, "Fallback lookup should populate the binary load address")
+
+        let buildID = try XCTUnwrap(unpackedProfile.pointee.string_table[Int(mapping.pointee.build_id)])
+        XCTAssertNotEqual(
+            String(cString: buildID),
+            "00000000-0000-0000-0000-000000000000",
+            "Fallback lookup should populate a non-zero build id"
+        )
+
+        let filename = try XCTUnwrap(unpackedProfile.pointee.string_table[Int(mapping.pointee.filename)])
+        XCTAssertFalse(String(cString: filename).isEmpty, "Fallback lookup should populate the binary filename")
+    }
+
     private func firstSerializedSampleEndTimestampSeconds(from profile: OpaquePointer?) throws -> TimeInterval {
         var data: UnsafeMutablePointer<UInt8>?
         let size = dd_pprof_serialize(profile, &data)
@@ -400,6 +442,25 @@ final class ProfileCxxTests: XCTestCase {
         return try XCTUnwrap(timestamp)
     }
 }
+
+private func anyKnownProgramCounter() -> UnsafeMutableRawPointer? {
+    guard let handle = dlopen(nil, RTLD_LAZY) else {
+        return nil
+    }
+
+    let symbols = [
+        "strlen",
+        "malloc",
+        "free",
+        "dlopen",
+        "dlsym"
+    ]
+    guard let randomSymbol = symbols.randomElement() else {
+        return nil
+    }
+    return randomSymbol.withCString { dlsym(handle, $0) }
+}
+
 ///  Deallocates a stack_trace_t and its subsequent frames
 func dd_free(_ trace: UnsafeMutablePointer<stack_trace_t>) {
     // Deallocate frames if they exist

--- a/DatadogProfiling/Tests/ProfilingHandlerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingHandlerTests.swift
@@ -242,7 +242,7 @@ final class ProfilingHandlerTests: XCTestCase {
             serverTimeOffset: serverTimeOffset
         )
 
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         Thread.sleep(forTimeInterval: 0.05)
         let profile = try XCTUnwrap(dd_profiler_flush_and_get_profile())
         let originalStart = dd_pprof_get_start_timestamp_s(profile)

--- a/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
+++ b/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
@@ -182,6 +182,25 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
     }
 
+    func testTrackingProfilingSessionMetric_attachesAggregationDiagnostics() throws {
+        // Given
+        let controller = ProfilingTelemetryController(telemetry: telemetry)
+        let diagnosticsKey = AggregationDiagnosticsMetric.Constants.diagnosticsKey
+
+        // When
+        controller.sendProfile(durationNs: 1, fileSize: 2, for: .continuousProfiling)
+        controller.sendProfileNotWritten(for: .customProfiling)
+
+        // Then
+        let diagnostics = telemetry.messages.compactMap { message in
+            message.asMetric?.attributes[diagnosticsKey] as? AggregationDiagnosticsMetric.Attributes
+        }
+        XCTAssertEqual(diagnostics.count, 2)
+        XCTAssertEqual(diagnostics.first?.aggregation.droppedBatchCount, 0)
+        XCTAssertEqual(diagnostics.first?.aggregation.droppedSampleCount, 0)
+        XCTAssertEqual(diagnostics.first?.aggregation.maxPendingBytes, 0)
+    }
+
     func testSendProfile_usesContinuousStartReason_forContinuousOperation() throws {
         // Given
         let controller = ProfilingTelemetryController(telemetry: telemetry)


### PR DESCRIPTION
### What and why?

This PR improves the iOS Mach profiler so aggregation work no longer blocks the sampling loop. It also reduces aggregation cost and adds bounded overload handling so normal profiling can keep sampling while heavy profile processing catches up.

### How?

Mach profiling now separates the sampling hot path from the aggregation cold path. The sampling thread only captures raw stack samples and hands off completed buffers, avoiding expensive profile mutation, binary image resolution and flush/profile-rotation work on the sampling loop.

Aggregation runs on a long-lived serialized `aggregation_worker`. The worker drains sample batches in order, executes flush requests as ordered barriers and performs profile swaps on the same serialized stream so `flush_and_get_profile()` produces a deterministic profile boundary while sampling continues.

Additionally, the `aggregation_worker` also:
- resolves binary image data lazily for first seen instruction pointers instead of resolving every frame in every batch.
- excludes profiler owned threads from collected profiles.
- uses reusable buffers plus temporary overflow buffers so the sampler does not pause when aggregation falls behind.
- applies a hard byte ceiling to queued aggregation work; if the ceiling is reached, new batches are dropped and internal diagnostics counters are recorded.
- exposes dropped batch diagnostics through a C API. This diagnostics are collected in the `Profiling Session` telemetry ([internal spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/edit-v2/5892964530)).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
