### PR TITLE
Fix ObjC bridge generator for nested DataPoint types

### DIFF
--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/ObjcInterop/ObjcInteropType+reflection.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/ObjcInterop/ObjcInteropType+reflection.swift
@@ -11,13 +11,13 @@ import Foundation
 // swiftlint:disable force_cast
 
 internal protocol ObjcInteropReflectable {
-    var objcRootClass: ObjcInteropRootClass { get }
+    var objcRootClass: ObjcInteropReflectable { get }
     var objcTypeName: String { get }
     var swiftTypeName: String { get }
 }
 
 extension ObjcInteropRootClass: ObjcInteropReflectable {
-    var objcRootClass: ObjcInteropRootClass { self }
+    var objcRootClass: ObjcInteropReflectable { self }
     var objcTypeName: String { bridgedSwiftStruct.name }
     var swiftTypeName: String { bridgedSwiftStruct.name }
 }
@@ -27,7 +27,12 @@ extension ObjcInteropTransitiveNestedClass: ObjcInteropReflectable {
         return parentProperty.owner
     }
 
-    var objcRootClass: ObjcInteropRootClass {
+    var objcRootClass: ObjcInteropReflectable {
+        // ObjcInteropNestedClass (array items) own their swiftModel and act as a local root.
+        // Stop here instead of walking up to the top-level event.
+        if let nestedParent = parentClass as? ObjcInteropNestedClass {
+            return nestedParent
+        }
         return (parentClass as! ObjcInteropReflectable).objcRootClass
     }
 
@@ -48,7 +53,7 @@ extension ObjcInteropNestedClass: ObjcInteropReflectable {
         return parentProperty.owner
     }
 
-    var objcRootClass: ObjcInteropRootClass {
+    var objcRootClass: ObjcInteropReflectable {
         return (parentClass as! ObjcInteropReflectable).objcRootClass
     }
 
@@ -66,7 +71,7 @@ extension ObjcInteropNestedEnum: ObjcInteropReflectable {
         return parentProperty.owner
     }
 
-    var objcRootClass: ObjcInteropRootClass {
+    var objcRootClass: ObjcInteropReflectable {
         return (parentClass as! ObjcInteropReflectable).objcRootClass
     }
 
@@ -87,7 +92,7 @@ extension ObjcInteropAssociatedTypeEnum: ObjcInteropReflectable {
         return parentProperty.owner
     }
 
-    var objcRootClass: ObjcInteropRootClass {
+    var objcRootClass: ObjcInteropReflectable {
         return (parentClass as! ObjcInteropReflectable).objcRootClass
     }
 


### PR DESCRIPTION
### What and why?

The ObjC interop code generator was walking all the way up to the top-level event class when resolving the root class for nested structs inside array items. This caused `DataPoint` wrapper classes to be typed as `objc_RUMTimeseriesCpuEvent` instead of `objc_RUMTimeseriesCpuEventTimeseriesData`, breaking the generated bridge.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs