### PR TITLE
Generate timeseries memory and CPU RUM event models

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -945,7 +945,6 @@ public struct RUMActionEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -1062,7 +1061,6 @@ public struct RUMActionEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -1837,7 +1835,6 @@ public struct RUMErrorEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -2391,7 +2388,6 @@ public struct RUMErrorEvent: RUMDataModel {
             case windows = "windows"
             case macos = "macos"
             case linux = "linux"
-            case maui = "maui"
         }
 
         /// Description of the thread in the process when error happened.
@@ -2517,7 +2513,6 @@ public struct RUMErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -3326,7 +3321,6 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -3630,7 +3624,6 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -4158,7 +4151,6 @@ public struct RUMResourceEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -4809,7 +4801,6 @@ public struct RUMResourceEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -5110,6 +5101,517 @@ public struct RUMTelemetryOperatingSystem: Codable {
         self.build = build
         self.name = name
         self.version = version
+    }
+}
+
+/// Schema for a CPU timeseries event.
+public struct RUMTimeseriesCpuEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Application properties
+    public let application: Application
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source
+
+    /// CPU timeseries properties
+    public let timeseries: Timeseries
+
+    /// RUM event type
+    public let type: String = "timeseries"
+
+    /// The version for this application
+    public let version: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case application = "application"
+        case date = "date"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case timeseries = "timeseries"
+        case type = "type"
+        case version = "version"
+    }
+
+    /// Schema for a CPU timeseries event.
+    ///
+    /// - Parameters:
+    ///   - dd: Internal properties
+    ///   - application: Application properties
+    ///   - date: Start of the event in ms from epoch
+    ///   - service: The service name for this application
+    ///   - session: Session properties
+    ///   - source: The source of this event
+    ///   - timeseries: CPU timeseries properties
+    ///   - version: The version for this application
+    public init(
+        dd: DD,
+        application: Application,
+        date: Int64,
+        service: String? = nil,
+        session: Session,
+        source: Source,
+        timeseries: Timeseries,
+        version: String? = nil
+    ) {
+        self.dd = dd
+        self.application = application
+        self.date = date
+        self.service = service
+        self.session = session
+        self.source = source
+        self.timeseries = timeseries
+        self.version = version
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        public enum CodingKeys: String, CodingKey {
+            case formatVersion = "format_version"
+        }
+
+        /// Internal properties
+        public init() { }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Application properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the application
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: RUMSessionType
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Session properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the session
+        ///   - type: Type of the session
+        public init(
+            id: String,
+            type: RUMSessionType
+        ) {
+            self.id = id
+            self.type = type
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+        case roku = "roku"
+        case unity = "unity"
+        case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
+        case rumCpp = "rum-cpp"
+    }
+
+    /// CPU timeseries properties
+    public struct Timeseries: Codable {
+        /// Array of CPU data points
+        public let data: [Data]
+
+        /// Timestamp of the last sample in nanoseconds from epoch
+        public let end: Int64
+
+        /// UUID of the timeseries batch
+        public let id: String
+
+        /// Name identifying the timeseries metric
+        public let name: String = "cpu"
+
+        /// Wire-shape discriminator for the data field
+        public let schema: Schema
+
+        /// Timestamp of the first sample in nanoseconds from epoch
+        public let start: Int64
+
+        public enum CodingKeys: String, CodingKey {
+            case data = "data"
+            case end = "end"
+            case id = "id"
+            case name = "name"
+            case schema = "schema"
+            case start = "start"
+        }
+
+        /// CPU timeseries properties
+        ///
+        /// - Parameters:
+        ///   - data: Array of CPU data points
+        ///   - end: Timestamp of the last sample in nanoseconds from epoch
+        ///   - id: UUID of the timeseries batch
+        ///   - schema: Wire-shape discriminator for the data field
+        ///   - start: Timestamp of the first sample in nanoseconds from epoch
+        public init(
+            data: [Data],
+            end: Int64,
+            id: String,
+            schema: Schema,
+            start: Int64
+        ) {
+            self.data = data
+            self.end = end
+            self.id = id
+            self.schema = schema
+            self.start = start
+        }
+
+        /// A single CPU data point
+        public struct Data: Codable {
+            /// CPU measurements for this sample
+            public let dataPoint: DataPoint
+
+            /// Sample timestamp in nanoseconds from epoch
+            public let timestamp: Int64
+
+            public enum CodingKeys: String, CodingKey {
+                case dataPoint = "data_point"
+                case timestamp = "timestamp"
+            }
+
+            /// A single CPU data point
+            ///
+            /// - Parameters:
+            ///   - dataPoint: CPU measurements for this sample
+            ///   - timestamp: Sample timestamp in nanoseconds from epoch
+            public init(
+                dataPoint: DataPoint,
+                timestamp: Int64
+            ) {
+                self.dataPoint = dataPoint
+                self.timestamp = timestamp
+            }
+
+            /// CPU measurements for this sample
+            public struct DataPoint: Codable {
+                /// CPU usage as a percentage (0.0 to 100.0)
+                public let cpuUsage: Double
+
+                public enum CodingKeys: String, CodingKey {
+                    case cpuUsage = "cpu_usage"
+                }
+
+                /// CPU measurements for this sample
+                ///
+                /// - Parameters:
+                ///   - cpuUsage: CPU usage as a percentage (0.0 to 100.0)
+                public init(
+                    cpuUsage: Double
+                ) {
+                    self.cpuUsage = cpuUsage
+                }
+            }
+        }
+
+        /// Wire-shape discriminator for the data field
+        public enum Schema: String, Codable {
+            case object = "object"
+            case deltaScalar = "delta-scalar"
+        }
+    }
+}
+
+/// Schema for a memory timeseries event.
+public struct RUMTimeseriesMemoryEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Application properties
+    public let application: Application
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source
+
+    /// Memory timeseries properties
+    public let timeseries: Timeseries
+
+    /// RUM event type
+    public let type: String = "timeseries"
+
+    /// The version for this application
+    public let version: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case application = "application"
+        case date = "date"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case timeseries = "timeseries"
+        case type = "type"
+        case version = "version"
+    }
+
+    /// Schema for a memory timeseries event.
+    ///
+    /// - Parameters:
+    ///   - dd: Internal properties
+    ///   - application: Application properties
+    ///   - date: Start of the event in ms from epoch
+    ///   - service: The service name for this application
+    ///   - session: Session properties
+    ///   - source: The source of this event
+    ///   - timeseries: Memory timeseries properties
+    ///   - version: The version for this application
+    public init(
+        dd: DD,
+        application: Application,
+        date: Int64,
+        service: String? = nil,
+        session: Session,
+        source: Source,
+        timeseries: Timeseries,
+        version: String? = nil
+    ) {
+        self.dd = dd
+        self.application = application
+        self.date = date
+        self.service = service
+        self.session = session
+        self.source = source
+        self.timeseries = timeseries
+        self.version = version
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        public enum CodingKeys: String, CodingKey {
+            case formatVersion = "format_version"
+        }
+
+        /// Internal properties
+        public init() { }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Application properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the application
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: RUMSessionType
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Session properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the session
+        ///   - type: Type of the session
+        public init(
+            id: String,
+            type: RUMSessionType
+        ) {
+            self.id = id
+            self.type = type
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+        case roku = "roku"
+        case unity = "unity"
+        case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
+        case rumCpp = "rum-cpp"
+    }
+
+    /// Memory timeseries properties
+    public struct Timeseries: Codable {
+        /// Array of memory data points
+        public let data: [Data]
+
+        /// Timestamp of the last sample in nanoseconds from epoch
+        public let end: Int64
+
+        /// UUID of the timeseries batch
+        public let id: String
+
+        /// Name identifying the timeseries metric
+        public let name: String = "memory"
+
+        /// Wire-shape discriminator for the data field
+        public let schema: Schema
+
+        /// Timestamp of the first sample in nanoseconds from epoch
+        public let start: Int64
+
+        public enum CodingKeys: String, CodingKey {
+            case data = "data"
+            case end = "end"
+            case id = "id"
+            case name = "name"
+            case schema = "schema"
+            case start = "start"
+        }
+
+        /// Memory timeseries properties
+        ///
+        /// - Parameters:
+        ///   - data: Array of memory data points
+        ///   - end: Timestamp of the last sample in nanoseconds from epoch
+        ///   - id: UUID of the timeseries batch
+        ///   - schema: Wire-shape discriminator for the data field
+        ///   - start: Timestamp of the first sample in nanoseconds from epoch
+        public init(
+            data: [Data],
+            end: Int64,
+            id: String,
+            schema: Schema,
+            start: Int64
+        ) {
+            self.data = data
+            self.end = end
+            self.id = id
+            self.schema = schema
+            self.start = start
+        }
+
+        /// A single memory data point
+        public struct Data: Codable {
+            /// Memory measurements for this sample
+            public let dataPoint: DataPoint
+
+            /// Sample timestamp in nanoseconds from epoch
+            public let timestamp: Int64
+
+            public enum CodingKeys: String, CodingKey {
+                case dataPoint = "data_point"
+                case timestamp = "timestamp"
+            }
+
+            /// A single memory data point
+            ///
+            /// - Parameters:
+            ///   - dataPoint: Memory measurements for this sample
+            ///   - timestamp: Sample timestamp in nanoseconds from epoch
+            public init(
+                dataPoint: DataPoint,
+                timestamp: Int64
+            ) {
+                self.dataPoint = dataPoint
+                self.timestamp = timestamp
+            }
+
+            /// Memory measurements for this sample
+            public struct DataPoint: Codable {
+                /// Physical memory footprint of the process in bytes
+                public let memoryMax: Double
+
+                /// Memory footprint as a percentage of total device RAM
+                public let memoryPercent: Double
+
+                public enum CodingKeys: String, CodingKey {
+                    case memoryMax = "memory_max"
+                    case memoryPercent = "memory_percent"
+                }
+
+                /// Memory measurements for this sample
+                ///
+                /// - Parameters:
+                ///   - memoryMax: Physical memory footprint of the process in bytes
+                ///   - memoryPercent: Memory footprint as a percentage of total device RAM
+                public init(
+                    memoryMax: Double,
+                    memoryPercent: Double
+                ) {
+                    self.memoryMax = memoryMax
+                    self.memoryPercent = memoryPercent
+                }
+            }
+        }
+
+        /// Wire-shape discriminator for the data field
+        public enum Schema: String, Codable {
+            case object = "object"
+            case deltaObject = "delta-object"
+        }
     }
 }
 
@@ -5783,7 +6285,6 @@ public struct RUMViewEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -6004,7 +6505,6 @@ public struct RUMViewEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -6914,8 +7414,6 @@ public struct RUMViewEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
-            case sessionRenewal = "session_renewal"
-            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -7818,7 +8316,6 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -8039,7 +8536,6 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -8949,8 +9445,6 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
-            case sessionRenewal = "session_renewal"
-            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -9928,7 +10422,6 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -10045,7 +10538,6 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -10672,7 +11164,6 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -10789,7 +11280,6 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -11376,7 +11866,6 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
-            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -11493,7 +11982,6 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// Stream properties
@@ -11836,7 +12324,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// The telemetry configuration information
@@ -11943,9 +12430,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether the SDK is initialised on the application's main or a secondary process
             public let isMainProcess: Bool?
 
-            /// The version of MAUI used in a .NET MAUI application
-            public var mauiVersion: String?
-
             /// The period between each Mobile Vital sample (in milliseconds)
             public var mobileVitalsUpdatePeriod: Int64?
 
@@ -11997,7 +12481,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether initialization fails silently if the SDK is already initialized
             public let silentMultipleInit: Bool?
 
-            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
+            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
             public var source: String?
 
             /// Whether Session Replay should automatically start a recording when enabled
@@ -12089,9 +12573,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
 
             /// Whether automatic collection of network requests is enabled
             public var trackNetworkRequests: Bool?
-
-            /// How the SDK tracks resource request/response headers
-            public var trackResourceHeaders: TrackResourceHeaders?
 
             /// Whether resources are tracked
             public var trackResources: Bool?
@@ -12192,7 +12673,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case initializationType = "initialization_type"
                 case invTimeThresholdMs = "inv_time_threshold_ms"
                 case isMainProcess = "is_main_process"
-                case mauiVersion = "maui_version"
                 case mobileVitalsUpdatePeriod = "mobile_vitals_update_period"
                 case numberOfDisplays = "number_of_displays"
                 case plugins = "plugins"
@@ -12241,7 +12721,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case trackNativeLongTasks = "track_native_long_tasks"
                 case trackNativeViews = "track_native_views"
                 case trackNetworkRequests = "track_network_requests"
-                case trackResourceHeaders = "track_resource_headers"
                 case trackResources = "track_resources"
                 case trackSessionAcrossSubdomains = "track_session_across_subdomains"
                 case trackUserInteractions = "track_user_interactions"
@@ -12293,7 +12772,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - initializationType: The type of initialization the SDK used, in case multiple are supported
             ///   - invTimeThresholdMs: Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used
             ///   - isMainProcess: Whether the SDK is initialised on the application's main or a secondary process
-            ///   - mauiVersion: The version of MAUI used in a .NET MAUI application
             ///   - mobileVitalsUpdatePeriod: The period between each Mobile Vital sample (in milliseconds)
             ///   - numberOfDisplays: The number of displays available to the device
             ///   - plugins: The list of plugins enabled
@@ -12311,7 +12789,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - silentMultipleInit: Whether initialization fails silently if the SDK is already initialized
-            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
+            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
             ///   - startRecordingImmediately: Whether Session Replay should automatically start a recording when enabled
             ///   - startSessionReplayRecordingManually: Whether the session replay start is handled manually
             ///   - storeContextsAcrossPages: Whether contexts are stored in local storage
@@ -12342,7 +12820,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - trackNativeLongTasks: Whether long task tracking is performed automatically
             ///   - trackNativeViews: Whether native views are tracked (for cross platform SDKs)
             ///   - trackNetworkRequests: Whether automatic collection of network requests is enabled
-            ///   - trackResourceHeaders: How the SDK tracks resource request/response headers
             ///   - trackResources: Whether resources are tracked
             ///   - trackSessionAcrossSubdomains: Whether sessions across subdomains for the same site are tracked
             ///   - trackUserInteractions: Whether user actions are tracked
@@ -12390,7 +12867,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 initializationType: String? = nil,
                 invTimeThresholdMs: Int64? = nil,
                 isMainProcess: Bool? = nil,
-                mauiVersion: String? = nil,
                 mobileVitalsUpdatePeriod: Int64? = nil,
                 numberOfDisplays: Int64? = nil,
                 plugins: [Plugins]? = nil,
@@ -12439,7 +12915,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 trackNativeLongTasks: Bool? = nil,
                 trackNativeViews: Bool? = nil,
                 trackNetworkRequests: Bool? = nil,
-                trackResourceHeaders: TrackResourceHeaders? = nil,
                 trackResources: Bool? = nil,
                 trackSessionAcrossSubdomains: Bool? = nil,
                 trackUserInteractions: Bool? = nil,
@@ -12487,7 +12962,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.initializationType = initializationType
                 self.invTimeThresholdMs = invTimeThresholdMs
                 self.isMainProcess = isMainProcess
-                self.mauiVersion = mauiVersion
                 self.mobileVitalsUpdatePeriod = mobileVitalsUpdatePeriod
                 self.numberOfDisplays = numberOfDisplays
                 self.plugins = plugins
@@ -12536,7 +13010,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.trackNativeLongTasks = trackNativeLongTasks
                 self.trackNativeViews = trackNativeViews
                 self.trackNetworkRequests = trackNetworkRequests
-                self.trackResourceHeaders = trackResourceHeaders
                 self.trackResources = trackResources
                 self.trackSessionAcrossSubdomains = trackSessionAcrossSubdomains
                 self.trackUserInteractions = trackUserInteractions
@@ -12697,12 +13170,6 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case resource = "resource"
                 case action = "action"
                 case longTask = "long_task"
-            }
-
-            /// How the SDK tracks resource request/response headers
-            public enum TrackResourceHeaders: String, Codable {
-                case defaultHeaders = "default_headers"
-                case custom = "custom"
             }
 
             /// The initial tracking consent value
@@ -12990,7 +13457,6 @@ public struct TelemetryDebugEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -13280,7 +13746,6 @@ public struct TelemetryErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -13606,7 +14071,6 @@ public struct TelemetryUsageEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
-        case maui = "maui"
     }
 
     /// The telemetry usage information
@@ -14360,7 +14824,6 @@ public struct TelemetryUsageEvent: RUMDataModel {
                     public enum AndroidNetworkInstrumentationType: String, Codable {
                         case cRONET = "CRONET"
                         case oKHTTP = "OKHTTP"
-                        case lEGACYOKHTTP = "LEGACY_OKHTTP"
                     }
                 }
             }
@@ -14422,4 +14885,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/1307c66921a47599d3b47b895abba44a5359343f

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -549,7 +549,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// Height of the target element (in pixels)
                 public let height: Int64?
 
-                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 public let permanentId: String?
 
                 /// CSS selector path of the target element
@@ -571,7 +571,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// - Parameters:
                 ///   - composedPathSelector: Selector data based on the click event composed path
                 ///   - height: Height of the target element (in pixels)
-                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 ///   - selector: CSS selector path of the target element
                 ///   - width: Width of the target element (in pixels)
                 public init(
@@ -945,6 +945,7 @@ public struct RUMActionEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -1061,6 +1062,7 @@ public struct RUMActionEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -1835,6 +1837,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -2388,6 +2391,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case windows = "windows"
             case macos = "macos"
             case linux = "linux"
+            case maui = "maui"
         }
 
         /// Description of the thread in the process when error happened.
@@ -2513,6 +2517,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -3321,6 +3326,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -3624,6 +3630,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -4151,6 +4158,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -4801,6 +4809,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -6285,6 +6294,7 @@ public struct RUMViewEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -6505,6 +6515,7 @@ public struct RUMViewEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -7414,6 +7425,8 @@ public struct RUMViewEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
+            case sessionRenewal = "session_renewal"
+            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -8316,6 +8329,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -8536,6 +8550,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -9445,6 +9460,8 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
+            case sessionRenewal = "session_renewal"
+            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -10422,6 +10439,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -10538,6 +10556,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -11164,6 +11183,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -11280,6 +11300,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -11866,6 +11887,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -11982,6 +12004,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -12324,6 +12347,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry configuration information
@@ -12430,6 +12454,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether the SDK is initialised on the application's main or a secondary process
             public let isMainProcess: Bool?
 
+            /// The version of MAUI used in a .NET MAUI application
+            public var mauiVersion: String?
+
             /// The period between each Mobile Vital sample (in milliseconds)
             public var mobileVitalsUpdatePeriod: Int64?
 
@@ -12481,7 +12508,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether initialization fails silently if the SDK is already initialized
             public let silentMultipleInit: Bool?
 
-            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
             public var source: String?
 
             /// Whether Session Replay should automatically start a recording when enabled
@@ -12573,6 +12600,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
 
             /// Whether automatic collection of network requests is enabled
             public var trackNetworkRequests: Bool?
+
+            /// How the SDK tracks resource request/response headers
+            public var trackResourceHeaders: TrackResourceHeaders?
 
             /// Whether resources are tracked
             public var trackResources: Bool?
@@ -12673,6 +12703,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case initializationType = "initialization_type"
                 case invTimeThresholdMs = "inv_time_threshold_ms"
                 case isMainProcess = "is_main_process"
+                case mauiVersion = "maui_version"
                 case mobileVitalsUpdatePeriod = "mobile_vitals_update_period"
                 case numberOfDisplays = "number_of_displays"
                 case plugins = "plugins"
@@ -12721,6 +12752,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case trackNativeLongTasks = "track_native_long_tasks"
                 case trackNativeViews = "track_native_views"
                 case trackNetworkRequests = "track_network_requests"
+                case trackResourceHeaders = "track_resource_headers"
                 case trackResources = "track_resources"
                 case trackSessionAcrossSubdomains = "track_session_across_subdomains"
                 case trackUserInteractions = "track_user_interactions"
@@ -12772,6 +12804,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - initializationType: The type of initialization the SDK used, in case multiple are supported
             ///   - invTimeThresholdMs: Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used
             ///   - isMainProcess: Whether the SDK is initialised on the application's main or a secondary process
+            ///   - mauiVersion: The version of MAUI used in a .NET MAUI application
             ///   - mobileVitalsUpdatePeriod: The period between each Mobile Vital sample (in milliseconds)
             ///   - numberOfDisplays: The number of displays available to the device
             ///   - plugins: The list of plugins enabled
@@ -12789,7 +12822,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - silentMultipleInit: Whether initialization fails silently if the SDK is already initialized
-            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
             ///   - startRecordingImmediately: Whether Session Replay should automatically start a recording when enabled
             ///   - startSessionReplayRecordingManually: Whether the session replay start is handled manually
             ///   - storeContextsAcrossPages: Whether contexts are stored in local storage
@@ -12820,6 +12853,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - trackNativeLongTasks: Whether long task tracking is performed automatically
             ///   - trackNativeViews: Whether native views are tracked (for cross platform SDKs)
             ///   - trackNetworkRequests: Whether automatic collection of network requests is enabled
+            ///   - trackResourceHeaders: How the SDK tracks resource request/response headers
             ///   - trackResources: Whether resources are tracked
             ///   - trackSessionAcrossSubdomains: Whether sessions across subdomains for the same site are tracked
             ///   - trackUserInteractions: Whether user actions are tracked
@@ -12867,6 +12901,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 initializationType: String? = nil,
                 invTimeThresholdMs: Int64? = nil,
                 isMainProcess: Bool? = nil,
+                mauiVersion: String? = nil,
                 mobileVitalsUpdatePeriod: Int64? = nil,
                 numberOfDisplays: Int64? = nil,
                 plugins: [Plugins]? = nil,
@@ -12915,6 +12950,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 trackNativeLongTasks: Bool? = nil,
                 trackNativeViews: Bool? = nil,
                 trackNetworkRequests: Bool? = nil,
+                trackResourceHeaders: TrackResourceHeaders? = nil,
                 trackResources: Bool? = nil,
                 trackSessionAcrossSubdomains: Bool? = nil,
                 trackUserInteractions: Bool? = nil,
@@ -12962,6 +12998,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.initializationType = initializationType
                 self.invTimeThresholdMs = invTimeThresholdMs
                 self.isMainProcess = isMainProcess
+                self.mauiVersion = mauiVersion
                 self.mobileVitalsUpdatePeriod = mobileVitalsUpdatePeriod
                 self.numberOfDisplays = numberOfDisplays
                 self.plugins = plugins
@@ -13010,6 +13047,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.trackNativeLongTasks = trackNativeLongTasks
                 self.trackNativeViews = trackNativeViews
                 self.trackNetworkRequests = trackNetworkRequests
+                self.trackResourceHeaders = trackResourceHeaders
                 self.trackResources = trackResources
                 self.trackSessionAcrossSubdomains = trackSessionAcrossSubdomains
                 self.trackUserInteractions = trackUserInteractions
@@ -13170,6 +13208,12 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case resource = "resource"
                 case action = "action"
                 case longTask = "long_task"
+            }
+
+            /// How the SDK tracks resource request/response headers
+            public enum TrackResourceHeaders: String, Codable {
+                case defaultHeaders = "default_headers"
+                case custom = "custom"
             }
 
             /// The initial tracking consent value
@@ -13457,6 +13501,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -13746,6 +13791,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -14071,6 +14117,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry usage information
@@ -14824,6 +14871,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
                     public enum AndroidNetworkInstrumentationType: String, Codable {
                         case cRONET = "CRONET"
                         case oKHTTP = "OKHTTP"
+                        case lEGACYOKHTTP = "LEGACY_OKHTTP"
                     }
                 }
             }
@@ -14885,4 +14933,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1307c66921a47599d3b47b895abba44a5359343f
+// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -818,7 +818,6 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -834,7 +833,6 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -848,7 +846,6 @@ public enum objc_RUMActionEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMActionEventContainerView)
@@ -1112,7 +1109,6 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -1129,7 +1125,6 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -1144,7 +1139,6 @@ public enum objc_RUMActionEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMActionEventStream)
@@ -1911,7 +1905,6 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -1927,7 +1920,6 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -1941,7 +1933,6 @@ public enum objc_RUMErrorEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMErrorEventContainerView)
@@ -2802,7 +2793,6 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows?: self = .windows
         case .macos?: self = .macos
         case .linux?: self = .linux
-        case .maui?: self = .maui
         }
     }
 
@@ -2821,7 +2811,6 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows: return .windows
         case .macos: return .macos
         case .linux: return .linux
-        case .maui: return .maui
         }
     }
 
@@ -2838,7 +2827,6 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
     case windows
     case macos
     case linux
-    case maui
 }
 
 @objc(DDRUMErrorEventErrorThreads)
@@ -2990,7 +2978,6 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -3007,7 +2994,6 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -3022,7 +3008,6 @@ public enum objc_RUMErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMErrorEventStream)
@@ -3769,7 +3754,6 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -3785,7 +3769,6 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -3799,7 +3782,6 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMLongTaskEventContainerView)
@@ -4230,7 +4212,6 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -4247,7 +4228,6 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -4262,7 +4242,6 @@ public enum objc_RUMLongTaskEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMLongTaskEventStream)
@@ -4938,7 +4917,6 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -4954,7 +4932,6 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -4968,7 +4945,6 @@ public enum objc_RUMResourceEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMResourceEventContainerView)
@@ -5908,7 +5884,6 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -5925,7 +5900,6 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -5940,7 +5914,6 @@ public enum objc_RUMResourceEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMResourceEventStream)
@@ -6061,6 +6034,524 @@ public class objc_RUMResourceEventView: NSObject {
         set { root.swiftModel.view.url = newValue }
         get { root.swiftModel.view.url }
     }
+}
+
+@objc(DDRUMTimeseriesCpuEvent)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEvent: NSObject {
+    public internal(set) var swiftModel: RUMTimeseriesCpuEvent
+    internal var root: objc_RUMTimeseriesCpuEvent { self }
+
+    public init(swiftModel: RUMTimeseriesCpuEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dd: objc_RUMTimeseriesCpuEventDD {
+        objc_RUMTimeseriesCpuEventDD(root: root)
+    }
+
+    public var application: objc_RUMTimeseriesCpuEventApplication {
+        objc_RUMTimeseriesCpuEventApplication(root: root)
+    }
+
+    public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    public var service: String? {
+        root.swiftModel.service
+    }
+
+    public var session: objc_RUMTimeseriesCpuEventSession {
+        objc_RUMTimeseriesCpuEventSession(root: root)
+    }
+
+    public var source: objc_RUMTimeseriesCpuEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    public var timeseries: objc_RUMTimeseriesCpuEventTimeseries {
+        objc_RUMTimeseriesCpuEventTimeseries(root: root)
+    }
+
+    public var type: String {
+        root.swiftModel.type
+    }
+
+    public var version: String? {
+        root.swiftModel.version
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDD)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDD: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventApplication)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventApplication: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventSession: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.session.id
+    }
+
+    public var type: objc_RUMTimeseriesCpuEventSessionRUMSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventSessionRUMSessionType)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventSessionRUMSessionType: Int {
+    internal init(swift: RUMSessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMSessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc(DDRUMTimeseriesCpuEventSource)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventSource: Int {
+    internal init(swift: RUMTimeseriesCpuEvent.Source) {
+        switch swift {
+        case .android: self = .android
+        case .ios: self = .ios
+        case .browser: self = .browser
+        case .flutter: self = .flutter
+        case .reactNative: self = .reactNative
+        case .roku: self = .roku
+        case .unity: self = .unity
+        case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
+        case .rumCpp: self = .rumCpp
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesCpuEvent.Source {
+        switch self {
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        case .roku: return .roku
+        case .unity: return .unity
+        case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
+        case .rumCpp: return .rumCpp
+        }
+    }
+
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case rumCpp
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseries)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseries: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var data: [objc_RUMTimeseriesCpuEventTimeseriesData] {
+        root.swiftModel.timeseries.data.map { objc_RUMTimeseriesCpuEventTimeseriesData(swiftModel: $0) }
+    }
+
+    public var end: NSNumber {
+        root.swiftModel.timeseries.end as NSNumber
+    }
+
+    public var id: String {
+        root.swiftModel.timeseries.id
+    }
+
+    public var name: String {
+        root.swiftModel.timeseries.name
+    }
+
+    public var schema: objc_RUMTimeseriesCpuEventTimeseriesSchema {
+        .init(swift: root.swiftModel.timeseries.schema)
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.timeseries.start as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseriesData)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseriesData: NSObject {
+    internal var swiftModel: RUMTimeseriesCpuEvent.Timeseries.Data
+    internal var root: objc_RUMTimeseriesCpuEventTimeseriesData { self }
+
+    internal init(swiftModel: RUMTimeseriesCpuEvent.Timeseries.Data) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dataPoint: objc_RUMTimeseriesCpuEventTimeseriesDataDataPoint {
+        objc_RUMTimeseriesCpuEventTimeseriesDataDataPoint(root: root)
+    }
+
+    public var timestamp: NSNumber {
+        root.swiftModel.timestamp as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseriesDataDataPoint)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseriesDataDataPoint: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEventTimeseriesData
+
+    internal init(root: objc_RUMTimeseriesCpuEventTimeseriesData) {
+        self.root = root
+    }
+
+    public var cpuUsage: NSNumber {
+        root.swiftModel.dataPoint.cpuUsage as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseriesSchema)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventTimeseriesSchema: Int {
+    internal init(swift: RUMTimeseriesCpuEvent.Timeseries.Schema) {
+        switch swift {
+        case .object: self = .object
+        case .deltaScalar: self = .deltaScalar
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesCpuEvent.Timeseries.Schema {
+        switch self {
+        case .object: return .object
+        case .deltaScalar: return .deltaScalar
+        }
+    }
+
+    case object
+    case deltaScalar
+}
+
+@objc(DDRUMTimeseriesMemoryEvent)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEvent: NSObject {
+    public internal(set) var swiftModel: RUMTimeseriesMemoryEvent
+    internal var root: objc_RUMTimeseriesMemoryEvent { self }
+
+    public init(swiftModel: RUMTimeseriesMemoryEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dd: objc_RUMTimeseriesMemoryEventDD {
+        objc_RUMTimeseriesMemoryEventDD(root: root)
+    }
+
+    public var application: objc_RUMTimeseriesMemoryEventApplication {
+        objc_RUMTimeseriesMemoryEventApplication(root: root)
+    }
+
+    public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    public var service: String? {
+        root.swiftModel.service
+    }
+
+    public var session: objc_RUMTimeseriesMemoryEventSession {
+        objc_RUMTimeseriesMemoryEventSession(root: root)
+    }
+
+    public var source: objc_RUMTimeseriesMemoryEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    public var timeseries: objc_RUMTimeseriesMemoryEventTimeseries {
+        objc_RUMTimeseriesMemoryEventTimeseries(root: root)
+    }
+
+    public var type: String {
+        root.swiftModel.type
+    }
+
+    public var version: String? {
+        root.swiftModel.version
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDD)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDD: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventApplication)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventApplication: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventSession: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.session.id
+    }
+
+    public var type: objc_RUMTimeseriesMemoryEventSessionRUMSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventSessionRUMSessionType)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventSessionRUMSessionType: Int {
+    internal init(swift: RUMSessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMSessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc(DDRUMTimeseriesMemoryEventSource)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventSource: Int {
+    internal init(swift: RUMTimeseriesMemoryEvent.Source) {
+        switch swift {
+        case .android: self = .android
+        case .ios: self = .ios
+        case .browser: self = .browser
+        case .flutter: self = .flutter
+        case .reactNative: self = .reactNative
+        case .roku: self = .roku
+        case .unity: self = .unity
+        case .kotlinMultiplatform: self = .kotlinMultiplatform
+        case .electron: self = .electron
+        case .rumCpp: self = .rumCpp
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesMemoryEvent.Source {
+        switch self {
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        case .roku: return .roku
+        case .unity: return .unity
+        case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
+        case .rumCpp: return .rumCpp
+        }
+    }
+
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case rumCpp
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseries)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseries: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var data: [objc_RUMTimeseriesMemoryEventTimeseriesData] {
+        root.swiftModel.timeseries.data.map { objc_RUMTimeseriesMemoryEventTimeseriesData(swiftModel: $0) }
+    }
+
+    public var end: NSNumber {
+        root.swiftModel.timeseries.end as NSNumber
+    }
+
+    public var id: String {
+        root.swiftModel.timeseries.id
+    }
+
+    public var name: String {
+        root.swiftModel.timeseries.name
+    }
+
+    public var schema: objc_RUMTimeseriesMemoryEventTimeseriesSchema {
+        .init(swift: root.swiftModel.timeseries.schema)
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.timeseries.start as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseriesData)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseriesData: NSObject {
+    internal var swiftModel: RUMTimeseriesMemoryEvent.Timeseries.Data
+    internal var root: objc_RUMTimeseriesMemoryEventTimeseriesData { self }
+
+    internal init(swiftModel: RUMTimeseriesMemoryEvent.Timeseries.Data) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dataPoint: objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint {
+        objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint(root: root)
+    }
+
+    public var timestamp: NSNumber {
+        root.swiftModel.timestamp as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseriesDataDataPoint)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEventTimeseriesData
+
+    internal init(root: objc_RUMTimeseriesMemoryEventTimeseriesData) {
+        self.root = root
+    }
+
+    public var memoryMax: NSNumber {
+        root.swiftModel.dataPoint.memoryMax as NSNumber
+    }
+
+    public var memoryPercent: NSNumber {
+        root.swiftModel.dataPoint.memoryPercent as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseriesSchema)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventTimeseriesSchema: Int {
+    internal init(swift: RUMTimeseriesMemoryEvent.Timeseries.Schema) {
+        switch swift {
+        case .object: self = .object
+        case .deltaObject: self = .deltaObject
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesMemoryEvent.Timeseries.Schema {
+        switch self {
+        case .object: return .object
+        case .deltaObject: return .deltaObject
+        }
+    }
+
+    case object
+    case deltaObject
 }
 
 @objc(DDRUMViewEvent)
@@ -6747,7 +7238,6 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -6763,7 +7253,6 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -6777,7 +7266,6 @@ public enum objc_RUMViewEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMViewEventContainerView)
@@ -7135,7 +7623,6 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -7152,7 +7639,6 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -7167,7 +7653,6 @@ public enum objc_RUMViewEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMViewEventStream)
@@ -7815,8 +8300,6 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
-        case .sessionRenewal?: self = .sessionRenewal
-        case .bfCache?: self = .bfCache
         }
     }
 
@@ -7831,8 +8314,6 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
-        case .sessionRenewal: return .sessionRenewal
-        case .bfCache: return .bfCache
         }
     }
 
@@ -7845,8 +8326,6 @@ public enum objc_RUMViewEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
-    case sessionRenewal
-    case bfCache
 }
 
 @objc(DDRUMViewEventViewLongTask)
@@ -8670,7 +9149,6 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -8686,7 +9164,6 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -8700,7 +9177,6 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMViewUpdateEventContainerView)
@@ -9058,7 +9534,6 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -9075,7 +9550,6 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -9090,7 +9564,6 @@ public enum objc_RUMViewUpdateEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMViewUpdateEventStream)
@@ -9738,8 +10211,6 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
-        case .sessionRenewal?: self = .sessionRenewal
-        case .bfCache?: self = .bfCache
         }
     }
 
@@ -9754,8 +10225,6 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
-        case .sessionRenewal: return .sessionRenewal
-        case .bfCache: return .bfCache
         }
     }
 
@@ -9768,8 +10237,6 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
-    case sessionRenewal
-    case bfCache
 }
 
 @objc(DDRUMViewUpdateEventViewLongTask)
@@ -10668,7 +11135,6 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -10684,7 +11150,6 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -10698,7 +11163,6 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventContainerView)
@@ -10962,7 +11426,6 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -10979,7 +11442,6 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -10994,7 +11456,6 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventStream)
@@ -11781,7 +12242,6 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -11797,7 +12257,6 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -11811,7 +12270,6 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalDurationEventContainerView)
@@ -12075,7 +12533,6 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -12092,7 +12549,6 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -12107,7 +12563,6 @@ public enum objc_RUMVitalDurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalDurationEventStream)
@@ -12833,7 +13288,6 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -12849,7 +13303,6 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -12863,7 +13316,6 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventContainerView)
@@ -13127,7 +13579,6 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
-        case .maui?: self = .maui
         }
     }
 
@@ -13144,7 +13595,6 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -13159,7 +13609,6 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventStream)
@@ -13513,7 +13962,6 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -13528,7 +13976,6 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -13541,7 +13988,6 @@ public enum objc_TelemetryConfigurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDTelemetryConfigurationEventTelemetry)
@@ -13670,11 +14116,6 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
 
     public var isMainProcess: NSNumber? {
         root.swiftModel.telemetry.configuration.isMainProcess as NSNumber?
-    }
-
-    public var mauiVersion: String? {
-        set { root.swiftModel.telemetry.configuration.mauiVersion = newValue }
-        get { root.swiftModel.telemetry.configuration.mauiVersion }
     }
 
     public var mobileVitalsUpdatePeriod: NSNumber? {
@@ -13901,11 +14342,6 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
     public var trackNetworkRequests: NSNumber? {
         set { root.swiftModel.telemetry.configuration.trackNetworkRequests = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.trackNetworkRequests as NSNumber? }
-    }
-
-    public var trackResourceHeaders: objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders {
-        set { root.swiftModel.telemetry.configuration.trackResourceHeaders = newValue.toSwift }
-        get { .init(swift: root.swiftModel.telemetry.configuration.trackResourceHeaders) }
     }
 
     public var trackResources: NSNumber? {
@@ -14205,30 +14641,6 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackFeatureFl
     case longTask
 }
 
-@objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders)
-@_spi(objc)
-public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders: Int {
-    internal init(swift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders?) {
-        switch swift {
-        case nil: self = .none
-        case .defaultHeaders?: self = .defaultHeaders
-        case .custom?: self = .custom
-        }
-    }
-
-    internal var toSwift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders? {
-        switch self {
-        case .none: return nil
-        case .defaultHeaders: return .defaultHeaders
-        case .custom: return .custom
-        }
-    }
-
-    case none
-    case defaultHeaders
-    case custom
-}
-
 @objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackingConsent)
 @_spi(objc)
 public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackingConsent: Int {
@@ -14497,7 +14909,6 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -14512,7 +14923,6 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -14525,7 +14935,6 @@ public enum objc_TelemetryDebugEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDTelemetryDebugEventTelemetry)
@@ -14775,7 +15184,6 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
-        case .maui: self = .maui
         }
     }
 
@@ -14790,7 +15198,6 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
-        case .maui: return .maui
         }
     }
 
@@ -14803,7 +15210,6 @@ public enum objc_TelemetryErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
-    case maui
 }
 
 @objc(DDTelemetryErrorEventTelemetry)
@@ -14940,4 +15346,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/1307c66921a47599d3b47b895abba44a5359343f

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -818,6 +818,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -833,6 +834,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -846,6 +848,7 @@ public enum objc_RUMActionEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMActionEventContainerView)
@@ -1109,6 +1112,7 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -1125,6 +1129,7 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -1139,6 +1144,7 @@ public enum objc_RUMActionEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMActionEventStream)
@@ -1905,6 +1911,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -1920,6 +1927,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -1933,6 +1941,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMErrorEventContainerView)
@@ -2793,6 +2802,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows?: self = .windows
         case .macos?: self = .macos
         case .linux?: self = .linux
+        case .maui?: self = .maui
         }
     }
 
@@ -2811,6 +2821,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows: return .windows
         case .macos: return .macos
         case .linux: return .linux
+        case .maui: return .maui
         }
     }
 
@@ -2827,6 +2838,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
     case windows
     case macos
     case linux
+    case maui
 }
 
 @objc(DDRUMErrorEventErrorThreads)
@@ -2978,6 +2990,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -2994,6 +3007,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -3008,6 +3022,7 @@ public enum objc_RUMErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMErrorEventStream)
@@ -3754,6 +3769,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -3769,6 +3785,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -3782,6 +3799,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMLongTaskEventContainerView)
@@ -4212,6 +4230,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -4228,6 +4247,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -4242,6 +4262,7 @@ public enum objc_RUMLongTaskEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMLongTaskEventStream)
@@ -4917,6 +4938,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -4932,6 +4954,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -4945,6 +4968,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMResourceEventContainerView)
@@ -5884,6 +5908,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -5900,6 +5925,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -5914,6 +5940,7 @@ public enum objc_RUMResourceEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMResourceEventStream)
@@ -7238,6 +7265,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -7253,6 +7281,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -7266,6 +7295,7 @@ public enum objc_RUMViewEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewEventContainerView)
@@ -7623,6 +7653,7 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -7639,6 +7670,7 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -7653,6 +7685,7 @@ public enum objc_RUMViewEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewEventStream)
@@ -8300,6 +8333,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        case .sessionRenewal?: self = .sessionRenewal
+        case .bfCache?: self = .bfCache
         }
     }
 
@@ -8314,6 +8349,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
+        case .sessionRenewal: return .sessionRenewal
+        case .bfCache: return .bfCache
         }
     }
 
@@ -8326,6 +8363,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 }
 
 @objc(DDRUMViewEventViewLongTask)
@@ -9149,6 +9188,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -9164,6 +9204,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -9177,6 +9218,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewUpdateEventContainerView)
@@ -9534,6 +9576,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -9550,6 +9593,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -9564,6 +9608,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewUpdateEventStream)
@@ -10211,6 +10256,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        case .sessionRenewal?: self = .sessionRenewal
+        case .bfCache?: self = .bfCache
         }
     }
 
@@ -10225,6 +10272,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
+        case .sessionRenewal: return .sessionRenewal
+        case .bfCache: return .bfCache
         }
     }
 
@@ -10237,6 +10286,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 }
 
 @objc(DDRUMViewUpdateEventViewLongTask)
@@ -11135,6 +11186,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -11150,6 +11202,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -11163,6 +11216,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventContainerView)
@@ -11426,6 +11480,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -11442,6 +11497,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -11456,6 +11512,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventStream)
@@ -12242,6 +12299,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -12257,6 +12315,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -12270,6 +12329,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalDurationEventContainerView)
@@ -12533,6 +12593,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -12549,6 +12610,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -12563,6 +12625,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalDurationEventStream)
@@ -13288,6 +13351,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -13303,6 +13367,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -13316,6 +13381,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventContainerView)
@@ -13579,6 +13645,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -13595,6 +13662,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -13609,6 +13677,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventStream)
@@ -13962,6 +14031,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -13976,6 +14046,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -13988,6 +14059,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryConfigurationEventTelemetry)
@@ -14116,6 +14188,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
 
     public var isMainProcess: NSNumber? {
         root.swiftModel.telemetry.configuration.isMainProcess as NSNumber?
+    }
+
+    public var mauiVersion: String? {
+        set { root.swiftModel.telemetry.configuration.mauiVersion = newValue }
+        get { root.swiftModel.telemetry.configuration.mauiVersion }
     }
 
     public var mobileVitalsUpdatePeriod: NSNumber? {
@@ -14342,6 +14419,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
     public var trackNetworkRequests: NSNumber? {
         set { root.swiftModel.telemetry.configuration.trackNetworkRequests = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.trackNetworkRequests as NSNumber? }
+    }
+
+    public var trackResourceHeaders: objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders {
+        set { root.swiftModel.telemetry.configuration.trackResourceHeaders = newValue.toSwift }
+        get { .init(swift: root.swiftModel.telemetry.configuration.trackResourceHeaders) }
     }
 
     public var trackResources: NSNumber? {
@@ -14641,6 +14723,30 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackFeatureFl
     case longTask
 }
 
+@objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders)
+@_spi(objc)
+public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders: Int {
+    internal init(swift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders?) {
+        switch swift {
+        case nil: self = .none
+        case .defaultHeaders?: self = .defaultHeaders
+        case .custom?: self = .custom
+        }
+    }
+
+    internal var toSwift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders? {
+        switch self {
+        case .none: return nil
+        case .defaultHeaders: return .defaultHeaders
+        case .custom: return .custom
+        }
+    }
+
+    case none
+    case defaultHeaders
+    case custom
+}
+
 @objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackingConsent)
 @_spi(objc)
 public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackingConsent: Int {
@@ -14909,6 +15015,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -14923,6 +15030,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -14935,6 +15043,7 @@ public enum objc_TelemetryDebugEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryDebugEventTelemetry)
@@ -15184,6 +15293,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -15198,6 +15308,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -15210,6 +15321,7 @@ public enum objc_TelemetryErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryErrorEventTelemetry)
@@ -15346,4 +15458,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/1307c66921a47599d3b47b895abba44a5359343f
+// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1


### PR DESCRIPTION
### What and why?

Regenerated `RUMDataModels.swift` and `RUMDataModels+objc.swift` from the `bplasovska/timeseries` branch of `rum-events-format`, adding `RUMTimeseriesMemoryEvent` and `RUMTimeseriesCpuEvent` to the SDK.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs