### PR TITLE
Add TimeseriesSessionCollector with memory and CPU collection

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -666,6 +666,7 @@
 		BB1A2B3C4D5E6F7800000005 /* DeltaEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */; };
 		7F8C00B87F71287FB535342E /* DeltaEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */; };
 		7F8C00B87F71287FB535342F /* DeltaEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */; };
+		7F8C00B87F71287FB535342B /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */; };
 		61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */; };
 		61E262D42EB2592C0041E70F /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
@@ -5851,6 +5852,7 @@
 			isa = PBXGroup;
 			children = (
 				BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */,
+				BB1A2B3C4D5E6F7800000001 /* TimeseriesSessionCollector.swift */,
 			);
 			path = Timeseries;
 			sourceTree = "<group>";
@@ -5859,6 +5861,7 @@
 			isa = PBXGroup;
 			children = (
 				7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */,
+				7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */,
 			);
 			path = Timeseries;
 			sourceTree = "<group>";
@@ -8790,6 +8793,7 @@
 				D29A9F5A29DD85BB005C54A4 /* RUMScopeDependencies.swift in Sources */,
 				D29A9F5B29DD85BB005C54A4 /* VitalMemoryReader.swift in Sources */,
 				BB1A2B3C4D5E6F7800000005 /* DeltaEncoder.swift in Sources */,
+				D29A9FFF29DD85BB005C54A4 /* TimeseriesSessionCollector.swift in Sources */,
 				5B1D02862E8EB78800AB2391 /* FlagEvaluationReceiver.swift in Sources */,
 				962900242D8351AB008DFE39 /* TopLevelReflector.swift in Sources */,
 				6194B9332BB451DB00179430 /* FatalAppHangsHandler.swift in Sources */,
@@ -8919,6 +8923,7 @@
 				6188697C2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
 				61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				7F8C00B87F71287FB535342F /* DeltaEncoderTests.swift in Sources */,
+				7F8C00B87F71287FB535342B /* TimeseriesSessionCollectorTests.swift in Sources */,
 				D29A9FA629DDB483005C54A4 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
 				61C4534A2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */,
 				D29A9FBD29DDB483005C54A4 /* RUMSessionScopeTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -662,6 +662,9 @@
 		61DA8CB828647A500074A606 /* InternalLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB728647A500074A606 /* InternalLoggerTests.swift */; };
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
+		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
+		B51668F3A97DEAC2917B0F44 /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */; };
+		21A5D61036FA5C28E71ED824 /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */; };
 		BB1A2B3C4D5E6F7800000004 /* DeltaEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */; };
 		BB1A2B3C4D5E6F7800000005 /* DeltaEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */; };
 		7F8C00B87F71287FB535342E /* DeltaEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */; };
@@ -1029,6 +1032,7 @@
 		D29A9F5929DD85BB005C54A4 /* RUMCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */; };
 		D29A9F5A29DD85BB005C54A4 /* RUMScopeDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6122514727FDFF82004F5AE4 /* RUMScopeDependencies.swift */; };
 		D29A9F5B29DD85BB005C54A4 /* VitalMemoryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BBBCB0265E71C600943419 /* VitalMemoryReader.swift */; };
+		D29A9FFF29DD85BB005C54A4 /* TimeseriesSessionCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000001 /* TimeseriesSessionCollector.swift */; };
 		D29A9F5C29DD85BB005C54A4 /* RUMSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20624C098FC00C0321C /* RUMSessionScope.swift */; };
 		D29A9F5D29DD85BB005C54A4 /* RUMCommandSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */; };
 		D29A9F5E29DD85BB005C54A4 /* UIKitRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */; };
@@ -2653,7 +2657,9 @@
 		AA0001012A000006000A0001 /* UIScrollViewDelegateProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewDelegateProxyTests.swift; sourceTree = "<group>"; };
 		AA0001012A000007000A0001 /* UIScrollViewSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSwizzlerTests.swift; sourceTree = "<group>"; };
 		B3BBBCB0265E71C600943419 /* VitalMemoryReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReader.swift; sourceTree = "<group>"; };
+		BB1A2B3C4D5E6F7800000001 /* TimeseriesSessionCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeseriesSessionCollector.swift; sourceTree = "<group>"; };
 		BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaEncoder.swift; sourceTree = "<group>"; };
+		7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeseriesSessionCollectorTests.swift; sourceTree = "<group>"; };
 		7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaEncoderTests.swift; sourceTree = "<group>"; };
 		B3BBBCBB265E71D100943419 /* VitalMemoryReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalMemoryReaderTests.swift; sourceTree = "<group>"; };
 		B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkContextProvider.swift; sourceTree = "<group>"; };

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -662,9 +662,6 @@
 		61DA8CB828647A500074A606 /* InternalLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB728647A500074A606 /* InternalLoggerTests.swift */; };
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
-		61DCC8482C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DCC8462C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift */; };
-		B51668F3A97DEAC2917B0F44 /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */; };
-		21A5D61036FA5C28E71ED824 /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342C /* TimeseriesSessionCollectorTests.swift */; };
 		BB1A2B3C4D5E6F7800000004 /* DeltaEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */; };
 		BB1A2B3C4D5E6F7800000005 /* DeltaEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1A2B3C4D5E6F7800000003 /* DeltaEncoder.swift */; };
 		7F8C00B87F71287FB535342E /* DeltaEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8C00B87F71287FB535342D /* DeltaEncoderTests.swift */; };

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -1,0 +1,256 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Defines the interface for collecting timeseries data during a RUM session.
+internal protocol TimeseriesCollecting: AnyObject {
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType)
+    func stop()
+}
+
+/// Collects memory and CPU samples at 1s intervals during a RUM session and flushes them
+/// as `RUMTimeseriesMemoryEvent` / `RUMTimeseriesCpuEvent` batches via the RUM feature scope.
+///
+/// At session start a coin is flipped: 50% of sessions send full-array `object` schema events,
+/// 50% send delta-compressed events (`delta-object` for memory, `delta-scalar` for CPU).
+internal class TimeseriesSessionCollector: TimeseriesCollecting {
+    private let memoryReader: SamplingBasedVitalReader
+    private let cpuUsageProvider: () -> Double?
+    private let compressionSampler: () -> Bool
+    private let batchSize: Int
+    private let samplingInterval: TimeInterval
+    private let featureScope: FeatureScope
+    private let totalRAM: Double
+
+    private var memoryBuffer: [RUMTimeseriesMemoryEvent.Timeseries.Data] = []
+    private var cpuBuffer: [RUMTimeseriesCpuEvent.Timeseries.Data] = []
+    private var sessionID: String = ""
+    private var applicationID: String = ""
+    private var sessionType: RUMSessionType = .user
+    private var useDeltaCompression: Bool = false
+    private var timer: DispatchSourceTimer?
+
+    /// All buffer mutations and timer events run on this queue.
+    private let queue = DispatchQueue(label: "com.datadoghq.timeseries-collector", qos: .utility)
+
+    init(
+        memoryReader: SamplingBasedVitalReader,
+        featureScope: FeatureScope,
+        batchSize: Int = 30,
+        samplingInterval: TimeInterval = 1,
+        cpuUsageProvider: (() -> Double?)? = nil,
+        compressionSampler: @escaping () -> Bool = { Bool.random() }
+    ) {
+        self.memoryReader = memoryReader
+        self.batchSize = batchSize
+        self.samplingInterval = samplingInterval
+        self.featureScope = featureScope
+        self.totalRAM = Double(ProcessInfo.processInfo.physicalMemory)
+        self.cpuUsageProvider = cpuUsageProvider ?? { TimeseriesSessionCollector.processCPU() }
+        self.compressionSampler = compressionSampler
+    }
+
+    /// Per-process CPU as a percentage (0–100+), summed across all app threads.
+    /// Separated into a static so it can be called from the init closure without capturing self.
+    private static func processCPU() -> Double? {
+        #if os(watchOS)
+        return nil
+        #else
+        var threadsList: thread_act_array_t?
+        var threadsCount = mach_msg_type_number_t()
+        let kr = withUnsafeMutablePointer(to: &threadsList) {
+            $0.withMemoryRebound(to: thread_act_array_t?.self, capacity: 1) {
+                task_threads(mach_task_self_, $0, &threadsCount)
+            }
+        }
+        guard kr == KERN_SUCCESS, let threadsList = threadsList else {
+            return nil
+        }
+        defer {
+            vm_deallocate(
+                mach_task_self_,
+                vm_address_t(bitPattern: threadsList),
+                vm_size_t(Int(threadsCount) * MemoryLayout<thread_t>.stride)
+            )
+        }
+        var total = 0.0
+        for i in 0..<threadsCount {
+            var info = thread_basic_info()
+            var infoCount = mach_msg_type_number_t(THREAD_INFO_MAX)
+            let kr = withUnsafeMutablePointer(to: &info) {
+                $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                    thread_info(threadsList[Int(i)], thread_flavor_t(THREAD_BASIC_INFO), $0, &infoCount)
+                }
+            }
+            guard kr == KERN_SUCCESS, info.flags != TH_FLAGS_IDLE else {
+                continue
+            }
+            total += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
+        }
+        return total
+        #endif
+    }
+
+    /// Resets state, flips the compression coin, and starts a 1s sampling timer for the new session.
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.sessionID = sessionID
+            self.applicationID = applicationID
+            self.sessionType = sessionType
+            self.useDeltaCompression = self.compressionSampler()
+            self.memoryBuffer = []
+            self.cpuBuffer = []
+
+            self.timer?.cancel()
+            let timer = DispatchSource.makeTimerSource(queue: self.queue)
+            timer.schedule(deadline: .now() + samplingInterval, repeating: samplingInterval)
+            timer.setEventHandler { [weak self] in self?.sample() }
+            timer.resume()
+            self.timer = timer
+        }
+    }
+
+    /// Stops sampling and flushes any remaining buffered data points.
+    func stop() {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.timer?.cancel()
+            self.timer = nil
+            self.flushMemory()
+            self.flushCPU()
+        }
+    }
+
+    // MARK: - Private
+
+    private func sample() {
+        let now = Int64(Date().timeIntervalSince1970 * 1_000_000_000)
+
+        if let bytes = memoryReader.readVitalData() {
+            let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
+            let dataPoint = RUMTimeseriesMemoryEvent.Timeseries.Data(
+                dataPoint: .init(memoryMax: bytes, memoryPercent: memoryPercent),
+                timestamp: now
+            )
+            memoryBuffer.append(dataPoint)
+            if memoryBuffer.count >= batchSize {
+                flushMemory()
+            }
+        }
+
+        if let cpuUsage = cpuUsageProvider() {
+            let dataPoint = RUMTimeseriesCpuEvent.Timeseries.Data(
+                dataPoint: .init(cpuUsage: cpuUsage),
+                timestamp: now
+            )
+            cpuBuffer.append(dataPoint)
+            if cpuBuffer.count >= batchSize {
+                flushCPU()
+            }
+        }
+    }
+
+    private func flushMemory() {
+        guard !memoryBuffer.isEmpty else {
+            return
+        }
+        let batch = memoryBuffer
+        memoryBuffer = []
+        let sessionID = self.sessionID
+        let applicationID = self.applicationID
+        let sessionType = self.sessionType
+        let start = batch[0].timestamp
+        let end = batch[batch.count - 1].timestamp
+        let eventID = UUID().uuidString.lowercased()
+        let useDelta = self.useDeltaCompression
+
+        featureScope.eventWriteContext { context, writer in
+            let objectEvent = RUMTimeseriesMemoryEvent(
+                dd: .init(),
+                application: .init(id: applicationID),
+                date: start / 1_000_000,
+                service: context.service,
+                session: .init(id: sessionID, type: sessionType),
+                source: .ios,
+                timeseries: .init(
+                    data: batch,
+                    end: end,
+                    id: eventID,
+                    schema: .object,
+                    start: start
+                ),
+                version: context.version
+            )
+
+            if useDelta,
+               let deltaData = DeltaEncoder.encodeMemory(batch),
+               let eventData = try? JSONEncoder().encode(objectEvent),
+               var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+               var ts = dict["timeseries"] as? [String: Any] {
+                ts["schema"] = "delta-object"
+                ts["data"] = deltaData
+                dict["timeseries"] = ts
+                writer.write(value: AnyEncodable(dict))
+            } else {
+                writer.write(value: objectEvent)
+            }
+        }
+    }
+
+    private func flushCPU() {
+        guard !cpuBuffer.isEmpty else {
+            return
+        }
+        let batch = cpuBuffer
+        cpuBuffer = []
+        let sessionID = self.sessionID
+        let applicationID = self.applicationID
+        let sessionType = self.sessionType
+        let start = batch[0].timestamp
+        let end = batch[batch.count - 1].timestamp
+        let eventID = UUID().uuidString.lowercased()
+        let useDelta = self.useDeltaCompression
+
+        featureScope.eventWriteContext { context, writer in
+            let objectEvent = RUMTimeseriesCpuEvent(
+                dd: .init(),
+                application: .init(id: applicationID),
+                date: start / 1_000_000,
+                service: context.service,
+                session: .init(id: sessionID, type: sessionType),
+                source: .ios,
+                timeseries: .init(
+                    data: batch,
+                    end: end,
+                    id: eventID,
+                    schema: .object,
+                    start: start
+                ),
+                version: context.version
+            )
+
+            if useDelta,
+               let deltaData = DeltaEncoder.encodeCPU(batch),
+               let eventData = try? JSONEncoder().encode(objectEvent),
+               var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+               var ts = dict["timeseries"] as? [String: Any] {
+                ts["schema"] = "delta-scalar"
+                ts["data"] = deltaData
+                dict["timeseries"] = ts
+                writer.write(value: AnyEncodable(dict))
+            } else {
+                writer.write(value: objectEvent)
+            }
+        }
+    }
+}

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -175,7 +175,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     // MARK: - Private
 
     private func sample() {
-        let now = Int64(Date().timeIntervalSince1970 * 1_000_000_000)
+        let now = Int64.ddWithNoOverflow(Date().timeIntervalSince1970 * 1_000_000_000)
 
         if let bytes = memoryReader.readVitalData() {
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -10,6 +10,8 @@ import DatadogInternal
 /// Defines the interface for collecting timeseries data during a RUM session.
 internal protocol TimeseriesCollecting: AnyObject {
     func start(sessionID: String, applicationID: String, sessionType: RUMSessionType)
+    func pause()
+    func resume()
     func stop()
 }
 
@@ -24,6 +26,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private let compressionSampler: () -> Bool
     private let batchSize: Int
     private let samplingInterval: TimeInterval
+    private let collectInBackground: Bool
     private let featureScope: FeatureScope
     private let totalRAM: Double
 
@@ -34,6 +37,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var useDeltaCompression: Bool = false
     private var timer: DispatchSourceTimer?
+    private var isPaused: Bool = false
 
     /// All buffer mutations and timer events run on this queue.
     private let queue = DispatchQueue(label: "com.datadoghq.timeseries-collector", qos: .utility)
@@ -43,12 +47,14 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         featureScope: FeatureScope,
         batchSize: Int = 30,
         samplingInterval: TimeInterval = 1,
+        collectInBackground: Bool = false,
         cpuUsageProvider: (() -> Double?)? = nil,
         compressionSampler: @escaping () -> Bool = { Bool.random() }
     ) {
         self.memoryReader = memoryReader
         self.batchSize = batchSize
         self.samplingInterval = samplingInterval
+        self.collectInBackground = collectInBackground
         self.featureScope = featureScope
         self.totalRAM = Double(ProcessInfo.processInfo.physicalMemory)
         self.cpuUsageProvider = cpuUsageProvider ?? { TimeseriesSessionCollector.processCPU() }
@@ -108,13 +114,39 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.useDeltaCompression = self.compressionSampler()
             self.memoryBuffer = []
             self.cpuBuffer = []
+            self.isPaused = false
 
             self.timer?.cancel()
-            let timer = DispatchSource.makeTimerSource(queue: self.queue)
-            timer.schedule(deadline: .now() + samplingInterval, repeating: samplingInterval)
-            timer.setEventHandler { [weak self] in self?.sample() }
-            timer.resume()
-            self.timer = timer
+            self.timer = self.makeTimer()
+        }
+    }
+
+    /// Suspends sampling and flushes buffered data. Session state is preserved for `resume()`. Idempotent.
+    /// No-op when `collectInBackground` is `true`.
+    func pause() {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if self.collectInBackground || self.isPaused || self.timer == nil {
+                return
+            }
+            self.timer?.cancel()
+            self.timer = nil
+            self.isPaused = true
+            self.flushMemory()
+            self.flushCPU()
+        }
+    }
+
+    /// Resumes sampling after `pause()`. Idempotent — only takes effect if currently paused.
+    func resume() {
+        queue.async { [weak self] in
+            guard let self = self, self.isPaused else {
+                return
+            }
+            self.isPaused = false
+            self.timer = self.makeTimer()
         }
     }
 
@@ -126,9 +158,18 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             }
             self.timer?.cancel()
             self.timer = nil
+            self.isPaused = false
             self.flushMemory()
             self.flushCPU()
         }
+    }
+
+    private func makeTimer() -> DispatchSourceTimer {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + samplingInterval, repeating: samplingInterval)
+        timer.setEventHandler { [weak self] in self?.sample() }
+        timer.resume()
+        return timer
     }
 
     // MARK: - Private

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -222,7 +222,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let useDelta = self.useDeltaCompression
 
         featureScope.eventWriteContext { context, writer in
-            let offsetNs = Int64(context.serverTimeOffset * 1_000_000_000)
+            let offsetNs = context.serverTimeOffset.dd.toInt64Nanoseconds
             let adjustedBatch = batch.map { sample in
                 RUMTimeseriesMemoryEvent.Timeseries.Data(
                     dataPoint: sample.dataPoint,
@@ -248,15 +248,16 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 version: context.version
             )
 
-            if useDelta,
-               let deltaData = DeltaEncoder.encodeMemory(adjustedBatch),
-               let eventData = try? JSONEncoder().encode(objectEvent),
-               var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
-               var ts = dict["timeseries"] as? [String: Any] {
-                ts["schema"] = "delta-object"
-                ts["data"] = deltaData
-                dict["timeseries"] = ts
-                writer.write(value: AnyEncodable(dict))
+            if useDelta {
+                if let deltaData = DeltaEncoder.encodeMemory(adjustedBatch),
+                   let eventData = try? JSONEncoder().encode(objectEvent),
+                   var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+                   var ts = dict["timeseries"] as? [String: Any] {
+                    ts["schema"] = "delta-object"
+                    ts["data"] = deltaData
+                    dict["timeseries"] = ts
+                    writer.write(value: AnyEncodable(dict))
+                }
             } else {
                 writer.write(value: objectEvent)
             }
@@ -278,7 +279,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let useDelta = self.useDeltaCompression
 
         featureScope.eventWriteContext { context, writer in
-            let offsetNs = Int64(context.serverTimeOffset * 1_000_000_000)
+            let offsetNs = context.serverTimeOffset.dd.toInt64Nanoseconds
             let adjustedBatch = batch.map { sample in
                 RUMTimeseriesCpuEvent.Timeseries.Data(
                     dataPoint: sample.dataPoint,
@@ -304,15 +305,16 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 version: context.version
             )
 
-            if useDelta,
-               let deltaData = DeltaEncoder.encodeCPU(adjustedBatch),
-               let eventData = try? JSONEncoder().encode(objectEvent),
-               var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
-               var ts = dict["timeseries"] as? [String: Any] {
-                ts["schema"] = "delta-scalar"
-                ts["data"] = deltaData
-                dict["timeseries"] = ts
-                writer.write(value: AnyEncodable(dict))
+            if useDelta {
+                if let deltaData = DeltaEncoder.encodeCPU(adjustedBatch),
+                   let eventData = try? JSONEncoder().encode(objectEvent),
+                   var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
+                   var ts = dict["timeseries"] as? [String: Any] {
+                    ts["schema"] = "delta-scalar"
+                    ts["data"] = deltaData
+                    dict["timeseries"] = ts
+                    writer.write(value: AnyEncodable(dict))
+                }
             } else {
                 writer.write(value: objectEvent)
             }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -15,7 +15,7 @@ internal protocol TimeseriesCollecting: AnyObject {
     func stop()
 }
 
-/// Collects memory and CPU samples at 1s intervals during a RUM session and flushes them
+/// Collects memory and CPU samples at configurable intervals (default: 1 s) during a RUM session and flushes them
 /// as `RUMTimeseriesMemoryEvent` / `RUMTimeseriesCpuEvent` batches via the RUM feature scope.
 ///
 /// At session start a coin is flipped: 50% of sessions send full-array `object` schema events,
@@ -49,14 +49,15 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         samplingInterval: TimeInterval = 1,
         collectInBackground: Bool = false,
         cpuUsageProvider: (() -> Double?)? = nil,
-        compressionSampler: @escaping () -> Bool = { Bool.random() }
+        compressionSampler: @escaping () -> Bool = { Bool.random() },
+        totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory)
     ) {
         self.memoryReader = memoryReader
         self.batchSize = batchSize
         self.samplingInterval = samplingInterval
         self.collectInBackground = collectInBackground
         self.featureScope = featureScope
-        self.totalRAM = Double(ProcessInfo.processInfo.physicalMemory)
+        self.totalRAM = totalRAM
         self.cpuUsageProvider = cpuUsageProvider ?? { TimeseriesSessionCollector.processCPU() }
         self.compressionSampler = compressionSampler
     }
@@ -86,6 +87,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         }
         var total = 0.0
         for i in 0..<threadsCount {
+            defer {
+                mach_port_deallocate(mach_task_self_, threadsList[Int(i)])
+            }
             var info = thread_basic_info()
             var infoCount = mach_msg_type_number_t(THREAD_INFO_MAX)
             let kr = withUnsafeMutablePointer(to: &info) {
@@ -102,12 +106,14 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         #endif
     }
 
-    /// Resets state, flips the compression coin, and starts a 1s sampling timer for the new session.
+    /// Resets state, flips the compression coin, and starts the sampling timer for the new session.
     func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
             }
+            self.flushMemory()
+            self.flushCPU()
             self.sessionID = sessionID
             self.applicationID = applicationID
             self.sessionType = sessionType
@@ -216,25 +222,34 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let useDelta = self.useDeltaCompression
 
         featureScope.eventWriteContext { context, writer in
+            let offsetNs = Int64(context.serverTimeOffset * 1_000_000_000)
+            let adjustedBatch = batch.map { sample in
+                RUMTimeseriesMemoryEvent.Timeseries.Data(
+                    dataPoint: sample.dataPoint,
+                    timestamp: sample.timestamp + offsetNs
+                )
+            }
+            let adjustedStart = start + offsetNs
+            let adjustedEnd = end + offsetNs
             let objectEvent = RUMTimeseriesMemoryEvent(
                 dd: .init(),
                 application: .init(id: applicationID),
-                date: start / 1_000_000,
+                date: (Double(start) / 1_000_000_000 + context.serverTimeOffset).dd.toInt64Milliseconds,
                 service: context.service,
                 session: .init(id: sessionID, type: sessionType),
-                source: .ios,
+                source: .init(rawValue: context.source) ?? .ios,
                 timeseries: .init(
-                    data: batch,
-                    end: end,
+                    data: adjustedBatch,
+                    end: adjustedEnd,
                     id: eventID,
                     schema: .object,
-                    start: start
+                    start: adjustedStart
                 ),
                 version: context.version
             )
 
             if useDelta,
-               let deltaData = DeltaEncoder.encodeMemory(batch),
+               let deltaData = DeltaEncoder.encodeMemory(adjustedBatch),
                let eventData = try? JSONEncoder().encode(objectEvent),
                var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
                var ts = dict["timeseries"] as? [String: Any] {
@@ -263,25 +278,34 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let useDelta = self.useDeltaCompression
 
         featureScope.eventWriteContext { context, writer in
+            let offsetNs = Int64(context.serverTimeOffset * 1_000_000_000)
+            let adjustedBatch = batch.map { sample in
+                RUMTimeseriesCpuEvent.Timeseries.Data(
+                    dataPoint: sample.dataPoint,
+                    timestamp: sample.timestamp + offsetNs
+                )
+            }
+            let adjustedStart = start + offsetNs
+            let adjustedEnd = end + offsetNs
             let objectEvent = RUMTimeseriesCpuEvent(
                 dd: .init(),
                 application: .init(id: applicationID),
-                date: start / 1_000_000,
+                date: (Double(start) / 1_000_000_000 + context.serverTimeOffset).dd.toInt64Milliseconds,
                 service: context.service,
                 session: .init(id: sessionID, type: sessionType),
-                source: .ios,
+                source: .init(rawValue: context.source) ?? .ios,
                 timeseries: .init(
-                    data: batch,
-                    end: end,
+                    data: adjustedBatch,
+                    end: adjustedEnd,
                     id: eventID,
                     schema: .object,
-                    start: start
+                    start: adjustedStart
                 ),
                 version: context.version
             )
 
             if useDelta,
-               let deltaData = DeltaEncoder.encodeCPU(batch),
+               let deltaData = DeltaEncoder.encodeCPU(adjustedBatch),
                let eventData = try? JSONEncoder().encode(objectEvent),
                var dict = try? JSONSerialization.jsonObject(with: eventData) as? [String: Any],
                var ts = dict["timeseries"] as? [String: Any] {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -1,0 +1,411 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogRUM
+
+class TimeseriesSessionCollectorTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+    private let memoryReader = SamplingBasedVitalReaderMock()
+
+    // MARK: - Memory events
+
+    func testWhenBatchSizeIsReached_itWritesMemoryEvent() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        // When
+        let expectation = self.expectation(description: "memory batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected at least one memory batch to be written")
+
+        let event = events[0]
+        XCTAssertEqual(event.session.id, "session-abc")
+        XCTAssertEqual(event.application.id, "app-123")
+        XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.source, .ios)
+        XCTAssertEqual(event.timeseries.name, "memory")
+        XCTAssertEqual(event.timeseries.data.count, 2)
+        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryMax, 1_000_000)
+        XCTAssertGreaterThan(event.timeseries.data[0].dataPoint.memoryPercent, 0)
+    }
+
+    func testWhenBatchSizeIsReached_itWritesCpuEvent() {
+        // Given
+        memoryReader.vitalData = nil
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 42.5 },
+            compressionSampler: { false }
+        )
+
+        // When
+        let expectation = self.expectation(description: "cpu batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected at least one CPU batch to be written")
+
+        let event = events[0]
+        XCTAssertEqual(event.session.id, "session-abc")
+        XCTAssertEqual(event.application.id, "app-123")
+        XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.source, .ios)
+        XCTAssertEqual(event.timeseries.name, "cpu")
+        XCTAssertEqual(event.timeseries.data.count, 2)
+        XCTAssertEqual(event.timeseries.data[0].dataPoint.cpuUsage, 42.5)
+    }
+
+    // MARK: - Flush on stop
+
+    func testWhenStopIsCalled_itFlushesPartialMemoryBuffer() {
+        // Given
+        memoryReader.vitalData = 2_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // large batch — won't auto-flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        // When — let a few samples accumulate then stop
+        let expectation = self.expectation(description: "samples collected")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-xyz", applicationID: "app-456", sessionType: .synthetics)
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected partial buffer to be flushed on stop")
+        XCTAssertEqual(events[0].session.id, "session-xyz")
+        XCTAssertEqual(events[0].application.id, "app-456")
+        XCTAssertEqual(events[0].session.type, .synthetics)
+    }
+
+    func testWhenStopIsCalled_itFlushesPartialCpuBuffer() {
+        // Given
+        memoryReader.vitalData = nil
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 10.0 },
+            compressionSampler: { false }
+        )
+
+        let expectation = self.expectation(description: "samples collected")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-xyz", applicationID: "app-456", sessionType: .ciTest)
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected partial CPU buffer to be flushed on stop")
+        XCTAssertEqual(events[0].session.type, .ciTest)
+    }
+
+    // MARK: - No-data readers
+
+    func testWhenReadersReturnNil_itWritesNoEvents() {
+        // Given
+        memoryReader.vitalData = nil
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil }
+        )
+
+        let expectation = self.expectation(description: "sampling time elapsed")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty)
+    }
+
+    // MARK: - Session restart
+
+    func testWhenStartIsCalledAgain_itUsesNewSessionMetadata() {
+        // Given
+        memoryReader.vitalData = 512_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        // First session
+        let firstExpectation = self.expectation(description: "first session samples")
+        firstExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { firstExpectation.fulfill() }
+        collector.start(sessionID: "session-1", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        // Second session — start() resets buffers and updates metadata
+        let secondExpectation = self.expectation(description: "second session samples")
+        secondExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { secondExpectation.fulfill() }
+        collector.start(sessionID: "session-2", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        // Flush second session
+        let stopExpectation = self.expectation(description: "stop completed")
+        collector.stop()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { stopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — the flushed event should carry session-2 metadata
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        let lastEvent = try! XCTUnwrap(events.last)
+        XCTAssertEqual(lastEvent.session.id, "session-2")
+    }
+
+    // MARK: - Schema coin flip
+
+    func testWhenDeltaCompressionSampled_itWritesDeltaEventForMemory() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 3,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { true }
+        )
+
+        let expectation = self.expectation(description: "memory batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-delta", applicationID: "app-delta", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — AnyEncodable delta-object event written, no typed object event
+        let typedEvents = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertTrue(typedEvents.isEmpty, "Object-schema typed event must not be written when delta is sampled")
+
+        let anyEncodableEvents = featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }
+        XCTAssertFalse(anyEncodableEvents.isEmpty, "Expected delta-schema AnyEncodable event")
+
+        let jsonData = try! JSONEncoder().encode(anyEncodableEvents[0])
+        let dict = try! XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let tsDict = try! XCTUnwrap(dict["timeseries"] as? [String: Any])
+        XCTAssertEqual(tsDict["schema"] as? String, "delta-object")
+        let dataDict = try! XCTUnwrap(tsDict["data"] as? [String: Any])
+        XCTAssertEqual(dataDict["resolution"] as? String, "ns")
+        XCTAssertNotNil(dataDict["ts"])
+        XCTAssertNotNil(dataDict["memory_max"])
+        XCTAssertNotNil(dataDict["memory_percent"])
+    }
+
+    func testWhenObjectSchemaSampled_itWritesObjectEventForMemory() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 3,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        let expectation = self.expectation(description: "memory batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-object", applicationID: "app-object", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — typed object event written, no AnyEncodable delta event
+        let typedEvents = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(typedEvents.isEmpty, "Expected object-schema typed memory event")
+        XCTAssertEqual(typedEvents[0].timeseries.schema, .object)
+        XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
+    }
+
+    func testWhenDeltaCompressionSampled_itWritesDeltaEventForCPU() {
+        // Given
+        memoryReader.vitalData = nil
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 3,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 50.0 },
+            compressionSampler: { true }
+        )
+
+        let expectation = self.expectation(description: "cpu batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-delta-cpu", applicationID: "app-delta", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — AnyEncodable delta-scalar event written, no typed object event
+        let typedEvents = featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)
+        XCTAssertTrue(typedEvents.isEmpty, "Object-schema typed event must not be written when delta is sampled")
+
+        let anyEncodableEvents = featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }
+        XCTAssertFalse(anyEncodableEvents.isEmpty, "Expected delta-schema AnyEncodable event")
+
+        let jsonData = try! JSONEncoder().encode(anyEncodableEvents[0])
+        let dict = try! XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let tsDict = try! XCTUnwrap(dict["timeseries"] as? [String: Any])
+        XCTAssertEqual(tsDict["schema"] as? String, "delta-scalar")
+        let dataDict = try! XCTUnwrap(tsDict["data"] as? [String: Any])
+        XCTAssertEqual(dataDict["resolution"] as? String, "ns")
+        XCTAssertNotNil(dataDict["ts"])
+        XCTAssertNotNil(dataDict["value"])
+    }
+
+    func testWhenObjectSchemaSampled_itWritesObjectEventForCPU() {
+        // Given
+        memoryReader.vitalData = nil
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 3,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 50.0 },
+            compressionSampler: { false }
+        )
+
+        let expectation = self.expectation(description: "cpu batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-object-cpu", applicationID: "app-object", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — typed object event written, no AnyEncodable delta event
+        let typedEvents = featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)
+        XCTAssertFalse(typedEvents.isEmpty, "Expected object-schema typed CPU event")
+        XCTAssertEqual(typedEvents[0].timeseries.schema, .object)
+        XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
+    }
+
+    func testWhenDeltaCompressionSampledWithSingleSample_itFallsBackToObjectEvent() {
+        // Given — delta sampled but only 1 sample: DeltaEncoder returns nil, falls back to object
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { true }
+        )
+
+        let expectation = self.expectation(description: "one sample collected")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { expectation.fulfill() }
+        collector.start(sessionID: "session-fallback", applicationID: "app-fallback", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        let stopExpectation = self.expectation(description: "stop completed")
+        collector.stop()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { stopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — falls back to object event, no AnyEncodable
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
+        XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
+    }
+
+    // MARK: - Timeseries range
+
+    func testTimestampsAreMonotonicallyIncreasing() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 3,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        let expectation = self.expectation(description: "first batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let event = events.first else {
+            XCTFail("Expected at least one memory event")
+            return
+        }
+        let timestamps = event.timeseries.data.map { $0.timestamp }
+        XCTAssertEqual(timestamps, timestamps.sorted(), "Timestamps should be monotonically increasing")
+        XCTAssertEqual(event.timeseries.start, timestamps.first)
+        XCTAssertEqual(event.timeseries.end, timestamps.last)
+    }
+}

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -26,7 +26,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             batchSize: 2,
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
-            compressionSampler: { false }
+            compressionSampler: { false },
+            totalRAM: 4_000_000_000
         )
 
         // When
@@ -50,7 +51,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.timeseries.name, "memory")
         XCTAssertEqual(event.timeseries.data.count, 2)
         XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryMax, 1_000_000)
-        XCTAssertGreaterThan(event.timeseries.data[0].dataPoint.memoryPercent, 0)
+        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryPercent, 0.025, accuracy: 0.001)
     }
 
     func testWhenBatchSizeIsReached_itWritesCpuEvent() {
@@ -86,6 +87,130 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.timeseries.name, "cpu")
         XCTAssertEqual(event.timeseries.data.count, 2)
         XCTAssertEqual(event.timeseries.data[0].dataPoint.cpuUsage, 42.5)
+    }
+
+    func testWhenBothReadersProvideData_itWritesBothMemoryAndCpuEvents() {
+        // Given
+        memoryReader.vitalData = 2_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 75.0 },
+            compressionSampler: { false },
+            totalRAM: 4_000_000_000
+        )
+
+        // When
+        let expectation = self.expectation(description: "both batches written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-both", applicationID: "app-both", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events")
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)[0].timeseries.data[0].dataPoint.memoryMax, 2_000_000)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)[0].timeseries.data[0].dataPoint.cpuUsage, 75.0)
+    }
+
+    func testWhenServerTimeOffsetIsNonZero_itAdjustsEventDate() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let scope = FeatureScopeMock(context: .mockWith(serverTimeOffset: 5.0))
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: scope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false },
+            totalRAM: 4_000_000_000
+        )
+
+        // When
+        let expectation = self.expectation(description: "batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-offset", applicationID: "app-offset", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — date and data point timestamps are server-adjusted
+        let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty)
+        let event = events[0]
+        // timeseries.start is offset-adjusted ns; date is offset-adjusted ms
+        let expectedDateMs = event.timeseries.start / 1_000_000
+        XCTAssertEqual(event.date, expectedDateMs, accuracy: 100)
+        XCTAssertEqual(event.timeseries.data[0].timestamp, event.timeseries.start)
+    }
+
+    func testWhenContextSourceIsReactNative_itUsesContextSource() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let scope = FeatureScopeMock(context: .mockWith(source: "react-native"))
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: scope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false },
+            totalRAM: 4_000_000_000
+        )
+
+        // When
+        let expectation = self.expectation(description: "batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-rn", applicationID: "app-rn", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then
+        let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty)
+        XCTAssertEqual(events[0].source, .reactNative)
+    }
+
+    func testWhenStartIsCalledWithoutStop_itFlushesPartialBufferBeforeNewSession() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false },
+            totalRAM: 4_000_000_000
+        )
+
+        // Accumulate some samples in session-1
+        let firstExpectation = self.expectation(description: "first session samples")
+        firstExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { firstExpectation.fulfill() }
+        collector.start(sessionID: "session-1", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        // Start session-2 without calling stop() first
+        let secondExpectation = self.expectation(description: "session-2 started")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { secondExpectation.fulfill() }
+        collector.start(sessionID: "session-2", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        // Then — session-1's partial buffer was flushed and labelled with session-1
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected session-1 partial buffer to be flushed on re-start")
+        XCTAssertEqual(events[0].session.id, "session-1")
+        collector.stop()
     }
 
     // MARK: - Flush on stop

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if !os(watchOS)
+
 import XCTest
 import TestUtilities
 import DatadogInternal
@@ -375,6 +377,136 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
     }
 
+    // MARK: - Pause / resume
+
+    func testWhenPaused_itStopsCollectingSamples() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        let samplingExpectation = self.expectation(description: "initial samples collected")
+        samplingExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { samplingExpectation.fulfill() }
+
+        collector.start(sessionID: "session-pause", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        let countBeforePause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countBeforePause, 0, "Should have collected events before pause")
+
+        // When — pause and wait for more potential samples
+        let pauseExpectation = self.expectation(description: "pause settled")
+        collector.pause()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { pauseExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — pause() flushes the partial buffer; no further events written
+        let countAfterPause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThanOrEqual(countAfterPause, countBeforePause, "pause() must not drop buffered data")
+
+        let countAfterSettle = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertEqual(countAfterPause, countAfterSettle, "No further events should be written while paused")
+        collector.stop()
+    }
+
+    func testWhenResumedAfterPause_itContinuesSampling() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        collector.start(sessionID: "session-resume", applicationID: "app-1", sessionType: .user)
+
+        let pauseExpectation = self.expectation(description: "pause settled")
+        collector.pause()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let countAfterPause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+
+        // When — resume and let samples accumulate
+        let resumeExpectation = self.expectation(description: "resumed samples collected")
+        resumeExpectation.assertForOverFulfill = false
+        collector.resume()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — new events were written after resume
+        let countAfterResume = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countAfterResume, countAfterPause, "Expected new events after resume")
+    }
+
+    func testWhenCollectInBackgroundEnabled_pauseIsNoOp() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            collectInBackground: true,
+            cpuUsageProvider: { nil },
+            compressionSampler: { false }
+        )
+
+        let startExpectation = self.expectation(description: "initial samples")
+        startExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { startExpectation.fulfill() }
+
+        collector.start(sessionID: "session-bg", applicationID: "app-1", sessionType: .user)
+        waitForExpectations(timeout: 2)
+
+        let countBeforePause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countBeforePause, 0)
+
+        // When — pause should be a no-op
+        let afterPauseExpectation = self.expectation(description: "sampling continues after pause")
+        afterPauseExpectation.assertForOverFulfill = false
+        collector.pause()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { afterPauseExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        collector.stop()
+
+        // Then — events keep accumulating
+        let countAfterPause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countAfterPause, countBeforePause, "Sampling should continue when collectInBackground = true")
+    }
+
+    func testWhenPauseCalledBeforeStart_itIsNoOp() {
+        // Given — collector not yet started
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil }
+        )
+
+        // When / Then — should not crash
+        collector.pause()
+        collector.resume()
+
+        let settleExpectation = self.expectation(description: "settle")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { settleExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        XCTAssertTrue(featureScope.eventsWritten.isEmpty)
+    }
+
     // MARK: - Timeseries range
 
     func testTimestampsAreMonotonicallyIncreasing() {
@@ -409,3 +541,5 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.timeseries.end, timestamps.last)
     }
 }
+
+#endif

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -181,7 +181,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
     // MARK: - Session restart
 
-    func testWhenStartIsCalledAgain_itUsesNewSessionMetadata() {
+    func testWhenStartIsCalledAgain_itUsesNewSessionMetadata() throws {
         // Given
         memoryReader.vitalData = 512_000
         let collector = TimeseriesSessionCollector(
@@ -215,13 +215,13 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // Then — the flushed event should carry session-2 metadata
         let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
-        let lastEvent = try! XCTUnwrap(events.last)
+        let lastEvent = try XCTUnwrap(events.last)
         XCTAssertEqual(lastEvent.session.id, "session-2")
     }
 
     // MARK: - Schema coin flip
 
-    func testWhenDeltaCompressionSampled_itWritesDeltaEventForMemory() {
+    func testWhenDeltaCompressionSampled_itWritesDeltaEventForMemory() throws {
         // Given
         memoryReader.vitalData = 1_000_000
         let collector = TimeseriesSessionCollector(
@@ -248,11 +248,11 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let anyEncodableEvents = featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }
         XCTAssertFalse(anyEncodableEvents.isEmpty, "Expected delta-schema AnyEncodable event")
 
-        let jsonData = try! JSONEncoder().encode(anyEncodableEvents[0])
-        let dict = try! XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
-        let tsDict = try! XCTUnwrap(dict["timeseries"] as? [String: Any])
+        let jsonData = try JSONEncoder().encode(anyEncodableEvents[0])
+        let dict = try XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let tsDict = try XCTUnwrap(dict["timeseries"] as? [String: Any])
         XCTAssertEqual(tsDict["schema"] as? String, "delta-object")
-        let dataDict = try! XCTUnwrap(tsDict["data"] as? [String: Any])
+        let dataDict = try XCTUnwrap(tsDict["data"] as? [String: Any])
         XCTAssertEqual(dataDict["resolution"] as? String, "ns")
         XCTAssertNotNil(dataDict["ts"])
         XCTAssertNotNil(dataDict["memory_max"])
@@ -286,7 +286,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
     }
 
-    func testWhenDeltaCompressionSampled_itWritesDeltaEventForCPU() {
+    func testWhenDeltaCompressionSampled_itWritesDeltaEventForCPU() throws {
         // Given
         memoryReader.vitalData = nil
         let collector = TimeseriesSessionCollector(
@@ -313,11 +313,11 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let anyEncodableEvents = featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }
         XCTAssertFalse(anyEncodableEvents.isEmpty, "Expected delta-schema AnyEncodable event")
 
-        let jsonData = try! JSONEncoder().encode(anyEncodableEvents[0])
-        let dict = try! XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
-        let tsDict = try! XCTUnwrap(dict["timeseries"] as? [String: Any])
+        let jsonData = try JSONEncoder().encode(anyEncodableEvents[0])
+        let dict = try XCTUnwrap(try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let tsDict = try XCTUnwrap(dict["timeseries"] as? [String: Any])
         XCTAssertEqual(tsDict["schema"] as? String, "delta-scalar")
-        let dataDict = try! XCTUnwrap(tsDict["data"] as? [String: Any])
+        let dataDict = try XCTUnwrap(tsDict["data"] as? [String: Any])
         XCTAssertEqual(dataDict["resolution"] as? String, "ns")
         XCTAssertNotNil(dataDict["ts"])
         XCTAssertNotNil(dataDict["value"])

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -475,8 +475,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
     }
 
-    func testWhenDeltaCompressionSampledWithSingleSample_itFallsBackToObjectEvent() {
-        // Given — delta sampled but only 1 sample: DeltaEncoder returns nil, falls back to object
+    func testWhenDeltaCompressionSampledWithSingleSample_itDropsTheEvent() {
+        // Given — delta sampled but only 1 sample: DeltaEncoder returns nil, event is dropped
         memoryReader.vitalData = 1_000_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
@@ -489,7 +489,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         let expectation = self.expectation(description: "one sample collected")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { expectation.fulfill() }
-        collector.start(sessionID: "session-fallback", applicationID: "app-fallback", sessionType: .user)
+        collector.start(sessionID: "session-drop", applicationID: "app-drop", sessionType: .user)
         waitForExpectations(timeout: 2)
 
         let stopExpectation = self.expectation(description: "stop completed")
@@ -497,8 +497,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { stopExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
-        // Then — falls back to object event, no AnyEncodable
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
+        // Then — event is dropped entirely, nothing written
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
         XCTAssertTrue(featureScope.eventsWritten.compactMap { $0 as? AnyEncodable }.isEmpty)
     }
 


### PR DESCRIPTION
### What and why?

Adds `TimeseriesSessionCollector`, the core sampling engine. Uses a `DispatchSourceTimer` at 1Hz to collect memory (`phys_footprint` via `task_info`) and CPU (Mach thread ticks summed across threads; `nil` on watchOS). Every 30-sample batch is flushed as a single event. A coin flip at session start decides whether the session emits the full array schema or the delta-encoded schema, so the backend receives both formats across the fleet.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs