### PR TITLE
Wire timeseries collection into RUM session and configuration

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -5591,26 +5591,26 @@ public struct RUMTimeseriesMemoryEvent: RUMDataModel {
             /// Memory measurements for this sample
             public struct DataPoint: Codable {
                 /// Physical memory footprint of the process in bytes
-                public let memoryMax: Double
+                public let memoryFootprint: Double
 
                 /// Memory footprint as a percentage of total device RAM
                 public let memoryPercent: Double
 
                 public enum CodingKeys: String, CodingKey {
-                    case memoryMax = "memory_max"
+                    case memoryFootprint = "memory_footprint"
                     case memoryPercent = "memory_percent"
                 }
 
                 /// Memory measurements for this sample
                 ///
                 /// - Parameters:
-                ///   - memoryMax: Physical memory footprint of the process in bytes
+                ///   - memoryFootprint: Physical memory footprint of the process in bytes
                 ///   - memoryPercent: Memory footprint as a percentage of total device RAM
                 public init(
-                    memoryMax: Double,
+                    memoryFootprint: Double,
                     memoryPercent: Double
                 ) {
-                    self.memoryMax = memoryMax
+                    self.memoryFootprint = memoryFootprint
                     self.memoryPercent = memoryPercent
                 }
             }
@@ -14933,4 +14933,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1
+// Generated from https://github.com/DataDog/rum-events-format/tree/eb33e481c74c6d84bbf29b6417acb5f0f3bb3b02

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -6551,8 +6551,8 @@ public class objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint: NSObject {
         self.root = root
     }
 
-    public var memoryMax: NSNumber {
-        root.swiftModel.dataPoint.memoryMax as NSNumber
+    public var memoryFootprint: NSNumber {
+        root.swiftModel.dataPoint.memoryFootprint as NSNumber
     }
 
     public var memoryPercent: NSNumber {
@@ -15458,4 +15458,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1
+// Generated from https://github.com/DataDog/rum-events-format/tree/eb33e481c74c6d84bbf29b6417acb5f0f3bb3b02

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -184,7 +184,16 @@ internal final class RUMFeature: DatadogRemoteFeature {
                     predicate: nextViewActionPredicate
                 )
             },
-            sessionType: configuration.sessionTypeOverride.flatMap { RUMSessionType(rawValue: $0) }
+            sessionType: configuration.sessionTypeOverride.flatMap { RUMSessionType(rawValue: $0) },
+            timeseriesCollector: {
+                guard configuration.enableTimeseries, let vitalsReaders = configuration.vitalsUpdateFrequency.map({
+                    VitalsReaders(frequency: $0.timeInterval, telemetry: core.telemetry)
+                }) else { return nil }
+                return TimeseriesSessionCollector(
+                    memoryReader: vitalsReaders.memory,
+                    featureScope: featureScope
+                )
+            }()
         )
 
         self.monitor = Monitor(

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -188,7 +188,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 TimeseriesSessionCollector(
                     memoryReader: $0.memory,
                     featureScope: featureScope,
-                    batchSize: configuration.timeseriesBatchSize
+                    batchSize: configuration.timeseriesBatchSize,
+                    collectInBackground: configuration.trackBackgroundEvents
                 )
             } : nil
         )

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -106,6 +106,10 @@ internal final class RUMFeature: DatadogRemoteFeature {
             }
         }()
 
+        let vitalsReaders = configuration.vitalsUpdateFrequency.map {
+            VitalsReaders(frequency: $0.timeInterval, telemetry: core.telemetry)
+        }
+
         let dependencies = RUMScopeDependencies(
             featureScope: featureScope,
             rumApplicationID: configuration.applicationID,
@@ -136,12 +140,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 ? ViewHitchesReader(hangThreshold: configuration.appHangThreshold)
                 : nil
             },
-            vitalsReaders: configuration.vitalsUpdateFrequency.map {
-                VitalsReaders(
-                    frequency: $0.timeInterval,
-                    telemetry: core.telemetry
-                )
-            },
+            vitalsReaders: vitalsReaders,
             accessibilityReader: accessibilityReader,
             onSessionStart: configuration.onSessionStart,
             viewCache: ViewCache(dateProvider: configuration.dateProvider),
@@ -185,16 +184,13 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 )
             },
             sessionType: configuration.sessionTypeOverride.flatMap { RUMSessionType(rawValue: $0) },
-            timeseriesCollector: {
-                guard configuration.enableTimeseries, let vitalsReaders = configuration.vitalsUpdateFrequency.map({
-                    VitalsReaders(frequency: $0.timeInterval, telemetry: core.telemetry)
-                }) else { return nil }
-                return TimeseriesSessionCollector(
-                    memoryReader: vitalsReaders.memory,
+            timeseriesCollector: configuration.enableTimeseries ? vitalsReaders.map {
+                TimeseriesSessionCollector(
+                    memoryReader: $0.memory,
                     featureScope: featureScope,
                     batchSize: configuration.timeseriesBatchSize
                 )
-            }()
+            } : nil
         )
 
         self.monitor = Monitor(

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -191,7 +191,8 @@ internal final class RUMFeature: DatadogRemoteFeature {
                 }) else { return nil }
                 return TimeseriesSessionCollector(
                     memoryReader: vitalsReaders.memory,
-                    featureScope: featureScope
+                    featureScope: featureScope,
+                    batchSize: configuration.timeseriesBatchSize
                 )
             }()
         )

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -326,6 +326,14 @@ extension RUM {
         /// Default: `false`.
         public var collectAccessibility: Bool
 
+        /// Enables collection of memory and CPU timeseries events.
+        ///
+        /// When enabled, memory footprint and CPU usage are sampled every second and uploaded as
+        /// timeseries events scoped to the RUM session. Requires `vitalsUpdateFrequency` to be set.
+        ///
+        /// Default: `false`.
+        public var enableTimeseries: Bool
+
         /// Feature flags to preview features in RUM.
         public var featureFlags: FeatureFlags
 
@@ -534,6 +542,7 @@ extension RUM.Configuration {
     ///   - trackSlowFrames: Enables the collection of slow frames (view hitches). Default: `true`.
     ///   - telemetrySampleRate: The sampling rate for SDK internal telemetry utilized by Datadog. Must be a value between `0` and `100`. Default: `20`.
     ///   - collectAccessibility: Determines whether accessibility data should be collected and included in RUM view events. Default: `false`.
+    ///   - enableTimeseries: Enables collection of memory and CPU timeseries events. Default: `false`.
     ///   - featureFlags: Experimental feature flags.
     /// 
     /// - Note: On watchOS, automatic UIKit and SwiftUI view/action tracking is unavailable. The predicate parameters will be ignored.
@@ -569,6 +578,7 @@ extension RUM.Configuration {
         trackSlowFrames: Bool = true,
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
+        enableTimeseries: Bool = false,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -598,6 +608,7 @@ extension RUM.Configuration {
         self.trackSlowFrames = trackSlowFrames
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
+        self.enableTimeseries = enableTimeseries
         self.featureFlags = featureFlags
     }
     #else
@@ -624,6 +635,7 @@ extension RUM.Configuration {
         trackSlowFrames: Bool = true,
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
+        enableTimeseries: Bool = false,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -648,6 +660,7 @@ extension RUM.Configuration {
         self.trackSlowFrames = trackSlowFrames
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
+        self.enableTimeseries = enableTimeseries
         self.featureFlags = featureFlags
     }
     #endif

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -334,6 +334,11 @@ extension RUM {
         /// Default: `false`.
         public var enableTimeseries: Bool
 
+        /// The number of samples collected before a timeseries batch is flushed.
+        ///
+        /// Default: `30`.
+        public var timeseriesBatchSize: Int
+
         /// Feature flags to preview features in RUM.
         public var featureFlags: FeatureFlags
 
@@ -543,6 +548,7 @@ extension RUM.Configuration {
     ///   - telemetrySampleRate: The sampling rate for SDK internal telemetry utilized by Datadog. Must be a value between `0` and `100`. Default: `20`.
     ///   - collectAccessibility: Determines whether accessibility data should be collected and included in RUM view events. Default: `false`.
     ///   - enableTimeseries: Enables collection of memory and CPU timeseries events. Default: `false`.
+    ///   - timeseriesBatchSize: The number of samples collected before a timeseries batch is flushed. Default: `30`.
     ///   - featureFlags: Experimental feature flags.
     /// 
     /// - Note: On watchOS, automatic UIKit and SwiftUI view/action tracking is unavailable. The predicate parameters will be ignored.
@@ -579,6 +585,7 @@ extension RUM.Configuration {
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
         enableTimeseries: Bool = false,
+        timeseriesBatchSize: Int = 30,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -609,6 +616,7 @@ extension RUM.Configuration {
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
         self.enableTimeseries = enableTimeseries
+        self.timeseriesBatchSize = timeseriesBatchSize
         self.featureFlags = featureFlags
     }
     #else
@@ -636,6 +644,7 @@ extension RUM.Configuration {
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
         enableTimeseries: Bool = false,
+        timeseriesBatchSize: Int = 30,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -661,6 +670,7 @@ extension RUM.Configuration {
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
         self.enableTimeseries = enableTimeseries
+        self.timeseriesBatchSize = timeseriesBatchSize
         self.featureFlags = featureFlags
     }
     #endif

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -46,6 +46,7 @@ internal struct RUMScopeDependencies {
     let firstFrameReader: RenderLoopReader
     let viewHitchesReaderFactory: () -> (RenderLoopReader & ViewHitchesModel)?
     let vitalsReaders: VitalsReaders?
+    let timeseriesCollector: TimeseriesCollecting?
     let accessibilityReader: AccessibilityReading?
     let onSessionStart: RUM.SessionListener?
     let viewCache: ViewCache
@@ -98,7 +99,8 @@ internal struct RUMScopeDependencies {
         watchdogTermination: WatchdogTerminationMonitor?,
         networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking,
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking?,
-        sessionType: RUMSessionType?
+        sessionType: RUMSessionType?,
+        timeseriesCollector: TimeseriesCollecting? = nil
     ) {
         self.featureScope = featureScope
         self.rumApplicationID = rumApplicationID
@@ -117,6 +119,7 @@ internal struct RUMScopeDependencies {
         self.firstFrameReader = firstFrameReader
         self.viewHitchesReaderFactory = viewHitchesReaderFactory
         self.vitalsReaders = vitalsReaders
+        self.timeseriesCollector = timeseriesCollector
         self.accessibilityReader = accessibilityReader
         self.onSessionStart = onSessionStart
         self.viewCache = viewCache

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -94,7 +94,9 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// Indicates whether the "ApplicationLaunch" view was active when the app entered the background.
     private var hadApplicationLaunchViewWhenEnteringBackground: Bool? = nil
     /// The reason why this session has ended or `nil` if it is still active.
-    private(set) var endReason: EndReason?
+    private(set) var endReason: EndReason? {
+        didSet { if endReason != nil { dependencies.timeseriesCollector?.stop() } }
+    }
 
     /// Counter to track the index of views in this session. Starts at 0 for the first view.
     private var nextViewIndex: Int = 0
@@ -161,6 +163,12 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Update fatal error context with recent RUM session state:
         dependencies.fatalErrorContext.sessionState = state
+
+        dependencies.timeseriesCollector?.start(
+            sessionID: sessionUUID.rawValue.uuidString.lowercased(),
+            applicationID: dependencies.rumApplicationID,
+            sessionType: dependencies.sessionType
+        )
     }
 
     /// Creates a new Session upon expiration of the previous one.

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -272,11 +272,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .didEnterBackground:
                 hadApplicationLaunchViewWhenEnteringBackground = activeViewPath == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
                 appLaunchManager.process(command, context: context, writer: writer)
+                dependencies.timeseriesCollector?.pause()
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .willEnterForeground:
                 if hadApplicationLaunchViewWhenEnteringBackground == true {
                     startApplicationLaunchView(on: appLifecycleCommand, context: context, writer: writer)
                 }
                 hadApplicationLaunchViewWhenEnteringBackground = nil
+                dependencies.timeseriesCollector?.resume()
 
             case let operationStepVitalCommand as RUMOperationStepVitalCommand:
                 let activeView = viewScopes.first { $0.isActiveView }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -164,11 +164,16 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         // Update fatal error context with recent RUM session state:
         dependencies.fatalErrorContext.sessionState = state
 
-        dependencies.timeseriesCollector?.start(
-            sessionID: sessionUUID.rawValue.uuidString.lowercased(),
-            applicationID: dependencies.rumApplicationID,
-            sessionType: dependencies.sessionType
-        )
+        if sampler.isSampled {
+            dependencies.timeseriesCollector?.start(
+                sessionID: sessionUUID.rawValue.uuidString.lowercased(),
+                applicationID: dependencies.rumApplicationID,
+                sessionType: dependencies.sessionType
+            )
+            if !context.applicationStateHistory.currentState.isRunningInForeground {
+                dependencies.timeseriesCollector?.pause()
+            }
+        }
     }
 
     /// Creates a new Session upon expiration of the previous one.

--- a/DatadogRUM/Sources/Timeseries/DeltaEncoder.swift
+++ b/DatadogRUM/Sources/Timeseries/DeltaEncoder.swift
@@ -24,7 +24,7 @@ internal enum DeltaEncoder {
     /// {
     ///   "precision": 4,
     ///   "ts": [absoluteNs, delta1, delta2, ...],
-    ///   "memory_max": [scaledInt64, delta1, delta2, ...],
+    ///   "memory_footprint": [scaledInt64, delta1, delta2, ...],
     ///   "memory_percent": [scaledInt64, delta1, ...]
     /// }
     /// ```
@@ -34,22 +34,22 @@ internal enum DeltaEncoder {
         }
 
         var ts: [Int64] = []
-        var memoryMax: [Int64] = []
+        var memoryFootprint: [Int64] = []
         var memoryPercent: [Int64] = []
 
         for (index, sample) in batch.enumerated() {
             if index == 0 {
                 ts.append(sample.timestamp)
-                memoryMax.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryMax * scale))
+                memoryFootprint.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryFootprint * scale))
                 memoryPercent.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryPercent * scale))
             } else {
                 let prev = batch[index - 1]
                 let (tsDelta, _) = sample.timestamp.subtractingReportingOverflow(prev.timestamp)
                 ts.append(tsDelta)
-                let curMax = Int64.ddWithNoOverflow(sample.dataPoint.memoryMax * scale)
-                let prevMax = Int64.ddWithNoOverflow(prev.dataPoint.memoryMax * scale)
+                let curMax = Int64.ddWithNoOverflow(sample.dataPoint.memoryFootprint * scale)
+                let prevMax = Int64.ddWithNoOverflow(prev.dataPoint.memoryFootprint * scale)
                 let (maxDelta, _) = curMax.subtractingReportingOverflow(prevMax)
-                memoryMax.append(maxDelta)
+                memoryFootprint.append(maxDelta)
                 let curPct = Int64.ddWithNoOverflow(sample.dataPoint.memoryPercent * scale)
                 let prevPct = Int64.ddWithNoOverflow(prev.dataPoint.memoryPercent * scale)
                 let (pctDelta, _) = curPct.subtractingReportingOverflow(prevPct)
@@ -61,7 +61,7 @@ internal enum DeltaEncoder {
             "precision": precision,
             "resolution": "ns",
             "ts": ts,
-            "memory_max": memoryMax,
+            "memory_footprint": memoryFootprint,
             "memory_percent": memoryPercent
         ]
     }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -52,9 +52,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         compressionSampler: @escaping () -> Bool = { Bool.random() },
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory)
     ) {
-        precondition(batchSize >= 2, "timeseriesBatchSize must be at least 2 — delta encoding requires a minimum of 2 samples")
         self.memoryReader = memoryReader
-        self.batchSize = batchSize
+        self.batchSize = max(2, batchSize)
         self.samplingInterval = samplingInterval
         self.collectInBackground = collectInBackground
         self.featureScope = featureScope

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -52,6 +52,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         compressionSampler: @escaping () -> Bool = { Bool.random() },
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory)
     ) {
+        precondition(batchSize >= 2, "timeseriesBatchSize must be at least 2 — delta encoding requires a minimum of 2 samples")
         self.memoryReader = memoryReader
         self.batchSize = batchSize
         self.samplingInterval = samplingInterval

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -186,7 +186,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         if let bytes = memoryReader.readVitalData() {
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
             let dataPoint = RUMTimeseriesMemoryEvent.Timeseries.Data(
-                dataPoint: .init(memoryMax: bytes, memoryPercent: memoryPercent),
+                dataPoint: .init(memoryFootprint: bytes, memoryPercent: memoryPercent),
                 timestamp: now
             )
             memoryBuffer.append(dataPoint)

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -706,4 +706,102 @@ class RUMSessionScopeTests: XCTestCase {
         // Then
         XCTAssertTrue(result)
     }
+
+    // MARK: - Timeseries collector lifecycle
+
+    func testWhenSessionScopeIsCreated_itStartsTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+
+        // When
+        let _: RUMSessionScope = .mockWith(
+            parent: parent,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        // Then
+        XCTAssertEqual(collector.startCallCount, 1)
+        XCTAssertEqual(collector.stopCallCount, 0)
+    }
+
+    func testWhenSessionExpiresDueToMaxDuration_itStopsTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        var currentTime = Date()
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: currentTime,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        // When — push past the max session duration
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
+        _ = scope.process(command: RUMCommandMock(time: currentTime), context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(collector.stopCallCount, 1)
+    }
+
+    func testWhenSessionExpiresDueToInactivity_itStopsTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        var currentTime = Date()
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: currentTime,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        _ = scope.process(command: RUMCommandMock(time: currentTime), context: context, writer: writer)
+
+        // When — push past the session inactivity timeout
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        _ = scope.process(command: RUMCommandMock(time: currentTime), context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(collector.stopCallCount, 1)
+    }
+
+    func testWhenSessionScopeStartsNewSession_itStartsCollectorWithCorrectSessionID() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        let applicationID = "test-app-id"
+
+        // When
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            dependencies: .mockWith(
+                rumApplicationID: applicationID,
+                timeseriesCollector: collector
+            )
+        )
+
+        // Then
+        XCTAssertEqual(collector.startCallCount, 1)
+        XCTAssertEqual(collector.lastStartedApplicationID, applicationID)
+        XCTAssertNotNil(collector.lastStartedSessionID, "Session ID should be set")
+        XCTAssertFalse(collector.lastStartedSessionID?.isEmpty ?? true)
+        XCTAssertEqual(collector.lastStartedSessionType, scope.context.sessionID != .nullUUID ? .user : .user)
+    }
+}
+
+// MARK: - Test Helpers
+
+private class TimeseriesCollectorSpy: TimeseriesCollecting {
+    var startCallCount = 0
+    var stopCallCount = 0
+    var lastStartedSessionID: String?
+    var lastStartedApplicationID: String?
+    var lastStartedSessionType: RUMSessionType?
+
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
+        startCallCount += 1
+        lastStartedSessionID = sessionID
+        lastStartedApplicationID = applicationID
+        lastStartedSessionType = sessionType
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -783,12 +783,58 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertFalse(collector.lastStartedSessionID?.isEmpty ?? true)
         XCTAssertEqual(collector.lastStartedSessionType, scope.context.sessionID != .nullUUID ? .user : .user)
     }
+
+    func testWhenAppEntersBackground_itPausesTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        let currentTime = Date()
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: currentTime,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        // When
+        _ = scope.process(
+            command: RUMHandleAppLifecycleEventCommand(time: currentTime, event: .didEnterBackground),
+            context: context,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(collector.pauseCallCount, 1)
+        XCTAssertEqual(collector.resumeCallCount, 0)
+    }
+
+    func testWhenAppEntersForeground_itResumesTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        let currentTime = Date()
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: currentTime,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        // When
+        _ = scope.process(
+            command: RUMHandleAppLifecycleEventCommand(time: currentTime, event: .willEnterForeground),
+            context: context,
+            writer: writer
+        )
+
+        // Then
+        XCTAssertEqual(collector.resumeCallCount, 1)
+        XCTAssertEqual(collector.pauseCallCount, 0)
+    }
 }
 
 // MARK: - Test Helpers
 
 private class TimeseriesCollectorSpy: TimeseriesCollecting {
     var startCallCount = 0
+    var pauseCallCount = 0
+    var resumeCallCount = 0
     var stopCallCount = 0
     var lastStartedSessionID: String?
     var lastStartedApplicationID: String?
@@ -800,6 +846,9 @@ private class TimeseriesCollectorSpy: TimeseriesCollecting {
         lastStartedApplicationID = applicationID
         lastStartedSessionType = sessionType
     }
+
+    func pause() { pauseCallCount += 1 }
+    func resume() { resumeCallCount += 1 }
 
     func stop() {
         stopCallCount += 1

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -784,6 +784,40 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertEqual(collector.lastStartedSessionType, .user)
     }
 
+    func testWhenSessionIsNotSampled_itDoesNotStartTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+
+        // When
+        _ = RUMSessionScope.mockWith(
+            parent: parent,
+            dependencies: .mockWith(samplingRate: 0, timeseriesCollector: collector)
+        )
+
+        // Then
+        XCTAssertEqual(collector.startCallCount, 0)
+    }
+
+    func testWhenSessionIsCreatedInBackground_itStartsThenPausesTimeseriesCollector() {
+        // Given
+        let collector = TimeseriesCollectorSpy()
+        let sessionStartTime = Date()
+        var context = self.context
+        context.applicationStateHistory = .mockAppInBackground(since: sessionStartTime)
+
+        // When
+        _ = RUMSessionScope.mockWith(
+            parent: parent,
+            startTime: sessionStartTime,
+            context: context,
+            dependencies: .mockWith(timeseriesCollector: collector)
+        )
+
+        // Then
+        XCTAssertEqual(collector.startCallCount, 1)
+        XCTAssertEqual(collector.pauseCallCount, 1)
+    }
+
     func testWhenAppEntersBackground_itPausesTimeseriesCollector() {
         // Given
         let collector = TimeseriesCollectorSpy()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -781,7 +781,7 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertEqual(collector.lastStartedApplicationID, applicationID)
         XCTAssertNotNil(collector.lastStartedSessionID, "Session ID should be set")
         XCTAssertFalse(collector.lastStartedSessionID?.isEmpty ?? true)
-        XCTAssertEqual(collector.lastStartedSessionType, scope.context.sessionID != .nullUUID ? .user : .user)
+        XCTAssertEqual(collector.lastStartedSessionType, .user)
     }
 
     func testWhenAppEntersBackground_itPausesTimeseriesCollector() {

--- a/DatadogRUM/Tests/Timeseries/DeltaEncoderTests.swift
+++ b/DatadogRUM/Tests/Timeseries/DeltaEncoderTests.swift
@@ -18,7 +18,7 @@ class DeltaEncoderTests: XCTestCase {
 
     func testEncodeMemory_returnsNilForSingleSample() {
         let sample = RUMTimeseriesMemoryEvent.Timeseries.Data(
-            dataPoint: .init(memoryMax: 100.0, memoryPercent: 10.0),
+            dataPoint: .init(memoryFootprint: 100.0, memoryPercent: 10.0),
             timestamp: 1_000_000_000
         )
         XCTAssertNil(DeltaEncoder.encodeMemory([sample]))
@@ -27,9 +27,9 @@ class DeltaEncoderTests: XCTestCase {
     func testEncodeMemory_correctDeltaEncoding() throws {
         // Given
         let samples: [RUMTimeseriesMemoryEvent.Timeseries.Data] = [
-            .init(dataPoint: .init(memoryMax: 100.0, memoryPercent: 10.0), timestamp: 1_000_000_000),
-            .init(dataPoint: .init(memoryMax: 200.5, memoryPercent: 20.0), timestamp: 2_000_000_000),
-            .init(dataPoint: .init(memoryMax: 200.5, memoryPercent: 20.5), timestamp: 3_000_000_000)
+            .init(dataPoint: .init(memoryFootprint: 100.0, memoryPercent: 10.0), timestamp: 1_000_000_000),
+            .init(dataPoint: .init(memoryFootprint: 200.5, memoryPercent: 20.0), timestamp: 2_000_000_000),
+            .init(dataPoint: .init(memoryFootprint: 200.5, memoryPercent: 20.5), timestamp: 3_000_000_000)
         ]
 
         // When
@@ -42,9 +42,9 @@ class DeltaEncoderTests: XCTestCase {
         let ts = try XCTUnwrap(result["ts"] as? [Int64])
         XCTAssertEqual(ts, [1_000_000_000, 1_000_000_000, 1_000_000_000])
 
-        // memory_max: 100*10000=1_000_000, (200.5-100)*10000=1_005_000, 0
-        let memoryMax = try XCTUnwrap(result["memory_max"] as? [Int64])
-        XCTAssertEqual(memoryMax, [1_000_000, 1_005_000, 0])
+        // memory_footprint: 100*10000=1_000_000, (200.5-100)*10000=1_005_000, 0
+        let memoryFootprint = try XCTUnwrap(result["memory_footprint"] as? [Int64])
+        XCTAssertEqual(memoryFootprint, [1_000_000, 1_005_000, 0])
 
         // memory_percent: 10*10000=100_000, (20-10)*10000=100_000, (20.5-20)*10000=5_000
         let memoryPercent = try XCTUnwrap(result["memory_percent"] as? [Int64])
@@ -55,12 +55,12 @@ class DeltaEncoderTests: XCTestCase {
         // Values scaled to near Int64.max / Int64.min to exercise subtractingReportingOverflow
         let hugeBytes = Double(Int64.max) / 10_000.0
         let samples: [RUMTimeseriesMemoryEvent.Timeseries.Data] = [
-            .init(dataPoint: .init(memoryMax: hugeBytes, memoryPercent: 100.0), timestamp: Int64.max),
-            .init(dataPoint: .init(memoryMax: 0.0, memoryPercent: 0.0), timestamp: 0)
+            .init(dataPoint: .init(memoryFootprint: hugeBytes, memoryPercent: 100.0), timestamp: Int64.max),
+            .init(dataPoint: .init(memoryFootprint: 0.0, memoryPercent: 0.0), timestamp: 0)
         ]
         // Should not crash
         let result = try XCTUnwrap(DeltaEncoder.encodeMemory(samples))
-        XCTAssertNotNil(result["memory_max"] as? [Int64])
+        XCTAssertNotNil(result["memory_footprint"] as? [Int64])
     }
 
     // MARK: - CPU encoding

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -50,7 +50,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.source, .ios)
         XCTAssertEqual(event.timeseries.name, "memory")
         XCTAssertEqual(event.timeseries.data.count, 2)
-        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryMax, 1_000_000)
+        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryFootprint, 1_000_000)
         XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryPercent, 0.025, accuracy: 0.001)
     }
 
@@ -114,7 +114,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // Then
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events")
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events")
-        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)[0].timeseries.data[0].dataPoint.memoryMax, 2_000_000)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)[0].timeseries.data[0].dataPoint.memoryFootprint, 2_000_000)
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)[0].timeseries.data[0].dataPoint.cpuUsage, 75.0)
     }
 
@@ -380,7 +380,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let dataDict = try XCTUnwrap(tsDict["data"] as? [String: Any])
         XCTAssertEqual(dataDict["resolution"] as? String, "ns")
         XCTAssertNotNil(dataDict["ts"])
-        XCTAssertNotNil(dataDict["memory_max"])
+        XCTAssertNotNil(dataDict["memory_footprint"])
         XCTAssertNotNil(dataDict["memory_percent"])
     }
 

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1153,7 +1153,8 @@ extension RUMScopeDependencies {
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking = {
             INVMetric(predicate: TimeBasedINVActionPredicate())
         },
-        sessionType: RUMSessionType? = nil
+        sessionType: RUMSessionType? = nil,
+        timeseriesCollector: TimeseriesCollecting? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             featureScope: featureScope,
@@ -1183,7 +1184,8 @@ extension RUMScopeDependencies {
             watchdogTermination: watchdogTermination,
             networkSettledMetricFactory: networkSettledMetricFactory,
             interactionToNextViewMetricFactory: interactionToNextViewMetricFactory,
-            sessionType: sessionType
+            sessionType: sessionType,
+            timeseriesCollector: timeseriesCollector
         )
     }
 
@@ -1545,6 +1547,7 @@ public class RUMActionsHandlerMock: RUMActionsHandling {
         onViewModifierTapped?(actionName, actionAttributes)
     }
 }
+#endif
 
 public class SamplingBasedVitalReaderMock: SamplingBasedVitalReader {
     public var vitalData: Double?
@@ -1577,7 +1580,6 @@ public class ContinuousVitalReaderMock: ContinuousVitalReader {
         }
     }
 }
-#endif
 
 extension TelemetryReceiver: AnyMockable {
     public static func mockAny() -> Self { .mockWith() }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -1640,7 +1640,7 @@ public class objc_RUMTimeseriesMemoryEventTimeseriesData: NSObject
     public var dataPoint: objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint
     public var timestamp: NSNumber
 public class objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint: NSObject
-    public var memoryMax: NSNumber
+    public var memoryFootprint: NSNumber
     public var memoryPercent: NSNumber
 public enum objc_RUMTimeseriesMemoryEventTimeseriesSchema: Int
     case object

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -1546,6 +1546,105 @@ public class objc_RUMResourceEventView: NSObject
     public var name: String?
     public var referrer: String?
     public var url: String
+public class objc_RUMTimeseriesCpuEvent: NSObject
+    public internal(set) var swiftModel: RUMTimeseriesCpuEvent
+    public init(swiftModel: RUMTimeseriesCpuEvent)
+    public var dd: objc_RUMTimeseriesCpuEventDD
+    public var application: objc_RUMTimeseriesCpuEventApplication
+    public var date: NSNumber
+    public var service: String?
+    public var session: objc_RUMTimeseriesCpuEventSession
+    public var source: objc_RUMTimeseriesCpuEventSource
+    public var timeseries: objc_RUMTimeseriesCpuEventTimeseries
+    public var type: String
+    public var version: String?
+public class objc_RUMTimeseriesCpuEventDD: NSObject
+    public var formatVersion: NSNumber
+public class objc_RUMTimeseriesCpuEventApplication: NSObject
+    public var id: String
+public class objc_RUMTimeseriesCpuEventSession: NSObject
+    public var id: String
+    public var type: objc_RUMTimeseriesCpuEventSessionRUMSessionType
+public enum objc_RUMTimeseriesCpuEventSessionRUMSessionType: Int
+    case user
+    case synthetics
+    case ciTest
+public enum objc_RUMTimeseriesCpuEventSource: Int
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case rumCpp
+public class objc_RUMTimeseriesCpuEventTimeseries: NSObject
+    public var data: [objc_RUMTimeseriesCpuEventTimeseriesData]
+    public var end: NSNumber
+    public var id: String
+    public var name: String
+    public var schema: objc_RUMTimeseriesCpuEventTimeseriesSchema
+    public var start: NSNumber
+public class objc_RUMTimeseriesCpuEventTimeseriesData: NSObject
+    public var dataPoint: objc_RUMTimeseriesCpuEventTimeseriesDataDataPoint
+    public var timestamp: NSNumber
+public class objc_RUMTimeseriesCpuEventTimeseriesDataDataPoint: NSObject
+    public var cpuUsage: NSNumber
+public enum objc_RUMTimeseriesCpuEventTimeseriesSchema: Int
+    case object
+    case deltaScalar
+public class objc_RUMTimeseriesMemoryEvent: NSObject
+    public internal(set) var swiftModel: RUMTimeseriesMemoryEvent
+    public init(swiftModel: RUMTimeseriesMemoryEvent)
+    public var dd: objc_RUMTimeseriesMemoryEventDD
+    public var application: objc_RUMTimeseriesMemoryEventApplication
+    public var date: NSNumber
+    public var service: String?
+    public var session: objc_RUMTimeseriesMemoryEventSession
+    public var source: objc_RUMTimeseriesMemoryEventSource
+    public var timeseries: objc_RUMTimeseriesMemoryEventTimeseries
+    public var type: String
+    public var version: String?
+public class objc_RUMTimeseriesMemoryEventDD: NSObject
+    public var formatVersion: NSNumber
+public class objc_RUMTimeseriesMemoryEventApplication: NSObject
+    public var id: String
+public class objc_RUMTimeseriesMemoryEventSession: NSObject
+    public var id: String
+    public var type: objc_RUMTimeseriesMemoryEventSessionRUMSessionType
+public enum objc_RUMTimeseriesMemoryEventSessionRUMSessionType: Int
+    case user
+    case synthetics
+    case ciTest
+public enum objc_RUMTimeseriesMemoryEventSource: Int
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case rumCpp
+public class objc_RUMTimeseriesMemoryEventTimeseries: NSObject
+    public var data: [objc_RUMTimeseriesMemoryEventTimeseriesData]
+    public var end: NSNumber
+    public var id: String
+    public var name: String
+    public var schema: objc_RUMTimeseriesMemoryEventTimeseriesSchema
+    public var start: NSNumber
+public class objc_RUMTimeseriesMemoryEventTimeseriesData: NSObject
+    public var dataPoint: objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint
+    public var timestamp: NSNumber
+public class objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint: NSObject
+    public var memoryMax: NSNumber
+    public var memoryPercent: NSNumber
+public enum objc_RUMTimeseriesMemoryEventTimeseriesSchema: Int
+    case object
+    case deltaObject
 public class objc_RUMViewEvent: NSObject
     public internal(set) var swiftModel: RUMViewEvent
     public init(swiftModel: RUMViewEvent)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -420,6 +420,8 @@ public enum RUM
         public var trackSlowFrames: Bool
         public var telemetrySampleRate: SampleRate
         public var collectAccessibility: Bool
+        public var enableTimeseries: Bool
+        public var timeseriesBatchSize: Int
         public var featureFlags: FeatureFlags
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
@@ -442,7 +444,7 @@ public enum RUM
         case matchHeaders([String])
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled)
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,enableTimeseries: Bool = false,timeseriesBatchSize: Int = 30,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
 [?] extension RUM.Configuration
@@ -1318,6 +1320,8 @@ public protocol FlagsClientProtocol: AnyObject
     func setEvaluationContext(_ context: FlagsEvaluationContext,completion: @escaping (Result<Void, FlagsError>) -> Void)
     func getDetails<T>(key: String, defaultValue: T) -> FlagDetails<T> where T: Equatable, T: FlagValue
 [?] extension FlagsClientProtocol
+    public var state: FlagsStateObservable
+[?] extension FlagsClientProtocol
     public func setEvaluationContext(_ context: FlagsEvaluationContext)
     public func setEvaluationContext(_ context: FlagsEvaluationContext) async throws
 [?] extension FlagsClientProtocol
@@ -1333,7 +1337,7 @@ public protocol FlagsClientProtocol: AnyObject
     public func getIntegerDetails(key: String, defaultValue: Int) -> FlagDetails<Int>
     public func getDoubleDetails(key: String, defaultValue: Double) -> FlagDetails<Double>
     public func getObjectDetails(key: String, defaultValue: AnyValue) -> FlagDetails<AnyValue>
-public enum FlagsClientState: Equatable
+public enum FlagsClientState: Sendable
     case notReady
     case ready
     case reconciling


### PR DESCRIPTION
### What and why?

Integrates the collector into the RUM stack. Adds `enableTimeseries: Bool = false` to `RUM.Configuration` (all platforms including the watchOS/tvOS `#else` branch). Threads it through `RUMScopeDependencies` and creates/starts the collector in `RUMSessionScope` for the session lifetime. `RUMFeature` constructs the collector when the flag is enabled. The feature is opt-in; setting `enableTimeseries: true` is all that's needed to activate collection.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs