### PR TITLE
[RUM-13811] Add feature doc sync system for *_FEATURE.md files

### DIFF
--- a/.claude/skills/update-feature-docs
+++ b/.claude/skills/update-feature-docs
@@ -1,0 +1,55 @@
+# update-feature-docs
+
+Review and update the feature documentation files to match the current public API.
+
+## When to use
+
+- After adding or modifying a public API (configuration options, new types, new methods)
+- Before opening a release PR, to make sure docs are in sync
+- Any time you want to audit whether feature docs are still accurate
+
+## What this skill covers
+
+All `*_FEATURE.md` files in the repo. Each doc's frontmatter is the source of truth:
+- `verified_against_commit` — the commit the doc was last verified against
+- `tracked_files` — the public API source files whose changes should trigger a doc update
+
+To add a new feature doc to the system, just create a `*_FEATURE.md` file with the correct frontmatter — no script changes needed.
+
+## Steps
+
+1. **Discover feature docs** — find all `*_FEATURE.md` files in the repo (excluding `build/` and `artifacts/`).
+
+2. **For each doc, read its frontmatter** — extract `verified_against_commit` and `tracked_files`.
+
+3. **Get the diff since that commit** — run:
+   ```
+   git diff <verified_against_commit>..HEAD -- <tracked_files>
+   ```
+   If there is no diff for a doc, it is up to date — skip it.
+
+4. **Read the current source files in full** — read each tracked source file to understand the current public API surface.
+
+5. **Compare against the feature doc** — identify every discrepancy:
+   - New configuration options or parameters missing from the doc
+   - Removed or renamed options still mentioned in the doc
+   - Changed defaults, behaviors, or platform availability
+   - New types, enums, or feature flags not documented
+   - Outdated code examples
+
+6. **Update the feature doc** — apply all necessary changes:
+   - Update the Quick Start example to reflect the current API
+   - Update the Configuration Categories section
+   - Update Troubleshooting if relevant
+   - Fix any stale descriptions or defaults
+
+7. **Update the frontmatter** — set:
+   - `verified_against_commit` → current HEAD commit hash (use `git rev-parse --short=9 HEAD`)
+   - `sdk_version` → current version from `DatadogCore.podspec`
+   - `last_updated` → today's date (YYYY-MM-DD)
+
+## Notes
+
+- Only update docs for features whose tracked source files actually changed.
+- Do not rewrite sections that are still accurate — only fix what is wrong or missing.
+- The Quick Start example should always compile against the current API.

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -28,6 +28,7 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
 2. **For each doc, read its frontmatter** — extract `verified_against_commit` and `tracked_files`.
    - If `tracked_files` is missing, derive the list from the doc's "Key Files" section (every source file path it references). Treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
    - If `verified_against_commit` is missing, treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
+   - **Audit `tracked_files` coverage** against the doc's "Key Files" section. Every public-API source file path referenced in "Key Files" must also appear in `tracked_files`. This audit must happen *here*, before step 3 — otherwise drift in untracked files is silently ignored. If any are missing, add them to `tracked_files` and treat the doc as fully out of date so the newly-tracked files are inspected in step 4.
 
 3. **Get the diff since that commit** — run:
    ```
@@ -42,6 +43,7 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
    - Removed or renamed options still mentioned in the doc
    - Changed defaults, behaviors, or platform availability
    - New types, enums, or feature flags not documented
+   - **Deprecated public cases not documented** — walk every public enum case, method, and property, including those marked `@available(*, deprecated, message:)`. Deprecated cases stay on the public API and must appear in the doc with a clear deprecation note, otherwise customers reading the doc won't know they exist or that they're being phased out.
    - Outdated code examples
 
 6. **Update the feature doc** — apply all necessary changes:

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -26,6 +26,8 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
 1. **Discover feature docs** — find all `*_FEATURE.md` files in the repo (excluding `build/` and `artifacts/`).
 
 2. **For each doc, read its frontmatter** — extract `verified_against_commit` and `tracked_files`.
+   - If `tracked_files` is missing, derive the list from the doc's "Key Files" section (every source file path it references). Treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
+   - If `verified_against_commit` is missing, treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
 
 3. **Get the diff since that commit** — run:
    ```
@@ -49,6 +51,7 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
    - Fix any stale descriptions or defaults
 
 7. **Update the frontmatter** — set:
+   - `tracked_files` → if it was missing or out of date, write the list derived in step 2
    - `verified_against_commit` → current HEAD commit hash (use `git rev-parse --short=9 HEAD`)
    - `sdk_version` → current version from `DatadogCore.podspec`
    - `last_updated` → today's date (YYYY-MM-DD)

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -33,7 +33,7 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
    ```
    git diff <verified_against_commit>..HEAD -- <tracked_files>
    ```
-   If there is no diff for a doc, it is up to date — skip it.
+   If there is no diff for a doc, it is up to date — skip steps 4–7 for that doc and move to the next one. **Do not skip step 8** — registry coverage must be checked even when every doc is fresh.
 
 4. **Read the current source files in full** — read each tracked source file to understand the current public API surface.
 
@@ -55,6 +55,11 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
    - `verified_against_commit` → current HEAD commit hash (use `git rev-parse --short=9 HEAD`)
    - `sdk_version` → current version from `DatadogCore.podspec`
    - `last_updated` → today's date (YYYY-MM-DD)
+
+8. **Update the registries** — when adding, renaming, or removing a `*_FEATURE.md` file, also update every place that hand-lists feature docs. `tools/feature-docs-verify.sh` enforces these and will fail CI otherwise:
+   - **`.github/workflows/changelog-to-confluence.yaml`** — both the `paths:` filter and the `cp` block. Use the relative path **without a leading slash** (`DatadogRUM/RUM_FEATURE.md`, not `/DatadogRUM/RUM_FEATURE.md`) — leading slashes silently never match in GitHub Actions `paths:` filters. The publish filename is kebab-case derived from the module + doc (`DatadogRUM/RUM_FEATURE.md` → `dd-sdk-ios-rum-feature.md`).
+   - **`AGENTS.md`** — add the doc to the file tree under "Feature-specific docs" and to the routing table ("Where to Look First").
+   - **`docs/LLM_FEATURE_DOCS_GUIDELINES.md`** — add the doc to the expected feature-docs list.
 
 ## Notes
 

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dd-sdk-ios:update-feature-docs
+description: Use when public API changes have been made to review and update all *_FEATURE.md documentation files, or to audit whether they are still accurate.
+---
+
 # update-feature-docs
 
 Review and update the feature documentation files to match the current public API.

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -46,6 +46,14 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
    - **Deprecated public cases not documented** — walk every public enum case, method, and property, including those marked `@available(*, deprecated, message:)`. Deprecated cases stay on the public API and must appear in the doc with a clear deprecation note, otherwise customers reading the doc won't know they exist or that they're being phased out.
    - Outdated code examples
 
+5b. **Audit every code snippet for compile-readiness** — for every constructor call, method call, and type reference in every code snippet (Quick Start and any inline examples):
+   - Locate the corresponding `init` / `func` / `struct` / `class` / `enum` declaration in the tracked source files (or in extension files providing convenience overloads).
+   - Confirm every parameter **without** a default value (`= ...`) is supplied in the snippet, with the correct label.
+   - Confirm parameter labels and argument ordering match the source.
+   - **Watch especially for newly-required parameters added to existing initializers.** A required parameter added to an existing `init` is the highest-risk drift — the constructor still looks "the same" at a glance, and the source diff is a one-line addition that is easy to skim past. Example regression: `DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled:)` gained the required `isLegacyDetectionEnabled` argument and the snippet was not updated, causing a compile failure customers hit.
+   - Placeholder identifiers (e.g. `<client_token>`, `MyCustomViewsPredicate`, `myView`) and user-defined helpers (e.g. `scrubURL`) are illustrative and need not resolve — only **SDK** API calls must be valid.
+   - If you find any mismatch, fix the snippet (this counts as a content update — proceed to step 6).
+
 6. **Update the feature doc** — apply all necessary changes:
    - Update the Quick Start example to reflect the current API
    - Update the Configuration Categories section

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -41,7 +41,7 @@ To add a new feature doc to the system, create a `*_FEATURE.md` file following t
    ```
    git diff <verified_against_commit>..HEAD -- <tracked_files>
    ```
-   If there is no diff for a doc, its own tracked source files are unchanged — skip steps 4–6 for that doc. **Do not skip step 5b**: cross-feature drift (e.g. a RUM API change affecting Session Replay's Quick Start) won't show up in this doc's `tracked_files` diff. **Do not skip step 8** either — registry coverage must be checked even when every doc is fresh.
+   If there is no diff for a doc, its own tracked source files are unchanged — skip steps 4–6 for that doc (no content updates needed). **Do not skip step 5b**: cross-feature drift (e.g. a RUM API change affecting Session Replay's Quick Start) won't show up in this doc's `tracked_files` diff. **Do not skip step 7**: even with no content changes, every skill invocation is a fresh verification — the frontmatter should be bumped so `verified_against_commit` points at a recently-pushed SHA rather than an older one that may not be reachable on a fresh clone. **Do not skip step 8** either — registry coverage must be checked even when every doc is fresh.
 
 4. **Read the current source files in full** — read each tracked source file to understand the current public API surface.
 
@@ -69,7 +69,7 @@ To add a new feature doc to the system, create a `*_FEATURE.md` file following t
    - Update Troubleshooting if relevant
    - Fix any stale descriptions or defaults
 
-7. **Update the frontmatter** — set:
+7. **Update the frontmatter** — runs on every skill invocation, **even when steps 4–6 were skipped**. A skill run is itself a verification event; bumping the frontmatter records that and keeps `verified_against_commit` pointing at a recently-pushed SHA (older SHAs may be unreachable on a fresh clone in CI). Set:
    - `tracked_files` → if it was missing or out of date, write the list derived in step 2
    - `verified_against_commit` → current HEAD commit hash (use `git rev-parse --short=9 HEAD`)
    - `sdk_version` → current version from `DatadogCore.podspec`

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -30,11 +30,18 @@ To add a new feature doc to the system, create a `*_FEATURE.md` file following t
    - If `verified_against_commit` is missing, treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
    - **Audit `tracked_files` coverage** against the doc's "Key Files" section. Every public-API source file path referenced in "Key Files" must also appear in `tracked_files`. This audit must happen *here*, before step 3 — otherwise drift in untracked files is silently ignored. If any are missing, add them to `tracked_files` and treat the doc as fully out of date so the newly-tracked files are inspected in step 4.
 
-3. **Get the diff since that commit** — run:
+3. **Get the diff since that commit** — first ensure the tracked source files have no uncommitted changes:
+   ```
+   git diff HEAD -- <tracked_files>
+   ```
+   If this returns anything, **abort** and tell the engineer:
+   > "Tracked source files have uncommitted changes. Please commit your API changes first, then re-run the skill — otherwise the diff in step 3 won't see them and I'd report the doc as up to date even though CI would fail later."
+
+   Then run the actual drift check:
    ```
    git diff <verified_against_commit>..HEAD -- <tracked_files>
    ```
-   If there is no diff for a doc, it is up to date — skip steps 4–7 for that doc and move to the next one. **Do not skip step 8** — registry coverage must be checked even when every doc is fresh.
+   If there is no diff for a doc, its own tracked source files are unchanged — skip steps 4–6 for that doc. **Do not skip step 5b**: cross-feature drift (e.g. a RUM API change affecting Session Replay's Quick Start) won't show up in this doc's `tracked_files` diff. **Do not skip step 8** either — registry coverage must be checked even when every doc is fresh.
 
 4. **Read the current source files in full** — read each tracked source file to understand the current public API surface.
 
@@ -48,8 +55,8 @@ To add a new feature doc to the system, create a `*_FEATURE.md` file following t
    - **Description accuracy** — for each documented option/method, compare the snippet's inline comment against the source's doc-comment. If the source description has been updated, update the doc to match.
    - **Outdated code examples** — anything in the snippets that no longer reflects the API.
 
-5b. **Audit every code snippet for compile-readiness** — for every constructor call, method call, and type reference in every code snippet (Quick Start and any inline examples):
-   - Locate the corresponding `init` / `func` / `struct` / `class` / `enum` declaration in the tracked source files (or in extension files providing convenience overloads).
+5b. **Audit every code snippet for compile-readiness** — runs for every doc on every skill invocation, **even if step 3's diff was empty**. This is the only check that catches cross-feature drift (e.g. a RUM predicate change breaking Session Replay's Quick Start). For every constructor call, method call, and type reference in every code snippet (Quick Start and any inline examples):
+   - Locate the corresponding `init` / `func` / `struct` / `class` / `enum` declaration **anywhere in the SDK source**, not just this doc's `tracked_files`. Snippets often reference types from other features (e.g. Session Replay's Quick Start uses `RUM.Configuration` and `DefaultSwiftUIRUMViewsPredicate` from DatadogRUM). Use the "Feature Interactions" section of each doc as a hint for which other modules may be relevant, but resolve symbols against the actual source regardless.
    - Confirm every parameter **without** a default value (`= ...`) is supplied in the snippet, with the correct label.
    - Confirm parameter labels and argument ordering match the source.
    - **Watch especially for newly-required parameters added to existing initializers.** A required parameter added to an existing `init` is the highest-risk drift — the constructor still looks "the same" at a glance, and the source diff is a one-line addition that is easy to skim past. Example regression: `DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled:)` gained the required `isLegacyDetectionEnabled` argument and the snippet was not updated, causing a compile failure customers hit.

--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -19,7 +19,7 @@ All `*_FEATURE.md` files in the repo. Each doc's frontmatter is the source of tr
 - `verified_against_commit` — the commit the doc was last verified against
 - `tracked_files` — the public API source files whose changes should trigger a doc update
 
-To add a new feature doc to the system, just create a `*_FEATURE.md` file with the correct frontmatter — no script changes needed.
+To add a new feature doc to the system, create a `*_FEATURE.md` file following the spec in [`docs/LLM_FEATURE_DOCS_GUIDELINES.md`](../../../docs/LLM_FEATURE_DOCS_GUIDELINES.md) and modeling it on existing docs (e.g. `DatadogRUM/RUM_FEATURE.md`, `DatadogSessionReplay/SESSION_REPLAY_FEATURE.md`). Then run this skill — it will discover the new doc, audit `tracked_files` coverage, and register it in the required places. No script changes needed.
 
 ## Steps
 
@@ -39,12 +39,14 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
 4. **Read the current source files in full** — read each tracked source file to understand the current public API surface.
 
 5. **Compare against the feature doc** — identify every discrepancy:
-   - New configuration options or parameters missing from the doc
-   - Removed or renamed options still mentioned in the doc
-   - Changed defaults, behaviors, or platform availability
-   - New types, enums, or feature flags not documented
-   - **Deprecated public cases not documented** — walk every public enum case, method, and property, including those marked `@available(*, deprecated, message:)`. Deprecated cases stay on the public API and must appear in the doc with a clear deprecation note, otherwise customers reading the doc won't know they exist or that they're being phased out.
-   - Outdated code examples
+   - **Configuration options** — new options missing from the doc, removed or renamed options still mentioned, changed defaults.
+   - **Public methods and properties** — for each public method/property on the tracked types (e.g. `RUMMonitor.shared()`, `startView()`, `stopView()`), confirm it appears in the doc or is intentionally excluded. Flag new public methods missing from the doc.
+   - **Types, enums, and feature flags** — confirm every public enum case (including `FeatureFlag` cases), nested type, and protocol is documented.
+   - **Deprecated public surface** — walk every case marked `@available(*, deprecated, message:)`. Deprecated cases stay on the public API and must appear in the doc with a clear deprecation note, otherwise customers reading the doc won't know they exist or that they're being phased out.
+   - **Platform support** — verify the doc's stated platform availability matches the source. Check `#if os(...)` directives and `@available(...)` annotations on tracked types; if these have changed, update the doc's Overview section.
+   - **Feature interactions** — verify the "Feature Interactions" section still holds. Look for new cross-feature dependencies (e.g. a new RUM-context read in Logs source) or removed ones.
+   - **Description accuracy** — for each documented option/method, compare the snippet's inline comment against the source's doc-comment. If the source description has been updated, update the doc to match.
+   - **Outdated code examples** — anything in the snippets that no longer reflects the API.
 
 5b. **Audit every code snippet for compile-readiness** — for every constructor call, method call, and type reference in every code snippet (Quick Start and any inline examples):
    - Locate the corresponding `init` / `func` / `struct` / `class` / `enum` declaration in the tracked source files (or in extension files providing convenience overloads).
@@ -69,7 +71,10 @@ To add a new feature doc to the system, just create a `*_FEATURE.md` file with t
 8. **Update the registries** — when adding, renaming, or removing a `*_FEATURE.md` file, also update every place that hand-lists feature docs. `tools/feature-docs-verify.sh` enforces these and will fail CI otherwise:
    - **`.github/workflows/changelog-to-confluence.yaml`** — both the `paths:` filter and the `cp` block. Use the relative path **without a leading slash** (`DatadogRUM/RUM_FEATURE.md`, not `/DatadogRUM/RUM_FEATURE.md`) — leading slashes silently never match in GitHub Actions `paths:` filters. The publish filename is kebab-case derived from the module + doc (`DatadogRUM/RUM_FEATURE.md` → `dd-sdk-ios-rum-feature.md`).
    - **`AGENTS.md`** — add the doc to the file tree under "Feature-specific docs" and to the routing table ("Where to Look First").
-   - **`docs/LLM_FEATURE_DOCS_GUIDELINES.md`** — add the doc to the expected feature-docs list.
+   - **`docs/LLM_FEATURE_DOCS_GUIDELINES.md`** — add the doc to the file inventory list.
+
+9. **Surface a reminder to the engineer** — at the end of your run, print this single-line note so it's visible right when the engineer is using the skill:
+   > "Note: `verified_against_commit` was set to `<short SHA>`. If you rebase, amend, or squash commits afterward, re-run the skill before pushing so the SHA stays reachable in the final history (otherwise CI verify will fail on a fresh clone)."
 
 ## Notes
 

--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -5,8 +5,8 @@ on:
             - master
         paths:
             - 'CHANGELOG.md'
-            - '/DatadogRUM/RUM_FEATURE.md'
-            - '/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md'
+            - 'DatadogRUM/RUM_FEATURE.md'
+            - 'DatadogSessionReplay/SESSION_REPLAY_FEATURE.md'
 permissions:
     contents: read
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,6 +137,13 @@ API Surface Verify:
     - make clean repo-setup ENV=ci
     - make api-surface-verify
 
+Feature Docs Verify:
+  stage: lint
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)\/.*/'
+  script:
+    - make feature-docs-verify
+
 Unit Tests (iOS):
   stage: test
   rules: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,6 +141,14 @@ Feature Docs Verify:
   stage: lint
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)\/.*/'
+  # tools/feature-docs-verify.sh runs `git diff <verified_against_commit>..HEAD`,
+  # which requires that commit to be reachable in the local history. GitLab CI
+  # shallow-clones at depth 20 by default, which would silently bury baselines
+  # for any feature doc that hasn't been touched in a few releases (e.g. Logs).
+  # The job only runs on release/hotfix branches (a handful of times per cycle),
+  # so the cost of a full clone is negligible.
+  variables:
+    GIT_DEPTH: "0"
   script:
     - make feature-docs-verify
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Use these skills (via `/skill-name`) for common workflows:
 | `dd-sdk-ios:open-pr` | Opening a pull request against `develop` |
 | `dd-sdk-ios:running-tests` | Running unit, module, or integration tests |
 | `dd-sdk-ios:xcode-file-management` | Adding, removing, moving, or renaming Swift source files |
+| `dd-sdk-ios:update-feature-docs` | Review and update all `*_FEATURE.md` docs after public API changes |
 
 ## CI Environment
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,10 +1,11 @@
 ---
-last_updated: 2026-05-05
+last_updated: 2026-05-08
 sdk_version: 3.10.0
-verified_against_commit: 228fb06d7
+verified_against_commit: 6bc779cf6
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift
+  - DatadogRUM/Sources/RUMMonitor.swift
   - DatadogRUM/Sources/RUMMonitorProtocol.swift
 ---
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-08
+last_updated: 2026-05-11
 sdk_version: 3.10.0
-verified_against_commit: 6bc779cf6
+verified_against_commit: b584ef3af
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift
@@ -156,6 +156,10 @@ RUM.enable(
         // Default: true
         trackMemoryWarnings: true,
         
+        // Track slow frames / view hitches
+        // Default: true
+        trackSlowFrames: true,
+        
         // SDK telemetry sampling rate (for Datadog internal monitoring)
         // Default: 20.0
         telemetrySampleRate: 20.0,
@@ -163,10 +167,6 @@ RUM.enable(
         // Collect accessibility settings in view events
         // Default: false
         collectAccessibility: false,
-        
-        // Track slow frames / view hitches
-        // Default: true
-        trackSlowFrames: true,
         
         // Experimental feature flags (currently no active flags for RUM)
         // Default: [:]

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,11 @@
 ---
-last_updated: 2025-01-03
-sdk_version: 3.3.0
-verified_against_commit: 1d3e80ec5
+last_updated: 2026-05-05
+sdk_version: 3.10.0
+verified_against_commit: 228fb06d7
+tracked_files:
+  - DatadogRUM/Sources/RUM.swift
+  - DatadogRUM/Sources/RUMConfiguration.swift
+  - DatadogRUM/Sources/RUMMonitorProtocol.swift
 ---
 
 # RUM (Real User Monitoring) Feature
@@ -48,12 +52,14 @@ RUM.enable(
         // Default: nil (disabled)
         // Or use custom: MyCustomViewsPredicate()
         // Note: Also requires uiKitViewsPredicate for SwiftUI tracking to work correctly
+        // Note: Experimental API - may change in future releases
         swiftUIViewsPredicate: DefaultSwiftUIRUMViewsPredicate(),
         
         // SwiftUI automatic action tracking - provide predicate to enable
         // Default: nil (disabled)
         // Or use custom: MyCustomActionsPredicate()
         // Note: Also requires uiKitActionsPredicate for SwiftUI tracking to work correctly
+        // Note: Experimental API - behavior differs between iOS 17 and below vs iOS 18+
         swiftUIActionsPredicate: DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true),
         
         // Automatic network resource tracking - provide config to enable
@@ -67,7 +73,14 @@ RUM.enable(
             // Optional: Add custom attributes to resources
             resourceAttributesProvider: { request, response, data, error in
                 return ["custom.attribute": "value"]
-            }
+            },
+            // Optional: Capture HTTP headers from requests and responses
+            // Default: .disabled
+            // Options:
+            //   .disabled - No header capture
+            //   .defaults - Capture predefined common headers (cache-control, content-type, etag, etc.)
+            //   .custom([rules]) - Capture headers by custom rules
+            trackResourceHeaders: .defaults
         ),
         
         // Track user frustrations (error taps following errors)
@@ -148,7 +161,15 @@ RUM.enable(
         
         // Collect accessibility settings in view events
         // Default: false
-        collectAccessibility: false
+        collectAccessibility: false,
+        
+        // Track slow frames / view hitches
+        // Default: true
+        trackSlowFrames: true,
+        
+        // Experimental feature flags (currently no active flags for RUM)
+        // Default: [:]
+        featureFlags: [:]
     )
 )
 
@@ -199,14 +220,16 @@ monitor.stopView(key: "ProductList")
 
 ### Automatic Tracking
 Requires configuration to be set, otherwise disabled by default:
-- **View tracking**: `uiKitViewsPredicate`, `swiftUIViewsPredicate`
-- **Action tracking**: `uiKitActionsPredicate`, `swiftUIActionsPredicate`
+- **View tracking**: `uiKitViewsPredicate`, `swiftUIViewsPredicate` *(SwiftUI: experimental)*
+- **Action tracking**: `uiKitActionsPredicate`, `swiftUIActionsPredicate` *(SwiftUI: experimental, behavior differs on iOS 17 vs iOS 18+)*
 - **Resource tracking**: `urlSessionTracking` (automatic), optionally call `URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: YourSessionDelegate.self))` for detailed timing
+- **Header capture**: `urlSessionTracking.trackResourceHeaders` — `.disabled` (default), `.defaults` (common headers), or `.custom([rules])`
 
 ### Performance Monitoring
 - **Long tasks**: `longTaskThreshold` (default: 0.1s)
 - **App hangs**: `appHangThreshold` (default: nil/disabled)
 - **Vitals**: `vitalsUpdateFrequency` (default: .average)
+- **Slow frames**: `trackSlowFrames` (default: true) — captures view hitches and attaches them to the corresponding RUM view
 
 ### Sampling
 - **Sessions**: `sessionSampleRate` (default: 100%)
@@ -231,7 +254,7 @@ Event mappers allow modifying or dropping events before upload:
 ### "Views or actions not tracked"
 1. Check if predicates are configured in RUMConfiguration
 2. For UIKit: `uiKitViewsPredicate` and `uiKitActionsPredicate` must be set
-3. For SwiftUI: `swiftUIViewsPredicate` and `swiftUIActionssPredicate` must be set, as well as UIKit predicates
+3. For SwiftUI: `swiftUIViewsPredicate` and `swiftUIActionsPredicate` must be set, as well as UIKit predicates
 
 ### "Network requests not tracked"
 1. Verify `urlSessionTracking` is configured in RUMConfiguration (RUM.enable() handles URLSessionInstrumentation internally)

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-19
+last_updated: 2026-06-01
 sdk_version: 3.11.0
-verified_against_commit: d71d93183
+verified_against_commit: d3b6c039d
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-11
-sdk_version: 3.10.0
-verified_against_commit: b584ef3af
+last_updated: 2026-05-19
+sdk_version: 3.11.0
+verified_against_commit: d71d93183
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,10 +1,13 @@
 ---
-last_updated: 2026-05-05
+last_updated: 2026-05-08
 sdk_version: 3.10.0
-verified_against_commit: 228fb06d7
+verified_against_commit: 6bc779cf6
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+  - DatadogSessionReplay/Sources/SessionReplayPrivacyOverrides.swift
+  - DatadogSessionReplay/Sources/SessionReplayPrivacyView.swift
+  - DatadogInternal/Sources/Models/SessionReplay/SessionReplayConfiguration.swift
 ---
 
 # Session Replay Feature
@@ -88,8 +91,9 @@ SessionReplay.enable(
         // Feature flags for experimental features
         // Default: [.swiftui: false]
         // Available flags:
-        //   .swiftui - Enable SwiftUI recording (experimental)
-        //   .heatmaps - Enable heatmap identifier computation (experimental)
+        //   .swiftui                - Enable SwiftUI recording (experimental)
+        //   .heatmaps               - Enable heatmap identifier computation (experimental)
+        //   .screenChangeScheduling - DEPRECATED: now default and always enabled; setting it has no effect
         featureFlags: [
             .swiftui: true,   // Enable SwiftUI recording (experimental)
             .heatmaps: false  // Enable heatmap identifier computation (experimental)
@@ -228,6 +232,7 @@ SessionReplayPrivacyView(
 ### Available feature flags
 - `.swiftui` — Enable SwiftUI recording (experimental, default: `false`)
 - `.heatmaps` — Enable heatmap identifier computation (experimental, default: `false`)
+- `.screenChangeScheduling` — **Deprecated.** Screen change scheduling is now the default and always enabled; setting this flag has no effect. Kept on the public API for backward compatibility.
 
 ## Feature Interactions
 

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,10 @@
 ---
-last_updated: 2025-01-03
-sdk_version: 3.3.0
-verified_against_commit: 1d3e80ec5
+last_updated: 2026-05-05
+sdk_version: 3.10.0
+verified_against_commit: 228fb06d7
+tracked_files:
+  - DatadogSessionReplay/Sources/SessionReplay.swift
+  - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
 ---
 
 # Session Replay Feature
@@ -84,8 +87,12 @@ SessionReplay.enable(
         
         // Feature flags for experimental features
         // Default: [.swiftui: false]
+        // Available flags:
+        //   .swiftui - Enable SwiftUI recording (experimental)
+        //   .heatmaps - Enable heatmap identifier computation (experimental)
         featureFlags: [
-            .swiftui: true  // Enable SwiftUI recording (experimental)
+            .swiftui: true,   // Enable SwiftUI recording (experimental)
+            .heatmaps: false  // Enable heatmap identifier computation (experimental)
         ]
     )
 )
@@ -217,6 +224,10 @@ SessionReplayPrivacyView(
 ### "SwiftUI views not recorded"
 1. Enable SwiftUI feature flag: `featureFlags: [.swiftui: true]`
 2. Note: Session Replay SwiftUI is experimental, and some components are not supported
+
+### Available feature flags
+- `.swiftui` — Enable SwiftUI recording (experimental, default: `false`)
+- `.heatmaps` — Enable heatmap identifier computation (experimental, default: `false`)
 
 ## Feature Interactions
 

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-08
+last_updated: 2026-05-12
 sdk_version: 3.10.0
-verified_against_commit: 6bc779cf6
+verified_against_commit: cab13ec55
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-12
-sdk_version: 3.10.0
-verified_against_commit: cab13ec55
+last_updated: 2026-05-19
+sdk_version: 3.11.0
+verified_against_commit: d71d93183
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -44,7 +44,7 @@ RUM.enable(
         uiKitActionsPredicate: DefaultUIKitRUMActionsPredicate(),
         // For SwiftUI or mixed apps: Both UIKit AND SwiftUI predicates needed
         swiftUIViewsPredicate: DefaultSwiftUIRUMViewsPredicate(),
-        swiftUIActionsPredicate: DefaultSwiftUIRUMActionsPredicate()
+        swiftUIActionsPredicate: DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
     )
 )
 

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-05-19
+last_updated: 2026-06-01
 sdk_version: 3.11.0
-verified_against_commit: d71d93183
+verified_against_commit: d3b6c039d
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,11 @@ api-surface-verify:
 		--output-file /tmp/api-surface-objc-generated \
 		../../api-surface-objc
 
+# Verify feature doc files are up to date
+feature-docs-verify:
+	@$(ECHO_TITLE) "make feature-docs-verify"
+	@./tools/feature-docs-verify.sh
+
 # Builds API documentation using the same process as Swift Package Index.
 spi-docs-build:
 	@$(ECHO_TITLE) "make spi-docs-build"

--- a/docs/LLM_FEATURE_DOCS_GUIDELINES.md
+++ b/docs/LLM_FEATURE_DOCS_GUIDELINES.md
@@ -10,6 +10,16 @@ These files serve as **LLM-optimized entry points** to the codebase. They are NO
 - Highlight troubleshooting patterns
 - Show feature interactions and dependencies
 
+## How updates flow
+
+Three pieces work together to keep these docs honest:
+
+- **`/dd-sdk-ios:update-feature-docs`** (Claude Code skill) — the canonical way to refresh feature docs. It discovers every `*_FEATURE.md`, audits `tracked_files` coverage against the doc's "Key Files" section, diffs against the last verified commit, updates the content where needed, and keeps the registries (the Confluence publish workflow + `AGENTS.md` + this file) in sync.
+- **`tools/feature-docs-verify.sh`** (`make feature-docs-verify`) — drift detection. Runs in a `Feature Docs Verify` GitLab CI job on `release/*` and `hotfix/*` branches. Fails with a clear "run the skill" recipe when any doc has drifted from its tracked source files or any registry is missing an entry.
+- **`.github/workflows/changelog-to-confluence.yaml`** — publishes the docs to the Confluence space used by Technical Escalation Engineers.
+
+For the full system overview (rationale, architecture, day-to-day workflow), see the *Feature Docs System* page in Confluence.
+
 ## Feature Documentation Files
 
 Each feature module contains a `*_FEATURE.md` file at its root:
@@ -26,21 +36,25 @@ Each feature documentation file contains a **"Key Files"** section listing all r
 
 ## File Metadata
 
-Each feature documentation file should include a metadata header at the top:
+Each feature documentation file must include a YAML frontmatter header at the top:
 
 ```markdown
 ---
 last_updated: YYYY-MM-DD
 sdk_version: X.Y.Z
 verified_against_commit: <short_commit_hash>
+tracked_files:
+  - Module/Sources/PublicAPI.swift
+  - Module/Sources/AnotherPublicAPI.swift
 ---
 ```
 
-- **last_updated**: Date when the file was last reviewed/updated
-- **sdk_version**: SDK version the documentation was verified against
-- **verified_against_commit**: Git commit hash of the source files used for verification
+- **last_updated**: Date when the file was last reviewed/updated.
+- **sdk_version**: SDK version the documentation was verified against.
+- **verified_against_commit**: Short git commit hash that **must be reachable from `develop`**. The verify script uses `git diff <verified_against_commit>..HEAD` to detect drift in the tracked files. Don't use a PR-branch SHA — it can be orphaned by local rebases/amends or by certain merge strategies. Use `git merge-base origin/develop HEAD` to compute a stable value, or use the most recent develop commit your branch is built on.
+- **tracked_files**: List of public-API source files whose changes should trigger a doc update. Every source file referenced in the doc's "Key Files" section must appear here — the verify script enforces this.
 
-When updating, always update these metadata fields to reflect the current state.
+When updating, always update these metadata fields to reflect the current state. The `/dd-sdk-ios:update-feature-docs` skill handles this automatically.
 
 ## Update Checklist
 

--- a/docs/LLM_FEATURE_DOCS_GUIDELINES.md
+++ b/docs/LLM_FEATURE_DOCS_GUIDELINES.md
@@ -1,26 +1,20 @@
-# LLM Guidelines for Feature Documentation Updates
+# `*_FEATURE.md` Specification
 
 This document provides guidelines for LLMs updating feature documentation files (`*_FEATURE.md`) in the Datadog iOS SDK repository.
 
-## Purpose of Feature Documentation Files
+> For the *workflow* around these docs (verification, publishing, the update skill), see the *Feature Docs System* page in Confluence. The canonical update procedure lives in [`.claude/skills/update-feature-docs/SKILL.md`](../.claude/skills/update-feature-docs/SKILL.md).
 
-These files serve as **LLM-optimized entry points** to the codebase. They are NOT meant to replicate public documentation but rather:
-- Provide quick navigation to key source files
-- Document configuration options with working examples
-- Highlight troubleshooting patterns
-- Show feature interactions and dependencies
+## Purpose
 
-## How updates flow
+These files serve as **LLM-optimized entry points** to the codebase:
+- Quick navigation to key source files
+- Documented configuration options with working examples
+- Troubleshooting patterns
+- Feature interactions and dependencies
 
-Three pieces work together to keep these docs honest:
+They are NOT a replacement for customer-facing documentation.
 
-- **`/dd-sdk-ios:update-feature-docs`** (Claude Code skill) — the canonical way to refresh feature docs. It discovers every `*_FEATURE.md`, audits `tracked_files` coverage against the doc's "Key Files" section, diffs against the last verified commit, updates the content where needed, and keeps the registries (the Confluence publish workflow + `AGENTS.md` + this file) in sync.
-- **`tools/feature-docs-verify.sh`** (`make feature-docs-verify`) — drift detection. Runs in a `Feature Docs Verify` GitLab CI job on `release/*` and `hotfix/*` branches. Fails with a clear "run the skill" recipe when any doc has drifted from its tracked source files or any registry is missing an entry.
-- **`.github/workflows/changelog-to-confluence.yaml`** — publishes the docs to the Confluence space used by Technical Escalation Engineers.
-
-For the full system overview (rationale, architecture, day-to-day workflow), see the *Feature Docs System* page in Confluence.
-
-## Feature Documentation Files
+## File Inventory
 
 Each feature module contains a `*_FEATURE.md` file at its root:
 
@@ -32,9 +26,7 @@ DatadogLogs/LOGS_FEATURE.md            # (future)
 DatadogWebViewTracking/WEBVIEW_FEATURE.md  # (future)
 ```
 
-Each feature documentation file contains a **"Key Files"** section listing all relevant source files for that feature. Use this section as the source of truth for which files to read during updates.
-
-## File Metadata
+## Frontmatter
 
 Each feature documentation file must include a YAML frontmatter header at the top:
 
@@ -51,177 +43,60 @@ tracked_files:
 
 - **last_updated**: Date when the file was last reviewed/updated.
 - **sdk_version**: SDK version the documentation was verified against.
-- **verified_against_commit**: Short git commit hash that **must be reachable from `develop`**. The verify script uses `git diff <verified_against_commit>..HEAD` to detect drift in the tracked files. Don't use a PR-branch SHA — it can be orphaned by local rebases/amends or by certain merge strategies. Use `git merge-base origin/develop HEAD` to compute a stable value, or use the most recent develop commit your branch is built on.
-- **tracked_files**: List of public-API source files whose changes should trigger a doc update. Every source file referenced in the doc's "Key Files" section must appear here — the verify script enforces this.
+- **verified_against_commit**: Short git commit hash at which the doc was last verified to match the source. The verify script uses `git diff <verified_against_commit>..HEAD -- <tracked_files>` to detect drift.
+- **tracked_files**: List of public-API source files whose changes should trigger a doc update.
 
-When updating, always update these metadata fields to reflect the current state. The `/dd-sdk-ios:update-feature-docs` skill handles this automatically.
+## Sections
 
-## Update Checklist
-
-### 1. Configuration Options
-
-**Source of Truth**: The `init()` method in the Configuration struct (e.g., `RUMConfiguration.swift`, `SessionReplayConfiguration.swift`)
-
-- [ ] **List ALL configuration options** - Do not omit any parameters from the initializer
-- [ ] **Correct parameter order** - Match the exact order in the source `init()` method
-- [ ] **Working example values** - Use valid, realistic values (not placeholders like `...`)
-- [ ] **Accurate defaults** - Verify default values match the source code
-- [ ] **Accurate descriptions** - Verify option descriptions match source code comments
-
-```swift
-// ✅ CORRECT: All options listed in correct order with working values
-RUM.Configuration(
-    applicationID: "<rum_application_id>",
-    sessionSampleRate: 100.0,
-    uiKitViewsPredicate: DefaultUIKitRUMViewsPredicate(),
-    // ... all other options in order
-)
-
-// ❌ WRONG: Options out of order or missing
-RUM.Configuration(
-    applicationID: "...",
-    trackFrustrations: true,  // Wrong position
-    sessionSampleRate: 100.0,
-    // Missing options
-)
-```
-
-### 2. Platform Support
-
-**Source of Truth**: Compiler directives (`#if os(iOS)`, etc.) in source files
-
-- [ ] Verify supported platforms match `#if` directives in source
-- [ ] Update "Platform" note in Overview section if changed
-
-### 3. Public APIs
-
-**Source of Truth**: Public protocol/class definitions (e.g., `RUMMonitorProtocol.swift`)
-
-- [ ] Verify all public methods are documented
-- [ ] Check for new APIs added
-- [ ] Check for deprecated APIs
-
-### 4. Feature Interactions
-
-- [ ] Verify dependency requirements (e.g., "Session Replay requires RUM")
-- [ ] Check for new feature integrations
-
-### 5. Quick Start Example
-
-The code snippet must:
-- [ ] Compile without errors (syntactically correct Swift)
-- [ ] Show realistic usage patterns
-- [ ] Include all required initialization steps in correct order
-- [ ] Have accurate inline comments
-
-## Validation Steps
-
-Before finalizing updates, perform these checks:
-
-### Step 1: Read Source Files Entirely
-1. Open the feature's `*_FEATURE.md` file
-2. Find the **"Key Files"** section
-3. Read **all** source files listed there entirely
-
-From these files, extract:
-- The `public init(...)` method - ALL parameters in order
-- Default values for each parameter
-- Documentation comments for each property
-- Nested types and enums (including `FeatureFlag`)
-- Platform conditionals (`#if os(iOS)`, etc.)
-- Public methods (start/stop recording, etc.)
-
-### Step 2: Compare with Feature Documentation
-For each item found in Step 1, verify against the feature markdown:
-
-**Configuration options:**
-- Is it documented?
-- Is it in the correct position (matching init order)?
-- Does the documented default match the source?
-- Is the description accurate?
-
-**Feature flags:**
-- Are all `FeatureFlag` enum cases documented?
-- Are defaults accurate?
-
-**Platform support:**
-- Does the documented platform match `#if` conditionals?
-
-**Public APIs:**
-- Are all public methods documented?
-- Are there new or deprecated APIs?
-
-Flag any discrepancies:
-- Missing items (in source but not in docs)
-- Removed items (in docs but not in source)
-- Reordered options
-- Changed defaults or descriptions
-
-## Common Pitfalls to Avoid
-
-### ❌ DON'T
-- Guess parameter order - always verify against source
-- Assume defaults haven't changed
-- Skip optional parameters in examples
-- Use placeholder values like `"..."` or `nil` without explanation
-- Replicate public documentation verbatim
-- Add features that don't exist in the source
-
-### ✅ DO
-- Read the actual source files before updating
-- Include ALL configuration options
-- Use realistic example values
-- Document behavioral nuances (e.g., SwiftUI image bundling heuristic)
-- Keep troubleshooting patterns based on real customer issues
-- Update file paths if source files are moved/renamed
-
-## Section-by-Section Guide
+Every feature doc contains these sections, in order:
 
 ### Overview
 - Brief description of feature purpose
-- Platform availability
-- Key dependencies
+- Platform availability (iOS, tvOS, watchOS, visionOS)
+- Key dependencies (e.g. "requires RUM")
 
 ### Quick Start Example
-- Complete, compilable code snippet
-- All configuration options with comments
-- Initialization order matters
-- Include optional features (manual control, per-view overrides)
+A complete, compilable Swift code snippet that:
+- Includes all required initialization steps in correct order
+- Lists every configuration option with a working example value
+- Has accurate inline comments describing each option and its default
+- Includes optional features (manual control, per-view overrides) where applicable
 
 ### Key Files
-- Entry points and configuration files
-- Full relative paths from repository root
-- Brief description of each file's purpose
+Full relative paths from repository root, with a brief description of each file's purpose. Group by role (Feature Entry Point, Configuration, Public API, Implementation).
 
 ### Configuration Categories
-- Group related options
-- Reference defaults
-- Explain interactions between options
+Logical groupings of configuration options (Sampling, Privacy, Performance Monitoring, Event Modification, etc.). Reference defaults and explain interactions between options.
 
 ### Common Troubleshooting Patterns
-- Format: Symptom → Causes → Solutions
-- Based on real customer issues
-- Include non-obvious behaviors
+Format: Symptom → Causes → Solutions. Based on real customer issues; include non-obvious behaviors.
 
 ### Feature Interactions
-- Dependencies on other features
-- Integration points (WebView, Tracing, etc.)
-- Required configuration for integrations
+Dependencies on other features, integration points, and any required configuration for integrations.
 
 ### Additional Context
-- Non-obvious behavioral notes
-- Platform-specific differences
-- Limitations and caveats
+Non-obvious behavioral notes, platform-specific differences, limitations and caveats.
 
-## Automation Notes
+## Quality Standards
 
-When running automated updates:
+### Configuration options
+- List ALL options from the Configuration struct's `init()` method — no omissions.
+- Match the exact parameter order from the `init()` signature. Swift named-argument calls must follow declaration order; the snippet won't compile otherwise.
+- Use realistic, working values. Avoid `"..."` or untyped `nil` without explanation.
+- Defaults and descriptions must match the source.
 
-1. **Parse Configuration Init**: Extract all parameters from the `init()` method
-2. **Compare with Documentation**: Identify added/removed/reordered parameters
-3. **Verify Defaults**: Check default values in source vs documentation
-4. **Check Enums**: Compare enum cases in source vs documentation
-5. **Validate Code Snippet**: Ensure example compiles (optional: use Swift syntax checker)
+### Examples must compile
+The Quick Start snippet should be valid Swift against the current SDK version. Placeholder identifiers (`<client_token>`, `MyCustomViewsPredicate`, `myView`) and user-defined helpers (`scrubURL`) are illustrative and need not resolve — only SDK API calls must be valid.
+
+### Deprecated public surface
+Cases marked `@available(*, deprecated, message:)` — enum cases, methods, properties — must appear in the doc with a clear deprecation note. They remain on the public API and customers can still encounter them.
+
+### Coverage
+Every source file referenced in the "Key Files" section should also appear in `tracked_files` (the `update-feature-docs` skill audits this).
+
+### What to skip
+- Don't replicate customer-facing public documentation verbatim — these files are LLM-optimized, not customer-facing.
+- Don't document features that don't exist in the source.
 
 ---
 
@@ -229,9 +104,3 @@ When running automated updates:
 - When the documentation structure or format changes
 - When new validation patterns are needed
 - When new features are added that require different documentation approaches
-
-**When to update feature documentation files (`*_FEATURE.md`):**
-- For each SDK release
-- When public APIs are added, changed, or deprecated
-- When configuration options are modified
-- When feature behavior changes

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -15,6 +15,12 @@ import sys
 repo_root = sys.argv[1]
 failed = False
 
+def print_fix_instructions(full_clone=False):
+    """Print the standard recipe for fixing a feature-doc verification failure."""
+    on_full_clone = " on a full clone" if full_clone else ""
+    print(f"   Run the '/dd-sdk-ios:update-feature-docs' skill in Claude Code{on_full_clone} to refresh the doc,")
+    print(f"   then `make feature-docs-verify` to confirm, and push the update.")
+
 def parse_frontmatter(path):
     """Return (verified_against_commit, tracked_files) from a doc's YAML frontmatter."""
     commit = None
@@ -69,11 +75,13 @@ for doc in sorted(docs):
 
     if not commit:
         print(f"❌ {doc_name}: missing verified_against_commit in frontmatter.")
+        print_fix_instructions()
         failed = True
         continue
 
     if not files:
         print(f"❌ {doc_name}: missing tracked_files in frontmatter.")
+        print_fix_instructions()
         failed = True
         continue
 
@@ -87,10 +95,25 @@ for doc in sorted(docs):
         capture_output=True, text=True
     )
 
-    if result.stdout.strip():
+    # `git diff` exits non-zero when the baseline commit isn't reachable
+    # (e.g. shallow clone on a release/hotfix branch, or a typo in the
+    # frontmatter). In that case stdout is empty, so we'd otherwise silently
+    # report the doc as up to date. Treat any non-zero exit as a failure and
+    # surface stderr so the engineer knows what to do.
+    if result.returncode != 0:
+        print(f"❌ {doc_name}: failed to diff against {commit}.")
+        stderr = result.stderr.strip()
+        if stderr:
+            for stderr_line in stderr.splitlines():
+                print(f"   {stderr_line}")
+        print(f"   The baseline commit is not reachable in this checkout (often a shallow clone on a")
+        print(f"   release/hotfix branch, or a typo in the frontmatter).")
+        print_fix_instructions(full_clone=True)
+        failed = True
+    elif result.stdout.strip():
         print(f"❌ {doc_name} may be out of date.")
         print(f"   Public API changed since commit {commit}.")
-        print(f"   Run the '/dd-sdk-ios:update-feature-docs' skill in Claude Code to update it.")
+        print_fix_instructions()
         failed = True
     else:
         print(f"✅ {doc_name} is up to date (verified at {commit}).")

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -85,6 +85,20 @@ for doc in sorted(docs):
         failed = True
         continue
 
+    # Validate each tracked path actually exists. `git diff <commit>..HEAD -- <missing>`
+    # exits 0 with empty output, so without this check a typo or stale renamed
+    # path would silently report the doc as up to date.
+    missing = [f for f in files if not os.path.isfile(os.path.join(repo_root, f))]
+    if missing:
+        print(f"❌ {doc_name}: tracked_files references paths that don't exist in the working tree:")
+        for m in missing:
+            print(f"   - {m}")
+        print(f"   The file was likely renamed, moved, or deleted. Update the frontmatter")
+        print(f"   to point at the current path(s).")
+        print_fix_instructions()
+        failed = True
+        continue
+
     # Check whether any tracked file changed since the doc was last verified
     print(f"Checking {doc_name} against:")
     for f in files:

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -119,15 +119,18 @@ for doc in sorted(docs):
         print(f"✅ {doc_name} is up to date (verified at {commit}).")
 
 # Each *_FEATURE.md must be wired into a few hand-maintained registries:
-# - the Confluence publish workflow (operational — drift breaks publishing)
-# - AGENTS.md (LLM doc map)
-# - docs/LLM_FEATURE_DOCS_GUIDELINES.md (expected docs list)
-# The workflow is checked strictly: a leading slash on a `paths:` entry never
-# matches anything in GitHub Actions, so we flag that case explicitly.
-REGISTRIES = [
-    (".github/workflows/changelog-to-confluence.yaml", "Confluence publish workflow", True),
-    ("AGENTS.md", "AGENTS.md", False),
-    ("docs/LLM_FEATURE_DOCS_GUIDELINES.md", "LLM feature-docs guidelines", False),
+# - the Confluence publish workflow
+# - AGENTS.md
+# - docs/LLM_FEATURE_DOCS_GUIDELINES.md
+# The Confluence workflow needs the path in TWO distinct places (the trigger
+# `paths:` filter AND the `cp` block), so it gets a dedicated check that
+# verifies both contexts separately. Other registries just need any mention.
+
+WORKFLOW_PATH = ".github/workflows/changelog-to-confluence.yaml"
+WORKFLOW_LABEL = "Confluence publish workflow"
+SUBSTRING_REGISTRIES = [
+    ("AGENTS.md", "AGENTS.md"),
+    ("docs/LLM_FEATURE_DOCS_GUIDELINES.md", "LLM feature-docs guidelines"),
 ]
 
 doc_rel_paths = sorted(os.path.relpath(d, repo_root) for d in docs)
@@ -135,10 +138,37 @@ registry_failed = False
 
 print()
 print("Checking that each feature doc is registered in:")
-for path, _, _ in REGISTRIES:
+print(f"  - {WORKFLOW_PATH} (paths: filter AND cp block)")
+for path, _ in SUBSTRING_REGISTRIES:
     print(f"  - {path}")
 
-for registry_path, label, strict in REGISTRIES:
+# --- Workflow check: two contexts must each contain the path ---
+abs_workflow = os.path.join(repo_root, WORKFLOW_PATH)
+if not os.path.exists(abs_workflow):
+    print(f"⚠️  {WORKFLOW_LABEL}: file not found at {WORKFLOW_PATH} — skipping.")
+else:
+    with open(abs_workflow) as f:
+        workflow_content = f.read()
+    for rel in doc_rel_paths:
+        # `paths:` filter entries appear as quoted YAML list items.
+        in_paths_filter = (f"'{rel}'" in workflow_content) or (f'"{rel}"' in workflow_content)
+        # `cp` lines start with `cp <relative_path> ...`.
+        in_cp_block = f"cp {rel} " in workflow_content
+
+        if not in_paths_filter and not in_cp_block:
+            print(f"❌ {WORKFLOW_LABEL}: '{rel}' is missing from BOTH the `paths:` filter and the `cp` block.")
+            registry_failed = True
+        elif not in_paths_filter:
+            print(f"❌ {WORKFLOW_LABEL}: '{rel}' is missing from the `paths:` filter")
+            print(f"   (expected as `'{rel}'` under `on.push.paths`). Without it, doc-only updates won't trigger publishing.")
+            registry_failed = True
+        elif not in_cp_block:
+            print(f"❌ {WORKFLOW_LABEL}: '{rel}' is missing from the `cp` block")
+            print(f"   (expected as `cp {rel} publish_folder/...`). Without it, the page is never copied for publishing.")
+            registry_failed = True
+
+# --- Substring registries (AGENTS.md, LLM guidelines): any mention is enough ---
+for registry_path, label in SUBSTRING_REGISTRIES:
     abs_path = os.path.join(repo_root, registry_path)
     if not os.path.exists(abs_path):
         print(f"⚠️  {label}: file not found at {registry_path} — skipping.")
@@ -146,16 +176,8 @@ for registry_path, label, strict in REGISTRIES:
     with open(abs_path) as f:
         content = f.read()
     for rel in doc_rel_paths:
-        total = content.count(rel)
-        with_slash = content.count("/" + rel)
-        if total == 0:
+        if rel not in content:
             print(f"❌ {label}: missing reference to '{rel}'.")
-            registry_failed = True
-        elif strict and with_slash > 0:
-            # In the workflow the path must never appear with a leading slash:
-            # GitHub Actions `paths:` filters treat `/path` as absolute and never match.
-            print(f"❌ {label}: '{rel}' is referenced with a leading slash (`/{rel}`),")
-            print(f"   which never matches in GitHub Actions `paths:` filters. Remove the leading slash.")
             registry_failed = True
 
 if registry_failed:

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -118,5 +118,51 @@ for doc in sorted(docs):
     else:
         print(f"✅ {doc_name} is up to date (verified at {commit}).")
 
+# Each *_FEATURE.md must be wired into a few hand-maintained registries:
+# - the Confluence publish workflow (operational — drift breaks publishing)
+# - AGENTS.md (LLM doc map)
+# - docs/LLM_FEATURE_DOCS_GUIDELINES.md (expected docs list)
+# The workflow is checked strictly: a leading slash on a `paths:` entry never
+# matches anything in GitHub Actions, so we flag that case explicitly.
+REGISTRIES = [
+    (".github/workflows/changelog-to-confluence.yaml", "Confluence publish workflow", True),
+    ("AGENTS.md", "AGENTS.md", False),
+    ("docs/LLM_FEATURE_DOCS_GUIDELINES.md", "LLM feature-docs guidelines", False),
+]
+
+doc_rel_paths = sorted(os.path.relpath(d, repo_root) for d in docs)
+registry_failed = False
+
+print()
+print("Checking that each feature doc is registered in:")
+for path, _, _ in REGISTRIES:
+    print(f"  - {path}")
+
+for registry_path, label, strict in REGISTRIES:
+    abs_path = os.path.join(repo_root, registry_path)
+    if not os.path.exists(abs_path):
+        print(f"⚠️  {label}: file not found at {registry_path} — skipping.")
+        continue
+    with open(abs_path) as f:
+        content = f.read()
+    for rel in doc_rel_paths:
+        total = content.count(rel)
+        with_slash = content.count("/" + rel)
+        if total == 0:
+            print(f"❌ {label}: missing reference to '{rel}'.")
+            registry_failed = True
+        elif strict and with_slash > 0:
+            # In the workflow the path must never appear with a leading slash:
+            # GitHub Actions `paths:` filters treat `/path` as absolute and never match.
+            print(f"❌ {label}: '{rel}' is referenced with a leading slash (`/{rel}`),")
+            print(f"   which never matches in GitHub Actions `paths:` filters. Remove the leading slash.")
+            registry_failed = True
+
+if registry_failed:
+    print_fix_instructions()
+    failed = True
+else:
+    print(f"✅ All {len(doc_rel_paths)} feature doc(s) registered in every required location.")
+
 sys.exit(1 if failed else 0)
 EOF

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Verifies that feature docs are up to date with the public API.
+# Discovers all *_FEATURE.md files in the repo. Each doc's frontmatter is the
+# source of truth: `verified_against_commit` and `tracked_files` drive the check.
+# Run `make feature-docs-verify` to execute.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 - "$REPO_ROOT" <<'EOF'
+import os
+import subprocess
+import sys
+
+repo_root = sys.argv[1]
+failed = False
+
+def parse_frontmatter(path):
+    """Return (verified_against_commit, tracked_files) from a doc's YAML frontmatter."""
+    commit = None
+    files = []
+    in_front = False   # True once we've seen the opening ---
+    in_files = False   # True while we're inside the tracked_files list
+
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+
+            # --- marks both the opening and closing of the frontmatter block
+            if line == "---":
+                if not in_front:
+                    in_front = True
+                    continue
+                else:
+                    break  # closing ---, stop parsing
+
+            if not in_front:
+                continue
+
+            if line.startswith("verified_against_commit:"):
+                commit = line.split(":", 1)[1].strip()
+                in_files = False
+            elif line.startswith("tracked_files:"):
+                in_files = True
+            elif in_files and line.startswith("  - "):
+                # Each list entry is "  - path/to/file.swift"
+                files.append(line[4:].strip())
+            elif line and not line.startswith(" "):
+                # Any non-indented key ends the tracked_files list
+                in_files = False
+
+    return commit, files
+
+# Discover all *_FEATURE.md files, skipping generated output directories
+docs = []
+for dirpath, dirnames, filenames in os.walk(repo_root):
+    dirnames[:] = [d for d in dirnames if d not in ("build", "artifacts")]
+    for name in filenames:
+        if name.endswith("_FEATURE.md"):
+            docs.append(os.path.join(dirpath, name))
+
+if not docs:
+    print("No *_FEATURE.md files found.")
+    sys.exit(0)
+
+for doc in sorted(docs):
+    doc_name = os.path.basename(doc)
+    commit, files = parse_frontmatter(doc)
+
+    if not commit:
+        print(f"❌ {doc_name}: missing verified_against_commit in frontmatter.")
+        failed = True
+        continue
+
+    if not files:
+        print(f"❌ {doc_name}: missing tracked_files in frontmatter.")
+        failed = True
+        continue
+
+    # Check whether any tracked file changed since the doc was last verified
+    print(f"Checking {doc_name} against:")
+    for f in files:
+        print(f"  - {f}")
+    abs_files = [os.path.join(repo_root, f) for f in files]
+    result = subprocess.run(
+        ["git", "-C", repo_root, "diff", f"{commit}..HEAD", "--", *abs_files],
+        capture_output=True, text=True
+    )
+
+    if result.stdout.strip():
+        print(f"❌ {doc_name} may be out of date.")
+        print(f"   Public API changed since commit {commit}.")
+        print(f"   Run the '/dd-sdk-ios:update-feature-docs' skill in Claude Code to update it.")
+        failed = True
+    else:
+        print(f"✅ {doc_name} is up to date (verified at {commit}).")
+
+sys.exit(1 if failed else 0)
+EOF


### PR DESCRIPTION
### What and why

`RUM_FEATURE.md` and `SESSION_REPLAY_FEATURE.md` had drifted from the current public API (last verified against SDK 3.3.0). This PR refreshes them to 3.10.0 **and** puts a CI guard in place so they can't silently drift again — covering not just the docs themselves, but every place that hand-lists them (`AGENTS.md`, the LLM guidelines, and the Confluence publish workflow).

### What changes

Three moving parts:

1. **The docs.** `RUM_FEATURE.md` and `SESSION_REPLAY_FEATURE.md` brought up to SDK 3.10.0. Each doc gains YAML frontmatter (`tracked_files`, `verified_against_commit`) so it is its own source of truth for what to watch.

2. **A verify script** — `tools/feature-docs-verify.sh`, run via `make feature-docs-verify`, wired into a new `Feature Docs Verify` GitLab CI job on `release/*` and `hotfix/*` branches. It checks two things for every discovered `*_FEATURE.md`:
   - the doc is up to date vs. its tracked source files;
   - the doc is registered in `AGENTS.md`, `docs/LLM_FEATURE_DOCS_GUIDELINES.md`, and `.github/workflows/changelog-to-confluence.yaml`.

3. **A Claude Code skill** — `/dd-sdk-ios:update-feature-docs` — that owns the refresh workflow, including keeping those three registries in sync when a doc is added/renamed/removed. Engineers don't need to memorize the touchpoints; the script + skill close the loop.

Read more in this [internal doc](https://datadoghq.atlassian.net/wiki/spaces/CS0/pages/6707773819/Understanding+_FEATURE.md+Files+Purpose+Structure+and+Daily+Use+for+iOS+SDK).

### Notable

- **Workflow bug fix.** `changelog-to-confluence.yaml` had leading slashes in its \`paths:\` filter (\`'/DatadogRUM/RUM_FEATURE.md'\`), which never match in GitHub Actions filters. The pages still got published, but only as a side effect of \`CHANGELOG.md\` triggering the workflow on releases (the \`cp\` block always runs once triggered). Doc-only updates have never triggered publishing on their own. Removed.
- **Single failure recipe.** Every failure mode in the verify script tells the engineer the same thing: run the skill, run \`make feature-docs-verify\` to confirm, push.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run \`make api-surface\` when adding new APIs