### PR TITLE
chore: Skip redundant linter runs on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,7 @@ default:
           - "IntegrationTests/**/*"
           - "SmokeTests/**/*"
           - "TestUtilities/**/*"
+          - "tools/**/*"
           - "*" # match any file in the root directory
         compare_to: 'develop' # cannot use $DEVELOP_BRANCH var due to: https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 

--- a/tools/lint/run-linter.sh
+++ b/tools/lint/run-linter.sh
@@ -4,6 +4,11 @@ if [ ! -f "Package.swift" ]; then
 	echo "\`run-linter.sh\` must be run in repository root folder: \`./tools/lint/run-linter.sh\`"; exit 1
 fi
 
+if [[ "${SKIP_LINT}" = "1" ]]; then
+	echo "warning: SwiftLint skipped (SKIP_LINT=1 in environment)"
+	exit 0
+fi
+
 automatic_fix=""
 while :; do
     case $1 in

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -24,6 +24,10 @@ define_arg "device" "" "Specifies the simulator device for running tests, e.g., 
 check_for_help "$@"
 parse_args "$@"
 
+# Suppress lint Build Phase in SmokeTests projects; the standalone CI Lint job
+# already covers SmokeTests sources.
+export SKIP_LINT=1
+
 echo_subtitle "Run 'make clean install test OS=\"$os\" PLATFORM=\"$platform\" DEVICE=\"$device\"' in '$test_directory'"
 echo_succ "Smoke testing for git ref: '$(current_git_ref)'"
 cd "$test_directory" && make clean install test OS="$os" PLATFORM="$platform" DEVICE="$device"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -92,6 +92,9 @@ if [ "$USE_TEST_VISIBILITY" = "1" ]; then
     setup_test_visibility
 fi
 
+# Suppress lint Build Phase during xcodebuild test runs. CI runs `make lint` standalone
+export SKIP_LINT=1
+
 set -x
 
 xcodebuild -version


### PR DESCRIPTION
### What and why?

📦⏱️ The `⚙️ Run linter` Build Phase was wired into 5 Xcode targets (DatadogCore, DatadogCoreTests, DatadogCrashReporting, DatadogCrashReportingTests, DatadogIntegrationTests) and into each SmokeTests project (spm, spm-6, carthage, xcframeworks). Each invocation runs two SwiftLint passes (~20s per pass on my laptop).

That's redundant on CI — the standalone `Lint` job already runs `make lint` across the codebase. Across Unit Tests (4 platforms × ~9–11 schemes) and Smoke Tests (iOS + tvOS × 5 dirs), the `⚙️ Run linter` Build Phase added **~96–116 duplicate lint invocations per pipeline**.

This PR keeps the Build Phase intact for local development but disables it during `xcodebuild` runs driven by `tools/test.sh` and `tools/smoke-test.sh`.

#### Local impact

`make test-ios-all` (11 iOS schemes, sequential):

|           | Time                         |
| --------- | ---------------------------- |
| Before    | 9:54                         |
| After     | 4:42                         |
| **Saved** | **~5 min 12s (~52% faster)** |

CI savings are harder to pin down — runners differ from local, and [TIA](https://docs.datadoghq.com/tests/test_impact_analysis) skips tests selectively, so individual runs aren't directly comparable.

### How?

`run-linter.sh` early-exits when `SKIP_LINT=1` is set; `test.sh` and `smoke-test.sh` export it before invoking `xcodebuild`. The standalone `Lint` CI job calls `make lint` directly, so it's unaffected.

**Why not just edit the Build Phases?** That opens a rabbit hole — which targets should lint, when, what about targets shared between schemes — for no real gain. `SKIP_LINT` sidesteps it, works in SmokeTests projects without touching any `pbxproj`, and can be leveraged for local development (open Xcode with `SKIP_LINT=1` in env for faster iteration without permanent config changes).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our guidelines (internal)
- [x] Run `make api-surface` when adding new APIs