### PR TITLE
Add result bundles to unit tests when running in CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,10 @@ Unit Tests (iOS):
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
     - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
+  artifacts:
+    paths:
+      - "ResultBundles/*.xcresult.zip"
+    when: always
 
 Unit Tests (tvOS):
   stage: test
@@ -165,6 +169,10 @@ Unit Tests (tvOS):
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
     - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
+  artifacts:
+    paths:
+      - "ResultBundles/*.xcresult.zip"
+    when: always
 
 Unit Tests (watchOS):
   stage: test
@@ -180,6 +188,10 @@ Unit Tests (watchOS):
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
     - make test-watchos-all OS="$DEFAULT_WATCHOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
+  artifacts:
+    paths:
+      - "ResultBundles/*.xcresult.zip"
+    when: always
 
 Unit Tests (visionOS):
   stage: test
@@ -195,6 +207,10 @@ Unit Tests (visionOS):
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
     - make test-visionos-all OS="$DEFAULT_VISIONOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=0
+  artifacts:
+    paths:
+      - "ResultBundles/*.xcresult.zip"
+    when: always
 
 UI Tests:
   stage: ui-test

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -100,6 +100,10 @@ if [ "$CI" = "true" ]; then
     mkdir -p ResultBundles
     RESULT_BUNDLE_PATH="ResultBundles/${SCHEME}.xcresult"
     rm -rf "$RESULT_BUNDLE_PATH"
+    # Because of "set -eo pipefail" we need the xcodebuild line to return 0, and cache the real result.
+    # Otherwise, the script ends before zipping the result bundle, and it's not uploaded. Thay would
+    # be against the point since the bundle that fails is usually the one we want to look at.
+    # After doing that, the cached result is returned.
     XCODEBUILD_EXIT=0
     xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" -resultBundlePath "$RESULT_BUNDLE_PATH" test 2>&1 | xcbeautify || XCODEBUILD_EXIT=$?
     zip -r -q "ResultBundles/${SCHEME}.xcresult.zip" "$RESULT_BUNDLE_PATH"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -95,4 +95,15 @@ fi
 set -x
 
 xcodebuild -version
-xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" test 2>&1 | xcbeautify
+
+if [ "$CI" = "true" ]; then
+    mkdir -p ResultBundles
+    RESULT_BUNDLE_PATH="ResultBundles/${SCHEME}.xcresult"
+    rm -rf "$RESULT_BUNDLE_PATH"
+    XCODEBUILD_EXIT=0
+    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" -resultBundlePath "$RESULT_BUNDLE_PATH" test 2>&1 | xcbeautify || XCODEBUILD_EXIT=$?
+    zip -r -q "ResultBundles/${SCHEME}.xcresult.zip" "$RESULT_BUNDLE_PATH"
+    exit $XCODEBUILD_EXIT
+else
+    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" test 2>&1 | xcbeautify
+fi


### PR DESCRIPTION
### What and why?

Generate test result bundles in CI saved as artifacts.

This allows us to easily download and inspect result bundles, which is specially useful when the test runner crashes. In that case there is no way to obtain the crash log except through the result bundle.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
