### PR TITLE
[CHORE] Add maui and mauiVersion to Telemetry objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVEMENT] Add support for `maui` source for cross-platform RUM events from .NET MAUI applications. See [#2891][]
 - [FEATURE] Add client state management to `DatadogFlags` module. See [#2719][]
 - [IMPROVEMENT] Skip malformed RUM attributes individually instead of dropping the entire event, and log clear error messages. See [#2844][]
 - [FIX] Propagate native `anonymous_id` to WebView RUM and Log events. See [#2847][]
@@ -1141,6 +1142,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2855]: https://github.com/DataDog/dd-sdk-ios/pull/2855
 [#2856]: https://github.com/DataDog/dd-sdk-ios/pull/2856
 [#2866]: https://github.com/DataDog/dd-sdk-ios/pull/2866
+[#2891]: https://github.com/DataDog/dd-sdk-ios/pull/2891
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -945,6 +945,7 @@ public struct RUMActionEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -1061,6 +1062,7 @@ public struct RUMActionEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -1835,6 +1837,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -2388,6 +2391,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case windows = "windows"
             case macos = "macos"
             case linux = "linux"
+            case maui = "maui"
         }
 
         /// Description of the thread in the process when error happened.
@@ -2513,6 +2517,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -3321,6 +3326,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -3624,6 +3630,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -4151,6 +4158,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -4801,6 +4809,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -5774,6 +5783,7 @@ public struct RUMViewEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -5994,6 +6004,7 @@ public struct RUMViewEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -6903,6 +6914,8 @@ public struct RUMViewEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
+            case sessionRenewal = "session_renewal"
+            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -7805,6 +7818,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -8025,6 +8039,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -8934,6 +8949,8 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case fragmentRedisplay = "fragment_redisplay"
             case viewControllerDisplay = "view_controller_display"
             case viewControllerRedisplay = "view_controller_redisplay"
+            case sessionRenewal = "session_renewal"
+            case bfCache = "bf_cache"
         }
 
         /// Properties of the long tasks of the view
@@ -9911,6 +9928,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -10027,6 +10045,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -10653,6 +10672,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -10769,6 +10789,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -11355,6 +11376,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
             case rumCpp = "rum-cpp"
+            case maui = "maui"
         }
 
         /// Attributes of the view's container
@@ -11471,6 +11493,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// Stream properties
@@ -11813,6 +11836,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry configuration information
@@ -11919,6 +11943,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether the SDK is initialised on the application's main or a secondary process
             public let isMainProcess: Bool?
 
+            /// The version of MAUI used in a .NET MAUI application
+            public var mauiVersion: String?
+
             /// The period between each Mobile Vital sample (in milliseconds)
             public var mobileVitalsUpdatePeriod: Int64?
 
@@ -11970,7 +11997,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether initialization fails silently if the SDK is already initialized
             public let silentMultipleInit: Bool?
 
-            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+            /// The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
             public var source: String?
 
             /// Whether Session Replay should automatically start a recording when enabled
@@ -12062,6 +12089,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
 
             /// Whether automatic collection of network requests is enabled
             public var trackNetworkRequests: Bool?
+
+            /// How the SDK tracks resource request/response headers
+            public var trackResourceHeaders: TrackResourceHeaders?
 
             /// Whether resources are tracked
             public var trackResources: Bool?
@@ -12162,6 +12192,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case initializationType = "initialization_type"
                 case invTimeThresholdMs = "inv_time_threshold_ms"
                 case isMainProcess = "is_main_process"
+                case mauiVersion = "maui_version"
                 case mobileVitalsUpdatePeriod = "mobile_vitals_update_period"
                 case numberOfDisplays = "number_of_displays"
                 case plugins = "plugins"
@@ -12210,6 +12241,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case trackNativeLongTasks = "track_native_long_tasks"
                 case trackNativeViews = "track_native_views"
                 case trackNetworkRequests = "track_network_requests"
+                case trackResourceHeaders = "track_resource_headers"
                 case trackResources = "track_resources"
                 case trackSessionAcrossSubdomains = "track_session_across_subdomains"
                 case trackUserInteractions = "track_user_interactions"
@@ -12261,6 +12293,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - initializationType: The type of initialization the SDK used, in case multiple are supported
             ///   - invTimeThresholdMs: Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used
             ///   - isMainProcess: Whether the SDK is initialised on the application's main or a secondary process
+            ///   - mauiVersion: The version of MAUI used in a .NET MAUI application
             ///   - mobileVitalsUpdatePeriod: The period between each Mobile Vital sample (in milliseconds)
             ///   - numberOfDisplays: The number of displays available to the device
             ///   - plugins: The list of plugins enabled
@@ -12278,7 +12311,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - silentMultipleInit: Whether initialization fails silently if the SDK is already initialized
-            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+            ///   - source: The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
             ///   - startRecordingImmediately: Whether Session Replay should automatically start a recording when enabled
             ///   - startSessionReplayRecordingManually: Whether the session replay start is handled manually
             ///   - storeContextsAcrossPages: Whether contexts are stored in local storage
@@ -12309,6 +12342,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - trackNativeLongTasks: Whether long task tracking is performed automatically
             ///   - trackNativeViews: Whether native views are tracked (for cross platform SDKs)
             ///   - trackNetworkRequests: Whether automatic collection of network requests is enabled
+            ///   - trackResourceHeaders: How the SDK tracks resource request/response headers
             ///   - trackResources: Whether resources are tracked
             ///   - trackSessionAcrossSubdomains: Whether sessions across subdomains for the same site are tracked
             ///   - trackUserInteractions: Whether user actions are tracked
@@ -12356,6 +12390,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 initializationType: String? = nil,
                 invTimeThresholdMs: Int64? = nil,
                 isMainProcess: Bool? = nil,
+                mauiVersion: String? = nil,
                 mobileVitalsUpdatePeriod: Int64? = nil,
                 numberOfDisplays: Int64? = nil,
                 plugins: [Plugins]? = nil,
@@ -12404,6 +12439,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 trackNativeLongTasks: Bool? = nil,
                 trackNativeViews: Bool? = nil,
                 trackNetworkRequests: Bool? = nil,
+                trackResourceHeaders: TrackResourceHeaders? = nil,
                 trackResources: Bool? = nil,
                 trackSessionAcrossSubdomains: Bool? = nil,
                 trackUserInteractions: Bool? = nil,
@@ -12451,6 +12487,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.initializationType = initializationType
                 self.invTimeThresholdMs = invTimeThresholdMs
                 self.isMainProcess = isMainProcess
+                self.mauiVersion = mauiVersion
                 self.mobileVitalsUpdatePeriod = mobileVitalsUpdatePeriod
                 self.numberOfDisplays = numberOfDisplays
                 self.plugins = plugins
@@ -12499,6 +12536,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.trackNativeLongTasks = trackNativeLongTasks
                 self.trackNativeViews = trackNativeViews
                 self.trackNetworkRequests = trackNetworkRequests
+                self.trackResourceHeaders = trackResourceHeaders
                 self.trackResources = trackResources
                 self.trackSessionAcrossSubdomains = trackSessionAcrossSubdomains
                 self.trackUserInteractions = trackUserInteractions
@@ -12659,6 +12697,12 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case resource = "resource"
                 case action = "action"
                 case longTask = "long_task"
+            }
+
+            /// How the SDK tracks resource request/response headers
+            public enum TrackResourceHeaders: String, Codable {
+                case defaultHeaders = "default_headers"
+                case custom = "custom"
             }
 
             /// The initial tracking consent value
@@ -12946,6 +12990,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -13235,6 +13280,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry log information
@@ -13560,6 +13606,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
         case rumCpp = "rum-cpp"
+        case maui = "maui"
     }
 
     /// The telemetry usage information
@@ -14313,6 +14360,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
                     public enum AndroidNetworkInstrumentationType: String, Codable {
                         case cRONET = "CRONET"
                         case oKHTTP = "OKHTTP"
+                        case lEGACYOKHTTP = "LEGACY_OKHTTP"
                     }
                 }
             }
@@ -14374,4 +14422,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/0ca44bb75f6d0d02df73ecdfb0e71ea8eeb3e2e4
+// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -54,6 +54,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let trackUserInteractions: Bool?
     public let trackViewsManually: Bool?
     public let unityVersion: String?
+    public let mauiVersion: String?
     public let useAllowedTracingUrls: Bool?
     public let useBeforeSend: Bool?
     public let useExcludedActivityUrls: Bool?
@@ -416,6 +417,7 @@ extension Telemetry {
         trackUserInteractions: Bool? = nil,
         trackViewsManually: Bool? = nil,
         unityVersion: String? = nil,
+        mauiVersion: String? = nil,
         useAllowedTracingUrls: Bool? = nil,
         useBeforeSend: Bool? = nil,
         useExcludedActivityUrls: Bool? = nil,
@@ -473,6 +475,7 @@ extension Telemetry {
             trackUserInteractions: trackUserInteractions,
             trackViewsManually: trackViewsManually,
             unityVersion: unityVersion,
+            mauiVersion: mauiVersion,
             useAllowedTracingUrls: useAllowedTracingUrls,
             useBeforeSend: useBeforeSend,
             useExcludedActivityUrls: useExcludedActivityUrls,
@@ -615,6 +618,7 @@ extension ConfigurationTelemetry {
             trackUserInteractions: other.trackUserInteractions ?? trackUserInteractions,
             trackViewsManually: other.trackViewsManually ?? trackViewsManually,
             unityVersion: other.unityVersion ?? unityVersion,
+            mauiVersion: other.mauiVersion ?? mauiVersion,
             useAllowedTracingUrls: other.useAllowedTracingUrls ?? useAllowedTracingUrls,
             useBeforeSend: other.useBeforeSend ?? useBeforeSend,
             useExcludedActivityUrls: other.useExcludedActivityUrls ?? useExcludedActivityUrls,

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -818,6 +818,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -833,6 +834,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -846,6 +848,7 @@ public enum objc_RUMActionEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMActionEventContainerView)
@@ -1109,6 +1112,7 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -1125,6 +1129,7 @@ public enum objc_RUMActionEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -1139,6 +1144,7 @@ public enum objc_RUMActionEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMActionEventStream)
@@ -1905,6 +1911,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -1920,6 +1927,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -1933,6 +1941,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMErrorEventContainerView)
@@ -2793,6 +2802,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows?: self = .windows
         case .macos?: self = .macos
         case .linux?: self = .linux
+        case .maui?: self = .maui
         }
     }
 
@@ -2811,6 +2821,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
         case .windows: return .windows
         case .macos: return .macos
         case .linux: return .linux
+        case .maui: return .maui
         }
     }
 
@@ -2827,6 +2838,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int {
     case windows
     case macos
     case linux
+    case maui
 }
 
 @objc(DDRUMErrorEventErrorThreads)
@@ -2978,6 +2990,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -2994,6 +3007,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -3008,6 +3022,7 @@ public enum objc_RUMErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMErrorEventStream)
@@ -3754,6 +3769,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -3769,6 +3785,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -3782,6 +3799,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMLongTaskEventContainerView)
@@ -4212,6 +4230,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -4228,6 +4247,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -4242,6 +4262,7 @@ public enum objc_RUMLongTaskEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMLongTaskEventStream)
@@ -4917,6 +4938,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -4932,6 +4954,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -4945,6 +4968,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMResourceEventContainerView)
@@ -5884,6 +5908,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -5900,6 +5925,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -5914,6 +5940,7 @@ public enum objc_RUMResourceEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMResourceEventStream)
@@ -6720,6 +6747,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -6735,6 +6763,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -6748,6 +6777,7 @@ public enum objc_RUMViewEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewEventContainerView)
@@ -7105,6 +7135,7 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -7121,6 +7152,7 @@ public enum objc_RUMViewEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -7135,6 +7167,7 @@ public enum objc_RUMViewEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewEventStream)
@@ -7782,6 +7815,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        case .sessionRenewal?: self = .sessionRenewal
+        case .bfCache?: self = .bfCache
         }
     }
 
@@ -7796,6 +7831,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
+        case .sessionRenewal: return .sessionRenewal
+        case .bfCache: return .bfCache
         }
     }
 
@@ -7808,6 +7845,8 @@ public enum objc_RUMViewEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 }
 
 @objc(DDRUMViewEventViewLongTask)
@@ -8631,6 +8670,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -8646,6 +8686,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -8659,6 +8700,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewUpdateEventContainerView)
@@ -9016,6 +9058,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -9032,6 +9075,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -9046,6 +9090,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMViewUpdateEventStream)
@@ -9693,6 +9738,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay?: self = .fragmentRedisplay
         case .viewControllerDisplay?: self = .viewControllerDisplay
         case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        case .sessionRenewal?: self = .sessionRenewal
+        case .bfCache?: self = .bfCache
         }
     }
 
@@ -9707,6 +9754,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
         case .fragmentRedisplay: return .fragmentRedisplay
         case .viewControllerDisplay: return .viewControllerDisplay
         case .viewControllerRedisplay: return .viewControllerRedisplay
+        case .sessionRenewal: return .sessionRenewal
+        case .bfCache: return .bfCache
         }
     }
 
@@ -9719,6 +9768,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int {
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 }
 
 @objc(DDRUMViewUpdateEventViewLongTask)
@@ -10617,6 +10668,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -10632,6 +10684,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -10645,6 +10698,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventContainerView)
@@ -10908,6 +10962,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -10924,6 +10979,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -10938,6 +10994,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalAppLaunchEventStream)
@@ -11724,6 +11781,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -11739,6 +11797,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -11752,6 +11811,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalDurationEventContainerView)
@@ -12015,6 +12075,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -12031,6 +12092,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -12045,6 +12107,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalDurationEventStream)
@@ -12770,6 +12833,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -12785,6 +12849,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -12798,6 +12863,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventContainerView)
@@ -13061,6 +13127,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
         case .rumCpp?: self = .rumCpp
+        case .maui?: self = .maui
         }
     }
 
@@ -13077,6 +13144,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -13091,6 +13159,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDRUMVitalOperationStepEventStream)
@@ -13444,6 +13513,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -13458,6 +13528,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -13470,6 +13541,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryConfigurationEventTelemetry)
@@ -13598,6 +13670,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
 
     public var isMainProcess: NSNumber? {
         root.swiftModel.telemetry.configuration.isMainProcess as NSNumber?
+    }
+
+    public var mauiVersion: String? {
+        set { root.swiftModel.telemetry.configuration.mauiVersion = newValue }
+        get { root.swiftModel.telemetry.configuration.mauiVersion }
     }
 
     public var mobileVitalsUpdatePeriod: NSNumber? {
@@ -13824,6 +13901,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
     public var trackNetworkRequests: NSNumber? {
         set { root.swiftModel.telemetry.configuration.trackNetworkRequests = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.trackNetworkRequests as NSNumber? }
+    }
+
+    public var trackResourceHeaders: objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders {
+        set { root.swiftModel.telemetry.configuration.trackResourceHeaders = newValue.toSwift }
+        get { .init(swift: root.swiftModel.telemetry.configuration.trackResourceHeaders) }
     }
 
     public var trackResources: NSNumber? {
@@ -14123,6 +14205,30 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackFeatureFl
     case longTask
 }
 
+@objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders)
+@_spi(objc)
+public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders: Int {
+    internal init(swift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders?) {
+        switch swift {
+        case nil: self = .none
+        case .defaultHeaders?: self = .defaultHeaders
+        case .custom?: self = .custom
+        }
+    }
+
+    internal var toSwift: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders? {
+        switch self {
+        case .none: return nil
+        case .defaultHeaders: return .defaultHeaders
+        case .custom: return .custom
+        }
+    }
+
+    case none
+    case defaultHeaders
+    case custom
+}
+
 @objc(DDTelemetryConfigurationEventTelemetryConfigurationTrackingConsent)
 @_spi(objc)
 public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackingConsent: Int {
@@ -14391,6 +14497,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -14405,6 +14512,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -14417,6 +14525,7 @@ public enum objc_TelemetryDebugEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryDebugEventTelemetry)
@@ -14666,6 +14775,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
         case .rumCpp: self = .rumCpp
+        case .maui: self = .maui
         }
     }
 
@@ -14680,6 +14790,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 
@@ -14692,6 +14803,7 @@ public enum objc_TelemetryErrorEventSource: Int {
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 }
 
 @objc(DDTelemetryErrorEventTelemetry)
@@ -14828,4 +14940,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/0ca44bb75f6d0d02df73ecdfb0e71ea8eeb3e2e4
+// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06

--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -59,6 +59,7 @@ internal extension RUMViewEvent.Source {
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
         case .rumCpp: return .rumCpp
+        case .maui: return .maui
         }
     }
 }

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -419,6 +419,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             initializationType: nil,
             invTimeThresholdMs: configuration.invTimeThresholdMs,
             isMainProcess: nil,
+            mauiVersion: configuration.mauiVersion,
             mobileVitalsUpdatePeriod: configuration.mobileVitalsUpdatePeriod,
             premiumSampleRate: nil,
             reactNativeVersion: nil,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -352,6 +352,7 @@ class TelemetryReceiverTests: XCTestCase {
         let trackNetworkRequests: Bool? = .mockRandom()
         let trackViewsManually: Bool? = .mockRandom()
         let unityVersion: String? = .mockRandom()
+        let mauiVersion: String? = .mockRandom()
         let useFirstPartyHosts: Bool? = .mockRandom()
         let useLocalEncryption: Bool? = .mockRandom()
         let useProxy: Bool? = .mockRandom()
@@ -382,6 +383,7 @@ class TelemetryReceiverTests: XCTestCase {
             trackUserInteractions: trackUserInteractions,
             trackViewsManually: trackViewsManually,
             unityVersion: unityVersion,
+            mauiVersion: mauiVersion,
             useFirstPartyHosts: useFirstPartyHosts,
             useLocalEncryption: useLocalEncryption,
             useProxy: useProxy,
@@ -418,6 +420,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.telemetry.configuration.trackNetworkRequests, trackNetworkRequests)
         XCTAssertEqual(event?.telemetry.configuration.trackViewsManually, trackViewsManually)
         XCTAssertEqual(event?.telemetry.configuration.unityVersion, unityVersion)
+        XCTAssertEqual(event?.telemetry.configuration.mauiVersion, mauiVersion)
         XCTAssertEqual(event?.telemetry.configuration.useFirstPartyHosts, useFirstPartyHosts)
         XCTAssertEqual(event?.telemetry.configuration.useLocalEncryption, useLocalEncryption)
         XCTAssertEqual(event?.telemetry.configuration.useProxy, useProxy)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -516,6 +516,7 @@ public enum objc_RUMActionEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMActionEventContainerView: NSObject
     public var id: String
 public class objc_RUMActionEventRUMEventAttributes: NSObject
@@ -574,6 +575,7 @@ public enum objc_RUMActionEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMActionEventStream: NSObject
     public var id: String
 public class objc_RUMActionEventRUMSyntheticsTest: NSObject
@@ -730,6 +732,7 @@ public enum objc_RUMErrorEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMErrorEventContainerView: NSObject
     public var id: String
 public class objc_RUMErrorEventRUMEventAttributes: NSObject
@@ -912,6 +915,7 @@ public enum objc_RUMErrorEventErrorSourceType: Int
     case windows
     case macos
     case linux
+    case maui
 public class objc_RUMErrorEventErrorThreads: NSObject
     public var crashed: NSNumber
     public var name: String
@@ -946,6 +950,7 @@ public enum objc_RUMErrorEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMErrorEventStream: NSObject
     public var id: String
 public class objc_RUMErrorEventRUMSyntheticsTest: NSObject
@@ -1097,6 +1102,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMLongTaskEventContainerView: NSObject
     public var id: String
 public class objc_RUMLongTaskEventRUMEventAttributes: NSObject
@@ -1190,6 +1196,7 @@ public enum objc_RUMLongTaskEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMLongTaskEventStream: NSObject
     public var id: String
 public class objc_RUMLongTaskEventRUMSyntheticsTest: NSObject
@@ -1328,6 +1335,7 @@ public enum objc_RUMResourceEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMResourceEventContainerView: NSObject
     public var id: String
 public class objc_RUMResourceEventRUMEventAttributes: NSObject
@@ -1517,6 +1525,7 @@ public enum objc_RUMResourceEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMResourceEventStream: NSObject
     public var id: String
 public class objc_RUMResourceEventRUMSyntheticsTest: NSObject
@@ -1681,6 +1690,7 @@ public enum objc_RUMViewEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMViewEventContainerView: NSObject
     public var id: String
 public class objc_RUMViewEventRUMEventAttributes: NSObject
@@ -1755,6 +1765,7 @@ public enum objc_RUMViewEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMViewEventStream: NSObject
     public var bitrate: NSNumber?
     public var completionPercent: NSNumber?
@@ -1893,6 +1904,8 @@ public enum objc_RUMViewEventViewLoadingType: Int
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 public class objc_RUMViewEventViewLongTask: NSObject
     public var count: NSNumber
 public class objc_RUMViewEventViewPerformance: NSObject
@@ -2058,6 +2071,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMViewUpdateEventContainerView: NSObject
     public var id: String
 public class objc_RUMViewUpdateEventRUMEventAttributes: NSObject
@@ -2132,6 +2146,7 @@ public enum objc_RUMViewUpdateEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMViewUpdateEventStream: NSObject
     public var bitrate: NSNumber?
     public var completionPercent: NSNumber?
@@ -2270,6 +2285,8 @@ public enum objc_RUMViewUpdateEventViewLoadingType: Int
     case fragmentRedisplay
     case viewControllerDisplay
     case viewControllerRedisplay
+    case sessionRenewal
+    case bfCache
 public class objc_RUMViewUpdateEventViewLongTask: NSObject
     public var count: NSNumber
 public class objc_RUMViewUpdateEventViewPerformance: NSObject
@@ -2449,6 +2466,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalAppLaunchEventContainerView: NSObject
     public var id: String
 public class objc_RUMVitalAppLaunchEventRUMEventAttributes: NSObject
@@ -2507,6 +2525,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalAppLaunchEventStream: NSObject
     public var id: String
 public class objc_RUMVitalAppLaunchEventRUMSyntheticsTest: NSObject
@@ -2667,6 +2686,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalDurationEventContainerView: NSObject
     public var id: String
 public class objc_RUMVitalDurationEventRUMEventAttributes: NSObject
@@ -2725,6 +2745,7 @@ public enum objc_RUMVitalDurationEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalDurationEventStream: NSObject
     public var id: String
 public class objc_RUMVitalDurationEventRUMSyntheticsTest: NSObject
@@ -2874,6 +2895,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalOperationStepEventContainerView: NSObject
     public var id: String
 public class objc_RUMVitalOperationStepEventRUMEventAttributes: NSObject
@@ -2932,6 +2954,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_RUMVitalOperationStepEventStream: NSObject
     public var id: String
 public class objc_RUMVitalOperationStepEventRUMSyntheticsTest: NSObject
@@ -3004,6 +3027,7 @@ public enum objc_TelemetryConfigurationEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_TelemetryConfigurationEventTelemetry: NSObject
     public var configuration: objc_TelemetryConfigurationEventTelemetryConfiguration
     public var device: objc_TelemetryConfigurationEventTelemetryRUMTelemetryDevice?
@@ -3031,6 +3055,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var initializationType: String?
     public var invTimeThresholdMs: NSNumber?
     public var isMainProcess: NSNumber?
+    public var mauiVersion: String?
     public var mobileVitalsUpdatePeriod: NSNumber?
     public var numberOfDisplays: NSNumber?
     public var plugins: [objc_TelemetryConfigurationEventTelemetryConfigurationPlugins]?
@@ -3079,6 +3104,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var trackNativeLongTasks: NSNumber?
     public var trackNativeViews: NSNumber?
     public var trackNetworkRequests: NSNumber?
+    public var trackResourceHeaders: objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders
     public var trackResources: NSNumber?
     public var trackSessionAcrossSubdomains: NSNumber?
     public var trackUserInteractions: NSNumber?
@@ -3135,6 +3161,10 @@ public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackFeatureFl
     case resource
     case action
     case longTask
+public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackResourceHeaders: Int
+    case none
+    case defaultHeaders
+    case custom
 public enum objc_TelemetryConfigurationEventTelemetryConfigurationTrackingConsent: Int
     case none
     case granted
@@ -3193,6 +3223,7 @@ public enum objc_TelemetryDebugEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_TelemetryDebugEventTelemetry: NSObject
     public var device: objc_TelemetryDebugEventTelemetryRUMTelemetryDevice?
     public var message: String
@@ -3247,6 +3278,7 @@ public enum objc_TelemetryErrorEventSource: Int
     case kotlinMultiplatform
     case electron
     case rumCpp
+    case maui
 public class objc_TelemetryErrorEventTelemetry: NSObject
     public var device: objc_TelemetryErrorEventTelemetryRUMTelemetryDevice?
     public var error: objc_TelemetryErrorEventTelemetryError?


### PR DESCRIPTION
### What and why?

This PR adds maui as a valid source and adds mauiVersion so they can be added to the RUMTelemetry event.

### How?

Adding maui on all relevant objects.

Also ran make rum-models-generate GIT_REF=master to get the latest changes done on rum-events-format and make api-surface to regenerate the api_surface files.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
