### PR TITLE
[PANA-7292] Add layer tree recording feature flag

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -401,6 +401,8 @@
 		61054E8D2A6EE10A00AAA894 /* RUMContextReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */; };
 		61054E8E2A6EE10A00AAA894 /* SRContextPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */; };
 		61054E8F2A6EE10A00AAA894 /* SegmentRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E412A6EE10A00AAA894 /* SegmentRequestBuilder.swift */; };
+		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
+		B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333D0D8EAED64F559835F384 /* RecordingComponents.swift */; };
 		61054E942A6EE10A00AAA894 /* TextObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4A2A6EE10A00AAA894 /* TextObfuscator.swift */; };
 		61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */; };
 		61054E962A6EE10A00AAA894 /* Diff+SRWireframes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4D2A6EE10A00AAA894 /* Diff+SRWireframes.swift */; };
@@ -2101,6 +2103,8 @@
 		61054E382A6EE10A00AAA894 /* ViewTreeRecordingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewTreeRecordingContext.swift; sourceTree = "<group>"; };
 		61054E392A6EE10A00AAA894 /* NodeIDGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeIDGenerator.swift; sourceTree = "<group>"; };
 		61054E3A2A6EE10A00AAA894 /* WindowViewTreeSnapshotProducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowViewTreeSnapshotProducer.swift; sourceTree = "<group>"; };
+		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
+		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		61054E3C2A6EE10A00AAA894 /* SessionReplayFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayFeature.swift; sourceTree = "<group>"; };
 		61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMContextReceiver.swift; sourceTree = "<group>"; };
 		61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRContextPublisher.swift; sourceTree = "<group>"; };
@@ -3996,6 +4000,8 @@
 			isa = PBXGroup;
 			children = (
 				A73A54972B16406900E1F7E3 /* ResourcesFeature.swift */,
+				333D0D8EAED64F559835F384 /* RecordingComponents.swift */,
+				7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */,
 				61054E3C2A6EE10A00AAA894 /* SessionReplayFeature.swift */,
 				61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */,
 				D2C5D52A2B84F6AB00B63F36 /* WebViewRecordReceiver.swift */,
@@ -8102,6 +8108,8 @@
 				61054E612A6EE10A00AAA894 /* SRCompression.swift in Sources */,
 				5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */,
 				61054E8F2A6EE10A00AAA894 /* SegmentRequestBuilder.swift in Sources */,
+				B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */,
+				6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */,
 				61054E8B2A6EE10A00AAA894 /* SessionReplayFeature.swift in Sources */,
 				61054E992A6EE10A00AAA894 /* WireframesBuilder.swift in Sources */,
 				61054E892A6EE10A00AAA894 /* NodeIDGenerator.swift in Sources */,

--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import DatadogInternal
+
+internal struct RecordingComponents {
+    let recordingCoordinator: any RecordingController
+    let messageReceiver: any FeatureMessageReceiver
+
+    init(
+        core: DatadogCoreProtocol,
+        configuration: SessionReplay.Configuration
+    ) throws {
+        if #available(iOS 13.0, tvOS 13.0, *), configuration.featureFlags[.layerTreeRecording] {
+            // TODO: PANA-6884 Implement layer tree recording pipeline
+            struct LayerTreeRecordingNotImplemented: Error {}
+            throw LayerTreeRecordingNotImplemented()
+        }
+
+        self = try .viewTreeRecordingComponents(core: core, configuration: configuration)
+    }
+
+    private init(
+        recordingCoordinator: any RecordingController,
+        messageReceiver: any FeatureMessageReceiver
+    ) {
+        self.recordingCoordinator = recordingCoordinator
+        self.messageReceiver = messageReceiver
+    }
+
+    private static func viewTreeRecordingComponents(
+        core: DatadogCoreProtocol,
+        configuration: SessionReplay.Configuration
+    ) throws -> Self {
+        let processorsQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.processors", qos: .utility)
+        // The telemetry queue targets the processors queue with a lower qos.
+        let telemetryQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.telemetry", qos: .background, target: processorsQueue)
+
+        let telemetry = SessionReplayTelemetry(
+            telemetry: core.telemetry,
+            queue: telemetryQueue
+        )
+
+        let resourceProcessor = ResourceProcessor(
+            queue: processorsQueue,
+            resourcesWriter: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
+        )
+
+        let snapshotProcessor = SnapshotProcessor(
+            queue: processorsQueue,
+            recordWriter: RecordWriter(core: core),
+            resourceProcessor: resourceProcessor,
+            srContextPublisher: SRContextPublisher(core: core),
+            telemetry: telemetry
+        )
+
+        let recorder = try Recorder(
+            snapshotProcessor: snapshotProcessor,
+            additionalNodeRecorders: configuration._additionalNodeRecorders,
+            core: core,
+            featureFlags: configuration.featureFlags
+        )
+
+        let scheduler = ScreenChangeScheduler(minimumInterval: 0.1, telemetry: telemetry)
+        let contextReceiver = RUMContextReceiver()
+        let recordingCoordinator = RecordingCoordinator(
+            scheduler: scheduler,
+            textAndInputPrivacy: configuration.textAndInputPrivacyLevel,
+            imagePrivacy: configuration.imagePrivacyLevel,
+            touchPrivacy: configuration.touchPrivacyLevel,
+            rumContextObserver: contextReceiver,
+            srContextPublisher: SRContextPublisher(core: core),
+            recorder: recorder,
+            replaySampleRate: configuration.debugSDK ? 100 : configuration.replaySampleRate,
+            telemetry: telemetry,
+            startRecordingImmediately: configuration.startRecordingImmediately
+        )
+
+        return .init(
+            recordingCoordinator: recordingCoordinator,
+            messageReceiver: contextReceiver
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Feature/RecordingController.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingController.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import DatadogInternal
+
+internal protocol RecordingController: AnyObject {
+    var replaySampleRate: SampleRate { get }
+    var textAndInputPrivacy: TextAndInputPrivacyLevel { get }
+    var imagePrivacy: ImagePrivacyLevel { get }
+    var touchPrivacy: TouchPrivacyLevel { get }
+
+    func startRecording()
+    func stopRecording()
+}
+
+extension RecordingCoordinator: RecordingController {
+}
+#endif

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -19,7 +19,7 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
     // MARK: - Main Components
 
     /// Orchestrates the process of capturing next snapshots on the main thread.
-    let recordingCoordinator: RecordingCoordinator
+    let recordingCoordinator: any RecordingController
 
     // MARK: - Initialization
 
@@ -27,64 +27,20 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
         core: DatadogCoreProtocol,
         configuration: SessionReplay.Configuration
     ) throws {
-        let processorsQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.processors", qos: .utility)
-        // The telemetry queue targets the processors queue with a lower qos.
-        let telemetryQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.telemetry", qos: .background, target: processorsQueue)
-
-        let telemetry = SessionReplayTelemetry(
-            telemetry: core.telemetry,
-            queue: telemetryQueue
-        )
-
-        let resourceProcessor = ResourceProcessor(
-            queue: processorsQueue,
-            resourcesWriter: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
-        )
-
-        let snapshotProcessor = SnapshotProcessor(
-            queue: processorsQueue,
-            recordWriter: RecordWriter(core: core),
-            resourceProcessor: resourceProcessor,
-            srContextPublisher: SRContextPublisher(core: core),
-            telemetry: telemetry
-        )
-
-        let recorder = try Recorder(
-            snapshotProcessor: snapshotProcessor,
-            additionalNodeRecorders: configuration._additionalNodeRecorders,
+        let recordingComponents = try RecordingComponents(
             core: core,
-            featureFlags: configuration.featureFlags
+            configuration: configuration
         )
 
-        let scheduler = ScreenChangeScheduler(minimumInterval: 0.1, telemetry: telemetry)
-        let contextReceiver = RUMContextReceiver()
-
-        self.messageReceiver = CombinedFeatureMessageReceiver([
-            contextReceiver,
-            WebViewRecordReceiver(
-                scope: core.scope(for: SessionReplayFeature.self)
-            )
-        ])
-
-        self.textAndInputPrivacyLevel = configuration.textAndInputPrivacyLevel
-        self.imagePrivacyLevel = configuration.imagePrivacyLevel
-        self.touchPrivacyLevel = configuration.touchPrivacyLevel
-
-        self.recordingCoordinator = RecordingCoordinator(
-            scheduler: scheduler,
-            textAndInputPrivacy: configuration.textAndInputPrivacyLevel,
-            imagePrivacy: configuration.imagePrivacyLevel,
-            touchPrivacy: configuration.touchPrivacyLevel,
-            rumContextObserver: contextReceiver,
-            srContextPublisher: SRContextPublisher(core: core),
-            recorder: recorder,
-            replaySampleRate: configuration.debugSDK ? 100 : configuration.replaySampleRate,
-            telemetry: telemetry,
-            startRecordingImmediately: configuration.startRecordingImmediately
-        )
         self.requestBuilder = SegmentRequestBuilder(
             customUploadURL: configuration.customEndpoint,
             telemetry: core.telemetry
+        )
+        self.messageReceiver = CombinedFeatureMessageReceiver(
+            [
+                recordingComponents.messageReceiver,
+                WebViewRecordReceiver(scope: core.scope(for: SessionReplayFeature.self))
+            ]
         )
         self.performanceOverride = PerformancePresetOverride(
             maxFileSize: SessionReplay.maxObjectSize,
@@ -97,6 +53,10 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
                 changeRate: 0.75 // vs 0.1 with `uploadFrequency: .frequent`
             )
         )
+        self.textAndInputPrivacyLevel = configuration.textAndInputPrivacyLevel
+        self.imagePrivacyLevel = configuration.imagePrivacyLevel
+        self.touchPrivacyLevel = configuration.touchPrivacyLevel
+        self.recordingCoordinator = recordingComponents.recordingCoordinator
     }
 
     func startRecording() {

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -114,6 +114,7 @@ extension SessionReplay.Configuration {
         @available(*, deprecated, message: "Screen change scheduling is now the default and always enabled. This flag has no effect.")
         case screenChangeScheduling
 
+        @_spi(Internal)
         @available(iOS 13.0, tvOS 13.0, *)
         case layerTreeRecording
     }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -113,6 +113,9 @@ extension SessionReplay.Configuration {
 
         @available(*, deprecated, message: "Screen change scheduling is now the default and always enabled. This flag has no effect.")
         case screenChangeScheduling
+
+        @available(iOS 13.0, tvOS 13.0, *)
+        case layerTreeRecording
     }
 }
 

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -30,6 +30,15 @@ class SessionReplayConfigurationTests: XCTestCase {
         XCTAssertEqual(config._additionalNodeRecorders.count, 0)
     }
 
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testDefaultConfigurationDisablesLayerTreeRecordingFeatureFlag() {
+        // When
+        let config = SessionReplay.Configuration()
+
+        // Then
+        XCTAssertFalse(config.featureFlags[.layerTreeRecording])
+    }
+
     func testDefaultConfigurationWithNewApi() {
         // When
         let config = SessionReplay.Configuration(

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@_spi(Internal)
 @testable import DatadogSessionReplay
 
 extension SessionReplay.Configuration.FeatureFlags {

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
@@ -12,10 +12,16 @@ import Foundation
 
 extension SessionReplay.Configuration.FeatureFlags {
     public static var allEnabled: Self {
-        [
+        var flags: Self = [
             .swiftui: true,
             .heatmaps: true,
         ]
+
+        if #available(iOS 13.0, tvOS 13.0, *) {
+            flags[.layerTreeRecording] = true
+        }
+
+        return flags
     }
 }
 

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1275,6 +1275,7 @@ public enum SessionReplay
         case swiftui
         case heatmaps
         case screenChangeScheduling
+        case layerTreeRecording
 [?] extension SessionReplay.Configuration.FeatureFlags
     public static var defaults: Self
     public subscript(flag: Key) -> Bool

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -75,7 +75,7 @@ attributes:
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference
     name: "TODO without JIRA"
-    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM|FFL)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
+    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM|FFL|PANA)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
     match_kinds:
       - comment
     message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUM-123\""

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -68,7 +68,7 @@ attributes:
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference
     name: "TODO without JIRA"
-    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM|FFL)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
+    regex: "(TODO|TO DO|FIX|FIXME|FIX ME|todo)(?!:? (RUMM|RUM|FFL|PANA)-[0-9]{2,})" # "TODO: RUM-123", "TODO RUM-123", "FIX RUM-123", etc.
     match_kinds:
       - comment
     message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUM-123\""


### PR DESCRIPTION
### What and why?

This is the first in a series of PRs integrating the work from the proof-of-concept [Session Replay Core Animation Recording Pipeline](https://github.com/DataDog/dd-sdk-ios/tree/feature/session-replay-calayer-recording-pipeline) into `develop` incrementally.

It adds the basics needed for the new `.layerTreeRecording` Session Replay feature flag while keeping the current view-tree recorder as the default path. The new flag is default-off and the layer-tree implementation itself is intentionally not landed in this PR.

[RFC](https://datadoghq.atlassian.net/wiki/x/v4AXjAE) (Internal)

### How?

- Adds the public `SessionReplay.Configuration.FeatureFlag.layerTreeRecording` flag.
- Extracts Session Replay recording setup into `RecordingComponents` so later PRs can plug in the layer-tree pipeline behind the flag.
- Introduces `RecordingController` as the shared internal interface for current and future recording coordinators.
- Keeps the flag unsupported for now by throwing from the placeholder layer-tree path.
- Updates TestUtilities feature flag mocks and Swift API surface.
- Allows `PANA-*` TODO references in the SwiftLint TODO rule.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
