### PR TITLE
Scope network test handler to its own ServerMock

### DIFF
--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -52,6 +52,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             skipIsMainThreadCheck: true
         )
 
+        // Scope the handler to this `ServerMock`'s traffic. The resume swizzle is process-global,
+        // so foreign URLSession activity in the test process would otherwise reach the handler.
+        handler.shouldInterceptRequest = { [weak server] req in server?.isMyRequest(req) ?? false }
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
@@ -1860,6 +1863,40 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         // Then
         XCTAssertEqual(intercepted.count, 0, "Should not intercept DatadogSDKTesting CI Visibility uploads (DD-API-KEY without DD-REQUEST-ID)")
+    }
+
+    /// Regression test: the resume swizzle is process-global, so foreign URLSession activity in
+    /// the test process (e.g. `DatadogSDKTesting`) was reaching the test handler and over-fulfilling
+    /// expectations with `NSInternalInconsistencyException: multiple calls made to -[XCTestExpectation fulfill]`.
+    /// `setupInterceptionTest` defends against this via `shouldInterceptRequest`; this test verifies
+    /// that a foreign request is not observed.
+    func testAutomaticMode_handlerIgnoresForeignURLSessionTraffic() throws {
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
+
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // Foreign URLSession not produced by `ServerMock` — simulates any other framework using
+        // URLSession in the same process.
+        let foreignSession = URLSession(configuration: .ephemeral)
+        let foreignTask = foreignSession.dataTask(with: URL(string: "http://example.invalid/foreign")!)
+        foreignTask.resume()
+        foreignTask.cancel() // resume hook has already fired; short-circuit any real network IO
+
+        // Real test traffic through the `ServerMock`-backed session.
+        let session = server.getInterceptedURLSession()
+        let task = session.dataTask(with: URL.mockAny())
+        task.resume()
+
+        wait(
+            for: [notifyInterceptionDidStart, notifyInterceptionDidComplete],
+            timeout: 5,
+            enforceOrder: true
+        )
+        _ = server.waitAndReturnRequests(count: 1)
+
+        XCTAssertEqual(handler.interceptions.count, 1, "Only the `ServerMock`-backed request should be captured")
+        let interception = try XCTUnwrap(handler.interceptions.first).value
+        XCTAssertEqual(interception.request.url, URL.mockAny(), "Should be the `ServerMock` task, not the foreign one")
     }
 
     // MARK: - URLSessionTask Interception

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1885,6 +1885,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Real test traffic through the `ServerMock`-backed session.
         let session = server.getInterceptedURLSession()
         let task = session.dataTask(with: URL.mockAny())
+
+        // The rest of this test depends on `httpAdditionalHeaders` having the UUID
+        // on `task.currentRequest` so ServerMock can recognize its own session.
+        let currentRequest = try XCTUnwrap(task.currentRequest)
+        XCTAssertTrue(server.isMyRequest(currentRequest), "ServerMock should recognize its own session's task")
+
         task.resume()
 
         wait(

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -38,27 +38,34 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     // MARK: - Test Helpers
 
-    /// Sets up a test with interception expectations for single-request scenarios.
+    /// Sets up a test with interception expectations.
     /// Returns server, start expectation, and complete expectation.
     private func setupInterceptionTest(
         dataSize: Int = 10,
-        statusCode: Int = 200,
-        skipIsMainThreadCheck: Bool = false
+        error: NSError? = nil,
+        skipIsMainThreadCheck: Bool = false,
+        expectedFulfillmentCount: Int = 1
     ) -> (ServerMock, XCTestExpectation, XCTestExpectation) {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+        notifyInterceptionDidStart.expectedFulfillmentCount = expectedFulfillmentCount
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: statusCode), data: .mock(ofSize: dataSize)),
-            skipIsMainThreadCheck: true
-        )
+        notifyInterceptionDidComplete.expectedFulfillmentCount = expectedFulfillmentCount
 
-        // Scope the handler to this `ServerMock`'s traffic. The resume swizzle is process-global,
-        // so foreign URLSession activity in the test process would otherwise reach the handler.
-        handler.shouldInterceptRequest = { [weak server] req in server?.isMyRequest(req) ?? false }
+        let delivery: ServerMock.Delivery = error.map { .failure(error: $0) } ?? .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: dataSize))
+        let server = ServerMock(delivery: delivery, skipIsMainThreadCheck: true)
+
+        scopeHandler(to: server)
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
 
         return (server, notifyInterceptionDidStart, notifyInterceptionDidComplete)
+    }
+
+    /// Scopes `handler` to traffic produced by `server`'s URLSession. The resume swizzle is
+    /// process-global, so foreign URLSession activity in the test process would otherwise reach
+    /// the handler.
+    private func scopeHandler(to server: ServerMock) {
+        handler.shouldInterceptRequest = { [weak server] req in server?.isMyRequest(req) ?? false }
     }
 
     // MARK: - Registered Delegate Mode
@@ -108,6 +115,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.onRequestMutation = { _, _, _ in notifyRequestMutation.fulfill() }
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        scopeHandler(to: server)
 
         // Given
         let url: URL = .mockAny()
@@ -416,6 +424,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             notifyInterceptionDidStart.fulfill()
         }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        scopeHandler(to: server)
 
         // Given
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
@@ -992,6 +1001,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
             skipIsMainThreadCheck: true
         )
+        scopeHandler(to: server)
 
         // Given - Enable both automatic and registered delegate modes (reflects real-world usage)
         let delegate1 = MockDelegate()
@@ -1294,18 +1304,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     @available(iOS 16, tvOS 16, watchOS 8, *)
     func testGivenBothModesEnabled_whenUsingAsyncAPI_itCapturesAllValues() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-        notifyInterceptionDidStart.expectedFulfillmentCount = 2
-        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
-
-        let server = ServerMock(
-            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(skipIsMainThreadCheck: true, expectedFulfillmentCount: 2)
 
         // Given - Enable both modes
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
@@ -1365,6 +1364,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
             skipIsMainThreadCheck: true
         )
+        scopeHandler(to: server)
 
         // Given - Both modes enabled
         let delegate = SessionDataDelegateMock()
@@ -1450,14 +1450,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenRegisteredDelegate_whenTaskCompletesWithFailure_itCapturesError() throws {
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
-        let server = ServerMock(delivery: .failure(error: expectedError))
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, _, _) = setupInterceptionTest(error: expectedError)
 
         let dateBeforeRequest = Date()
 
@@ -1495,13 +1489,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenRegisteredDelegate_whenTaskCompletesWithSuccess_itCapturesAllValues() throws {
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mockRandom()))
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, _, _) = setupInterceptionTest()
 
         let dateBeforeRequest = Date()
 
@@ -1598,6 +1586,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        scopeHandler(to: server)
 
         // Given - Enable only automatic mode
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
@@ -1644,14 +1633,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenAutomaticMode_whenTaskCompletesWithFailure_itCapturesError() throws {
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-
         let testError = NSError(domain: "test", code: 123, userInfo: nil)
-        let server = ServerMock(delivery: .failure(error: testError))
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(error: testError)
 
         // Given - Enable only automatic mode
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
@@ -1689,19 +1672,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     @available(iOS 16, tvOS 16, watchOS 8, *)
     func testGivenRegisteredDelegate_whenUsingAsyncAPI_itCapturesAllValues() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-        notifyInterceptionDidStart.expectedFulfillmentCount = 2
-        notifyInterceptionDidComplete.expectedFulfillmentCount = 2
-
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
-        let server = ServerMock(
-            delivery: .failure(error: expectedError),
-            skipIsMainThreadCheck: true
-        )
-
-        handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
-        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest(error: expectedError, skipIsMainThreadCheck: true, expectedFulfillmentCount: 2)
 
         let dateBeforeAnyRequests = Date()
 
@@ -2022,6 +1994,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testAutomaticMode_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        scopeHandler(to: server)
 
         // Given - Configure first-party hosts
         let url = URL(string: "https://api.example.com")!
@@ -2052,6 +2025,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        scopeHandler(to: server)
 
         // Given - Configure first-party hosts
         let url = URL(string: "https://api.example.com")!
@@ -2086,6 +2060,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testAutomaticMode_doesNotInjectHeadersForThirdPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        scopeHandler(to: server)
 
         // Given - Configure first-party hosts that don't match the request URL
         handler.firstPartyHosts = .init(
@@ -2118,6 +2093,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testRegisteredDelegate_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        scopeHandler(to: server)
 
         // Given
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -118,11 +118,12 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         task1.resume()
 
         wait(for: [task1CompletedExpectation], timeout: 3)
-        let countAfterTask1 = interceptionCount
-        XCTAssertGreaterThanOrEqual(countAfterTask1, 2, "Task1 should have at least 2 state changes")
 
         // Unswizzle
         swizzler.unswizzle()
+
+        let countAfterTask1 = interceptionCount
+        XCTAssertGreaterThanOrEqual(countAfterTask1, 2, "Task1 should have at least 2 state changes")
 
         // When - Second task should NOT be intercepted
         let task2 = session.dataTask(with: url) { _, _, _ in }

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -133,6 +133,9 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
 
     public var modifiedRequest: URLRequest?
     public var injectedTraceContext: TraceContext?
+
+    /// When set, gates `interceptionDidStart` / `interceptionDidComplete`: events whose request
+    /// fails this predicate are dropped — no callback fires and nothing is stored in `interceptions`.
     public var shouldInterceptRequest: ((URLRequest) -> Bool)?
 
     public var onRequestMutation: ((URLRequest, Set<TracingHeaderType>, NetworkContext?) -> Void)?
@@ -161,11 +164,17 @@ public final class URLSessionHandlerMock: DatadogURLSessionHandler {
     }
 
     public func interceptionDidStart(interception: URLSessionTaskInterception, capturedStates: [any URLSessionHandlerCapturedState]) {
+        guard shouldInterceptRequest?(interception.request.unsafeOriginal) ?? true else {
+            return
+        }
         onInterceptionDidStart?(interception)
         interceptions[interception.identifier] = interception
     }
 
     public func interceptionDidComplete(interception: URLSessionTaskInterception) {
+        guard shouldInterceptRequest?(interception.request.unsafeOriginal) ?? true else {
+            return
+        }
         onInterceptionDidComplete?(interception)
         interceptions[interception.identifier] = interception
     }

--- a/TestUtilities/Sources/Proxies/ServerMock.swift
+++ b/TestUtilities/Sources/Proxies/ServerMock.swift
@@ -248,19 +248,29 @@ public class ServerMock {
         precondition(!doesInterceptSession, "This instance of `ServerMock` already intercepts the `URLSession`. Re-use the existing one.")
         doesInterceptSession = true
 
+        let configuration: URLSessionConfiguration = .ephemeral
+        // Tag every request emitted by this session with our UUID. `ServerMockProtocol` uses it
+        // for delivery routing; `isMyRequest(_:)` uses it to scope test handlers to this session.
+        configuration.httpAdditionalHeaders = [ddURLSessionUUIDHeaderField: urlSessionUUID.uuidString]
+
         #if os(watchOS)
         // On watchOS, `URLProtocol` is non-functional. We swizzle `__NSCFLocalSessionTask._onqueue_resume`
         // instead to intercept requests and deliver mocked responses directly via the task's internal callbacks.
         taskResumeSwizzler = try? .build()
         taskResumeSwizzler?.swizzle()
-        return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
         #else
-        let configuration: URLSessionConfiguration = .ephemeral
-        // Set utility header so we can identify this request in `ServerMockProtocol`.
-        configuration.httpAdditionalHeaders = [ddURLSessionUUIDHeaderField: urlSessionUUID.uuidString]
         configuration.protocolClasses = [ServerMockProtocol.self]
-        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
         #endif
+
+        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    }
+
+    /// Returns `true` if `request` was produced by this `ServerMock`'s intercepted `URLSession`.
+    ///
+    /// Test handlers can use this to ignore traffic from foreign URLSessions sharing the
+    /// process-global `__NSCFLocalSessionTask.resume` swizzle.
+    public func isMyRequest(_ request: URLRequest) -> Bool {
+        return request.value(forHTTPHeaderField: ddURLSessionUUIDHeaderField) == urlSessionUUID.uuidString
     }
 
     // MARK: - Waiting for total number of requests


### PR DESCRIPTION
### What and why?

We had a flaky test in `NetworkInstrumentationFeatureTests` crashing in CI with:

```
testAutomaticMode_tracksAsyncUploadTasks, API violation - multiple calls made to -[XCTestExpectation fulfill] for Notify interception did start. (NSInternalInconsistencyException)
```

Root cause: `URLSessionInstrumentation` swizzles `__NSCFLocalSessionTask.resume`, which is process-global. So any `URLSession` traffic happening in the test process (like DatadogSDKTesting CI Visibility uploads) also goes through `URLSessionHandlerMock` and over-fulfills the test expectations.

Anything else in the test process using `URLSession` (like `DatadogSDKTesting`'s CI Visibility uploads) reaches `URLSessionHandlerMock` and over-fulfils the test's expectations.

PR #2887 already filters DatadogSDKTesting requests at the production level through `isDatadogIntakeRequest` using the `DD-API-KEY` header. This PR adds second layer at the test mock layer, so any future foreign traffic is filtered without having to patch the production filter for every new source of foreign traffic.

### How?

- `URLSessionHandlerMock` already has a `shouldInterceptRequest` predicate but it wasn't wired up. Now it gates both `interceptionDidStart` and `interceptionDidComplete`: if the predicate returns `false`, the event is dropped. 
- Added `isMyRequest` on `ServerMock`. It uses the `dd-urlsession-uuid` header that's already attached to every intercepted session. 
- `setupInterceptionTest` in `NetworkInstrumentationFeatureTests` installs the predicate by default, so every test using the helper is scoped to its own `ServerMock`.
- New regression test `testAutomaticMode_handlerIgnoresForeignURLSessionTraffic` fires a foreign request alongside a `ServerMock` request and asserts only the `ServerMock` one is captured. If you remove the predicate, the test crashes the same as in CI.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — *test infrastructure only, no user-facing change*
- [ ] Add Objective-C interface for public APIs — *no new public APIs*
- [ ] Run `make api-surface` when adding new APIs — *no new public APIs*