### PR TITLE
[PANA-7300] Anchor heatmap identifiers to views with a Session Replay wireframe

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
@@ -87,12 +87,12 @@ internal final class UITouchCommandFactory: UIEventCommandFactory {
 
         var heatmapAttributes: HeatmapAttributes?
 
-        if let heatmapIdentifier = heatmapIdentifierRegistry.heatmapIdentifier(for: ObjectIdentifier(targetView)) {
-            let location = tap.location(in: targetView)
+        // Heatmap identifiers are looked up by `tap.view`, not the action target
+        if let heatmapIdentifier = heatmapIdentifierRegistry.heatmapIdentifier(for: ObjectIdentifier(view)) {
             heatmapAttributes = HeatmapAttributes(
                 identifier: heatmapIdentifier,
-                size: targetView.bounds.size,
-                location: location
+                size: view.bounds.size,
+                location: tap.location(in: view)
             )
         }
 

--- a/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
@@ -16,11 +16,12 @@ class RUMActionsHandlerTests: XCTestCase {
     #if !os(watchOS)
     private func touchHandler(
         with uiKitPredicate: UITouchRUMActionsPredicate = DefaultUIKitRUMActionsPredicate(),
-        swiftUIPredicate: SwiftUIRUMActionsPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
+        swiftUIPredicate: SwiftUIRUMActionsPredicate = DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true),
+        heatmapRegistry: HeatmapIdentifierRegistryMock = HeatmapIdentifierRegistryMock()
     ) -> RUMActionsHandler {
         let handler = RUMActionsHandler(
             dateProvider: dateProvider,
-            heatmapIdentifierRegistry: HeatmapIdentifierRegistryMock(),
+            heatmapIdentifierRegistry: heatmapRegistry,
             uiKitPredicate: uiKitPredicate,
             swiftUIPredicate: swiftUIPredicate,
             swiftUIDetector: SwiftUIComponentFactory.createDetector()
@@ -142,6 +143,60 @@ class RUMActionsHandlerTests: XCTestCase {
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
             XCTAssertEqual(command?.attributes.count, 0)
         }
+    }
+
+    // MARK: - Heatmap attributes
+
+    func testWhenTapViewIsInRegistry_itLooksUpHeatmapByTapView() {
+        // Given
+        let cell = UITableViewCell(frame: .init(x: 0, y: 0, width: 320, height: 88))
+        mockAppWindow.addSubview(cell)
+        cell.accessibilityIdentifier = "Item: 3"
+        let leaf = UIView(frame: .init(x: 10, y: 20, width: 100, height: 30))
+        cell.contentView.addSubview(leaf)
+
+        let registry = HeatmapIdentifierRegistryMock(identifiers: [
+            ObjectIdentifier(cell): HeatmapIdentifier(rawValue: "cell-id"),
+            ObjectIdentifier(leaf): HeatmapIdentifier(rawValue: "leaf-id"),
+        ])
+        let handler = touchHandler(heatmapRegistry: registry)
+
+        // When
+        handler.notify_sendEvent(
+            application: .shared,
+            event: .mockWith(touch: .mockWith(view: leaf))
+        )
+
+        // Then
+        let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
+        XCTAssertEqual(command?.heatmapAttributes?.targetPermanentID, "leaf-id")
+        XCTAssertEqual(command?.heatmapAttributes?.targetWidth, 100)
+        XCTAssertEqual(command?.heatmapAttributes?.targetHeight, 30)
+    }
+
+    func testWhenTapViewIsNotInRegistry_itDoesNotAttachHeatmapAttributes() {
+        // Given
+        let cell = UITableViewCell()
+        mockAppWindow.addSubview(cell)
+        cell.accessibilityIdentifier = "Item: 3"
+        let leaf = UIView()
+        cell.contentView.addSubview(leaf)
+
+        let registry = HeatmapIdentifierRegistryMock(identifiers: [
+            ObjectIdentifier(cell): HeatmapIdentifier(rawValue: "cell-id"),
+        ])
+        let handler = touchHandler(heatmapRegistry: registry)
+
+        // When
+        handler.notify_sendEvent(
+            application: .shared,
+            event: .mockWith(touch: .mockWith(view: leaf))
+        )
+
+        // Then
+        let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
+        XCTAssertNotNil(command)
+        XCTAssertNil(command?.heatmapAttributes)
     }
 
     // MARK: - UIKit Automatic Action Tracking (iOS, UITouch events)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -59,9 +59,8 @@ internal struct ViewTreeRecorder {
             context.clip = frame.intersection(context.clip)
         }
 
-        // Compute the heatmap identifier when heatmaps are enabled
-        let heatmapIdentifier: HeatmapIdentifier?
-        if let heatmapCache = context.heatmapCache, let viewPath = context.recorder.viewPath {
+        // Append this view to the node path when heatmaps are enabled
+        if context.heatmapCache != nil {
             let component: String
             if let accessibilityIdentifier = view.accessibilityIdentifier, !accessibilityIdentifier.isEmpty {
                 component = accessibilityIdentifier
@@ -69,22 +68,23 @@ internal struct ViewTreeRecorder {
                 component = "cls:\(String(describing: type(of: view)))#\(typeIndex)"
             }
             context.nodePath.append(component)
-
-            let identifier = HeatmapIdentifier(
-                elementPath: context.nodePath,
-                screenName: viewPath,
-                bundleIdentifier: bundleIdentifier() ?? "unknown"
-            )
-            heatmapCache.identifiers[ObjectIdentifier(view)] = identifier
-            heatmapIdentifier = identifier
-        } else {
-            heatmapIdentifier = nil
         }
 
         let attributes = ViewAttributes(view: view, frame: frame, clip: context.clip, overrides: overrides)
         let semantics = nodeSemantics(for: view, with: attributes, in: context)
 
         if !semantics.nodes.isEmpty {
+            // Compute the heatmap identifier
+            var heatmapIdentifier: HeatmapIdentifier?
+            if let heatmapCache = context.heatmapCache, let viewPath = context.recorder.viewPath {
+                let identifier = HeatmapIdentifier(
+                    elementPath: context.nodePath,
+                    screenName: viewPath,
+                    bundleIdentifier: bundleIdentifier() ?? "unknown"
+                )
+                heatmapCache.identifiers[ObjectIdentifier(view)] = identifier
+                heatmapIdentifier = identifier
+            }
             nodes.append(
                 contentsOf: heatmapIdentifier.map { heatmapIdentifier in
                     semantics.nodes.map {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
@@ -131,6 +131,7 @@ struct HeatmapIdentifierComputationTests {
     func registryPopulation() {
         // Given
         let parent = UIView(frame: .init(x: 0, y: 0, width: 320, height: 480))
+        parent.backgroundColor = .blue
         let child = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
         child.backgroundColor = .red
         parent.addSubview(child)
@@ -153,6 +154,34 @@ struct HeatmapIdentifierComputationTests {
         #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] != nil)
         #expect(heatmapCache.identifiers[ObjectIdentifier(child)] != nil)
         #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] != heatmapCache.identifiers[ObjectIdentifier(child)])
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips heatmap cache write for views that produce no rendered nodes")
+    func skipsCacheForViewsWithEmptySemantics() {
+        // Given
+        let parent = UIView(frame: .init(x: 0, y: 0, width: 320, height: 480))
+        let child = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        child.backgroundColor = .red
+        parent.addSubview(child)
+
+        let recorder = ViewTreeRecorder(
+            nodeRecorders: [UIViewRecorder(identifier: UUID())],
+            bundleIdentifier: "com.example.app"
+        )
+        let heatmapCache = HeatmapCache()
+        let context = ViewTreeRecordingContext.mockWith(
+            recorder: .mockWith(rumContext: .mockWith(viewPath: "Home")),
+            coordinateSpace: parent,
+            heatmapCache: heatmapCache
+        )
+
+        // When
+        _ = recorder.record(parent, in: context)
+
+        // Then
+        #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] == nil)
+        #expect(heatmapCache.identifiers[ObjectIdentifier(child)] != nil)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)


### PR DESCRIPTION
### What and why?

RUM tap actions could report a heatmap ID with no matching Session Replay wireframe. The recorder cached IDs for every view, but only views that rendered attached them to a wireframe. RUM looked up by the action target, often a transparent container, so the lookup returned an ID no wireframe carried.

### How?

The recorder now caches heatmap identifiers only for views that produce a wireframe. RUM now looks up by `tap.view` instead of the action target. If `tap.view` has no entry, the action ships without heatmap data; the action itself still fires.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
