### PR TITLE
[chain-pr 2/13] Migrate test utilities to support typed MessageBus

### DIFF
--- a/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
@@ -108,15 +108,11 @@ public class CrashReportSenderMock: CrashReportSender {
     public func send(launch: DatadogInternal.LaunchReport) {}
 }
 
-public class CrashReceiverMock: FeatureMessageReceiver {
+public final class CrashReceiverMock: BusMessageReceiver {
     public var receivedCrash: Crash?
 
-    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .payload(crash as Crash) = message else {
-            return false
-        }
-        receivedCrash = crash
-        return true
+    public func receive(message: Crash, from core: DatadogCoreProtocol) {
+        receivedCrash = message
     }
 
     public init() {}

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
@@ -59,6 +59,8 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         // not supported - use different type of core mock if you need this
     }
 
+    public var messageBus: MessageBus { NOPMessageBus() }
+
     public func mostRecentModifiedFileAt(before: Date) throws -> Date? {
         return nil
     }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -34,13 +34,17 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
     /// Current context that will be passed to feature-scopes.
     @ReadWriteLock
     public var context: DatadogContext {
-        didSet { send(message: .context(context)) }
+        didSet { _messageBus.send(message: context) }
     }
 
     let writer = FileWriterMock()
 
-    /// The message receiver.
+    /// The legacy `FeatureMessage` receiver.
     public var messageReceiver: FeatureMessageReceiver
+
+    /// The typed message bus. Owns its own dispatcher table and holds a weak reference
+    /// to this core so that feature objects storing the bus do not create retain cycles.
+    private lazy var _messageBus = PassthroughMessageBusMock(core: self)
 
     /// Callback called when `eventWriteContext` closure is executed.
     public var onEventWriteContext: ((Bool) -> Void)?
@@ -59,8 +63,6 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
         self.dataStore = dataStore
         self.messageReceiver = messageReceiver
 
-        messageReceiver.receive(message: .context(context), from: self)
-
         PassthroughCoreMock.referenceCount += 1
     }
 
@@ -68,14 +70,36 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
         PassthroughCoreMock.referenceCount -= 1
     }
 
+    /// The typed message bus — delegates to `_messageBus`.
+    public var messageBus: MessageBus { _messageBus }
+
+    /// Subscribes `receiver` to the typed bus and, for `DatadogContext` receivers,
+    /// delivers the current context immediately (mirrors `DatadogCore.add(messageReceiver:forKey:)`).
+    public func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        _messageBus.subscribe(receiver: receiver)
+        if let currentContext = context as? Receiver.Message {
+            receiver.receive(message: currentContext, from: self)
+        }
+    }
+
+    /// Removes `receiver` from the typed bus.
+    public func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        _messageBus.unsubscribe(receiver: receiver)
+    }
+
+    /// Delivers `message` to the typed bus.
+    public func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage {
+        _messageBus.send(message: message, else: fallback)
+    }
+
     /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
     public func feature<T>(named name: String, type: T.Type) -> T? { nil }
 
-    /// Always returns a feature-scope.
+    /// Returns a feature-scope backed by a weak reference to avoid retain cycles.
     public func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature {
-        self
+        PassthroughScopeMock(core: self)
     }
 
     public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
@@ -135,5 +159,86 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
 
     public func mostRecentModifiedFileAt(before: Date) throws -> Date? {
         return nil
+    }
+}
+
+/// A `FeatureScope` backed by a **weak** reference to a `PassthroughCoreMock`.
+///
+/// Returned by `PassthroughCoreMock.scope(for:)` so that receivers holding the scope
+/// do not retain the mock core, preventing retain cycles in tests.
+public final class PassthroughScopeMock: FeatureScope, @unchecked Sendable {
+    private weak var core: PassthroughCoreMock?
+
+    public init(core: PassthroughCoreMock) {
+        self.core = core
+    }
+
+    public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+        core?.eventWriteContext(bypassConsent: bypassConsent, block)
+    }
+
+    public func context(_ block: @escaping (DatadogContext) -> Void) {
+        core?.context(block)
+    }
+
+    public var dataStore: DataStore { core?.dataStore ?? NOPDataStore() }
+
+    public var telemetry: Telemetry { core?.telemetry ?? NOPTelemetry() }
+
+    public func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
+        if let core = core { core.send(message: message, else: fallback) } else { fallback() }
+    }
+
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        core?.set(context: context)
+    }
+
+    public func set(anonymousId: String?) {
+        core?.set(anonymousId: anonymousId)
+    }
+}
+
+/// A standalone `MessageBus` returned by `PassthroughCoreMock.messageBus`.
+///
+/// Owns its own dispatcher table and holds the core **weakly** so that feature objects
+/// (e.g. `FatalErrorContextNotifier`) that store the bus do not create retain cycles
+/// back to the mock core.
+public final class PassthroughMessageBusMock: MessageBus, @unchecked Sendable {
+    private typealias Dispatch = (any BusMessage, DatadogCoreProtocol) -> Void
+
+    private weak var core: (any DatadogCoreProtocol)?
+
+    /// Per-message-key dispatchers, keyed by receiver identity.
+    private var dispatchers: [String: [ObjectIdentifier: Dispatch]] = [:]
+
+    public init(core: DatadogCoreProtocol) {
+        self.core = core
+    }
+
+    public func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        let id = ObjectIdentifier(receiver)
+        dispatchers[Receiver.Message.key, default: [:]][id] = { message, core in
+            guard let typed = message as? Receiver.Message else {
+                return
+            }
+            receiver.receive(message: typed, from: core)
+        }
+    }
+
+    public func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        let id = ObjectIdentifier(receiver)
+        dispatchers[Receiver.Message.key]?.removeValue(forKey: id)
+    }
+
+    public func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage {
+        guard let core = core else {
+            fallback()
+            return
+        }
+        guard let bucket = dispatchers[Message.key], !bucket.isEmpty else {
+            fallback()
+            return
+        }
+        bucket.values.forEach { $0(message, core) }
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/TelemetryReceiverMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/TelemetryReceiverMock.swift
@@ -7,19 +7,14 @@
 import Foundation
 import DatadogInternal
 
-/// `FeatureMessageReceiver` that records received telemetry events.
-public class TelemetryReceiverMock: FeatureMessageReceiver {
+/// `BusMessageReceiver` that records received telemetry events.
+public final class TelemetryReceiverMock: BusMessageReceiver {
     @ReadWriteLock
     public private(set) var messages: [TelemetryMessage] = []
 
     public init() {}
 
-    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .telemetry(message) = message else {
-            return false
-        }
-
+    public func receive(message: TelemetryMessage, from core: DatadogCoreProtocol) {
         messages.append(message)
-        return true
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogLogs/LoggingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogLogs/LoggingFeatureMocks.swift
@@ -54,16 +54,14 @@ extension LogsFeature {
 }
 
 extension LogMessageReceiver: AnyMockable {
-    public static func mockAny() -> Self {
-        .mockWith()
+    public static func mockAny() -> LogMessageReceiver {
+        mockWith()
     }
 
     public static func mockWith(
         logEventMapper: LogEventMapper? = nil
-    ) -> Self {
-        .init(
-            logEventMapper: logEventMapper
-        )
+    ) -> LogMessageReceiver {
+        LogMessageReceiver(logEventMapper: logEventMapper)
     }
 }
 

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1580,19 +1580,26 @@ public class ContinuousVitalReaderMock: ContinuousVitalReader {
 #endif
 
 extension TelemetryReceiver: AnyMockable {
-    public static func mockAny() -> Self { .mockWith() }
+    public static func mockAny() -> TelemetryReceiver { mockWith() }
 
     public static func mockWith(
         featureScope: FeatureScope = NOPFeatureScope(),
         dateProvider: DateProvider = SystemDateProvider(),
         sampler: Sampler = .mockKeepAll(),
-        configurationExtraSampler: Sampler = .mockKeepAll()
-    ) -> Self {
-        .init(
+        configurationExtraSampler: Sampler = .mockKeepAll(),
+        sessionEndedMetric: SessionEndedMetricController = SessionEndedMetricController(
+            telemetry: NOPTelemetry(),
+            sampleRate: 100,
+            tracksBackgroundEvents: false,
+            isUsingSceneLifecycle: false
+        )
+    ) -> TelemetryReceiver {
+        TelemetryReceiver(
             featureScope: featureScope,
             dateProvider: dateProvider,
             sampler: sampler,
-            configurationExtraSampler: configurationExtraSampler
+            configurationExtraSampler: configurationExtraSampler,
+            sessionEndedMetric: sessionEndedMetric
         )
     }
 }

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -129,6 +129,8 @@ public final class DatadogCoreProxy: DatadogCoreProtocol {
         core.send(message: message, else: fallback)
     }
 
+    public var messageBus: MessageBus { core.messageBus }
+
     public func mostRecentModifiedFileAt(before: Date) throws -> Date? {
         return try core.mostRecentModifiedFileAt(before: before)
     }


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Updates `PassthroughCoreMock` to own a real typed bus (`PassthroughMessageBusMock`) and a weak-backed scope (`PassthroughScopeMock`) to avoid retain cycles. Adds `subscribe`/`unsubscribe`/`send` helpers. Migrates `TelemetryReceiverMock` and `CrashReceiverMock` to `BusMessageReceiver`. Adds `messageBus` accessors to `DatadogCoreProxy` and `FeatureRegistrationCoreMock`. Updates Logs/RUM test factories for the new initializers. Required by every downstream test in subsequent groups.

---
_Draft — pending author review. Merge in order unless marked parallel._