### PR TITLE
[chain-pr 3/13] Implement typed MessageBus in DatadogCore and migrate core extensions

### DIFF
--- a/DatadogCore/Sources/Core/CoreMessageBus.swift
+++ b/DatadogCore/Sources/Core/CoreMessageBus.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 /// The message-bus sends messages to a set of registered receivers.
 ///
 /// The bus dispatches messages on a serial queue.
-internal final class MessageBus {
+internal final class CoreMessageBus: @unchecked Sendable {
     /// The message bus GDC queue.
     let queue = DispatchQueue(
         label: "com.datadoghq.ios-sdk-message-bus",
@@ -27,6 +27,25 @@ internal final class MessageBus {
     /// The bus **must** be accessed within the queue.
     private var bus: [String: FeatureMessageReceiver] = [:]
 
+    /// A closure that delivers a `BusMessage` to a single subscriber.
+    ///
+    /// Captures the receiver strongly and performs the runtime cast from `Any`
+    /// to the receiver's expected `Message` type.
+    private typealias Dispatch = (Any, DatadogCoreProtocol) -> Void
+
+    /// Typed `BusMessageReceiver` subscribers grouped by `BusMessage.key`.
+    ///
+    /// The outer key is the `BusMessage.key` of the message kind a subscriber
+    /// is registered for; the inner key is the receiver's object identity. The
+    /// keyed layout means dispatch only iterates receivers for the matching
+    /// message kind instead of the full subscriber set.
+    ///
+    /// Each `Dispatch` captures its receiver strongly, so the bus retains
+    /// subscribers until they are explicitly removed via `unsubscribe(receiver:)`.
+    ///
+    /// Must be accessed within the queue.
+    private var receivers: [String: [ObjectIdentifier: Dispatch]] = [:]
+
     /// The current configuration.
     ///
     /// The message-bus wil accumulate configuration by merge. A message
@@ -42,11 +61,18 @@ internal final class MessageBus {
     /// - Parameter configurationDispatchTime: The delay to dispatch the
     /// configuration telemetry
     init(configurationDispatchTime: DispatchTimeInterval = .seconds(5)) {
-        queue.asyncAfter(deadline: .now() + configurationDispatchTime) {
-            guard let core = self.core, let configuration = self.configuration else {
+        queue.asyncAfter(deadline: .now() + configurationDispatchTime) { [weak self] in
+            guard let self = self, let core = self.core, let configuration = self.configuration else {
                 return
             }
 
+            // Dispatch via typed bus to TelemetryMessage subscribers.
+            if let bucket = self.receivers[TelemetryMessage.key] {
+                let message = TelemetryMessage.configuration(configuration)
+                bucket.values.forEach { dispatch in dispatch(message, core) }
+            }
+
+            // Dispatch via legacy bus for receivers still on the legacy bus.
             self.bus.values.forEach {
                 $0.receive(message: .telemetry(.configuration(configuration)), from: core)
             }
@@ -125,7 +151,69 @@ internal final class MessageBus {
     }
 }
 
-extension MessageBus: Flushable {
+extension CoreMessageBus: MessageBus {
+    /// Adds `receiver` to the bucket for `Receiver.Message.key`.
+    ///
+    /// The receiver is retained by the bus (via the captured closure) until
+    /// `unsubscribe(receiver:)` is called. Re-subscribing the same instance for
+    /// the same message kind replaces the previous subscription — entries are
+    /// keyed by object identity.
+    func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        queue.async {
+            let id = ObjectIdentifier(receiver)
+            self.receivers[Receiver.Message.key, default: [:]][id] = { message, core in
+                guard let typed = message as? Receiver.Message else {
+                    return
+                }
+                receiver.receive(message: typed, from: core)
+            }
+        }
+    }
+
+    /// Removes `receiver` from the bucket for `Receiver.Message.key`.
+    ///
+    /// No-op if `receiver` is not currently subscribed. Empty buckets are
+    /// pruned to keep the registry tidy.
+    func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        queue.async {
+            let key = Receiver.Message.key
+            let id = ObjectIdentifier(receiver)
+            self.receivers[key]?.removeValue(forKey: id)
+            if self.receivers[key]?.isEmpty == true {
+                self.receivers.removeValue(forKey: key)
+            }
+        }
+    }
+
+    /// Publishes `message` to every receiver in the bucket for `Message.key`.
+    ///
+    /// Configuration telemetry messages are intercepted and accumulated for deferred
+    /// batch dispatch; they are never routed to subscribers immediately.
+    ///
+    /// `fallback` is invoked when the bus has no core, or when the bucket is
+    /// empty. Delivery is dispatched on the bus's serial queue.
+    func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage {
+        // Intercept configuration telemetry for deferred accumulated dispatch.
+        if let telemetry = message as? TelemetryMessage, case .configuration(let config) = telemetry {
+            save(configuration: config)
+            return
+        }
+
+        queue.async {
+            guard let core = self.core else {
+                return fallback()
+            }
+            guard let bucket = self.receivers[Message.key], !bucket.isEmpty else {
+                return fallback()
+            }
+            bucket.values.forEach { dispatch in
+                dispatch(message, core)
+            }
+        }
+    }
+}
+
+extension CoreMessageBus: Flushable {
     /// Awaits completion of all asynchronous operations.
     ///
     /// **blocks the caller thread**

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -53,7 +53,7 @@ internal final class DatadogCore {
     let applicationVersionPublisher: ApplicationVersionPublisher
 
     /// The message-bus instance.
-    let bus = MessageBus()
+    let bus = CoreMessageBus()
 
     /// Registry for Features.
     @ReadWriteLock
@@ -119,9 +119,9 @@ internal final class DatadogCore {
         // the bus will keep a weak ref to the core.
         bus.connect(core: self)
 
-        // forward any context change on the message-bus
+        // forward any context change on the typed message-bus
         self.contextProvider.publish { [weak self] context in
-            self?.send(message: .context(context))
+            self?.bus.send(message: context)
         }
     }
 
@@ -264,8 +264,9 @@ internal final class DatadogCore {
     ///   - key: The key associated with the receiver.
     private func add(messageReceiver: FeatureMessageReceiver, forKey key: String) {
         bus.connect(messageReceiver, forKey: key)
+        // Push current context to typed-bus DatadogContext subscribers.
         contextProvider.read { context in
-            self.bus.queue.async { messageReceiver.receive(message: .context(context), from: self) }
+            self.bus.send(message: context)
         }
     }
 
@@ -323,6 +324,8 @@ internal final class DatadogCore {
 }
 
 extension DatadogCore: DatadogCoreProtocol {
+    var messageBus: MessageBus { bus }
+
     /// Registers a Feature instance.
     ///
     /// A Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can

--- a/DatadogCore/Sources/Extensions/ContextSharing/ContextSharingTransformer.swift
+++ b/DatadogCore/Sources/Extensions/ContextSharing/ContextSharingTransformer.swift
@@ -6,24 +6,16 @@
 
 import DatadogInternal
 
-internal final class ContextSharingTransformer: FeatureMessageReceiver, ContextValuePublisher {
+internal final class ContextSharingTransformer: BusMessageReceiver, ContextValuePublisher {
     @ReadWriteLock
     private var sharedContext: SharedContext? = nil
     @ReadWriteLock
     private var receiver: ContextValueReceiver<SharedContext?>? = nil
 
-    // MARK: - FeatureMessageReceiver
-
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .context(let context):
-            let newContext = SharedContext(datadogContext: context)
-            sharedContext = newContext
-            receiver?(newContext)
-            return true
-        default:
-            return false
-        }
+    func receive(message context: DatadogContext, from core: DatadogCoreProtocol) {
+        let newContext = SharedContext(datadogContext: context)
+        sharedContext = newContext
+        receiver?(newContext)
     }
 
     // MARK: - ContextValuePublisher

--- a/DatadogCore/Sources/Extensions/CrossPlatformExtension.swift
+++ b/DatadogCore/Sources/Extensions/CrossPlatformExtension.swift
@@ -29,7 +29,9 @@ public final class CrossPlatformExtension: NSObject {
         if Self.contextSharingTransformer == nil {
             let core = CoreRegistry.default
             let contextSharingTransformer = ContextSharingTransformer()
-            try? core.register(feature: ContextSharingFeature(messageReceiver: contextSharingTransformer))
+            // Subscribe before registration so initial context push is received:
+            core.messageBus.subscribe(receiver: contextSharingTransformer)
+            try? core.register(feature: ContextSharingFeature(messageReceiver: NOPFeatureMessageReceiver()))
             Self.contextSharingTransformer = contextSharingTransformer
         }
         contextSharingTransformer?.publish(to: toSharedContext)

--- a/DatadogCore/Tests/Datadog/DatadogCore/CoreMessageBusTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/CoreMessageBusTests.swift
@@ -1,0 +1,266 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+
+@testable import DatadogCore
+
+class CoreMessageBusTests: XCTestCase {
+    func testCoreMessageBus() throws {
+        let expectation = XCTestExpectation(description: "dispatch message")
+        expectation.expectedFulfillmentCount = 2
+
+        // Given
+        let core = PassthroughCoreMock()
+
+        let receiver = FeatureMessageReceiverMock { message in
+            // Then
+            switch message {
+            case let .payload(payload as String) where payload == "value":
+                expectation.fulfill()
+            default:
+                XCTFail("wrong message case")
+            }
+        }
+
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        bus.connect(receiver, forKey: "receiver 1")
+        bus.connect(receiver, forKey: "receiver 2")
+
+        // When
+        bus.send(message: .payload("value"))
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testItForwardConfigurationAfterDispatch() throws {
+        let expectation = XCTestExpectation(description: "dispatch configuration")
+        let receiver = FeatureMessageReceiverMock { message in
+            guard
+                case .telemetry(let telemetry) = message,
+                case .configuration(let configuration) = telemetry
+            else {
+                return XCTFail("Message bus should send configuration telemetry")
+            }
+
+            XCTAssertEqual(configuration.batchSize, 1)
+            XCTAssertTrue(configuration.trackErrors ?? false)
+            expectation.fulfill()
+        }
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus(configurationDispatchTime: .milliseconds(90))
+        bus.connect(core: core)
+        bus.connect(receiver, forKey: "test")
+
+        // When
+        bus.configuration(batchSize: 1)
+        bus.configuration(trackErrors: true)
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    // MARK: - typed bus (subscribe / unsubscribe / send)
+
+    func testSubscribe_deliversMessageToReceiver() throws {
+        let expectation = XCTestExpectation(description: "receiver invoked")
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        let receiver = AlphaReceiver { message, _ in
+            XCTAssertEqual(message.value, "value")
+            expectation.fulfill()
+        }
+        bus.subscribe(receiver: receiver)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value"))
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testSubscribe_routesByMessageType() throws {
+        let expectation = XCTestExpectation(description: "matching receiver invoked")
+        expectation.assertForOverFulfill = true
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        let alpha = AlphaReceiver { _, _ in expectation.fulfill() }
+        let beta = BetaReceiver { _, _ in
+            XCTFail("BetaReceiver must not receive AlphaMessage")
+        }
+        bus.subscribe(receiver: alpha)
+        bus.subscribe(receiver: beta)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value"))
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testSubscribe_deliversToMultipleReceiversOfSameType() throws {
+        let expectation = XCTestExpectation(description: "all receivers invoked")
+        expectation.expectedFulfillmentCount = 3
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        let receivers = (0..<3).map { _ in
+            AlphaReceiver { _, _ in expectation.fulfill() }
+        }
+        receivers.forEach { bus.subscribe(receiver: $0) }
+
+        // When
+        bus.send(message: AlphaMessage(value: "value"))
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testUnsubscribe_stopsDelivery() throws {
+        let fallbackExpectation = XCTestExpectation(description: "fallback invoked")
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        let receiver = AlphaReceiver { _, _ in
+            XCTFail("receiver must not be invoked after unsubscribe")
+        }
+        bus.subscribe(receiver: receiver)
+        bus.unsubscribe(receiver: receiver)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value")) { fallbackExpectation.fulfill() }
+
+        // Then
+        wait(for: [fallbackExpectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testSend_callsFallbackWhenNoSubscribers() throws {
+        let expectation = XCTestExpectation(description: "fallback invoked")
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value")) { expectation.fulfill() }
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testSend_callsFallbackWhenCoreNotConnected() throws {
+        let expectation = XCTestExpectation(description: "fallback invoked")
+
+        // Given (no `connect(core:)` call)
+        let bus = CoreMessageBus()
+        let receiver = AlphaReceiver { _, _ in
+            XCTFail("receiver must not be invoked without a connected core")
+        }
+        bus.subscribe(receiver: receiver)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value")) { expectation.fulfill() }
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+        bus.flush()
+    }
+
+    func testSend_doesNotCallFallbackWhenDelivered() throws {
+        let delivery = XCTestExpectation(description: "receiver invoked")
+        let fallback = XCTestExpectation(description: "fallback NOT invoked")
+        fallback.isInverted = true
+
+        // Given
+        let core = PassthroughCoreMock()
+        let bus = CoreMessageBus()
+        bus.connect(core: core)
+
+        let receiver = AlphaReceiver { _, _ in delivery.fulfill() }
+        bus.subscribe(receiver: receiver)
+
+        // When
+        bus.send(message: AlphaMessage(value: "value")) { fallback.fulfill() }
+
+        // Then
+        wait(for: [delivery, fallback], timeout: 0.5)
+        bus.flush()
+    }
+}
+
+// MARK: - typed-bus fixtures
+
+private struct AlphaMessage: BusMessage {
+    static let key = "test.alpha"
+    let value: String
+}
+
+private struct BetaMessage: BusMessage {
+    static let key = "test.beta"
+}
+
+private final class AlphaReceiver: BusMessageReceiver {
+    typealias Message = AlphaMessage
+
+    let onReceive: (AlphaMessage, DatadogCoreProtocol) -> Void
+
+    init(_ onReceive: @escaping (AlphaMessage, DatadogCoreProtocol) -> Void) {
+        self.onReceive = onReceive
+    }
+
+    func receive(message: AlphaMessage, from core: DatadogCoreProtocol) {
+        onReceive(message, core)
+    }
+}
+
+private final class BetaReceiver: BusMessageReceiver {
+    typealias Message = BetaMessage
+
+    let onReceive: (BetaMessage, DatadogCoreProtocol) -> Void
+
+    init(_ onReceive: @escaping (BetaMessage, DatadogCoreProtocol) -> Void) {
+        self.onReceive = onReceive
+    }
+
+    func receive(message: BetaMessage, from core: DatadogCoreProtocol) {
+        onReceive(message, core)
+    }
+}
+
+extension CoreMessageBus: @retroactive Telemetry {
+    public func send(telemetry: DatadogInternal.TelemetryMessage) {
+        send(message: .telemetry(telemetry))
+    }
+}

--- a/DatadogCore/Tests/Datadog/Extensions/ContextSharing/ContextSharingTransformerTests.swift
+++ b/DatadogCore/Tests/Datadog/Extensions/ContextSharing/ContextSharingTransformerTests.swift
@@ -27,25 +27,11 @@ class ContextSharingTransformerTests: XCTestCase {
     func testReceiveContextMessage_transformsToSharedContext() throws {
         // Given
         let transformer = ContextSharingTransformer()
-        let message = FeatureMessage.context(.mockRandom())
 
         // When
-        let handled = transformer.receive(message: message, from: core)
+        transformer.receive(message: .mockRandom(), from: core)
 
-        // Then
-        XCTAssertTrue(handled)
-    }
-
-    func testReceiveNonContextMessage_returnsNotHandled() throws {
-        // Given
-        let transformer = ContextSharingTransformer()
-        let customMessage = FeatureMessage.payload("")
-
-        // When
-        let handled = transformer.receive(message: customMessage, from: core)
-
-        // Then
-        XCTAssertFalse(handled)
+        // Then — no assertion needed; just checking it doesn't crash
     }
 
     func testPublish_callsReceiverImmediately() throws {
@@ -78,8 +64,7 @@ class ContextSharingTransformerTests: XCTestCase {
         let userInfo = UserInfo(id: "user-456")
         let accountInfo = AccountInfo(id: "account-789")
         let context = DatadogContext.mockWith(userInfo: userInfo, accountInfo: accountInfo)
-        let message = FeatureMessage.context(context)
-        _ = transformer.receive(message: message, from: core)
+        transformer.receive(message: context, from: core)
 
         // Then
         XCTAssertEqual(receivedContexts.count, 2)
@@ -101,8 +86,7 @@ class ContextSharingTransformerTests: XCTestCase {
         transformer.cancel()
 
         let context = DatadogContext.mockWith(userInfo: UserInfo(id: "user-789"))
-        let message = FeatureMessage.context(context)
-        _ = transformer.receive(message: message, from: core)
+        transformer.receive(message: context, from: core)
 
         // Then - receiver must not be called after cancel
         XCTAssertEqual(callCount, 1) // Only initial call from publish


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Renames the internal `MessageBus` class to `CoreMessageBus` and makes it implement the new `MessageBus` protocol with typed subscribe/unsubscribe/send. Wires `DatadogCore.messageBus` to expose it, and forwards `DatadogContext` updates through the typed bus. Migrates `ContextSharingTransformer` to `BusMessageReceiver`, and `CrossPlatformExtension` to subscribe via the typed bus. Updates the renamed test and adds a comprehensive new `CoreMessageBusTests`.

## Refactoring rationale

Core's bus implementation must now satisfy the new `MessageBus` protocol while still supporting legacy `FeatureMessageReceiver` subscribers during the migration. The rename clarifies the distinction between the public protocol and the concrete implementation. Configuration telemetry continues to be intercepted and deferred-dispatched to both buses.

---
_Draft — pending author review. Merge in order unless marked parallel._