### PR TITLE
[chain-pr 4/13] Migrate DatadogCrashReporting to typed MessageBus

### DIFF
--- a/DatadogCrashReporting/Sources/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContextProvider.swift
@@ -47,6 +47,9 @@ internal class CrashContextCoreProvider: CrashContextProvider {
         didSet { _context?.lastRUMAttributes = rumAttributes }
     }
 
+    /// Typed-bus subscription handles. Retaining these keeps the closures alive.
+    private var subscriptions: [MessageBusSubscription] = []
+
     // MARK: - CrashContextProviderType
 
     var currentCrashContext: CrashContext? {
@@ -61,30 +64,13 @@ internal class CrashContextCoreProvider: CrashContextProvider {
 
 extension CrashContextCoreProvider: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .context(let context):
-            update(context: context)
-        case let .payload(viewEvent as RUMViewEvent):
-            queue.async { self.viewEvent = viewEvent }
-        case let .payload(message as String) where message == RUMPayloadMessages.viewReset:
-            queue.async { self.viewEvent = nil }
-        case let .payload(sessionState as RUMSessionState):
-            queue.async { self.sessionState = sessionState }
-        case let .payload(rumAttributes as RUMEventAttributes):
-            queue.async { self.rumAttributes = rumAttributes }
-        case let .payload(logAttributes as LogEventAttributes):
-            queue.async { self.logAttributes = logAttributes }
-        default:
-            return false
-        }
-
-        return true
+        return false
     }
 
     /// Updates crash context.
     ///
     /// - Parameter context: The updated core context.
-    private func update(context: DatadogContext) {
+    fileprivate func update(context: DatadogContext) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
@@ -102,6 +88,37 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
                 self._context = crashContext
             }
         }
+    }
+}
+
+// MARK: - Typed-bus subscriptions
+
+extension CrashContextCoreProvider {
+    /// Subscribes to all crash-context update messages on the typed bus.
+    ///
+    /// Call once from `CrashReporting.enableOrThrow`. The returned subscriptions are retained
+    /// by the provider and cancelled when it is deallocated.
+    func subscribe(to bus: MessageBus) {
+        subscriptions = [
+            bus.subscribe { [weak self] (context: DatadogContext, _) in
+                self?.update(context: context)
+            },
+            bus.subscribe { [weak self] (message: RUMViewEvent, _) in
+                self?.queue.async { self?.viewEvent = message }
+            },
+            bus.subscribe { [weak self] (_: RUMViewReset, _) in
+                self?.queue.async { self?.viewEvent = nil }
+            },
+            bus.subscribe { [weak self] (message: RUMSessionState, _) in
+                self?.queue.async { self?.sessionState = message }
+            },
+            bus.subscribe { [weak self] (message: RUMEventAttributes, _) in
+                self?.queue.async { self?.rumAttributes = message }
+            },
+            bus.subscribe { [weak self] (message: LogEventAttributes, _) in
+                self?.queue.async { self?.logAttributes = message }
+            },
+        ]
     }
 }
 

--- a/DatadogCrashReporting/Sources/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/CrashReportSender.swift
@@ -41,10 +41,8 @@ internal struct MessageBusSender: CrashReportSender {
             return
         }
 
-        core.send(
-            message: .payload(
-                Crash(report: report, context: context)
-            ),
+        core.messageBus.send(
+            message: Crash(report: report, context: context),
             else: {
                 DD.logger.warn(
                     """

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -62,6 +62,9 @@ public final class CrashReporting {
 
         try core.register(feature: reporter)
 
+        // Subscribe typed-bus receivers for crash context updates:
+        contextProvider.subscribe(to: core.messageBus)
+
         if let backtraceReporter = plugin.backtraceReporter {
             try core.register(backtraceReporter: backtraceReporter)
         }

--- a/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
@@ -11,25 +11,36 @@ import DatadogInternal
 @testable import DatadogCrashReporting
 
 class CrashContextCoreProviderTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var core: PassthroughCoreMock!
+    private var provider: CrashContextCoreProvider!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+        provider = CrashContextCoreProvider()
+        provider.subscribe(to: core.messageBus)
+    }
+
+    override func tearDown() {
+        core = nil
+        provider = nil
+        super.tearDown()
+    }
+
     // MARK: - Context Update Tests
 
     func testItUpdatesContextFromDatadogContext() {
-        // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockWith(
+        // When
+        XCTAssertTrue(provider.receive(message: .context(.mockWith(
             service: "test-service",
             env: "test-env",
             version: "1.0.0"
-        )
-
-        // When
-        let message: FeatureMessage = .context(context)
-        XCTAssertTrue(provider.receive(message: message, from: core))
+        )), from: core))
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext)
         XCTAssertEqual(provider.currentCrashContext?.service, "test-service")
         XCTAssertEqual(provider.currentCrashContext?.env, "test-env")
         XCTAssertEqual(provider.currentCrashContext?.version, "1.0.0")
@@ -37,21 +48,16 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItDoesNotUpdateContextWhenContextIsUnchanged() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
         let context: DatadogContext = .mockWith(service: "test-service")
         var callbackCount = 0
-
-        provider.onCrashContextChange = { _ in
-            callbackCount += 1
-        }
+        provider.onCrashContextChange = { _ in callbackCount += 1 }
 
         // When
         XCTAssertTrue(provider.receive(message: .context(context), from: core))
         XCTAssertTrue(provider.receive(message: .context(context), from: core))
         provider.flush()
 
-        // Then - callback should only be called once for the actual change
+        // Then — callback fires once per distinct value
         XCTAssertEqual(callbackCount, 1)
     }
 
@@ -59,36 +65,27 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItStoresRUMViewEvent() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let viewEvent: RUMViewEvent = .mockRandom()
+        XCTAssertTrue(provider.receive(message: .context(.mockAny()), from: core))
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(viewEvent), from: core))
+        core.messageBus.send(message: viewEvent)
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext?.lastRUMViewEvent)
         XCTAssertEqual(provider.currentCrashContext?.lastRUMViewEvent?.view.id, viewEvent.view.id)
     }
 
     func testItResetsRUMViewEventOnViewReset() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let viewEvent: RUMViewEvent = .mockRandom()
-
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(viewEvent), from: core))
+        XCTAssertTrue(provider.receive(message: .context(.mockAny()), from: core))
+        core.messageBus.send(message: viewEvent)
         provider.flush()
-
         XCTAssertNotNil(provider.currentCrashContext?.lastRUMViewEvent)
 
         // When
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: core))
+        core.messageBus.send(message: RUMViewReset())
         provider.flush()
 
         // Then
@@ -99,18 +96,15 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItStoresRUMSessionState() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let sessionState: RUMSessionState = .mockRandom()
+        XCTAssertTrue(provider.receive(message: .context(.mockAny()), from: core))
+        provider.flush()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(sessionState), from: core))
+        core.messageBus.send(message: sessionState)
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext?.lastRUMSessionState)
         XCTAssertEqual(provider.currentCrashContext?.lastRUMSessionState?.sessionUUID, sessionState.sessionUUID)
     }
 
@@ -118,35 +112,23 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItInvokesCallbackOnContextChange() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockWith(service: "test-service")
         var receivedContext: CrashContext?
-
-        provider.onCrashContextChange = { crashContext in
-            receivedContext = crashContext
-        }
+        provider.onCrashContextChange = { receivedContext = $0 }
         provider.flush()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
+        XCTAssertTrue(provider.receive(message: .context(.mockWith(service: "test-service")), from: core))
         provider.flush()
 
         // Then
-        XCTAssertNotNil(receivedContext)
         XCTAssertEqual(receivedContext?.service, "test-service")
     }
 
     // MARK: - Message Handling Tests
 
     func testItReturnsFalseForUnhandledMessages() {
-        // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let unrelatedMessage = "some unrelated message"
-
         // When
-        let handled = provider.receive(message: .payload(unrelatedMessage), from: core)
+        let handled = provider.receive(message: .payload("unrelated"), from: core)
 
         // Then
         XCTAssertFalse(handled)

--- a/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
@@ -16,7 +16,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItSendsCrashReportWhenTrackingConsentIsGranted() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .granted)
         let crashReport: DDCrashReport = .mockAny()
@@ -33,7 +34,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItDoesNotSendCrashReportWhenTrackingConsentIsNotGranted() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .notGranted)
         let crashReport: DDCrashReport = .mockAny()
@@ -48,7 +50,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItDoesNotSendCrashReportWhenTrackingConsentIsPending() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .pending)
         let crashReport: DDCrashReport = .mockAny()
@@ -63,7 +66,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItSendsCrashReportWithCorrectContext() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(
             service: "test-service",


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Migrates `CrashContextCoreProvider` to subscribe to the typed bus for `DatadogContext`, RUM events, session state, attributes, and view-reset. Migrates `MessageBusSender` to publish typed `Crash` messages. Wires the subscription in `CrashReporting.enableOrThrow`. Updates accompanying tests.

## Refactoring rationale

The crash-reporting feature was the heaviest consumer of `.context` and `.payload` messages. Splitting subscriptions per typed message removes the single-receiver fan-in and lets each update path be tested independently.

---
_Draft — pending author review. Merge in order unless marked parallel._