### PR TITLE
[chain-pr 5/13] Migrate DatadogLogs to typed MessageBus

### DIFF
--- a/DatadogLogs/Sources/Feature/LogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/LogsFeature.swift
@@ -14,6 +14,12 @@ internal struct LogsFeature: DatadogRemoteFeature {
 
     let messageReceiver: FeatureMessageReceiver
 
+    /// Typed-bus receiver for `LogMessage`.
+    let logMessageReceiver: LogMessageReceiver
+
+    /// Typed-bus receiver for WebView log events.
+    let webViewLogReceiver: WebViewLogReceiver
+
     let logEventMapper: LogEventMapper?
 
     let backtraceReporter: BacktraceReporting?
@@ -40,10 +46,7 @@ internal struct LogsFeature: DatadogRemoteFeature {
                 customIntakeURL: customIntakeURL,
                 telemetry: telemetry
             ),
-            messageReceiver: CombinedFeatureMessageReceiver(
-                LogMessageReceiver(logEventMapper: logEventMapper),
-                WebViewLogReceiver()
-            ),
+            messageReceiver: NOPFeatureMessageReceiver(),
             dateProvider: dateProvider,
             backtraceReporter: backtraceReporter
         )
@@ -59,6 +62,8 @@ internal struct LogsFeature: DatadogRemoteFeature {
         self.logEventMapper = logEventMapper
         self.requestBuilder = requestBuilder
         self.messageReceiver = messageReceiver
+        self.logMessageReceiver = LogMessageReceiver(logEventMapper: logEventMapper)
+        self.webViewLogReceiver = WebViewLogReceiver()
         self.dateProvider = dateProvider
         self.backtraceReporter = backtraceReporter
         self.attributes = SynchronizedAttributes(attributes: [:])

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -8,26 +8,21 @@ import Foundation
 import DatadogInternal
 
 /// Receiver to consume a Log message
-internal struct LogMessageReceiver: FeatureMessageReceiver {
+internal final class LogMessageReceiver: BusMessageReceiver {
     /// The log event mapper
     let logEventMapper: LogEventMapper?
 
-    /// Process messages receives from the bus.
-    ///
-    /// - Parameters:
-    ///   - message: The Feature message
-    ///   - core: The core from which the message is transmitted.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .payload(log as LogMessage) = message else {
-            return false
-        }
+    init(logEventMapper: LogEventMapper?) {
+        self.logEventMapper = logEventMapper
+    }
 
+    func receive(message log: LogMessage, from core: DatadogCoreProtocol) {
         core.scope(for: LogsFeature.self).eventWriteContext { context, writer in
             let builder = LogEventBuilder(
                 service: log.service ?? context.service,
                 loggerName: log.logger,
                 networkInfoEnabled: log.networkInfoEnabled ?? false,
-                eventMapper: logEventMapper
+                eventMapper: self.logEventMapper
             )
 
             builder.createLogEvent(
@@ -56,22 +51,13 @@ internal struct LogMessageReceiver: FeatureMessageReceiver {
                 callback: writer.write
             )
         }
-
-        return true
     }
 }
 
 /// Receiver to consume a Log event coming from Browser SDK.
-internal struct WebViewLogReceiver: FeatureMessageReceiver {
-    /// Process messages receives from the bus.
-    ///
-    /// - Parameters:
-    ///   - message: The Feature message
-    ///   - core: The core from which the message is transmitted.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case var .webview(.log(event)) = message else {
-            return false
-        }
+internal final class WebViewLogReceiver: BusMessageReceiver {
+    func receive(message: WebViewLogMessage, from core: DatadogCoreProtocol) {
+        var event = message.event
 
         let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
         let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
@@ -105,7 +91,5 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
 
             writer.write(value: AnyEncodable(event))
         }
-
-        return true
     }
 }

--- a/DatadogLogs/Sources/Logger.swift
+++ b/DatadogLogs/Sources/Logger.swift
@@ -155,6 +155,7 @@ public struct Logger {
 
             return RemoteLogger(
                 featureScope: core.scope(for: LogsFeature.self),
+                messageBus: core.messageBus,
                 globalAttributes: feature.attributes,
                 configuration: RemoteLogger.Configuration(
                     service: configuration.service,

--- a/DatadogLogs/Sources/Logs.swift
+++ b/DatadogLogs/Sources/Logs.swift
@@ -89,6 +89,10 @@ public enum Logs {
         )
 
         try core.register(feature: feature)
+
+        // Subscribe typed-bus receivers:
+        core.messageBus.subscribe(receiver: feature.logMessageReceiver)
+        core.messageBus.subscribe(receiver: feature.webViewLogReceiver)
     }
 
     /// Adds a custom attribute to all future logs sent by any logger created from the provided Core.
@@ -120,10 +124,10 @@ public enum Logs {
     }
 
     private static func sendAttributesChanged(for feature: LogsFeature, in core: DatadogCoreProtocol) {
-        core.send(
-            message: .payload(LogEventAttributes(
+        core.messageBus.send(
+            message: LogEventAttributes(
                 attributes: feature.attributes.getAttributes()
-            ))
+            )
         )
     }
 }

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -27,6 +27,8 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
 
     /// Logs feature scope.
     let featureScope: FeatureScope
+    /// Typed message bus, used to forward log errors to RUM.
+    let messageBus: MessageBus
     /// Configuration specific to this logger.
     let configuration: Configuration
     /// Date provider for logs.
@@ -48,6 +50,7 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
 
     init(
         featureScope: FeatureScope,
+        messageBus: MessageBus,
         globalAttributes: SynchronizedAttributes,
         configuration: Configuration,
         dateProvider: DateProvider,
@@ -56,6 +59,7 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
         backtraceReporter: BacktraceReporting?
     ) {
         self.featureScope = featureScope
+        self.messageBus = messageBus
         self.globalAttributes = globalAttributes
         self.loggerAttributes = SynchronizedAttributes(attributes: [:])
         self.loggerTags = SynchronizedTags(tags: [])
@@ -193,17 +197,15 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
                     busCombinedAttributes[Logs.Attributes.errorFingerprint] = errorFingerprint
                 }
 
-                self.featureScope.send(
-                    message: .payload(
-                        RUMErrorMessage(
-                            time: date,
-                            message: log.error?.message ?? log.message,
-                            source: "logger",
-                            type: log.error?.kind,
-                            stack: log.error?.stack,
-                            attributes: busCombinedAttributes,
-                            binaryImages: binaryImages
-                        )
+                self.messageBus.send(
+                    message: RUMErrorMessage(
+                        time: date,
+                        message: log.error?.message ?? log.message,
+                        source: "logger",
+                        type: log.error?.kind,
+                        stack: log.error?.stack,
+                        attributes: busCombinedAttributes,
+                        binaryImages: binaryImages
                     )
                 )
             }

--- a/DatadogLogs/Tests/LogMessageReceiverTests.swift
+++ b/DatadogLogs/Tests/LogMessageReceiverTests.swift
@@ -13,27 +13,23 @@ class LogMessageReceiverTests: XCTestCase {
     func testReceivePartialLogMessage() throws {
         // Given
         let expectation = expectation(description: "Send log")
-        let core = PassthroughCoreMock(
-            context: .mockWith(service: "service-test"),
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let core = PassthroughCoreMock(context: .mockWith(service: "service-test"))
+        core.subscribe(receiver: LogMessageReceiver.mockAny())
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        core.send(
-            message: .payload(
-                LogMessage(
-                    logger: "logger-test",
-                    service: nil,
-                    date: .mockDecember15th2019At10AMUTC(),
-                    message: "message-test",
-                    error: nil,
-                    level: .info,
-                    thread: "thread-test",
-                    networkInfoEnabled: nil,
-                    userAttributes: nil,
-                    internalAttributes: nil
-                )
+        core.messageBus.send(
+            message: LogMessage(
+                logger: "logger-test",
+                service: nil,
+                date: .mockDecember15th2019At10AMUTC(),
+                message: "message-test",
+                error: nil,
+                level: .info,
+                thread: "thread-test",
+                networkInfoEnabled: nil,
+                userAttributes: nil,
+                internalAttributes: nil
             )
         )
 
@@ -56,27 +52,23 @@ class LogMessageReceiverTests: XCTestCase {
     func testReceiveCompleteLogMessage() throws {
         // Given
         let expectation = expectation(description: "Send log")
-        let core = PassthroughCoreMock(
-            context: .mockAny(),
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let core = PassthroughCoreMock(context: .mockAny())
+        core.subscribe(receiver: LogMessageReceiver.mockAny())
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        core.send(
-            message: .payload(
-                LogMessage(
-                    logger: "logger-test",
-                    service: "service-test",
-                    date: .mockDecember15th2019At10AMUTC(),
-                    message: "message-test",
-                    error: .mockAny(),
-                    level: .info,
-                    thread: "thread-test",
-                    networkInfoEnabled: true,
-                    userAttributes: ["user": "attribute"],
-                    internalAttributes: ["internal": "attribute"]
-                )
+        core.messageBus.send(
+            message: LogMessage(
+                logger: "logger-test",
+                service: "service-test",
+                date: .mockDecember15th2019At10AMUTC(),
+                message: "message-test",
+                error: .mockAny(),
+                level: .info,
+                thread: "thread-test",
+                networkInfoEnabled: true,
+                userAttributes: ["user": "attribute"],
+                internalAttributes: ["internal": "attribute"]
             )
         )
 
@@ -105,29 +97,25 @@ class LogMessageReceiverTests: XCTestCase {
     func testReceiveRejectedLogMessage() throws {
         // Given
         let expectation = expectation(description: "Open scope but don't send log")
-        let core = PassthroughCoreMock(
-            context: .mockWith(service: "service-test"),
-            messageReceiver: LogMessageReceiver(
-                logEventMapper: SyncLogEventMapper { _ in nil }
-            )
-        )
+        let core = PassthroughCoreMock(context: .mockWith(service: "service-test"))
+        core.subscribe(receiver: LogMessageReceiver(
+            logEventMapper: SyncLogEventMapper { _ in nil }
+        ))
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        core.send(
-            message: .payload(
-                LogMessage(
-                    logger: "logger-test",
-                    service: nil,
-                    date: .mockDecember15th2019At10AMUTC(),
-                    message: "message-test",
-                    error: nil,
-                    level: .info,
-                    thread: "thread-test",
-                    networkInfoEnabled: nil,
-                    userAttributes: nil,
-                    internalAttributes: nil
-                )
+        core.messageBus.send(
+            message: LogMessage(
+                logger: "logger-test",
+                service: nil,
+                date: .mockDecember15th2019At10AMUTC(),
+                message: "message-test",
+                error: nil,
+                level: .info,
+                thread: "thread-test",
+                networkInfoEnabled: nil,
+                userAttributes: nil,
+                internalAttributes: nil
             )
         )
 

--- a/DatadogLogs/Tests/LogsTests.swift
+++ b/DatadogLogs/Tests/LogsTests.swift
@@ -128,12 +128,10 @@ class LogsTests: XCTestCase {
 
     func testItSendsGlobalLogUpdates_whenAddAttribute() throws {
         // Given
-        let mockMessageReceiver = FeatureMessageReceiverMock()
-        let core = SingleFeatureCoreMock<LogsFeature>(
-            messageReceiver: mockMessageReceiver
-        )
-        let config = Logs.Configuration()
-        Logs.enable(with: config, in: core)
+        let core = SingleFeatureCoreMock<LogsFeature>()
+        Logs.enable(with: .init(), in: core)
+        var received: [LogEventAttributes] = []
+        _ = core.messageBus.subscribe { (attrs: LogEventAttributes, _) in received.append(attrs) }
 
         // When
         let attributeKey: String = .mockRandom()
@@ -141,20 +139,17 @@ class LogsTests: XCTestCase {
         Logs.addAttribute(forKey: attributeKey, value: attributeValue, in: core)
 
         // Then
-        let messages = mockMessageReceiver.messages.compactMap { $0.asPayload as? LogEventAttributes }
-        XCTAssertEqual(messages.count, 1)
-        let message = try XCTUnwrap(messages.first)
+        XCTAssertEqual(received.count, 1)
+        let message = try XCTUnwrap(received.first)
         XCTAssertEqual(message.attributes[attributeKey] as? String, attributeValue)
     }
 
     func testItSendsGlobalLogUpdates_whenRemoveAttribute() throws {
         // Given
-        let mockMessageReceiver = FeatureMessageReceiverMock()
-        let core = SingleFeatureCoreMock<LogsFeature>(
-            messageReceiver: mockMessageReceiver
-        )
-        let config = Logs.Configuration()
-        Logs.enable(with: config, in: core)
+        let core = SingleFeatureCoreMock<LogsFeature>()
+        Logs.enable(with: .init(), in: core)
+        var received: [LogEventAttributes] = []
+        _ = core.messageBus.subscribe { (attrs: LogEventAttributes, _) in received.append(attrs) }
         let attributeKey: String = .mockRandom()
         let attributeValue: String = .mockRandom()
         Logs.addAttribute(forKey: attributeKey, value: attributeValue, in: core)
@@ -163,9 +158,8 @@ class LogsTests: XCTestCase {
         Logs.removeAttribute(forKey: attributeKey, in: core)
 
         // Then
-        let messages = mockMessageReceiver.messages.compactMap { $0.asPayload as? LogEventAttributes }
-        XCTAssertEqual(messages.count, 2)
-        let message = try XCTUnwrap(messages.last)
+        XCTAssertEqual(received.count, 2)
+        let message = try XCTUnwrap(received.last)
         XCTAssertNil(message.attributes[attributeKey])
     }
 }

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -9,8 +9,22 @@ import TestUtilities
 import DatadogInternal
 @testable import DatadogLogs
 
+private final class RUMErrorMessageRecorder: BusMessageReceiver {
+    private(set) var messages: [RUMErrorMessage] = []
+    func receive(message: RUMErrorMessage, from core: DatadogCoreProtocol) {
+        messages.append(message)
+    }
+}
+
 class RemoteLoggerTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
+    private let messageBus = PassthroughCoreMock()
+    private let errorRecorder = RUMErrorMessageRecorder()
+
+    override func setUp() {
+        super.setUp()
+        messageBus.subscribe(receiver: errorRecorder)
+    }
 
     // MARK: - Sending Error Message over Message Bus
 
@@ -33,6 +47,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -45,13 +60,14 @@ class RemoteLoggerTests: XCTestCase {
         logger.info("Info message")
 
         // Then
-        XCTAssertEqual(featureScope.messagesSent().count, 0)
+        XCTAssertEqual(errorRecorder.messages.count, 0)
     }
 
     func testWhenErrorLogged_itPostsToMessageBus() throws {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -64,7 +80,7 @@ class RemoteLoggerTests: XCTestCase {
         logger.error("Error message")
 
         // Then
-        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        let errorMessage = try XCTUnwrap(errorRecorder.messages.first)
         XCTAssertEqual(errorMessage.message, "Error message")
     }
 
@@ -72,6 +88,7 @@ class RemoteLoggerTests: XCTestCase {
         let stubBacktrace: BacktraceReport = .mockRandom()
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -84,7 +101,7 @@ class RemoteLoggerTests: XCTestCase {
         logger.error("Information message", error: ErrorMock(), attributes: [CrossPlatformAttributes.includeBinaryImages: true])
 
         // Then
-        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        let errorMessage = try XCTUnwrap(errorRecorder.messages.first)
         // This is removed because binary images are sent in the message, so the additional attribute isn't needed
         XCTAssertNil(errorMessage.attributes[CrossPlatformAttributes.includeBinaryImages])
         XCTAssertEqual(errorMessage.binaryImages?.count, stubBacktrace.binaryImages.count)
@@ -104,6 +121,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -124,7 +142,7 @@ class RemoteLoggerTests: XCTestCase {
         )
 
         // Then
-        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        let errorMessage = try XCTUnwrap(errorRecorder.messages.first)
         XCTAssertEqual(errorMessage.attributes[CrossPlatformAttributes.errorSourceType] as? String, "flutter")
         XCTAssertEqual(errorMessage.attributes[Logs.Attributes.errorFingerprint] as? String, mockFingerprint)
     }
@@ -133,6 +151,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -156,7 +175,7 @@ class RemoteLoggerTests: XCTestCase {
         )
 
         // Then
-        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        let errorMessage = try XCTUnwrap(errorRecorder.messages.first)
         XCTAssertEqual(errorMessage.attributes[CrossPlatformAttributes.errorSourceType] as? String, "flutter")
         XCTAssertEqual(errorMessage.attributes[Logs.Attributes.errorFingerprint] as? String, mockFingerprint)
     }
@@ -169,6 +188,7 @@ class RemoteLoggerTests: XCTestCase {
 
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -214,6 +234,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -250,6 +271,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: SynchronizedAttributes(attributes: [attributeKey: attributeValue]),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -277,6 +299,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: SynchronizedAttributes(attributes: [attributeKey: globalAttributeValue]),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -306,6 +329,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: SynchronizedAttributes(attributes: [attributeKey: globalAttributeValue]),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -333,6 +357,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: SynchronizedAttributes(attributes: [attributeKey: attributeValue]),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -345,7 +370,7 @@ class RemoteLoggerTests: XCTestCase {
         logger.error("Error message")
 
         // Then
-        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        let errorMessage = try XCTUnwrap(errorRecorder.messages.first)
         XCTAssertEqual(errorMessage.attributes[attributeKey] as? String, attributeValue)
     }
 
@@ -353,6 +378,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -378,6 +404,7 @@ class RemoteLoggerTests: XCTestCase {
         let stubBacktrace: BacktraceReport = .mockRandom()
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -415,6 +442,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -454,6 +482,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -497,6 +526,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -537,6 +567,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -566,6 +597,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -601,6 +633,7 @@ class RemoteLoggerTests: XCTestCase {
         // Given
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -638,6 +671,7 @@ class RemoteLoggerTests: XCTestCase {
 
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),
@@ -685,6 +719,7 @@ class RemoteLoggerTests: XCTestCase {
 
         let logger = RemoteLogger(
             featureScope: featureScope,
+            messageBus: messageBus.messageBus,
             globalAttributes: .mockAny(),
             configuration: .mockAny(),
             dateProvider: RelativeDateProvider(),

--- a/DatadogLogs/Tests/WebViewLogReceiverTests.swift
+++ b/DatadogLogs/Tests/WebViewLogReceiverTests.swift
@@ -65,11 +65,9 @@ class WebViewLogReceiverTests: XCTestCase {
         let value: String = .mockRandom()
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(["test": value])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: ["test": value]),
+            from: core
         )
 
         // Then
@@ -117,11 +115,9 @@ class WebViewLogReceiverTests: XCTestCase {
         ]
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(webLogEvent)),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: webLogEvent),
+            from: core
         )
 
         // Then
@@ -167,11 +163,9 @@ class WebViewLogReceiverTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(["test": "value"])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: ["test": "value"]),
+            from: core
         )
 
         // Then
@@ -204,17 +198,15 @@ class WebViewLogReceiverTests: XCTestCase {
                         sessionSampler: .mockRejectAll()
                     )
                 ]
-            ),
-            messageReceiver: telemetryReceiver
+            )
         )
+        core.subscribe(receiver: telemetryReceiver)
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(["test": "value"])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: ["test": "value"]),
+            from: core
         )
 
         // Then
@@ -236,15 +228,14 @@ class WebViewLogReceiverTests: XCTestCase {
         let messageReceiver = WebViewLogReceiver()
         let telemetryReceiver = TelemetryReceiverMock()
         let expectation = expectation(description: "Send log")
-        let core = PassthroughCoreMock(messageReceiver: telemetryReceiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetryReceiver)
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(["test": "value"])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: ["test": "value"]),
+            from: core
         )
 
         // Then
@@ -279,14 +270,12 @@ class WebViewLogReceiverTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log([
-                    "test": "value",
-                    "usr": ["id": webUsrId, "name": webUsrName]
-                ])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: [
+                "test": "value",
+                "usr": ["id": webUsrId, "name": webUsrName]
+            ]),
+            from: core
         )
 
         // Then
@@ -313,14 +302,12 @@ class WebViewLogReceiverTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log([
-                    "test": "value",
-                    "usr": ["anonymous_id": browserAnonymousId]
-                ])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: [
+                "test": "value",
+                "usr": ["anonymous_id": browserAnonymousId]
+            ]),
+            from: core
         )
 
         // Then
@@ -344,11 +331,9 @@ class WebViewLogReceiverTests: XCTestCase {
         core.onEventWriteContext = { _ in expectation.fulfill() }
 
         // When
-        XCTAssert(
-            messageReceiver.receive(
-                message: .webview(.log(["test": "value"])),
-                from: core
-            )
+        messageReceiver.receive(
+            message: WebViewLogMessage(event: ["test": "value"]),
+            from: core
         )
 
         // Then


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Converts `LogMessageReceiver` and `WebViewLogReceiver` to `BusMessageReceiver`, exposes them on `LogsFeature`, and subscribes them via `Logs.enable`. Routes `RemoteLogger`'s error messages and `Logs.addAttribute`/`removeAttribute` notifications through the typed bus. Updates Log/WebView/RemoteLogger tests.

## Refactoring rationale

Logs receivers had to scrutinise every `FeatureMessage` value to find their payload. Typed receivers remove the runtime check and make the WebView and log entry points symmetric.

---
_Draft — pending author review. Merge in order unless marked parallel._