### PR TITLE
[chain-pr 6/13] Migrate DatadogTrace to typed MessageBus

### DIFF
--- a/DatadogTrace/Sources/Feature/MessageReceivers.swift
+++ b/DatadogTrace/Sources/Feature/MessageReceivers.swift
@@ -21,7 +21,7 @@ internal struct CoreContext {
     var accountInfo: AccountInfo?
 }
 
-internal final class ContextMessageReceiver: FeatureMessageReceiver {
+internal final class ContextMessageReceiver: BusMessageReceiver {
     /// Creates a new `ContextMessageReceiver`.
     ///
     /// - parameters:
@@ -41,24 +41,7 @@ internal final class ContextMessageReceiver: FeatureMessageReceiver {
     /// The tracer sampler that should be updated with the RUM deterministic sampler.
     let samplerProvider: SamplerProvider
 
-    /// Process messages receives from the bus.
-    ///
-    /// - Parameters:
-    ///   - message: The Feature message
-    ///   - core: The core from which the message is transmitted.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .context(let context):
-            return update(context: context, from: core)
-        default:
-            return false
-        }
-    }
-
-    /// Updates context of the `DatadogTracer` if available.
-    ///
-    /// - Parameter context: The updated core context.
-    private func update(context datadogContext: DatadogContext, from core: DatadogCoreProtocol) -> Bool {
+    func receive(message datadogContext: DatadogContext, from core: DatadogCoreProtocol) {
         let rumContext = datadogContext.additionalContext(ofType: RUMCoreContext.self)
 
         _context.mutate {
@@ -69,7 +52,5 @@ internal final class ContextMessageReceiver: FeatureMessageReceiver {
         }
 
         samplerProvider.updateWith(deterministicSampler: rumContext?.sessionSampler)
-
-        return true
     }
 }

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -11,7 +11,7 @@ internal final class TraceFeature: DatadogRemoteFeature {
     static let name = "tracing"
 
     let requestBuilder: FeatureRequestBuilder
-    var messageReceiver: FeatureMessageReceiver { contextReceiver }
+    let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
 
     let tracer: DatadogTracer
     let contextReceiver: ContextMessageReceiver

--- a/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
+++ b/DatadogTrace/Sources/Integrations/TracingWithLoggingIntegration.swift
@@ -61,23 +61,21 @@ internal struct TracingWithLoggingIntegration {
             )
         : nil
 
-        core.send(
-            message: .payload(
-                LogMessage(
-                    logger: "trace",
-                    service: service,
-                    date: date,
-                    message: message,
-                    error: extractedError,
-                    level: level,
-                    thread: Thread.current.dd.name,
-                    networkInfoEnabled: networkInfoEnabled,
-                    userAttributes: userAttributes,
-                    internalAttributes: [
-                        Constants.traceIDKey: String(spanContext.traceID, representation: .hexadecimal),
-                        Constants.spanIDKey: String(spanContext.spanID, representation: .hexadecimal)
-                    ]
-                )
+        core.messageBus.send(
+            message: LogMessage(
+                logger: "trace",
+                service: service,
+                date: date,
+                message: message,
+                error: extractedError,
+                level: level,
+                thread: Thread.current.dd.name,
+                networkInfoEnabled: networkInfoEnabled,
+                userAttributes: userAttributes,
+                internalAttributes: [
+                    Constants.traceIDKey: String(spanContext.traceID, representation: .hexadecimal),
+                    Constants.spanIDKey: String(spanContext.spanID, representation: .hexadecimal)
+                ]
             ),
             else: fallback
         )

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -42,6 +42,10 @@ public enum Trace {
 
         // Register Trace feature:
         let trace = TraceFeature(in: core, configuration: configuration)
+
+        // Subscribe typed-bus receivers before registration so initial context push is received:
+        core.messageBus.subscribe(receiver: trace.contextReceiver)
+
         try core.register(feature: trace)
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:

--- a/DatadogTrace/Tests/ContextMessageReceiverTests.swift
+++ b/DatadogTrace/Tests/ContextMessageReceiverTests.swift
@@ -14,10 +14,8 @@ class ContextMessageReceiverTests: XCTestCase {
     func testItReceivesApplicationStateHistory() throws {
         // Given
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        let core = PassthroughCoreMock(
-            context: .mockWith(applicationStateHistory: .mockAppInBackground()),
-            messageReceiver: receiver
-        )
+        let core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        core.subscribe(receiver: receiver)
 
         XCTAssertEqual(receiver.context.applicationStateHistory?.currentState, .background)
 

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -20,7 +20,8 @@ class TracingURLSessionHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        core = PassthroughCoreMock(messageReceiver: receiver)
+        core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
 
         tracer = .mockWith(
             core: core,


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Converts `ContextMessageReceiver` to `BusMessageReceiver<DatadogContext>`, makes `TraceFeature` opt out of the legacy receiver, routes `TracingWithLoggingIntegration` log emission through `core.messageBus`, and subscribes the context receiver in `Trace.enable`. Updates trace tests.

## Refactoring rationale

Trace only listens for `DatadogContext` and only emits `LogMessage` — both are now typed messages, so the bridging layer collapses to direct typed publishes.

---
_Draft — pending author review. Merge in order unless marked parallel._