### PR TITLE
[chain-pr 7/13] Migrate DatadogFlags to typed MessageBus

### DIFF
--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -189,7 +189,7 @@ public final class FlagsClient {
             ),
             exposureLogger: feature.makeExposureLogger(featureScope),
             evaluationLogger: feature.makeEvaluationLogger(featureScope),
-            rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter(featureScope)
+            rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter()
         )
 
         feature.clientRegistry.register(client, named: name)

--- a/DatadogFlags/Sources/Client/RUMFlagEvaluationReporter.swift
+++ b/DatadogFlags/Sources/Client/RUMFlagEvaluationReporter.swift
@@ -12,19 +12,17 @@ internal protocol RUMFlagEvaluationReporting {
 }
 
 internal final class RUMFlagEvaluationReporter: RUMFlagEvaluationReporting {
-    private let featureScope: any FeatureScope
+    private let messageBus: any MessageBus
 
-    init(featureScope: any FeatureScope) {
-        self.featureScope = featureScope
+    init(messageBus: any MessageBus) {
+        self.messageBus = messageBus
     }
 
     func sendFlagEvaluation<T>(flagKey: String, value: T) where T: FlagValue {
-        featureScope.send(
-            message: .payload(
-                RUMFlagEvaluationMessage(
-                    flagKey: flagKey,
-                    value: value
-                )
+        messageBus.send(
+            message: RUMFlagEvaluationMessage(
+                flagKey: flagKey,
+                value: value
             )
         )
     }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -21,7 +21,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
     let clientRegistry: FlagsClientRegistry
     let makeExposureLogger: (any FeatureScope) -> any ExposureLogging
     let makeEvaluationLogger: (any FeatureScope) -> any EvaluationLogging
-    let makeRUMFlagEvaluationReporter: (any FeatureScope) -> any RUMFlagEvaluationReporting
+    let makeRUMFlagEvaluationReporter: () -> any RUMFlagEvaluationReporting
     let performanceOverride: PerformancePresetOverride?
     let issueReporter: IssueReporter
     private let evaluationAggregator: EvaluationAggregator?
@@ -76,11 +76,11 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             return EvaluationLogger(aggregator: aggregator)
         }
 
-        makeRUMFlagEvaluationReporter = { featureScope in
+        makeRUMFlagEvaluationReporter = { [messageBus = core.messageBus] in
             guard configuration.rumIntegrationEnabled else {
                 return NOPRUMFlagEvaluationReporter()
             }
-            return RUMFlagEvaluationReporter(featureScope: featureScope)
+            return RUMFlagEvaluationReporter(messageBus: messageBus)
         }
         performanceOverride = PerformancePresetOverride(maxObjectsInFile: 50)
 

--- a/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
+++ b/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
@@ -10,12 +10,20 @@ import DatadogInternal
 
 @testable import DatadogFlags
 
-final class RUMFlagEvaluationReporterTests: XCTestCase {
-    private let featureScope = FeatureScopeMock()
+private final class RUMFlagEvaluationRecorder: BusMessageReceiver {
+    private(set) var messages: [RUMFlagEvaluationMessage] = []
+    func receive(message: RUMFlagEvaluationMessage, from core: DatadogCoreProtocol) {
+        messages.append(message)
+    }
+}
 
+final class RUMFlagEvaluationReporterTests: XCTestCase {
     func testSendFlagEvaluation() throws {
         // Given
-        let reporter = RUMFlagEvaluationReporter(featureScope: featureScope)
+        let messageBus = PassthroughCoreMock()
+        let recorder = RUMFlagEvaluationRecorder()
+        messageBus.subscribe(receiver: recorder)
+        let reporter = RUMFlagEvaluationReporter(messageBus: messageBus)
 
         // When
         reporter.sendFlagEvaluation(
@@ -24,10 +32,9 @@ final class RUMFlagEvaluationReporterTests: XCTestCase {
         )
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1, "Should send flag evaluation message")
+        XCTAssertEqual(recorder.messages.count, 1, "Should send flag evaluation message")
 
-        let flagEvaluation = try XCTUnwrap(messages.firstPayload as? RUMFlagEvaluationMessage)
+        let flagEvaluation = try XCTUnwrap(recorder.messages.first)
         XCTAssertEqual(flagEvaluation.flagKey, "feature-flag")
         XCTAssertEqual(flagEvaluation.value as? Bool, true)
     }


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

`RUMFlagEvaluationReporter` now takes a `MessageBus` (instead of a `FeatureScope`) and publishes `RUMFlagEvaluationMessage` directly. `FlagsFeature` captures the core's bus when building the reporter. Updates the reporter test to assert via a typed recorder.

## Refactoring rationale

The reporter previously emitted RUM messages through its own feature's scope, conflating storage and bus concerns. Holding the bus directly makes the reporter's intent explicit and lets the test record on the typed channel.

---
_Draft — pending author review. Merge in order unless marked parallel._