### PR TITLE
[chain-pr 8/13] Migrate DatadogSessionReplay to typed MessageBus

### DIFF
--- a/DatadogSessionReplay/Sources/Feature/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/Feature/RUMContextReceiver.swift
@@ -19,18 +19,12 @@ internal protocol RUMContextObserver {
 }
 
 /// Receives RUM context from `DatadogCore` and notifies it through `RUMContextObserver` interface.
-internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
+internal final class RUMContextReceiver: BusMessageReceiver, RUMContextObserver {
     /// Notifies new `RUMContext` or `nil` if current RUM session is not sampled.
     private var onNew: ((RUMCoreContext?) -> Void)?
     private var previous: RUMCoreContext?
 
-    // MARK: - FeatureMessageReceiver
-
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .context(context) = message else {
-            return false
-        }
-
+    func receive(message context: DatadogContext, from core: DatadogCoreProtocol) {
         let new = context.additionalContext(ofType: RUMCoreContext.self)
 
         // Notify only if it has changed:
@@ -38,8 +32,6 @@ internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
             onNew?(new)
             previous = new
         }
-
-        return true
     }
 
     // MARK: - RUMContextObserver

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -11,6 +11,8 @@ import DatadogInternal
 internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFeature {
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
+    let contextReceiver: RUMContextReceiver
+    let webViewRecordReceiver: WebViewRecordReceiver
     let performanceOverride: PerformancePresetOverride?
     let textAndInputPrivacyLevel: TextAndInputPrivacyLevel
     let imagePrivacyLevel: ImagePrivacyLevel
@@ -58,13 +60,11 @@ internal class SessionReplayFeature: SessionReplayConfiguration, DatadogRemoteFe
 
         let scheduler = ScreenChangeScheduler(minimumInterval: 0.1, telemetry: telemetry)
         let contextReceiver = RUMContextReceiver()
-
-        self.messageReceiver = CombinedFeatureMessageReceiver([
-            contextReceiver,
-            WebViewRecordReceiver(
-                scope: core.scope(for: SessionReplayFeature.self)
-            )
-        ])
+        self.contextReceiver = contextReceiver
+        self.webViewRecordReceiver = WebViewRecordReceiver(
+            scope: core.scope(for: SessionReplayFeature.self)
+        )
+        self.messageReceiver = NOPFeatureMessageReceiver()
 
         self.textAndInputPrivacyLevel = configuration.textAndInputPrivacyLevel
         self.imagePrivacyLevel = configuration.imagePrivacyLevel

--- a/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
+++ b/DatadogSessionReplay/Sources/Feature/WebViewRecordReceiver.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-internal struct WebViewRecordReceiver: FeatureMessageReceiver {
+internal final class WebViewRecordReceiver: BusMessageReceiver {
     internal struct WebRecord: Encodable {
         /// The RUM application ID of all records.
         let applicationID: String
@@ -22,10 +22,13 @@ internal struct WebViewRecordReceiver: FeatureMessageReceiver {
     /// Session Replay feature scope.
     let scope: FeatureScope
 
-    func receive(message: DatadogInternal.FeatureMessage, from core: DatadogInternal.DatadogCoreProtocol) -> Bool {
-        guard case let .webview(.record(event, view)) = message else {
-            return false
-        }
+    init(scope: FeatureScope) {
+        self.scope = scope
+    }
+
+    func receive(message: WebViewRecordMessage, from core: DatadogCoreProtocol) {
+        let event = message.event
+        let view = message.view
 
         scope.eventWriteContext { context, writer in
             // Extract the `RUMContext` or `nil` if RUM session is not sampled:
@@ -53,7 +56,5 @@ internal struct WebViewRecordReceiver: FeatureMessageReceiver {
 
             writer.write(value: record)
         }
-
-        return true
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -88,6 +88,11 @@ public enum SessionReplay {
         try core.register(feature: resources)
 
         let sessionReplay = try SessionReplayFeature(core: core, configuration: configuration)
+
+        // Subscribe typed-bus receivers before registration so initial context push is received:
+        core.messageBus.subscribe(receiver: sessionReplay.contextReceiver)
+        core.messageBus.subscribe(receiver: sessionReplay.webViewRecordReceiver)
+
         try core.register(feature: sessionReplay)
         core.set(
             context: SessionReplayCoreContext.Configuration(

--- a/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/WebViewRecordReceiverTests.swift
@@ -42,8 +42,8 @@ class WebViewRecordReceiverTests: XCTestCase {
 
         // When
 
-        let message = WebViewMessage.record(webRecordMock, WebViewMessage.View(id: browserViewID))
-        let result = receiver.receive(message: .webview(message), from: NOPDatadogCore())
+        let message = WebViewRecordMessage(event: webRecordMock, view: WebViewMessage.View(id: browserViewID))
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
         let expectedWebSegmentWritten: [String: Any] = [
@@ -58,7 +58,6 @@ class WebViewRecordReceiverTests: XCTestCase {
             ]
         ]
 
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(scope.eventsWritten.count, 1, "It must write web segment to core")
         let actualWebEventWritten = try XCTUnwrap(scope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebSegmentWritten))
@@ -73,26 +72,11 @@ class WebViewRecordReceiverTests: XCTestCase {
         let receiver = WebViewRecordReceiver(scope: scope)
 
         // When
-        let record = WebViewMessage.record(mockRandomAttributes(), WebViewMessage.View(id: .mockRandom()))
-        let result = receiver.receive(message: .webview(record), from: NOPDatadogCore())
+        let message = WebViewRecordMessage(event: mockRandomAttributes(), view: WebViewMessage.View(id: .mockRandom()))
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertTrue(scope.eventsWritten.isEmpty, "The event must be dropped")
-    }
-
-    func testWhenReceivingOtherMessage_itRejectsIt() throws {
-        let scope = FeatureScopeMock()
-
-        // Given
-        let receiver = WebViewRecordReceiver(scope: scope)
-
-        // When
-        let otherMessage: FeatureMessage = .payload(String.mockRandom())
-        let result = receiver.receive(message: otherMessage, from: NOPDatadogCore())
-
-        // Then
-        XCTAssertFalse(result, "It must reject messages addressed to other receivers")
     }
 }
 


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Converts `RUMContextReceiver` to a typed `DatadogContext` subscriber and `WebViewRecordReceiver` to consume `WebViewRecordMessage`. Exposes them on `SessionReplayFeature`, subscribes them in `SessionReplay.enable`, and updates the receiver tests.

## Refactoring rationale

Session Replay had two distinct receivers wrapped in a `CombinedFeatureMessageReceiver` purely to satisfy the legacy single-receiver hook. Typed subscriptions remove the wrapper and let each receiver be owned by the feature directly.

---
_Draft — pending author review. Merge in order unless marked parallel._