### PR TITLE
[chain-pr 9/13] Migrate DatadogWebViewTracking to typed MessageBus

### DIFF
--- a/DatadogWebViewTracking/Sources/MessageEmitter.swift
+++ b/DatadogWebViewTracking/Sources/MessageEmitter.swift
@@ -66,15 +66,27 @@ internal final class MessageEmitter: InternalExtension<WebViewTracking>.Abstract
             return
         }
 
-        core.send(message: .webview(message), else: {
+        guard case let .log(event) = message else {
+            return
+        }
+        core.messageBus.send(message: WebViewLogMessage(event: event), else: {
             DD.logger.warn("A WebView log is lost because Logging is disabled in the SDK")
         })
     }
 
     private func send(rum message: WebViewMessage, in core: DatadogCoreProtocol) {
-        core.send(message: .webview(message), else: {
-            DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
-        })
+        switch message {
+        case let .rum(event):
+            core.messageBus.send(message: WebViewRUMMessage(kind: .rum, event: event), else: {
+                DD.logger.warn("A WebView RUM event is lost because RUM is disabled in the SDK")
+            })
+        case let .telemetry(event):
+            core.messageBus.send(message: WebViewRUMMessage(kind: .telemetry, event: event), else: {
+                DD.logger.warn("A WebView RUM telemetry event is lost because RUM is disabled in the SDK")
+            })
+        default:
+            break
+        }
     }
 
     private func send(record event: WebViewMessage.Event, view: WebViewMessage.View, slotId: String?, in core: DatadogCoreProtocol) {
@@ -82,7 +94,7 @@ internal final class MessageEmitter: InternalExtension<WebViewTracking>.Abstract
         // inject the slotId
         event["slotId"] = slotId
 
-        core.send(message: .webview(.record(event, view)), else: {
+        core.messageBus.send(message: WebViewRecordMessage(event: event, view: view), else: {
             DD.logger.warn("A WebView Replay record is lost because Session Replay is disabled in the SDK")
         })
     }

--- a/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
+++ b/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
@@ -17,8 +17,9 @@ class MessageEmitterTests: XCTestCase {
         let sampler = Sampler(samplingRate: 100)
 
         // Given
-        let receiverMock = FeatureMessageReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiverMock)
+        let core = PassthroughCoreMock()
+        var received: [WebViewLogMessage] = []
+        _ = core.messageBus.subscribe { (msg: WebViewLogMessage, _) in received.append(msg) }
         let emitter = MessageEmitter(logsSampler: sampler, core: core)
 
         // When
@@ -34,11 +35,7 @@ class MessageEmitterTests: XCTestCase {
         """)
 
         // Then
-        let message = try XCTUnwrap(receiverMock.messages.firstWebViewMessage)
-        guard case let .log(event) = message else {
-            return XCTFail("not a log message")
-        }
-
+        let event = try XCTUnwrap(received.first?.event)
         let json = JSONObjectMatcher(object: event)
         XCTAssertEqual(try json.value("attribute1"), 123)
         XCTAssertEqual(try json.value("attribute2"), "foo")
@@ -47,33 +44,32 @@ class MessageEmitterTests: XCTestCase {
 
     func testGivenSampleRate0_whenReceivingLogEvent_itIsDropped() throws {
         let sampler = Sampler(samplingRate: 0)
-        let eventType = "log"
 
         // Given
-        let receiverMock = FeatureMessageReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiverMock)
+        let core = PassthroughCoreMock()
+        var received: [WebViewLogMessage] = []
+        _ = core.messageBus.subscribe { (msg: WebViewLogMessage, _) in received.append(msg) }
         let emitter = MessageEmitter(logsSampler: sampler, core: core)
 
         // When
         emitter.send(body: """
         {
-          "eventType": "\(eventType)",
+          "eventType": "log",
           "event": {
-            "attribute1": 123,
-            "attribute2": "foo",
-            "attribute3": ["foo", "bar", "bizz"]
+            "attribute1": 123
           }
         }
         """)
 
         // Then
-        XCTAssertNil(receiverMock.messages.firstWebViewMessage)
+        XCTAssertTrue(received.isEmpty)
     }
 
     func testWhenReceivingRUMEvent_itForwardsToRUM() throws {
         // Given
-        let receiverMock = FeatureMessageReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiverMock)
+        let core = PassthroughCoreMock()
+        var received: [WebViewRUMMessage] = []
+        _ = core.messageBus.subscribe { (msg: WebViewRUMMessage, _) in received.append(msg) }
         let emitter = MessageEmitter(logsSampler: .mockRandom(), core: core)
 
         // When
@@ -89,12 +85,9 @@ class MessageEmitterTests: XCTestCase {
         """)
 
         // Then
-        let message = try XCTUnwrap(receiverMock.messages.firstWebViewMessage)
-        guard case let .rum(event) = message else {
-            return XCTFail("not a rum message")
-        }
-
-        let json = JSONObjectMatcher(object: event)
+        let msg = try XCTUnwrap(received.first)
+        XCTAssertEqual(msg.kind, .rum)
+        let json = JSONObjectMatcher(object: msg.event)
         XCTAssertEqual(try json.value("attribute1"), 123)
         XCTAssertEqual(try json.value("attribute2"), "foo")
         XCTAssertEqual(try json.array("attribute3").values(), ["foo", "bar", "bizz"])
@@ -102,8 +95,9 @@ class MessageEmitterTests: XCTestCase {
 
     func testWhenReceivingTelemetryEvent_itForwardsToTelemetry() throws {
         // Given
-        let receiverMock = FeatureMessageReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiverMock)
+        let core = PassthroughCoreMock()
+        var received: [WebViewRUMMessage] = []
+        _ = core.messageBus.subscribe { (msg: WebViewRUMMessage, _) in received.append(msg) }
         let emitter = MessageEmitter(logsSampler: .mockRandom(), core: core)
 
         // When
@@ -119,12 +113,9 @@ class MessageEmitterTests: XCTestCase {
         """)
 
         // Then
-        let message = try XCTUnwrap(receiverMock.messages.firstWebViewMessage)
-        guard case let .telemetry(event) = message else {
-            return XCTFail("not a telemetry message")
-        }
-
-        let json = JSONObjectMatcher(object: event)
+        let msg = try XCTUnwrap(received.first)
+        XCTAssertEqual(msg.kind, .telemetry)
+        let json = JSONObjectMatcher(object: msg.event)
         XCTAssertEqual(try json.value("attribute1"), 123)
         XCTAssertEqual(try json.value("attribute2"), "foo")
         XCTAssertEqual(try json.array("attribute3").values(), ["foo", "bar", "bizz"])
@@ -138,7 +129,8 @@ class MessageEmitterTests: XCTestCase {
 
         // Given
         let telemetry = TelemetryReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: telemetry)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
         let bridge = MessageEmitter(logsSampler: .mockAny(), core: core)
 
         // When

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -238,25 +238,17 @@ class WebViewTrackingTests: XCTestCase {
 
     func testSendingWebEvents() throws {
         let logMessageExpectation = expectation(description: "Log message received")
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                switch message {
-                case let .webview(.log(event)):
-                    let matcher = JSONObjectMatcher(object: event)
-                    XCTAssertEqual(try? matcher.value("date"), 1_635_932_927_012)
-                    XCTAssertEqual(try? matcher.value("message"), "console error: error")
-                    XCTAssertEqual(try? matcher.value("status"), "error")
-                    XCTAssertEqual(try? matcher.value("view"), ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
-                    XCTAssertEqual(try? matcher.value("error"), ["origin": "console"])
-                    XCTAssertEqual(try? matcher.value("session_id"), "0110cab4-7471-480e-aa4e-7ce039ced355")
-                    logMessageExpectation.fulfill()
-                case .context, .telemetry:
-                    break
-                default:
-                    XCTFail("Unexpected message received: \(message)")
-                }
-            }
-        )
+        let core = PassthroughCoreMock()
+        let subscription = core.messageBus.subscribe { (message: WebViewLogMessage, _) in
+            let matcher = JSONObjectMatcher(object: message.event)
+            XCTAssertEqual(try? matcher.value("date"), 1_635_932_927_012)
+            XCTAssertEqual(try? matcher.value("message"), "console error: error")
+            XCTAssertEqual(try? matcher.value("status"), "error")
+            XCTAssertEqual(try? matcher.value("view"), ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"])
+            XCTAssertEqual(try? matcher.value("error"), ["origin": "console"])
+            XCTAssertEqual(try? matcher.value("session_id"), "0110cab4-7471-480e-aa4e-7ce039ced355")
+            logMessageExpectation.fulfill()
+        }
 
         let controller = DDUserContentController()
         try WebViewTracking.enableOrThrow(
@@ -295,20 +287,12 @@ class WebViewTrackingTests: XCTestCase {
 
     func testSendingWebRUMEvent() throws {
         let rumMessageExpectation = expectation(description: "RUM message received")
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                switch message {
-                case let .webview(.rum(event)):
-                    let matcher = JSONObjectMatcher(object: event)
-                    XCTAssertEqual(try? matcher.value("view.id"), "64308fd4-83f9-48cb-b3e1-1e91f6721230")
-                    rumMessageExpectation.fulfill()
-                case .context, .telemetry:
-                    break
-                default:
-                    XCTFail("Unexpected message received: \(message)")
-                }
-            }
-        )
+        let core = PassthroughCoreMock()
+        let subscription = core.messageBus.subscribe { (message: WebViewRUMMessage, _) in
+            let matcher = JSONObjectMatcher(object: message.event)
+            XCTAssertEqual(try? matcher.value("view.id"), "64308fd4-83f9-48cb-b3e1-1e91f6721230")
+            rumMessageExpectation.fulfill()
+        }
 
         let controller = DDUserContentController()
         try WebViewTracking.enableOrThrow(
@@ -386,22 +370,14 @@ class WebViewTrackingTests: XCTestCase {
         let webView = WKWebView()
         let controller = DDUserContentController()
 
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                switch message {
-                case let .webview(.record(event, view)):
-                    XCTAssertEqual(view.id, "64308fd4-83f9-48cb-b3e1-1e91f6721230")
-                    let matcher = JSONObjectMatcher(object: event)
-                    XCTAssertEqual(try? matcher.value("date"), 1_635_932_927_012)
-                    XCTAssertEqual(try? matcher.value("slotId"), String(webView.hash))
-                    recordMessageExpectation.fulfill()
-                case .context, .telemetry:
-                    break
-                default:
-                    XCTFail("Unexpected message received: \(message)")
-                }
-            }
-        )
+        let core = PassthroughCoreMock()
+        let subscription = core.messageBus.subscribe { (message: WebViewRecordMessage, _) in
+            XCTAssertEqual(message.view.id, "64308fd4-83f9-48cb-b3e1-1e91f6721230")
+            let matcher = JSONObjectMatcher(object: message.event)
+            XCTAssertEqual(try? matcher.value("date"), 1_635_932_927_012)
+            XCTAssertEqual(try? matcher.value("slotId"), String(webView.hash))
+            recordMessageExpectation.fulfill()
+        }
 
         try WebViewTracking.enableOrThrow(
             tracking: controller,
@@ -428,14 +404,9 @@ class WebViewTrackingTests: XCTestCase {
 
     func testItSendsTrackWebViewUsageTelemetry() throws {
         // Given
-        var capturedUsage: UsageTelemetry?
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                if case .telemetry(.usage(let usage)) = message {
-                    capturedUsage = usage
-                }
-            }
-        )
+        let telemetry = TelemetryReceiverMock()
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
         let controller = DDUserContentController()
 
         // When
@@ -448,7 +419,7 @@ class WebViewTrackingTests: XCTestCase {
         )
 
         // Then
-        let usage = try XCTUnwrap(capturedUsage, "Expected a usage telemetry event to be sent")
+        let usage = try XCTUnwrap(telemetry.messages.firstUsage(), "Expected a usage telemetry event to be sent")
         XCTAssertEqual(usage.sampleRate, UsageTelemetry.defaultSampleRate)
         guard case .trackWebView = usage.event else {
             XCTFail("Expected .trackWebView usage event")
@@ -458,14 +429,9 @@ class WebViewTrackingTests: XCTestCase {
 
     func testItSendsTrackWebViewUsageTelemetryOnlyOnce() throws {
         // Given
-        var trackWebViewUsageCount = 0
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                if case .telemetry(.usage(let usage)) = message, case .trackWebView = usage.event {
-                    trackWebViewUsageCount += 1
-                }
-            }
-        )
+        let telemetry = TelemetryReceiverMock()
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
         let controller = DDUserContentController()
 
         // When - enable is called multiple times on the same controller
@@ -480,19 +446,21 @@ class WebViewTrackingTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(trackWebViewUsageCount, 1)
+        let usageCount = telemetry.messages.filter {
+            if case .usage = $0 {
+                return true
+            } else {
+                return false
+            }
+        }.count
+        XCTAssertEqual(usageCount, 1)
     }
 
     func testItSendsTrackWebViewUsageTelemetryAgainAfterDisable() throws {
         // Given
-        var trackWebViewUsageCount = 0
-        let core = PassthroughCoreMock(
-            messageReceiver: FeatureMessageReceiverMock { message in
-                if case .telemetry(.usage(let usage)) = message, case .trackWebView = usage.event {
-                    trackWebViewUsageCount += 1
-                }
-            }
-        )
+        let telemetry = TelemetryReceiverMock()
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
         let controller = DDUserContentController()
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = controller
@@ -500,13 +468,27 @@ class WebViewTrackingTests: XCTestCase {
 
         // When
         WebViewTracking.enable(webView: webview, in: core)
-        XCTAssertEqual(trackWebViewUsageCount, 1)
+        let countAfterFirstEnable = telemetry.messages.filter {
+            if case .usage = $0 {
+                return true
+            } else {
+                return false
+            }
+        }.count
+        XCTAssertEqual(countAfterFirstEnable, 1)
 
         WebViewTracking.disable(webView: webview)
         WebViewTracking.enable(webView: webview, in: core)
 
         // Then - disable clears user scripts so the duplicate guard passes again on re-enable
-        XCTAssertEqual(trackWebViewUsageCount, 2)
+        let countAfterSecondEnable = telemetry.messages.filter {
+            if case .usage = $0 {
+                return true
+            } else {
+                return false
+            }
+        }.count
+        XCTAssertEqual(countAfterSecondEnable, 2)
     }
 }
 


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Rewrites `MessageEmitter` to dispatch typed `WebViewLogMessage`, `WebViewRUMMessage`, and `WebViewRecordMessage` instead of the legacy `.webview(...)` case. Updates `MessageEmitterTests` and `WebViewTrackingTests` to subscribe via the typed bus.

## Refactoring rationale

The webview bridge is the only producer of webview messages and was emitting through the legacy enum. Switching it to typed publishes lets RUM, Logs, and Session Replay subscribe by message kind without sharing a single `.webview` discriminator.

---
_Draft — pending author review. Merge in order unless marked parallel._