### PR TITLE
[chain-pr 10/13] Migrate DatadogRUM to typed MessageBus and merge TelemetryInterceptor into TelemetryReceiver

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -15,6 +15,18 @@ internal final class RUMFeature: DatadogRemoteFeature {
 
     let messageReceiver: FeatureMessageReceiver
 
+    let crashReportReceiver: CrashReportReceiver
+
+    let errorMessageReceiver: ErrorMessageReceiver
+
+    let flagEvaluationReceiver: FlagEvaluationReceiver
+
+    let telemetryReceiver: TelemetryReceiver
+
+    let webViewEventReceiver: WebViewEventReceiver
+
+    let watchdogTerminationMonitor: WatchdogTerminationMonitor?
+
     let monitor: Monitor
 
     let instrumentation: RUMInstrumentation
@@ -145,7 +157,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             accessibilityReader: accessibilityReader,
             onSessionStart: configuration.onSessionStart,
             viewCache: ViewCache(dateProvider: configuration.dateProvider),
-            fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope),
+            fatalErrorContext: FatalErrorContextNotifier(messageBus: core.messageBus),
             sessionEndedMetric: sessionEndedMetric,
             viewEndedMetricFactory: {
                 let viewEndedController = ViewEndedController(
@@ -255,49 +267,48 @@ internal final class RUMFeature: DatadogRemoteFeature {
             telemetry: core.telemetry
         )
 
-        var messageReceivers: [FeatureMessageReceiver] = [
-            TelemetryInterceptor(sessionEndedMetric: sessionEndedMetric),
-            TelemetryReceiver(
-                featureScope: featureScope,
-                dateProvider: configuration.dateProvider,
-                sampler: Sampler(samplingRate: configuration.telemetrySampleRate),
-                configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate)
-            ),
-            ErrorMessageReceiver(
-                featureScope: featureScope,
-                monitor: monitor
-            ),
-            FlagEvaluationReceiver(monitor: monitor),
-            WebViewEventReceiver(
-                featureScope: featureScope,
-                dateProvider: configuration.dateProvider,
-                commandSubscriber: monitor,
-                viewCache: dependencies.viewCache
-            ),
-            CrashReportReceiver(
-                featureScope: featureScope,
-                applicationID: configuration.applicationID,
-                dateProvider: configuration.dateProvider,
-                sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
-                trackBackgroundEvents: configuration.trackBackgroundEvents,
-                uuidGenerator: configuration.uuidGenerator,
-                ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
-                syntheticsTest: {
-                    if let testId = configuration.syntheticsTestId, let resultId = configuration.syntheticsResultId {
-                        return RUMSyntheticsTest(injected: nil, resultId: resultId, testId: testId, syntheticsInfo: [:])
-                    } else {
-                        return nil
-                    }
-                }(),
-                eventsMapper: eventsMapper
-            )
-        ]
+        self.crashReportReceiver = CrashReportReceiver(
+            featureScope: featureScope,
+            applicationID: configuration.applicationID,
+            dateProvider: configuration.dateProvider,
+            sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
+            trackBackgroundEvents: configuration.trackBackgroundEvents,
+            uuidGenerator: configuration.uuidGenerator,
+            ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
+            syntheticsTest: {
+                if let testId = configuration.syntheticsTestId, let resultId = configuration.syntheticsResultId {
+                    return RUMSyntheticsTest(injected: nil, resultId: resultId, testId: testId, syntheticsInfo: [:])
+                } else {
+                    return nil
+                }
+            }(),
+            eventsMapper: eventsMapper
+        )
 
-        if let watchdogTermination = watchdogTermination {
-            messageReceivers.append(watchdogTermination)
-        }
+        self.errorMessageReceiver = ErrorMessageReceiver(
+            featureScope: featureScope,
+            monitor: monitor
+        )
 
-        self.messageReceiver = CombinedFeatureMessageReceiver(messageReceivers)
+        self.flagEvaluationReceiver = FlagEvaluationReceiver(monitor: monitor)
+
+        self.telemetryReceiver = TelemetryReceiver(
+            featureScope: featureScope,
+            dateProvider: configuration.dateProvider,
+            sampler: Sampler(samplingRate: configuration.telemetrySampleRate),
+            configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate),
+            sessionEndedMetric: sessionEndedMetric
+        )
+
+        self.webViewEventReceiver = WebViewEventReceiver(
+            featureScope: featureScope,
+            dateProvider: configuration.dateProvider,
+            commandSubscriber: monitor,
+            viewCache: dependencies.viewCache
+        )
+
+        self.watchdogTerminationMonitor = watchdogTermination
+        self.messageReceiver = NOPFeatureMessageReceiver()
 
         // Forward instrumentation calls to monitor:
         instrumentation.publish(to: monitor)

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitor.swift
@@ -139,36 +139,21 @@ extension WatchdogTerminationMonitor: Flushable {
     }
 }
 
-extension WatchdogTerminationMonitor: FeatureMessageReceiver {
-    /// Receives the feature message and updates the app state based on the context message.
-    /// It relies on `ApplicationStatePublisher` context message to update the app state.
-    /// Other messages are ignored.
-    /// - Parameters:
-    ///   - message: The feature message.
-    ///   - core: The core instance.
-    /// - Returns: Always `false`, because it doesn't block the message propagation.
-    func receive(message: DatadogInternal.FeatureMessage, from core: any DatadogInternal.DatadogCoreProtocol) -> Bool {
-        guard case .context(let context) = message else {
-            return false
-        }
-
+extension WatchdogTerminationMonitor: BusMessageReceiver {
+    /// Receives DatadogContext updates and tracks app state for watchdog termination detection.
+    func receive(message context: DatadogContext, from core: any DatadogCoreProtocol) {
         if currentState == .stopped {
             guard let launchReport = context.additionalContext(ofType: LaunchReport.self) else {
-                return false
+                return
             }
-
             self.start(launchReport: launchReport)
         }
 
-        // Once the monitor has started, ie watchdog termination check has been done
-        // we can start updating the app state based on the context message
         guard currentState == .started else {
-            return false
+            return
         }
 
         let state = context.applicationStateHistory.currentState
         appStateManager.updateAppState(state: state)
-
-        return false
     }
 }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 
 /// Receiver to consume crash reports as RUM events.
-internal struct CrashReportReceiver: FeatureMessageReceiver {
+internal final class CrashReportReceiver: BusMessageReceiver {
     private struct AdjustedCrashTimings {
         /// Crash date read from `CrashReport`. It uses device time.
         let crashDate: Date
@@ -57,15 +57,11 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         self.eventsMapper = eventsMapper
     }
 
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .payload(crash as Crash) = message else {
-            return false
-        }
-
-        return send(report: crash.report, with: crash.context)
+    func receive(message: Crash, from core: DatadogCoreProtocol) {
+        send(report: message.report, with: message.context)
     }
 
-    private func send(report: DDCrashReport, with context: CrashContext) -> Bool {
+    private func send(report: DDCrashReport, with context: CrashContext) {
         // The `crashReport.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
         // to the server time before processing. Following use of the current correction is not ideal (it's not the correction
         // from the moment of crash), but this is the best approximation we can get.
@@ -100,18 +96,17 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 )
             } else {
                 DD.logger.debug("There was a crash in previous session, but it is ignored due to another crash already present in the last view.")
-                return false
             }
 
-            return true
+            return
         }
 
         if let lastRUMSessionState = context.lastRUMSessionState {
             sendCrashReportToPreviousSession(report, crashContext: context, lastRUMSessionStateInPreviousSession: lastRUMSessionState, using: adjustedCrashTimings)
-            return true
+            return
         }
 
-        return sendCrashReportToNewSession(report, crashContext: context, using: adjustedCrashTimings)
+        sendCrashReportToNewSession(report, crashContext: context, using: adjustedCrashTimings)
     }
 
     /// If the crash occurred in an existing RUM session and we know its `lastRUMViewEvent` we send the error using that session UUID and link
@@ -128,7 +123,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             // To avoid inconsistency, we only send the RUM error.
             DD.logger.debug("Sending crash as RUM error.")
             featureScope.eventWriteContext(bypassConsent: true) { context, writer in
-                let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
+                let builder = self.createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
                 let rumError = builder.createRUMError(with: lastRUMViewEvent)
 
                 if let mappedError = self.eventsMapper.map(event: rumError) {
@@ -200,7 +195,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         _ crashReport: DDCrashReport,
         crashContext: CrashContext,
         using crashTimings: AdjustedCrashTimings
-    ) -> Bool {
+    ) {
         let sessionID = uuidGenerator.generateUnique()
         let sampled = DeterministicSampler(
             uuid: sessionID.rawValue,
@@ -209,7 +204,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
 
         guard sampled else {
             DD.logger.debug("There was a crash in previous session, but it is ignored due to sampling.")
-            return false
+            return
         }
 
         // We can ignore `sessionState` for building the rule as we can assume there was no session sent - otherwise,
@@ -258,8 +253,6 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         if let newRUMView = newRUMView {
             send(crashReport: crashReport, to: newRUMView, using: crashTimings)
         }
-
-        return true
     }
 
     /// Sends given `CrashReport` by linking it to given `rumView` and updating view counts accordingly.
@@ -269,7 +262,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
         featureScope.eventWriteContext(bypassConsent: true) { context, writer in
-            let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
+            let builder = self.createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
             let updatedRUMView = builder.updateRUMViewWithError(rumView)
             let rumError = builder.createRUMError(with: updatedRUMView)
 

--- a/DatadogRUM/Sources/Integrations/ErrorMessageReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/ErrorMessageReceiver.swift
@@ -7,17 +7,18 @@
 import Foundation
 import DatadogInternal
 
-internal struct ErrorMessageReceiver: FeatureMessageReceiver {
+internal final class ErrorMessageReceiver: BusMessageReceiver {
     /// RUM feature scope.
     let featureScope: FeatureScope
     let monitor: Monitor
 
-    /// Adds RUM Error with given message and stack to current RUM View.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .payload(error as RUMErrorMessage) = message else {
-            return false
-        }
+    init(featureScope: FeatureScope, monitor: Monitor) {
+        self.featureScope = featureScope
+        self.monitor = monitor
+    }
 
+    /// Adds RUM Error with given message and stack to current RUM View.
+    func receive(message error: RUMErrorMessage, from core: DatadogCoreProtocol) {
         monitor._internal?.addError(
             at: error.time,
             message: error.message,
@@ -28,7 +29,5 @@ internal struct ErrorMessageReceiver: FeatureMessageReceiver {
             attributes: error.attributes,
             binaryImages: error.binaryImages
         )
-
-        return true
     }
 }

--- a/DatadogRUM/Sources/Integrations/FatalErrorContextNotifier.swift
+++ b/DatadogRUM/Sources/Integrations/FatalErrorContextNotifier.swift
@@ -23,10 +23,10 @@ internal protocol FatalErrorContextNotifying: AnyObject {
 /// Manages RUM information necessary for building context of fatal errors such as Crashes or Fatal App Hangs.
 /// It tracks value changes and notifies updates on message bus.
 internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
-    /// Message bus interface to send context updates to Crash Reporting.
-    private let messageBus: MessageSending
+    /// Typed message bus to send context updates to Crash Reporting.
+    private let messageBus: MessageBus
 
-    init(messageBus: MessageSending) {
+    init(messageBus: MessageBus) {
         self.messageBus = messageBus
     }
 
@@ -36,7 +36,7 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     var sessionState: RUMSessionState? {
         didSet {
             if let sessionState {
-                messageBus.send(message: .payload(sessionState))
+                messageBus.send(message: sessionState)
             }
         }
     }
@@ -47,9 +47,9 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     var view: RUMViewEvent? {
         didSet {
             if let view {
-                messageBus.send(message: .payload(view))
+                messageBus.send(message: view)
             } else {
-                messageBus.send(message: .payload(RUMPayloadMessages.viewReset))
+                messageBus.send(message: RUMViewReset())
             }
         }
     }
@@ -57,7 +57,7 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     @ReadWriteLock
     var globalAttributes: [String: Encodable] = [:] {
         didSet {
-            messageBus.send(message: .payload(RUMEventAttributes(contextInfo: globalAttributes)))
+            messageBus.send(message: RUMEventAttributes(contextInfo: globalAttributes))
         }
     }
 }

--- a/DatadogRUM/Sources/Integrations/FlagEvaluationReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/FlagEvaluationReceiver.swift
@@ -8,21 +8,19 @@ import Foundation
 import DatadogInternal
 
 /// Receives flag evaluation messages and adds them to RUM.
-internal struct FlagEvaluationReceiver: FeatureMessageReceiver {
+internal final class FlagEvaluationReceiver: BusMessageReceiver {
     /// The RUM monitor instance.
     let monitor: Monitor
 
-    /// Adds feature flag evaluation to the current RUM view.
-    func receive(message: FeatureMessage, from core: any DatadogCoreProtocol) -> Bool {
-        guard case let .payload(flagEvaluation as RUMFlagEvaluationMessage) = message else {
-            return false
-        }
+    init(monitor: Monitor) {
+        self.monitor = monitor
+    }
 
+    /// Adds feature flag evaluation to the current RUM view.
+    func receive(message flagEvaluation: RUMFlagEvaluationMessage, from core: any DatadogCoreProtocol) {
         monitor.addFeatureFlagEvaluation(
             name: flagEvaluation.flagKey,
             value: flagEvaluation.value
         )
-
-        return true
     }
 }

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-internal final class TelemetryReceiver: FeatureMessageReceiver {
+internal final class TelemetryReceiver: BusMessageReceiver {
     /// Maximum number of telemetry events allowed per RUM  sessions.
     static let maxEventsPerSessions: Int = 100
 
@@ -24,6 +24,9 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     let sampler: Sampler
     /// Additional sampler for configuration telemetry events, applied in addition to the `sampler`.
     let configurationExtraSampler: Sampler
+
+    /// "RUM Session Ended" controller to count SDK errors and upload quality metrics.
+    let sessionEndedMetric: SessionEndedMetricController
 
     /// Keeps track of current session
     @ReadWriteLock
@@ -44,47 +47,36 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///   - dateProvider: Current device time provider.
     ///   - sampler: Telemetry events sampler.
     ///   - configurationExtraSampler: Extra sampler for configuration events (applied on top of `sampler`).
+    ///   - sessionEndedMetric: Controller for tracking session-ended metric data.
     init(
         featureScope: FeatureScope,
         dateProvider: DateProvider,
         sampler: Sampler,
-        configurationExtraSampler: Sampler
+        configurationExtraSampler: Sampler,
+        sessionEndedMetric: SessionEndedMetricController
     ) {
         self.featureScope = featureScope
         self.dateProvider = dateProvider
         self.sampler = sampler
         self.configurationExtraSampler = configurationExtraSampler
+        self.sessionEndedMetric = sessionEndedMetric
     }
 
-    /// Receives a message from the bus.
-    ///
-    /// The receiver will only consume `TelemetryMessage`.
-    ///
-    /// - Parameters:
-    ///   - message: The message to consume.
-    ///   - core: The core sending the message.
-    /// - Returns: `true` if the message is a `.telemetry` case.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .telemetry(telemetry) = message else {
-            return false
-        }
-
-        return receive(telemetry: telemetry)
-    }
-
-    /// Receives a Telemetry message from the bus.
-    ///
-    /// - Parameter telemetry: The telemetry message to consume.
-    /// - Returns: Always `true`.
-    private func receive(telemetry: TelemetryMessage) -> Bool {
+    func receive(message telemetry: TelemetryMessage, from core: DatadogCoreProtocol) {
         switch telemetry {
         case let .debug(id, message, attributes):
             debug(id: id, message: message, attributes: attributes)
         case let .error(id, message, kind, stack):
+            sessionEndedMetric.track(sdkErrorKind: kind, in: nil)
             error(id: id, message: message, kind: kind, stack: stack)
         case .configuration(let configuration):
             send(configuration: configuration)
         case let .metric(metric):
+            if metric.name == UploadQualityMetric.name {
+                sessionEndedMetric.track(uploadQuality: metric.attributes, in: nil)
+                // Upload quality metrics are intercepted for the session-ended metric and not forwarded.
+                return
+            }
             if sampled(event: metric) {
                 send(metric: metric)
             }
@@ -93,8 +85,6 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
                 send(usage: usage)
             }
         }
-
-        return true
     }
 
     private func sampled(event: SampledTelemetry) -> Bool {

--- a/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/WebViewEventReceiver.swift
@@ -10,7 +10,7 @@ import DatadogInternal
 internal typealias JSON = [String: Any]
 
 /// Receiver to consume a RUM event coming from Browser SDK.
-internal final class WebViewEventReceiver: FeatureMessageReceiver {
+internal final class WebViewEventReceiver: BusMessageReceiver {
     /// RUM feature scope.
     let featureScope: FeatureScope
     /// Subscriber that can process a `RUMKeepSessionAliveCommand`.
@@ -46,17 +46,13 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
     /// - Parameters:
     ///   - message: The message containing the Browser RUM event.
     ///   - core: The core to write the event.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case let .webview(.rum(event)):
-            receive(rum: event)
-        case let .webview(.telemetry(event)):
-            receive(telemetry: event)
-        default:
-            return false
+    func receive(message: WebViewRUMMessage, from core: DatadogCoreProtocol) {
+        switch message.kind {
+        case .rum:
+            receive(rum: message.event)
+        case .telemetry:
+            receive(telemetry: message.event)
         }
-
-        return true
     }
 
     private func receive(rum event: JSON) {

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -43,6 +43,17 @@ public enum RUM {
 
         // Register RUM feature:
         let rum = try RUMFeature(in: core, configuration: configuration)
+
+        // Subscribe typed-bus receivers before registration so initial context push is received:
+        core.messageBus.subscribe(receiver: rum.crashReportReceiver)
+        core.messageBus.subscribe(receiver: rum.errorMessageReceiver)
+        core.messageBus.subscribe(receiver: rum.flagEvaluationReceiver)
+        core.messageBus.subscribe(receiver: rum.telemetryReceiver)
+        core.messageBus.subscribe(receiver: rum.webViewEventReceiver)
+        if let watchdog = rum.watchdogTerminationMonitor {
+            core.messageBus.subscribe(receiver: watchdog)
+        }
+
         try core.register(feature: rum)
 
         // If resource tracking is configured, register URLSessionHandler to enable network instrumentation:

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -24,7 +24,7 @@ private class WatchdogThreadMock: AppHangsObservingThread {
 class AppHangsMonitorTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
     private let watchdogThread = WatchdogThreadMock()
-    private let fatalErrorContext = FatalErrorContextNotifier(messageBus: NOPFeatureScope())
+    private let fatalErrorContext = FatalErrorContextNotifier(messageBus: NOPMessageBus())
     private let currentProcessID = UUID()
     private let dateProvider = DateProviderMock()
     private let uuidGenerator = RUMUUIDGeneratorMock()

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationMonitorTests.swift
@@ -40,7 +40,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut.update(viewEvent: viewEvent1)
 
         // monitor reveives the launch report
-        _ = sut.receive(message: .context(featureScope.contextMock), from: NOPDatadogCore())
+        sut.receive(message: featureScope.contextMock, from: NOPDatadogCore())
 
         // Flush the queue to ensure the monitor has transitioned to `.started`
         // before updating the view event. Without this, the update would be
@@ -69,7 +69,7 @@ final class WatchdogTerminationMonitorTests: XCTestCase {
         sut.update(viewEvent: viewEvent3)
 
         // monitor reveives the launch report
-        _ = sut.receive(message: .context(featureScope.contextMock), from: NOPDatadogCore())
+        sut.receive(message: featureScope.contextMock, from: NOPDatadogCore())
 
         waitForExpectations(timeout: 1)
         XCTAssertEqual(reporter.sendParams?.viewEvent.view.id, viewEvent2.view.id)

--- a/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/ErrorMessageReceiverTests.swift
@@ -30,22 +30,19 @@ class ErrorMessageReceiverTests: XCTestCase {
 
     func testReceivePartialLogError() throws {
         // When
-        let message: FeatureMessage = .payload(
-            RUMErrorMessage(
-                time: Date(),
-                message: "message-test",
-                source: "logger",
-                type: nil,
-                stack: nil,
-                attributes: [:],
-                binaryImages: nil
-            )
+        let message = RUMErrorMessage(
+            time: Date(),
+            message: "message-test",
+            source: "logger",
+            type: nil,
+            stack: nil,
+            attributes: [:],
+            binaryImages: nil
         )
 
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         let event: RUMErrorEvent = try XCTUnwrap(featureScope.eventsWritten().last, "It should send error")
         XCTAssertEqual(event.error.message, "message-test")
         XCTAssertEqual(event.error.source, .logger)
@@ -55,25 +52,22 @@ class ErrorMessageReceiverTests: XCTestCase {
         // Given
         let mockAttribute: String = .mockRandom()
         let mockBinaryImage: BinaryImage = .mockRandom()
-        let message: FeatureMessage = .payload(
-            RUMErrorMessage(
-                time: Date(),
-                message: "message-test",
-                source: "custom",
-                type: "type-test",
-                stack: "stack-test",
-                attributes: [
-                    "any-key": mockAttribute
-                ],
-                binaryImages: [mockBinaryImage]
-            )
+        let message = RUMErrorMessage(
+            time: Date(),
+            message: "message-test",
+            source: "custom",
+            type: "type-test",
+            stack: "stack-test",
+            attributes: [
+                "any-key": mockAttribute
+            ],
+            binaryImages: [mockBinaryImage]
         )
 
         // When
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         let event: RUMErrorEvent = try XCTUnwrap(featureScope.eventsWritten().last, "It should send error")
         XCTAssertEqual(event.error.message, "message-test")
         XCTAssertEqual(event.error.type, "type-test")

--- a/DatadogRUM/Tests/Integrations/FlagEvaluationReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/FlagEvaluationReceiverTests.swift
@@ -21,19 +21,15 @@ class FlagEvaluationReceiverTests: XCTestCase {
                 dateProvider: SystemDateProvider()
             )
         )
-        let message: FeatureMessage = .payload(
-            RUMFlagEvaluationMessage(
-                flagKey: "feature-flag",
-                value: true
-            )
+        let message = RUMFlagEvaluationMessage(
+            flagKey: "feature-flag",
+            value: true
         )
 
         // When
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
-
         let viewEvents: [RUMViewEvent] = featureScope.eventsWritten()
         XCTAssertFalse(viewEvents.isEmpty, "It should write a view event")
 

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -6,11 +6,12 @@
 
 import XCTest
 import TestUtilities
-import DatadogInternal
+@testable import DatadogInternal
 @testable import DatadogRUM
 
 /// Utility to access the convenience methods defined in `Telemetry` protocol extension while sending telemetry to tested receiver.
-private struct TelemetryMock: Telemetry {
+/// Routes `Telemetry` calls directly to a `TelemetryReceiver` for unit testing.
+private struct TelemetryReceiverProxy: Telemetry {
     let receiver: TelemetryReceiver
 
     init(with receiver: TelemetryReceiver) {
@@ -18,8 +19,7 @@ private struct TelemetryMock: Telemetry {
     }
 
     func send(telemetry: TelemetryMessage) {
-        let result = receiver.receive(message: .telemetry(telemetry), from: NOPDatadogCore())
-        XCTAssertTrue(result, "It must accept every message")
+        receiver.receive(message: telemetry, from: NOPDatadogCore())
     }
 }
 
@@ -44,7 +44,7 @@ class TelemetryReceiverTests: XCTestCase {
         )
 
         // When
-        TelemetryMock(with: receiver).debug("Hello world!", attributes: ["foo": 42])
+        TelemetryReceiverProxy(with: receiver).debug("Hello world!", attributes: ["foo": 42])
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -73,7 +73,7 @@ class TelemetryReceiverTests: XCTestCase {
         )
 
         // When
-        TelemetryMock(with: receiver).error("Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
+        TelemetryReceiverProxy(with: receiver).error("Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryErrorEvent.self).first
@@ -94,7 +94,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
 
         // When
-        TelemetryMock(with: receiver).debug("telemetry debug", attributes: ["foo": 42])
+        TelemetryReceiverProxy(with: receiver).debug("telemetry debug", attributes: ["foo": 42])
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -114,7 +114,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
 
         // When
-        TelemetryMock(with: receiver).error("telemetry error")
+        TelemetryReceiverProxy(with: receiver).error("telemetry error")
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryErrorEvent.self).first
@@ -135,7 +135,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, dateProvider: dateProvider)
 
         // When
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
         telemetry.debug("Debug", attributes: ["foo": 1])
         telemetry.error("Error")
         telemetry.metric(name: "Metric", attributes: ["bar": 2], sampleRate: 100)
@@ -161,7 +161,7 @@ class TelemetryReceiverTests: XCTestCase {
     func testSendTelemetry_discardDuplicates() throws {
         // Given
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         telemetry.debug(id: "0", message: "telemetry debug 0")
@@ -195,7 +195,7 @@ class TelemetryReceiverTests: XCTestCase {
     func testSendTelemetry_toSessionLimit() throws {
         // Given
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockKeepAll())
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         // sends 101 telemetry events
@@ -220,7 +220,7 @@ class TelemetryReceiverTests: XCTestCase {
     func testSampledTelemetry_rejectAll() throws {
         // Given
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockRejectAll())
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         // sends 10 telemetry events
@@ -247,7 +247,7 @@ class TelemetryReceiverTests: XCTestCase {
             sampler: .mockKeepAll(),
             configurationExtraSampler: .mockRejectAll()
         )
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         for index in 0..<10 {
@@ -269,7 +269,7 @@ class TelemetryReceiverTests: XCTestCase {
             featureScope: featureScope,
             sampler: .mockKeepAll()
         )
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         for index in 0..<10 {
@@ -288,7 +288,7 @@ class TelemetryReceiverTests: XCTestCase {
     func testSendTelemetry_resetAfterSessionExpire() throws {
         // Given
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
         let applicationId: String = .mockRandom()
 
         featureScope.contextMock.set(
@@ -327,7 +327,7 @@ class TelemetryReceiverTests: XCTestCase {
             featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: .init(timeIntervalSince1970: 0))
         )
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         let backgroundTasksEnabled: Bool? = .mockRandom()
         let batchProcessingLevel: Int64? = .mockRandom()
@@ -450,7 +450,7 @@ class TelemetryReceiverTests: XCTestCase {
         // When
         let randomName: String = .mockRandom()
         let randomAttributes = mockRandomAttributes()
-        TelemetryMock(with: receiver).metric(name: randomName, attributes: randomAttributes, sampleRate: 100)
+        TelemetryReceiverProxy(with: receiver).metric(name: randomName, attributes: randomAttributes, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -485,7 +485,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
 
         // When
-        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes(), sampleRate: 100)
+        TelemetryReceiverProxy(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes(), sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -514,7 +514,7 @@ class TelemetryReceiverTests: XCTestCase {
         // When
         var attributes = mockRandomAttributes()
         attributes[SDKMetricFields.sessionIDOverrideKey] = sessionIDOverride
-        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: attributes, sampleRate: 100)
+        TelemetryReceiverProxy(with: receiver).metric(name: .mockRandom(), attributes: attributes, sampleRate: 100)
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
@@ -531,7 +531,7 @@ class TelemetryReceiverTests: XCTestCase {
         let osMock: OperatingSystem = .mockRandom()
         featureScope.contextMock = .mockWith(device: deviceMock, os: osMock)
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         let operationName = String.mockRandom()
@@ -565,7 +565,7 @@ class TelemetryReceiverTests: XCTestCase {
             featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: .init(timeIntervalSince1970: 0))
         )
-        let telemetry = TelemetryMock(with: receiver)
+        let telemetry = TelemetryReceiverProxy(with: receiver)
 
         // When
         let trace = telemetry.startMethodCalled(
@@ -588,11 +588,7 @@ class TelemetryReceiverTests: XCTestCase {
         let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sampler: .mockKeepAll())
 
         // When
-        let result = receiver.receive(
-            message: .telemetry(.usage(.init(event: .trackWebView, sampleRate: 100))),
-            from: NOPDatadogCore()
-        )
-        XCTAssertTrue(result)
+        receiver.receive(message: .usage(.init(event: .trackWebView, sampleRate: 100)), from: NOPDatadogCore())
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryUsageEvent.self).first
@@ -606,5 +602,56 @@ class TelemetryReceiverTests: XCTestCase {
             XCTFail("Expected .telemetryMobileFeaturesUsage(.trackWebView)")
             return
         }
+    }
+
+    // MARK: - Interceptor behaviour (merged from TelemetryInterceptorTests)
+
+    func testWhenInterceptingErrorTelemetry_itUpdatesSessionEndedMetric() throws {
+        let telemetry = TelemetryMock()
+        let sessionID: RUMUUID = .mockRandom()
+        let metricController = SessionEndedMetricController(
+            telemetry: telemetry,
+            sampleRate: 100,
+            tracksBackgroundEvents: .mockAny(),
+            isUsingSceneLifecycle: .mockAny()
+        )
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sessionEndedMetric: metricController)
+
+        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny())
+        receiver.receive(
+            message: .error(id: .mockAny(), message: .mockAny(), kind: .mockAny(), stack: .mockAny()),
+            from: NOPDatadogCore()
+        )
+
+        metricController.endMetric(sessionID: sessionID, with: .mockRandom())
+        let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
+        let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
+        XCTAssertEqual(rse.sdkErrorsCount.total, 1)
+    }
+
+    func testWhenInterceptingUploadQualityMetric_itUpdatesSessionEndedMetricAndDoesNotForward() throws {
+        let telemetry = TelemetryMock()
+        let sessionID: RUMUUID = .mockRandom()
+        let metricController = SessionEndedMetricController(
+            telemetry: telemetry,
+            sampleRate: 100,
+            tracksBackgroundEvents: .mockAny(),
+            isUsingSceneLifecycle: .mockAny()
+        )
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, sessionEndedMetric: metricController)
+
+        metricController.startMetric(sessionID: sessionID, precondition: .mockRandom(), context: .mockAny())
+        receiver.receive(
+            message: .metric(MetricTelemetry(name: UploadQualityMetric.name, attributes: [UploadQualityMetric.track: "feature"], sampleRate: 100)),
+            from: NOPDatadogCore()
+        )
+
+        // Upload quality metric should NOT be forwarded as a RUM event
+        XCTAssertTrue(featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).isEmpty)
+
+        metricController.endMetric(sessionID: sessionID, with: .mockRandom())
+        let metric = try XCTUnwrap(telemetry.messages.lastMetric(named: SessionEndedMetric.Constants.name))
+        let rse = try XCTUnwrap(metric.attributes[SessionEndedMetric.Constants.rseKey] as? SessionEndedMetric.Attributes)
+        XCTAssertEqual(rse.uploadQuality["feature"]?.cycleCount, 1)
     }
 }

--- a/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/WebViewEventReceiverTests.swift
@@ -15,12 +15,7 @@ class WebViewEventReceiverTests: XCTestCase {
     /// Both mobile and browser events conform to the same schema, so we can consider mobile events browser-compatible.
     private func randomWebEvent() -> JSON { try! randomRUMEvent().toJSONObject() }
 
-    /// Creates message sent from `DatadogWebViewTracking`.
-    private func webViewTrackingMessage(with webEvent: JSON) -> FeatureMessage {
-        return .webview(.rum(webEvent))
-    }
-
-    // MARK: - Handling `FeatureMessage`
+    // MARK: - Parsing Web Events
 
     func testParsingViewEvent() throws {
         // Given
@@ -199,30 +194,11 @@ class WebViewEventReceiverTests: XCTestCase {
         )
 
         // When
-        let message = webViewTrackingMessage(with: randomWebEvent())
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: randomWebEvent()), from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must acknowledge the message")
         let command = try XCTUnwrap(commandsSubscriberMock.receivedCommands.firstElement(of: RUMKeepSessionAliveCommand.self), "It must keep RUM session alive")
         XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
-    }
-
-    func testWhenReceivingOtherMessage_itRejectsIt() throws {
-        // Given
-        let receiver = WebViewEventReceiver(
-            featureScope: featureScope,
-            dateProvider: DateProviderMock(),
-            commandSubscriber: RUMCommandSubscriberMock(),
-            viewCache: ViewCache(dateProvider: SystemDateProvider())
-        )
-
-        // When
-        let otherMessage: FeatureMessage = .payload(String.mockRandom())
-        let result = receiver.receive(message: otherMessage, from: NOPDatadogCore())
-
-        // Then
-        XCTAssertFalse(result, "It must reject messages addressed to other receivers")
     }
 
     // MARK: - Modifying Web Events
@@ -257,8 +233,7 @@ class WebViewEventReceiverTests: XCTestCase {
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
         // When
-
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
         let expectedWebEventWritten: JSON = [
@@ -274,7 +249,6 @@ class WebViewEventReceiverTests: XCTestCase {
             "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
@@ -292,10 +266,9 @@ class WebViewEventReceiverTests: XCTestCase {
         )
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: randomWebEvent()), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: randomWebEvent()), from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertTrue(featureScope.eventsWritten.isEmpty, "The event must be dropped")
     }
 
@@ -349,7 +322,7 @@ class WebViewEventReceiverTests: XCTestCase {
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
         let expectedWebEventWritten: JSON = [
@@ -375,7 +348,6 @@ class WebViewEventReceiverTests: XCTestCase {
             "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
@@ -430,7 +402,7 @@ class WebViewEventReceiverTests: XCTestCase {
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
         let expectedWebEventWritten: JSON = [
@@ -451,7 +423,6 @@ class WebViewEventReceiverTests: XCTestCase {
             "date": date + featureScope.contextMock.serverTimeOffset.dd.toInt64Milliseconds,
         ].merging(random, uniquingKeysWith: { old, _ in old })
 
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         DDAssertJSONEqual(AnyCodable(actualWebEventWritten), AnyCodable(expectedWebEventWritten))
@@ -492,10 +463,9 @@ class WebViewEventReceiverTests: XCTestCase {
         ]
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result)
         XCTAssertEqual(featureScope.eventsWritten.count, 1, "It must write web event to core")
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         let expectedWebEventWritten: JSON = [
@@ -541,10 +511,9 @@ class WebViewEventReceiverTests: XCTestCase {
         ]
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result)
         XCTAssertEqual(featureScope.eventsWritten.count, 1)
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         let expectedWebEventWritten: JSON = [
@@ -584,10 +553,9 @@ class WebViewEventReceiverTests: XCTestCase {
         ]
 
         // When
-        let result = receiver.receive(message: webViewTrackingMessage(with: webEventMock), from: NOPDatadogCore())
+        receiver.receive(message: WebViewRUMMessage(kind: .rum, event: webEventMock), from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result)
         XCTAssertEqual(featureScope.eventsWritten.count, 1)
         let actualWebEventWritten = try XCTUnwrap(featureScope.eventsWritten.first)
         let expectedWebEventWritten: JSON = [

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
@@ -10,28 +10,40 @@ import TestUtilities
 @testable import DatadogRUM
 
 class FatalErrorContextNotifierTests: XCTestCase {
-    private let featureScope = FeatureScopeMock()
+    private var bus: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        bus = PassthroughCoreMock()
+    }
+
+    override func tearDown() {
+        bus = nil
+        super.tearDown()
+    }
 
     // MARK: - Changing Session State
 
     func testWhenSessionStateIsSet_itSendsSessionStateMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus.messageBus)
+        var received: [RUMSessionState] = []
+        _ = bus.messageBus.subscribe { (state: RUMSessionState, _) in received.append(state) }
         let newSessionState: RUMSessionState = .mockRandom()
 
         // When
         fatalErrorContext.sessionState = newSessionState
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let sessionStateMessage = try XCTUnwrap(messages.lastPayload as? RUMSessionState)
-        XCTAssertEqual(newSessionState, sessionStateMessage)
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, newSessionState)
     }
 
     func testWhenSessionStateIsReset_itDoesNotSendNextSessionStateMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus.messageBus)
+        var received: [RUMSessionState] = []
+        _ = bus.messageBus.subscribe { (state: RUMSessionState, _) in received.append(state) }
         let originalSessionState: RUMSessionState = .mockRandom()
         fatalErrorContext.sessionState = originalSessionState
 
@@ -39,58 +51,55 @@ class FatalErrorContextNotifierTests: XCTestCase {
         fatalErrorContext.sessionState = nil
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let sessionStateMessage = try XCTUnwrap(messages.lastPayload as? RUMSessionState)
-        XCTAssertEqual(originalSessionState, sessionStateMessage)
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, originalSessionState)
     }
 
     // MARK: - Changing View State
 
     func testWhenViewIsSet_itSendsViewEventMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus.messageBus)
+        var receivedViews: [RUMViewEvent] = []
+        _ = bus.messageBus.subscribe { (event: RUMViewEvent, _) in receivedViews.append(event) }
         let newViewEvent: RUMViewEvent = .mockRandom()
 
         // When
         fatalErrorContext.view = newViewEvent
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let viewEventMessage = try XCTUnwrap(messages.firstPayload as? RUMViewEvent)
-        DDAssertJSONEqual(newViewEvent, viewEventMessage)
+        XCTAssertEqual(receivedViews.count, 1)
+        DDAssertJSONEqual(receivedViews.first, newViewEvent)
     }
 
     func testWhenViewIsReset_itSendsViewResetMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus.messageBus)
+        var resetCount = 0
+        _ = bus.messageBus.subscribe { (_: RUMViewReset, _) in resetCount += 1 }
         fatalErrorContext.view = .mockRandom()
 
         // When
         fatalErrorContext.view = nil
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 2)
-        let viewEventMessage = try XCTUnwrap(messages.lastPayload as? String)
-        XCTAssertEqual(viewEventMessage, RUMPayloadMessages.viewReset)
+        XCTAssertEqual(resetCount, 1)
     }
 
     // MARK: - Changing Global Attributes
 
     func testWhenGlobalAttributesAreSet_itSendsAttributesMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus.messageBus)
+        var received: [RUMEventAttributes] = []
+        _ = bus.messageBus.subscribe { (attrs: RUMEventAttributes, _) in received.append(attrs) }
         let newGlobalAttributes = mockRandomAttributes()
 
         // When
         fatalErrorContext.globalAttributes = newGlobalAttributes
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let attributesMessage = try XCTUnwrap(messages.lastPayload as? RUMEventAttributes)
-        DDAssertJSONEqual(newGlobalAttributes, attributesMessage)
+        XCTAssertEqual(received.count, 1)
+        DDAssertJSONEqual(received.first, newGlobalAttributes)
     }
 }

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -87,14 +87,14 @@ class RUMTests: XCTestCase {
         // Then
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
-        let telemetryReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: TelemetryReceiver.self)
-        let crashReportReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
+        let telemetryReceiver: TelemetryReceiver? = rum.telemetryReceiver
+        let crashReportReceiver = rum.crashReportReceiver
         XCTAssertEqual(rum.performanceOverride?.maxFileAgeForRead, 24.hours)
         XCTAssertEqual(monitor.scopes.dependencies.rumApplicationID, applicationID)
         XCTAssertEqual(monitor.scopes.dependencies.samplingRate, 100)
         XCTAssertEqual(monitor.scopes.dependencies.sessionEndedMetric.sampleRate, 15)
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 20)
-        XCTAssertEqual(crashReportReceiver?.sessionSampler.samplingRate, 100)
+        XCTAssertEqual(crashReportReceiver.sessionSampler.samplingRate, 100)
     }
 
     #if !os(watchOS)
@@ -345,9 +345,9 @@ class RUMTests: XCTestCase {
         // Then
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
-        let crashReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
+        let crashReceiver = rum.crashReportReceiver
         XCTAssertEqual(monitor.scopes.dependencies.samplingRate, 100)
-        XCTAssertEqual(crashReceiver?.sessionSampler.samplingRate, 100)
+        XCTAssertEqual(crashReceiver.sessionSampler.samplingRate, 100)
     }
 
     func testWhenEnabledWithNoDebugSDKArgument() throws {
@@ -362,9 +362,9 @@ class RUMTests: XCTestCase {
         // Then
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
         let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
-        let crashReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: CrashReportReceiver.self)
+        let crashReceiver = rum.crashReportReceiver
         XCTAssertEqual(monitor.scopes.dependencies.samplingRate, random)
-        XCTAssertEqual(crashReceiver?.sessionSampler.samplingRate, random)
+        XCTAssertEqual(crashReceiver.sessionSampler.samplingRate, random)
     }
 
     func testWhenEnabledWithDebugViewsArgument() {
@@ -398,7 +398,7 @@ class RUMTests: XCTestCase {
 
         // Then
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
-        let telemetryReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: TelemetryReceiver.self)
+        let telemetryReceiver: TelemetryReceiver? = rum.telemetryReceiver
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 42)
     }
 
@@ -408,7 +408,7 @@ class RUMTests: XCTestCase {
 
         // Then
         let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
-        let telemetryReceiver = (rum.messageReceiver as! CombinedFeatureMessageReceiver).receivers.firstElement(of: TelemetryReceiver.self)
+        let telemetryReceiver: TelemetryReceiver? = rum.telemetryReceiver
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 20)
     }
 


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Converts every RUM integration receiver (`CrashReportReceiver`, `ErrorMessageReceiver`, `FlagEvaluationReceiver`, `TelemetryReceiver`, `WebViewEventReceiver`, `WatchdogTerminationMonitor`) to `BusMessageReceiver`. Folds `TelemetryInterceptor` into `TelemetryReceiver` (which now owns `sessionEndedMetric` and intercepts `upload_quality`/error telemetry). Updates `FatalErrorContextNotifier` to use a typed `MessageBus`. `RUMFeature` exposes individual receivers, and `RUM.enable` subscribes them. Updates affected tests; removes `TelemetryInterceptor` and its test.

## Refactoring rationale

RUM had the largest fan-in of legacy bus receivers; collapsing them to typed subscribers eliminates the `CombinedFeatureMessageReceiver` plumbing. Merging `TelemetryInterceptor` into `TelemetryReceiver` simplifies the telemetry pipeline — both components consumed `TelemetryMessage`, so a single typed subscriber that branches on case is clearer than a stack of receivers, and the upload-quality short-circuit no longer needs the legacy 'consumed' return value.

---
_Draft — pending author review. Merge in order unless marked parallel._