### PR TITLE
[chain-pr 11/13] Migrate shared NetworkInstrumentation context receiver

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/DatadogURLSessionHandler.swift
@@ -46,8 +46,13 @@ extension DatadogCoreProtocol {
     ///
     /// - Parameter urlSessionHandler: The `URLSession` handler to register.
     public func register(urlSessionHandler: DatadogURLSessionHandler) throws {
-        let contextProvider = NetworkContextCoreProvider()
-        let feature = get(feature: NetworkInstrumentationFeature.self) ?? .init(networkContextProvider: contextProvider, messageReceiver: contextProvider)
+        let feature = get(feature: NetworkInstrumentationFeature.self) ?? {
+            let contextProvider = NetworkContextCoreProvider()
+            let feature = NetworkInstrumentationFeature(networkContextProvider: contextProvider, messageReceiver: NOPFeatureMessageReceiver())
+            // Subscribe typed-bus receiver before registration so initial context push is received:
+            messageBus.subscribe(receiver: contextProvider)
+            return feature
+        }()
         feature.handlers.append(urlSessionHandler)
         try register(feature: feature)
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkContextProvider.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkContextProvider.swift
@@ -19,12 +19,8 @@ internal class NetworkContextCoreProvider: NetworkContextProvider {
     var currentNetworkContext: NetworkContext?
 }
 
-extension NetworkContextCoreProvider: FeatureMessageReceiver {
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .context(context) = message else {
-            return false
-        }
-
+extension NetworkContextCoreProvider: BusMessageReceiver {
+    func receive(message context: DatadogContext, from core: DatadogCoreProtocol) {
         let userConfigurationContext: UserConfigurationContext? = {
             guard let userInfo = context.userInfo else {
                 return nil
@@ -45,6 +41,5 @@ extension NetworkContextCoreProvider: FeatureMessageReceiver {
             userConfigurationContext: userConfigurationContext,
             accountConfigurationContext: accountConfigurationContext
         )
-        return true
     }
 }


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Moves `NetworkContextCoreProvider` from `FeatureMessageReceiver` to `BusMessageReceiver<DatadogContext>` and updates `DatadogCoreProtocol.register(urlSessionHandler:)` to subscribe it via the typed bus before feature registration so the initial context push is received.

## Refactoring rationale

URLSession instrumentation is shared by RUM (resources) and Trace (auto-tracing). It only consumes `DatadogContext`, so the typed subscription is a one-line conversion and the registration path mirrors how other features now wire up their typed receivers.

---
_Draft — pending author review. Merge in order unless marked parallel._