### PR TITLE
[chain-pr 12/13] Migrate remaining DatadogCore integration tests

### DIFF
--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -20,7 +20,21 @@ import TestUtilities
 /// This suite tests if `CrashContextProvider` gets updated by different SDK components, each updating
 /// separate part of the `CrashContext` information.
 class CrashContextProviderTests: XCTestCase {
-    private let provider = CrashContextCoreProvider()
+    private var provider: CrashContextCoreProvider! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+        provider = CrashContextCoreProvider()
+        provider.subscribe(to: core.messageBus)
+    }
+
+    override func tearDown() {
+        core = nil
+        provider = nil
+        super.tearDown()
+    }
 
     // MARK: - Receiving SDK Context
 
@@ -32,7 +46,7 @@ class CrashContextProviderTests: XCTestCase {
         let sdkContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext)
 
         // Then
         provider.flush()
@@ -49,8 +63,8 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore())) // receive next
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial
+        core.messageBus.send(message: nextSDKContext) // receive next
 
         // Then
         provider.flush()
@@ -70,8 +84,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumView: RUMViewEvent = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext)
+        core.messageBus.send(message: rumView)
 
         // Then
         provider.flush()
@@ -90,9 +104,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -113,9 +127,9 @@ class CrashContextProviderTests: XCTestCase {
         let rumView: RUMViewEvent = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: RUMViewReset())
 
         // Then
         provider.flush()
@@ -134,10 +148,10 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: RUMViewReset())
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -158,8 +172,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumSessionState: RUMSessionState = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumSessionState), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumSessionState)
 
         // Then
         provider.flush()
@@ -178,9 +192,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumSessionState), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumSessionState)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -201,8 +215,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumAttributes: RUMEventAttributes = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumAttributes), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumAttributes)
 
         // Then
         provider.flush()
@@ -221,9 +235,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumAttributes), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumAttributes)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -244,8 +258,8 @@ class CrashContextProviderTests: XCTestCase {
         let logAttributes: LogEventAttributes = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(logAttributes), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: logAttributes)
 
         // Then
         provider.flush()
@@ -264,9 +278,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(logAttributes), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: logAttributes)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -279,24 +293,27 @@ class CrashContextProviderTests: XCTestCase {
     // MARK: - Thread safety
 
     func testWhenContextIsWrittenAndReadFromDifferentThreads_itRunsAllOperationsSafely() {
-        let provider = CrashContextCoreProvider()
+        let localProvider = CrashContextCoreProvider()
+        let localCore = PassthroughCoreMock()
+        localProvider.subscribe(to: localCore.messageBus)
+
         let viewEvent: RUMViewEvent = .mockRandom()
         let sessionState: RUMSessionState = .mockRandom()
 
         // swiftlint:disable opening_brace
         callConcurrently(
             closures: [
-                { _ = provider.currentCrashContext },
-                { _ = provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(viewEvent), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(sessionState), from: NOPDatadogCore()) },
+                { _ = localProvider.currentCrashContext },
+                { localCore.messageBus.send(message: DatadogContext.mockRandom()) },
+                { localCore.messageBus.send(message: viewEvent) },
+                { localCore.messageBus.send(message: RUMViewReset()) },
+                { localCore.messageBus.send(message: sessionState) },
             ],
             iterations: 50
         )
         // swiftlint:enable opening_brace
 
-        provider.flush()
+        localProvider.flush()
     }
 
     // MARK: - Helpers

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -57,7 +57,8 @@ class CrashReporterTests: XCTestCase {
         let crashReport: DDCrashReport = .mockRandomWith(context: crashContext)
         let rumCrashReceiver = CrashReceiverMock()
 
-        let core = PassthroughCoreMock(messageReceiver: rumCrashReceiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: rumCrashReceiver)
 
         let plugin = CrashReportingPluginMock()
 

--- a/DatadogCore/Tests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
+++ b/DatadogCore/Tests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
@@ -17,7 +17,8 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        core = PassthroughCoreMock(messageReceiver: LogMessageReceiver.mockAny())
+        core = PassthroughCoreMock()
+        core.subscribe(receiver: LogMessageReceiver.mockAny())
     }
 
     override func tearDown() {

--- a/DatadogCore/Tests/Datadog/InternalProxyTests.swift
+++ b/DatadogCore/Tests/Datadog/InternalProxyTests.swift
@@ -17,7 +17,8 @@ class InternalProxyTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        core = PassthroughCoreMock(messageReceiver: telemetry)
+        core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
     }
 
     override func tearDown() {

--- a/DatadogCore/Tests/Datadog/Mocks/RUM/RUMFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUM/RUMFeatureMocks.swift
@@ -33,8 +33,8 @@ extension RUM.Configuration {
 }
 
 extension WebViewEventReceiver: AnyMockable {
-    public static func mockAny() -> Self {
-        .mockWith()
+    public static func mockAny() -> WebViewEventReceiver {
+        mockWith()
     }
 
     static func mockWith(
@@ -42,7 +42,7 @@ extension WebViewEventReceiver: AnyMockable {
         dateProvider: DateProvider = SystemDateProvider(),
         commandSubscriber: RUMCommandSubscriber = RUMCommandSubscriberMock(),
         viewCache: ViewCache = ViewCache(dateProvider: SystemDateProvider())
-    ) -> Self {
+    ) -> WebViewEventReceiver {
         .init(
             featureScope: featureScope,
             dateProvider: dateProvider,

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -18,16 +18,13 @@ class CrashReportReceiverTests: XCTestCase {
         let receiver: CrashReportReceiver = .mockWith(featureScope: featureScope)
 
         // When
-        let message: FeatureMessage = .payload(
-            Crash(
-                report: DDCrashReport.mockAny(),
-                context: CrashContext.mockWith(lastRUMViewEvent: nil)
-            )
+        let message = Crash(
+            report: DDCrashReport.mockAny(),
+            context: CrashContext.mockWith(lastRUMViewEvent: nil)
         )
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMErrorEvent.self).count, 1, "It should send error event")
     }
 
@@ -37,18 +34,15 @@ class CrashReportReceiverTests: XCTestCase {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // When
-        let message: FeatureMessage = .payload(
-            Crash(
-                report: DDCrashReport.mockWith(date: Date()),
-                context: CrashContext.mockWith(
-                    lastRUMViewEvent: lastRUMViewEvent
-                )
+        let message = Crash(
+            report: DDCrashReport.mockWith(date: Date()),
+            context: CrashContext.mockWith(
+                lastRUMViewEvent: lastRUMViewEvent
             )
         )
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(message: message, from: NOPDatadogCore())
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMErrorEvent.self).count, 1, "It should send error event")
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMViewEvent.self).count, 1, "It should send view event")
     }
@@ -77,10 +71,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -111,10 +104,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertFalse(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -143,10 +135,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -182,10 +173,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -220,10 +210,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -252,10 +241,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertFalse(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -282,10 +270,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -318,10 +305,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -351,10 +337,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -452,10 +437,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -534,10 +518,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -579,10 +562,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -652,10 +634,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -733,10 +714,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -766,10 +746,9 @@ class CrashReportReceiverTests: XCTestCase {
         )
 
         // When
-        XCTAssertTrue(
-            receiver.receive(message: .payload(
-                Crash(report: crashReport, context: crashContext)
-            ), from: NOPDatadogCore())
+        receiver.receive(
+            message: Crash(report: crashReport, context: crashContext),
+            from: NOPDatadogCore()
         )
 
         // Then
@@ -842,10 +821,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -978,10 +956,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1055,10 +1032,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1123,10 +1099,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1194,10 +1169,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1317,10 +1291,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1394,10 +1367,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then
@@ -1477,10 +1449,9 @@ class CrashReportReceiverTests: XCTestCase {
             )
 
             // When
-            XCTAssertTrue(
-                receiver.receive(message: .payload(
-                    Crash(report: crashReport, context: crashContext)
-                ), from: NOPDatadogCore())
+            receiver.receive(
+                message: Crash(report: crashReport, context: crashContext),
+                from: NOPDatadogCore()
             )
 
             // Then

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -618,10 +618,9 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With Logging Feature
 
     func testSendingSpanLogs() throws {
-        let logging: LogsFeature = .mockWith(
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let logging: LogsFeature = .mockWith()
         try core.register(feature: logging)
+        core.messageBus.subscribe(receiver: logging.logMessageReceiver)
 
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
@@ -651,10 +650,9 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        let logging: LogsFeature = .mockWith(
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let logging: LogsFeature = .mockWith()
         try core.register(feature: logging)
+        core.messageBus.subscribe(receiver: logging.logMessageReceiver)
 
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
@@ -676,10 +674,9 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        let logging: LogsFeature = .mockWith(
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let logging: LogsFeature = .mockWith()
         try core.register(feature: logging)
+        core.messageBus.subscribe(receiver: logging.logMessageReceiver)
 
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)
@@ -707,10 +704,9 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
-        let logging: LogsFeature = .mockWith(
-            messageReceiver: LogMessageReceiver.mockAny()
-        )
+        let logging: LogsFeature = .mockWith()
         try core.register(feature: logging)
+        core.messageBus.subscribe(receiver: logging.logMessageReceiver)
 
         Trace.enable(with: config, in: core)
         let tracer = Tracer.shared(in: core)

--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -21,10 +21,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        core = PassthroughCoreMock(messageReceiver: CombinedFeatureMessageReceiver([
-            LogMessageReceiver.mockAny(),
-            receiver
-        ]))
+        core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
+        core.subscribe(receiver: LogMessageReceiver.mockAny())
 
         tracer = .mockWith(
             core: core,
@@ -225,8 +224,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 )
             ]
         )
-        let message = FeatureMessage.context(fakeContext)
-        _ = handler.contextReceiver.receive(message: message, from: core)
+        handler.contextReceiver.receive(message: fakeContext, from: core)
         let (modifiedRequest, _, _) = handler.modify(
             request: request,
             headerTypes: [.datadog, .tracecontext, .b3, .b3multi],

--- a/DatadogCore/Tests/Objc/DDInternalLoggerTests.swift
+++ b/DatadogCore/Tests/Objc/DDInternalLoggerTests.swift
@@ -17,7 +17,8 @@ class DDInternalLoggerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        core = PassthroughCoreMock(messageReceiver: telemetry)
+        core = PassthroughCoreMock()
+        core.subscribe(receiver: telemetry)
     }
 
     override func tearDown() {


### PR DESCRIPTION
> This PR is part of a chain split from #0 _maxep/message-bus-subscription_ by chain-pr.

## Changes

Updates the remaining DatadogCore-side tests that exercised cross-feature wiring (`CrashContextProvider`, `CrashReporter`, `TracingWithLogging`, `InternalProxy`, `TracerTests`, `TracingURLSessionHandler`, `DDInternalLogger`, RUM feature mocks, RUM `CrashReportReceiver` tests) to use typed subscriptions and the new receiver APIs.

---
_Draft — pending author review. Merge in order unless marked parallel._