### PR TITLE
Add DDSketch implementation for latency distributions

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -7,7 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0474714B086BA0F36C4D3EBB /* DDSketch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DD22142B7F7F44A9BAC86 /* DDSketch.swift */; };
 		05B9B20299CF44BB97F4A7C8 /* HeatmapIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048E335C84F4B41E3ACA3B91 /* HeatmapIdentifierTests.swift */; };
+		101425D8A43F7B735CF27468 /* ProtoEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F105FFCAFF3B8B9C95CDD5D9 /* ProtoEncoderTests.swift */; };
+		1078B5138B9AC8B7ECA58D7C /* CollapsingLowestDenseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B98EA5D5BFA33BE350E840 /* CollapsingLowestDenseStore.swift */; };
 		0904F9F42EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
 		0904F9F62EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
 		093AC32A2F56F8AA00267CE1 /* ActiveSpanProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */; };
@@ -1256,6 +1259,11 @@
 		E996B2C5B9B268490842F924 /* HeatmapAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3DACDED0DB3C9908B93EB9 /* HeatmapAttributes.swift */; };
 		F603F12B2CAEA4FA0088E6B7 /* DDInternalLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F603F1282CAEA4E90088E6B7 /* DDInternalLoggerTests.swift */; };
 		F603F1302CAEA7620088E6B7 /* DDInternalLogger+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F603F12D2CAEA7590088E6B7 /* DDInternalLogger+apiTests.m */; };
+		E0114863DA85419446E3F9F6 /* ProtoEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D8F4E81764B7CB8702E87E /* ProtoEncoder.swift */; };
+		E0C3AB4D04F40B9AF96DD1F1 /* LogarithmicMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494934821A8A7BB3D4D475BE /* LogarithmicMapping.swift */; };
+		BBFB0D5A71C212ECA613AC7B /* LogarithmicMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA76045D2C506FBC17AE5D67 /* LogarithmicMappingTests.swift */; };
+		6804F0BC4D67E9416B418186 /* CollapsingLowestDenseStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7CEC7C5D50941F6E11D2D3 /* CollapsingLowestDenseStoreTests.swift */; };
+		EDC13F3F220F554EE9C5CA36 /* DDSketchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490510BE3F80C9EA26B065D9 /* DDSketchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2973,6 +2981,14 @@
 		F603F12D2CAEA7590088E6B7 /* DDInternalLogger+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDInternalLogger+apiTests.m"; sourceTree = "<group>"; };
 		F637AED12697404200516F32 /* UIKitRUMUserActionsPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsPredicate.swift; sourceTree = "<group>"; };
 		FCD4671FE899787D04A9ADD6 /* EvaluationRequestBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationRequestBuilder.swift; sourceTree = "<group>"; };
+		C2D8F4E81764B7CB8702E87E /* ProtoEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtoEncoder.swift; sourceTree = "<group>"; };
+		494934821A8A7BB3D4D475BE /* LogarithmicMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogarithmicMapping.swift; sourceTree = "<group>"; };
+		59B98EA5D5BFA33BE350E840 /* CollapsingLowestDenseStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsingLowestDenseStore.swift; sourceTree = "<group>"; };
+		0B9DD22142B7F7F44A9BAC86 /* DDSketch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSketch.swift; sourceTree = "<group>"; };
+		F105FFCAFF3B8B9C95CDD5D9 /* ProtoEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtoEncoderTests.swift; sourceTree = "<group>"; };
+		FA76045D2C506FBC17AE5D67 /* LogarithmicMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogarithmicMappingTests.swift; sourceTree = "<group>"; };
+		4B7CEC7C5D50941F6E11D2D3 /* CollapsingLowestDenseStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsingLowestDenseStoreTests.swift; sourceTree = "<group>"; };
+		490510BE3F80C9EA26B065D9 /* DDSketchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSketchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6259,6 +6275,7 @@
 				61C5A8A324509FAA00DA608C /* Span */,
 				095AE9512F7D30BD00C332AE /* Sampling */,
 				61C5A87A24509A0C00DA608C /* Utils */,
+				973EF724C408F6C307F8D322 /* DDSketch */,
 			);
 			name = DatadogTrace;
 			path = ../DatadogTrace/Sources;
@@ -6280,6 +6297,7 @@
 				61C5A89924509C1100DA608C /* Utils */,
 				619CE7602A458D66005588CB /* TraceTests.swift */,
 				E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */,
+				C3DA51A343C9DC7532745612 /* DDSketch */,
 			);
 			name = DatadogTraceTests;
 			path = ../DatadogTrace/Tests;
@@ -6747,6 +6765,28 @@
 				D1E553EF33633FBFBB288899 /* HeatmapIdentifierStore.swift */,
 			);
 			path = Heatmaps;
+			sourceTree = "<group>";
+		};
+		973EF724C408F6C307F8D322 /* DDSketch */ = {
+			isa = PBXGroup;
+			children = (
+				59B98EA5D5BFA33BE350E840 /* CollapsingLowestDenseStore.swift */,
+				0B9DD22142B7F7F44A9BAC86 /* DDSketch.swift */,
+				494934821A8A7BB3D4D475BE /* LogarithmicMapping.swift */,
+				C2D8F4E81764B7CB8702E87E /* ProtoEncoder.swift */,
+			);
+			path = DDSketch;
+			sourceTree = "<group>";
+		};
+		C3DA51A343C9DC7532745612 /* DDSketch */ = {
+			isa = PBXGroup;
+			children = (
+				4B7CEC7C5D50941F6E11D2D3 /* CollapsingLowestDenseStoreTests.swift */,
+				490510BE3F80C9EA26B065D9 /* DDSketchTests.swift */,
+				FA76045D2C506FBC17AE5D67 /* LogarithmicMappingTests.swift */,
+				F105FFCAFF3B8B9C95CDD5D9 /* ProtoEncoderTests.swift */,
+			);
+			path = DDSketch;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -8719,6 +8759,10 @@
 				E7CSS01129C4D5A800000011 /* SpanSnapshot.swift in Sources */,
 				D2C1A50829C4C4CB00946C31 /* TracingURLSessionHandler.swift in Sources */,
 				D2C1A50529C4C4CB00946C31 /* DatadogTracer.swift in Sources */,
+				E0114863DA85419446E3F9F6 /* ProtoEncoder.swift in Sources */,
+				E0C3AB4D04F40B9AF96DD1F1 /* LogarithmicMapping.swift in Sources */,
+				1078B5138B9AC8B7ECA58D7C /* CollapsingLowestDenseStore.swift in Sources */,
+				0474714B086BA0F36C4D3EBB /* DDSketch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8749,6 +8793,10 @@
 				3C6C7FFB2B459AF6006F5CBC /* OTelSpanId+DatadogTests.swift in Sources */,
 				D2C1A51F29C4C75700946C31 /* ActiveSpansPoolTests.swift in Sources */,
 				D2C1A52529C4C75700946C31 /* SpanSanitizerTests.swift in Sources */,
+				101425D8A43F7B735CF27468 /* ProtoEncoderTests.swift in Sources */,
+				BBFB0D5A71C212ECA613AC7B /* LogarithmicMappingTests.swift in Sources */,
+				6804F0BC4D67E9416B418186 /* CollapsingLowestDenseStoreTests.swift in Sources */,
+				EDC13F3F220F554EE9C5CA36 /* DDSketchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
+++ b/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
@@ -1,0 +1,150 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A contiguous array of bin counts that collapses the lowest bins when the
+/// number of bins exceeds `maxNumBins`.
+///
+/// Ported from the Go reference:
+/// https://github.com/DataDog/sketches-go/blob/master/ddsketch/store/collapsing_lowest_dense_store.go
+///
+/// Collapsing the lowest bins trades accuracy on the lowest quantiles for bounded
+/// memory usage. This is the correct trade-off for latency distributions where
+/// higher percentiles (p50, p90, p99) matter more than p1.
+internal struct CollapsingLowestDenseStore {
+    private(set) var bins: [Double]
+    private(set) var count: Double = 0
+    private(set) var minIndex: Int = 0
+    private(set) var maxIndex: Int = 0
+    private(set) var offset: Int = 0
+    private(set) var isCollapsed: Bool = false
+    let maxNumBins: Int
+    private var isEmpty: Bool = true
+
+    init(maxNumBins: Int) {
+        precondition(maxNumBins > 0, "maxNumBins must be positive")
+        self.maxNumBins = maxNumBins
+        self.bins = []
+    }
+
+    /// Adds `count` to the bin at the given index, extending or collapsing as needed.
+    mutating func add(index: Int, count: Double) {
+        if count == 0 {
+            return
+        }
+
+        if isEmpty {
+            setupFirstValue(index: index)
+        }
+
+        if index < minIndex {
+            if isCollapsed {
+                bins[minIndex - offset] += count
+                self.count += count
+                return
+            }
+            extendRange(newMin: index, newMax: maxIndex)
+            if isCollapsed {
+                bins[minIndex - offset] += count
+                self.count += count
+                return
+            }
+        } else if index > maxIndex {
+            extendRange(newMin: minIndex, newMax: index)
+        }
+
+        let arrayIndex = index - offset
+        bins[arrayIndex] += count
+        self.count += count
+    }
+
+    /// Returns the contiguous bin data for protobuf serialization.
+    /// The `offset` is the index of the first bin in the contiguous array.
+    func contiguousBins() -> (counts: [Double], indexOffset: Int32) {
+        if isEmpty {
+            return ([], 0)
+        }
+
+        let startArrayIndex = minIndex - offset
+        let endArrayIndex = maxIndex - offset
+        let slice = Array(bins[startArrayIndex...endArrayIndex])
+        return (slice, Int32(minIndex))
+    }
+
+    // MARK: - Private
+
+    private mutating func setupFirstValue(index: Int) {
+        isEmpty = false
+        minIndex = index
+        maxIndex = index
+        offset = index
+        bins = [0]
+    }
+
+    private mutating func extendRange(newMin: Int, newMax: Int) {
+        let requiredBins = newMax - newMin + 1
+
+        if requiredBins > maxNumBins {
+            collapse(newMin: newMin, newMax: newMax)
+            return
+        }
+
+        if newMax > maxIndex {
+            let neededCapacity = newMax - offset + 1
+            if neededCapacity > bins.count {
+                bins.append(contentsOf: [Double](repeating: 0, count: neededCapacity - bins.count))
+            }
+            maxIndex = newMax
+        }
+
+        if newMin < minIndex {
+            let shift = offset - newMin
+            if shift > 0 {
+                let newBins = [Double](repeating: 0, count: shift) + bins
+                bins = newBins
+                offset = newMin
+            }
+            minIndex = newMin
+        }
+    }
+
+    /// Rebuilds the bins array to cover exactly `adjustedMin...newMax` within `maxNumBins`.
+    /// Values below `adjustedMin` are folded into the lowest surviving bin.
+    private mutating func collapse(newMin: Int, newMax: Int) {
+        let adjustedMin = newMax - maxNumBins + 1
+
+        if bins.isEmpty || adjustedMin >= maxIndex {
+            let totalCount = count
+            bins = [Double](repeating: 0, count: maxNumBins)
+            bins[0] = totalCount
+            offset = adjustedMin
+            minIndex = adjustedMin
+            maxIndex = newMax
+            isCollapsed = true
+            return
+        }
+
+        var newBins = [Double](repeating: 0, count: maxNumBins)
+        for oldIdx in minIndex...maxIndex {
+            let srcArrayIdx = oldIdx - offset
+            if srcArrayIdx < 0 || srcArrayIdx >= bins.count {
+                continue
+            }
+            let dstIdx = max(oldIdx, adjustedMin)
+            let dstArrayIdx = dstIdx - adjustedMin
+            if dstArrayIdx >= 0 && dstArrayIdx < newBins.count {
+                newBins[dstArrayIdx] += bins[srcArrayIdx]
+            }
+        }
+
+        bins = newBins
+        offset = adjustedMin
+        minIndex = adjustedMin
+        maxIndex = newMax
+        isCollapsed = true
+    }
+}

--- a/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
+++ b/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
@@ -63,8 +63,12 @@ internal struct CollapsingLowestDenseStore {
     private var isEmpty: Bool = true
 
     init(maxNumBins: Int) {
-        precondition(maxNumBins > 0, "maxNumBins must be positive")
-        self.maxNumBins = maxNumBins
+        // An SDK must never crash the host app on internal misuse. A non-positive
+        // `maxNumBins` has no sensible interpretation, so we clamp to 1 and keep
+        // the store operational. The resulting store will only ever hold one bin,
+        // which makes percentiles degenerate, but no metric outside this sketch
+        // is affected.
+        self.maxNumBins = Swift.max(1, maxNumBins)
         self.bins = []
     }
 

--- a/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
+++ b/DatadogTrace/Sources/DDSketch/CollapsingLowestDenseStore.swift
@@ -15,14 +15,51 @@ import Foundation
 /// Collapsing the lowest bins trades accuracy on the lowest quantiles for bounded
 /// memory usage. This is the correct trade-off for latency distributions where
 /// higher percentiles (p50, p90, p99) matter more than p1.
+///
+/// ### Storage model
+///
+/// Bin indices can be any signed integer (positive or negative), but the backing
+/// array `bins` is a flat `[Double]` indexed from `0`. The mapping between a logical
+/// bin index `i` and its position in `bins` is:
+///
+///     bins[i - offset]
+///
+/// `offset` is the logical index of `bins[0]`. `minIndex` and `maxIndex` track the
+/// range of logical indices that currently hold non-zero counts. The store may
+/// reserve more array slots than this range (e.g. after collapsing).
+///
+/// ### Collapsing
+///
+/// When inserting a new index would require more than `maxNumBins` bins to span
+/// `[minIndex, maxIndex]`, the store collapses the lowest bins: the new logical
+/// range becomes `[newMax - maxNumBins + 1, newMax]`, and all counts below that
+/// new minimum are folded into the lowest surviving bin. Once collapsed,
+/// `isCollapsed` stays `true` for the lifetime of the store.
 internal struct CollapsingLowestDenseStore {
+    /// Flat array of bin counts. `bins[i - offset]` holds the count for logical bin `i`.
+    /// May contain trailing zeros beyond `maxIndex` due to capacity reservation.
     private(set) var bins: [Double]
+
+    /// Sum of all bin counts. Updated incrementally by `add`.
     private(set) var count: Double = 0
+
+    /// Lowest logical bin index currently in use. Undefined when the store is empty.
     private(set) var minIndex: Int = 0
+
+    /// Highest logical bin index currently in use. Undefined when the store is empty.
     private(set) var maxIndex: Int = 0
+
+    /// Logical index corresponding to `bins[0]`. Adjusted when the range shifts.
     private(set) var offset: Int = 0
+
+    /// `true` once the store has collapsed at least once. Drives the fast path in `add`
+    /// for values below `minIndex`.
     private(set) var isCollapsed: Bool = false
+
+    /// Maximum number of bins the store will allocate before collapsing.
     let maxNumBins: Int
+
+    /// `true` until the first non-zero `add(index:count:)` call.
     private var isEmpty: Bool = true
 
     init(maxNumBins: Int) {
@@ -31,7 +68,16 @@ internal struct CollapsingLowestDenseStore {
         self.bins = []
     }
 
-    /// Adds `count` to the bin at the given index, extending or collapsing as needed.
+    /// Adds `count` to the bin at the given logical `index`, extending or collapsing
+    /// the backing array as needed.
+    ///
+    /// - If `index` falls inside `[minIndex, maxIndex]`, the count is added in place.
+    /// - If `index` is below `minIndex` and the store is already collapsed, the count
+    ///   is folded into the lowest surviving bin.
+    /// - Otherwise, the range is extended and may trigger a collapse if it would
+    ///   exceed `maxNumBins`.
+    ///
+    /// Passing `count == 0` is a no-op.
     mutating func add(index: Int, count: Double) {
         if count == 0 {
             return
@@ -57,26 +103,27 @@ internal struct CollapsingLowestDenseStore {
             extendRange(newMin: minIndex, newMax: index)
         }
 
-        let arrayIndex = index - offset
-        bins[arrayIndex] += count
+        bins[index - offset] += count
         self.count += count
     }
 
     /// Returns the contiguous bin data for protobuf serialization.
-    /// The `offset` is the index of the first bin in the contiguous array.
-    func contiguousBins() -> (counts: [Double], indexOffset: Int32) {
+    /// The `indexOffset` is the logical index of the first bin in the returned slice.
+    /// The slice borrows from `bins` directly to avoid copying.
+    func contiguousBins() -> (counts: ArraySlice<Double>, indexOffset: Int32) {
         if isEmpty {
             return ([], 0)
         }
 
-        let startArrayIndex = minIndex - offset
-        let endArrayIndex = maxIndex - offset
-        let slice = Array(bins[startArrayIndex...endArrayIndex])
-        return (slice, Int32(minIndex))
+        let startArrayIndex = bins.startIndex.advanced(by: minIndex - offset)
+        let endArrayIndex = bins.startIndex.advanced(by: maxIndex - offset)
+        return (bins[startArrayIndex...endArrayIndex], Int32(minIndex))
     }
 
     // MARK: - Private
 
+    /// Initialises the store on its first `add` call: a single bin centred on `index`
+    /// with `offset == index` so the new value sits at `bins[0]`.
     private mutating func setupFirstValue(index: Int) {
         isEmpty = false
         minIndex = index
@@ -85,6 +132,9 @@ internal struct CollapsingLowestDenseStore {
         bins = [0]
     }
 
+    /// Extends `[minIndex, maxIndex]` to cover `[newMin, newMax]`, allocating more
+    /// capacity if needed. If the resulting range would exceed `maxNumBins`,
+    /// delegates to `collapse` instead.
     private mutating func extendRange(newMin: Int, newMax: Int) {
         let requiredBins = newMax - newMin + 1
 
@@ -112,15 +162,20 @@ internal struct CollapsingLowestDenseStore {
         }
     }
 
-    /// Rebuilds the bins array to cover exactly `adjustedMin...newMax` within `maxNumBins`.
-    /// Values below `adjustedMin` are folded into the lowest surviving bin.
+    /// Rebuilds the bins array to cover exactly `[adjustedMin, newMax]` within
+    /// `maxNumBins`. Values below `adjustedMin` are folded into the lowest surviving
+    /// bin.
+    ///
+    /// The new array is assembled as four concatenated slices:
+    /// `[leading zeros] + [fold] + [preserved] + [trailing zeros]`,
+    /// each of which may be empty depending on whether this is a downward
+    /// (`adjustedMin <= minIndex`) or upward (`adjustedMin > minIndex`) collapse.
     private mutating func collapse(newMin: Int, newMax: Int) {
         let adjustedMin = newMax - maxNumBins + 1
 
         if bins.isEmpty || adjustedMin >= maxIndex {
-            let totalCount = count
             bins = [Double](repeating: 0, count: maxNumBins)
-            bins[0] = totalCount
+            bins[0] = count
             offset = adjustedMin
             minIndex = adjustedMin
             maxIndex = newMax
@@ -128,20 +183,42 @@ internal struct CollapsingLowestDenseStore {
             return
         }
 
-        var newBins = [Double](repeating: 0, count: maxNumBins)
-        for oldIdx in minIndex...maxIndex {
-            let srcArrayIdx = oldIdx - offset
-            if srcArrayIdx < 0 || srcArrayIdx >= bins.count {
-                continue
-            }
-            let dstIdx = max(oldIdx, adjustedMin)
-            let dstArrayIdx = dstIdx - adjustedMin
-            if dstArrayIdx >= 0 && dstArrayIdx < newBins.count {
-                newBins[dstArrayIdx] += bins[srcArrayIdx]
-            }
+        let leadingZeros: [Double]
+        let fold: [Double]
+        let preservedStartIdx: Int
+
+        if adjustedMin > minIndex {
+            // Upward collapse: sum bins in `[minIndex, adjustedMin]` into a single
+            // bin at the new floor.
+            let foldStart = bins.startIndex.advanced(by: minIndex - offset)
+            let foldEnd = bins.startIndex.advanced(by: adjustedMin - offset)
+            let foldedCount = bins[foldStart...foldEnd].reduce(0, +)
+            leadingZeros = []
+            fold = [foldedCount]
+            preservedStartIdx = adjustedMin + 1
+        } else {
+            // Downward collapse (or no shift): pad zeros on the left, then copy
+            // the preserved range verbatim.
+            leadingZeros = [Double](repeating: 0, count: minIndex - adjustedMin)
+            fold = []
+            preservedStartIdx = minIndex
         }
 
-        bins = newBins
+        let preserved: [Double]
+        if preservedStartIdx <= maxIndex {
+            let srcStart = bins.startIndex.advanced(by: preservedStartIdx - offset)
+            let srcEnd = bins.startIndex.advanced(by: maxIndex - offset)
+            preserved = Array(bins[srcStart...srcEnd])
+        } else {
+            preserved = []
+        }
+
+        let trailingZeros = [Double](
+            repeating: 0,
+            count: maxNumBins - leadingZeros.count - fold.count - preserved.count
+        )
+        bins = leadingZeros + fold + preserved + trailingZeros
+
         offset = adjustedMin
         minIndex = adjustedMin
         maxIndex = newMax

--- a/DatadogTrace/Sources/DDSketch/DDSketch.swift
+++ b/DatadogTrace/Sources/DDSketch/DDSketch.swift
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A quantile sketch for computing approximate percentiles of a distribution
+/// using logarithmic index mapping and bounded memory.
+///
+/// Ported from the Go reference:
+/// https://github.com/DataDog/sketches-go/blob/master/ddsketch/ddsketch.go
+///
+/// This implementation is intentionally self-contained (no SDK dependencies)
+/// so it can be extracted to a standalone repository.
+///
+/// Usage for client-side stats:
+/// ```
+/// var sketch = DDSketch.makeForStats()
+/// sketch.add(durationInNanoseconds)
+/// let protoBytes = sketch.toProtoBytes()
+/// ```
+internal struct DDSketch {
+    let mapping: LogarithmicMapping
+    private(set) var positiveStore: CollapsingLowestDenseStore
+    private(set) var negativeStore: CollapsingLowestDenseStore
+    private(set) var zeroCount: Double = 0
+
+    private(set) var count: Double = 0
+    private(set) var sum: Double = 0
+    private(set) var min: Double = .infinity
+    private(set) var max: Double = -.infinity
+
+    /// Creates a DDSketch with the given relative accuracy and maximum bin count.
+    ///
+    /// - Parameters:
+    ///   - relativeAccuracy: Controls bin width. 0.01 gives 1% relative accuracy.
+    ///   - maxNumBins: Maximum number of bins per store. Excess bins are collapsed.
+    init(relativeAccuracy: Double, maxNumBins: Int) {
+        self.mapping = LogarithmicMapping(relativeAccuracy: relativeAccuracy)
+        self.positiveStore = CollapsingLowestDenseStore(maxNumBins: maxNumBins)
+        self.negativeStore = CollapsingLowestDenseStore(maxNumBins: maxNumBins)
+    }
+
+    /// Creates a DDSketch configured for client-side stats: 1% relative accuracy, 2048 max bins.
+    static func makeForStats() -> DDSketch {
+        return DDSketch(relativeAccuracy: 0.01, maxNumBins: 2_048)
+    }
+
+    /// Records a value into the sketch.
+    ///
+    /// - Parameter value: The value to record. For client-side stats, this is the span duration in nanoseconds.
+    ///   NaN and infinite values are silently ignored.
+    mutating func add(_ value: Double) {
+        if value.isNaN || value.isInfinite {
+            return
+        }
+
+        if value > mapping.minIndexableValue {
+            if value > mapping.maxIndexableValue {
+                return
+            }
+            let index = mapping.index(for: value)
+            positiveStore.add(index: index, count: 1.0)
+        } else if value < -mapping.minIndexableValue {
+            if value < -mapping.maxIndexableValue {
+                return
+            }
+            let index = mapping.index(for: -value)
+            negativeStore.add(index: index, count: 1.0)
+        } else {
+            zeroCount += 1
+        }
+
+        count += 1
+        sum += value
+        if value < min { min = value }
+        if value > max { max = value }
+    }
+
+    /// Returns whether the sketch has no recorded values.
+    var isEmpty: Bool { count == 0 }
+
+    /// Serializes the sketch to protobuf bytes matching the `DDSketch` message
+    /// in `ddsketch.proto`.
+    ///
+    /// Wire layout:
+    /// ```
+    /// DDSketch {
+    ///   1: IndexMapping { gamma, indexOffset, interpolation=NONE }
+    ///   2: Store positiveValues { contiguousBinCounts, contiguousBinIndexOffset }
+    ///   3: Store negativeValues { contiguousBinCounts, contiguousBinIndexOffset }
+    ///   4: double zeroCount
+    /// }
+    /// ```
+    func toProtoBytes() -> Data {
+        var encoder = ProtoEncoder()
+
+        let mappingBytes = encodeMappingProto()
+        encoder.encodeNestedMessage(fieldNumber: 1, payload: mappingBytes)
+
+        let posBytes = encodeStoreProto(positiveStore)
+        encoder.encodeNestedMessage(fieldNumber: 2, payload: posBytes)
+
+        let negBytes = encodeStoreProto(negativeStore)
+        encoder.encodeNestedMessage(fieldNumber: 3, payload: negBytes)
+
+        encoder.encodeDoubleField(fieldNumber: 4, value: zeroCount)
+
+        return encoder.data
+    }
+
+    // MARK: - Protobuf Helpers
+
+    private func encodeMappingProto() -> Data {
+        var enc = ProtoEncoder()
+        enc.encodeDoubleField(fieldNumber: 1, value: mapping.gamma)
+        enc.encodeDoubleField(fieldNumber: 2, value: mapping.indexOffset)
+        // interpolation = NONE (0) is proto3 default, omitted
+        return enc.data
+    }
+
+    private func encodeStoreProto(_ store: CollapsingLowestDenseStore) -> Data {
+        let (counts, indexOffset) = store.contiguousBins()
+        if counts.isEmpty {
+            return Data()
+        }
+        var enc = ProtoEncoder()
+        enc.encodePackedDoubles(fieldNumber: 2, values: counts)
+        enc.encodeSInt32Field(fieldNumber: 3, value: indexOffset)
+        return enc.data
+    }
+}

--- a/DatadogTrace/Sources/DDSketch/DDSketch.swift
+++ b/DatadogTrace/Sources/DDSketch/DDSketch.swift
@@ -15,21 +15,51 @@ import Foundation
 /// This implementation is intentionally self-contained (no SDK dependencies)
 /// so it can be extracted to a standalone repository.
 ///
-/// Usage for client-side stats:
+/// ### How it works
+///
+/// Each added value is mapped to a bin index by `LogarithmicMapping`. Counts for
+/// positive and negative values are stored separately in two `CollapsingLowestDenseStore`
+/// instances, and a third bucket counts values whose magnitude falls below the
+/// mapping's minimum indexable value (treated as zero).
+///
+/// The serialized protobuf payload (`toProtoBytes()`) matches the `DDSketch` message
+/// in `ddsketch.proto`. It is consumed by the APM stats intake to compute approximate
+/// latency percentiles on the backend.
+///
+/// ### Usage for client-side stats
+///
 /// ```
 /// var sketch = DDSketch.makeForStats()
 /// sketch.add(durationInNanoseconds)
 /// let protoBytes = sketch.toProtoBytes()
 /// ```
 internal struct DDSketch {
+    /// Maps values to bin indices. Shared by both stores so positive and negative
+    /// magnitudes use the same scale.
     let mapping: LogarithmicMapping
+
+    /// Bin counts for values strictly greater than `mapping.minIndexableValue`.
     private(set) var positiveStore: CollapsingLowestDenseStore
+
+    /// Bin counts for values strictly less than `-mapping.minIndexableValue`,
+    /// indexed by the absolute value.
     private(set) var negativeStore: CollapsingLowestDenseStore
+
+    /// Number of values whose magnitude is below the mapping's resolution; these
+    /// would all collapse to the same bin index, so we track them as a single count.
     private(set) var zeroCount: Double = 0
 
+    /// Total number of recorded values, including those in the zero bucket.
     private(set) var count: Double = 0
+
+    /// Running sum of all recorded values. Useful for computing the mean without
+    /// reconstructing the distribution.
     private(set) var sum: Double = 0
+
+    /// Minimum recorded value. `.infinity` when no values have been added.
     private(set) var min: Double = .infinity
+
+    /// Maximum recorded value. `-.infinity` when no values have been added.
     private(set) var max: Double = -.infinity
 
     /// Creates a DDSketch with the given relative accuracy and maximum bin count.

--- a/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
+++ b/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Maps positive `Double` values to integer bin indices using logarithmic scaling.
+///
+/// Ported from the Go reference:
+/// https://github.com/DataDog/sketches-go/blob/master/ddsketch/mapping/logarithmic_mapping.go
+///
+/// The mapping guarantees that any value `v` mapped to index `i` satisfies:
+///   `value(at: i)` is within `relativeAccuracy` of `v`.
+internal struct LogarithmicMapping {
+    /// Ratio controlling bin width: `(1 + relativeAccuracy) / (1 - relativeAccuracy)`.
+    let gamma: Double
+
+    /// Precomputed `1.0 / log(gamma)` for fast index computation.
+    let multiplier: Double
+
+    /// Offset applied to the index (0.0 for standard usage).
+    let indexOffset: Double
+
+    /// Smallest positive value that can be mapped to a valid `Int32` index.
+    let minIndexableValue: Double
+
+    /// Largest positive value that can be mapped to a valid `Int32` index.
+    let maxIndexableValue: Double
+
+    /// The target relative accuracy, in (0, 1). A value of 0.01 means 1% accuracy.
+    let relativeAccuracy: Double
+
+    init(relativeAccuracy: Double) {
+        precondition(relativeAccuracy > 0 && relativeAccuracy < 1, "relativeAccuracy must be in (0, 1)")
+
+        self.relativeAccuracy = relativeAccuracy
+        self.gamma = (1 + relativeAccuracy) / (1 - relativeAccuracy)
+        self.multiplier = 1.0 / log(gamma)
+        self.indexOffset = 0.0
+
+        self.minIndexableValue = max(
+            exp((Double(Int32.min) - indexOffset) / multiplier + 1),
+            Double.leastNormalMagnitude * gamma
+        )
+
+        self.maxIndexableValue = min(
+            exp((Double(Int32.max) - indexOffset) / multiplier - 1),
+            exp(709.0) / (2.0 * gamma / (1.0 + gamma))
+        )
+    }
+
+    /// Returns the bin index for a positive value.
+    func index(for value: Double) -> Int {
+        let rawIndex = log(value) * multiplier + indexOffset
+        if rawIndex >= 0 {
+            return Int(rawIndex)
+        }
+        return Int(rawIndex) - 1
+    }
+
+    /// Returns a representative value for a given bin index.
+    /// The returned value is within `relativeAccuracy` of any value mapped to this index.
+    func value(at index: Int) -> Double {
+        return lowerBound(index: index) * (1 + relativeAccuracy)
+    }
+
+    /// Returns the lower bound of the bin at the given index.
+    func lowerBound(index: Int) -> Double {
+        return exp((Double(index) - indexOffset) / multiplier)
+    }
+}

--- a/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
+++ b/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
@@ -38,11 +38,30 @@ internal struct LogarithmicMapping {
     /// Go reference: https://github.com/DataDog/sketches-go/blob/master/ddsketch/mapping/logarithmic_mapping.go
     private static let maxSafeExpArgument: Double = 709.0
 
-    init(relativeAccuracy: Double) {
-        precondition(relativeAccuracy > 0 && relativeAccuracy < 1, "relativeAccuracy must be in (0, 1)")
+    /// Lower bound for the `relativeAccuracy` clamp. Values below this would make
+    /// `gamma` round to `1.0` in double precision and `multiplier = 1 / log(gamma)`
+    /// non-finite, which would later trap when converting raw indices to `Int`.
+    private static let minSafeRelativeAccuracy: Double = 0.0001
 
-        self.relativeAccuracy = relativeAccuracy
-        self.gamma = (1 + relativeAccuracy) / (1 - relativeAccuracy)
+    /// Upper bound for the `relativeAccuracy` clamp. Values too close to `1.0`
+    /// produce a tiny `(1 - r)` denominator and an enormous `gamma`. The bound
+    /// here is generous; the production value used by `DDSketch.makeForStats()`
+    /// is `0.01`.
+    private static let maxSafeRelativeAccuracy: Double = 0.9999
+
+    init(relativeAccuracy: Double) {
+        // An SDK must never crash the host app on internal misuse. The math is
+        // only well-defined for `relativeAccuracy` in `(0, 1)`, and even then the
+        // open-interval boundaries produce non-finite intermediate values that
+        // would trap downstream. We clamp to a safe inner range; the resulting
+        // sketch stays operational and only this one sketch is affected.
+        let clamped = Swift.min(
+            Swift.max(relativeAccuracy, LogarithmicMapping.minSafeRelativeAccuracy),
+            LogarithmicMapping.maxSafeRelativeAccuracy
+        )
+
+        self.relativeAccuracy = clamped
+        self.gamma = (1 + clamped) / (1 - clamped)
         self.multiplier = 1.0 / log(gamma)
         self.indexOffset = 0.0
 

--- a/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
+++ b/DatadogTrace/Sources/DDSketch/LogarithmicMapping.swift
@@ -32,6 +32,12 @@ internal struct LogarithmicMapping {
     /// The target relative accuracy, in (0, 1). A value of 0.01 means 1% accuracy.
     let relativeAccuracy: Double
 
+    /// Largest exponent that does not overflow `exp()` for IEEE 754 doubles.
+    /// `exp(709.78...)` reaches `Double.greatestFiniteMagnitude`; `710` returns `+infinity`.
+    /// Used as a conservative ceiling when deriving `maxIndexableValue`. Matches the
+    /// Go reference: https://github.com/DataDog/sketches-go/blob/master/ddsketch/mapping/logarithmic_mapping.go
+    private static let maxSafeExpArgument: Double = 709.0
+
     init(relativeAccuracy: Double) {
         precondition(relativeAccuracy > 0 && relativeAccuracy < 1, "relativeAccuracy must be in (0, 1)")
 
@@ -47,7 +53,7 @@ internal struct LogarithmicMapping {
 
         self.maxIndexableValue = min(
             exp((Double(Int32.max) - indexOffset) / multiplier - 1),
-            exp(709.0) / (2.0 * gamma / (1.0 + gamma))
+            exp(LogarithmicMapping.maxSafeExpArgument) / (2.0 * gamma / (1.0 + gamma))
         )
     }
 

--- a/DatadogTrace/Sources/DDSketch/ProtoEncoder.swift
+++ b/DatadogTrace/Sources/DDSketch/ProtoEncoder.swift
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Minimal protobuf encoder for the DDSketch wire format.
+///
+/// Supports only the subset of proto3 needed by `ddsketch.proto`:
+/// varint, fixed64 (double), sint32 (zigzag), length-delimited (nested messages),
+/// and packed repeated doubles.
+///
+/// This encoder is intentionally self-contained with no SDK dependencies
+/// so the DDSketch code can be extracted to a standalone repository.
+internal struct ProtoEncoder {
+    private(set) var data = Data()
+
+    // MARK: - Wire Types
+
+    private enum WireType: UInt8 {
+        case varint = 0
+        case fixed64 = 1
+        case lengthDelimited = 2
+    }
+
+    // MARK: - Tag
+
+    private mutating func encodeTag(fieldNumber: Int, wireType: WireType) {
+        encodeVarint(UInt64(fieldNumber) << 3 | UInt64(wireType.rawValue))
+    }
+
+    // MARK: - Varint
+
+    mutating func encodeVarint(_ value: UInt64) {
+        var v = value
+        while v > 0x7F {
+            data.append(UInt8(v & 0x7F) | 0x80)
+            v >>= 7
+        }
+        data.append(UInt8(v))
+    }
+
+    // MARK: - ZigZag (for sint32)
+
+    static func zigZagEncode(_ value: Int32) -> UInt64 {
+        return UInt64(UInt32(bitPattern: (value << 1) ^ (value >> 31)))
+    }
+
+    // MARK: - Double (fixed64, little-endian IEEE 754)
+
+    private mutating func encodeDouble(_ value: Double) {
+        var bits = value.bitPattern
+        withUnsafeBytes(of: &bits) { data.append(contentsOf: $0) }
+    }
+
+    // MARK: - Field Encoders
+
+    /// Encodes a `double` field (wire type: fixed64). Skips if value is 0.0 (proto3 default).
+    mutating func encodeDoubleField(fieldNumber: Int, value: Double) {
+        guard value.bitPattern != 0 else {
+            return
+        }
+        encodeTag(fieldNumber: fieldNumber, wireType: .fixed64)
+        encodeDouble(value)
+    }
+
+    /// Encodes a `uint64`/`int32`/`enum` field as varint. Skips if value is 0 (proto3 default).
+    mutating func encodeVarintField(fieldNumber: Int, value: UInt64) {
+        guard value != 0 else {
+            return
+        }
+        encodeTag(fieldNumber: fieldNumber, wireType: .varint)
+        encodeVarint(value)
+    }
+
+    /// Encodes a `sint32` field using zigzag encoding. Skips if value is 0 (proto3 default).
+    mutating func encodeSInt32Field(fieldNumber: Int, value: Int32) {
+        guard value != 0 else {
+            return
+        }
+        encodeTag(fieldNumber: fieldNumber, wireType: .varint)
+        encodeVarint(ProtoEncoder.zigZagEncode(value))
+    }
+
+    /// Encodes a nested message as a length-delimited field. Skips if payload is empty.
+    mutating func encodeNestedMessage(fieldNumber: Int, payload: Data) {
+        guard !payload.isEmpty else {
+            return
+        }
+        encodeTag(fieldNumber: fieldNumber, wireType: .lengthDelimited)
+        encodeVarint(UInt64(payload.count))
+        data.append(payload)
+    }
+
+    /// Encodes a packed repeated `double` array. Skips if the array is empty.
+    mutating func encodePackedDoubles(fieldNumber: Int, values: [Double]) {
+        guard !values.isEmpty else {
+            return
+        }
+        encodeTag(fieldNumber: fieldNumber, wireType: .lengthDelimited)
+        let byteCount = values.count * MemoryLayout<Double>.size
+        encodeVarint(UInt64(byteCount))
+        for value in values {
+            encodeDouble(value)
+        }
+    }
+}

--- a/DatadogTrace/Sources/DDSketch/ProtoEncoder.swift
+++ b/DatadogTrace/Sources/DDSketch/ProtoEncoder.swift
@@ -94,8 +94,10 @@ internal struct ProtoEncoder {
         data.append(payload)
     }
 
-    /// Encodes a packed repeated `double` array. Skips if the array is empty.
-    mutating func encodePackedDoubles(fieldNumber: Int, values: [Double]) {
+    /// Encodes a packed repeated `double` field. Skips if the slice is empty.
+    /// Accepts an `ArraySlice` so callers can pass a view into their backing array
+    /// without copying.
+    mutating func encodePackedDoubles(fieldNumber: Int, values: ArraySlice<Double>) {
         guard !values.isEmpty else {
             return
         }

--- a/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
+++ b/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
@@ -1,0 +1,220 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+@testable import DatadogTrace
+import XCTest
+
+final class CollapsingLowestDenseStoreTests: XCTestCase {
+    // MARK: - Basic Operations
+
+    func testEmpty_contiguousBins() {
+        let store = CollapsingLowestDenseStore(maxNumBins: 128)
+        let (counts, offset) = store.contiguousBins()
+        XCTAssertTrue(counts.isEmpty)
+        XCTAssertEqual(offset, 0)
+        XCTAssertEqual(store.count, 0)
+    }
+
+    func testAddSingleValue() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: 10, count: 1.0)
+
+        XCTAssertEqual(store.count, 1.0)
+        XCTAssertEqual(store.minIndex, 10)
+        XCTAssertEqual(store.maxIndex, 10)
+
+        let (counts, offset) = store.contiguousBins()
+        XCTAssertEqual(counts, [1.0])
+        XCTAssertEqual(offset, 10)
+    }
+
+    func testAddMultipleValues_sameIndex() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: 5, count: 1.0)
+        store.add(index: 5, count: 3.0)
+
+        XCTAssertEqual(store.count, 4.0)
+
+        let (counts, _) = store.contiguousBins()
+        XCTAssertEqual(counts, [4.0])
+    }
+
+    func testAddMultipleValues_differentIndices() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: 5, count: 1.0)
+        store.add(index: 7, count: 2.0)
+        store.add(index: 10, count: 3.0)
+
+        XCTAssertEqual(store.count, 6.0)
+        XCTAssertEqual(store.minIndex, 5)
+        XCTAssertEqual(store.maxIndex, 10)
+
+        let (counts, offset) = store.contiguousBins()
+        XCTAssertEqual(offset, 5)
+        XCTAssertEqual(counts.count, 6) // indices 5..10
+        XCTAssertEqual(counts[0], 1.0) // index 5
+        XCTAssertEqual(counts[1], 0.0) // index 6
+        XCTAssertEqual(counts[2], 2.0) // index 7
+        XCTAssertEqual(counts[5], 3.0) // index 10
+    }
+
+    func testAddZeroCount_noEffect() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: 5, count: 0)
+        XCTAssertEqual(store.count, 0)
+        let (counts, _) = store.contiguousBins()
+        XCTAssertTrue(counts.isEmpty)
+    }
+
+    // MARK: - Extend Low
+
+    func testAddLowerIndex_extendsRange() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: 10, count: 1.0)
+        store.add(index: 5, count: 2.0)
+
+        XCTAssertEqual(store.minIndex, 5)
+        XCTAssertEqual(store.maxIndex, 10)
+        XCTAssertEqual(store.count, 3.0)
+
+        let (counts, offset) = store.contiguousBins()
+        XCTAssertEqual(offset, 5)
+        XCTAssertEqual(counts[0], 2.0) // index 5
+        XCTAssertEqual(counts[5], 1.0) // index 10
+    }
+
+    // MARK: - Collapsing
+
+    func testCollapse_whenExceedingMaxBins() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 4)
+
+        // Add values at indices 0..4 (needs 5 bins, exceeds max of 4)
+        for i in 0...4 {
+            store.add(index: i, count: 1.0)
+        }
+
+        XCTAssertEqual(store.count, 5.0)
+        XCTAssertTrue(store.isCollapsed)
+
+        let (counts, _) = store.contiguousBins()
+        XCTAssertLessThanOrEqual(counts.count, 4)
+
+        // Total count must be preserved even after collapsing
+        let totalCount = counts.reduce(0, +)
+        XCTAssertEqual(totalCount, 5.0)
+    }
+
+    func testCollapse_preservesTotalCount() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 3)
+
+        for i in 0..<10 {
+            store.add(index: i, count: Double(i + 1))
+        }
+
+        let expectedTotal: Double = (1...10).reduce(0) { $0 + Double($1) } // 55
+        XCTAssertEqual(store.count, expectedTotal)
+
+        let (counts, _) = store.contiguousBins()
+        let totalCount = counts.reduce(0, +)
+        XCTAssertEqual(totalCount, expectedTotal)
+    }
+
+    // MARK: - Negative Indices
+
+    func testNegativeIndices() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 128)
+        store.add(index: -5, count: 1.0)
+        store.add(index: -3, count: 2.0)
+
+        XCTAssertEqual(store.count, 3.0)
+        XCTAssertEqual(store.minIndex, -5)
+        XCTAssertEqual(store.maxIndex, -3)
+
+        let (counts, offset) = store.contiguousBins()
+        XCTAssertEqual(offset, -5)
+        XCTAssertEqual(counts.count, 3) // -5, -4, -3
+        XCTAssertEqual(counts[0], 1.0) // index -5
+        XCTAssertEqual(counts[2], 2.0) // index -3
+    }
+
+    // MARK: - Collapsing After Already Collapsed
+
+    func testCollapse_addBelow_goesToFirstBin() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 3)
+        store.add(index: 0, count: 1.0)
+        store.add(index: 1, count: 1.0)
+        store.add(index: 2, count: 1.0)
+        store.add(index: 3, count: 1.0) // triggers collapse
+
+        XCTAssertTrue(store.isCollapsed)
+
+        // Adding below minimum should go to the lowest valid bin
+        store.add(index: -10, count: 5.0)
+        XCTAssertEqual(store.count, 9.0) // 4 original + 5 new
+
+        let (counts, _) = store.contiguousBins()
+        let totalCount = counts.reduce(0, +)
+        XCTAssertEqual(totalCount, 9.0)
+    }
+
+    func testCollapse_downward_restructuresBins() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 4)
+        store.add(index: 10, count: 1.0)
+        store.add(index: 0, count: 1.0) // triggers downward collapse
+
+        XCTAssertTrue(store.isCollapsed)
+        XCTAssertEqual(store.count, 2.0)
+
+        // adjustedMin = 10 - 4 + 1 = 7, so bins should cover 7...10
+        XCTAssertEqual(store.minIndex, 7)
+        XCTAssertEqual(store.maxIndex, 10)
+
+        let (counts, indexOffset) = store.contiguousBins()
+        XCTAssertEqual(indexOffset, 7)
+        XCTAssertEqual(counts.count, 4) // indices 7, 8, 9, 10
+
+        // index 0 collapsed into the lowest valid bin (7), index 10 stays at position 3
+        XCTAssertEqual(counts[0], 1.0) // collapsed value at index 7
+        XCTAssertEqual(counts[3], 1.0) // original value at index 10
+
+        let totalCount = counts.reduce(0, +)
+        XCTAssertEqual(totalCount, 2.0)
+    }
+
+    func testCollapse_monotonicallyIncreasing_staysBounded() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 10)
+
+        for i in 0...1_000 {
+            store.add(index: i, count: 1.0)
+        }
+
+        XCTAssertEqual(store.count, 1_001)
+        XCTAssertLessThanOrEqual(store.bins.count, 10)
+
+        let (counts, _) = store.contiguousBins()
+        XCTAssertLessThanOrEqual(counts.count, 10)
+
+        let totalCount = counts.reduce(0, +)
+        XCTAssertEqual(totalCount, 1_001)
+    }
+
+    // MARK: - Large Sparse Range
+
+    func testSparseRange_withinMaxBins() {
+        var store = CollapsingLowestDenseStore(maxNumBins: 2_048)
+        store.add(index: 0, count: 1.0)
+        store.add(index: 100, count: 1.0)
+
+        XCTAssertEqual(store.count, 2.0)
+        XCTAssertEqual(store.minIndex, 0)
+        XCTAssertEqual(store.maxIndex, 100)
+
+        let (counts, _) = store.contiguousBins()
+        XCTAssertEqual(counts.count, 101)
+        XCTAssertEqual(counts[0], 1.0)
+        XCTAssertEqual(counts[100], 1.0)
+    }
+}

--- a/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
+++ b/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
@@ -27,7 +27,7 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.maxIndex, 10)
 
         let (counts, offset) = store.contiguousBins()
-        XCTAssertEqual(counts, [1.0])
+        XCTAssertEqual(Array(counts), [1.0])
         XCTAssertEqual(offset, 10)
     }
 
@@ -39,7 +39,7 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.count, 4.0)
 
         let (counts, _) = store.contiguousBins()
-        XCTAssertEqual(counts, [4.0])
+        XCTAssertEqual(Array(counts), [4.0])
     }
 
     func testAddMultipleValues_differentIndices() {
@@ -53,12 +53,13 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.maxIndex, 10)
 
         let (counts, offset) = store.contiguousBins()
+        let countsArray = Array(counts)
         XCTAssertEqual(offset, 5)
-        XCTAssertEqual(counts.count, 6) // indices 5..10
-        XCTAssertEqual(counts[0], 1.0) // index 5
-        XCTAssertEqual(counts[1], 0.0) // index 6
-        XCTAssertEqual(counts[2], 2.0) // index 7
-        XCTAssertEqual(counts[5], 3.0) // index 10
+        XCTAssertEqual(countsArray.count, 6) // indices 5..10
+        XCTAssertEqual(countsArray[0], 1.0) // index 5
+        XCTAssertEqual(countsArray[1], 0.0) // index 6
+        XCTAssertEqual(countsArray[2], 2.0) // index 7
+        XCTAssertEqual(countsArray[5], 3.0) // index 10
     }
 
     func testAddZeroCount_noEffect() {
@@ -81,9 +82,10 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.count, 3.0)
 
         let (counts, offset) = store.contiguousBins()
+        let countsArray = Array(counts)
         XCTAssertEqual(offset, 5)
-        XCTAssertEqual(counts[0], 2.0) // index 5
-        XCTAssertEqual(counts[5], 1.0) // index 10
+        XCTAssertEqual(countsArray[0], 2.0) // index 5
+        XCTAssertEqual(countsArray[5], 1.0) // index 10
     }
 
     // MARK: - Collapsing
@@ -134,10 +136,11 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.maxIndex, -3)
 
         let (counts, offset) = store.contiguousBins()
+        let countsArray = Array(counts)
         XCTAssertEqual(offset, -5)
-        XCTAssertEqual(counts.count, 3) // -5, -4, -3
-        XCTAssertEqual(counts[0], 1.0) // index -5
-        XCTAssertEqual(counts[2], 2.0) // index -3
+        XCTAssertEqual(countsArray.count, 3) // -5, -4, -3
+        XCTAssertEqual(countsArray[0], 1.0) // index -5
+        XCTAssertEqual(countsArray[2], 2.0) // index -3
     }
 
     // MARK: - Collapsing After Already Collapsed
@@ -173,14 +176,15 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.maxIndex, 10)
 
         let (counts, indexOffset) = store.contiguousBins()
+        let countsArray = Array(counts)
         XCTAssertEqual(indexOffset, 7)
-        XCTAssertEqual(counts.count, 4) // indices 7, 8, 9, 10
+        XCTAssertEqual(countsArray.count, 4) // indices 7, 8, 9, 10
 
         // index 0 collapsed into the lowest valid bin (7), index 10 stays at position 3
-        XCTAssertEqual(counts[0], 1.0) // collapsed value at index 7
-        XCTAssertEqual(counts[3], 1.0) // original value at index 10
+        XCTAssertEqual(countsArray[0], 1.0) // collapsed value at index 7
+        XCTAssertEqual(countsArray[3], 1.0) // original value at index 10
 
-        let totalCount = counts.reduce(0, +)
+        let totalCount = countsArray.reduce(0, +)
         XCTAssertEqual(totalCount, 2.0)
     }
 
@@ -213,8 +217,9 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(store.maxIndex, 100)
 
         let (counts, _) = store.contiguousBins()
-        XCTAssertEqual(counts.count, 101)
-        XCTAssertEqual(counts[0], 1.0)
-        XCTAssertEqual(counts[100], 1.0)
+        let countsArray = Array(counts)
+        XCTAssertEqual(countsArray.count, 101)
+        XCTAssertEqual(countsArray[0], 1.0)
+        XCTAssertEqual(countsArray[100], 1.0)
     }
 }

--- a/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
+++ b/DatadogTrace/Tests/DDSketch/CollapsingLowestDenseStoreTests.swift
@@ -188,6 +188,29 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
         XCTAssertEqual(totalCount, 2.0)
     }
 
+    func testCollapse_whenNewValueFarAboveRange_resetsToFloor() {
+        // When the new value is so far above the existing range that
+        // `adjustedMin >= maxIndex`, the entire previous range collapses into the
+        // new floor in a single step. This exercises the early-return branch of
+        // `collapse()`.
+        var store = CollapsingLowestDenseStore(maxNumBins: 3)
+        store.add(index: 0, count: 2.0)
+        store.add(index: 1, count: 3.0)
+        // adjustedMin = 100 - 3 + 1 = 98, which is >> maxIndex (1).
+        store.add(index: 100, count: 1.0)
+
+        XCTAssertTrue(store.isCollapsed)
+        XCTAssertEqual(store.count, 6.0)
+        XCTAssertEqual(store.minIndex, 98)
+        XCTAssertEqual(store.maxIndex, 100)
+
+        let (counts, indexOffset) = store.contiguousBins()
+        XCTAssertEqual(indexOffset, 98)
+        // All previous counts (2 + 3 = 5) folded into the new floor at index 98;
+        // the new value (1) lands at the new top index 100.
+        XCTAssertEqual(Array(counts), [5.0, 0.0, 1.0])
+    }
+
     func testCollapse_monotonicallyIncreasing_staysBounded() {
         var store = CollapsingLowestDenseStore(maxNumBins: 10)
 
@@ -203,6 +226,54 @@ final class CollapsingLowestDenseStoreTests: XCTestCase {
 
         let totalCount = counts.reduce(0, +)
         XCTAssertEqual(totalCount, 1_001)
+    }
+
+    // MARK: - Example-Based Collapse
+
+    func testFixture_upwardCollapseProducesExpectedBinLayout() {
+        // Concrete example pinning the upward-collapse layout end-to-end:
+        // five consecutive adds at indices 0..4 into a store with maxNumBins = 4
+        // force a collapse where indices 0 and 1 fold into the new floor (bin 1).
+        var store = CollapsingLowestDenseStore(maxNumBins: 4)
+        for i in 0...4 {
+            store.add(index: i, count: 1.0)
+        }
+
+        // After the collapse: adjustedMin = 4 - 4 + 1 = 1.
+        //   bin 1 = 2 (folded from old indices 0 and 1)
+        //   bin 2 = 1 (preserved)
+        //   bin 3 = 1 (preserved)
+        //   bin 4 = 1 (newly added)
+        XCTAssertTrue(store.isCollapsed)
+        XCTAssertEqual(store.count, 5.0)
+        XCTAssertEqual(store.minIndex, 1)
+        XCTAssertEqual(store.maxIndex, 4)
+
+        let (counts, indexOffset) = store.contiguousBins()
+        XCTAssertEqual(indexOffset, 1)
+        XCTAssertEqual(Array(counts), [2.0, 1.0, 1.0, 1.0])
+    }
+
+    // MARK: - Defensive Initialization
+
+    func testInit_clampsZeroMaxNumBinsToOne() {
+        // A non-positive `maxNumBins` would have no sensible interpretation; the SDK
+        // must not crash on internal misuse, so the store clamps to 1 and stays operational.
+        var store = CollapsingLowestDenseStore(maxNumBins: 0)
+        XCTAssertEqual(store.maxNumBins, 1)
+
+        store.add(index: 5, count: 1.0)
+        store.add(index: 6, count: 1.0) // would trigger collapse since maxNumBins == 1
+        XCTAssertEqual(store.count, 2.0)
+        XCTAssertTrue(store.isCollapsed)
+    }
+
+    func testInit_clampsNegativeMaxNumBinsToOne() {
+        var store = CollapsingLowestDenseStore(maxNumBins: -10)
+        XCTAssertEqual(store.maxNumBins, 1)
+
+        store.add(index: 0, count: 3.0)
+        XCTAssertEqual(store.count, 3.0)
     }
 
     // MARK: - Large Sparse Range

--- a/DatadogTrace/Tests/DDSketch/DDSketchTests.swift
+++ b/DatadogTrace/Tests/DDSketch/DDSketchTests.swift
@@ -1,0 +1,248 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+@testable import DatadogTrace
+import XCTest
+
+final class DDSketchTests: XCTestCase {
+    // MARK: - Factory
+
+    func testMakeForStats_configures1PercentAccuracyAnd2048Bins() {
+        let sketch = DDSketch.makeForStats()
+        XCTAssertEqual(sketch.mapping.relativeAccuracy, 0.01)
+        XCTAssertEqual(sketch.positiveStore.maxNumBins, 2_048)
+        XCTAssertEqual(sketch.negativeStore.maxNumBins, 2_048)
+    }
+
+    // MARK: - Empty Sketch
+
+    func testEmptySketch() {
+        let sketch = DDSketch.makeForStats()
+        XCTAssertTrue(sketch.isEmpty)
+        XCTAssertEqual(sketch.count, 0)
+        XCTAssertEqual(sketch.sum, 0)
+        XCTAssertEqual(sketch.zeroCount, 0)
+    }
+
+    func testEmptySketch_toProtoBytes_isNotEmpty() {
+        let sketch = DDSketch.makeForStats()
+        let bytes = sketch.toProtoBytes()
+        // Even empty, the mapping message must be encoded
+        XCTAssertGreaterThan(bytes.count, 0)
+    }
+
+    // MARK: - Adding Values
+
+    func testAddPositiveValues() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(100.0)
+        sketch.add(200.0)
+        sketch.add(300.0)
+
+        XCTAssertEqual(sketch.count, 3)
+        XCTAssertEqual(sketch.sum, 600.0)
+        XCTAssertEqual(sketch.min, 100.0)
+        XCTAssertEqual(sketch.max, 300.0)
+        XCTAssertFalse(sketch.isEmpty)
+    }
+
+    func testAddZero_goesToZeroBucket() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(0.0)
+
+        XCTAssertEqual(sketch.count, 1)
+        XCTAssertEqual(sketch.zeroCount, 1)
+        XCTAssertEqual(sketch.sum, 0)
+    }
+
+    func testAddNegativeValues() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(-50.0)
+        sketch.add(-100.0)
+
+        XCTAssertEqual(sketch.count, 2)
+        XCTAssertEqual(sketch.sum, -150.0)
+        XCTAssertEqual(sketch.min, -100.0)
+        XCTAssertEqual(sketch.max, -50.0)
+    }
+
+    func testAddMixedValues() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(-10.0)
+        sketch.add(0.0)
+        sketch.add(10.0)
+
+        XCTAssertEqual(sketch.count, 3)
+        XCTAssertEqual(sketch.zeroCount, 1)
+        XCTAssertEqual(sketch.sum, 0.0)
+    }
+
+    // MARK: - Edge Cases
+
+    func testAddNaN_isIgnored() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(Double.nan)
+        XCTAssertTrue(sketch.isEmpty)
+        XCTAssertEqual(sketch.count, 0)
+    }
+
+    func testAddInfinity_isIgnored() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(Double.infinity)
+        sketch.add(-Double.infinity)
+        XCTAssertTrue(sketch.isEmpty)
+        XCTAssertEqual(sketch.count, 0)
+    }
+
+    func testAddVerySmallPositive_goesToZeroBucket() {
+        var sketch = DDSketch.makeForStats()
+        let tinyValue = Double.leastNonzeroMagnitude
+        sketch.add(tinyValue)
+        // Very small values below minIndexableValue go to zero bucket
+        XCTAssertEqual(sketch.zeroCount, 1)
+    }
+
+    // MARK: - Protobuf Serialization
+
+    func testToProtoBytes_notEmpty_afterAdding() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(1_000_000.0) // 1ms in nanoseconds
+        sketch.add(5_000_000.0) // 5ms
+        sketch.add(10_000_000.0) // 10ms
+
+        let bytes = sketch.toProtoBytes()
+        XCTAssertGreaterThan(bytes.count, 0)
+    }
+
+    func testToProtoBytes_hasValidProtobufStructure() {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(42.0)
+
+        let bytes = sketch.toProtoBytes()
+        // First byte should be the tag for field 1, wire type 2 (length-delimited)
+        // (1 << 3) | 2 = 0x0A
+        XCTAssertEqual(bytes[0], 0x0A, "First field should be mapping (field 1, length-delimited)")
+    }
+
+    func testToProtoBytes_mappingContainsGamma() {
+        let sketch = DDSketch.makeForStats()
+        let bytes = sketch.toProtoBytes()
+
+        // The mapping message should contain the gamma value
+        // gamma for 1% accuracy = 1.01 / 0.99 ≈ 1.0202020202020...
+        // This is encoded as a fixed64 double somewhere in the output
+        XCTAssertGreaterThan(bytes.count, 9, "Should at least contain mapping with gamma")
+    }
+
+    // MARK: - Latency Distribution (CSS Use Case)
+
+    func testLatencyDistribution_typicalSpanDurations() {
+        var sketch = DDSketch.makeForStats()
+
+        // Typical span durations in nanoseconds (1ms to 5s)
+        let durations: [Double] = [
+            1_000_000,    // 1ms
+            5_000_000,    // 5ms
+            10_000_000,   // 10ms
+            50_000_000,   // 50ms
+            100_000_000,  // 100ms
+            500_000_000,  // 500ms
+            1_000_000_000, // 1s
+            5_000_000_000  // 5s
+        ]
+
+        for d in durations {
+            sketch.add(d)
+        }
+
+        XCTAssertEqual(sketch.count, 8)
+        XCTAssertEqual(sketch.min, 1_000_000)
+        XCTAssertEqual(sketch.max, 5_000_000_000)
+
+        let bytes = sketch.toProtoBytes()
+        XCTAssertGreaterThan(bytes.count, 0)
+    }
+
+    func testManyValues_staysWithinBinLimit() {
+        var sketch = DDSketch.makeForStats()
+
+        // Add 10,000 values spanning a wide range
+        for i in 1...10_000 {
+            sketch.add(Double(i) * 1_000_000) // i ms in nanoseconds
+        }
+
+        XCTAssertEqual(sketch.count, 10_000)
+
+        // Positive store should not exceed 2048 bins
+        let (counts, _) = sketch.positiveStore.contiguousBins()
+        XCTAssertLessThanOrEqual(counts.count, 2_048)
+
+        let bytes = sketch.toProtoBytes()
+        XCTAssertGreaterThan(bytes.count, 0)
+    }
+
+    // MARK: - Determinism
+
+    func testSameInputs_produceSameOutput() {
+        var sketch1 = DDSketch.makeForStats()
+        var sketch2 = DDSketch.makeForStats()
+
+        let values: [Double] = [1.0, 2.0, 3.0, 100.0, 1_000.0]
+        for v in values {
+            sketch1.add(v)
+            sketch2.add(v)
+        }
+
+        XCTAssertEqual(sketch1.toProtoBytes(), sketch2.toProtoBytes())
+    }
+
+    // MARK: - Protobuf Round-Trip Validation
+
+    func testProtoBytes_canBeParsed() throws {
+        var sketch = DDSketch.makeForStats()
+        sketch.add(100.0)
+        sketch.add(200.0)
+
+        let bytes = sketch.toProtoBytes()
+
+        // Manually parse the protobuf to validate structure
+        var offset = 0
+
+        // Field 1: mapping (length-delimited)
+        let (field1Tag, field1WireType) = try parseTag(bytes, offset: &offset)
+        XCTAssertEqual(field1Tag, 1)
+        XCTAssertEqual(field1WireType, 2) // length-delimited
+        let mappingLength = try parseVarint(bytes, offset: &offset)
+        offset += Int(mappingLength) // skip mapping payload
+
+        // Field 2: positiveValues (length-delimited)
+        let (field2Tag, field2WireType) = try parseTag(bytes, offset: &offset)
+        XCTAssertEqual(field2Tag, 2)
+        XCTAssertEqual(field2WireType, 2)
+    }
+
+    // MARK: - Helpers
+
+    private func parseTag(_ data: Data, offset: inout Int) throws -> (fieldNumber: Int, wireType: Int) {
+        let varint = try parseVarint(data, offset: &offset)
+        return (Int(varint >> 3), Int(varint & 0x07))
+    }
+
+    private func parseVarint(_ data: Data, offset: inout Int) throws -> UInt64 {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while offset < data.count {
+            let byte = data[offset]
+            offset += 1
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 {
+                return result
+            }
+            shift += 7
+        }
+        throw NSError(domain: "ProtoParseError", code: 1)
+    }
+}

--- a/DatadogTrace/Tests/DDSketch/DDSketchTests.swift
+++ b/DatadogTrace/Tests/DDSketch/DDSketchTests.swift
@@ -199,6 +199,50 @@ final class DDSketchTests: XCTestCase {
         XCTAssertEqual(sketch1.toProtoBytes(), sketch2.toProtoBytes())
     }
 
+    // MARK: - Example-Based Protobuf Layout
+
+    func testFixture_emptySketch_encodesOnlyMapping() {
+        // An empty sketch with default config (`makeForStats()`) encodes only the
+        // IndexMapping field. The positive/negative stores are empty and
+        // `zeroCount == 0`, all of which the encoder skips (proto3 default).
+        //
+        // Expected byte-by-byte layout:
+        //   [0]  = 0x0A   tag: field 1 (mapping), wire type 2 (length-delimited)
+        //   [1]  = 0x09   length: 9 bytes of mapping payload
+        //   [2]  = 0x09   tag: field 1 (gamma) within mapping, wire type 1 (fixed64)
+        //   [3..10]       gamma as little-endian IEEE 754 double
+        let sketch = DDSketch.makeForStats()
+        let bytes = sketch.toProtoBytes()
+
+        XCTAssertEqual(bytes.count, 11)
+        XCTAssertEqual(bytes[0], 0x0A)
+        XCTAssertEqual(bytes[1], 0x09)
+        XCTAssertEqual(bytes[2], 0x09)
+
+        let gamma = bytes.subdata(in: 3..<11).withUnsafeBytes { $0.load(as: Double.self) }
+        XCTAssertEqual(gamma, 1.01 / 0.99, accuracy: 1e-12)
+    }
+
+    func testFixture_singleZeroValue_encodesMappingAndZeroCount() {
+        // Adding `0.0` to an empty sketch increments only `zeroCount`; both stores
+        // stay empty. The encoded payload is therefore the 11-byte mapping (as in
+        // the empty-sketch case) followed by the `zeroCount` field.
+        //
+        // Expected layout for the zeroCount tail:
+        //   [11] = 0x21   tag: field 4 (zeroCount), wire type 1 (fixed64)
+        //   [12..19]      1.0 as little-endian IEEE 754 double
+        var sketch = DDSketch.makeForStats()
+        sketch.add(0.0)
+        let bytes = sketch.toProtoBytes()
+
+        XCTAssertEqual(bytes.count, 20)
+        XCTAssertEqual(bytes[0], 0x0A) // same mapping prefix as the empty case
+        XCTAssertEqual(bytes[11], 0x21)
+
+        let zeroCountValue = bytes.subdata(in: 12..<20).withUnsafeBytes { $0.load(as: Double.self) }
+        XCTAssertEqual(zeroCountValue, 1.0)
+    }
+
     // MARK: - Protobuf Round-Trip Validation
 
     func testProtoBytes_canBeParsed() throws {

--- a/DatadogTrace/Tests/DDSketch/LogarithmicMappingTests.swift
+++ b/DatadogTrace/Tests/DDSketch/LogarithmicMappingTests.swift
@@ -1,0 +1,136 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+@testable import DatadogTrace
+import XCTest
+
+final class LogarithmicMappingTests: XCTestCase {
+    // MARK: - Initialization
+
+    func testInit_relativeAccuracyOf1Percent() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+
+        XCTAssertEqual(mapping.relativeAccuracy, 0.01)
+        XCTAssertEqual(mapping.gamma, (1.01) / (0.99), accuracy: 1e-12)
+        XCTAssertEqual(mapping.multiplier, 1.0 / log(mapping.gamma), accuracy: 1e-12)
+        XCTAssertEqual(mapping.indexOffset, 0.0)
+    }
+
+    // MARK: - Index Computation
+
+    func testIndex_oneReturnsZeroOrNegativeOne() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        let idx = mapping.index(for: 1.0)
+        // log(1.0) = 0.0, so index should be 0 or -1 depending on floor behavior
+        XCTAssertTrue(idx == 0 || idx == -1)
+    }
+
+    func testIndex_monotonicallyIncreasing() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        let values: [Double] = [0.001, 0.01, 0.1, 1, 10, 100, 1_000, 10_000, 1_000_000]
+        var previousIndex = Int.min
+
+        for value in values {
+            let idx = mapping.index(for: value)
+            XCTAssertGreaterThanOrEqual(idx, previousIndex, "index must increase for value \(value)")
+            previousIndex = idx
+        }
+    }
+
+    func testIndex_closeValues_sameOrAdjacentBins() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        let v1 = 100.0
+        let v2 = 100.5
+        let idx1 = mapping.index(for: v1)
+        let idx2 = mapping.index(for: v2)
+        // Close values within 1% should be in same or adjacent bin
+        XCTAssertTrue(abs(idx1 - idx2) <= 1)
+    }
+
+    // MARK: - Relative Accuracy Guarantee
+
+    func testRelativeAccuracy_valuesAreWithinBounds() {
+        let accuracy = 0.01
+        let mapping = LogarithmicMapping(relativeAccuracy: accuracy)
+        let testValues: [Double] = [0.1, 1.0, 10.0, 100.0, 1_000.0, 50_000.0, 1_000_000.0]
+
+        for value in testValues {
+            let idx = mapping.index(for: value)
+            let lower = mapping.lowerBound(index: idx)
+            let upper = mapping.lowerBound(index: idx + 1)
+
+            XCTAssertLessThanOrEqual(
+                lower,
+                value * (1 + accuracy),
+                "lower bound \(lower) should be <= value*1.01 (\(value * 1.01)) for value \(value)"
+            )
+            XCTAssertGreaterThanOrEqual(
+                upper,
+                value * (1 - accuracy),
+                "upper bound \(upper) should be >= value*0.99 (\(value * 0.99)) for value \(value)"
+            )
+        }
+    }
+
+    // MARK: - Value at Index
+
+    func testValue_roundTrip() {
+        let accuracy = 0.01
+        let mapping = LogarithmicMapping(relativeAccuracy: accuracy)
+
+        for value in [1.0, 50.0, 1_000.0, 500_000.0] {
+            let idx = mapping.index(for: value)
+            let recovered = mapping.value(at: idx)
+            let relativeError = abs(recovered - value) / value
+            XCTAssertLessThan(
+                relativeError,
+                accuracy * 2,
+                "recovered value \(recovered) should be close to \(value)"
+            )
+        }
+    }
+
+    // MARK: - Boundary Values
+
+    func testMinIndexableValue_isPositive() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        XCTAssertGreaterThan(mapping.minIndexableValue, 0)
+    }
+
+    func testMaxIndexableValue_isFinite() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        XCTAssertTrue(mapping.maxIndexableValue.isFinite)
+        XCTAssertGreaterThan(mapping.maxIndexableValue, 1e300)
+    }
+
+    func testMinIndexableValue_producesValidIndex() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        let idx = mapping.index(for: mapping.minIndexableValue)
+        XCTAssertGreaterThanOrEqual(idx, Int(Int32.min))
+    }
+
+    func testMaxIndexableValue_producesValidIndex() {
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+        let idx = mapping.index(for: mapping.maxIndexableValue)
+        XCTAssertLessThanOrEqual(idx, Int(Int32.max))
+    }
+
+    // MARK: - Different Accuracies
+
+    func testHigherAccuracy_producesMoreBins() {
+        let coarse = LogarithmicMapping(relativeAccuracy: 0.05)
+        let fine = LogarithmicMapping(relativeAccuracy: 0.01)
+
+        let idxCoarse = coarse.index(for: 1_000_000.0) - coarse.index(for: 1.0)
+        let idxFine = fine.index(for: 1_000_000.0) - fine.index(for: 1.0)
+
+        XCTAssertGreaterThan(
+            idxFine,
+            idxCoarse,
+            "finer accuracy should use more bins for the same range"
+        )
+    }
+}

--- a/DatadogTrace/Tests/DDSketch/LogarithmicMappingTests.swift
+++ b/DatadogTrace/Tests/DDSketch/LogarithmicMappingTests.swift
@@ -133,4 +133,67 @@ final class LogarithmicMappingTests: XCTestCase {
             "finer accuracy should use more bins for the same range"
         )
     }
+
+    // MARK: - Example-Based Indices
+
+    func testIndex_knownValuesAt1PercentAccuracy() {
+        // With relativeAccuracy = 0.01:
+        //   gamma      = 1.01 / 0.99 ≈ 1.020_202
+        //   multiplier = 1 / log(gamma) ≈ 49.998_333
+        // Therefore index(v) = floor(log(v) * 49.998_333).
+        //
+        // The integer outputs below are exact for this multiplier; they pin the
+        // indexing math to specific reference points instead of relying on
+        // property-style assertions alone.
+        let mapping = LogarithmicMapping(relativeAccuracy: 0.01)
+
+        // log(1.0) * 49.998... = 0       -> bin 0
+        XCTAssertEqual(mapping.index(for: 1.0), 0)
+        // log(100) * 49.998... ≈ 230.250 -> bin 230
+        XCTAssertEqual(mapping.index(for: 100.0), 230)
+        // log(1e6) * 49.998... ≈ 690.752 -> bin 690
+        XCTAssertEqual(mapping.index(for: 1_000_000.0), 690)
+        // log(0.1) * 49.998... ≈ -115.13 -> bin -116 (floor for negative rawIndex)
+        XCTAssertEqual(mapping.index(for: 0.1), -116)
+    }
+
+    // MARK: - Defensive Initialization
+
+    func testInit_clampsZeroAccuracy_keepsMathFinite() {
+        // A `relativeAccuracy` of 0 would make `log(gamma) == 0` and `multiplier`
+        // non-finite, which would later trap when converting raw indices to `Int`.
+        // The init must clamp into a safe range and keep all derived values finite.
+        let mapping = LogarithmicMapping(relativeAccuracy: 0)
+
+        XCTAssertGreaterThan(mapping.relativeAccuracy, 0)
+        XCTAssertLessThan(mapping.relativeAccuracy, 1)
+        XCTAssertTrue(mapping.gamma.isFinite)
+        XCTAssertTrue(mapping.multiplier.isFinite)
+        XCTAssertTrue(mapping.minIndexableValue.isFinite)
+        XCTAssertTrue(mapping.maxIndexableValue.isFinite)
+
+        // Indexing must not crash on a clamped mapping.
+        let idx = mapping.index(for: 100.0)
+        XCTAssertGreaterThanOrEqual(idx, Int(Int32.min))
+        XCTAssertLessThanOrEqual(idx, Int(Int32.max))
+    }
+
+    func testInit_clampsNegativeAccuracy_keepsMathFinite() {
+        let mapping = LogarithmicMapping(relativeAccuracy: -0.5)
+
+        XCTAssertGreaterThan(mapping.relativeAccuracy, 0)
+        XCTAssertTrue(mapping.gamma.isFinite)
+        XCTAssertTrue(mapping.multiplier.isFinite)
+    }
+
+    func testInit_clampsAccuracyAtOrAboveOne_keepsMathFinite() {
+        let one = LogarithmicMapping(relativeAccuracy: 1.0)
+        XCTAssertLessThan(one.relativeAccuracy, 1)
+        XCTAssertTrue(one.gamma.isFinite)
+        XCTAssertTrue(one.multiplier.isFinite)
+
+        let tooLarge = LogarithmicMapping(relativeAccuracy: 5.0)
+        XCTAssertLessThan(tooLarge.relativeAccuracy, 1)
+        XCTAssertTrue(tooLarge.gamma.isFinite)
+    }
 }

--- a/DatadogTrace/Tests/DDSketch/ProtoEncoderTests.swift
+++ b/DatadogTrace/Tests/DDSketch/ProtoEncoderTests.swift
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+@testable import DatadogTrace
+import XCTest
+
+final class ProtoEncoderTests: XCTestCase {
+    // MARK: - Varint
+
+    func testEncodeVarint_singleByte() {
+        var enc = ProtoEncoder()
+        enc.encodeVarint(1)
+        XCTAssertEqual(enc.data, Data([0x01]))
+    }
+
+    func testEncodeVarint_zero() {
+        var enc = ProtoEncoder()
+        enc.encodeVarint(0)
+        XCTAssertEqual(enc.data, Data([0x00]))
+    }
+
+    func testEncodeVarint_multiByte() {
+        var enc = ProtoEncoder()
+        // 300 = 0b100101100 -> varint: [0xAC, 0x02]
+        enc.encodeVarint(300)
+        XCTAssertEqual(enc.data, Data([0xAC, 0x02]))
+    }
+
+    func testEncodeVarint_maxUInt64() {
+        var enc = ProtoEncoder()
+        enc.encodeVarint(UInt64.max)
+        // UInt64.max = 10 bytes of varint (9 full bytes + 1 byte)
+        XCTAssertEqual(enc.data.count, 10)
+        // First 9 bytes should all have continuation bit set
+        for i in 0..<9 {
+            XCTAssertEqual(enc.data[i] & 0x80, 0x80)
+        }
+        // Last byte should not have continuation bit
+        XCTAssertEqual(enc.data[9] & 0x80, 0x00)
+    }
+
+    // MARK: - ZigZag
+
+    func testZigZagEncode_positive() {
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(0), 0)
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(1), 2)
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(2), 4)
+    }
+
+    func testZigZagEncode_negative() {
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(-1), 1)
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(-2), 3)
+    }
+
+    func testZigZagEncode_extremes() {
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(Int32.max), UInt64(UInt32.max - 1))
+        XCTAssertEqual(ProtoEncoder.zigZagEncode(Int32.min), UInt64(UInt32.max))
+    }
+
+    // MARK: - Double Field
+
+    func testEncodeDoubleField_nonZero() {
+        var enc = ProtoEncoder()
+        enc.encodeDoubleField(fieldNumber: 1, value: 1.0)
+        // Tag: (1 << 3) | 1 = 0x09
+        // Value: 1.0 as IEEE-754 little-endian = 0x000000000000F03F
+        XCTAssertEqual(enc.data.count, 9) // 1 byte tag + 8 bytes double
+        XCTAssertEqual(enc.data[0], 0x09)
+    }
+
+    func testEncodeDoubleField_zero_skipped() {
+        var enc = ProtoEncoder()
+        enc.encodeDoubleField(fieldNumber: 1, value: 0.0)
+        XCTAssertTrue(enc.data.isEmpty)
+    }
+
+    func testEncodeDoubleField_negativeZero_notSkipped() {
+        var enc = ProtoEncoder()
+        enc.encodeDoubleField(fieldNumber: 1, value: -0.0)
+        XCTAssertEqual(enc.data.count, 9)
+    }
+
+    // MARK: - Varint Field
+
+    func testEncodeVarintField_nonZero() {
+        var enc = ProtoEncoder()
+        enc.encodeVarintField(fieldNumber: 2, value: 150)
+        // Tag: (2 << 3) | 0 = 0x10
+        // Value: 150 = [0x96, 0x01]
+        XCTAssertEqual(enc.data, Data([0x10, 0x96, 0x01]))
+    }
+
+    func testEncodeVarintField_zero_skipped() {
+        var enc = ProtoEncoder()
+        enc.encodeVarintField(fieldNumber: 1, value: 0)
+        XCTAssertTrue(enc.data.isEmpty)
+    }
+
+    // MARK: - SInt32 Field
+
+    func testEncodeSInt32Field_positive() {
+        var enc = ProtoEncoder()
+        enc.encodeSInt32Field(fieldNumber: 3, value: 1)
+        // Tag: (3 << 3) | 0 = 0x18
+        // zigzag(1) = 2
+        XCTAssertEqual(enc.data, Data([0x18, 0x02]))
+    }
+
+    func testEncodeSInt32Field_negative() {
+        var enc = ProtoEncoder()
+        enc.encodeSInt32Field(fieldNumber: 3, value: -1)
+        // zigzag(-1) = 1
+        XCTAssertEqual(enc.data, Data([0x18, 0x01]))
+    }
+
+    func testEncodeSInt32Field_zero_skipped() {
+        var enc = ProtoEncoder()
+        enc.encodeSInt32Field(fieldNumber: 3, value: 0)
+        XCTAssertTrue(enc.data.isEmpty)
+    }
+
+    // MARK: - Nested Message
+
+    func testEncodeNestedMessage() {
+        var inner = ProtoEncoder()
+        inner.encodeVarintField(fieldNumber: 1, value: 42)
+
+        var outer = ProtoEncoder()
+        outer.encodeNestedMessage(fieldNumber: 1, payload: inner.data)
+
+        // Tag: (1 << 3) | 2 = 0x0A
+        // Length: 2 bytes (tag 0x08 + varint 42 = 0x2A)
+        XCTAssertEqual(outer.data[0], 0x0A)
+        XCTAssertEqual(outer.data[1], 0x02)
+        XCTAssertEqual(outer.data[2], 0x08)
+        XCTAssertEqual(outer.data[3], 0x2A)
+    }
+
+    func testEncodeNestedMessage_emptyPayload_skipped() {
+        var enc = ProtoEncoder()
+        enc.encodeNestedMessage(fieldNumber: 1, payload: Data())
+        XCTAssertTrue(enc.data.isEmpty)
+    }
+
+    // MARK: - Packed Doubles
+
+    func testEncodePackedDoubles() {
+        var enc = ProtoEncoder()
+        enc.encodePackedDoubles(fieldNumber: 2, values: [1.0, 2.0])
+        // Tag: (2 << 3) | 2 = 0x12
+        // Length: 16 bytes (2 doubles)
+        XCTAssertEqual(enc.data[0], 0x12)
+        XCTAssertEqual(enc.data[1], 16) // length varint
+
+        // Verify the doubles can be read back
+        let double1 = enc.data.subdata(in: 2..<10).withUnsafeBytes { $0.load(as: Double.self) }
+        let double2 = enc.data.subdata(in: 10..<18).withUnsafeBytes { $0.load(as: Double.self) }
+        XCTAssertEqual(double1, 1.0)
+        XCTAssertEqual(double2, 2.0)
+    }
+
+    func testEncodePackedDoubles_empty_skipped() {
+        var enc = ProtoEncoder()
+        enc.encodePackedDoubles(fieldNumber: 2, values: [])
+        XCTAssertTrue(enc.data.isEmpty)
+    }
+
+    // MARK: - Round-Trip Field Numbers
+
+    func testFieldNumbers_upTo15_singleByteTag() {
+        var enc = ProtoEncoder()
+        enc.encodeVarintField(fieldNumber: 15, value: 1)
+        // Tag should be single byte: (15 << 3) | 0 = 120 = 0x78
+        XCTAssertEqual(enc.data[0], 0x78)
+    }
+
+    func testFieldNumbers_above15_multiByteTag() {
+        var enc = ProtoEncoder()
+        enc.encodeVarintField(fieldNumber: 16, value: 1)
+        // Tag: (16 << 3) | 0 = 128 = varint [0x80, 0x01]
+        XCTAssertEqual(enc.data[0], 0x80)
+        XCTAssertEqual(enc.data[1], 0x01)
+    }
+}

--- a/DatadogTrace/Tests/DDSketch/ProtoEncoderTests.swift
+++ b/DatadogTrace/Tests/DDSketch/ProtoEncoderTests.swift
@@ -149,7 +149,7 @@ final class ProtoEncoderTests: XCTestCase {
 
     func testEncodePackedDoubles() {
         var enc = ProtoEncoder()
-        enc.encodePackedDoubles(fieldNumber: 2, values: [1.0, 2.0])
+        enc.encodePackedDoubles(fieldNumber: 2, values: ArraySlice<Double>([1.0, 2.0]))
         // Tag: (2 << 3) | 2 = 0x12
         // Length: 16 bytes (2 doubles)
         XCTAssertEqual(enc.data[0], 0x12)
@@ -164,7 +164,7 @@ final class ProtoEncoderTests: XCTestCase {
 
     func testEncodePackedDoubles_empty_skipped() {
         var enc = ProtoEncoder()
-        enc.encodePackedDoubles(fieldNumber: 2, values: [])
+        enc.encodePackedDoubles(fieldNumber: 2, values: ArraySlice<Double>())
         XCTAssertTrue(enc.data.isEmpty)
     }
 


### PR DESCRIPTION
### What and why?

Adds a self-contained DDSketch implementation in `DatadogTrace/Sources/DDSketch/` for
computing approximate latency percentiles in client-side stats. The `okSummary` and
`errorSummary` fields in the stats payload require DDSketch data serialized as protobuf bytes.

DDSketch lives in `DatadogTrace` (not `DatadogInternal`) because it has exactly one consumer
today. The code is self-contained with no SDK dependencies, so extracting it to its own
package later remains straightforward.

### How?

Four source files, ported from the [Go reference implementation](https://github.com/DataDog/sketches-go):

- **`ProtoEncoder`**: Minimal protobuf encoder supporting only the subset needed by
  `ddsketch.proto`: varint, fixed64, sint32/zigzag, length-delimited, and packed doubles.
- **`LogarithmicMapping`**: Maps positive doubles to integer bin indices. 1% relative
  accuracy, `index(for:)` is a line-for-line match with Go's `LogarithmicMapping.Index()`.
- **`CollapsingLowestDenseStore`**: Contiguous bin array that collapses lowest bins when
  exceeding `maxNumBins` (2048). Trades lowest-quantile accuracy for bounded memory.
  Initializer clamps `maxNumBins` to `max(1, ...)` rather than asserting - an SDK must
  never crash the host app on internal misuse.
- **`DDSketch`**: Internal struct with `makeForStats()` factory (1% accuracy, 2048 bins),
  `add()` for recording values, and `toProtoBytes()` for protobuf serialization. All proto
  field numbers verified against [`ddsketch.proto`](https://github.com/DataDog/sketches-go/blob/master/ddsketch/pb/ddsketch.proto).
  Initializer clamps `relativeAccuracy` to `[0.0001, 0.9999]` - the mathematical `(0, 1)`
  boundary is unsafe at runtime because it leaves `multiplier` non-finite.

72 unit tests: property assertions (relative accuracy guarantees, bin bounds, monotonic
indexing, round-trip), edge cases (NaN, infinity, zero, very small values), collapse
correctness in both directions, protobuf wire-format correctness, and fixture-style
example tests for debuggability.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes - N/A (internal, not user-facing)
- [x] Add Objective-C interface for public APIs - N/A (internal to DatadogTrace)
- [x] Run `make api-surface` when adding new APIs - N/A (internal to DatadogTrace)