### PR TITLE
Chore: add retry option for gitlab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -467,7 +467,7 @@ Publish GH Asset:
 
 Publish CP podspecs (internal):
   stage: release-publish
-  retry: 5
+  retry: 2
   rules:
     - !reference [.release-pipeline-job, rules]
   before_script:
@@ -480,7 +480,7 @@ Publish CP podspecs (internal):
 
 .publish-dependent-podspec:
   stage: release-publish
-  retry: 5
+  retry: 2
   rules:
     - !reference [.release-pipeline-20m-delayed-job, rules]
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -467,7 +467,8 @@ Publish GH Asset:
 
 Publish CP podspecs (internal):
   stage: release-publish
-  rules: 
+  retry: 5
+  rules:
     - !reference [.release-pipeline-job, rules]
   before_script:
     - *export_MAKE_release_params
@@ -479,6 +480,7 @@ Publish CP podspecs (internal):
 
 .publish-dependent-podspec:
   stage: release-publish
+  retry: 5
   rules:
     - !reference [.release-pipeline-20m-delayed-job, rules]
   before_script:


### PR DESCRIPTION
### What and why?

Add a retry option for Cocoapods jobs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
