### PR TITLE
Report `track_resource_headers` in configuration telemetry

### DIFF
--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -49,6 +49,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let trackNativeLongTasks: Bool?
     public let trackNativeViews: Bool?
     public let trackNetworkRequests: Bool?
+    public let trackResourceHeaders: String?
     public let trackResources: Bool?
     public let trackSessionAcrossSubdomains: Bool?
     public let trackUserInteractions: Bool?
@@ -412,6 +413,7 @@ extension Telemetry {
         trackNativeLongTasks: Bool? = nil,
         trackNativeViews: Bool? = nil,
         trackNetworkRequests: Bool? = nil,
+        trackResourceHeaders: String? = nil,
         trackResources: Bool? = nil,
         trackSessionAcrossSubdomains: Bool? = nil,
         trackUserInteractions: Bool? = nil,
@@ -470,6 +472,7 @@ extension Telemetry {
             trackNativeLongTasks: trackNativeLongTasks,
             trackNativeViews: trackNativeViews,
             trackNetworkRequests: trackNetworkRequests,
+            trackResourceHeaders: trackResourceHeaders,
             trackResources: trackResources,
             trackSessionAcrossSubdomains: trackSessionAcrossSubdomains,
             trackUserInteractions: trackUserInteractions,
@@ -613,6 +616,7 @@ extension ConfigurationTelemetry {
             trackNativeLongTasks: other.trackNativeLongTasks ?? trackNativeLongTasks,
             trackNativeViews: other.trackNativeViews ?? trackNativeViews,
             trackNetworkRequests: other.trackNetworkRequests ?? trackNetworkRequests,
+            trackResourceHeaders: other.trackResourceHeaders ?? trackResourceHeaders,
             trackResources: other.trackResources ?? trackResources,
             trackSessionAcrossSubdomains: other.trackSessionAcrossSubdomains ?? trackSessionAcrossSubdomains,
             trackUserInteractions: other.trackUserInteractions ?? trackUserInteractions,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -334,6 +334,14 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         let trackUserInteractions = false
         #endif
 
+        let trackResourceHeaders: String? = {
+            switch configuration.urlSessionTracking?.trackResourceHeaders {
+            case .none, .disabled: return nil
+            case .defaults: return "default_headers"
+            case .custom: return "custom"
+            }
+        }()
+
         core.telemetry.configuration(
             appHangThreshold: configuration.appHangThreshold?.dd.toInt64Milliseconds,
             invTimeThresholdMs: configuration.nextViewActionPredicate?.invTimeThresholdMs,
@@ -350,6 +358,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             trackNativeLongTasks: configuration.longTaskThreshold != nil,
             trackNativeViews: trackNativeViews,
             trackNetworkRequests: configuration.urlSessionTracking != nil,
+            trackResourceHeaders: trackResourceHeaders,
             trackUserInteractions: trackUserInteractions,
             useFirstPartyHosts: configuration.urlSessionTracking?.firstPartyHostsTracing != nil
         )

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -457,6 +457,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             trackNativeLongTasks: configuration.trackNativeLongTasks,
             trackNativeViews: configuration.trackNativeViews,
             trackNetworkRequests: configuration.trackNetworkRequests,
+            trackResourceHeaders: configuration.trackResourceHeaders.flatMap { .init(rawValue: $0) },
             trackResources: nil,
             trackSessionAcrossSubdomains: nil,
             trackUserInteractions: configuration.trackUserInteractions,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -428,6 +428,22 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
 
+    // MARK: - Track Resource Headers Configuration Telemetry
+
+    func testSendTelemetryConfiguration_trackResourceHeaders() {
+        // Given
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
+        let telemetry = TelemetryMock(with: receiver)
+        let trackResourceHeaders: TelemetryConfigurationEvent.Telemetry.Configuration.TrackResourceHeaders = [.defaultHeaders, .custom].randomElement()!
+
+        // When
+        telemetry.configuration(trackResourceHeaders: trackResourceHeaders.rawValue)
+
+        // Then
+        let event = featureScope.eventsWritten(ofType: TelemetryConfigurationEvent.self).first
+        XCTAssertEqual(event?.telemetry.configuration.trackResourceHeaders, trackResourceHeaders)
+    }
+
     // MARK: - Metrics Telemetry Events
 
     func testSendTelemetryMetric() throws {


### PR DESCRIPTION
### What and why?

Report `trackResourceHeaders` in telemetry to see the usage of Network Header capture on iOS.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs