### PR TITLE
ci: Add self.cr-agent dd-octo-sts policy

### DIFF
--- a/.github/chainguard/self.cr-agent.sts.yaml
+++ b/.github/chainguard/self.cr-agent.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-ios:ref_type:branch:ref:.*"
+
+claim_pattern:
+  project_path: "DataDog/dd-sdk-ios"
+  ref_type: "branch"
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-sdk-ios//.gitlab-ci.yml@refs/heads/.*"
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
### What and why?

Adds the `dd-octo-sts` trust policy required by the cr-agent Code Review CI job (#2923) so it can mint a GitHub token with `pull_requests: write` and post reviews + inline comments on PRs.

### How?

GitLab issuer, scoped to branch pipelines on this repo with `.gitlab-ci.yml` from `refs/heads/.*`. Minimal permissions: `pull_requests: write`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests — N/A, infra policy file
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference — links #2923
- [x] Add CHANGELOG entry for user facing changes — N/A, internal CI
- [x] Add Objective-C interface for public APIs — N/A
- [x] Run \`make api-surface\` when adding new APIs — N/A