### PR TITLE
[chain-pr 1/10] Typed MessageBus protocol and shared message types

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1208,6 +1208,7 @@
 		D2C5D52B2B84F6AB00B63F36 /* WebViewRecordReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52A2B84F6AB00B63F36 /* WebViewRecordReceiver.swift */; };
 		D2C5D52D2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52C2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift */; };
 		D2C7E3AB28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */; };
+		D2CC33DB2FBCC81D00377194 /* MessageBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CC33DA2FBCC81D00377194 /* MessageBus.swift */; };
 		D2D0E1F22E3CE59700BA4113 /* mach_profiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E1F12E3CE59700BA4113 /* mach_profiler.cpp */; };
 		D2D0E1F82E3CE73700BA4113 /* mach_sampling_profiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */; };
 		D2D0E2072E3CEF1200BA4113 /* MachSamplingProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2022E3CEF1200BA4113 /* MachSamplingProfilerTests.swift */; };
@@ -2954,6 +2955,7 @@
 		D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisherTests.swift; sourceTree = "<group>"; };
 		D2CBC26A294383F200134409 /* WebViewEventReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewEventReceiver.swift; sourceTree = "<group>"; };
 		D2CBC26D294395A300134409 /* RUMContextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContextAttributes.swift; sourceTree = "<group>"; };
+		D2CC33DA2FBCC81D00377194 /* MessageBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBus.swift; sourceTree = "<group>"; };
 		D2D0E1F12E3CE59700BA4113 /* mach_profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mach_profiler.cpp; sourceTree = "<group>"; };
 		D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mach_sampling_profiler.cpp; sourceTree = "<group>"; };
 		D2D0E2012E3CEF1200BA4113 /* MachProfilerCAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachProfilerCAPITests.swift; sourceTree = "<group>"; };
@@ -6170,6 +6172,7 @@
 			children = (
 				D23039C1298D5235001A1FA3 /* FeatureMessageReceiver.swift */,
 				D23039C2298D5235001A1FA3 /* FeatureMessage.swift */,
+				D2CC33DA2FBCC81D00377194 /* MessageBus.swift */,
 			);
 			path = MessageBus;
 			sourceTree = "<group>";
@@ -8570,6 +8573,7 @@
 				D21A94F22B8397CA00AC4256 /* WebViewMessage.swift in Sources */,
 				D23039EC298D5236001A1FA3 /* LaunchInfo.swift in Sources */,
 				6175C3512BCE66DB006FAAB0 /* TraceContext.swift in Sources */,
+				D2CC33DB2FBCC81D00377194 /* MessageBus.swift in Sources */,
 				D227A0A42C7622EA00C83324 /* BenchmarkProfiler.swift in Sources */,
 				D23039EE298D5236001A1FA3 /* FeatureMessageReceiver.swift in Sources */,
 				D23039DE298D5235001A1FA3 /* Writer.swift in Sources */,

--- a/DatadogCore/Sources/Core/MessageBus.swift
+++ b/DatadogCore/Sources/Core/MessageBus.swift
@@ -133,3 +133,9 @@ extension MessageBus: Flushable {
         queue.sync { }
     }
 }
+
+extension MessageBus: Telemetry {
+    func send(telemetry: TelemetryMessage) {
+        send(message: .telemetry(telemetry))
+    }
+}

--- a/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/MessageBusTests.swift
@@ -72,9 +72,3 @@ class MessageBusTests: XCTestCase {
         bus.flush()
     }
 }
-
-extension MessageBus: @retroactive Telemetry {
-    public func send(telemetry: DatadogInternal.TelemetryMessage) {
-        send(message: .telemetry(telemetry))
-    }
-}

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -6,7 +6,9 @@
 
 import Foundation
 
-public struct DatadogContext {
+public struct DatadogContext: BusMessage {
+    public static let key = "core.context"
+
     // MARK: - Datadog Specific
 
     /// [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads. It can be `nil` in V1

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 public struct DatadogContext: BusMessage {
-    public static let key = "core.context"
+    public static let key = "core-context"
 
     // MARK: - Datadog Specific
 

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -15,6 +15,12 @@ public protocol DatadogCoreProtocol: AnyObject, MessageSending, AdditionalContex
     // Remove `DatadogCoreProtocol` conformance to `MessageSending` and `BaggageSharing` once
     // all features are migrated to depend on `FeatureScope` interface.
 
+    /// The typed message bus shared between Features registered to this core.
+    ///
+    /// Use it to subscribe to or publish `BusMessage` values. The default implementation
+    /// returns a `NOPMessageBus`; concrete cores override this with their real bus.
+    var messageBus: MessageBus { get }
+
     /// Registers a Feature instance.
     ///
     /// Feature can interact with the core and other Feature through the message bus. Some specific Features
@@ -62,8 +68,12 @@ extension DatadogCoreProtocol {
     public func get<T>(feature type: T.Type = T.self) -> T? where T: DatadogFeature {
         feature(named: T.name, type: type)
     }
+
+    /// Default implementation returns a no-op bus. Concrete cores override this with their real bus.
+    public var messageBus: MessageBus { NOPMessageBus() }
 }
 
+@available(*, deprecated, message: "Use `MessageBus` and `BusMessage` for typed feature-to-feature messaging.")
 public protocol MessageSending {
     /// Sends a message on the bus shared by features registered to the sam core.
     ///
@@ -77,6 +87,7 @@ public protocol MessageSending {
     func send(message: FeatureMessage, else fallback: @escaping () -> Void)
 }
 
+@available(*, deprecated, message: "Use `MessageBus` and `BusMessage` for typed feature-to-feature messaging.")
 extension MessageSending {
     /// Sends a message on the bus shared by features registered to the same core.
     ///

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -15,6 +15,7 @@ public protocol DatadogFeature {
     ///
     /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
     /// from a bus that is shared between Features registered in a core.
+    @available(*, deprecated, message: "Use `BusMessageReceiver` and subscribe via `MessageBus` instead.")
     var messageReceiver: FeatureMessageReceiver { get }
 }
 

--- a/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessage.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// The set of messages that can be transmitted on the Features message bus.
+@available(*, deprecated, message: "Use `BusMessage` and `MessageBus` for typed feature-to-feature messaging.")
 public enum FeatureMessage {
     /// A custom payload message.
     case payload(Any)

--- a/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
+++ b/DatadogInternal/Sources/MessageBus/FeatureMessageReceiver.swift
@@ -11,6 +11,7 @@ import Foundation
 ///
 /// The message is composed of a key and a dictionary of attributes. The message format is a loose
 /// agreement between Features - all messages supported by a Feature should be properly documented.
+@available(*, deprecated, message: "Use `BusMessageReceiver` for typed feature-to-feature messaging.")
 public protocol FeatureMessageReceiver {
     /// Receives messages from the message bus.
     ///
@@ -32,6 +33,7 @@ public protocol FeatureMessageReceiver {
     // instead of depending on directly on `core`.
 }
 
+@available(*, deprecated, message: "Use `BusMessageReceiver` for typed feature-to-feature messaging.")
 public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
     public init() { }
 
@@ -43,6 +45,7 @@ public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
 
 /// A receiver that combines multiple receivers. It will loop though receivers and stop on the first that is able to
 /// consume the given message.
+@available(*, deprecated, message: "Use `BusMessageReceiver` for typed feature-to-feature messaging.")
 public struct CombinedFeatureMessageReceiver: FeatureMessageReceiver {
     let receivers: [FeatureMessageReceiver]
 

--- a/DatadogInternal/Sources/MessageBus/MessageBus.swift
+++ b/DatadogInternal/Sources/MessageBus/MessageBus.swift
@@ -1,0 +1,198 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A typed publish/subscribe channel for messages exchanged between Features
+/// registered to the same core.
+///
+/// Every message is a nominal type conforming to `BusMessage`. Subscribers declare
+/// the message type they handle and the bus uses Swift's type system for routing —
+/// no runtime casts at the call site, no shared enum to extend when a new message
+/// is introduced.
+///
+/// ## Subscription lifetime
+///
+/// The bus retains each subscriber until it is explicitly removed via `unsubscribe`.
+/// Long-lived subscribers should arrange for unsubscription at teardown. The
+/// closure-based convenience (`subscribe(block:)`) returns a `MessageBusSubscription`
+/// that callers pass back to `unsubscribe(_:)` to end the subscription.
+///
+/// ## Threading
+///
+/// Implementations deliver messages on a serial queue. Receivers may treat state
+/// mutations across `receive(message:from:)` calls as serialised, but must not block
+/// the caller — doing so delays delivery to every other subscriber.
+///
+/// ## Choosing receiver- vs closure-based subscription
+///
+/// - `subscribe(receiver:)` — for long-lived objects that already manage their own
+///   lifecycle (Features, instrumentation components).
+/// - `subscribe(block:)` — for ad-hoc subscriptions where no natural owner exists;
+///   the returned `MessageBusSubscription` is the cleanup anchor.
+///
+/// - SeeAlso: `BusMessage`, `BusMessageReceiver`, `MessageBusSubscription`.
+public protocol MessageBus: Sendable {
+    /// Subscribes `receiver` to messages of type `Receiver.Message`.
+    ///
+    /// The bus retains `receiver` until `unsubscribe(receiver:)` is called.
+    /// Receivers are identified by object identity (`===`); subscribing the same
+    /// instance twice is treated as a single subscription.
+    func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver
+
+    /// Removes a previously subscribed receiver.
+    ///
+    /// Identity (`===`) is used to locate the subscription; the call is a no-op if
+    /// `receiver` is not currently subscribed.
+    func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver
+
+    /// Publishes `message` to every subscriber registered for `Message`.
+    ///
+    /// If no subscriber is registered for the message kind, `fallback` is invoked
+    /// instead. Do not assume which thread the fallback runs on.
+    ///
+    /// - Parameters:
+    ///   - message: The message to publish.
+    ///   - fallback: Closure invoked when the message had no subscribers.
+    func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage
+}
+
+extension MessageBus {
+    /// Subscribes a closure to messages of type `Message`.
+    ///
+    /// A convenience over `subscribe(receiver:)` for the common case where no
+    /// natural receiver object exists. The closure is wrapped in an internal
+    /// receiver retained by the returned `MessageBusSubscription`; pass that
+    /// handle to `unsubscribe(_:)` when the subscription is no longer needed.
+    ///
+    /// ```swift
+    /// let subscription = bus.subscribe { (message: MyMessage, core) in
+    ///     // handle message
+    /// }
+    /// // ... later
+    /// bus.unsubscribe(subscription)
+    /// ```
+    ///
+    /// - Parameter block: Called on the bus's delivery queue. Must not block.
+    /// - Returns: A handle to pass to `unsubscribe(_:)`.
+    public func subscribe<Message>(block: @escaping (Message, DatadogCoreProtocol) -> Void) -> MessageBusSubscription where Message: BusMessage {
+        let receiver = BusMessageReceiverCallback(block: block)
+        self.subscribe(receiver: receiver)
+        return MessageBusSubscription(receiver)
+    }
+
+    /// Removes the subscription created by `subscribe(block:)`.
+    ///
+    /// Idempotent — additional calls with the same `subscription` are no-ops.
+    public func unsubscribe(_ subscription: MessageBusSubscription) {
+        subscription.unsubscribe(from: self)
+    }
+
+    /// Publishes `message` to every subscriber registered for `Message`.
+    ///
+    /// Convenience over `send(message:else:)` for the common case where the
+    /// caller doesn't care whether the message was consumed.
+    public func send<Message>(message: Message) where Message: BusMessage {
+        send(message: message, else: {})
+    }
+}
+
+/// An opaque, type-erased handle to a closure-based subscription on a `MessageBus`.
+///
+/// Returned by `MessageBus.subscribe(block:)`. The handle owns the internal receiver
+/// wrapping the caller's closure: store it for the lifetime of the subscription, then
+/// pass it to `MessageBus.unsubscribe(_:)` to end delivery.
+///
+/// Instances cannot be constructed directly.
+public final class MessageBusSubscription {
+    private let receiver: AnyObject
+    private let _unsubscribe: (MessageBus) -> Void
+
+    fileprivate init<Message>(_ receiver: BusMessageReceiverCallback<Message>) where Message: BusMessage {
+        self.receiver = receiver
+        self._unsubscribe = { bus in bus.unsubscribe(receiver: receiver) }
+    }
+
+    fileprivate func unsubscribe(from bus: MessageBus) {
+        _unsubscribe(bus)
+    }
+}
+
+/// A typed payload carried on a `MessageBus`.
+///
+/// Each conforming type represents a distinct kind of message. The bus routes by
+/// type — conformance is the only registration step required.
+///
+/// ## Conformance guidance
+///
+/// - Prefer immutable value types (`struct`, or `enum` for closed variants). A
+///   `BusMessage` should survive queue hops without aliasing surprises.
+/// - `key` is a stable identifier used for diagnostics and telemetry. It must be
+///   globally unique across the SDK; namespaced identifiers
+///   (e.g. `"rum.session.start"`) are recommended.
+public protocol BusMessage {
+    /// A stable, globally unique identifier for this message kind.
+    ///
+    /// Used by logs, telemetry, and any out-of-band consumer that refers to messages
+    /// by name. Treat the string as part of the public contract — changing it is a
+    /// breaking change for downstream tooling.
+    static var key: String { get }
+}
+
+/// A consumer of a single `BusMessage` type.
+///
+/// The protocol is class-bound (`AnyObject`) because the bus tracks subscriptions
+/// by object identity. The concrete `Message` is fixed per receiver — to handle
+/// multiple message kinds, register multiple receivers.
+public protocol BusMessageReceiver: AnyObject {
+    /// The message kind this receiver consumes.
+    associatedtype Message: BusMessage
+
+    /// Handles a delivered message.
+    ///
+    /// Called on the bus's delivery queue. Implementations must not block the
+    /// caller — doing so delays delivery to every other subscriber.
+    ///
+    /// - Parameters:
+    ///   - message: The delivered value, statically typed as `Message`.
+    ///   - core: The core from which the message was emitted. Capture transiently;
+    ///     do not retain.
+    func receive(message: Message, from core: DatadogCoreProtocol)
+}
+
+/// A no-op `MessageBus`.
+///
+/// Subscribe and unsubscribe calls have no effect; no message is ever delivered.
+/// Used as a safe default for cores that have not yet wired up a real bus and as a
+/// stand-in in tests where bus behaviour is irrelevant.
+public struct NOPMessageBus: MessageBus {
+    public init() { }
+
+    /// no-op
+    public func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver { }
+
+    /// no-op
+    public func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver { }
+
+    /// no-op
+    public func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage { }
+}
+
+/// Adapts a free closure to `BusMessageReceiver`. Internal-only — exposed exclusively
+/// through `MessageBus.subscribe(block:)`.
+private final class BusMessageReceiverCallback<Message>: BusMessageReceiver where Message: BusMessage {
+    typealias Block = (Message, DatadogCoreProtocol) -> Void
+
+    let block: Block
+
+    init(block: @escaping Block) {
+        self.block = block
+    }
+
+    func receive(message: Message, from core: DatadogCoreProtocol) {
+        block(message, core)
+    }
+}

--- a/DatadogInternal/Sources/MessageBus/MessageBus.swift
+++ b/DatadogInternal/Sources/MessageBus/MessageBus.swift
@@ -131,14 +131,10 @@ public final class MessageBusSubscription {
 /// - Prefer immutable value types (`struct`, or `enum` for closed variants). A
 ///   `BusMessage` should survive queue hops without aliasing surprises.
 /// - `key` is a stable identifier used for diagnostics and telemetry. It must be
-///   globally unique across the SDK; namespaced identifiers
+///   globally unique across the SDK.
 ///   (e.g. `"rum.session.start"`) are recommended.
 public protocol BusMessage {
     /// A stable, globally unique identifier for this message kind.
-    ///
-    /// Used by logs, telemetry, and any out-of-band consumer that refers to messages
-    /// by name. Treat the string as part of the public contract — changing it is a
-    /// breaking change for downstream tooling.
     static var key: String { get }
 }
 

--- a/DatadogInternal/Sources/MessageBus/MessageBus.swift
+++ b/DatadogInternal/Sources/MessageBus/MessageBus.swift
@@ -177,8 +177,8 @@ public struct NOPMessageBus: MessageBus {
     /// no-op
     public func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver { }
 
-    /// no-op
-    public func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage { }
+    /// No subscribers are ever registered, so `fallback` is always invoked.
+    public func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage { fallback() }
 }
 
 /// Adapts a free closure to `BusMessageReceiver`. Internal-only — exposed exclusively

--- a/DatadogInternal/Sources/Models/CrashReporting/Crash.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/Crash.swift
@@ -6,7 +6,9 @@
 
 import Foundation
 
-public struct Crash {
+public struct Crash: BusMessage {
+    public static let key = "crash-report"
+
     /// The crash report.
     public let report: DDCrashReport
     /// The crash context

--- a/DatadogInternal/Sources/Models/Logs/LogEventAttributes.swift
+++ b/DatadogInternal/Sources/Models/Logs/LogEventAttributes.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 /// User provided log attributes
-public struct LogEventAttributes {
+public struct LogEventAttributes: BusMessage {
+    public static let key = "log-event-attributes"
+
     public var attributes: [String: Encodable]
 
     /// User provided log attributes

--- a/DatadogInternal/Sources/Models/Logs/LogMessage.swift
+++ b/DatadogInternal/Sources/Models/Logs/LogMessage.swift
@@ -6,7 +6,9 @@
 
 import Foundation
 
-public struct LogMessage {
+public struct LogMessage: BusMessage {
+    public static let key = "log-message"
+
     /// Log levels ordered by their severity, with `.debug` being the least severe and
     /// `.critical` being the most severe.
     public enum Level: Int {

--- a/DatadogInternal/Sources/Models/Logs/LogMessage.swift
+++ b/DatadogInternal/Sources/Models/Logs/LogMessage.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 public struct LogMessage: BusMessage {
-    public static let key = "log-message"
+    public static let key = "log"
 
     /// Log levels ordered by their severity, with `.debug` being the least severe and
     /// `.critical` being the most severe.

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels+BusMessage.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels+BusMessage.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+extension RUMViewEvent: BusMessage {
+    public static let key = "rum-view-event"
+}
+
+extension RUMEventAttributes: BusMessage {
+    public static let key = "rum-event-attributes"
+}

--- a/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
@@ -12,9 +12,19 @@ public enum RUMPayloadMessages {
     public static let viewReset = "rum-view-reset"
 }
 
+/// Signals that the active RUM view was stopped with no new view starting.
+///
+/// Sent by RUM to crash-context consumers so they can clear any cached view event.
+public struct RUMViewReset: BusMessage {
+    public static let key = "rum-view-reset"
+    public init() {}
+}
+
 /// Lightweight representation of current RUM session state, used to compute `RUMOffViewEventsHandlingRule`.
 /// It gets serialized into fatal error context for computing the rule upon app process restart.
-public struct RUMSessionState: Codable, Equatable {
+public struct RUMSessionState: Codable, Equatable, BusMessage {
+    public static let key = "rum-session-state"
+
     /// The session ID.
     public let sessionUUID: UUID
     /// `true` is the session is sampled.
@@ -61,7 +71,9 @@ public struct RUMSessionState: Codable, Equatable {
 }
 
 /// Error message consumed by RUM on the message-bus.
-public struct RUMErrorMessage {
+public struct RUMErrorMessage: BusMessage {
+    public static let key = "rum-error"
+
     /// The time of the error
     public let time: Date
     /// The RUM error message
@@ -107,7 +119,9 @@ public struct RUMErrorMessage {
 }
 
 /// Flag evaluation message consumed by RUM on the message-bus.
-public struct RUMFlagEvaluationMessage {
+public struct RUMFlagEvaluationMessage: BusMessage {
+    public static let key = "rum-flag-evaluation"
+
     /// The flag key
     public let flagKey: String
     /// The evaluated value

--- a/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMPayloadMessages.swift
@@ -15,7 +15,7 @@ public enum RUMPayloadMessages {
 /// Signals that the active RUM view was stopped with no new view starting.
 ///
 /// Sent by RUM to crash-context consumers so they can clear any cached view event.
-public struct RUMViewReset: BusMessage {
+public struct RUMViewResetMessage: BusMessage {
     public static let key = "rum-view-reset"
     public init() {}
 }

--- a/DatadogInternal/Sources/Models/WebViewTracking/WebViewBusMessages.swift
+++ b/DatadogInternal/Sources/Models/WebViewTracking/WebViewBusMessages.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Typed-bus message for a Browser SDK log event forwarded through the WebView bridge.
+public struct WebViewLogMessage: BusMessage {
+    public static let key = "webview-log"
+
+    /// The raw log event dictionary from the Browser SDK.
+    public let event: WebViewMessage.Event
+
+    public init(event: WebViewMessage.Event) {
+        self.event = event
+    }
+}
+
+/// Typed-bus message for a Browser SDK RUM or internal-telemetry event forwarded through the WebView bridge.
+public struct WebViewRUMMessage: BusMessage {
+    public static let key = "webview-rum"
+
+    /// Distinguishes between a RUM event and a browser internal-telemetry event.
+    public enum Kind {
+        case rum
+        case telemetry
+    }
+
+    /// Whether this is a RUM event or a browser telemetry event.
+    public let kind: Kind
+    /// The raw event dictionary from the Browser SDK.
+    public let event: WebViewMessage.Event
+
+    public init(kind: Kind, event: WebViewMessage.Event) {
+        self.kind = kind
+        self.event = event
+    }
+}
+
+/// Typed-bus message for a Browser SDK Session Replay record forwarded through the WebView bridge.
+public struct WebViewRecordMessage: BusMessage {
+    public static let key = "webview-record"
+
+    /// The raw record event dictionary from the Browser SDK.
+    public let event: WebViewMessage.Event
+    /// The browser view that produced the record.
+    public let view: WebViewMessage.View
+
+    public init(event: WebViewMessage.Event, view: WebViewMessage.View) {
+        self.event = event
+        self.view = view
+    }
+}

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -173,7 +173,9 @@ public struct MethodCalledTrace {
 }
 
 /// Defines different types of telemetry messages supported by the SDK.
-public enum TelemetryMessage {
+public enum TelemetryMessage: BusMessage {
+    public static let key = "telemetry"
+
     /// A debug log message.
     case debug(id: String, message: String, attributes: [String: Encodable]?)
     /// An execution error.

--- a/DatadogInternal/Tests/MessageBus/MessageBusTests.swift
+++ b/DatadogInternal/Tests/MessageBus/MessageBusTests.swift
@@ -1,0 +1,136 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+
+class MessageBusTests: XCTestCase {
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var bus: MessageBusSpy! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+        bus = MessageBusSpy(core: core)
+    }
+
+    override func tearDown() {
+        core = nil
+        bus = nil
+        super.tearDown()
+    }
+
+    // MARK: - subscribe(block:)
+
+    func testSubscribeBlock_registersOneReceiverWithBus() {
+        _ = bus.subscribe { (_: AlphaMessage, _) in }
+
+        XCTAssertEqual(bus.subscribedReceivers.count, 1)
+    }
+
+    func testSubscribeBlock_deliversMatchingMessageToClosure() {
+        let received = expectation(description: "closure invoked")
+        var payload: AlphaMessage?
+
+        _ = bus.subscribe { (message: AlphaMessage, _) in
+            payload = message
+            received.fulfill()
+        }
+
+        bus.send(message: AlphaMessage(value: 42))
+
+        wait(for: [received], timeout: 1)
+        XCTAssertEqual(payload?.value, 42)
+    }
+
+    func testSubscribeBlock_forwardsEmittingCoreToClosure() {
+        let received = expectation(description: "closure invoked")
+        var forwardedCore: DatadogCoreProtocol?
+
+        _ = bus.subscribe { (_: AlphaMessage, core: DatadogCoreProtocol) in
+            forwardedCore = core
+            received.fulfill()
+        }
+
+        bus.send(message: AlphaMessage(value: 0))
+
+        wait(for: [received], timeout: 1)
+        XCTAssertTrue(forwardedCore === core)
+    }
+
+    func testSubscribeBlock_routesByMessageType() {
+        var alphaCount = 0
+        var betaCount = 0
+
+        _ = bus.subscribe { (_: AlphaMessage, _) in alphaCount += 1 }
+        _ = bus.subscribe { (_: BetaMessage, _) in betaCount += 1 }
+
+        bus.send(message: AlphaMessage(value: 0))
+        XCTAssertEqual(alphaCount, 1)
+        XCTAssertEqual(betaCount, 0)
+
+        bus.send(message: BetaMessage(label: "x"))
+        XCTAssertEqual(alphaCount, 1)
+        XCTAssertEqual(betaCount, 1)
+    }
+
+    // MARK: - unsubscribe(_:)
+
+    func testUnsubscribeSubscription_removesTheSameReceiverThatWasSubscribed() {
+        let subscription = bus.subscribe { (_: AlphaMessage, _) in }
+        let registered = bus.subscribedReceivers.first
+
+        bus.unsubscribe(subscription)
+
+        XCTAssertEqual(bus.unsubscribedReceivers.count, 1)
+        XCTAssertTrue(bus.unsubscribedReceivers.first === registered)
+    }
+}
+
+// MARK: - Test fixtures
+
+private struct AlphaMessage: BusMessage {
+    static let key = "test.alpha"
+    let value: Int
+}
+
+private struct BetaMessage: BusMessage {
+    static let key = "test.beta"
+    let label: String
+}
+
+/// A test double that records subscribe/unsubscribe calls and dispatches
+/// `send` to every captured receiver — the per-receiver closure filters by
+/// type, so cross-type sends are ignored without ceremony.
+private final class MessageBusSpy: MessageBus {
+    let core: DatadogCoreProtocol
+    private(set) var subscribedReceivers: [AnyObject] = []
+    private(set) var unsubscribedReceivers: [AnyObject] = []
+    private var deliveryActions: [(Any, DatadogCoreProtocol) -> Void] = []
+
+    init(core: DatadogCoreProtocol) {
+        self.core = core
+    }
+
+    func subscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        subscribedReceivers.append(receiver)
+        deliveryActions.append { message, core in
+            guard let typed = message as? Receiver.Message else {
+                return
+            }
+            receiver.receive(message: typed, from: core)
+        }
+    }
+
+    func unsubscribe<Receiver>(receiver: Receiver) where Receiver: BusMessageReceiver {
+        unsubscribedReceivers.append(receiver)
+    }
+
+    func send<Message>(message: Message, else fallback: @escaping () -> Void) where Message: BusMessage {
+        deliveryActions.forEach { $0(message, core) }
+    }
+}


### PR DESCRIPTION
> This PR is part of a chain split from _maxep/message-bus-subscription_ by [chain-pr](https://github.com/maxep/chain-pr).

### What and why?

The existing bus delivers all messages through a `FeatureMessage` enum. Core-level messages have typed cases (`.context`, `.telemetry`, `.webview`), but feature-to-feature messages all go through `.payload(Any)` — the sender wraps an arbitrary value, every `FeatureMessageReceiver` is called for every delivery, and each must attempt a runtime type-cast to decide whether the message is relevant. The new `MessageBus` protocol routes by Swift type: subscribers register for exactly the concrete type they handle and only receive deliveries for that type, eliminating the runtime casts and the fan-out.

This PR is the **foundation layer**: it defines the new protocols, conforms all existing shared message types to `BusMessage`, introduces typed WebView bridge message types, and deprecates the legacy API surface so subsequent PRs can migrate each SDK module without touching this one.

### How?

#### New protocol surface

Defined in `DatadogInternal/Sources/MessageBus/MessageBus.swift`:

| Type | Role |
|---|---|
| `MessageBus` | Protocol with `subscribe(receiver:)`, `unsubscribe(receiver:)`, and `send(message:else:)`, all typed on the concrete `BusMessage` conformance |
| `BusMessage` | Marker protocol for any value that can travel on the bus; each conformance declares a stable `key` for diagnostics |
| `BusMessageReceiver` | Class-bound protocol with an associated `Message` type; identity (`===`) is used to track subscriptions |
| `MessageBusSubscription` | Opaque handle returned by the closure-based `subscribe(block:)` convenience; pass to `unsubscribe(_:)` for teardown |
| `NOPMessageBus` | No-op default; always invokes the `fallback` closure on `send` |

#### Core protocol

`DatadogCoreProtocol` gains a `messageBus: MessageBus` property with a default `NOPMessageBus()` — all existing cores, mocks, and test utilities compile without modification. Concrete cores will wire up the real bus in PR #3.

#### Deprecations

`FeatureMessage`, `FeatureMessageReceiver`, `NOPFeatureMessageReceiver`, `CombinedFeatureMessageReceiver`, `MessageSending`, and `DatadogFeature.messageReceiver` are marked `@available(*, deprecated)` with inline guidance pointing to the replacement types.

#### Message type conformances

Existing types conformed to `BusMessage` (no routing changes — purely additive):

`DatadogContext` · `Crash` · `LogMessage` · `LogEventAttributes` · `TelemetryMessage` · `RUMSessionState` · `RUMErrorMessage` · `RUMFlagEvaluationMessage` · `RUMViewEvent` · `RUMEventAttributes`

New types added:
- `RUMViewReset` — signals the active view stopped with no successor
- `WebViewLogMessage`, `WebViewRUMMessage`, `WebViewRecordMessage` — typed replacements for the untyped `.payload` WebView bridge messages

#### Other

- `DatadogCore.MessageBus` gains a `Telemetry` conformance in production code (previously a retroactive conformance in the test target).
- New unit tests in `DatadogInternal/Tests/MessageBus/MessageBusTests.swift` covering closure-based subscription, type-based routing, and unsubscription via handle.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

---

## Chain overview

| # | PR | Title |
|---|---|---|
| **1** | ← _this PR_ | Typed MessageBus protocol and shared message types |
| 2 | — | Test infrastructure for typed message bus |
| 3 | — | DatadogCore: CoreMessageBus implementation and rename |
| 4 | — | DatadogCrashReporting: typed-bus migration |
| 5 | — | DatadogLogs: typed-bus migration |
| 6 | — | DatadogTrace: typed-bus migration |
| 7 | — | DatadogFlags: typed-bus migration |
| 8 | — | DatadogRUM: typed-bus migration and TelemetryInterceptor merge |
| 9 | — | DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration |
| 10 | — | Documentation updates |

```mermaid
graph LR
    G1["1 — Typed MessageBus protocol and shared message types"]
    G2["2 — Test infrastructure for typed message bus"]
    G3["3 — DatadogCore: CoreMessageBus implementation and rename"]
    G4["4 — DatadogCrashReporting: typed-bus migration"]
    G5["5 — DatadogLogs: typed-bus migration"]
    G6["6 — DatadogTrace: typed-bus migration"]
    G7["7 — DatadogFlags: typed-bus migration"]
    G8["8 — DatadogRUM: typed-bus migration and TelemetryInterceptor merge"]
    G9["9 — DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration"]
    G10["10 — Documentation updates"]
    G1 --> G2
    G2 --> G3
    G3 --> G4
    G3 --> G5
    G5 --> G6
    G3 --> G7
    G6 --> G8
    G7 --> G8
    G8 --> G9
    G1 --> G10
```

_Merge in dependency order. PRs with no incoming edges from un-merged PRs can be reviewed in parallel._