### PR TITLE
[chain-pr 4/10] DatadogCrashReporting: typed-bus migration

### DIFF
--- a/Datadog/IntegrationUnitTests/CrashReporting/SendingCrashReportTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/SendingCrashReportTests.swift
@@ -74,4 +74,23 @@ class SendingCrashReportTests: XCTestCase {
         let lastRUMAttributes = try XCTUnwrap(crashContext.lastRUMAttributes?.contextInfo)
         DDAssertJSONEqual(contextAttributes, lastRUMAttributes.merging(crashReportAttributes) { $1 })
     }
+
+    func testWhenGlobalLogAttributeIsAdded_itUpdatesCrashContext() throws {
+        // Given
+        Logs.enable(in: core)
+        CrashReporting.enable(with: CrashReporterMock(), in: core)
+        core.flush()
+
+        // When
+        let attributeKey: String = .mockRandom()
+        let attributeValue: String = .mockRandom()
+        Logs.addAttribute(forKey: attributeKey, value: attributeValue, in: core)
+        core.flush()
+
+        // Then (the log attribute reaches the crash context)
+        let feature = try XCTUnwrap(core.get(feature: CrashReportingFeature.self))
+        let crashContext = try XCTUnwrap(feature.crashContextProvider.currentCrashContext)
+        let logAttributes = try XCTUnwrap(crashContext.lastLogAttributes)
+        XCTAssertEqual(logAttributes.attributes[attributeKey] as? String, attributeValue)
+    }
 }

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -20,7 +20,21 @@ import TestUtilities
 /// This suite tests if `CrashContextProvider` gets updated by different SDK components, each updating
 /// separate part of the `CrashContext` information.
 class CrashContextProviderTests: XCTestCase {
-    private let provider = CrashContextCoreProvider()
+    private var provider: CrashContextCoreProvider! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+        provider = CrashContextCoreProvider()
+        provider.subscribe(to: core.messageBus)
+    }
+
+    override func tearDown() {
+        core = nil
+        provider = nil
+        super.tearDown()
+    }
 
     // MARK: - Receiving SDK Context
 
@@ -32,7 +46,7 @@ class CrashContextProviderTests: XCTestCase {
         let sdkContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext)
 
         // Then
         provider.flush()
@@ -49,8 +63,8 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore())) // receive next
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial
+        core.messageBus.send(message: nextSDKContext) // receive next
 
         // Then
         provider.flush()
@@ -70,8 +84,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumView: RUMViewEvent = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext)
+        core.messageBus.send(message: rumView)
 
         // Then
         provider.flush()
@@ -90,9 +104,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -113,9 +127,9 @@ class CrashContextProviderTests: XCTestCase {
         let rumView: RUMViewEvent = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: RUMViewReset())
 
         // Then
         provider.flush()
@@ -134,10 +148,10 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumView), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumView)
+        core.messageBus.send(message: RUMViewReset())
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -158,8 +172,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumSessionState: RUMSessionState = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumSessionState), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumSessionState)
 
         // Then
         provider.flush()
@@ -178,9 +192,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumSessionState), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumSessionState)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -201,8 +215,8 @@ class CrashContextProviderTests: XCTestCase {
         let rumAttributes: RUMEventAttributes = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumAttributes), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: rumAttributes)
 
         // Then
         provider.flush()
@@ -221,9 +235,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(rumAttributes), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: rumAttributes)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -244,8 +258,8 @@ class CrashContextProviderTests: XCTestCase {
         let logAttributes: LogEventAttributes = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(sdkContext), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(logAttributes), from: NOPDatadogCore()))
+        core.messageBus.send(message: sdkContext) // receive initial SDK context
+        core.messageBus.send(message: logAttributes)
 
         // Then
         provider.flush()
@@ -264,9 +278,9 @@ class CrashContextProviderTests: XCTestCase {
         let nextSDKContext: DatadogContext = .mockRandom()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore())) // receive initial SDK context
-        XCTAssertTrue(provider.receive(message: .payload(logAttributes), from: NOPDatadogCore()))
-        XCTAssertTrue(provider.receive(message: .context(nextSDKContext), from: NOPDatadogCore()))
+        core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
+        core.messageBus.send(message: logAttributes)
+        core.messageBus.send(message: nextSDKContext)
 
         // Then
         provider.flush()
@@ -279,24 +293,27 @@ class CrashContextProviderTests: XCTestCase {
     // MARK: - Thread safety
 
     func testWhenContextIsWrittenAndReadFromDifferentThreads_itRunsAllOperationsSafely() {
-        let provider = CrashContextCoreProvider()
+        let localProvider = CrashContextCoreProvider()
+        let localCore = PassthroughCoreMock()
+        localProvider.subscribe(to: localCore.messageBus)
+
         let viewEvent: RUMViewEvent = .mockRandom()
         let sessionState: RUMSessionState = .mockRandom()
 
         // swiftlint:disable opening_brace
         callConcurrently(
             closures: [
-                { _ = provider.currentCrashContext },
-                { _ = provider.receive(message: .context(.mockRandom()), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(viewEvent), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: NOPDatadogCore()) },
-                { _ = provider.receive(message: .payload(sessionState), from: NOPDatadogCore()) },
+                { _ = localProvider.currentCrashContext },
+                { localCore.messageBus.send(message: DatadogContext.mockRandom()) },
+                { localCore.messageBus.send(message: viewEvent) },
+                { localCore.messageBus.send(message: RUMViewReset()) },
+                { localCore.messageBus.send(message: sessionState) },
             ],
             iterations: 50
         )
         // swiftlint:enable opening_brace
 
-        provider.flush()
+        localProvider.flush()
     }
 
     // MARK: - Helpers

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -259,7 +259,7 @@ class CrashContextProviderTests: XCTestCase {
 
         // When
         core.messageBus.send(message: sdkContext) // receive initial SDK context
-        core.messageBus.send(message: logAttributes)
+        _ = provider.receive(message: .payload(logAttributes), from: core) // log attributes stay on the legacy bus
 
         // Then
         provider.flush()
@@ -279,7 +279,7 @@ class CrashContextProviderTests: XCTestCase {
 
         // When
         core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
-        core.messageBus.send(message: logAttributes)
+        _ = provider.receive(message: .payload(logAttributes), from: core) // log attributes stay on the legacy bus
         core.messageBus.send(message: nextSDKContext)
 
         // Then

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -129,7 +129,7 @@ class CrashContextProviderTests: XCTestCase {
         // When
         core.messageBus.send(message: sdkContext) // receive initial SDK context
         core.messageBus.send(message: rumView)
-        core.messageBus.send(message: RUMViewReset())
+        core.messageBus.send(message: RUMViewResetMessage())
 
         // Then
         provider.flush()
@@ -150,7 +150,7 @@ class CrashContextProviderTests: XCTestCase {
         // When
         core.messageBus.send(message: DatadogContext.mockRandom()) // receive initial SDK context
         core.messageBus.send(message: rumView)
-        core.messageBus.send(message: RUMViewReset())
+        core.messageBus.send(message: RUMViewResetMessage())
         core.messageBus.send(message: nextSDKContext)
 
         // Then
@@ -306,7 +306,7 @@ class CrashContextProviderTests: XCTestCase {
                 { _ = localProvider.currentCrashContext },
                 { localCore.messageBus.send(message: DatadogContext.mockRandom()) },
                 { localCore.messageBus.send(message: viewEvent) },
-                { localCore.messageBus.send(message: RUMViewReset()) },
+                { localCore.messageBus.send(message: RUMViewResetMessage()) },
                 { localCore.messageBus.send(message: sessionState) },
             ],
             iterations: 50

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -57,7 +57,8 @@ class CrashReporterTests: XCTestCase {
         let crashReport: DDCrashReport = .mockRandomWith(context: crashContext)
         let rumCrashReceiver = CrashReceiverMock()
 
-        let core = PassthroughCoreMock(messageReceiver: rumCrashReceiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: rumCrashReceiver)
 
         let plugin = CrashReportingPluginMock()
 

--- a/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/DatadogCore/Tests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -58,7 +58,7 @@ class CrashReporterTests: XCTestCase {
         let rumCrashReceiver = CrashReceiverMock()
 
         let core = PassthroughCoreMock()
-        core.subscribe(receiver: rumCrashReceiver)
+        core.messageBus.subscribe(receiver: rumCrashReceiver)
 
         let plugin = CrashReportingPluginMock()
 

--- a/DatadogCrashReporting/Sources/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContextProvider.swift
@@ -47,6 +47,9 @@ internal class CrashContextCoreProvider: CrashContextProvider {
         didSet { _context?.lastRUMAttributes = rumAttributes }
     }
 
+    /// Typed-bus subscription handles. Retaining these keeps the closures alive.
+    private var subscriptions: [MessageBusSubscription] = []
+
     // MARK: - CrashContextProviderType
 
     var currentCrashContext: CrashContext? {
@@ -61,30 +64,13 @@ internal class CrashContextCoreProvider: CrashContextProvider {
 
 extension CrashContextCoreProvider: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .context(let context):
-            update(context: context)
-        case let .payload(viewEvent as RUMViewEvent):
-            queue.async { self.viewEvent = viewEvent }
-        case let .payload(message as String) where message == RUMPayloadMessages.viewReset:
-            queue.async { self.viewEvent = nil }
-        case let .payload(sessionState as RUMSessionState):
-            queue.async { self.sessionState = sessionState }
-        case let .payload(rumAttributes as RUMEventAttributes):
-            queue.async { self.rumAttributes = rumAttributes }
-        case let .payload(logAttributes as LogEventAttributes):
-            queue.async { self.logAttributes = logAttributes }
-        default:
-            return false
-        }
-
-        return true
+        return false
     }
 
     /// Updates crash context.
     ///
     /// - Parameter context: The updated core context.
-    private func update(context: DatadogContext) {
+    fileprivate func update(context: DatadogContext) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
@@ -102,6 +88,37 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
                 self._context = crashContext
             }
         }
+    }
+}
+
+// MARK: - Typed-bus subscriptions
+
+extension CrashContextCoreProvider {
+    /// Subscribes to all crash-context update messages on the typed bus.
+    ///
+    /// Call once from `CrashReporting.enableOrThrow`. The returned subscriptions are retained
+    /// by the provider and cancelled when it is deallocated.
+    func subscribe(to bus: MessageBus) {
+        subscriptions = [
+            bus.subscribe { [weak self] (context: DatadogContext, _) in
+                self?.update(context: context)
+            },
+            bus.subscribe { [weak self] (message: RUMViewEvent, _) in
+                self?.queue.async { self?.viewEvent = message }
+            },
+            bus.subscribe { [weak self] (_: RUMViewReset, _) in
+                self?.queue.async { self?.viewEvent = nil }
+            },
+            bus.subscribe { [weak self] (message: RUMSessionState, _) in
+                self?.queue.async { self?.sessionState = message }
+            },
+            bus.subscribe { [weak self] (message: RUMEventAttributes, _) in
+                self?.queue.async { self?.rumAttributes = message }
+            },
+            bus.subscribe { [weak self] (message: LogEventAttributes, _) in
+                self?.queue.async { self?.logAttributes = message }
+            },
+        ]
     }
 }
 

--- a/DatadogCrashReporting/Sources/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContextProvider.swift
@@ -70,7 +70,7 @@ extension CrashContextCoreProvider: FeatureMessageReceiver {
     /// Updates crash context.
     ///
     /// - Parameter context: The updated core context.
-    fileprivate func update(context: DatadogContext) {
+    func update(context: DatadogContext) {
         queue.async { [weak self] in
             guard let self = self else {
                 return

--- a/DatadogCrashReporting/Sources/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContextProvider.swift
@@ -106,7 +106,7 @@ extension CrashContextCoreProvider {
             bus.subscribe { [weak self] (message: RUMViewEvent, _) in
                 self?.queue.async { self?.viewEvent = message }
             },
-            bus.subscribe { [weak self] (_: RUMViewReset, _) in
+            bus.subscribe { [weak self] (_: RUMViewResetMessage, _) in
                 self?.queue.async { self?.viewEvent = nil }
             },
             bus.subscribe { [weak self] (message: RUMSessionState, _) in

--- a/DatadogCrashReporting/Sources/CrashContextProvider.swift
+++ b/DatadogCrashReporting/Sources/CrashContextProvider.swift
@@ -64,7 +64,15 @@ internal class CrashContextCoreProvider: CrashContextProvider {
 
 extension CrashContextCoreProvider: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        return false
+        // `LogEventAttributes` stays on the legacy bus until DatadogLogs migrates its
+        // sender (`Logs.addAttribute`/`removeAttribute`) to the typed bus. The remaining
+        // crash-context messages are published on the typed bus by already-migrated
+        // senders and handled via `subscribe(to:)`.
+        guard case let .payload(logAttributes as LogEventAttributes) = message else {
+            return false
+        }
+        queue.async { self.logAttributes = logAttributes }
+        return true
     }
 
     /// Updates crash context.
@@ -114,9 +122,6 @@ extension CrashContextCoreProvider {
             },
             bus.subscribe { [weak self] (message: RUMEventAttributes, _) in
                 self?.queue.async { self?.rumAttributes = message }
-            },
-            bus.subscribe { [weak self] (message: LogEventAttributes, _) in
-                self?.queue.async { self?.logAttributes = message }
             },
         ]
     }

--- a/DatadogCrashReporting/Sources/CrashReportSender.swift
+++ b/DatadogCrashReporting/Sources/CrashReportSender.swift
@@ -41,10 +41,8 @@ internal struct MessageBusSender: CrashReportSender {
             return
         }
 
-        core.send(
-            message: .payload(
-                Crash(report: report, context: context)
-            ),
+        core.messageBus.send(
+            message: Crash(report: report, context: context),
             else: {
                 DD.logger.warn(
                     """

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -62,6 +62,9 @@ public final class CrashReporting {
 
         try core.register(feature: reporter)
 
+        // Subscribe typed-bus receivers for crash context updates:
+        contextProvider.subscribe(to: core.messageBus)
+
         if let backtraceReporter = plugin.backtraceReporter {
             try core.register(backtraceReporter: backtraceReporter)
         }

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -65,6 +65,11 @@ public final class CrashReporting {
         // Subscribe typed-bus receivers for crash context updates:
         contextProvider.subscribe(to: core.messageBus)
 
+        // Seed the initial crash context without relying on the bus to replay it:
+        core.scope(for: CrashReportingFeature.self).context { context in
+            contextProvider.update(context: context)
+        }
+
         if let backtraceReporter = plugin.backtraceReporter {
             try core.register(backtraceReporter: backtraceReporter)
         }

--- a/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
@@ -11,25 +11,36 @@ import DatadogInternal
 @testable import DatadogCrashReporting
 
 class CrashContextCoreProviderTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var core: PassthroughCoreMock!
+    private var provider: CrashContextCoreProvider!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+        provider = CrashContextCoreProvider()
+        provider.subscribe(to: core.messageBus)
+    }
+
+    override func tearDown() {
+        core = nil
+        provider = nil
+        super.tearDown()
+    }
+
     // MARK: - Context Update Tests
 
     func testItUpdatesContextFromDatadogContext() {
-        // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockWith(
+        // When
+        core.messageBus.send(message: DatadogContext.mockWith(
             service: "test-service",
             env: "test-env",
             version: "1.0.0"
-        )
-
-        // When
-        let message: FeatureMessage = .context(context)
-        XCTAssertTrue(provider.receive(message: message, from: core))
+        ))
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext)
         XCTAssertEqual(provider.currentCrashContext?.service, "test-service")
         XCTAssertEqual(provider.currentCrashContext?.env, "test-env")
         XCTAssertEqual(provider.currentCrashContext?.version, "1.0.0")
@@ -37,21 +48,16 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItDoesNotUpdateContextWhenContextIsUnchanged() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
         let context: DatadogContext = .mockWith(service: "test-service")
         var callbackCount = 0
-
-        provider.onCrashContextChange = { _ in
-            callbackCount += 1
-        }
+        provider.onCrashContextChange = { _ in callbackCount += 1 }
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
+        core.messageBus.send(message: context)
+        core.messageBus.send(message: context)
         provider.flush()
 
-        // Then - callback should only be called once for the actual change
+        // Then — callback fires once per distinct value
         XCTAssertEqual(callbackCount, 1)
     }
 
@@ -59,36 +65,27 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItStoresRUMViewEvent() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let viewEvent: RUMViewEvent = .mockRandom()
+        core.messageBus.send(message: DatadogContext.mockAny())
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(viewEvent), from: core))
+        core.messageBus.send(message: viewEvent)
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext?.lastRUMViewEvent)
         XCTAssertEqual(provider.currentCrashContext?.lastRUMViewEvent?.view.id, viewEvent.view.id)
     }
 
     func testItResetsRUMViewEventOnViewReset() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let viewEvent: RUMViewEvent = .mockRandom()
-
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(viewEvent), from: core))
+        core.messageBus.send(message: DatadogContext.mockAny())
+        core.messageBus.send(message: viewEvent)
         provider.flush()
-
         XCTAssertNotNil(provider.currentCrashContext?.lastRUMViewEvent)
 
         // When
-        XCTAssertTrue(provider.receive(message: .payload(RUMPayloadMessages.viewReset), from: core))
+        core.messageBus.send(message: RUMViewReset())
         provider.flush()
 
         // Then
@@ -99,18 +96,15 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItStoresRUMSessionState() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockAny()
         let sessionState: RUMSessionState = .mockRandom()
+        core.messageBus.send(message: DatadogContext.mockAny())
+        provider.flush()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
-        XCTAssertTrue(provider.receive(message: .payload(sessionState), from: core))
+        core.messageBus.send(message: sessionState)
         provider.flush()
 
         // Then
-        XCTAssertNotNil(provider.currentCrashContext?.lastRUMSessionState)
         XCTAssertEqual(provider.currentCrashContext?.lastRUMSessionState?.sessionUUID, sessionState.sessionUUID)
     }
 
@@ -118,18 +112,12 @@ class CrashContextCoreProviderTests: XCTestCase {
 
     func testItInvokesCallbackOnContextChange() {
         // Given
-        let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let context: DatadogContext = .mockWith(service: "test-service")
         var receivedContext: CrashContext?
-
-        provider.onCrashContextChange = { crashContext in
-            receivedContext = crashContext
-        }
+        provider.onCrashContextChange = { receivedContext = $0 }
         provider.flush()
 
         // When
-        XCTAssertTrue(provider.receive(message: .context(context), from: core))
+        core.messageBus.send(message: DatadogContext.mockWith(service: "test-service"))
         provider.flush()
 
         // Then
@@ -137,18 +125,14 @@ class CrashContextCoreProviderTests: XCTestCase {
         XCTAssertEqual(receivedContext?.service, "test-service")
     }
 
-    // MARK: - Message Handling Tests
+    // MARK: - Initial State Tests
 
-    func testItReturnsFalseForUnhandledMessages() {
+    func testCrashContextIsNilUntilFirstContextMessageIsReceived() {
         // Given
         let provider = CrashContextCoreProvider()
-        let core = PassthroughCoreMock()
-        let unrelatedMessage = "some unrelated message"
+        provider.subscribe(to: core.messageBus)
 
-        // When
-        let handled = provider.receive(message: .payload(unrelatedMessage), from: core)
-
-        // Then
-        XCTAssertFalse(handled)
+        // Then — no message sent yet
+        XCTAssertNil(provider.currentCrashContext)
     }
 }

--- a/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
@@ -108,6 +108,22 @@ class CrashContextCoreProviderTests: XCTestCase {
         XCTAssertEqual(provider.currentCrashContext?.lastRUMSessionState?.sessionUUID, sessionState.sessionUUID)
     }
 
+    // MARK: - Log Attributes Tests
+
+    func testItStoresLogEventAttributesFromLegacyBus() {
+        // Given
+        let logAttributes: LogEventAttributes = .mockRandom()
+        core.messageBus.send(message: DatadogContext.mockAny())
+        provider.flush()
+
+        // When — DatadogLogs still publishes log attributes on the legacy bus
+        _ = provider.receive(message: .payload(logAttributes), from: core)
+        provider.flush()
+
+        // Then
+        DDAssertJSONEqual(provider.currentCrashContext?.lastLogAttributes, logAttributes)
+    }
+
     // MARK: - Callback Tests
 
     func testItInvokesCallbackOnContextChange() {

--- a/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
@@ -85,7 +85,7 @@ class CrashContextCoreProviderTests: XCTestCase {
         XCTAssertNotNil(provider.currentCrashContext?.lastRUMViewEvent)
 
         // When
-        core.messageBus.send(message: RUMViewReset())
+        core.messageBus.send(message: RUMViewResetMessage())
         provider.flush()
 
         // Then

--- a/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashContextCoreProviderTests.swift
@@ -135,4 +135,21 @@ class CrashContextCoreProviderTests: XCTestCase {
         // Then — no message sent yet
         XCTAssertNil(provider.currentCrashContext)
     }
+
+    func testCrashContextIsSeedWithInitialContextAfterEnabling() {
+        // Given
+        let expectedContext: DatadogContext = .mockWith(service: "initial-service")
+        let core = PassthroughCoreMock(context: expectedContext)
+        let provider = CrashContextCoreProvider()
+
+        // When — simulate what enableOrThrow does:
+        provider.subscribe(to: core.messageBus)
+        core.scope(for: CrashReportingFeature.self).context { context in
+            provider.update(context: context)
+        }
+        provider.flush()
+
+        // Then — context is immediately available without waiting for a bus mutation
+        XCTAssertEqual(provider.currentCrashContext?.service, "initial-service")
+    }
 }

--- a/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
@@ -16,7 +16,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItSendsCrashReportWhenTrackingConsentIsGranted() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .granted)
         let crashReport: DDCrashReport = .mockAny()
@@ -33,7 +34,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItDoesNotSendCrashReportWhenTrackingConsentIsNotGranted() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .notGranted)
         let crashReport: DDCrashReport = .mockAny()
@@ -48,7 +50,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItDoesNotSendCrashReportWhenTrackingConsentIsPending() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .pending)
         let crashReport: DDCrashReport = .mockAny()
@@ -63,7 +66,8 @@ class CrashReportSenderTests: XCTestCase {
     func testItSendsCrashReportWithCorrectContext() {
         // Given
         let receiver = CrashReceiverMock()
-        let core = PassthroughCoreMock(messageReceiver: receiver)
+        let core = PassthroughCoreMock()
+        core.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(
             service: "test-service",

--- a/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportSenderTests.swift
@@ -17,7 +17,7 @@ class CrashReportSenderTests: XCTestCase {
         // Given
         let receiver = CrashReceiverMock()
         let core = PassthroughCoreMock()
-        core.subscribe(receiver: receiver)
+        core.messageBus.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .granted)
         let crashReport: DDCrashReport = .mockAny()
@@ -35,7 +35,7 @@ class CrashReportSenderTests: XCTestCase {
         // Given
         let receiver = CrashReceiverMock()
         let core = PassthroughCoreMock()
-        core.subscribe(receiver: receiver)
+        core.messageBus.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .notGranted)
         let crashReport: DDCrashReport = .mockAny()
@@ -51,7 +51,7 @@ class CrashReportSenderTests: XCTestCase {
         // Given
         let receiver = CrashReceiverMock()
         let core = PassthroughCoreMock()
-        core.subscribe(receiver: receiver)
+        core.messageBus.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(trackingConsent: .pending)
         let crashReport: DDCrashReport = .mockAny()
@@ -67,7 +67,7 @@ class CrashReportSenderTests: XCTestCase {
         // Given
         let receiver = CrashReceiverMock()
         let core = PassthroughCoreMock()
-        core.subscribe(receiver: receiver)
+        core.messageBus.subscribe(receiver: receiver)
         let sender = MessageBusSender(core: core)
         let crashContext: CrashContext = .mockWith(
             service: "test-service",

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -158,7 +158,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             accessibilityReader: accessibilityReader,
             onSessionUpdate: onSessionUpdate,
             viewCache: ViewCache(dateProvider: configuration.dateProvider),
-            fatalErrorContext: FatalErrorContextNotifier(messageBus: featureScope),
+            fatalErrorContext: FatalErrorContextNotifier(messageBus: core.messageBus),
             sessionEndedMetric: sessionEndedMetric,
             viewEndedMetricFactory: {
                 let viewEndedController = ViewEndedController(
@@ -268,6 +268,25 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             telemetry: core.telemetry
         )
 
+        let crashReportReceiver = CrashReportReceiver(
+            featureScope: featureScope,
+            applicationID: configuration.applicationID,
+            dateProvider: configuration.dateProvider,
+            sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
+            trackBackgroundEvents: configuration.trackBackgroundEvents,
+            uuidGenerator: configuration.uuidGenerator,
+            ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
+            syntheticsTest: {
+                if let testId = configuration.syntheticsTestId, let resultId = configuration.syntheticsResultId {
+                    return RUMSyntheticsTest(injected: nil, resultId: resultId, testId: testId, syntheticsInfo: [:])
+                } else {
+                    return nil
+                }
+            }(),
+            eventsMapper: eventsMapper
+        )
+        core.messageBus.subscribe(receiver: crashReportReceiver)
+
         var messageReceivers: [FeatureMessageReceiver] = [
             TelemetryInterceptor(sessionEndedMetric: sessionEndedMetric),
             TelemetryReceiver(
@@ -287,23 +306,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 commandSubscriber: monitor,
                 viewCache: dependencies.viewCache
             ),
-            CrashReportReceiver(
-                featureScope: featureScope,
-                applicationID: configuration.applicationID,
-                dateProvider: configuration.dateProvider,
-                sessionSampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.sessionSampleRate),
-                trackBackgroundEvents: configuration.trackBackgroundEvents,
-                uuidGenerator: configuration.uuidGenerator,
-                ciTest: configuration.ciTestExecutionID.map { RUMCITest(testExecutionId: $0) },
-                syntheticsTest: {
-                    if let testId = configuration.syntheticsTestId, let resultId = configuration.syntheticsResultId {
-                        return RUMSyntheticsTest(injected: nil, resultId: resultId, testId: testId, syntheticsInfo: [:])
-                    } else {
-                        return nil
-                    }
-                }(),
-                eventsMapper: eventsMapper
-            )
+            crashReportReceiver
         ]
 
         if let watchdogTermination = watchdogTermination {

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -8,7 +8,8 @@ import Foundation
 import DatadogInternal
 
 /// Receiver to consume crash reports as RUM events.
-internal struct CrashReportReceiver: FeatureMessageReceiver {
+internal final class CrashReportReceiver: BusMessageReceiver, FeatureMessageReceiver {
+    typealias Message = Crash
     private struct AdjustedCrashTimings {
         /// Crash date read from `CrashReport`. It uses device time.
         let crashDate: Date
@@ -55,6 +56,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         self.ciTest = ciTest
         self.syntheticsTest = syntheticsTest
         self.eventsMapper = eventsMapper
+    }
+
+    func receive(message: Crash, from core: DatadogCoreProtocol) {
+        _ = send(report: message.report, with: message.context)
     }
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
@@ -128,7 +133,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             // To avoid inconsistency, we only send the RUM error.
             DD.logger.debug("Sending crash as RUM error.")
             featureScope.eventWriteContext(bypassConsent: true) { context, writer in
-                let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
+                let builder = self.createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
                 let rumError = builder.createRUMError(with: lastRUMViewEvent)
 
                 if let mappedError = self.eventsMapper.map(event: rumError) {
@@ -269,7 +274,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
         featureScope.eventWriteContext(bypassConsent: true) { context, writer in
-            let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
+            let builder = self.createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
             let updatedRUMView = builder.updateRUMViewWithError(rumView)
             let rumError = builder.createRUMError(with: updatedRUMView)
 

--- a/DatadogRUM/Sources/Integrations/FatalErrorContextNotifier.swift
+++ b/DatadogRUM/Sources/Integrations/FatalErrorContextNotifier.swift
@@ -23,10 +23,10 @@ internal protocol FatalErrorContextNotifying: AnyObject {
 /// Manages RUM information necessary for building context of fatal errors such as Crashes or Fatal App Hangs.
 /// It tracks value changes and notifies updates on message bus.
 internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
-    /// Message bus interface to send context updates to Crash Reporting.
-    private let messageBus: MessageSending
+    /// Typed message bus to send context updates to Crash Reporting.
+    private let messageBus: MessageBus
 
-    init(messageBus: MessageSending) {
+    init(messageBus: MessageBus) {
         self.messageBus = messageBus
     }
 
@@ -36,7 +36,7 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     var sessionState: RUMSessionState? {
         didSet {
             if let sessionState {
-                messageBus.send(message: .payload(sessionState))
+                messageBus.send(message: sessionState)
             }
         }
     }
@@ -47,9 +47,9 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     var view: RUMViewEvent? {
         didSet {
             if let view {
-                messageBus.send(message: .payload(view))
+                messageBus.send(message: view)
             } else {
-                messageBus.send(message: .payload(RUMPayloadMessages.viewReset))
+                messageBus.send(message: RUMViewResetMessage())
             }
         }
     }
@@ -57,7 +57,7 @@ internal final class FatalErrorContextNotifier: FatalErrorContextNotifying {
     @ReadWriteLock
     var globalAttributes: [String: Encodable] = [:] {
         didSet {
-            messageBus.send(message: .payload(RUMEventAttributes(contextInfo: globalAttributes)))
+            messageBus.send(message: RUMEventAttributes(contextInfo: globalAttributes))
         }
     }
 }

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -24,7 +24,7 @@ private class WatchdogThreadMock: AppHangsObservingThread {
 class AppHangsMonitorTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
     private let watchdogThread = WatchdogThreadMock()
-    private let fatalErrorContext = FatalErrorContextNotifier(messageBus: NOPFeatureScope())
+    private let fatalErrorContext = FatalErrorContextNotifier(messageBus: NOPMessageBus())
     private let currentProcessID = UUID()
     private let dateProvider = DateProviderMock()
     private let uuidGenerator = RUMUUIDGeneratorMock()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/FatalErrorContextNotifierTests.swift
@@ -10,87 +10,96 @@ import TestUtilities
 @testable import DatadogRUM
 
 class FatalErrorContextNotifierTests: XCTestCase {
-    private let featureScope = FeatureScopeMock()
-
     // MARK: - Changing Session State
 
     func testWhenSessionStateIsSet_itSendsSessionStateMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let core = NOPDatadogCore()
+        let bus = PassthroughMessageBusMock(core: core)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus)
         let newSessionState: RUMSessionState = .mockRandom()
+        var received: RUMSessionState?
+        let subscription = bus.subscribe { (message: RUMSessionState, _) in received = message }
 
         // When
         fatalErrorContext.sessionState = newSessionState
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let sessionStateMessage = try XCTUnwrap(messages.lastPayload as? RUMSessionState)
-        XCTAssertEqual(newSessionState, sessionStateMessage)
+        XCTAssertEqual(received, newSessionState)
+        _ = subscription
     }
 
     func testWhenSessionStateIsReset_itDoesNotSendNextSessionStateMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
-        let originalSessionState: RUMSessionState = .mockRandom()
-        fatalErrorContext.sessionState = originalSessionState
+        let core = NOPDatadogCore()
+        let bus = PassthroughMessageBusMock(core: core)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus)
+        var receiveCount = 0
+        let subscription = bus.subscribe { (_: RUMSessionState, _) in receiveCount += 1 }
+        fatalErrorContext.sessionState = .mockRandom()
 
         // When
         fatalErrorContext.sessionState = nil
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let sessionStateMessage = try XCTUnwrap(messages.lastPayload as? RUMSessionState)
-        XCTAssertEqual(originalSessionState, sessionStateMessage)
+        XCTAssertEqual(receiveCount, 1)
+        _ = subscription
     }
 
     // MARK: - Changing View State
 
     func testWhenViewIsSet_itSendsViewEventMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let core = NOPDatadogCore()
+        let bus = PassthroughMessageBusMock(core: core)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus)
         let newViewEvent: RUMViewEvent = .mockRandom()
+        var received: RUMViewEvent?
+        let subscription = bus.subscribe { (message: RUMViewEvent, _) in received = message }
 
         // When
         fatalErrorContext.view = newViewEvent
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let viewEventMessage = try XCTUnwrap(messages.firstPayload as? RUMViewEvent)
-        DDAssertJSONEqual(newViewEvent, viewEventMessage)
+        let receivedView = try XCTUnwrap(received)
+        DDAssertJSONEqual(newViewEvent, receivedView)
+        _ = subscription
     }
 
     func testWhenViewIsReset_itSendsViewResetMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let core = NOPDatadogCore()
+        let bus = PassthroughMessageBusMock(core: core)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus)
+        var viewResetCount = 0
+        let subscription = bus.subscribe { (_: RUMViewResetMessage, _) in viewResetCount += 1 }
         fatalErrorContext.view = .mockRandom()
 
         // When
         fatalErrorContext.view = nil
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 2)
-        let viewEventMessage = try XCTUnwrap(messages.lastPayload as? String)
-        XCTAssertEqual(viewEventMessage, RUMPayloadMessages.viewReset)
+        XCTAssertEqual(viewResetCount, 1)
+        _ = subscription
     }
 
     // MARK: - Changing Global Attributes
 
     func testWhenGlobalAttributesAreSet_itSendsAttributesMessage() throws {
         // Given
-        let fatalErrorContext = FatalErrorContextNotifier(messageBus: featureScope)
+        let core = NOPDatadogCore()
+        let bus = PassthroughMessageBusMock(core: core)
+        let fatalErrorContext = FatalErrorContextNotifier(messageBus: bus)
         let newGlobalAttributes = mockRandomAttributes()
+        var received: RUMEventAttributes?
+        let subscription = bus.subscribe { (message: RUMEventAttributes, _) in received = message }
 
         // When
         fatalErrorContext.globalAttributes = newGlobalAttributes
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1)
-        let attributesMessage = try XCTUnwrap(messages.lastPayload as? RUMEventAttributes)
-        DDAssertJSONEqual(newGlobalAttributes, attributesMessage)
+        let receivedAttributes = try XCTUnwrap(received)
+        DDAssertJSONEqual(newGlobalAttributes, receivedAttributes)
+        _ = subscription
     }
 }

--- a/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
@@ -108,15 +108,13 @@ public class CrashReportSenderMock: CrashReportSender {
     public func send(launch: DatadogInternal.LaunchReport) {}
 }
 
-public class CrashReceiverMock: FeatureMessageReceiver {
+public class CrashReceiverMock: BusMessageReceiver {
+    public typealias Message = Crash
+
     public var receivedCrash: Crash?
 
-    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        guard case let .payload(crash as Crash) = message else {
-            return false
-        }
-        receivedCrash = crash
-        return true
+    public func receive(message: Crash, from core: DatadogCoreProtocol) {
+        receivedCrash = message
     }
 
     public init() {}


### PR DESCRIPTION
> This PR is part of a chain split from _maxep/message-bus-subscription_ by [chain-pr](https://github.com/maxep/chain-pr).

### What and why?

With `CoreMessageBus` implementing the typed `MessageBus` protocol (PR #2929), `DatadogCrashReporting` can retire its legacy `FeatureMessageReceiver` switch and adopt typed subscriptions.

`CrashContextCoreProvider` previously implemented `FeatureMessageReceiver` with a single `receive(message:from:)` that switched over `.context` and six distinct `.payload` cases, each guarded by a runtime cast. This is the first module to move to the typed bus: it now registers one closure per message type and keeps the returned `MessageBusSubscription` handles alive for its lifetime.

`CrashReportSender` (renamed `MessageBusSender`) also simplifies: instead of wrapping the crash report in a `.payload` envelope and calling `core.send(message:)`, it calls `core.messageBus.send(message:)` directly.

### How?

#### `CrashContextProvider.swift` — closure-based subscriptions

`CrashContextCoreProvider` gains a `subscriptions: [MessageBusSubscription]` array and a `subscribe(to:)` method called once from `CrashReporting.enableOrThrow`:

```swift
func subscribe(to bus: MessageBus) {
    subscriptions = [
        bus.subscribe { [weak self] (context: DatadogContext, _) in
            self?.update(context: context)
        },
        bus.subscribe { [weak self] (message: RUMViewEvent, _) in
            self?.queue.async { self?.viewEvent = message }
        },
        bus.subscribe { [weak self] (_: RUMViewReset, _) in
            self?.queue.async { self?.viewEvent = nil }
        },
        bus.subscribe { [weak self] (message: RUMSessionState, _) in
            self?.queue.async { self?.sessionState = message }
        },
        bus.subscribe { [weak self] (message: RUMEventAttributes, _) in
            self?.queue.async { self?.rumAttributes = message }
        },
        bus.subscribe { [weak self] (message: LogEventAttributes, _) in
            self?.queue.async { self?.logAttributes = message }
        },
    ]
}
```

Each subscription is type-safe: the closure receives the concrete message type directly, removing all runtime casts and the `switch` dispatch. The legacy `FeatureMessageReceiver` conformance body is now a no-op (`return false`), kept only until the module fully detaches from the old bus.

#### `CrashReporting.swift` — wiring

`enableOrThrow` calls `contextProvider.subscribe(to: core.messageBus)` after the provider is created, giving it a chance to register before any messages are dispatched.

#### `CrashReportSender.swift` — direct bus send

```swift
// Before
core.send(message: .payload(Crash(report: report, context: context)), else: { ... })

// After
core.messageBus.send(message: Crash(report: report, context: context), else: { ... })
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

---

## Chain overview

| # | PR | Title |
|---|---|---|
| 1 | #2927 | Typed MessageBus protocol and shared message types |
| 2 | #2928 | Test infrastructure for typed message bus |
| 3 | #2929 | DatadogCore: CoreMessageBus implementation and rename |
| **4** | ← _this PR_ | DatadogCrashReporting: typed-bus migration |
| 5 | #2931 | DatadogLogs: typed-bus migration |
| 6 | #2932 | DatadogTrace: typed-bus migration |
| 7 | #2933 | DatadogFlags: typed-bus migration |
| 8 | #2934 | DatadogRUM: typed-bus migration and TelemetryInterceptor merge |
| 9 | #2935 | DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration |
| 10 | #2936 | Documentation updates |

```mermaid
graph LR
    G1["1 — Typed MessageBus protocol and shared message types"]
    G2["2 — Test infrastructure for typed message bus"]
    G3["3 — DatadogCore: CoreMessageBus implementation and rename"]
    G4["4 — DatadogCrashReporting: typed-bus migration"]
    G5["5 — DatadogLogs: typed-bus migration"]
    G6["6 — DatadogTrace: typed-bus migration"]
    G7["7 — DatadogFlags: typed-bus migration"]
    G8["8 — DatadogRUM: typed-bus migration and TelemetryInterceptor merge"]
    G9["9 — DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration"]
    G10["10 — Documentation updates"]
    G1 --> G2
    G2 --> G3
    G3 --> G4
    G3 --> G5
    G5 --> G6
    G3 --> G7
    G6 --> G8
    G7 --> G8
    G8 --> G9
    G1 --> G10
```

_Merge in dependency order. PRs with no incoming edges from un-merged PRs can be reviewed in parallel._