### PR TITLE
[chain-pr 6/10] DatadogTrace: typed-bus migration

### DIFF
--- a/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/TracingURLSessionHandlerTests.swift
@@ -21,8 +21,10 @@ class TracingURLSessionHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        core = PassthroughCoreMock(messageReceiver: receiver)
+        core = PassthroughCoreMock()
+        core.messageBus.subscribe(receiver: receiver)
         core.messageBus.subscribe(receiver: LogMessageReceiver.mockAny())
+        core.context = core.context
 
         tracer = .mockWith(
             core: core,
@@ -223,8 +225,7 @@ class TracingURLSessionHandlerTests: XCTestCase {
                 )
             ]
         )
-        let message = FeatureMessage.context(fakeContext)
-        _ = handler.contextReceiver.receive(message: message, from: core)
+        handler.contextReceiver.receive(message: fakeContext, from: core)
         let (modifiedRequest, _, _) = handler.modify(
             request: request,
             headerTypes: [.datadog, .tracecontext, .b3, .b3multi],

--- a/DatadogTrace/Sources/Feature/MessageReceivers.swift
+++ b/DatadogTrace/Sources/Feature/MessageReceivers.swift
@@ -21,7 +21,7 @@ internal struct CoreContext {
     var accountInfo: AccountInfo?
 }
 
-internal final class ContextMessageReceiver: FeatureMessageReceiver {
+internal final class ContextMessageReceiver: BusMessageReceiver {
     /// Creates a new `ContextMessageReceiver`.
     ///
     /// - parameters:
@@ -41,24 +41,7 @@ internal final class ContextMessageReceiver: FeatureMessageReceiver {
     /// The tracer sampler that should be updated with the RUM deterministic sampler.
     let samplerProvider: SamplerProvider
 
-    /// Process messages receives from the bus.
-    ///
-    /// - Parameters:
-    ///   - message: The Feature message
-    ///   - core: The core from which the message is transmitted.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
-        switch message {
-        case .context(let context):
-            return update(context: context, from: core)
-        default:
-            return false
-        }
-    }
-
-    /// Updates context of the `DatadogTracer` if available.
-    ///
-    /// - Parameter context: The updated core context.
-    private func update(context datadogContext: DatadogContext, from core: DatadogCoreProtocol) -> Bool {
+    func receive(message datadogContext: DatadogContext, from core: DatadogCoreProtocol) {
         let rumContext = datadogContext.additionalContext(ofType: RUMCoreContext.self)
 
         _context.mutate {
@@ -69,7 +52,5 @@ internal final class ContextMessageReceiver: FeatureMessageReceiver {
         }
 
         samplerProvider.updateWith(deterministicSampler: rumContext?.sessionSampler)
-
-        return true
     }
 }

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -11,7 +11,7 @@ internal final class TraceFeature: DatadogRemoteFeature {
     static let name = "tracing"
 
     let requestBuilder: FeatureRequestBuilder
-    var messageReceiver: FeatureMessageReceiver { contextReceiver }
+    let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
 
     let tracer: DatadogTracer
     let contextReceiver: ContextMessageReceiver

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -42,6 +42,10 @@ public enum Trace {
 
         // Register Trace feature:
         let trace = TraceFeature(in: core, configuration: configuration)
+
+        // Subscribe typed-bus receivers before registration so initial context push is received:
+        core.messageBus.subscribe(receiver: trace.contextReceiver)
+
         try core.register(feature: trace)
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -42,11 +42,10 @@ public enum Trace {
 
         // Register Trace feature:
         let trace = TraceFeature(in: core, configuration: configuration)
-
-        // Subscribe typed-bus receivers before registration so initial context push is received:
-        core.messageBus.subscribe(receiver: trace.contextReceiver)
-
         try core.register(feature: trace)
+
+        // Subscribe typed-bus receivers only after successful registration:
+        core.messageBus.subscribe(receiver: trace.contextReceiver)
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:
         if let urlSessionTracking = configuration.urlSessionTracking {

--- a/DatadogTrace/Tests/ContextMessageReceiverTests.swift
+++ b/DatadogTrace/Tests/ContextMessageReceiverTests.swift
@@ -14,11 +14,13 @@ class ContextMessageReceiverTests: XCTestCase {
     func testItReceivesApplicationStateHistory() throws {
         // Given
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        let core = PassthroughCoreMock(
-            context: .mockWith(applicationStateHistory: .mockAppInBackground()),
-            messageReceiver: receiver
-        )
+        let core = PassthroughCoreMock()
+        core.messageBus.subscribe(receiver: receiver)
 
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockAppInBackground())
+
+        // Then
         XCTAssertEqual(receiver.context.applicationStateHistory?.currentState, .background)
 
         // When

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -21,7 +21,9 @@ class TracingURLSessionHandlerTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         let receiver = ContextMessageReceiver(samplerProvider: SamplerProvider(sampleRate: .mockAny()))
-        core = PassthroughCoreMock(messageReceiver: receiver)
+        core = PassthroughCoreMock()
+        core.messageBus.subscribe(receiver: receiver)
+        core.context = core.context
 
         tracer = .mockWith(
             core: core,


### PR DESCRIPTION
> This PR is part of a chain split from _maxep/message-bus-subscription_ by [chain-pr](https://github.com/maxep/chain-pr).

### What and why?

With `CoreMessageBus` implementing the typed `MessageBus` protocol (PR #2929), `DatadogTrace` can retire its `FeatureMessageReceiver` switch and adopt the typed bus.

`ContextMessageReceiver` previously implemented `FeatureMessageReceiver` with a switch on the `.context` case, delegating to a private `update(context:from:)` that returned a `Bool`. It now conforms to `BusMessageReceiver`, receiving `DatadogContext` directly with no envelope, switch, or return value.

`TraceFeature.messageReceiver` (the legacy `FeatureMessageReceiver` slot required by `DatadogRemoteFeature`) is replaced with `NOPFeatureMessageReceiver()`, since context updates now flow through the typed bus instead.

### How?

#### `MessageReceivers.swift` — `BusMessageReceiver` conformance

```swift
// Before
internal final class ContextMessageReceiver: FeatureMessageReceiver {
    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
        switch message {
        case .context(let context):
            return update(context: context, from: core)
        default:
            return false
        }
    }

    private func update(context datadogContext: DatadogContext, from core: DatadogCoreProtocol) -> Bool {
        ...
        return true
    }
}

// After
internal final class ContextMessageReceiver: BusMessageReceiver {
    func receive(message datadogContext: DatadogContext, from core: DatadogCoreProtocol) {
        ...
    }
}
```

#### `TraceFeature.swift` and `Trace.swift` — subscription wiring

```swift
// Before
var messageReceiver: FeatureMessageReceiver { contextReceiver }

// After
let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
```

`Trace.enable` now subscribes `contextReceiver` on `core.messageBus` before `core.register(feature:)`, so it receives the initial context push:

```swift
let trace = TraceFeature(in: core, configuration: configuration)

// Subscribe typed-bus receivers before registration so initial context push is received:
core.messageBus.subscribe(receiver: trace.contextReceiver)

try core.register(feature: trace)
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

---

## Chain overview

| # | PR | Title |
|---|---|---|
| 1 | #2927 | Typed MessageBus protocol and shared message types |
| 2 | #2928 | Test infrastructure for typed message bus |
| 3 | #2929 | DatadogCore: CoreMessageBus implementation and rename |
| 4 | #2930 | DatadogCrashReporting: typed-bus migration |
| 5 | #2931 | DatadogLogs: typed-bus migration |
| **6** | ← _this PR_ | DatadogTrace: typed-bus migration |
| 7 | #2933 | DatadogFlags: typed-bus migration |
| 8 | #2934 | DatadogRUM: typed-bus migration and TelemetryInterceptor merge |
| 9 | #2935 | DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration |
| 10 | #2936 | Documentation updates |

```mermaid
graph LR
    G1["1 — Typed MessageBus protocol and shared message types"]
    G2["2 — Test infrastructure for typed message bus"]
    G3["3 — DatadogCore: CoreMessageBus implementation and rename"]
    G4["4 — DatadogCrashReporting: typed-bus migration"]
    G5["5 — DatadogLogs: typed-bus migration"]
    G6["6 — DatadogTrace: typed-bus migration"]
    G7["7 — DatadogFlags: typed-bus migration"]
    G8["8 — DatadogRUM: typed-bus migration and TelemetryInterceptor merge"]
    G9["9 — DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration"]
    G10["10 — Documentation updates"]
    G1 --> G2
    G2 --> G3
    G3 --> G4
    G3 --> G5
    G5 --> G6
    G3 --> G7
    G6 --> G8
    G7 --> G8
    G8 --> G9
    G1 --> G10
```

_Merge in dependency order. PRs with no incoming edges from un-merged PRs can be reviewed in parallel._
