### PR TITLE
[chain-pr 7/10] DatadogFlags: typed-bus migration

### DIFF
--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -189,7 +189,7 @@ public final class FlagsClient {
             ),
             exposureLogger: feature.makeExposureLogger(featureScope),
             evaluationLogger: feature.makeEvaluationLogger(featureScope),
-            rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter(featureScope)
+            rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter()
         )
 
         feature.clientRegistry.register(client, named: name)

--- a/DatadogFlags/Sources/Client/RUMFlagEvaluationReporter.swift
+++ b/DatadogFlags/Sources/Client/RUMFlagEvaluationReporter.swift
@@ -12,19 +12,17 @@ internal protocol RUMFlagEvaluationReporting {
 }
 
 internal final class RUMFlagEvaluationReporter: RUMFlagEvaluationReporting {
-    private let featureScope: any FeatureScope
+    private let messageBus: any MessageBus
 
-    init(featureScope: any FeatureScope) {
-        self.featureScope = featureScope
+    init(messageBus: any MessageBus) {
+        self.messageBus = messageBus
     }
 
     func sendFlagEvaluation<T>(flagKey: String, value: T) where T: FlagValue {
-        featureScope.send(
-            message: .payload(
-                RUMFlagEvaluationMessage(
-                    flagKey: flagKey,
-                    value: value
-                )
+        messageBus.send(
+            message: RUMFlagEvaluationMessage(
+                flagKey: flagKey,
+                value: value
             )
         )
     }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -21,7 +21,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
     let clientRegistry: FlagsClientRegistry
     let makeExposureLogger: (any FeatureScope) -> any ExposureLogging
     let makeEvaluationLogger: (any FeatureScope) -> any EvaluationLogging
-    let makeRUMFlagEvaluationReporter: (any FeatureScope) -> any RUMFlagEvaluationReporting
+    let makeRUMFlagEvaluationReporter: () -> any RUMFlagEvaluationReporting
     let performanceOverride: PerformancePresetOverride?
     let issueReporter: IssueReporter
     private let evaluationAggregator: EvaluationAggregator?
@@ -76,11 +76,11 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             return EvaluationLogger(aggregator: aggregator)
         }
 
-        makeRUMFlagEvaluationReporter = { featureScope in
+        makeRUMFlagEvaluationReporter = { [messageBus = core.messageBus] in
             guard configuration.rumIntegrationEnabled else {
                 return NOPRUMFlagEvaluationReporter()
             }
-            return RUMFlagEvaluationReporter(featureScope: featureScope)
+            return RUMFlagEvaluationReporter(messageBus: messageBus)
         }
         performanceOverride = PerformancePresetOverride(maxObjectsInFile: 50)
 

--- a/DatadogFlags/Tests/Client/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientTests.swift
@@ -309,15 +309,18 @@ final class FlagsClientTests: XCTestCase {
             date: .mockAny()
         )
         let data = try JSONEncoder().encode(initialState)
-        let messageReceiver = FeatureMessageReceiverMock()
         let core = SingleFeatureCoreMock<FlagsFeature>(
             dataStore: DataStoreMock(
                 storage: [
                     FlagsClient.defaultName: .value(data, dataStoreDefaultKeyVersion)
                 ]
-            ),
-            messageReceiver: messageReceiver
+            )
         )
+        var rumMessages: [RUMFlagEvaluationMessage] = []
+        let subscription = core.messageBus.subscribe { (msg: RUMFlagEvaluationMessage, _) in
+            rumMessages.append(msg)
+        }
+        defer { core.messageBus.unsubscribe(subscription) }
 
         // When
         Flags.enable(with: .init(trackExposures: false), in: core)
@@ -327,7 +330,7 @@ final class FlagsClientTests: XCTestCase {
 
         // Then
         XCTAssertEqual(core.events(ofType: ExposureEvent.self).count, 0, "No exposure events should be written")
-        XCTAssertEqual(messageReceiver.messages.filter(\.isRUMMessage).count, 1, "RUM integration should still work")
+        XCTAssertEqual(rumMessages.count, 1, "RUM integration should still work")
     }
 
     func testRUMIntegrationDisabled() throws {
@@ -338,15 +341,18 @@ final class FlagsClientTests: XCTestCase {
             date: .mockAny()
         )
         let data = try JSONEncoder().encode(initialState)
-        let messageReceiver = FeatureMessageReceiverMock()
         let core = SingleFeatureCoreMock<FlagsFeature>(
             dataStore: DataStoreMock(
                 storage: [
                     FlagsClient.defaultName: .value(data, dataStoreDefaultKeyVersion)
                 ]
-            ),
-            messageReceiver: messageReceiver
+            )
         )
+        var rumMessages: [RUMFlagEvaluationMessage] = []
+        let subscription = core.messageBus.subscribe { (msg: RUMFlagEvaluationMessage, _) in
+            rumMessages.append(msg)
+        }
+        defer { core.messageBus.unsubscribe(subscription) }
 
         // When
         Flags.enable(with: .init(rumIntegrationEnabled: false), in: core)
@@ -356,7 +362,7 @@ final class FlagsClientTests: XCTestCase {
 
         // Then
         XCTAssertEqual(core.events(ofType: ExposureEvent.self).count, 1, "Exposure should still be logged")
-        XCTAssertEqual(messageReceiver.messages.filter(\.isRUMMessage).count, 0, "No RUM messages should be sent")
+        XCTAssertEqual(rumMessages.count, 0, "No RUM messages should be sent")
     }
 
     func testSnapshot() {

--- a/DatadogFlags/Tests/Client/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientTests.swift
@@ -747,14 +747,3 @@ final class FlagsClientTests: XCTestCase {
         XCTAssertNil(evaluationLogger.logEvaluationCalls[0].error)
     }
 }
-
-extension FeatureMessage {
-    fileprivate var isRUMMessage: Bool {
-        switch self {
-        case .payload(let message) where message is RUMFlagEvaluationMessage:
-            return true
-        default:
-            return false
-        }
-    }
-}

--- a/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
+++ b/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
@@ -10,12 +10,20 @@ import DatadogInternal
 
 @testable import DatadogFlags
 
-final class RUMFlagEvaluationReporterTests: XCTestCase {
-    private let featureScope = FeatureScopeMock()
+private final class RUMFlagEvaluationRecorder: BusMessageReceiver {
+    private(set) var messages: [RUMFlagEvaluationMessage] = []
+    func receive(message: RUMFlagEvaluationMessage, from core: DatadogCoreProtocol) {
+        messages.append(message)
+    }
+}
 
+final class RUMFlagEvaluationReporterTests: XCTestCase {
     func testSendFlagEvaluation() throws {
         // Given
-        let reporter = RUMFlagEvaluationReporter(featureScope: featureScope)
+        let core = PassthroughCoreMock()
+        let recorder = RUMFlagEvaluationRecorder()
+        core.subscribe(receiver: recorder)
+        let reporter = RUMFlagEvaluationReporter(messageBus: core.messageBus)
 
         // When
         reporter.sendFlagEvaluation(
@@ -24,10 +32,9 @@ final class RUMFlagEvaluationReporterTests: XCTestCase {
         )
 
         // Then
-        let messages = featureScope.messagesSent()
-        XCTAssertEqual(messages.count, 1, "Should send flag evaluation message")
+        XCTAssertEqual(recorder.messages.count, 1, "Should send flag evaluation message")
 
-        let flagEvaluation = try XCTUnwrap(messages.firstPayload as? RUMFlagEvaluationMessage)
+        let flagEvaluation = try XCTUnwrap(recorder.messages.first)
         XCTAssertEqual(flagEvaluation.flagKey, "feature-flag")
         XCTAssertEqual(flagEvaluation.value as? Bool, true)
     }

--- a/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
+++ b/DatadogFlags/Tests/Client/RUMFlagEvaluationReporterTests.swift
@@ -22,7 +22,7 @@ final class RUMFlagEvaluationReporterTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let recorder = RUMFlagEvaluationRecorder()
-        core.subscribe(receiver: recorder)
+        core.messageBus.subscribe(receiver: recorder)
         let reporter = RUMFlagEvaluationReporter(messageBus: core.messageBus)
 
         // When

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -271,6 +271,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             telemetry: core.telemetry
         )
 
+        core.messageBus.subscribe(receiver: FlagEvaluationReceiver(monitor: monitor))
         self.crashReportReceiver = CrashReportReceiver(
             featureScope: featureScope,
             applicationID: configuration.applicationID,
@@ -302,7 +303,6 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 featureScope: featureScope,
                 monitor: monitor
             ),
-            FlagEvaluationReceiver(monitor: monitor),
             WebViewEventReceiver(
                 featureScope: featureScope,
                 dateProvider: configuration.dateProvider,

--- a/DatadogRUM/Sources/Integrations/FlagEvaluationReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/FlagEvaluationReceiver.swift
@@ -8,21 +8,18 @@ import Foundation
 import DatadogInternal
 
 /// Receives flag evaluation messages and adds them to RUM.
-internal struct FlagEvaluationReceiver: FeatureMessageReceiver {
+internal final class FlagEvaluationReceiver: BusMessageReceiver {
     /// The RUM monitor instance.
     let monitor: Monitor
 
-    /// Adds feature flag evaluation to the current RUM view.
-    func receive(message: FeatureMessage, from core: any DatadogCoreProtocol) -> Bool {
-        guard case let .payload(flagEvaluation as RUMFlagEvaluationMessage) = message else {
-            return false
-        }
+    init(monitor: Monitor) {
+        self.monitor = monitor
+    }
 
+    func receive(message: RUMFlagEvaluationMessage, from core: DatadogCoreProtocol) {
         monitor.addFeatureFlagEvaluation(
-            name: flagEvaluation.flagKey,
-            value: flagEvaluation.value
+            name: message.flagKey,
+            value: message.value
         )
-
-        return true
     }
 }

--- a/DatadogRUM/Tests/Integrations/FlagEvaluationReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/FlagEvaluationReceiverTests.swift
@@ -21,19 +21,17 @@ class FlagEvaluationReceiverTests: XCTestCase {
                 dateProvider: SystemDateProvider()
             )
         )
-        let message: FeatureMessage = .payload(
-            RUMFlagEvaluationMessage(
-                flagKey: "feature-flag",
-                value: true
-            )
-        )
 
         // When
-        let result = receiver.receive(message: message, from: NOPDatadogCore())
+        receiver.receive(
+            message: RUMFlagEvaluationMessage(
+                flagKey: "feature-flag",
+                value: true
+            ),
+            from: NOPDatadogCore()
+        )
 
         // Then
-        XCTAssertTrue(result, "It must accept the message")
-
         let viewEvents: [RUMViewEvent] = featureScope.eventsWritten()
         XCTAssertFalse(viewEvents.isEmpty, "It should write a view event")
 


### PR DESCRIPTION
> This PR is part of a chain split from _maxep/message-bus-subscription_ by [chain-pr](https://github.com/maxep/chain-pr).

### What and why?

With `CoreMessageBus` implementing the typed `MessageBus` protocol (PR #2929), `DatadogFlags` can stop routing flag evaluation events through `FeatureScope` and send them directly on the typed bus.

`RUMFlagEvaluationReporter` previously held a `FeatureScope` reference and called `featureScope.send(message: .payload(RUMFlagEvaluationMessage(...)))`. The `FeatureScope` was only used for its `send` capability, not for event writing, making it a heavier dependency than needed. It now holds a `MessageBus` reference and calls `messageBus.send(message:)` directly.

This simplifies the `FlagsFeature` factory: `makeRUMFlagEvaluationReporter` previously required a `FeatureScope` argument passed through from `FlagsClient`. That argument is removed — the factory closure now captures `core.messageBus` directly at feature initialisation time.

### How?

#### `RUMFlagEvaluationReporter.swift` — `FeatureScope` → `MessageBus`

```swift
// Before
private let featureScope: any FeatureScope
init(featureScope: any FeatureScope) { ... }

func sendFlagEvaluation<T>(flagKey: String, value: T) where T: FlagValue {
    featureScope.send(message: .payload(RUMFlagEvaluationMessage(flagKey: flagKey, value: value)))
}

// After
private let messageBus: any MessageBus
init(messageBus: any MessageBus) { ... }

func sendFlagEvaluation<T>(flagKey: String, value: T) where T: FlagValue {
    messageBus.send(message: RUMFlagEvaluationMessage(flagKey: flagKey, value: value))
}
```

#### `FlagsFeature.swift` — factory closure captures `messageBus`

```swift
// Before
let makeRUMFlagEvaluationReporter: (any FeatureScope) -> any RUMFlagEvaluationReporting

makeRUMFlagEvaluationReporter = { featureScope in
    return RUMFlagEvaluationReporter(featureScope: featureScope)
}

// After
let makeRUMFlagEvaluationReporter: () -> any RUMFlagEvaluationReporting

makeRUMFlagEvaluationReporter = { [messageBus = core.messageBus] in
    return RUMFlagEvaluationReporter(messageBus: messageBus)
}
```

#### `FlagsClient.swift` — call site simplification

```swift
// Before
rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter(featureScope)

// After
rumFlagEvaluationReporter: feature.makeRUMFlagEvaluationReporter()
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

---

## Chain overview

| # | PR | Title |
|---|---|---|
| 1 | #2927 | Typed MessageBus protocol and shared message types |
| 2 | #2928 | Test infrastructure for typed message bus |
| 3 | #2929 | DatadogCore: CoreMessageBus implementation and rename |
| 4 | #2930 | DatadogCrashReporting: typed-bus migration |
| 5 | #2931 | DatadogLogs: typed-bus migration |
| 6 | #2932 | DatadogTrace: typed-bus migration |
| **7** | ← _this PR_ | DatadogFlags: typed-bus migration |
| 8 | #2934 | DatadogRUM: typed-bus migration and TelemetryInterceptor merge |
| 9 | #2935 | DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration |
| 10 | #2936 | Documentation updates |

```mermaid
graph LR
    G1["1 — Typed MessageBus protocol and shared message types"]
    G2["2 — Test infrastructure for typed message bus"]
    G3["3 — DatadogCore: CoreMessageBus implementation and rename"]
    G4["4 — DatadogCrashReporting: typed-bus migration"]
    G5["5 — DatadogLogs: typed-bus migration"]
    G6["6 — DatadogTrace: typed-bus migration"]
    G7["7 — DatadogFlags: typed-bus migration"]
    G8["8 — DatadogRUM: typed-bus migration and TelemetryInterceptor merge"]
    G9["9 — DatadogSessionReplay and DatadogWebViewTracking: typed-bus migration"]
    G10["10 — Documentation updates"]
    G1 --> G2
    G2 --> G3
    G3 --> G4
    G3 --> G5
    G5 --> G6
    G3 --> G7
    G6 --> G8
    G7 --> G8
    G8 --> G9
    G1 --> G10
```

_Merge in dependency order. PRs with no incoming edges from un-merged PRs can be reviewed in parallel._