### PR TITLE
[RUM-16413] Expose RemoteConfiguration on DatadogCoreProtocol

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -401,8 +401,6 @@
 		61054E8D2A6EE10A00AAA894 /* RUMContextReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */; };
 		61054E8E2A6EE10A00AAA894 /* SRContextPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */; };
 		61054E8F2A6EE10A00AAA894 /* SegmentRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E412A6EE10A00AAA894 /* SegmentRequestBuilder.swift */; };
-		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
-		B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333D0D8EAED64F559835F384 /* RecordingComponents.swift */; };
 		61054E942A6EE10A00AAA894 /* TextObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4A2A6EE10A00AAA894 /* TextObfuscator.swift */; };
 		61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */; };
 		61054E962A6EE10A00AAA894 /* Diff+SRWireframes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4D2A6EE10A00AAA894 /* Diff+SRWireframes.swift */; };
@@ -678,6 +676,7 @@
 		61F930CB2BA213AC005F0EE2 /* AppHang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F930CA2BA213AC005F0EE2 /* AppHang.swift */; };
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
 		6482FB0E2EE885C60042234B /* FlagsClientInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */; };
+		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
 		770E0BF093842AF7D350E888 /* EvaluationLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC44AD2847746ED69201F65 /* EvaluationLoggingTests.swift */; };
 		86092FDE2DEDC6830075D63B /* AccessibilityValuesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */; };
 		861FD6862DF2EAED00F59823 /* LocaleInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */; };
@@ -792,6 +791,7 @@
 		B202DBC9FC73EEF0D237D306 /* HeatmapIdentifierComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F610A698379D300D06E515 /* HeatmapIdentifierComputationTests.swift */; };
 		B3E46CAB2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */; };
 		B3E46CAE2D91B40000BABF66 /* NetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */; };
+		B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333D0D8EAED64F559835F384 /* RecordingComponents.swift */; };
 		CD91654B77EEEB08CD20B3B0 /* HeatmapIdentifierStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC78B982F5C5B87E754DF44 /* HeatmapIdentifierStoreTests.swift */; };
 		D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
@@ -1182,6 +1182,7 @@
 		D2C5D52B2B84F6AB00B63F36 /* WebViewRecordReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52A2B84F6AB00B63F36 /* WebViewRecordReceiver.swift */; };
 		D2C5D52D2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C5D52C2B84F6D800B63F36 /* WebViewRecordReceiverTests.swift */; };
 		D2C7E3AB28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */; };
+		D2CC33E92FBEF4A400377194 /* RCDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CC33E72FBEF4A400377194 /* RCDataModels.swift */; };
 		D2D0E1F22E3CE59700BA4113 /* mach_profiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E1F12E3CE59700BA4113 /* mach_profiler.cpp */; };
 		D2D0E1F82E3CE73700BA4113 /* mach_sampling_profiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */; };
 		D2D0E2072E3CEF1200BA4113 /* MachSamplingProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2022E3CEF1200BA4113 /* MachSamplingProfilerTests.swift */; };
@@ -1939,6 +1940,7 @@
 		269035A12E41F93F00F1A830 /* UserConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfigurationContextMocks.swift; sourceTree = "<group>"; };
 		269035A42E41FAA500F1A830 /* AccountConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountConfigurationContextMocks.swift; sourceTree = "<group>"; };
 		2B6A3B154836FEB32C07EB50 /* EvaluationAggregator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationAggregator.swift; sourceTree = "<group>"; };
+		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
 		3C08F9CF2C2D652D002B0FF2 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporter.swift; sourceTree = "<group>"; };
 		3C0D5DD62A543B3B00446CF9 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -2103,8 +2105,6 @@
 		61054E382A6EE10A00AAA894 /* ViewTreeRecordingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewTreeRecordingContext.swift; sourceTree = "<group>"; };
 		61054E392A6EE10A00AAA894 /* NodeIDGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeIDGenerator.swift; sourceTree = "<group>"; };
 		61054E3A2A6EE10A00AAA894 /* WindowViewTreeSnapshotProducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowViewTreeSnapshotProducer.swift; sourceTree = "<group>"; };
-		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
-		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		61054E3C2A6EE10A00AAA894 /* SessionReplayFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayFeature.swift; sourceTree = "<group>"; };
 		61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMContextReceiver.swift; sourceTree = "<group>"; };
 		61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRContextPublisher.swift; sourceTree = "<group>"; };
@@ -2511,6 +2511,7 @@
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
 		6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientInternal.swift; sourceTree = "<group>"; };
 		6FE4202BC457504AC37A51D6 /* HeatmapIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifier.swift; sourceTree = "<group>"; };
+		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityValuesMock.swift; sourceTree = "<group>"; };
 		861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleInfoPublisherTests.swift; sourceTree = "<group>"; };
 		861FD6872DF3366400F59823 /* LocaleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleInfo.swift; sourceTree = "<group>"; };
@@ -2903,6 +2904,7 @@
 		D2C7E3AA28F97DCF0023B2CC /* BatteryStatusPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisherTests.swift; sourceTree = "<group>"; };
 		D2CBC26A294383F200134409 /* WebViewEventReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewEventReceiver.swift; sourceTree = "<group>"; };
 		D2CBC26D294395A300134409 /* RUMContextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContextAttributes.swift; sourceTree = "<group>"; };
+		D2CC33E72FBEF4A400377194 /* RCDataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCDataModels.swift; sourceTree = "<group>"; };
 		D2D0E1F12E3CE59700BA4113 /* mach_profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mach_profiler.cpp; sourceTree = "<group>"; };
 		D2D0E1F72E3CE73700BA4113 /* mach_sampling_profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mach_sampling_profiler.cpp; sourceTree = "<group>"; };
 		D2D0E2012E3CEF1200BA4113 /* MachProfilerCAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachProfilerCAPITests.swift; sourceTree = "<group>"; };
@@ -4984,6 +4986,7 @@
 				619F5CEB2BF5089B004BFE70 /* RUM */,
 				D2EA0F442C0E1A8700CB20F8 /* SessionReplay */,
 				D25C834D2B88A261008E73B1 /* WebViewTracking */,
+				D2CC33E82FBEF4A400377194 /* RC */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -6561,6 +6564,14 @@
 			);
 			name = DatadogProfilingTests;
 			path = ../DatadogProfiling/Tests;
+			sourceTree = "<group>";
+		};
+		D2CC33E82FBEF4A400377194 /* RC */ = {
+			isa = PBXGroup;
+			children = (
+				D2CC33E72FBEF4A400377194 /* RCDataModels.swift */,
+			);
+			path = RC;
 			sourceTree = "<group>";
 		};
 		D2D748282DC1210A00C61353 /* Logs */ = {
@@ -8429,6 +8440,7 @@
 				D2EBEE2929BA160F00B15732 /* HTTPHeadersWriter.swift in Sources */,
 				D2432CF929EDB22C00D93657 /* Flushable.swift in Sources */,
 				96CD20652ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */,
+				D2CC33E92FBEF4A400377194 /* RCDataModels.swift in Sources */,
 				D23039F7298D5236001A1FA3 /* AttributesSanitizer.swift in Sources */,
 				D23039EB298D5236001A1FA3 /* DatadogFeature.swift in Sources */,
 				D2BEEDBA2B33638F0065F3AC /* NetworkInstrumentationSwizzler.swift in Sources */,

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -75,6 +75,10 @@ internal final class DatadogCore {
     /// Maximum number of batches per upload.
     internal let maxBatchesPerUpload: Int
 
+    /// The last successfully fetched and cached remote configuration, if any.
+    @ReadWriteLock
+    var remoteConfiguration: RemoteConfiguration? = nil
+
     /// Creates a core instance.
     ///
     /// - Parameters:

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -12,6 +12,15 @@ import Foundation
 /// Any reference to `DatadogCoreProtocol` must be captured as `weak` within a Feature. This is to avoid
 /// retain cycle of core holding the Feature and vice-versa.
 public protocol DatadogCoreProtocol: AnyObject, MessageSending, AdditionalContextSharing, Storage {
+    /// The last successfully fetched and cached remote configuration for the RUM SDK, or `nil` if
+    /// none is available.
+    ///
+    /// Features read this synchronously when they are enabled to apply remote values on top of their
+    /// developer-supplied `Configuration`. The core must return whatever remote document was cached
+    /// at initialization time; it must return `nil` when remote configuration was not opted into or
+    /// when no document has been cached yet (e.g. first-ever launch).
+    var remoteConfiguration: RemoteConfiguration? { get }
+
     // Remove `DatadogCoreProtocol` conformance to `MessageSending` and `BaggageSharing` once
     // all features are migrated to depend on `FeatureScope` interface.
 
@@ -250,6 +259,8 @@ public extension FeatureScope {
 /// No-op implementation of `DatadogFeatureRegistry`.
 public class NOPDatadogCore: DatadogCoreProtocol {
     public init() { }
+    /// no-op
+    public var remoteConfiguration: RemoteConfiguration? { nil }
     /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op

--- a/DatadogInternal/Sources/Models/RC/RCDataModels.swift
+++ b/DatadogInternal/Sources/Models/RC/RCDataModels.swift
@@ -9,7 +9,7 @@
 // swiftlint:disable all
 
 /// RUM Browser & Mobile SDKs Remote Configuration properties
-public struct RUMSdkConfig: Codable {
+public struct RemoteConfiguration: Codable {
     /// RUM feature Remote Configuration properties
     public let rum: RUM?
 

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
@@ -35,7 +35,7 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         FeatureRegistrationCoreMock.referenceCount -= 1
     }
 
-    public var remoteConfiguration: RemoteConfiguration? { nil }
+    public var remoteConfiguration: RemoteConfiguration? = nil
 
     // MARK: - Supported
 

--- a/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/FeatureRegistrationCoreMock.swift
@@ -35,6 +35,8 @@ public class FeatureRegistrationCoreMock: DatadogCoreProtocol {
         FeatureRegistrationCoreMock.referenceCount -= 1
     }
 
+    public var remoteConfiguration: RemoteConfiguration? { nil }
+
     // MARK: - Supported
 
     public func register<T>(feature: T) throws where T: DatadogFeature {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -69,7 +69,7 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
     }
 
     /// no-op
-    public var remoteConfiguration: RemoteConfiguration? { nil }
+    public var remoteConfiguration: RemoteConfiguration? = nil
     /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op

--- a/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -69,6 +69,8 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
     }
 
     /// no-op
+    public var remoteConfiguration: RemoteConfiguration? { nil }
+    /// no-op
     public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
     public func feature<T>(named name: String, type: T.Type) -> T? { nil }

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -76,7 +76,7 @@ public final class DatadogCoreProxy: DatadogCoreProtocol {
         }
     }
 
-    public var remoteConfiguration: RemoteConfiguration? { nil }
+    public var remoteConfiguration: RemoteConfiguration? { core.remoteConfiguration }
 
     public func register<T>(feature: T) throws where T: DatadogFeature {
         try core.register(feature: feature)

--- a/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
+++ b/TestUtilities/Sources/Proxies/DatadogCoreProxy.swift
@@ -76,6 +76,8 @@ public final class DatadogCoreProxy: DatadogCoreProtocol {
         }
     }
 
+    public var remoteConfiguration: RemoteConfiguration? { nil }
+
     public func register<T>(feature: T) throws where T: DatadogFeature {
         try core.register(feature: feature)
     }

--- a/tools/rum-models-generator/Sources/CodeDecoration/RCCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RCCodeDecorator.swift
@@ -32,6 +32,11 @@ public class RCCodeDecorator: SwiftCodeDecorator {
             fixedName = fixedName.prefix(3).uppercased() + fixedName.suffix(fixedName.count - 3)
         }
 
+        // Rename the root schema type to a product-neutral name.
+        if fixedName == "RUMSdkConfig" {
+            fixedName = "RemoteConfiguration"
+        }
+
         return fixedName
     }
 }


### PR DESCRIPTION
### What and why?

Exposes the remote configuration on `DatadogCoreProtocol` so features can read it synchronously at enable-time and apply remote values on top of their developer-supplied configuration.

### How?

- Added `var remoteConfiguration: RemoteConfiguration? { get }` to `DatadogCoreProtocol` with documentation describing the cache-then-apply semantics and nil conditions.
- `DatadogCore` stores the value in a `@ReadWriteLock`-protected property for thread-safe reads and writes.
- All other conformances (`NOPDatadogCore`, `FeatureRegistrationCoreMock`, `PassthroughCoreMock`, `DatadogCoreProxy`) return `nil`.
- `RCCodeDecorator` renames the generated root type from `RUMSdkConfig` to `RemoteConfiguration` for a product-neutral name.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes — N/A, internal API
- [x] Add Objective-C interface for public APIs — N/A, internal API
- [x] Run `make api-surface` when adding new APIs — N/A, internal API