### PR TITLE
Prevent inverted timestamp crash in URL tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Fix `NSInvalidArgumentException` ("unrecognized selector") crash in automatic scroll action tracking when UIKit dispatches a cached delegate method after the original `UIScrollViewDelegate` has been deallocated. See [#2942][].
 - [IMPROVEMENT] Add `trackScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
+- [FIX] Prevent crash in `TracingURLSessionHandler` when wall-clock adjustments produce an inverted start/end timestamp pair during a tracked URL request. See [#2941][]
 
 # 3.11.0 / 12-05-2026
 
@@ -1149,6 +1150,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2891]: https://github.com/DataDog/dd-sdk-ios/pull/2891
 [#2942]: https://github.com/DataDog/dd-sdk-ios/pull/2942
 [#2944]: https://github.com/DataDog/dd-sdk-ios/pull/2944
+[#2941]: https://github.com/DataDog/dd-sdk-ios/pull/2941
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -3501,7 +3501,6 @@
 			isa = PBXGroup;
 			children = (
 				11A2F2482E70CC08006EDC52 /* FrameInfoProvider.swift */,
-				11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -6091,6 +6090,7 @@
 				D23039BC298D5235001A1FA3 /* DeviceInfo.swift */,
 				D23039BE298D5235001A1FA3 /* LaunchInfo.swift */,
 				861FD6872DF3366400F59823 /* LocaleInfo.swift */,
+				11A2F2492E70CC08006EDC52 /* MediaTimeProvider.swift */,
 				D23039B9298D5235001A1FA3 /* NetworkConnectionInfo.swift */,
 				11B5439E2DE9C40B006F6C0A /* OperatingSystem+Utils.swift */,
 				D23039B8298D5235001A1FA3 /* Sysctl.swift */,
@@ -8554,6 +8554,7 @@
 				D22F06D729DAFD500026CC3C /* FixedWidthInteger+Convenience.swift in Sources */,
 				3C08F9D02C2D652D002B0FF2 /* Storage.swift in Sources */,
 				D23039E5298D5236001A1FA3 /* DateProvider.swift in Sources */,
+				11A2F24B2E70CC08006EDC52 /* MediaTimeProvider.swift in Sources */,
 				861FD6892DF3366400F59823 /* LocaleInfo.swift in Sources */,
 				D23039E0298D5235001A1FA3 /* DatadogCoreProtocol.swift in Sources */,
 				D27465812E7B1C4D00C47FE2 /* ProfilingMessages.swift in Sources */,
@@ -8896,7 +8897,6 @@
 				AA0001012A000002000B0001 /* UIScrollViewDelegateProxy.swift in Sources */,
 				AA0001012A000001000B0001 /* RUMScrollHandler.swift in Sources */,
 				11A2F24A2E70CC08006EDC52 /* FrameInfoProvider.swift in Sources */,
-				11A2F24B2E70CC08006EDC52 /* MediaTimeProvider.swift in Sources */,
 				D29A9F5229DD85BB005C54A4 /* RUMUUIDGenerator.swift in Sources */,
 				61DCC84E2C071DCD00CB59E5 /* TelemetryInterceptor.swift in Sources */,
 				4062CCAEB02C9EEF6761F4F8 /* HeatmapIdentifierStore.swift in Sources */,

--- a/DatadogInternal/Sources/Context/MediaTimeProvider.swift
+++ b/DatadogInternal/Sources/Context/MediaTimeProvider.swift
@@ -10,6 +10,11 @@ import QuartzCore
 #endif
 
 /// Provides current media uptime.
+/// Media uptime is a monotonic clock value, expressed in seconds, that is **not** affected by
+/// wall-clock corrections (NTP, DST, manual changes). Only deltas between two readings carry
+/// meaning — the absolute value is implementation-defined. Use this provider in combination
+/// with a `DateProvider` whenever you need a duration that must be `>= 0` regardless of
+/// wall-clock adjustments.
 public protocol CACurrentMediaTimeProvider: Sendable {
     /// Current media uptime.
     var current: CFTimeInterval { get }

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -33,6 +33,11 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
 
     let networkContextProvider: NetworkContextProvider
 
+    /// The media uptime provider to calculate the deltas between request start and completion.
+    /// Captured alongside `Date()` at start and end; the delta is used to build `endDate` so
+    /// that `endDate >= startDate` always holds.
+    let mediaTimeProvider: CACurrentMediaTimeProvider
+
     /// The list of registered handlers.
     ///
     /// Accessing this list will acquire a read-write lock for fast read operation when mutating
@@ -56,10 +61,12 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
 
     init(
         networkContextProvider: NetworkContextProvider,
-        messageReceiver: FeatureMessageReceiver
+        messageReceiver: FeatureMessageReceiver,
+        mediaTimeProvider: CACurrentMediaTimeProvider = MediaTimeProvider()
     ) {
         self.networkContextProvider = networkContextProvider
         self.messageReceiver = messageReceiver
+        self.mediaTimeProvider = mediaTimeProvider
     }
 
     /// Configures network instrumentation for the specified tracking mode.
@@ -425,7 +432,11 @@ extension NetworkInstrumentationFeature {
         let request = ImmutableRequest(request: currentRequest)
 
         // Capture start time before entering the queue for more accurate timing.
+        // `startMediaTime` is captured from a monotonic clock so the duration computed at
+        // completion is immune to wall-clock corrections that
+        // could otherwise produce `endDate < startDate` and crash range-based consumers.
         let startTime = Date()
+        let startMediaTime = mediaTimeProvider.current
 
         queue.async { [weak self] in
             guard let self = self else {
@@ -456,7 +467,7 @@ extension NetworkInstrumentationFeature {
             // Capture approximate start time for all modes
             // This enables Trace to work in automatic mode (where `URLSessionTaskMetrics` are unavailable)
             if interception.startDate == nil {
-                interception.register(startDate: startTime)
+                interception.register(startDate: startTime, mediaTime: startMediaTime)
             }
 
             if let traceContext = instrumentationContexts.compactMap({ $0.traceContext }).first {
@@ -531,7 +542,10 @@ extension NetworkInstrumentationFeature {
     ///   - error: If an error occurred, an error object indicating how the transfer failed, otherwise NULL.
     func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
         // Capture end time before entering the queue for more accurate timing.
+        // `endMediaTime` is from the same monotonic clock as `startMediaTime` so the derived
+        // duration is guaranteed `>= 0` regardless of wall-clock corrections.
         let endTime = Date()
+        let endMediaTime = mediaTimeProvider.current
 
         queue.async { [weak self] in
             guard let self = self, let interception = self.interceptions[task] else {
@@ -551,7 +565,7 @@ extension NetworkInstrumentationFeature {
             }
 
             if interception.isDone {
-                self.finish(task: task, interception: interception, endDate: endTime)
+                self.finish(task: task, interception: interception, endDate: endTime, endMediaTime: endMediaTime)
             }
         }
     }
@@ -560,11 +574,11 @@ extension NetworkInstrumentationFeature {
         handlers.reduce(.init()) { $0 + $1.firstPartyHosts } + additionalFirstPartyHosts
     }
 
-    private func finish(task: URLSessionTask, interception: URLSessionTaskInterception, endDate: Date?) {
+    private func finish(task: URLSessionTask, interception: URLSessionTaskInterception, endDate: Date?, endMediaTime: CFTimeInterval? = nil) {
         // Register `endDate` if provided.
         // Note: in registered delegate mode, `endDate` is `nil` because `URLSessionTaskMetrics` provides accurate timing.
         if let endDate {
-            interception.register(endDate: endDate)
+            interception.register(endDate: endDate, mediaTime: endMediaTime)
         }
 
         handlers.forEach { $0.interceptionDidComplete(interception: interception) }
@@ -578,7 +592,10 @@ extension NetworkInstrumentationFeature {
     ///   - state: The new state of the task (maps to URLSessionTask.State: 0=running, 1=suspended, 2=canceling, 3=completed).
     func task(_ task: URLSessionTask, didChangeToState state: Int) {
         // Capture end time before entering the queue for more accurate timing.
+        // `endMediaTime` is from the same monotonic clock as `startMediaTime` so the derived
+        // duration is guaranteed `>= 0` regardless of wall-clock corrections.
         let endTime = Date()
+        let endMediaTime = mediaTimeProvider.current
 
         queue.async { [weak self] in
             guard let self = self, let interception = self.interceptions[task] else {
@@ -610,7 +627,7 @@ extension NetworkInstrumentationFeature {
             // This ensures we capture the response data through completion handler swizzling before finishing.
             // The completion handler will call finish() after capturing the data.
             if interception.isDone && !task.dd.hasCompletion {
-                self.finish(task: task, interception: interception, endDate: endTime)
+                self.finish(task: task, interception: interception, endDate: endTime, endMediaTime: endMediaTime)
             }
         }
     }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -68,7 +68,13 @@ public class URLSessionTaskInterception {
     public private(set) var startDate: Date?
 
     /// Approximate end time captured in Automatic mode when interception completes.
+    /// Guaranteed to be `>= startDate` once registered via `register(endDate:mediaTime:)`.
     internal var endDate: Date?
+
+    /// Monotonic uptime captured alongside `startDate` / `endDate`. Used to derive `endDate`
+    /// immune to wall-clock corrections (NTP, DST, manual changes).
+    internal var startMediaTime: CFTimeInterval?
+    internal var endMediaTime: CFTimeInterval?
 
     /// Returns the most accurate start time available.
     /// Prefers `URLSessionTaskMetrics` timing (registered delegate mode) over approximate timing (automatic mode).
@@ -145,12 +151,28 @@ public class URLSessionTaskInterception {
         self.responseSize = responseSize
     }
 
-    func register(startDate: Date) {
+    func register(startDate: Date, mediaTime: CFTimeInterval? = nil) {
         self.startDate = startDate
+        self.startMediaTime = mediaTime
     }
 
-    func register(endDate: Date) {
-        self.endDate = endDate
+    /// Registers the end date and guarantees `endDate >= startDate`.
+    /// When both media times are available, derives `endDate` from the monotonic delta;
+    /// otherwise clamps to `max(endDate, startDate)`.
+    func register(endDate: Date, mediaTime: CFTimeInterval? = nil) {
+        self.endMediaTime = mediaTime
+
+        guard let startDate else {
+            self.endDate = endDate
+            return
+        }
+
+        if let startMediaTime, let endMediaTime = mediaTime {
+            let monotonicDuration = max(0, endMediaTime - startMediaTime)
+            self.endDate = startDate.addingTimeInterval(monotonicDuration)
+        } else {
+            self.endDate = max(endDate, startDate)
+        }
     }
 
     /// Tells if the interception is done.

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -138,6 +138,68 @@ class URLSessionTaskInterceptionTests: XCTestCase {
         XCTAssertNil(interception.fetchStartDate)
         XCTAssertNil(interception.fetchEndDate)
     }
+
+    // MARK: - Monotonic-clock-based duration
+
+    func testFetchDates_whenMediaTimesAreProvided_endDateIsDerivedFromMonotonicDelta() {
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let startMediaTime: CFTimeInterval = 1_000
+        let endMediaTime: CFTimeInterval = 1_002.5
+
+        // When
+        interception.register(startDate: startDate, mediaTime: startMediaTime)
+        // Register an `endDate` value that is INCONSISTENT with the monotonic delta — the
+        // monotonic timestamps should win because they're the safer source of duration.
+        let bogusEndDate = startDate.addingTimeInterval(-10)
+        interception.register(endDate: bogusEndDate, mediaTime: endMediaTime)
+
+        // Then
+        XCTAssertEqual(interception.fetchStartDate, startDate)
+        XCTAssertEqual(interception.fetchEndDate, startDate.addingTimeInterval(2.5))
+    }
+
+    func testFetchDates_whenEndDateIsBeforeStartDateAndNoMediaTimes_endDateIsClampedToStartDate() {
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let earlierEndDate = startDate.addingTimeInterval(-3)
+
+        // When — wall-clock corrected backwards mid-request (e.g. NTP), no monotonic data.
+        interception.register(startDate: startDate)
+        interception.register(endDate: earlierEndDate)
+
+        // Then — endDate must be `>= startDate` to keep `startDate...endDate` ranges valid.
+        XCTAssertEqual(interception.fetchStartDate, startDate)
+        XCTAssertEqual(interception.fetchEndDate, startDate)
+    }
+
+    func testFetchDates_whenEndDateIsAfterStartDateAndNoMediaTimes_endDateIsPreserved() {
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let endDate = startDate.addingTimeInterval(3)
+
+        // When
+        interception.register(startDate: startDate)
+        interception.register(endDate: endDate)
+
+        // Then
+        XCTAssertEqual(interception.fetchStartDate, startDate)
+        XCTAssertEqual(interception.fetchEndDate, endDate)
+    }
+
+    func testFetchDates_whenStartDateIsMissing_endDateIsStoredAsRegistered() {
+        // It is possible (defensively) that `endDate` is registered without a prior `startDate`.
+        // In that case we cannot anchor or clamp; simply store the value as registered.
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .mockAny(), trackingMode: .automatic)
+        let endDate = Date.mockDecember15th2019At10AMUTC()
+
+        // When
+        interception.register(endDate: endDate, mediaTime: 1_002)
+
+        // Then
+        XCTAssertNil(interception.fetchStartDate)
+        XCTAssertEqual(interception.fetchEndDate, endDate)
+    }
 }
 
 class ResourceMetricsTests: XCTestCase {

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -20,6 +20,8 @@ import QuartzCore
 @_exported import struct DatadogInternal.RUMActionEvent
 @_exported import struct DatadogInternal.RUMLongTaskEvent
 @_exported import struct DatadogInternal.ProfilingOptions
+@_exported import protocol DatadogInternal.CACurrentMediaTimeProvider
+@_exported import struct DatadogInternal.MediaTimeProvider
 // swiftlint:enable duplicate_imports
 
 extension RUM {

--- a/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
+++ b/DatadogTrace/Sources/Integrations/TracingURLSessionHandler.swift
@@ -310,17 +310,20 @@ internal struct TracingURLSessionHandler: DatadogURLSessionHandler {
             }
         }
 
+        // Ensure `endTime >= startTime` before constructing the range below.
+        let safeEndTime = max(startTime, endTime)
+
         if let history = contextReceiver.context.applicationStateHistory {
-            let fetchDuration = startTime...endTime
+            let fetchDuration = startTime...safeEndTime
             let foregroundDuration = history.foregroundDuration(during: fetchDuration)
             span.setTag(key: SpanTags.foregroundDuration, value: foregroundDuration.dd.toNanoseconds)
 
             let didStartInBackground = history.state(at: startTime) == .background
-            let doesEndInBackground = history.state(at: endTime) == .background
+            let doesEndInBackground = history.state(at: safeEndTime) == .background
             span.setTag(key: SpanTags.isBackground, value: didStartInBackground || doesEndInBackground)
         }
 
-        span.finish(at: endTime)
+        span.finish(at: safeEndTime)
     }
 
     /// Creates a helper struct with collected elements from a possible parent span context.

--- a/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
+++ b/DatadogTrace/Tests/TracingURLSessionHandlerTests.swift
@@ -952,6 +952,36 @@ class TracingURLSessionHandlerTests: XCTestCase {
         XCTAssertFalse(span.isError, "5xx responses are not client errors and should not set the error flag")
     }
 
+    // MARK: - Defensive against inverted timestamps (start > end)
+
+    func testGivenInterceptionWithEndBeforeStart_itDoesNotCrashAndStillEmitsSpan() throws {
+        // Reproduces the crash reported in https://github.com/DataDog/dd-sdk-ios/issues/2939.
+        // where `fetchStartDate > fetchEndDate` (e.g. wall-clock corrected backwards mid-request).
+        let expectation = expectation(description: "Send span")
+        core.onEventWriteContext = { _ in expectation.fulfill() }
+
+        // Given — `URLSessionTaskMetrics` with start > end
+        let interception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: true, trackingMode: .registeredDelegate)
+        interception.register(response: .mockAny(), error: nil)
+        interception.register(
+            metrics: .mockWith(
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(addingTimeInterval: 10),
+                    end: .mockDecember15th2019At10AMUTC()
+                )
+            )
+        )
+
+        // When
+        handler.interceptionDidComplete(interception: interception)
+
+        // Then — does not crash and still emits a span with a non-negative foreground duration.
+        waitForExpectations(timeout: 0.5, handler: nil)
+        let envelope: SpanEventsEnvelope? = core.events().last
+        let span = try XCTUnwrap(envelope?.spans.first)
+        XCTAssertEqual(span.tags[SpanTags.foregroundDuration], "0")
+    }
+
     private func assert(capturedState: URLSessionHandlerCapturedState?, has span: OTSpan?) {
         guard let state = capturedState as? TracingURLSessionHandler.TracingURLSessionHandlerCapturedState else {
             XCTFail("Expected TracingURLSessionHandlerCapturedState instance, got \(String(describing: capturedState))")

--- a/TestUtilities/Sources/Mocks/DatadogRUM/MediaTimeProviderMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/MediaTimeProviderMock.swift
@@ -5,7 +5,6 @@
  */
 
 import DatadogInternal
-import DatadogRUM
 import Foundation
 import QuartzCore
 

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -567,11 +567,6 @@ public enum PerformanceMetric
     case flutterBuildTime
     case flutterRasterTime
     case jsFrameTimeSeconds
-public protocol CACurrentMediaTimeProvider: Sendable
-    var current: CFTimeInterval
-public struct MediaTimeProvider: CACurrentMediaTimeProvider
-    public init()
-    public var current: CFTimeInterval
 
 # ----------------------------------
 # API surface for DatadogCrashReporting:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5da86dcb-ae23-4d39-8326-31f06dee7072","source":"chat","resourceId":"6adcf77d-a4e4-427e-a31a-d8f5be9be78c","workflowId":"4037a07c-80a1-4891-9e30-d28c844d81a8","codeChangeId":"4037a07c-80a1-4891-9e30-d28c844d81a8","sourceType":"chat"} -->
### What and why?

Fixes a crash in `TracingURLSessionHandler` when wall-clock adjustments produce inverted start/end timestamp pairs during tracked URL requests. This addresses issue #2939 where constructing a range with `start > end` would crash with "Range requires lowerBound <= upperBound".

### How?

1. **Moved `MediaTimeProvider` to `DatadogInternal`**: Relocated from `DatadogRUM` so other modules can use monotonic clock readings for computing durations immune to wall-clock corrections.

2. **Enhanced `URLSessionTaskInterception`**: Added `startMediaTime` and `endMediaTime` fields to store monotonic clock readings alongside wall-clock timestamps. The `register(endDate:mediaTime:)` method now derives `endDate` from the monotonic delta when both media times are available, guaranteeing `endDate >= startDate`.

3. **Updated `NetworkInstrumentationFeature`**: Injected `CACurrentMediaTimeProvider` and captured monotonic timestamps at request start and completion, passing them to the interception's registration methods.

4. **Defensive fix in `TracingURLSessionHandler`**: Added `safeEndTime = max(startTime, endTime)` to clamp inverted intervals before constructing ranges and finishing spans, ensuring the SDK never crashes on malformed timestamp pairs.

5. **Added comprehensive tests**: New test cases verify monotonic delta behavior, clamping logic for missing media times, and defensive handling of inverted timestamps from upstream metrics.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/6adcf77d-a4e4-427e-a31a-d8f5be9be78c)

Comment @datadog to request changes