### PR TITLE
[RUM-16361] Fix UIScrollViewDelegateProxy crash during VC teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Fix `NSInvalidArgumentException` ("unrecognized selector") crash in automatic scroll action tracking when UIKit dispatches a cached delegate method after the original `UIScrollViewDelegate` has been deallocated. See [#2942][].
+
 # 3.11.0 / 12-05-2026
 
 - [IMPROVEMENT] Add support for `maui` source for cross-platform RUM events from .NET MAUI applications. See [#2891][]
@@ -1144,6 +1146,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2856]: https://github.com/DataDog/dd-sdk-ios/pull/2856
 [#2866]: https://github.com/DataDog/dd-sdk-ios/pull/2866
 [#2891]: https://github.com/DataDog/dd-sdk-ios/pull/2891
+[#2942]: https://github.com/DataDog/dd-sdk-ios/pull/2942
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -401,8 +401,6 @@
 		61054E8D2A6EE10A00AAA894 /* RUMContextReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */; };
 		61054E8E2A6EE10A00AAA894 /* SRContextPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */; };
 		61054E8F2A6EE10A00AAA894 /* SegmentRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E412A6EE10A00AAA894 /* SegmentRequestBuilder.swift */; };
-		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
-		B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333D0D8EAED64F559835F384 /* RecordingComponents.swift */; };
 		61054E942A6EE10A00AAA894 /* TextObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4A2A6EE10A00AAA894 /* TextObfuscator.swift */; };
 		61054E952A6EE10A00AAA894 /* SnapshotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4B2A6EE10A00AAA894 /* SnapshotProcessor.swift */; };
 		61054E962A6EE10A00AAA894 /* Diff+SRWireframes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61054E4D2A6EE10A00AAA894 /* Diff+SRWireframes.swift */; };
@@ -678,6 +676,7 @@
 		61F930CB2BA213AC005F0EE2 /* AppHang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F930CA2BA213AC005F0EE2 /* AppHang.swift */; };
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
 		6482FB0E2EE885C60042234B /* FlagsClientInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */; };
+		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
 		770E0BF093842AF7D350E888 /* EvaluationLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC44AD2847746ED69201F65 /* EvaluationLoggingTests.swift */; };
 		86092FDE2DEDC6830075D63B /* AccessibilityValuesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */; };
 		861FD6862DF2EAED00F59823 /* LocaleInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */; };
@@ -729,6 +728,9 @@
 		9678E2772E55CD200094B106 /* RUMFeatureOperationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E2752E55CD200094B106 /* RUMFeatureOperationManagerTests.swift */; };
 		96867B992D08826B004AE0BC /* TextReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96867B982D08826B004AE0BC /* TextReflectionTests.swift */; };
 		96867B9B2D0883DD004AE0BC /* ColorReflectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96867B9A2D0883DD004AE0BC /* ColorReflectionTests.swift */; };
+		968A6CA02FBF2EBD00B87826 /* DDForwardingProxyBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 968A6C9F2FBF2EBD00B87826 /* DDForwardingProxyBase.m */; };
+		968A6CAB2FBF2FB100B87826 /* DDForwardingProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 968A6CA92FBF2FB100B87826 /* DDForwardingProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		968A6CAD2FBF3DEF00B87826 /* DatadogRUM.h in Headers */ = {isa = PBXBuildFile; fileRef = 968A6CAC2FBF3DEF00B87826 /* DatadogRUM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */; };
 		969B3B232C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */; };
 		96CD20652ED4808900B4686E /* URLSessionTaskStateSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */; };
@@ -792,6 +794,7 @@
 		B202DBC9FC73EEF0D237D306 /* HeatmapIdentifierComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F610A698379D300D06E515 /* HeatmapIdentifierComputationTests.swift */; };
 		B3E46CAB2D91B3AD00BABF66 /* NetworkContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAA2D91B3A400BABF66 /* NetworkContextProvider.swift */; };
 		B3E46CAE2D91B40000BABF66 /* NetworkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E46CAD2D91B3FC00BABF66 /* NetworkContext.swift */; };
+		B5B633BD7EC649AC9F29F246 /* RecordingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333D0D8EAED64F559835F384 /* RecordingComponents.swift */; };
 		CD91654B77EEEB08CD20B3B0 /* HeatmapIdentifierStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC78B982F5C5B87E754DF44 /* HeatmapIdentifierStoreTests.swift */; };
 		D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
@@ -1939,6 +1942,7 @@
 		269035A12E41F93F00F1A830 /* UserConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfigurationContextMocks.swift; sourceTree = "<group>"; };
 		269035A42E41FAA500F1A830 /* AccountConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountConfigurationContextMocks.swift; sourceTree = "<group>"; };
 		2B6A3B154836FEB32C07EB50 /* EvaluationAggregator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationAggregator.swift; sourceTree = "<group>"; };
+		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
 		3C08F9CF2C2D652D002B0FF2 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		3C0CB3442C19A1ED003B0E9B /* WatchdogTerminationReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporter.swift; sourceTree = "<group>"; };
 		3C0D5DD62A543B3B00446CF9 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -2103,8 +2107,6 @@
 		61054E382A6EE10A00AAA894 /* ViewTreeRecordingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewTreeRecordingContext.swift; sourceTree = "<group>"; };
 		61054E392A6EE10A00AAA894 /* NodeIDGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeIDGenerator.swift; sourceTree = "<group>"; };
 		61054E3A2A6EE10A00AAA894 /* WindowViewTreeSnapshotProducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowViewTreeSnapshotProducer.swift; sourceTree = "<group>"; };
-		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
-		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		61054E3C2A6EE10A00AAA894 /* SessionReplayFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionReplayFeature.swift; sourceTree = "<group>"; };
 		61054E3E2A6EE10A00AAA894 /* RUMContextReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMContextReceiver.swift; sourceTree = "<group>"; };
 		61054E3F2A6EE10A00AAA894 /* SRContextPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRContextPublisher.swift; sourceTree = "<group>"; };
@@ -2511,6 +2513,7 @@
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
 		6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientInternal.swift; sourceTree = "<group>"; };
 		6FE4202BC457504AC37A51D6 /* HeatmapIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifier.swift; sourceTree = "<group>"; };
+		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityValuesMock.swift; sourceTree = "<group>"; };
 		861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleInfoPublisherTests.swift; sourceTree = "<group>"; };
 		861FD6872DF3366400F59823 /* LocaleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleInfo.swift; sourceTree = "<group>"; };
@@ -2560,6 +2563,9 @@
 		9678E2752E55CD200094B106 /* RUMFeatureOperationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureOperationManagerTests.swift; sourceTree = "<group>"; };
 		96867B982D08826B004AE0BC /* TextReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReflectionTests.swift; sourceTree = "<group>"; };
 		96867B9A2D0883DD004AE0BC /* ColorReflectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorReflectionTests.swift; sourceTree = "<group>"; };
+		968A6C9F2FBF2EBD00B87826 /* DDForwardingProxyBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDForwardingProxyBase.m; sourceTree = "<group>"; };
+		968A6CA92FBF2FB100B87826 /* DDForwardingProxyBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DDForwardingProxyBase.h; sourceTree = "<group>"; };
+		968A6CAC2FBF3DEF00B87826 /* DatadogRUM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DatadogRUM.h; path = TargetSupport/DatadogRUM/DatadogRUM.h; sourceTree = SOURCE_ROOT; };
 		969B3B202C33F80500D62400 /* UIActivityIndicatorRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorder.swift; sourceTree = "<group>"; };
 		969B3B222C33F81E00D62400 /* UIActivityIndicatorRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorRecorderTests.swift; sourceTree = "<group>"; };
 		96CD20632ED4808900B4686E /* URLSessionTaskStateSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskStateSwizzler.swift; sourceTree = "<group>"; };
@@ -4351,6 +4357,7 @@
 		61133B78242393DE00786299 = {
 			isa = PBXGroup;
 			children = (
+				968A6C9E2FBF2E5700B87826 /* DatadogRUMPrivate */,
 				61133B9C2423979B00786299 /* DatadogCore */,
 				9E68FB52244707FD0013A8AA /* DatadogPrivate */,
 				61133C122423990D00786299 /* DatadogCoreTests */,
@@ -5691,6 +5698,25 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		968A6C9E2FBF2E5700B87826 /* DatadogRUMPrivate */ = {
+			isa = PBXGroup;
+			children = (
+				968A6CAA2FBF2FB100B87826 /* include */,
+				968A6C9F2FBF2EBD00B87826 /* DDForwardingProxyBase.m */,
+			);
+			name = DatadogRUMPrivate;
+			path = ../DatadogRUM/Private;
+			sourceTree = "<group>";
+		};
+		968A6CAA2FBF2FB100B87826 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				968A6CAC2FBF3DEF00B87826 /* DatadogRUM.h */,
+				968A6CA92FBF2FB100B87826 /* DDForwardingProxyBase.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
 		9E06058F26EF904200F5F935 /* LongTasks */ = {
 			isa = PBXGroup;
 			children = (
@@ -6831,6 +6857,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				968A6CAD2FBF3DEF00B87826 /* DatadogRUM.h in Headers */,
+				968A6CAB2FBF2FB100B87826 /* DDForwardingProxyBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8850,6 +8878,7 @@
 				D29A9F5C29DD85BB005C54A4 /* RUMSessionScope.swift in Sources */,
 				A7E6EA822D3146AD00997201 /* AnonymousIdentifierManager.swift in Sources */,
 				D29A9F6629DD85BB005C54A4 /* RUMUser.swift in Sources */,
+				968A6CA02FBF2EBD00B87826 /* DDForwardingProxyBase.m in Sources */,
 				D29A9F8229DD85BB005C54A4 /* UIKitRUMUserActionsPredicate.swift in Sources */,
 				3C5CD8CD2C3ECB9400B12303 /* MemoryWarningReporter.swift in Sources */,
 				D29A9F8E29DD8665005C54A4 /* SwiftUIExtensions.swift in Sources */,

--- a/Datadog/TargetSupport/DatadogRUM/DatadogRUM.h
+++ b/Datadog/TargetSupport/DatadogRUM/DatadogRUM.h
@@ -1,0 +1,15 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for DatadogRUM.
+FOUNDATION_EXPORT double DatadogRUMVersionNumber;
+
+//! Project version string for DatadogRUM.
+FOUNDATION_EXPORT const unsigned char DatadogRUMVersionString[];
+
+#import "DDForwardingProxyBase.h"

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -22,7 +22,8 @@ Pod::Spec.new do |s|
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 
-  s.source_files = ["DatadogRUM/Sources/**/*.swift"]
+  s.source_files = ["DatadogRUM/Sources/**/*.swift",
+                    "DatadogRUM/Private/**/*.{h,m}"]
 
   s.resource_bundle = {
     "DatadogRUM" => "DatadogRUM/Resources/PrivacyInfo.xcprivacy"

--- a/DatadogRUM/Private/DDForwardingProxyBase.m
+++ b/DatadogRUM/Private/DDForwardingProxyBase.m
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import "DDForwardingProxyBase.h"
+
+#if TARGET_OS_IOS || TARGET_OS_VISION
+#import <UIKit/UIKit.h>
+#endif
+
+@implementation __dd_private_DDForwardingProxyBase
+
+- (nullable id)forwardingTargetOrNil {
+    return nil;
+}
+
+#pragma mark - ObjC forwarding chain
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    // Happy path: if the target is alive and responds, hand the call straight to it.
+    // The ObjC runtime re-dispatches the selector directly to the returned object,
+    // skipping the NSInvocation machinery entirely.
+    id target = [self forwardingTargetOrNil];
+    if (target != nil && [target respondsToSelector:aSelector]) {
+        return target;
+    }
+    // Otherwise: returning nil tells the runtime to continue down the forwarding chain,
+    // which means it will call our methodSignatureForSelector: + forwardInvocation: below
+    // (where we can safely drop the call instead of crashing).
+    return nil;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
+    // 1. Selectors that we (or NSObject) implement directly.
+    NSMethodSignature *signature = [super methodSignatureForSelector:aSelector];
+    if (signature != nil) {
+        return signature;
+    }
+
+    // 2. Ask the live target if any.
+    id target = [self forwardingTargetOrNil];
+    if (target != nil) {
+        signature = [target methodSignatureForSelector:aSelector];
+        if (signature != nil) {
+            return signature;
+        }
+    }
+
+    // 3. The target is gone or doesn't know the selector. Try to recover the signature
+    // from known UIKit delegate protocols so the NSInvocation has accurate return/arg shapes.
+    // The invocation will still be dropped in forwardInvocation:; this just keeps the
+    // runtime from raising "unrecognized selector".
+#if TARGET_OS_IOS || TARGET_OS_VISION
+    // Protocols UIKit dispatches via UIScrollView.delegate (and its subclass slots).
+    // Includes informal protocols (e.g. UICollectionViewDelegateFlowLayout) that UIKit
+    // probes via respondsToSelector: on the same delegate slot, not separate properties.
+    Protocol * const knownProtocols[] = {
+        @protocol(UIScrollViewDelegate),
+        @protocol(UITableViewDelegate),
+        @protocol(UICollectionViewDelegate),
+        @protocol(UICollectionViewDelegateFlowLayout),
+        @protocol(UITextViewDelegate),
+    };
+    const size_t count = sizeof(knownProtocols) / sizeof(knownProtocols[0]);
+    for (size_t i = 0; i < count; i++) {
+        struct objc_method_description description = protocol_getMethodDescription(
+            knownProtocols[i], aSelector, NO /* isRequired */, YES /* isInstance */);
+        if (description.types != NULL) {
+            return [NSMethodSignature signatureWithObjCTypes:description.types];
+        }
+    }
+#endif
+
+    // 4. Final fallback: assume a void-returning, single-object-argument selector.
+    // The invocation is still dropped safely; for non-void selectors outside every known
+    // protocol the return register may contain garbage, but the call itself does not crash.
+    // If a customer surfaces a selector that hits this fallback, add its protocol above.
+    return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation {
+    id target = [self forwardingTargetOrNil];
+    if (target != nil && [target respondsToSelector:anInvocation.selector]) {
+        [anInvocation invokeWithTarget:target];
+        return;
+    }
+    // Target is gone or does not respond. Drop the invocation, but zero the return-value
+    // buffer first so non-void callers (e.g. UITableViewDelegate's CGFloat-returning
+    // sizing methods, UIScrollViewDelegate's UIView*-returning `viewForZooming`) get a
+    // defined zero/nil default instead of reading undefined bytes from the return register.
+    // For UIKit delegate methods, zeroed defaults map to "use system default" semantics
+    // (e.g. CGFloat 0 = hidden row/header, nil UIView = no zoom target, BOOL NO = don't
+    // perform action).
+    NSUInteger returnLength = anInvocation.methodSignature.methodReturnLength;
+    if (returnLength > 0) {
+        void *zeroedReturn = calloc(1, returnLength);
+        [anInvocation setReturnValue:zeroedReturn];
+        free(zeroedReturn);
+    }
+}
+
+@end

--- a/DatadogRUM/Private/DDForwardingProxyBase.m
+++ b/DatadogRUM/Private/DDForwardingProxyBase.m
@@ -75,11 +75,11 @@
     }
 #endif
 
-    // 4. Final fallback: assume a void-returning, single-object-argument selector.
-    // The invocation is still dropped safely; for non-void selectors outside every known
-    // protocol the return register may contain garbage, but the call itself does not crash.
-    // If a customer surfaces a selector that hits this fallback, add its protocol above.
-    return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
+    // 4. Final fallback: minimal void(self, _cmd) signature. Selectors with explicit
+    // arguments must have their signatures recovered above; assuming any argument layout
+    // here would risk misdescribing the ABI of unknown selectors. If a customer surfaces a
+    // selector that hits this fallback, add its protocol to `knownProtocols` above.
+    return [NSMethodSignature signatureWithObjCTypes:"v@:"];
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation {

--- a/DatadogRUM/Private/include/DDForwardingProxyBase.h
+++ b/DatadogRUM/Private/include/DDForwardingProxyBase.h
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Safe ObjC forwarding base class for proxy types whose forwarding target (a weak reference
+/// to the original delegate) can disappear between when UIKit caches `responds(to:)` and
+/// when it dispatches the cached selector — typically during view-controller teardown.
+///
+/// Without this base class, a stale dispatch raises `NSInvalidArgumentException`
+/// ("unrecognized selector"). This base class returns a valid `NSMethodSignature` so the
+/// runtime can construct an `NSInvocation`, then silently drops the invocation in
+/// `forwardInvocation:` if the target is gone.
+///
+/// Subclasses override `forwardingTargetOrNil` to return the current target (or `nil` if gone).
+@interface __dd_private_DDForwardingProxyBase : NSObject
+
+/// Subclasses override to return the current forwarding target (may be `nil`).
+/// The default implementation returns `nil`.
+- (nullable id)forwardingTargetOrNil;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxy.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxy.swift
@@ -8,9 +8,23 @@
 
 import UIKit
 
+// swiftlint:disable duplicate_imports
+#if SPM_BUILD
+    #if swift(>=6.0)
+    internal import DatadogRUMPrivate
+    #else
+    @_implementationOnly import DatadogRUMPrivate
+    #endif
+#endif
+// swiftlint:enable duplicate_imports
+
 /// A proxy that wraps the original UIScrollView delegate to intercept scroll lifecycle events
 /// while forwarding all calls to the original delegate transparently.
-internal final class UIScrollViewDelegateProxy: NSObject, UIScrollViewDelegate {
+///
+/// Inherits from `__dd_private_DDForwardingProxyBase` so that any delegate selector forwarded
+/// through this proxy is safely dropped (rather than crashing) when `originalDelegate` is
+/// mid-dealloc. See RUM-16361.
+internal final class UIScrollViewDelegateProxy: __dd_private_DDForwardingProxyBase, UIScrollViewDelegate {
     /// The original delegate receiving forwarded calls.
     weak var originalDelegate: UIScrollViewDelegate?
 
@@ -45,6 +59,14 @@ internal final class UIScrollViewDelegateProxy: NSObject, UIScrollViewDelegate {
 
     // MARK: - Forwarding
 
+    /// Provides the current forwarding target to `__dd_private_DDForwardingProxyBase`.
+    /// When `originalDelegate` is `nil` (e.g. mid-dealloc), the base class returns a benign
+    /// method signature and silently drops the invocation in `forwardInvocation:` — closing
+    /// the `unrecognized selector` crash family (RUM-16361, GH #2867).
+    override func forwardingTargetOrNil() -> Any? {
+        return originalDelegate
+    }
+
     /// Guards against re-entrant calls to `responds(to:)` that arise when a third-party
     /// delegate proxy (e.g. RxSwift's `DelegateProxy`) and this proxy hold mutual references,
     /// causing infinite recursion.
@@ -61,14 +83,6 @@ internal final class UIScrollViewDelegateProxy: NSObject, UIScrollViewDelegate {
         isRespondingToSelector = true
         defer { isRespondingToSelector = false }
         return originalDelegate?.responds(to: aSelector) ?? false
-    }
-
-    // swiftlint:disable:next implicitly_unwrapped_optional
-    override func forwardingTarget(for aSelector: Selector!) -> Any? {
-        if let original = originalDelegate, original.responds(to: aSelector) {
-            return original
-        }
-        return super.forwardingTarget(for: aSelector)
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
@@ -112,51 +112,117 @@ class UIScrollViewDelegateProxyTests: XCTestCase {
         scrollView.setContentOffset(CGPoint(x: 0, y: 100), animated: false)
     }
 
-    // MARK: - Regression for RUM-16361: Forwarding after originalDelegate deallocates
+    // MARK: - RUM-16361: Forwarding crash regression
 
-    /// Reproduces the crash reported in:
-    /// - RUM-16361 / RUMS-5941 (Salesforce escalation; Kidsnote SDK 3.9.1, SOOP SDK 3.11.0)
-    /// - https://github.com/DataDog/dd-sdk-ios/issues/2867 (Shaadi, SDK 3.10.0)
+    /// Reproduces the crash from RUMS-5962 / RUMS-5941 and GH #2867.
     ///
-    /// Crash signature:
-    ///   NSInvalidArgumentException
-    ///   -[DatadogRUM.UIScrollViewDelegateProxy scrollViewDidScroll:]: unrecognized selector
-    ///   ___forwarding___ → _CF_forwarding_prep_0 → _notifyDidScroll
+    /// Crash signature: `-[DatadogRUM.UIScrollViewDelegateProxy <selector>]: unrecognized
+    /// selector`, dispatched from `_notifyDidScroll` during view-controller teardown.
     ///
-    /// Mechanism (production):
-    /// A UIViewController owns its UIScrollView AND is its delegate. When the VC deallocates,
-    /// its `deallocating` flag is set BEFORE its associated objects are released. Inside that
-    /// window, UIKit may dispatch `scrollViewDidScroll:` to the still-alive proxy (e.g. from
-    /// layout invalidation during the scroll view's own teardown). The proxy does not implement
-    /// that selector directly, so the ObjC runtime invokes `forwardingTarget(for:)` — which
-    /// reads the weak `originalDelegate` (now nil because the VC is mid-dealloc) and returns
-    /// nil. The runtime then raises "unrecognized selector".
-    ///
-    /// Why prior fixes missed it:
-    /// - PR #2776 tied proxy lifetime to delegate lifetime, but the proxy is still alive during
-    ///   the VC's dealloc body. The bug is about reading `originalDelegate` after the delegate's
-    ///   `deallocating` flag is set, not about the proxy outliving the delegate by minutes.
-    /// - PR #2791 added a setter re-entrancy guard; orthogonal code path.
+    /// Mechanism: a VC that owns its scroll view AND is its delegate hits a dealloc-time
+    /// race — the VC's `deallocating` flag zeros the weak `originalDelegate` while the
+    /// proxy is still alive. UIKit dispatches a cached selector to the proxy; the proxy
+    /// doesn't implement it directly; `forwardingTarget(for:)` returns nil; the runtime
+    /// raises "unrecognized selector".
     func test_whenOriginalDelegateIsDeallocated_dispatchingForwardedSelector_doesNotCrash() {
-        // Given - a proxy whose original delegate has been deallocated. The weak
-        // `originalDelegate` reference must be nil; the proxy itself is still alive.
+        // Given - a proxy whose original delegate has been deallocated.
         var delegate: MockScrollViewDelegate? = MockScrollViewDelegate()
         let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
         delegate = nil
 
-        XCTAssertNil(proxy.originalDelegate, "Sanity: weak reference must be nil after delegate deallocates")
+        XCTAssertNil(proxy.originalDelegate, "weak reference must be nil after delegate deallocates")
 
-        // When - UIKit dispatches a forwarded UIScrollViewDelegate selector to the proxy.
-        // `perform(_:with:)` exercises the same ObjC forwarding chain UIKit uses internally
-        // (objc_msgSend → forwardingTarget(for:) → forwardInvocation:).
+        // When - `perform(_:with:)` exercises the same ObjC forwarding chain UIKit uses
+        // internally (objc_msgSend → forwardingTarget(for:) → forwardInvocation:).
         let scrollView = UIScrollView()
         _ = proxy.perform(
             #selector(UIScrollViewDelegate.scrollViewDidScroll(_:)),
             with: scrollView
         )
 
-        // Then - the proxy must handle the dispatch without crashing. The unfixed proxy raises
-        // NSInvalidArgumentException from inside `perform`, which XCTest reports as a failure.
+        // Then - the proxy handles the dispatch without crashing.
+    }
+
+    /// Same mechanism as above, but with a UITableViewDelegate selector — proves the fix
+    /// covers selectors outside `UIScrollViewDelegate`. Mirrors the RxCocoa-wrapped
+    /// `tableView:estimatedHeightForHeaderInSection:` crash from RUMS-5941.
+    func test_whenOriginalDelegateIsDeallocated_dispatchingUITableViewDelegateSelector_doesNotCrash() {
+        // Given - a proxy whose original delegate (a UITableViewDelegate) has been deallocated.
+        var delegate: MockTableViewDelegate? = MockTableViewDelegate()
+        let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
+        delegate = nil
+
+        XCTAssertNil(proxy.originalDelegate, "weak reference must be nil after delegate deallocates")
+
+        // When - dispatch a UITableViewDelegate selector via the ObjC forwarding chain.
+        let tableView = UITableView()
+        _ = proxy.perform(
+            #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:)),
+            with: tableView,
+            with: 0
+        )
+
+        // Then - the proxy handles the dispatch without crashing.
+    }
+
+    /// Verifies that non-void forwarded selectors get a zero/nil default return (instead
+    /// of undefined bytes) when the original delegate is gone. Uses an object-returning
+    /// UIScrollViewDelegate selector since `perform(_:with:)` can only validate object
+    /// returns; the underlying `setReturnValue:` fix in the base class zeros the entire
+    /// `methodReturnLength`, so verifying one return type implicitly covers all of them.
+    func test_whenOriginalDelegateIsDeallocated_dispatchingNonVoidForwardedSelector_returnsZeroedDefault() {
+        // Given - a proxy whose original delegate has been deallocated.
+        var delegate: MockScrollViewDelegate? = MockScrollViewDelegate()
+        let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
+        delegate = nil
+
+        XCTAssertNil(proxy.originalDelegate)
+
+        // When - dispatching `viewForZooming(in:)` (returns UIView?) through the forwarding chain.
+        let result = proxy.perform(
+            #selector(UIScrollViewDelegate.viewForZooming(in:)),
+            with: UIScrollView()
+        )
+
+        // Then - the proxy must return nil (zeroed object pointer), not garbage.
+        XCTAssertNil(result, "Expected nil for object-typed forwarded selector when delegate is gone")
+    }
+
+    // MARK: - RUM-16361: Forwarding happy path (via __dd_private_DDForwardingProxyBase)
+
+    /// Proves alive-delegate forwarding still works end-to-end for a UIScrollViewDelegate
+    /// selector the proxy does NOT implement directly.
+    func test_whenOriginalDelegateIsAlive_dispatchingForwardedSelector_reachesTheOriginalDelegate() {
+        // Given - a proxy whose original delegate is alive and counts calls.
+        let delegate = CountingDelegate()
+        let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
+
+        // When - dispatch a forwarded UIScrollViewDelegate selector.
+        _ = proxy.perform(
+            #selector(UIScrollViewDelegate.scrollViewDidScroll(_:)),
+            with: UIScrollView()
+        )
+
+        // Then - the call reached the original delegate.
+        XCTAssertEqual(delegate.scrollViewDidScrollCount, 1)
+    }
+
+    /// Same as above for a UITableViewDelegate selector — exercises the protocol-lookup
+    /// branch in the base class's `methodSignatureForSelector:`.
+    func test_whenOriginalDelegateIsAlive_dispatchingUITableViewDelegateSelector_reachesTheOriginalDelegate() {
+        // Given - a proxy whose UITableViewDelegate target is alive and counts calls.
+        let delegate = CountingDelegate()
+        let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
+
+        // When - dispatch a UITableViewDelegate selector via the ObjC forwarding chain.
+        _ = proxy.perform(
+            #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:)),
+            with: UITableView(),
+            with: 0
+        )
+
+        // Then - the call reached the original delegate.
+        XCTAssertEqual(delegate.estimatedHeightCallCount, 1)
     }
 
     // MARK: - Circular Proxy Chain (regression for RxSwift-style delegate proxy conflict)
@@ -198,6 +264,28 @@ private class MockScrollViewHandler: UIScrollViewHandler {
 
 private class MockScrollViewDelegate: NSObject, UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    }
+}
+
+private class MockTableViewDelegate: NSObject, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        44
+    }
+}
+
+/// Counts forwarded calls. Conforms to UITableViewDelegate (which extends UIScrollViewDelegate),
+/// so satisfies both forwarding paths exercised by the happy-path tests.
+private class CountingDelegate: NSObject, UITableViewDelegate {
+    var scrollViewDidScrollCount = 0
+    var estimatedHeightCallCount = 0
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollViewDidScrollCount += 1
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        estimatedHeightCallCount += 1
+        return 44
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
@@ -112,6 +112,53 @@ class UIScrollViewDelegateProxyTests: XCTestCase {
         scrollView.setContentOffset(CGPoint(x: 0, y: 100), animated: false)
     }
 
+    // MARK: - Regression for RUM-16361: Forwarding after originalDelegate deallocates
+
+    /// Reproduces the crash reported in:
+    /// - RUM-16361 / RUMS-5941 (Salesforce escalation; Kidsnote SDK 3.9.1, SOOP SDK 3.11.0)
+    /// - https://github.com/DataDog/dd-sdk-ios/issues/2867 (Shaadi, SDK 3.10.0)
+    ///
+    /// Crash signature:
+    ///   NSInvalidArgumentException
+    ///   -[DatadogRUM.UIScrollViewDelegateProxy scrollViewDidScroll:]: unrecognized selector
+    ///   ___forwarding___ → _CF_forwarding_prep_0 → _notifyDidScroll
+    ///
+    /// Mechanism (production):
+    /// A UIViewController owns its UIScrollView AND is its delegate. When the VC deallocates,
+    /// its `deallocating` flag is set BEFORE its associated objects are released. Inside that
+    /// window, UIKit may dispatch `scrollViewDidScroll:` to the still-alive proxy (e.g. from
+    /// layout invalidation during the scroll view's own teardown). The proxy does not implement
+    /// that selector directly, so the ObjC runtime invokes `forwardingTarget(for:)` — which
+    /// reads the weak `originalDelegate` (now nil because the VC is mid-dealloc) and returns
+    /// nil. The runtime then raises "unrecognized selector".
+    ///
+    /// Why prior fixes missed it:
+    /// - PR #2776 tied proxy lifetime to delegate lifetime, but the proxy is still alive during
+    ///   the VC's dealloc body. The bug is about reading `originalDelegate` after the delegate's
+    ///   `deallocating` flag is set, not about the proxy outliving the delegate by minutes.
+    /// - PR #2791 added a setter re-entrancy guard; orthogonal code path.
+    func test_whenOriginalDelegateIsDeallocated_dispatchingForwardedSelector_doesNotCrash() {
+        // Given - a proxy whose original delegate has been deallocated. The weak
+        // `originalDelegate` reference must be nil; the proxy itself is still alive.
+        var delegate: MockScrollViewDelegate? = MockScrollViewDelegate()
+        let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
+        delegate = nil
+
+        XCTAssertNil(proxy.originalDelegate, "Sanity: weak reference must be nil after delegate deallocates")
+
+        // When - UIKit dispatches a forwarded UIScrollViewDelegate selector to the proxy.
+        // `perform(_:with:)` exercises the same ObjC forwarding chain UIKit uses internally
+        // (objc_msgSend → forwardingTarget(for:) → forwardInvocation:).
+        let scrollView = UIScrollView()
+        _ = proxy.perform(
+            #selector(UIScrollViewDelegate.scrollViewDidScroll(_:)),
+            with: scrollView
+        )
+
+        // Then - the proxy must handle the dispatch without crashing. The unfixed proxy raises
+        // NSInvalidArgumentException from inside `perform`, which XCTest reports as a failure.
+    }
+
     // MARK: - Circular Proxy Chain (regression for RxSwift-style delegate proxy conflict)
 
     func testRespondsTo_withCircularProxyChain_doesNotCauseInfiniteRecursion() {

--- a/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/UIKit/UIScrollViewDelegateProxyTests.swift
@@ -154,15 +154,15 @@ class UIScrollViewDelegateProxyTests: XCTestCase {
 
         XCTAssertNil(proxy.originalDelegate, "weak reference must be nil after delegate deallocates")
 
-        // When - dispatch a UITableViewDelegate selector via the ObjC forwarding chain.
-        let tableView = UITableView()
-        _ = proxy.perform(
-            #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:)),
-            with: tableView,
-            with: 0
-        )
+        // When - dispatch a UITableViewDelegate selector with a correctly typed function
+        // pointer (scalar `Int` argument, `CGFloat` return).
+        let selector = #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:))
+        typealias EstimatedHeightIMP = @convention(c) (AnyObject, Selector, UITableView, Int) -> CGFloat
+        let implementation = unsafeBitCast(proxy.method(for: selector), to: EstimatedHeightIMP.self)
+        let result = implementation(proxy, selector, UITableView(), 0)
 
-        // Then - the proxy handles the dispatch without crashing.
+        // Then - the proxy handles the dispatch without crashing, returning the zeroed default.
+        XCTAssertEqual(result, 0)
     }
 
     /// Verifies that non-void forwarded selectors get a zero/nil default return (instead
@@ -214,15 +214,16 @@ class UIScrollViewDelegateProxyTests: XCTestCase {
         let delegate = CountingDelegate()
         let proxy = UIScrollViewDelegateProxy(originalDelegate: delegate, handler: handler)
 
-        // When - dispatch a UITableViewDelegate selector via the ObjC forwarding chain.
-        _ = proxy.perform(
-            #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:)),
-            with: UITableView(),
-            with: 0
-        )
+        // When - dispatch a UITableViewDelegate selector with a correctly typed function
+        // pointer (scalar `Int` argument, `CGFloat` return).
+        let selector = #selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:))
+        typealias EstimatedHeightIMP = @convention(c) (AnyObject, Selector, UITableView, Int) -> CGFloat
+        let implementation = unsafeBitCast(proxy.method(for: selector), to: EstimatedHeightIMP.self)
+        let result = implementation(proxy, selector, UITableView(), 0)
 
-        // Then - the call reached the original delegate.
+        // Then - the call reached the original delegate and returned its value.
         XCTAssertEqual(delegate.estimatedHeightCallCount, 1)
+        XCTAssertEqual(result, 44)
     }
 
     // MARK: - Circular Proxy Chain (regression for RxSwift-style delegate proxy conflict)

--- a/Package.swift
+++ b/Package.swift
@@ -127,17 +127,24 @@ let package = Package(
             name: "DatadogRUM",
             dependencies: [
                 .target(name: "DatadogInternal"),
+                .target(name: "DatadogRUMPrivate"),
             ],
             path: "DatadogRUM",
             sources: ["Sources"],
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")
-            ]
+            ],
+            swiftSettings: [.define("SPM_BUILD")] + internalSwiftSettings
+        ),
+        .target(
+            name: "DatadogRUMPrivate",
+            path: "DatadogRUM/Private"
         ),
         .testTarget(
             name: "DatadogRUMTests",
             dependencies: [
                 .target(name: "DatadogRUM"),
+                .target(name: "DatadogRUMPrivate"),
                 .target(name: "TestUtilities"),
             ],
             path: "DatadogRUM/Tests"

--- a/Package.swift
+++ b/Package.swift
@@ -144,7 +144,6 @@ let package = Package(
             name: "DatadogRUMTests",
             dependencies: [
                 .target(name: "DatadogRUM"),
-                .target(name: "DatadogRUMPrivate"),
                 .target(name: "TestUtilities"),
             ],
             path: "DatadogRUM/Tests"


### PR DESCRIPTION
### What and why?

Fixes a recurring `NSInvalidArgumentException` ("unrecognized selector") crash in `UIScrollViewDelegateProxy` reported in:
- [RUMS-5962](https://datadoghq.atlassian.net/browse/RUMS-5962)
- [RUMS-5941](https://datadoghq.atlassian.net/browse/RUMS-5941)
- [#2867](https://github.com/DataDog/dd-sdk-ios/issues/2867)

Crash signature: `-[DatadogRUM.UIScrollViewDelegateProxy <selector>]: unrecognized selector`, dispatched from `_notifyDidScroll` during view-controller teardown.

**Mechanism:** when a `UIViewController` owns its `UIScrollView` AND is its delegate, the two tear down together. The VC's `deallocating` flag is set BEFORE its associated objects are released. Inside that window, UIKit can dispatch a cached delegate selector to the still-alive proxy — whose weak `originalDelegate` reads as `nil`. The proxy didn't implement that selector directly, so the ObjC runtime invoked `forwardingTarget(for:)`, which returned `nil`, and raised "unrecognized selector".

**Why prior fixes missed it:**
- #2776 (proxy lifetime tied to delegate) — the proxy is still alive in this race window.
- #2791 (setter re-entrancy guard) — orthogonal code path.

### How?

Introduces a small Objective-C base class `__dd_private_DDForwardingProxyBase` in a new `DatadogRUMPrivate` SPM target (mirrors the `DatadogPrivate` pattern used by `DatadogCore`). It overrides three ObjC runtime hooks:

- `forwardingTargetForSelector:` — fast-forwards to a live target.
- `methodSignatureForSelector:` — returns the selector's real signature from known UIKit delegate protocols (`UIScrollViewDelegate`, `UITableViewDelegate`, `UICollectionViewDelegate`, `UITextViewDelegate`) via `protocol_getMethodDescription`; falls back to `v@:@` for unknown selectors.
- `forwardInvocation:` — invokes on a live target, or silently drops the invocation if the target is gone.

`UIScrollViewDelegateProxy` now inherits from the base class, overrides `forwardingTargetOrNil` to return `originalDelegate`, and drops its own `forwardingTarget(for:)` override (now in the base). `responds(to:)` is unchanged, so the RxSwift re-entrancy guard from #2761 still applies on the alive-delegate path.

This closes the entire forwarding-crash family uniformly — any selector, any UIKit delegate protocol, present or future.

This closes the forwarding-crash family for selectors in the enumerated UIKit delegate protocols (`UIScrollViewDelegate`, `UITableViewDelegate`, `UICollectionViewDelegate`, `UICollectionViewDelegateFlowLayout`, `UITextViewDelegate`) — covering all customer crashes seen so far. Selectors outside those protocols still drop without crashing, but use a generic v@:@ fallback signature; non-void returns with non-matching ABIs may have partially-defined values. Adding a new protocol is a one-line change if future selectors fall outside the current list.

**Build wiring:**
- New `DatadogRUMPrivate` SPM target at `DatadogRUM/Private/`.
- `DatadogRUM.podspec` `source_files` glob extended to include the new ObjC files.
- New umbrella header `Datadog/TargetSupport/DatadogRUM/DatadogRUM.h` to expose the ObjC class to Swift in the Xcode framework build (Carthage / XCFramework).
- `Datadog/Datadog.xcodeproj` updated: new `DatadogRUMPrivate` group, files added to `DatadogRUM` target's Compile Sources + Headers phase (Public). Some unrelated `RecordingController`/`RecordingComponents` line reorderings appear in the diff — Xcode auto-sorts these on save; they're noise, not functional changes.

**Tests** (`UIScrollViewDelegateProxyTests`, 4 new tests covering a 2×2 matrix of {alive, deallocated} × {UIScrollViewDelegate, UITableViewDelegate}):
- `..._dispatchingForwardedSelector_doesNotCrash` — UIScrollViewDelegate, deallocated. Reproduces the production crash; fails on `hotfix/3.11.1` baseline.
- `..._dispatchingUITableViewDelegateSelector_doesNotCrash` — same with a UITableViewDelegate selector (covers the RxCocoa-wrapped path documented in RUMS-5941).
- `..._dispatchingForwardedSelector_reachesTheOriginalDelegate` — alive-delegate happy path, UIScrollViewDelegate.
- `..._dispatchingUITableViewDelegateSelector_reachesTheOriginalDelegate` — alive-delegate happy path, UITableViewDelegate (exercises protocol-lookup branch).

**Testing:**
- All `UIScrollViewDelegateProxyTests` pass on iOS / tvOS / watchOS / visionOS.
- Full `DatadogRUM` module test suite passes on iOS / tvOS / watchOS.
- `UIKitExtensionsTests` shows pre-existing failures on visionOS that also fail on `hotfix/3.11.1` baseline — unrelated to this PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs — N/A (new ObjC is module-internal; \`__dd_private_\` prefix matches existing convention)
- [ ] Run \`make api-surface\` when adding new APIs — N/A (no new public Swift APIs)

[RUMS-5962]: https://datadoghq.atlassian.net/browse/RUMS-5962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUMS-5941]: https://datadoghq.atlassian.net/browse/RUMS-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ