### PR TITLE
[RUM-16361] Add trackScrollAndSwipeActions feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 
 - [FIX] Fix `NSInvalidArgumentException` ("unrecognized selector") crash in automatic scroll action tracking when UIKit dispatches a cached delegate method after the original `UIScrollViewDelegate` has been deallocated. See [#2942][].
-- [IMPROVEMENT] Add `disableScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
 - [IMPROVEMENT] Add `trackScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
 
 # 3.11.0 / 12-05-2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Fix `NSInvalidArgumentException` ("unrecognized selector") crash in automatic scroll action tracking when UIKit dispatches a cached delegate method after the original `UIScrollViewDelegate` has been deallocated. See [#2942][].
 - [IMPROVEMENT] Add `disableScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
+- [IMPROVEMENT] Add `trackScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
 
 # 3.11.0 / 12-05-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Fix `NSInvalidArgumentException` ("unrecognized selector") crash in automatic scroll action tracking when UIKit dispatches a cached delegate method after the original `UIScrollViewDelegate` has been deallocated. See [#2942][].
+- [IMPROVEMENT] Add `disableScrollAndSwipeActions` feature flag in RUM configuration to opt out of automatic scroll and swipe action tracking. See [#2944][].
 
 # 3.11.0 / 12-05-2026
 
@@ -1147,6 +1148,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2866]: https://github.com/DataDog/dd-sdk-ios/pull/2866
 [#2891]: https://github.com/DataDog/dd-sdk-ios/pull/2891
 [#2942]: https://github.com/DataDog/dd-sdk-ios/pull/2942
+[#2944]: https://github.com/DataDog/dd-sdk-ios/pull/2944
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -218,7 +218,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             uiKitRUMActionsPredicate: configuration.uiKitActionsPredicate,
             swiftUIRUMViewsPredicate: configuration.swiftUIViewsPredicate,
             swiftUIRUMActionsPredicate: configuration.swiftUIActionsPredicate,
-            scrollAndSwipeActionsDisabled: configuration.featureFlags[.disableScrollAndSwipeActions],
+            trackScrollAndSwipeActions: configuration.featureFlags[.trackScrollAndSwipeActions],
             longTaskThreshold: configuration.longTaskThreshold,
             appHangThreshold: configuration.appHangThreshold,
             mainQueue: configuration.mainQueue,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -218,6 +218,7 @@ internal final class RUMFeature: DatadogRemoteFeature {
             uiKitRUMActionsPredicate: configuration.uiKitActionsPredicate,
             swiftUIRUMViewsPredicate: configuration.swiftUIViewsPredicate,
             swiftUIRUMActionsPredicate: configuration.swiftUIActionsPredicate,
+            scrollAndSwipeActionsDisabled: configuration.featureFlags[.disableScrollAndSwipeActions],
             longTaskThreshold: configuration.longTaskThreshold,
             appHangThreshold: configuration.appHangThreshold,
             mainQueue: configuration.mainQueue,

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -56,13 +56,14 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     // MARK: - Initialization
 
     #if !os(watchOS)
+    //swiftlint:disable function_default_parameter_at_end
     init(
         featureScope: FeatureScope,
         uiKitRUMViewsPredicate: UIKitRUMViewsPredicate?,
         uiKitRUMActionsPredicate: UIKitRUMActionsPredicate?,
         swiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate?,
         swiftUIRUMActionsPredicate: SwiftUIRUMActionsPredicate?,
-        scrollAndSwipeActionsDisabled: Bool,
+        scrollAndSwipeActionsDisabled: Bool = false,
         longTaskThreshold: TimeInterval?,
         appHangThreshold: TimeInterval?,
         mainQueue: DispatchQueue,
@@ -196,6 +197,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         self.appHangs?.start()
         self.memoryWarningMonitor?.start()
     }
+    //swiftlint:enable function_default_parameter_at_end
 
     #else
 

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -62,6 +62,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         uiKitRUMActionsPredicate: UIKitRUMActionsPredicate?,
         swiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate?,
         swiftUIRUMActionsPredicate: SwiftUIRUMActionsPredicate?,
+        scrollAndSwipeActionsDisabled: Bool,
         longTaskThreshold: TimeInterval?,
         appHangThreshold: TimeInterval?,
         mainQueue: DispatchQueue,
@@ -135,10 +136,11 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         }()
 
         #if !os(tvOS)
-        // Create scroll handler and swizzler if UIKit action tracking is enabled:
+        // Create scroll handler and swizzler if UIKit action tracking is enabled
+        // AND the `disableScrollAndSwipeActions` feature flag is not set:
         let scrollHandler: RUMScrollHandler?
         let scrollViewSwizzler: UIScrollViewSwizzler?
-        if let uiKitRUMActionsPredicate = uiKitRUMActionsPredicate {
+        if let uiKitRUMActionsPredicate = uiKitRUMActionsPredicate, !scrollAndSwipeActionsDisabled {
             let handler = RUMScrollHandler(
                 dateProvider: dateProvider,
                 predicate: uiKitRUMActionsPredicate

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -63,7 +63,7 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         uiKitRUMActionsPredicate: UIKitRUMActionsPredicate?,
         swiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate?,
         swiftUIRUMActionsPredicate: SwiftUIRUMActionsPredicate?,
-        scrollAndSwipeActionsDisabled: Bool = false,
+        trackScrollAndSwipeActions: Bool = true,
         longTaskThreshold: TimeInterval?,
         appHangThreshold: TimeInterval?,
         mainQueue: DispatchQueue,
@@ -138,10 +138,10 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
 
         #if !os(tvOS)
         // Create scroll handler and swizzler if UIKit action tracking is enabled
-        // AND the `disableScrollAndSwipeActions` feature flag is not set:
+        // AND the `trackScrollAndSwipeActions` feature flag is set:
         let scrollHandler: RUMScrollHandler?
         let scrollViewSwizzler: UIScrollViewSwizzler?
-        if let uiKitRUMActionsPredicate = uiKitRUMActionsPredicate, !scrollAndSwipeActionsDisabled {
+        if let uiKitRUMActionsPredicate = uiKitRUMActionsPredicate, trackScrollAndSwipeActions {
             let handler = RUMScrollHandler(
                 dateProvider: dateProvider,
                 predicate: uiKitRUMActionsPredicate

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -672,20 +672,24 @@ extension RUM.Configuration {
     /// Feature Flag available in RUM
     public enum FeatureFlag: String {
         case none
-        /// When `true`, disables automatic scroll and swipe action tracking
+        /// When `false`, disables automatic scroll and swipe action tracking
         /// performed by the SDK via `UIScrollView.delegate` swizzling.
-        /// Defaults to `false`. Has no effect if `uiKitActionsPredicate` is `nil`.
+        /// Defaults to `true`. Has no effect if `uiKitActionsPredicate` is `nil`.
         ///
         /// Note: in addition to suppressing `action.type = scroll/swipe` events, it also means these
         /// gestures will no longer count as candidate "last interactions" for INV
         /// (Interaction-to-Next-View) attribution.
-        case disableScrollAndSwipeActions
+        case trackScrollAndSwipeActions
     }
 }
 
 extension RUM.Configuration.FeatureFlags {
     /// The defaults Feature Flags applied to RUM Configuration
-    public static var defaults: Self { [:] }
+    public static var defaults: Self {
+        [
+            .trackScrollAndSwipeActions: true
+        ]
+    }
 
     /// Accesses the feature flag value.
     ///

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -672,6 +672,14 @@ extension RUM.Configuration {
     /// Feature Flag available in RUM
     public enum FeatureFlag: String {
         case none
+        /// When `true`, disables automatic scroll and swipe action tracking
+        /// performed by the SDK via `UIScrollView.delegate` swizzling.
+        /// Defaults to `false`. Has no effect if `uiKitActionsPredicate` is `nil`.
+        ///
+        /// Note: in addition to suppressing `action.type = scroll/swipe` events, it also means these
+        /// gestures will no longer count as candidate "last interactions" for INV
+        /// (Interaction-to-Next-View) attribution.
+        case disableScrollAndSwipeActions
     }
 }
 

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -144,6 +144,38 @@ class RUMInstrumentationTests: XCTestCase {
         }
     }
 
+    func testWhenScrollAndSwipeActionsTrackingIsDisabled_itDoesNotInstrumentUIScrollView() throws {
+        // When
+        let instrumentation = RUMInstrumentation(
+            featureScope: NOPFeatureScope(),
+            uiKitRUMViewsPredicate: nil,
+            uiKitRUMActionsPredicate: UIKitRUMActionsPredicateMock(),
+            swiftUIRUMViewsPredicate: nil,
+            swiftUIRUMActionsPredicate: nil,
+            trackScrollAndSwipeActions: false,
+            longTaskThreshold: nil,
+            appHangThreshold: .mockAny(),
+            mainQueue: .main,
+            dateProvider: SystemDateProvider(),
+            backtraceReporter: BacktraceReporterMock(),
+            fatalErrorContext: FatalErrorContextNotifierMock(),
+            processID: .mockAny(),
+            notificationCenter: .default,
+            bundleType: .iOSApp,
+            watchdogTermination: .mockRandom(),
+            memoryWarningMonitor: .mockRandom(),
+            uuidGenerator: RUMUUIDGeneratorMock(),
+            heatmapIdentifierRegistry: HeatmapIdentifierRegistryMock()
+        )
+
+        // Then
+        withExtendedLifetime(instrumentation) {
+            DDAssertActiveSwizzlings(["sendEvent:"])
+            XCTAssertNil(instrumentation.scrollViewSwizzler)
+            XCTAssertNil(instrumentation.scrollHandler)
+        }
+    }
+
     func testWhenOnlyLongTasksThresholdIsConfigured_itInstrumentsRunLoop() throws {
         // When
         let instrumentation = RUMInstrumentation(

--- a/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/RUMInstrumentationTests.swift
@@ -144,6 +144,7 @@ class RUMInstrumentationTests: XCTestCase {
         }
     }
 
+    #if !os(tvOS)
     func testWhenScrollAndSwipeActionsTrackingIsDisabled_itDoesNotInstrumentUIScrollView() throws {
         // When
         let instrumentation = RUMInstrumentation(
@@ -175,6 +176,7 @@ class RUMInstrumentationTests: XCTestCase {
             XCTAssertNil(instrumentation.scrollHandler)
         }
     }
+    #endif
 
     func testWhenOnlyLongTasksThresholdIsConfigured_itInstrumentsRunLoop() throws {
         // When

--- a/DatadogRUM/Tests/RUMConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfigurationTests.swift
@@ -37,5 +37,6 @@ class RUMConfigurationTests: XCTestCase {
         XCTAssertNil(config.onSessionStart)
         XCTAssertNil(config.customEndpoint)
         XCTAssertTrue(config.trackAnonymousUser)
+        XCTAssertTrue(config.featureFlags[.trackScrollAndSwipeActions])
     }
 }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -449,6 +449,7 @@ public enum RUM
     public typealias FeatureFlags = [FeatureFlag: Bool]
     public enum FeatureFlag: String
         case none
+        case disableScrollAndSwipeActions
 [?] extension RUM.Configuration.FeatureFlags
     public static var defaults: Self
     public subscript(flag: Key) -> Bool

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -449,7 +449,7 @@ public enum RUM
     public typealias FeatureFlags = [FeatureFlag: Bool]
     public enum FeatureFlag: String
         case none
-        case disableScrollAndSwipeActions
+        case trackScrollAndSwipeActions
 [?] extension RUM.Configuration.FeatureFlags
     public static var defaults: Self
     public subscript(flag: Key) -> Bool


### PR DESCRIPTION
### What and why?

Adds an opt-out feature flag for automatic scroll and swipe action tracking, so customers experiencing the crash being fixed in companion PR #2942 (`[RUM-16361] Fix UIScrollViewDelegateProxy crash during VC teardown`) — or any future scroll-related issue — can disable scroll/swipe action tracking, without waiting for an SDK release.

### How?

Adds one case to the existing `RUM.Configuration.FeatureFlag` enum.

Usage (opt-out):

```swift
let configuration = RUM.Configuration(applicationID: "...")
configuration.featureFlags[.trackScrollAndSwipeActions] = false
```

Default behaviour (flag absent or `true`): scroll/swipe action tracking remains enabled exactly as today. The flag defaults to `true` via `FeatureFlags.defaults`, so existing customers see no behaviour change.

When the flag is `false`, `RUMInstrumentation` skips creating both `RUMScrollHandler` and `UIScrollViewSwizzler` — the swizzles are never installed. Tap action tracking (the `sendEvent:` swizzle) is unaffected.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs

[RUM-16361]: https://datadoghq.atlassian.net/browse/RUM-16361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ