### PR TITLE
Wire DDSketch into StatsConcentrator for latency summaries

### DIFF
--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -35,19 +35,48 @@ internal struct AggregationKey: Hashable, Sendable {
 
 // MARK: - Grouped Stats
 
-/// Running counters for a single aggregation key within a time bucket.
+/// Running counters and latency distributions for a single aggregation key within a
+/// time bucket.
+///
 /// Counters use `Double` to support fractional weighted sampling (weight per span).
 /// Currently weight is always 1.0, so these are effectively integers.
+///
+/// `duration` is the total nanoseconds across all spans in the group; `okSummary` and
+/// `errorSummary` are DDSketches tracking the distribution of those same durations
+/// split by `isError`. Both representations are required by the v1.2.0 stats payload.
+///
+/// Each sketch is bounded by `DDSketch.makeForStats()` to 2048 bins (max ~16 KB per
+/// sketch), so a fully saturated group caps at roughly 32 KB of sketch memory.
 internal final class GroupedStats {
     var hits: Double = 0
     var topLevelHits: Double = 0
     var errors: Double = 0
     var duration: Double = 0
+    var okSummary: DDSketch = .makeForStats()
+    var errorSummary: DDSketch = .makeForStats()
     /// Peer tags stored as `"key:value"` pairs for export, matching Go's `matchingPeerTags`.
     let peerTags: [String]
 
     init(peerTags: [String]) {
         self.peerTags = peerTags
+    }
+
+    /// Absorbs a single span into the group: bumps the relevant counters and adds the
+    /// span's duration (in nanoseconds) to the matching latency sketch.
+    func update(with snapshot: SpanSnapshot) {
+        let durationDouble = Double(snapshot.duration)
+
+        hits += 1
+        duration += durationDouble
+        if snapshot.isTopLevel {
+            topLevelHits += 1
+        }
+        if snapshot.isError {
+            errors += 1
+            errorSummary.add(durationDouble)
+        } else {
+            okSummary.add(durationDouble)
+        }
     }
 }
 
@@ -217,15 +246,7 @@ internal final class StatsConcentrator: @unchecked Sendable {
             let bucket = buckets[bucketKey, default: StatsBucket(start: bucketKey, duration: bucketDuration)]
 
             let group = bucket.groups[aggregationKey, default: GroupedStats(peerTags: peerTagStrings)]
-
-            group.hits += 1
-            if snapshot.isError {
-                group.errors += 1
-            }
-            group.duration += Double(snapshot.duration)
-            if snapshot.isTopLevel {
-                group.topLevelHits += 1
-            }
+            group.update(with: snapshot)
 
             bucket.groups[aggregationKey] = group
             buckets[bucketKey] = bucket
@@ -266,8 +287,8 @@ internal final class StatsConcentrator: @unchecked Sendable {
                         errors: StatsUtils.stochasticRound(group.errors),
                         duration: StatsUtils.stochasticRound(group.duration),
                         topLevelHits: StatsUtils.stochasticRound(group.topLevelHits),
-                        okSummary: Data(),
-                        errorSummary: Data(),
+                        okSummary: group.okSummary.toProtoBytes(),
+                        errorSummary: group.errorSummary.toProtoBytes(),
                         peerTags: group.peerTags,
                         serviceSource: key.serviceSource
                     )

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -546,10 +546,35 @@ class StatsConcentratorTests: XCTestCase {
         XCTAssertEqual(buckets[0].duration, bucketDuration)
     }
 
-    func testExportedGroupedStatsHasEmptySketchPlaceholders() {
+    // MARK: - Latency Sketches
+
+    func testOkSpanPopulatesOkSummaryNotErrorSummary() {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
+            isError: false,
+            startTime: 0,
+            duration: 1_000_000_000, // 1s
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+
+        // An empty DDSketch encodes only the mapping field (11 bytes); a sketch
+        // that has recorded at least one value also encodes a positive store.
+        // The ok summary must therefore be longer than the empty (mapping-only)
+        // baseline, and the error summary must be exactly the baseline.
+        let emptySketchBytes = DDSketch.makeForStats().toProtoBytes()
+        XCTAssertGreaterThan(stats.okSummary.count, emptySketchBytes.count)
+        XCTAssertEqual(stats.errorSummary, emptySketchBytes)
+    }
+
+    func testErrorSpanPopulatesErrorSummaryNotOkSummary() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            isError: true,
             startTime: 0,
             duration: 1_000_000_000,
             isTopLevel: true
@@ -557,8 +582,120 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         let stats = buckets[0].stats[0]
-        XCTAssertEqual(stats.okSummary, Data())
-        XCTAssertEqual(stats.errorSummary, Data())
+
+        let emptySketchBytes = DDSketch.makeForStats().toProtoBytes()
+        XCTAssertEqual(stats.okSummary, emptySketchBytes)
+        XCTAssertGreaterThan(stats.errorSummary.count, emptySketchBytes.count)
+    }
+
+    func testMixedOkAndErrorSpans_populateBothSummaries() {
+        let concentrator = makeConcentrator(now: 0)
+
+        // Two ok spans + one error span, all into the same aggregation group.
+        for _ in 0..<2 {
+            concentrator.add(SpanSnapshot.mockWith(
+                isError: false,
+                startTime: 0,
+                duration: 500_000_000, // 0.5s
+                isTopLevel: true
+            ))
+        }
+        concentrator.add(SpanSnapshot.mockWith(
+            isError: true,
+            startTime: 0,
+            duration: 2_000_000_000, // 2s
+            isTopLevel: true
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+        let stats = buckets[0].stats[0]
+
+        XCTAssertEqual(stats.hits, 3)
+        XCTAssertEqual(stats.errors, 1)
+
+        // Both sketches contain values now, so both must exceed the empty baseline.
+        let emptySketchBytes = DDSketch.makeForStats().toProtoBytes()
+        XCTAssertGreaterThan(stats.okSummary.count, emptySketchBytes.count)
+        XCTAssertGreaterThan(stats.errorSummary.count, emptySketchBytes.count)
+    }
+
+    func testIneligibleSpansDoNotContributeToSummaries() {
+        let concentrator = makeConcentrator(now: 0)
+
+        // Ineligible (not top-level, not measured, no qualifying span_kind).
+        concentrator.add(SpanSnapshot.mockWith(
+            isError: false,
+            startTime: 0,
+            duration: 1_000_000_000,
+            isTopLevel: false,
+            isMeasured: false
+        ))
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty, "ineligible spans must not produce any group")
+    }
+
+    /// Fixture-style cross-check: the bytes emitted for a populated `okSummary` are
+    /// exactly what a `DDSketch` built independently from the same input produces.
+    /// Catches any future regression where the wiring stops feeding the sketch the
+    /// raw `Double(duration)` we expect.
+    func testOkSummaryBytesMatchIndependentlyBuiltSketch() {
+        let concentrator = makeConcentrator(now: 0)
+        let durations: [Nanoseconds] = [100_000_000, 250_000_000, 1_000_000_000, 2_500_000_000]
+
+        for duration in durations {
+            concentrator.add(SpanSnapshot.mockWith(
+                isError: false,
+                startTime: 0,
+                duration: duration,
+                isTopLevel: true
+            ))
+        }
+
+        var reference = DDSketch.makeForStats()
+        for duration in durations {
+            reference.add(Double(duration))
+        }
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        let stats = buckets[0].stats[0]
+        XCTAssertEqual(stats.okSummary, reference.toProtoBytes())
+    }
+
+    /// Two spans with different resources land in two distinct aggregation groups.
+    /// Each group's sketch must reflect only its own span's duration, not the other's.
+    func testDistinctAggregationKeysGetIndependentSketches() {
+        let concentrator = makeConcentrator(now: 0)
+
+        concentrator.add(SpanSnapshot.mockWith(
+            resource: "GET /a",
+            isError: false,
+            startTime: 0,
+            duration: 100_000_000,
+            isTopLevel: true
+        ))
+        concentrator.add(SpanSnapshot.mockWith(
+            resource: "GET /b",
+            isError: false,
+            startTime: 0,
+            duration: 2_000_000_000,
+            isTopLevel: true
+        ))
+
+        var sketchA = DDSketch.makeForStats()
+        sketchA.add(100_000_000)
+        var sketchB = DDSketch.makeForStats()
+        sketchB.add(2_000_000_000)
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+        let allStats = buckets[0].stats
+        XCTAssertEqual(allStats.count, 2)
+
+        let statsByResource = Dictionary(uniqueKeysWithValues: allStats.map { ($0.resource, $0) })
+        XCTAssertEqual(statsByResource["GET /a"]?.okSummary, sketchA.toProtoBytes())
+        XCTAssertEqual(statsByResource["GET /b"]?.okSummary, sketchB.toProtoBytes())
     }
 
     // MARK: - Thread Safety


### PR DESCRIPTION
### What and why?

The `okSummary` and `errorSummary` fields in `ExportedGroupedStats` have been empty `Data()` placeholders since [PR #2871 (StatsConcentrator)](https://github.com/DataDog/dd-sdk-ios/pull/2871), which landed the aggregation pipeline before the DDSketch implementation was ready. Now that [PR #2914 (Add DDSketch implementation for latency distributions)](https://github.com/DataDog/dd-sdk-ios/pull/2914) has merged, this PR plugs DDSketch into the aggregation path so the latency distributions are actually populated when buckets are flushed.

### How?

- `GroupedStats` now owns two `DDSketch` instances, `okSummary` and `errorSummary`, created via `DDSketch.makeForStats()` (1% relative accuracy, 2048 max bins).
- A new `update(with: SpanSnapshot)` method on `GroupedStats` absorbs each span in one place: bumps the relevant counters and routes the duration into exactly one sketch based on `isError`. This replaces the inline mutations that previously sat in `StatsConcentrator.add()`, keeping the per-span state transition local to `GroupedStats`.
- `StatsConcentrator.add()` is now a clean "find or create bucket, find or create group, hand the snapshot to the group".
- `StatsConcentrator.flush()` calls `toProtoBytes()` on each sketch when assembling `ExportedGroupedStats`, replacing the placeholders.

### Tests

Six new tests on `StatsConcentratorTests`:

- `testOkSpanPopulatesOkSummaryNotErrorSummary`: a non-error span produces an `okSummary` larger than the empty-sketch baseline and an `errorSummary` equal to it.
- `testErrorSpanPopulatesErrorSummaryNotOkSummary`: mirror case.
- `testMixedOkAndErrorSpans_populateBothSummaries`: a group that sees both span kinds populates both sketches.
- `testIneligibleSpansDoNotContributeToSummaries`: the eligibility filter still drops non-qualifying spans before any sketch update.
- `testOkSummaryBytesMatchIndependentlyBuiltSketch`: fixture-style cross-check. The emitted bytes are byte-equal to a `DDSketch` built independently from the same input, so any future regression in the wiring shows up here immediately.
- `testDistinctAggregationKeysGetIndependentSketches`: two spans with different resources produce two distinct groups, each carrying its own sketch.

The previous `testExportedGroupedStatsHasEmptySketchPlaceholders` is removed; it asserted the placeholder behavior this PR is replacing.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes. N/A (internal, not user-facing)
- [x] Add Objective-C interface for public APIs. N/A (internal to DatadogTrace)
- [x] Run `make api-surface` when adding new APIs. N/A (internal to DatadogTrace)