### PR TITLE
RUM-16112 Stop overwriting fatal error context view from inactive RUM view scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 
 # 3.11.0 / 12-05-2026
@@ -1147,6 +1148,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2866]: https://github.com/DataDog/dd-sdk-ios/pull/2866
 [#2891]: https://github.com/DataDog/dd-sdk-ios/pull/2891
 [#2859]: https://github.com/DataDog/dd-sdk-ios/pull/2859
+[#2948]: https://github.com/DataDog/dd-sdk-ios/pull/2948
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -679,8 +679,11 @@ extension RUMViewScope {
                 completion: completionHandler
             )
 
-            // Update fatal error context with recent RUM view:
-            dependencies.fatalErrorContext.view = event
+            // Only update fatal error context when this event describes the still-active view,
+            // an inactive view's terminal event must not clobber the active view's pointer.
+            if isActiveView {
+                dependencies.fatalErrorContext.view = event
+            }
 
             // Track this view in Session Ended metric:
             var instrumentationType: InstrumentationType?

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -3745,6 +3745,66 @@ class RUMViewScopeTests: XCTestCase {
         DDAssertReflectionEqual(rumViewWritten, rumViewInFatalErrorContext, "It must update fatal error context with the view event written")
     }
 
+    func testWhenInactiveViewEmitsTerminalEventAfterStopResource_itDoesNotOverwriteFatalErrorContext() throws {
+        // Given
+        let identityA = ViewIdentifier.mockRandomString()
+        let identityB = ViewIdentifier.mockRandomString()
+        let fatalErrorContext = FatalErrorContextNotifierMock()
+        let deps = RUMScopeDependencies.mockWith(fatalErrorContext: fatalErrorContext)
+
+        let scopeA = RUMViewScope(
+            isInitialView: false,
+            parent: parent,
+            dependencies: deps,
+            identity: identityA,
+            path: "ViewControllerA",
+            name: "ViewA",
+            customTimings: [:],
+            startTime: Date(),
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
+        )
+
+        // Step 1: Start View A
+        _ = scopeA.process(command: RUMStartViewCommand.mockWith(identity: identityA), context: context, writer: writer)
+
+        // Step 2: Start a resource on A while it is still active
+        _ = scopeA.process(command: RUMStartResourceCommand.mockWith(resourceKey: "/resource"), context: context, writer: writer)
+
+        // Step 3: Start View B — A becomes inactive but stays alive due to the pending resource
+        let startViewBCommand = RUMStartViewCommand.mockWith(identity: identityB)
+        XCTAssertTrue(
+            scopeA.process(command: startViewBCommand, context: context, writer: writer),
+            "View A must stay alive while '/resource' is pending"
+        )
+        XCTAssertFalse(scopeA.isActiveView, "View A must be inactive after View B starts")
+
+        let scopeB = RUMViewScope(
+            isInitialView: false,
+            parent: parent,
+            dependencies: deps,
+            identity: identityB,
+            path: "ViewControllerB",
+            name: "ViewB",
+            customTimings: [:],
+            startTime: Date(),
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
+        )
+        _ = scopeB.process(command: startViewBCommand, context: context, writer: writer)
+
+        let snapshotForB = try XCTUnwrap(fatalErrorContext.view, "Fatal error context must reflect View B after it starts")
+
+        // Step 4: Stop the resource on A — triggers A's terminal view event (is_active: false, resource.count: 1)
+        _ = scopeA.process(command: RUMStopResourceCommand.mockWith(resourceKey: "/resource"), context: context, writer: writer)
+
+        // Then: fatal error context must still point to View B, not A's terminal event
+        let finalView = try XCTUnwrap(fatalErrorContext.view)
+        DDAssertReflectionEqual(finalView, snapshotForB, "Inactive view's terminal event must not overwrite the active view in fatal error context")
+    }
+
     // MARK: - Tracking Time To Network Settled Metric
 
     func testWhenViewIsStopped_itStopsTrackingTNSMetric() throws {


### PR DESCRIPTION
### What and why?

When a view became inactive (because another view started) but stayed open for a pending resource, the terminal event emitted on `stopResource()` would overwrite `fatalErrorContext.view`, causing crashes to be misattributed to the deactivated view.

### How?

Gates the `fatalErrorContext.view` assignment in `RUMViewScope` on `isActiveView`. Writes to `sessionEndedMetric`, `viewEndedMetric`, and `watchdogTermination` are outside the gate and still fire for every event. The `nil` write in `RUMSessionScope` (which drives the `rum-view-reset` sentinel) is left untouched.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs