### PR TITLE
RUM-4844 Add logger case to RUMErrorSource and DDRUMErrorSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
+- [IMPROVEMENT] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2949][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 - [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
 
@@ -1162,6 +1163,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2948]: https://github.com/DataDog/dd-sdk-ios/pull/2948
 [#2956]: https://github.com/DataDog/dd-sdk-ios/pull/2956
 [#2966]: https://github.com/DataDog/dd-sdk-ios/pull/2966
+[#2949]: https://github.com/DataDog/dd-sdk-ios/pull/2949
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [IMPROVEMENT] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2949][]
+- [FIX] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2952][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 - [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
 
@@ -1164,6 +1165,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2956]: https://github.com/DataDog/dd-sdk-ios/pull/2956
 [#2966]: https://github.com/DataDog/dd-sdk-ios/pull/2966
 [#2949]: https://github.com/DataDog/dd-sdk-ios/pull/2949
+[#2952]: https://github.com/DataDog/dd-sdk-ios/pull/2952
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -305,6 +305,8 @@ public enum objc_RUMErrorSource: Int {
     case webview
     /// Error originated in a web console (used by bridges).
     case console
+    /// Error originated in a logger.
+    case logger
     /// Custom error source.
     case custom
 
@@ -315,6 +317,7 @@ public enum objc_RUMErrorSource: Int {
         case .webview: return .webview
         case .custom: return .custom
         case .console: return .console
+        case .logger: return .logger
         default: return .custom
         }
     }

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -305,10 +305,10 @@ public enum objc_RUMErrorSource: Int {
     case webview
     /// Error originated in a web console (used by bridges).
     case console
-    /// Error originated in a logger.
-    case logger
     /// Custom error source.
     case custom
+    /// Error originated in a logger.
+    case logger
 
     internal var swiftType: RUMErrorSource {
         switch self {

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -88,6 +88,7 @@ internal enum RUMInternalErrorSource: String, Decodable {
         case .network: self = .network
         case .webview: self = .webview
         case .console: self = .console
+        case .logger: self = .logger
         }
     }
 }

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -37,6 +37,8 @@ public enum RUMErrorSource {
     case webview
     /// Error originated in a web console (used by bridges).
     case console
+    /// Error originated in a logger.
+    case logger
     /// Custom error source.
     case custom
 }

--- a/DatadogRUM/Tests/DataModels/RUMDataModelsMappingTests.swift
+++ b/DatadogRUM/Tests/DataModels/RUMDataModelsMappingTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+@_spi(objc)
 @testable import DatadogRUM
 
 private protocol RUMDataFormatConvertible {
@@ -90,6 +91,7 @@ class RUMInternalDataModelsMappingTests: XCTestCase {
             case .source: XCTAssertEqual(internalSource, .source)
             case .webview: XCTAssertEqual(internalSource, .webview)
             case .console: XCTAssertEqual(internalSource, .console)
+            case .logger: XCTAssertEqual(internalSource, .logger)
             }
         }
         // verify all known cases
@@ -98,5 +100,10 @@ class RUMInternalDataModelsMappingTests: XCTestCase {
         verifyErrorSource(.source)
         verifyErrorSource(.webview)
         verifyErrorSource(.console)
+        verifyErrorSource(.logger)
+    }
+
+    func testObjcRUMErrorSourceLoggerMapsToSwiftLogger() {
+        XCTAssertEqual(objc_RUMErrorSource.logger.swiftType, .logger)
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3357,6 +3357,7 @@ public enum objc_RUMErrorSource: Int
     case network
     case webview
     case console
+    case logger
     case custom
 public enum objc_RUMActionType: Int
     case tap

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3357,8 +3357,8 @@ public enum objc_RUMErrorSource: Int
     case network
     case webview
     case console
-    case logger
     case custom
+    case logger
 public enum objc_RUMActionType: Int
     case tap
     case scroll

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -588,7 +588,6 @@ public protocol CrashReportingPlugin: AnyObject
 
 public enum WebViewTracking
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
-    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -521,6 +521,7 @@ public enum RUMErrorSource
     case network
     case webview
     case console
+    case logger
     case custom
 public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject
     func addAttribute(forKey key: AttributeKey, value: AttributeValue)
@@ -587,6 +588,7 @@ public protocol CrashReportingPlugin: AnyObject
 
 public enum WebViewTracking
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter


### PR DESCRIPTION
### What and why?

Adds a `logger` case to the public `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) enums. The underlying RUM data model and internal `RUMInternalErrorSource` already support `logger`, but it was unreachable from the public API. This unblocks RUM-4845, which wires the case through the `dd-sdk-kotlin-multiplatform` iOS source set so KMP consumers can attribute logger-sourced errors correctly.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs