### PR TITLE
Lowercase the ID returned from currentSessionID

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -229,7 +229,7 @@ extension Monitor: RUMMonitorProtocol {
 
             var sessionIdValue: String? = nil
             if activeSession.sampler.isSampled, activeSession.sessionUUID != .nullUUID {
-                sessionIdValue = activeSession.sessionUUID.rawValue.uuidString
+                sessionIdValue = activeSession.sessionUUID.rawValue.uuidString.lowercased()
             }
 
             completion(sessionIdValue)


### PR DESCRIPTION
### What and why?

Filtering in DataDog is case sensitive. The `currentSessionID` is returned as all caps, while elsewhere internally it is consistently lowercased. This PR ensures the String returned by `currentSessionID` is lowercased.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
