### PR TITLE
RUM-4288 Add instanceName overloads to Obj-C API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [FIX] Expose RUM operation options to Objective-C from `DatadogRUM`. See [#2969][]
+- [IMPROVEMENT] Add Objective-C API support for custom SDK instance names across all modules. See [#2955][]
 
 # 3.11.1 / 28-05-2026
 
@@ -1173,6 +1174,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2968]: https://github.com/DataDog/dd-sdk-ios/pull/2968
 [#2969]: https://github.com/DataDog/dd-sdk-ios/pull/2969
 [#2963]: https://github.com/DataDog/dd-sdk-ios/pull/2963
+[#2955]: https://github.com/DataDog/dd-sdk-ios/pull/2955
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Sources/Datadog+objc.swift
+++ b/DatadogCore/Sources/Datadog+objc.swift
@@ -79,80 +79,80 @@ public final class objc_Datadog: NSObject {
         Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes)
     }
 
-    public static func setUserInfo(userId: String, instanceName: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:]) {
-        Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    public static func setUserInfo(userId: String, instanceName: String?, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:]) {
+        Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func clearUserInfo() {
         Datadog.clearUserInfo()
     }
 
-    public static func clearUserInfo(instanceName: String) {
-        Datadog.clearUserInfo(in: CoreRegistry.instance(named: instanceName))
+    public static func clearUserInfo(instanceName: String?) {
+        Datadog.clearUserInfo(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func addUserExtraInfo(_ extraInfo: [String: Any]) {
         Datadog.addUserExtraInfo(extraInfo.dd.swiftAttributes)
     }
 
-    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String) {
-        Datadog.addUserExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String?) {
+        Datadog.addUserExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:]) {
         Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes)
     }
 
-    public static func setAccountInfo(accountId: String, instanceName: String, name: String? = nil, extraInfo: [String: Any] = [:]) {
-        Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    public static func setAccountInfo(accountId: String, instanceName: String?, name: String? = nil, extraInfo: [String: Any] = [:]) {
+        Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func addAccountExtraInfo(_ extraInfo: [String: Any]) {
         Datadog.addAccountExtraInfo(extraInfo.dd.swiftAttributes)
     }
 
-    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String) {
-        Datadog.addAccountExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String?) {
+        Datadog.addAccountExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func clearAccountInfo() {
         Datadog.clearAccountInfo()
     }
 
-    public static func clearAccountInfo(instanceName: String) {
-        Datadog.clearAccountInfo(in: CoreRegistry.instance(named: instanceName))
+    public static func clearAccountInfo(instanceName: String?) {
+        Datadog.clearAccountInfo(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func setTrackingConsent(consent: objc_TrackingConsent) {
         Datadog.set(trackingConsent: consent.sdkConsent)
     }
 
-    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String) {
-        Datadog.set(trackingConsent: consent.sdkConsent, in: CoreRegistry.instance(named: instanceName))
+    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String?) {
+        Datadog.set(trackingConsent: consent.sdkConsent, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func isInitialized() -> Bool {
         return Datadog.isInitialized()
     }
 
-    public static func isInitialized(instanceName: String) -> Bool {
-        return Datadog.isInitialized(instanceName: instanceName)
+    public static func isInitialized(instanceName: String?) -> Bool {
+        return Datadog.isInitialized(instanceName: instanceName ?? CoreRegistry.defaultInstanceName)
     }
 
     public static func stopInstance() {
         Datadog.stopInstance()
     }
 
-    public static func stopInstance(instanceName: String) {
-        Datadog.stopInstance(named: instanceName)
+    public static func stopInstance(instanceName: String?) {
+        Datadog.stopInstance(named: instanceName ?? CoreRegistry.defaultInstanceName)
     }
 
     public static func clearAllData() {
         Datadog.clearAllData()
     }
 
-    public static func clearAllData(instanceName: String) {
-        Datadog.clearAllData(in: CoreRegistry.instance(named: instanceName))
+    public static func clearAllData(instanceName: String?) {
+        Datadog.clearAllData(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
@@ -160,8 +160,8 @@ public final class objc_Datadog: NSObject {
         Datadog.flushAndDeinitialize()
     }
 
-    public static func flushAndDeinitialize(instanceName: String) {
-        Datadog.flushAndDeinitialize(instanceName: instanceName)
+    public static func flushAndDeinitialize(instanceName: String?) {
+        Datadog.flushAndDeinitialize(instanceName: instanceName ?? CoreRegistry.defaultInstanceName)
     }
 #endif
 }

--- a/DatadogCore/Sources/Datadog+objc.swift
+++ b/DatadogCore/Sources/Datadog+objc.swift
@@ -43,6 +43,18 @@ public final class objc_Datadog: NSObject {
         )
     }
 
+    public static func initialize(
+        configuration: objc_Configuration,
+        trackingConsent: objc_TrackingConsent,
+        instanceName: String
+    ) {
+        Datadog.initialize(
+            with: configuration.sdkConfiguration,
+            trackingConsent: trackingConsent.sdkConsent,
+            instanceName: instanceName
+        )
+    }
+
     public static func setVerbosityLevel(_ verbosityLevel: objc_CoreLoggerLevel) {
         switch verbosityLevel {
         case .debug: Datadog.verbosityLevel = .debug
@@ -67,45 +79,89 @@ public final class objc_Datadog: NSObject {
         Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes)
     }
 
+    public static func setUserInfo(userId: String, instanceName: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:]) {
+        Datadog.setUserInfo(id: userId, name: name, email: email, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func clearUserInfo() {
         Datadog.clearUserInfo()
+    }
+
+    public static func clearUserInfo(instanceName: String) {
+        Datadog.clearUserInfo(in: CoreRegistry.instance(named: instanceName))
     }
 
     public static func addUserExtraInfo(_ extraInfo: [String: Any]) {
         Datadog.addUserExtraInfo(extraInfo.dd.swiftAttributes)
     }
 
+    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String) {
+        Datadog.addUserExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:]) {
         Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes)
+    }
+
+    public static func setAccountInfo(accountId: String, instanceName: String, name: String? = nil, extraInfo: [String: Any] = [:]) {
+        Datadog.setAccountInfo(id: accountId, name: name, extraInfo: extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
     }
 
     public static func addAccountExtraInfo(_ extraInfo: [String: Any]) {
         Datadog.addAccountExtraInfo(extraInfo.dd.swiftAttributes)
     }
 
+    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String) {
+        Datadog.addAccountExtraInfo(extraInfo.dd.swiftAttributes, in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func clearAccountInfo() {
         Datadog.clearAccountInfo()
+    }
+
+    public static func clearAccountInfo(instanceName: String) {
+        Datadog.clearAccountInfo(in: CoreRegistry.instance(named: instanceName))
     }
 
     public static func setTrackingConsent(consent: objc_TrackingConsent) {
         Datadog.set(trackingConsent: consent.sdkConsent)
     }
 
+    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String) {
+        Datadog.set(trackingConsent: consent.sdkConsent, in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func isInitialized() -> Bool {
         return Datadog.isInitialized()
+    }
+
+    public static func isInitialized(instanceName: String) -> Bool {
+        return Datadog.isInitialized(instanceName: instanceName)
     }
 
     public static func stopInstance() {
         Datadog.stopInstance()
     }
 
+    public static func stopInstance(instanceName: String) {
+        Datadog.stopInstance(named: instanceName)
+    }
+
     public static func clearAllData() {
         Datadog.clearAllData()
+    }
+
+    public static func clearAllData(instanceName: String) {
+        Datadog.clearAllData(in: CoreRegistry.instance(named: instanceName))
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
     public static func flushAndDeinitialize() {
         Datadog.flushAndDeinitialize()
+    }
+
+    public static func flushAndDeinitialize(instanceName: String) {
+        Datadog.flushAndDeinitialize(instanceName: instanceName)
     }
 #endif
 }

--- a/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
+++ b/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
@@ -103,4 +103,12 @@ public final class objc_URLSessionInstrumentation: NSObject {
     public static func disable(delegateClass: URLSessionDataDelegate.Type) {
         URLSessionInstrumentation.disable(delegateClass: delegateClass)
     }
+
+    /// Disables URLSession instrumentation on a named SDK instance.
+    /// - Parameters:
+    ///   - delegateClass: The delegate class to unbind.
+    ///   - instanceName: The name of the SDK instance to disable.
+    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String) {
+        URLSessionInstrumentation.disable(delegateClass: delegateClass, in: CoreRegistry.instance(named: instanceName))
+    }
 }

--- a/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
+++ b/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
@@ -69,6 +69,15 @@ public final class objc_URLSessionInstrumentation: NSObject {
         URLSessionInstrumentation.enableDurationBreakdown(with: configuration.swiftConfig)
     }
 
+    /// Enables duration breakdown capture for URLSession tasks on a named SDK instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: Configuration of the feature.
+    ///   - instanceName: The name of the SDK instance to use.
+    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String) {
+        URLSessionInstrumentation.enableDurationBreakdown(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    }
+
     /// Enables URLSession instrumentation.
     ///
     /// - Parameters:
@@ -76,6 +85,16 @@ public final class objc_URLSessionInstrumentation: NSObject {
     @available(*, deprecated, renamed: "enableDurationBreakdown(with:)", message: "Use enableDurationBreakdown(with:) instead.")
     public static func enable(configuration: objc_URLSessionInstrumentationConfiguration) {
         URLSessionInstrumentation.enable(with: configuration.swiftConfig)
+    }
+
+    /// Enables URLSession instrumentation on a named SDK instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: Configuration of the feature.
+    ///   - instanceName: The name of the SDK instance to use.
+    @available(*, deprecated, renamed: "enableDurationBreakdown(with:instanceName:)", message: "Use enableDurationBreakdown(with:instanceName:) instead.")
+    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String) {
+        URLSessionInstrumentation.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
     }
 
     /// Disables URLSession instrumentation.

--- a/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
+++ b/DatadogCore/Sources/NetworkInstrumentation/URLSessionInstrumentation+objc.swift
@@ -74,8 +74,8 @@ public final class objc_URLSessionInstrumentation: NSObject {
     /// - Parameters:
     ///   - configuration: Configuration of the feature.
     ///   - instanceName: The name of the SDK instance to use.
-    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String) {
-        URLSessionInstrumentation.enableDurationBreakdown(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String?) {
+        URLSessionInstrumentation.enableDurationBreakdown(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     /// Enables URLSession instrumentation.
@@ -93,8 +93,8 @@ public final class objc_URLSessionInstrumentation: NSObject {
     ///   - configuration: Configuration of the feature.
     ///   - instanceName: The name of the SDK instance to use.
     @available(*, deprecated, renamed: "enableDurationBreakdown(with:instanceName:)", message: "Use enableDurationBreakdown(with:instanceName:) instead.")
-    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String) {
-        URLSessionInstrumentation.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String?) {
+        URLSessionInstrumentation.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     /// Disables URLSession instrumentation.
@@ -108,7 +108,7 @@ public final class objc_URLSessionInstrumentation: NSObject {
     /// - Parameters:
     ///   - delegateClass: The delegate class to unbind.
     ///   - instanceName: The name of the SDK instance to disable.
-    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String) {
-        URLSessionInstrumentation.disable(delegateClass: delegateClass, in: CoreRegistry.instance(named: instanceName))
+    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String?) {
+        URLSessionInstrumentation.disable(delegateClass: delegateClass, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 }

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDDatadog+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDDatadog+apiTests.m
@@ -43,6 +43,27 @@
     [DDDatadog stopInstance];
 }
 
+- (void)testDDDatadogInstanceNameAPI {
+    NSString *instanceName = @"test-instance";
+    DDConfiguration *configuration = [[DDConfiguration alloc] initWithClientToken:@"abc" env:@"def"];
+
+    [DDDatadog initializeWithConfiguration:configuration trackingConsent:[DDTrackingConsent notGranted] instanceName:instanceName];
+
+    XCTAssertTrue([DDDatadog isInitializedWithInstanceName:instanceName]);
+
+    [DDDatadog setUserInfoWithUserId:@"user-id" instanceName:instanceName name:@"name" email:@"email" extraInfo:@{}];
+    [DDDatadog addUserExtraInfo:@{} instanceName:instanceName];
+    [DDDatadog clearUserInfoWithInstanceName:instanceName];
+
+    [DDDatadog setAccountInfoWithAccountId:@"account-id" instanceName:instanceName name:@"name" extraInfo:@{}];
+    [DDDatadog addAccountExtraInfo:@{} instanceName:instanceName];
+    [DDDatadog clearAccountInfoWithInstanceName:instanceName];
+
+    [DDDatadog setTrackingConsentWithConsent:[DDTrackingConsent notGranted] instanceName:instanceName];
+    [DDDatadog clearAllDataWithInstanceName:instanceName];
+    [DDDatadog stopInstanceWithInstanceName:instanceName];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDLogs+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDLogs+apiTests.m
@@ -36,7 +36,7 @@
 - (void)testDDLogsInstanceNameAPI {
     NSString *instanceName = @"logs-test-instance";
     DDLogsConfiguration *config = [[DDLogsConfiguration alloc] init];
-    [DDLogs enableWithInstanceName:instanceName with:config];
+    [DDLogs enableWith:config instanceName:instanceName];
 
     [DDLogs addAttributeForKey:@"key1" value:@"value" instanceName:instanceName];
     [DDLogs removeAttributeForKey:@"key1" instanceName:instanceName];
@@ -45,7 +45,7 @@
 - (void)testDDLoggerInstanceNameAPI {
     NSString *instanceName = @"logger-test-instance";
     DDLoggerConfiguration *config = [[DDLoggerConfiguration alloc] init];
-    DDLogger *logger = [DDLogger createWithInstanceName:instanceName with:config];
+    DDLogger *logger = [DDLogger createWith:config instanceName:instanceName];
     [logger debug:@"debug"];
 }
 

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDLogs+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDLogs+apiTests.m
@@ -33,6 +33,22 @@
     [DDLogs removeAttributeForKey:@"keyNotAdded"];
 }
 
+- (void)testDDLogsInstanceNameAPI {
+    NSString *instanceName = @"logs-test-instance";
+    DDLogsConfiguration *config = [[DDLogsConfiguration alloc] init];
+    [DDLogs enableWithInstanceName:instanceName with:config];
+
+    [DDLogs addAttributeForKey:@"key1" value:@"value" instanceName:instanceName];
+    [DDLogs removeAttributeForKey:@"key1" instanceName:instanceName];
+}
+
+- (void)testDDLoggerInstanceNameAPI {
+    NSString *instanceName = @"logger-test-instance";
+    DDLoggerConfiguration *config = [[DDLoggerConfiguration alloc] init];
+    DDLogger *logger = [DDLogger createWithInstanceName:instanceName with:config];
+    [logger debug:@"debug"];
+}
+
 - (void)testDDLogsConfigurationAPI {
     DDLogsConfiguration *config = [[DDLogsConfiguration alloc] initWithCustomEndpoint:nil];
 

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
@@ -80,6 +80,14 @@
     [DDRUM enableWith:config];
 }
 
+- (void)testDDRUMInstanceNameAPI {
+    DDRUMConfiguration *config = [[DDRUMConfiguration alloc] initWithApplicationID:@"app-id"];
+    NSString *instanceName = @"rum-test-instance";
+    [DDRUM enableWith:config instanceName:instanceName];
+    DDRUMMonitor *monitor = [DDRUMMonitor sharedWithInstanceName:instanceName];
+    (void)monitor;
+}
+
 - (void)testDDRUMConfigurationAPI {
     DDRUMConfiguration *config = [[DDRUMConfiguration alloc] initWithApplicationID:@"app-id"];
     XCTAssertEqual(config.applicationID, @"app-id");

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDSessionReplay+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDSessionReplay+apiTests.m
@@ -37,6 +37,18 @@
     [DDSessionReplay stopRecording];
 }
 
+- (void)testSessionReplayInstanceNameAPI {
+    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100
+                                                                                        textAndInputPrivacyLevel:DDTextAndInputPrivacyLevelMaskAll
+                                                                                               imagePrivacyLevel:DDImagePrivacyLevelMaskNone
+                                                                                               touchPrivacyLevel:DDTouchPrivacyLevelShow
+                                                                                                    featureFlags:nil];
+    NSString *instanceName = @"sr-test-instance";
+    [DDSessionReplay enableWith:configuration instanceName:instanceName];
+    [DDSessionReplay startRecordingWithInstanceName:instanceName];
+    [DDSessionReplay stopRecordingWithInstanceName:instanceName];
+}
+
 - (void)testStartRecordingImmediately {
     DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100
                                                                                         textAndInputPrivacyLevel:DDTextAndInputPrivacyLevelMaskAll

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDTrace+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDTrace+apiTests.m
@@ -24,6 +24,14 @@
     [DDTrace enableWith:config];
 }
 
+- (void)testDDTraceInstanceNameAPI {
+    DDTraceConfiguration *config = [[DDTraceConfiguration alloc] init];
+    NSString *instanceName = @"trace-test-instance";
+    [DDTrace enableWith:config instanceName:instanceName];
+    id<OTTracer> tracer = [DDTracer sharedWithInstanceName:instanceName];
+    (void)tracer;
+}
+
 - (void)testDDTraceConfigurationAPI {
     DDTraceConfiguration *config = [[DDTraceConfiguration alloc] init];
 

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDURLSessionInstrumentationTests+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDURLSessionInstrumentationTests+apiTests.m
@@ -63,6 +63,13 @@
     [DDURLSessionInstrumentation disableWithDelegateClass:[MockDelegate class]];
 }
 
+- (void)testURLSessionInstrumentationInstanceNameAPI {
+    DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[MockDelegate class]];
+    NSString *instanceName = @"urlsession-test-instance";
+    [DDURLSessionInstrumentation enableDurationBreakdownWith:config instanceName:instanceName];
+    [DDURLSessionInstrumentation disableWithDelegateClass:[MockDelegate class]];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDURLSessionInstrumentationTests+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDURLSessionInstrumentationTests+apiTests.m
@@ -67,7 +67,7 @@
     DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[MockDelegate class]];
     NSString *instanceName = @"urlsession-test-instance";
     [DDURLSessionInstrumentation enableDurationBreakdownWith:config instanceName:instanceName];
-    [DDURLSessionInstrumentation disableWithDelegateClass:[MockDelegate class]];
+    [DDURLSessionInstrumentation disableWithDelegateClass:[MockDelegate class] instanceName:instanceName];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDWebViewTracking+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDWebViewTracking+apiTests.m
@@ -40,6 +40,17 @@
     [DDWebViewTracking disableWithWebView:webView];
 }
 
+- (void)testDDWebViewTrackingInstanceNameAPI {
+    WebViewMock *webView = [WebViewMock new];
+    NSString *instanceName = @"webview-test-instance";
+    [DDWebViewTracking enableWithWebView:webView
+                            instanceName:instanceName
+                                   hosts:[NSSet<NSString*> setWithArray:@[@"host1.com"]]
+                          logsSampleRate:100.0
+    ];
+    [DDWebViewTracking disableWithWebView:webView];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/DatadogLogs/Sources/Logs+objc.swift
+++ b/DatadogLogs/Sources/Logs+objc.swift
@@ -92,7 +92,7 @@ public final class objc_Logs: NSObject {
         Logs.enable(with: configuration.configuration)
     }
 
-    public static func enable(instanceName: String, with configuration: objc_LogsConfiguration = .init()) {
+    public static func enable(with configuration: objc_LogsConfiguration, instanceName: String) {
         Logs.enable(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName))
     }
 
@@ -347,7 +347,7 @@ public final class objc_Logger: NSObject {
         return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration))
     }
 
-    public static func create(instanceName: String, with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger {
+    public static func create(with configuration: objc_LoggerConfiguration, instanceName: String) -> objc_Logger {
         return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName)))
     }
 }

--- a/DatadogLogs/Sources/Logs+objc.swift
+++ b/DatadogLogs/Sources/Logs+objc.swift
@@ -92,24 +92,24 @@ public final class objc_Logs: NSObject {
         Logs.enable(with: configuration.configuration)
     }
 
-    public static func enable(with configuration: objc_LogsConfiguration, instanceName: String) {
-        Logs.enable(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName))
+    public static func enable(with configuration: objc_LogsConfiguration, instanceName: String?) {
+        Logs.enable(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func addAttribute(forKey key: String, value: Any) {
         Logs.addAttribute(forKey: key, value: AnyEncodable(value))
     }
 
-    public static func addAttribute(forKey key: String, value: Any, instanceName: String) {
-        Logs.addAttribute(forKey: key, value: AnyEncodable(value), in: CoreRegistry.instance(named: instanceName))
+    public static func addAttribute(forKey key: String, value: Any, instanceName: String?) {
+        Logs.addAttribute(forKey: key, value: AnyEncodable(value), in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     public static func removeAttribute(forKey key: String) {
         Logs.removeAttribute(forKey: key)
     }
 
-    public static func removeAttribute(forKey key: String, instanceName: String) {
-        Logs.removeAttribute(forKey: key, in: CoreRegistry.instance(named: instanceName))
+    public static func removeAttribute(forKey key: String, instanceName: String?) {
+        Logs.removeAttribute(forKey: key, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 }
 
@@ -347,8 +347,8 @@ public final class objc_Logger: NSObject {
         return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration))
     }
 
-    public static func create(with configuration: objc_LoggerConfiguration, instanceName: String) -> objc_Logger {
-        return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName)))
+    public static func create(with configuration: objc_LoggerConfiguration, instanceName: String?) -> objc_Logger {
+        return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)))
     }
 }
 

--- a/DatadogLogs/Sources/Logs+objc.swift
+++ b/DatadogLogs/Sources/Logs+objc.swift
@@ -92,12 +92,24 @@ public final class objc_Logs: NSObject {
         Logs.enable(with: configuration.configuration)
     }
 
+    public static func enable(instanceName: String, with configuration: objc_LogsConfiguration = .init()) {
+        Logs.enable(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func addAttribute(forKey key: String, value: Any) {
         Logs.addAttribute(forKey: key, value: AnyEncodable(value))
     }
 
+    public static func addAttribute(forKey key: String, value: Any, instanceName: String) {
+        Logs.addAttribute(forKey: key, value: AnyEncodable(value), in: CoreRegistry.instance(named: instanceName))
+    }
+
     public static func removeAttribute(forKey key: String) {
         Logs.removeAttribute(forKey: key)
+    }
+
+    public static func removeAttribute(forKey key: String, instanceName: String) {
+        Logs.removeAttribute(forKey: key, in: CoreRegistry.instance(named: instanceName))
     }
 }
 
@@ -333,6 +345,10 @@ public final class objc_Logger: NSObject {
 
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger {
         return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration))
+    }
+
+    public static func create(instanceName: String, with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger {
+        return objc_Logger(sdkLogger: Logger.create(with: configuration.configuration, in: CoreRegistry.instance(named: instanceName)))
     }
 }
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -732,6 +732,10 @@ public class objc_RUM: NSObject {
     public static func enable(with configuration: objc_RUMConfiguration) {
         RUM.enable(with: configuration.swiftConfig)
     }
+
+    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String) {
+        RUM.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    }
 }
 
 @objc(DDRUMMonitor)
@@ -750,6 +754,10 @@ public class objc_RUMMonitor: NSObject {
 
     public static func shared() -> objc_RUMMonitor {
         objc_RUMMonitor(swiftRUMMonitor: RUMMonitor.shared())
+    }
+
+    public static func shared(instanceName: String) -> objc_RUMMonitor {
+        objc_RUMMonitor(swiftRUMMonitor: RUMMonitor.shared(in: CoreRegistry.instance(named: instanceName)))
     }
 
     public func currentSessionID(completion: @escaping (String?) -> Void) {

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -733,8 +733,8 @@ public class objc_RUM: NSObject {
         RUM.enable(with: configuration.swiftConfig)
     }
 
-    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String) {
-        RUM.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String?) {
+        RUM.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 }
 
@@ -756,8 +756,8 @@ public class objc_RUMMonitor: NSObject {
         objc_RUMMonitor(swiftRUMMonitor: RUMMonitor.shared())
     }
 
-    public static func shared(instanceName: String) -> objc_RUMMonitor {
-        objc_RUMMonitor(swiftRUMMonitor: RUMMonitor.shared(in: CoreRegistry.instance(named: instanceName)))
+    public static func shared(instanceName: String?) -> objc_RUMMonitor {
+        objc_RUMMonitor(swiftRUMMonitor: RUMMonitor.shared(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)))
     }
 
     public func currentSessionID(completion: @escaping (String?) -> Void) {

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -35,8 +35,8 @@ public final class objc_SessionReplay: NSObject {
     ///   - configuration: Configuration of the feature.
     ///   - instanceName: The name of the SDK instance to enable Session Replay on.
     @objc
-    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String) {
-        SessionReplay.enable(with: configuration._swift, in: CoreRegistry.instance(named: instanceName))
+    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String?) {
+        SessionReplay.enable(with: configuration._swift, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     /// Starts the recording manually.
@@ -47,8 +47,8 @@ public final class objc_SessionReplay: NSObject {
 
     /// Starts the recording manually on a named SDK instance.
     @objc
-    public static func startRecording(instanceName: String) {
-        SessionReplay.startRecording(in: CoreRegistry.instance(named: instanceName))
+    public static func startRecording(instanceName: String?) {
+        SessionReplay.startRecording(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 
     /// Stops the recording manually.
@@ -59,8 +59,8 @@ public final class objc_SessionReplay: NSObject {
 
     /// Stops the recording manually on a named SDK instance.
     @objc
-    public static func stopRecording(instanceName: String) {
-        SessionReplay.stopRecording(in: CoreRegistry.instance(named: instanceName))
+    public static func stopRecording(instanceName: String?) {
+        SessionReplay.stopRecording(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 }
 

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -29,16 +29,38 @@ public final class objc_SessionReplay: NSObject {
         SessionReplay.enable(with: configuration._swift)
     }
 
+    /// Enables Datadog Session Replay feature on a named SDK instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: Configuration of the feature.
+    ///   - instanceName: The name of the SDK instance to enable Session Replay on.
+    @objc
+    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String) {
+        SessionReplay.enable(with: configuration._swift, in: CoreRegistry.instance(named: instanceName))
+    }
+
     /// Starts the recording manually.
     @objc
     public static func startRecording() {
         SessionReplay.startRecording(in: CoreRegistry.default)
     }
 
+    /// Starts the recording manually on a named SDK instance.
+    @objc
+    public static func startRecording(instanceName: String) {
+        SessionReplay.startRecording(in: CoreRegistry.instance(named: instanceName))
+    }
+
     /// Stops the recording manually.
     @objc
     public static func stopRecording() {
         SessionReplay.stopRecording(in: CoreRegistry.default)
+    }
+
+    /// Stops the recording manually on a named SDK instance.
+    @objc
+    public static func stopRecording(instanceName: String) {
+        SessionReplay.stopRecording(in: CoreRegistry.instance(named: instanceName))
     }
 }
 

--- a/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
+++ b/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
@@ -107,8 +107,8 @@ public final class objc_Trace: NSObject {
         Trace.enable(with: configuration.swiftConfig)
     }
 
-    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String) {
-        Trace.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String?) {
+        Trace.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName))
     }
 }
 
@@ -130,8 +130,8 @@ public final class objc_Tracer: NSObject, objc_OTTracer {
         objc_Tracer(swiftTracer: Tracer.shared())
     }
 
-    public static func shared(instanceName: String) -> objc_OTTracer {
-        objc_Tracer(swiftTracer: Tracer.shared(in: CoreRegistry.instance(named: instanceName)))
+    public static func shared(instanceName: String?) -> objc_OTTracer {
+        objc_Tracer(swiftTracer: Tracer.shared(in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)))
     }
 
     public func startSpan(_ operationName: String) -> objc_OTSpan {

--- a/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
+++ b/DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift
@@ -106,6 +106,10 @@ public final class objc_Trace: NSObject {
     public static func enable(with configuration: objc_TraceConfiguration) {
         Trace.enable(with: configuration.swiftConfig)
     }
+
+    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String) {
+        Trace.enable(with: configuration.swiftConfig, in: CoreRegistry.instance(named: instanceName))
+    }
 }
 
 @objc(DDTracer)
@@ -124,6 +128,10 @@ public final class objc_Tracer: NSObject, objc_OTTracer {
 
     public static func shared() -> objc_OTTracer {
         objc_Tracer(swiftTracer: Tracer.shared())
+    }
+
+    public static func shared(instanceName: String) -> objc_OTTracer {
+        objc_Tracer(swiftTracer: Tracer.shared(in: CoreRegistry.instance(named: instanceName)))
     }
 
     public func startSpan(_ operationName: String) -> objc_OTSpan {

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -63,10 +63,10 @@ public final class objc_WebViewTracking: NSObject {
     ///
     /// - Parameters:
     ///   - webView: The web-view to track.
+    ///   - instanceName: The name of the SDK instance to use for tracking.
     ///   - hosts: A set of hosts instrumented with Browser SDK to capture Datadog events from.
     ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
     ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
-    ///   - instanceName: The name of the SDK instance to use for tracking.
     @objc
     public static func enable(
         webView: WKWebView,

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -59,6 +59,30 @@ public final class objc_WebViewTracking: NSObject {
         )
     }
 
+    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session
+    /// using wildcard host patterns, on a named SDK instance.
+    ///
+    /// - Parameters:
+    ///   - webView: The web-view to track.
+    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
+    ///   - instanceName: The name of the SDK instance to use for tracking.
+    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
+    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
+    @objc
+    public static func enable(
+        webView: WKWebView,
+        hostPatterns: [String],
+        instanceName: String?,
+        logsSampleRate: SampleRate = .maxSampleRate
+    ) {
+        WebViewTracking.enable(
+            webView: webView,
+            hostPatterns: hostPatterns,
+            logsSampleRate: logsSampleRate,
+            in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)
+        )
+    }
+
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session on a named SDK instance.
     ///
     /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified
@@ -73,7 +97,7 @@ public final class objc_WebViewTracking: NSObject {
     @objc
     public static func enable(
         webView: WKWebView,
-        instanceName: String,
+        instanceName: String?,
         hosts: Set<String> = [],
         logsSampleRate: SampleRate = .maxSampleRate
     ) {
@@ -81,7 +105,7 @@ public final class objc_WebViewTracking: NSObject {
             webView: webView,
             hosts: hosts,
             logsSampleRate: logsSampleRate,
-            in: CoreRegistry.instance(named: instanceName)
+            in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)
         )
     }
 

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -59,6 +59,29 @@ public final class objc_WebViewTracking: NSObject {
         )
     }
 
+    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session on a named SDK instance.
+    ///
+    /// - Parameters:
+    ///   - webView: The web-view to track.
+    ///   - hosts: A set of hosts instrumented with Browser SDK to capture Datadog events from.
+    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
+    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
+    ///   - instanceName: The name of the SDK instance to use for tracking.
+    @objc
+    public static func enable(
+        webView: WKWebView,
+        instanceName: String,
+        hosts: Set<String> = [],
+        logsSampleRate: SampleRate = .maxSampleRate
+    ) {
+        WebViewTracking.enable(
+            webView: webView,
+            hosts: hosts,
+            logsSampleRate: logsSampleRate,
+            in: CoreRegistry.instance(named: instanceName)
+        )
+    }
+
     /// Disables Datadog iOS SDK and Datadog Browser SDK integration.
     ///
     /// Removes Datadog's ScriptMessageHandler and UserScript from the caller.

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -61,6 +61,9 @@ public final class objc_WebViewTracking: NSObject {
 
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session on a named SDK instance.
     ///
+    /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified
+    /// `hosts`, web events will be correlated with the RUM session from native SDK.
+    ///
     /// - Parameters:
     ///   - webView: The web-view to track.
     ///   - instanceName: The name of the SDK instance to use for tracking.

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -12,25 +12,25 @@ public final class objc_Datadog: NSObject
     public static func setVerbosityLevel(_ verbosityLevel: objc_CoreLoggerLevel)
     public static func verbosityLevel() -> objc_CoreLoggerLevel
     public static func setUserInfo(userId: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
-    public static func setUserInfo(userId: String, instanceName: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
+    public static func setUserInfo(userId: String, instanceName: String?, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
     public static func clearUserInfo()
-    public static func clearUserInfo(instanceName: String)
+    public static func clearUserInfo(instanceName: String?)
     public static func addUserExtraInfo(_ extraInfo: [String: Any])
-    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String)
+    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String?)
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:])
-    public static func setAccountInfo(accountId: String, instanceName: String, name: String? = nil, extraInfo: [String: Any] = [:])
+    public static func setAccountInfo(accountId: String, instanceName: String?, name: String? = nil, extraInfo: [String: Any] = [:])
     public static func addAccountExtraInfo(_ extraInfo: [String: Any])
-    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String)
+    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String?)
     public static func clearAccountInfo()
-    public static func clearAccountInfo(instanceName: String)
+    public static func clearAccountInfo(instanceName: String?)
     public static func setTrackingConsent(consent: objc_TrackingConsent)
-    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String)
+    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String?)
     public static func isInitialized() -> Bool
-    public static func isInitialized(instanceName: String) -> Bool
+    public static func isInitialized(instanceName: String?) -> Bool
     public static func stopInstance()
-    public static func stopInstance(instanceName: String)
+    public static func stopInstance(instanceName: String?)
     public static func clearAllData()
-    public static func clearAllData(instanceName: String)
+    public static func clearAllData(instanceName: String?)
 public final class objc_DatadogSite: NSObject
     public static func us1() -> objc_DatadogSite
     public static func us3() -> objc_DatadogSite
@@ -82,11 +82,11 @@ public final class objc_URLSessionInstrumentationFirstPartyHostsTracing: NSObjec
     public init(hosts: Set<String>)
 public final class objc_URLSessionInstrumentation: NSObject
     public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration)
-    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String)
+    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String?)
     public static func enable(configuration: objc_URLSessionInstrumentationConfiguration)
-    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String)
+    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String?)
     public static func disable(delegateClass: URLSessionDataDelegate.Type)
-    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String)
+    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String?)
 
 # ----------------------------------
 # API surface for DatadogLogs:
@@ -106,11 +106,11 @@ public final class objc_LogsConfiguration: NSObject
     public func setEventMapper(_ mapper: @escaping (objc_LogEvent) -> objc_LogEvent?)
 public final class objc_Logs: NSObject
     public static func enable(with configuration: objc_LogsConfiguration = .init())
-    public static func enable(with configuration: objc_LogsConfiguration,instanceName: String)
+    public static func enable(with configuration: objc_LogsConfiguration,instanceName: String?)
     public static func addAttribute(forKey key: String, value: Any)
-    public static func addAttribute(forKey key: String, value: Any, instanceName: String)
+    public static func addAttribute(forKey key: String, value: Any, instanceName: String?)
     public static func removeAttribute(forKey key: String)
-    public static func removeAttribute(forKey key: String, instanceName: String)
+    public static func removeAttribute(forKey key: String, instanceName: String?)
 public final class objc_LoggerConfiguration: NSObject
     public var service: String?
     public var name: String?
@@ -148,7 +148,7 @@ public final class objc_Logger: NSObject
     public func add(tag: String)
     public func remove(tag: String)
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
-    public static func create(with configuration: objc_LoggerConfiguration,instanceName: String) -> objc_Logger
+    public static func create(with configuration: objc_LoggerConfiguration,instanceName: String?) -> objc_Logger
 [?] extension objc_Logger
     public func _internal_sync_critical(message: String,error: Error?,attributes: [String: Any])
 public class objc_LogEvent: NSObject
@@ -354,10 +354,10 @@ public final class objc_TraceURLSessionTracking: NSObject
     public func setRedactedStatusCodes(_ codes: [NSNumber])
 public final class objc_Trace: NSObject
     public static func enable(with configuration: objc_TraceConfiguration)
-    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String)
+    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String?)
 public final class objc_Tracer: NSObject, objc_OTTracer
     public static func shared() -> objc_OTTracer
-    public static func shared(instanceName: String) -> objc_OTTracer
+    public static func shared(instanceName: String?) -> objc_OTTracer
     public func startSpan(_ operationName: String) -> objc_OTSpan
     public func startSpan(_ operationName: String, tags: NSDictionary?) -> objc_OTSpan
     public func startSpan(_ operationName: String, childOf parent: objc_OTSpanContext?) -> objc_OTSpan
@@ -3466,10 +3466,10 @@ public class objc_RUMConfiguration: NSObject
     public var trackAnonymousUser: Bool
 public class objc_RUM: NSObject
     public static func enable(with configuration: objc_RUMConfiguration)
-    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String)
+    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String?)
 public class objc_RUMMonitor: NSObject
     public static func shared() -> objc_RUMMonitor
-    public static func shared(instanceName: String) -> objc_RUMMonitor
+    public static func shared(instanceName: String?) -> objc_RUMMonitor
     public func currentSessionID(completion: @escaping (String?) -> Void)
     public func stopSession()
     public func reportAppFullyDisplayed()
@@ -3524,7 +3524,8 @@ public class objc_RUMMonitor: NSObject
 public final class objc_WebViewTracking: NSObject
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
     public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate)
-    public static func enable(webView: WKWebView,instanceName: String,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
+    public static func enable(webView: WKWebView,hostPatterns: [String],instanceName: String?,logsSampleRate: SampleRate = .maxSampleRate)
+    public static func enable(webView: WKWebView,instanceName: String?,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
     public static func disable(webView: WKWebView)
 
 # ----------------------------------
@@ -3533,11 +3534,11 @@ public final class objc_WebViewTracking: NSObject
 
 public final class objc_SessionReplay: NSObject
     public static func enable(with configuration: objc_SessionReplayConfiguration)
-    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String)
+    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String?)
     public static func startRecording()
-    public static func startRecording(instanceName: String)
+    public static func startRecording(instanceName: String?)
     public static func stopRecording()
-    public static func stopRecording(instanceName: String)
+    public static func stopRecording(instanceName: String?)
 public final class objc_SessionReplayConfiguration: NSObject
     @objc public var replaySampleRate: Float
     @objc public var textAndInputPrivacyLevel: objc_TextAndInputPrivacyLevel

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -86,6 +86,7 @@ public final class objc_URLSessionInstrumentation: NSObject
     public static func enable(configuration: objc_URLSessionInstrumentationConfiguration)
     public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String)
     public static func disable(delegateClass: URLSessionDataDelegate.Type)
+    public static func disable(delegateClass: URLSessionDataDelegate.Type, instanceName: String)
 
 # ----------------------------------
 # API surface for DatadogLogs:

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -105,7 +105,7 @@ public final class objc_LogsConfiguration: NSObject
     public func setEventMapper(_ mapper: @escaping (objc_LogEvent) -> objc_LogEvent?)
 public final class objc_Logs: NSObject
     public static func enable(with configuration: objc_LogsConfiguration = .init())
-    public static func enable(instanceName: String, with configuration: objc_LogsConfiguration = .init())
+    public static func enable(with configuration: objc_LogsConfiguration,instanceName: String)
     public static func addAttribute(forKey key: String, value: Any)
     public static func addAttribute(forKey key: String, value: Any, instanceName: String)
     public static func removeAttribute(forKey key: String)
@@ -147,7 +147,7 @@ public final class objc_Logger: NSObject
     public func add(tag: String)
     public func remove(tag: String)
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
-    public static func create(instanceName: String, with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
+    public static func create(with configuration: objc_LoggerConfiguration,instanceName: String) -> objc_Logger
 [?] extension objc_Logger
     public func _internal_sync_critical(message: String,error: Error?,attributes: [String: Any])
 public class objc_LogEvent: NSObject

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -8,18 +8,29 @@ public final class objc_TrackingConsent: NSObject
     public static func pending() -> objc_TrackingConsent
 public final class objc_Datadog: NSObject
     public static func initialize(configuration: objc_Configuration,trackingConsent: objc_TrackingConsent)
+    public static func initialize(configuration: objc_Configuration,trackingConsent: objc_TrackingConsent,instanceName: String)
     public static func setVerbosityLevel(_ verbosityLevel: objc_CoreLoggerLevel)
     public static func verbosityLevel() -> objc_CoreLoggerLevel
     public static func setUserInfo(userId: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
+    public static func setUserInfo(userId: String, instanceName: String, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
     public static func clearUserInfo()
+    public static func clearUserInfo(instanceName: String)
     public static func addUserExtraInfo(_ extraInfo: [String: Any])
+    public static func addUserExtraInfo(_ extraInfo: [String: Any], instanceName: String)
     public static func setAccountInfo(accountId: String, name: String? = nil, extraInfo: [String: Any] = [:])
+    public static func setAccountInfo(accountId: String, instanceName: String, name: String? = nil, extraInfo: [String: Any] = [:])
     public static func addAccountExtraInfo(_ extraInfo: [String: Any])
+    public static func addAccountExtraInfo(_ extraInfo: [String: Any], instanceName: String)
     public static func clearAccountInfo()
+    public static func clearAccountInfo(instanceName: String)
     public static func setTrackingConsent(consent: objc_TrackingConsent)
+    public static func setTrackingConsent(consent: objc_TrackingConsent, instanceName: String)
     public static func isInitialized() -> Bool
+    public static func isInitialized(instanceName: String) -> Bool
     public static func stopInstance()
+    public static func stopInstance(instanceName: String)
     public static func clearAllData()
+    public static func clearAllData(instanceName: String)
 public final class objc_DatadogSite: NSObject
     public static func us1() -> objc_DatadogSite
     public static func us3() -> objc_DatadogSite
@@ -71,7 +82,9 @@ public final class objc_URLSessionInstrumentationFirstPartyHostsTracing: NSObjec
     public init(hosts: Set<String>)
 public final class objc_URLSessionInstrumentation: NSObject
     public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration)
+    public static func enableDurationBreakdown(with configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String)
     public static func enable(configuration: objc_URLSessionInstrumentationConfiguration)
+    public static func enable(configuration: objc_URLSessionInstrumentationConfiguration, instanceName: String)
     public static func disable(delegateClass: URLSessionDataDelegate.Type)
 
 # ----------------------------------
@@ -92,8 +105,11 @@ public final class objc_LogsConfiguration: NSObject
     public func setEventMapper(_ mapper: @escaping (objc_LogEvent) -> objc_LogEvent?)
 public final class objc_Logs: NSObject
     public static func enable(with configuration: objc_LogsConfiguration = .init())
+    public static func enable(instanceName: String, with configuration: objc_LogsConfiguration = .init())
     public static func addAttribute(forKey key: String, value: Any)
+    public static func addAttribute(forKey key: String, value: Any, instanceName: String)
     public static func removeAttribute(forKey key: String)
+    public static func removeAttribute(forKey key: String, instanceName: String)
 public final class objc_LoggerConfiguration: NSObject
     public var service: String?
     public var name: String?
@@ -131,6 +147,7 @@ public final class objc_Logger: NSObject
     public func add(tag: String)
     public func remove(tag: String)
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
+    public static func create(instanceName: String, with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
 [?] extension objc_Logger
     public func _internal_sync_critical(message: String,error: Error?,attributes: [String: Any])
 public class objc_LogEvent: NSObject
@@ -336,8 +353,10 @@ public final class objc_TraceURLSessionTracking: NSObject
     public func setRedactedStatusCodes(_ codes: [NSNumber])
 public final class objc_Trace: NSObject
     public static func enable(with configuration: objc_TraceConfiguration)
+    public static func enable(with configuration: objc_TraceConfiguration, instanceName: String)
 public final class objc_Tracer: NSObject, objc_OTTracer
     public static func shared() -> objc_OTTracer
+    public static func shared(instanceName: String) -> objc_OTTracer
     public func startSpan(_ operationName: String) -> objc_OTSpan
     public func startSpan(_ operationName: String, tags: NSDictionary?) -> objc_OTSpan
     public func startSpan(_ operationName: String, childOf parent: objc_OTSpanContext?) -> objc_OTSpan
@@ -3446,8 +3465,10 @@ public class objc_RUMConfiguration: NSObject
     public var trackAnonymousUser: Bool
 public class objc_RUM: NSObject
     public static func enable(with configuration: objc_RUMConfiguration)
+    public static func enable(with configuration: objc_RUMConfiguration, instanceName: String)
 public class objc_RUMMonitor: NSObject
     public static func shared() -> objc_RUMMonitor
+    public static func shared(instanceName: String) -> objc_RUMMonitor
     public func currentSessionID(completion: @escaping (String?) -> Void)
     public func stopSession()
     public func reportAppFullyDisplayed()
@@ -3502,6 +3523,7 @@ public class objc_RUMMonitor: NSObject
 public final class objc_WebViewTracking: NSObject
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
     public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate)
+    public static func enable(webView: WKWebView,instanceName: String,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
     public static func disable(webView: WKWebView)
 
 # ----------------------------------
@@ -3510,8 +3532,11 @@ public final class objc_WebViewTracking: NSObject
 
 public final class objc_SessionReplay: NSObject
     public static func enable(with configuration: objc_SessionReplayConfiguration)
+    public static func enable(with configuration: objc_SessionReplayConfiguration, instanceName: String)
     public static func startRecording()
+    public static func startRecording(instanceName: String)
     public static func stopRecording()
+    public static func stopRecording(instanceName: String)
 public final class objc_SessionReplayConfiguration: NSObject
     @objc public var replaySampleRate: Float
     @objc public var textAndInputPrivacyLevel: objc_TextAndInputPrivacyLevel


### PR DESCRIPTION
### What and why?

Adds `instanceName:` parameter overloads to the Objective-C API surface so Obj-C and KMP iOS consumers can initialize and operate on a non-default SDK core instance, achieving parity with the Android SDK and the existing Swift API.

Affected classes: `DDDatadog`, `DDLogs`, `DDLogger`, `DDRUM`, `DDRUMMonitor`, `DDTrace`, `DDTracer`, `DDSessionReplay`, `DDWebViewTracking`, `DDURLSessionInstrumentation`.

### How?

Each new overload accepts a trailing `instanceName: String` parameter, resolves the named core via `CoreRegistry.instance(named:)` and forwards to the same Swift API the existing zero-arg method already calls.

`WebViewTracking.disable(webView:)` and `URLSessionInstrumentation.disable(delegateClass:)` were intentionally left without `instanceName` overloads since their Swift counterparts do not accept `in core:`.

Note: `api-surface-swift` also removes the stale `in core:` entry for `WebViewTracking.disable` — this reflects a pre-existing Swift source change from a prior PR and is correctly cleaned up here.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs