### PR TITLE
chore: Align public RUM session IDs with event formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
+- [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
 
 # 3.11.1 / 28-05-2026
 
@@ -1158,6 +1159,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2944]: https://github.com/DataDog/dd-sdk-ios/pull/2944
 [#2859]: https://github.com/DataDog/dd-sdk-ios/pull/2859
 [#2948]: https://github.com/DataDog/dd-sdk-ios/pull/2948
+[#2956]: https://github.com/DataDog/dd-sdk-ios/pull/2956
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
@@ -1196,3 +1198,4 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [@tdr-alays]: https://github.com/tdr-alays
 [@blimmer]: https://github.com/blimmer
 [@thedavidharris]: https://github.com/thedavidharris
+[@noremac]: https://github.com/noremac

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -120,7 +120,7 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         // Then
         let metric = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent())
         let expectedSessionID = try XCTUnwrap(currentSessionID)
-        XCTAssertEqual(metric.session?.id, expectedSessionID.lowercased())
+        XCTAssertEqual(metric.session?.id, expectedSessionID)
         XCTAssertEqual(metric.attributes?.hasBackgroundEventsTrackingEnabled, rumConfig.trackBackgroundEvents)
     }
 

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -46,8 +46,13 @@ class RUMMonitorTests: XCTestCase {
         let expectation = XCTestExpectation(description: "currentSessionID callback received")
         monitor.currentSessionID { sessionId in
             // Then
-            XCTAssertNotNil(sessionId)
+            guard let sessionId else {
+                XCTFail("Expected a session ID")
+                expectation.fulfill()
+                return
+            }
             XCTAssertEqual(capturedSession, sessionId)
+            XCTAssertEqual(sessionId, sessionId.lowercased())
             expectation.fulfill()
         }
 
@@ -891,6 +896,7 @@ class RUMMonitorTests: XCTestCase {
         config.sessionSampleRate = keepAllSessions ? 100 : 0
         config.onSessionStart = { sessionID, isDiscarded in
             XCTAssertTrue(sessionID.matches(regex: .uuidRegex))
+            XCTAssertEqual(sessionID, sessionID.lowercased())
             XCTAssertEqual(isDiscarded, !keepAllSessions)
             expectation.fulfill()
         }

--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -228,6 +228,7 @@ class DDRUMMonitorTests: XCTestCase {
         waitForExpectations(timeout: 0.5)
         let sessionID = try XCTUnwrap(currentSessionID)
         XCTAssertTrue(sessionID.matches(regex: .uuidRegex))
+        XCTAssertEqual(sessionID, sessionID.lowercased())
     }
 
     func testStoppingSession() throws {

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -127,6 +127,7 @@ RUM.enable(
         
         // Session start callback
         onSessionStart: { sessionId, isDiscarded in
+            // `sessionId` matches the emitted RUM event `session.id`
             print("Session \(sessionId) started, sampled out: \(isDiscarded)")
         },
         

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -112,7 +112,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let onSessionUpdate: RUM.SessionUpdater = { [onSessionStart = configuration.onSessionStart, _rumSessionSampler] sessionScope in
             if let sessionScope {
-                let sessionID = sessionScope.sessionUUID.rawValue.uuidString
+                let sessionID = sessionScope.sessionUUID.toRUMDataFormat
                 let isDiscarded = !sessionScope.sampler.isSampled
                 onSessionStart?(sessionID, isDiscarded)
             }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -277,7 +277,7 @@ extension RUM {
         /// RUM session start callback.
         ///
         /// It takes 2 arguments:
-        /// - Newly started session ID.
+        /// - Newly started session ID, matching the `session.id` field in emitted RUM events.
         /// - Flag indicating whether or not the session was discarded due to the sampling rate.
         /// Keep the implementation fast and do not make any assumptions on the thread that runs this callback.
         ///
@@ -538,7 +538,7 @@ extension RUM.Configuration {
     ///   - actionEventMapper: Custom mapper for RUM action events. Default: `nil`.
     ///   - errorEventMapper: Custom mapper for RUM error events. Default: `nil`.
     ///   - longTaskEventMapper: Custom mapper for RUM long task events. Default: `nil`.
-    ///   - onSessionStart: RUM session start callback. Default: `nil`.
+    ///   - onSessionStart: RUM session start callback receiving a session ID matching emitted RUM event `session.id`. Default: `nil`.
     ///   - customEndpoint: Custom server url for sending RUM data. Default: `nil`.
     ///   - trackAnonymousUser: Enables the collection of anonymous user id across sessions. Default: `true`.
     ///   - trackMemoryWarnings: Enables the collection of memory warnings. Default: `true`.

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -156,10 +156,10 @@ internal class Monitor: RUMCommandSubscriber {
 
                 return RUMCoreContext(
                     applicationID: context.rumApplicationID,
-                    sessionID: context.sessionID.rawValue.uuidString.lowercased(),
+                    sessionID: context.sessionID.toRUMDataFormat,
                     sessionSampler: activeSession.sampler,
-                    viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
-                    userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
+                    viewID: context.activeViewID?.toRUMDataFormat,
+                    userActionID: context.activeUserActionID?.toRUMDataFormat,
                     viewServerTimeOffset: activeSession.viewScopes.last?.serverTimeOffset,
                     viewPath: context.activeViewPath
                 )
@@ -229,7 +229,7 @@ extension Monitor: RUMMonitorProtocol {
 
             var sessionIdValue: String? = nil
             if activeSession.sampler.isSampled, activeSession.sessionUUID != .nullUUID {
-                sessionIdValue = activeSession.sessionUUID.rawValue.uuidString
+                sessionIdValue = activeSession.sessionUUID.toRUMDataFormat
             }
 
             completion(sessionIdValue)

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -71,6 +71,7 @@ public protocol RUMMonitorProtocol: RUMMonitorViewProtocol, AnyObject {
 
     /// Get the currently active session ID. Returns `nil` if no sessions are currently active or if
     /// the current session is sampled out.
+    /// The returned value matches the `session.id` field in emitted RUM events.
     /// This method uses an asynchronous callback to ensure all pending RUM events have been processed
     /// up to the moment of the call.
     /// - Parameters:

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -436,6 +436,7 @@ class RUMTests: XCTestCase {
         config.onSessionStart = { sessionID, isDiscarded in
             // Then
             XCTAssertTrue(sessionID.matches(regex: .uuidRegex))
+            XCTAssertEqual(sessionID, sessionID.lowercased())
             expectation.fulfill()
         }
 


### PR DESCRIPTION
> [!NOTE]
> This PR follows up on the contribution from @noremac in https://github.com/DataDog/dd-sdk-ios/pull/2953.

### What and why?

This PR aligns RUM session IDs exposed by iOS with the canonical RUM data format used in emitted events and core context.

Previously, some public and internal surfaces were building UUID strings directly, while RUM events used the normalized `toRUMDataFormat` representation. That could lead to mismatches when comparing IDs across those paths. This change makes them consistent.

### How?

This PR updates the RUM Monitor and session update flow to use `toRUMDataFormat` when constructing:
- `currentSessionID`
- `onSessionStart`
- `RUMCoreContext`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
