### PR TITLE
Apply EventMapper before SpanSnapshot creation

### DIFF
--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -130,64 +130,18 @@ internal final class DDSpan: OTSpan {
             activity.leave()
         }
 
-        ddTracer.onSpanFinished?(createSnapshot(finishTime: time))
-
-        if self.ddContext.samplingDecision.samplingPriority.isKept {
-            sendSpan(finishTime: time)
-        }
-    }
-
-    // MARK: - Snapshot
-
-    /// Creates a lightweight `SpanSnapshot` capturing the data needed for client-side stats.
-    /// Called before the sampling decision so that all spans contribute to stats.
-    private func createSnapshot(finishTime: Date) -> SpanSnapshot {
-        let tagsReducer = SpanTagsReducer(spanTags: tags, logFields: logFields)
-        let resolvedService = tagsReducer.extractedServiceName ?? eventBuilder.service ?? ""
-        let resolvedResource = tagsReducer.extractedResourceName ?? operationName
-        let resolvedOperationName = tagsReducer.extractedOperationName ?? operationName
-
-        let spanKind: String? = tags[SpanTags.kind] as? String ?? tags[OTTags.spanKind] as? String
-        let httpStatusCode = (tags[OTTags.httpStatusCode] as? Int).flatMap { UInt32(exactly: $0) } ?? 0
-        let isError = tagsReducer.extractedIsError ?? false
-        let isTopLevel = ddContext.parentSpanID == nil || (tags["_dd.top_level"] as? Int == 1)
-        let isMeasured = tags["_dd.measured"] as? Int == 1
-        let serviceSource: String = tags["_dd.svc_src"] as? String ?? ""
-
-        let peerTagKeys = [
-            "peer.service", "db.instance", "db.system",
-            "out.host", "net.peer.name", "server.address"
-        ]
-        var peerTags: [String: String] = [:]
-        for key in peerTagKeys {
-            if let value = tags[key] as? String, !value.isEmpty {
-                peerTags[key] = value
+        if let onSpanFinished = ddTracer.onSpanFinished {
+            // Client-side stats path: build the `SpanEvent` first (which runs the user-configured
+            // `SpanEventMapper`) and derive the `SpanSnapshot` from it, so stats and trace uploads
+            // agree on resource/service/tags. The same event is reused for upload when sampled in,
+            // ensuring the mapper runs exactly once per finished span.
+            buildEventAndDispatch(finishTime: time, onSpanFinished: onSpanFinished)
+        } else {
+            // Stats disabled: original flow, mapper runs only on the sampled-in upload path.
+            if self.ddContext.samplingDecision.samplingPriority.isKept {
+                sendSpan(finishTime: time)
             }
         }
-
-        let startNanos = startTime.timeIntervalSince1970.dd.toNanoseconds
-        let durationNanos = finishTime.timeIntervalSince(startTime).dd.toNanoseconds
-
-        let spanType = tags["span.type"] as? String ?? "custom"
-
-        return SpanSnapshot(
-            traceID: ddContext.traceID,
-            spanID: ddContext.spanID,
-            parentSpanID: ddContext.parentSpanID,
-            service: resolvedService,
-            operationName: resolvedOperationName,
-            resource: resolvedResource,
-            type: spanType,
-            spanKind: spanKind,
-            httpStatusCode: httpStatusCode,
-            isError: isError,
-            startTime: startNanos,
-            duration: durationNanos,
-            isTopLevel: isTopLevel,
-            isMeasured: isMeasured,
-            peerTags: peerTags,
-            serviceSource: serviceSource
-        )
     }
 
     // MARK: - Writing SpanEvent
@@ -213,6 +167,35 @@ internal final class DDSpan: OTSpan {
 
             let envelope = SpanEventsEnvelope(span: event, environment: context.env)
             writer.write(value: envelope)
+        }
+    }
+
+    /// Builds the `SpanEvent` once (running the mapper), delivers the derived `SpanSnapshot`
+    /// to the stats hook, and writes the upload envelope when the span is sampled in.
+    private func buildEventAndDispatch(finishTime: Date, onSpanFinished: @escaping (SpanSnapshot) -> Void) {
+        eventWriter.spanWriteContext { context, writer in
+            let event = self.eventBuilder.createSpanEvent(
+                context: context,
+                traceID: self.ddContext.traceID,
+                spanID: self.ddContext.spanID,
+                parentSpanID: self.ddContext.parentSpanID,
+                operationName: self.operationName,
+                startTime: self.startTime,
+                finishTime: finishTime,
+                samplingRate: self.ddContext.sampleRate / 100.0,
+                samplingPriority: self.ddContext.samplingDecision.samplingPriority,
+                samplingDecisionMaker: self.ddContext.samplingDecision.decisionMaker,
+                tags: self.tags,
+                baggageItems: self.ddContext.baggageItems.all,
+                logFields: self.logFields
+            )
+
+            onSpanFinished(SpanSnapshot(from: event))
+
+            if self.ddContext.samplingDecision.samplingPriority.isKept {
+                let envelope = SpanEventsEnvelope(span: event, environment: context.env)
+                writer.write(value: envelope)
+            }
         }
     }
 

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -14,7 +14,25 @@ internal typealias Nanoseconds = UInt64
 ///
 /// Created in `DDSpan.finish()` **before** the sampling decision, so that all spans
 /// (including sampled-out ones) contribute to accurate aggregate metrics.
+///
+/// The snapshot is derived from a post-`SpanEventMapper` `SpanEvent`, which guarantees
+/// that stats and trace uploads agree on resource name, service name, tags, and the
+/// `isError` flag. Without this, a customer-supplied mapper that rewrites resource
+/// names (e.g. to redact PII or normalize cardinality) would key stats off the
+/// pre-mapper values while traces carry post-mapper values, leading to dashboard
+/// inconsistencies and potential cardinality explosions in the stats pipeline.
 internal struct SpanSnapshot: Encodable, Sendable {
+    /// Span tag keys that participate in peer-service aggregation. Mirrors the
+    /// `peer_tags_aggregation` set used by the Datadog Agent.
+    static let peerTagKeys: [String] = [
+        "peer.service",
+        "db.instance",
+        "db.system",
+        "out.host",
+        "net.peer.name",
+        "server.address"
+    ]
+
     let traceID: TraceID
     let spanID: SpanID
     let parentSpanID: SpanID?
@@ -36,4 +54,51 @@ internal struct SpanSnapshot: Encodable, Sendable {
     let peerTags: [String: String]
     /// The source of the service name override, from `_dd.svc_src` span meta tag.
     let serviceSource: String
+}
+
+extension SpanSnapshot {
+    /// Creates a snapshot from a post-mapper `SpanEvent`.
+    ///
+    /// All fields are read from the event (and its `tags`), so any mutation applied by
+    /// the user-configured `SpanEventMapper` is reflected in the stats aggregation.
+    init(from event: SpanEvent) {
+        let spanKind = event.tags[SpanTags.kind]
+        let httpStatusCode: UInt32 = {
+            guard let raw = event.tags[OTTags.httpStatusCode],
+                  let intValue = Int(raw),
+                  let uint32 = UInt32(exactly: intValue) else {
+                return 0
+            }
+            return uint32
+        }()
+        let isTopLevel = event.parentID == nil || event.tags["_dd.top_level"] == "1"
+        let isMeasured = event.tags["_dd.measured"] == "1"
+        let serviceSource = event.tags["_dd.svc_src"] ?? ""
+
+        var peerTags: [String: String] = [:]
+        for key in SpanSnapshot.peerTagKeys {
+            if let value = event.tags[key], !value.isEmpty {
+                peerTags[key] = value
+            }
+        }
+
+        self.init(
+            traceID: event.traceID,
+            spanID: event.spanID,
+            parentSpanID: event.parentID,
+            service: event.serviceName,
+            operationName: event.operationName,
+            resource: event.resource,
+            type: event.tags["span.type"] ?? "custom",
+            spanKind: spanKind,
+            httpStatusCode: httpStatusCode,
+            isError: event.isError,
+            startTime: event.startTime.timeIntervalSince1970.dd.toNanoseconds,
+            duration: event.duration.dd.toNanoseconds,
+            isTopLevel: isTopLevel,
+            isMeasured: isMeasured,
+            peerTags: peerTags,
+            serviceSource: serviceSource
+        )
+    }
 }

--- a/DatadogTrace/Tests/DDSpanTests.swift
+++ b/DatadogTrace/Tests/DDSpanTests.swift
@@ -258,6 +258,81 @@ class DDSpanTests: XCTestCase {
         )
     }
 
+    // MARK: - EventMapper Invocation Count
+    //
+    // The `SpanEventMapper` must run at most once per finished span. When client-side stats is
+    // enabled, the stats path builds the `SpanEvent` (running the mapper) to derive the snapshot,
+    // and the same event is reused for upload when sampled in. Running the mapper twice would
+    // amplify any side effects the customer's mapper relies on and would double the per-span cost
+    // for high-volume mappers.
+
+    func testWhenStatsEnabled_eventMapperRunsExactlyOnce_forSampledInSpan() {
+        let invocations = MapperInvocationCounter()
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockKeepAll(),
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+        )
+        tracer.onSpanFinished = { _ in /* stats hook installed */ }
+
+        tracer.startSpan(operationName: .mockAny()).finish()
+
+        XCTAssertEqual(invocations.count, 1)
+        let envelopes: [SpanEventsEnvelope] = core.events()
+        XCTAssertEqual(envelopes.count, 1, "Sampled-in span should produce one upload")
+    }
+
+    func testWhenStatsEnabled_eventMapperRunsExactlyOnce_forSampledOutSpan() {
+        let invocations = MapperInvocationCounter()
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockRejectAll(),
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+        )
+
+        var snapshotDelivered = false
+        tracer.onSpanFinished = { _ in snapshotDelivered = true }
+
+        tracer.startSpan(operationName: .mockAny()).finish()
+
+        XCTAssertEqual(invocations.count, 1, "Mapper must run for the snapshot even when sampled out")
+        XCTAssertTrue(snapshotDelivered)
+        let envelopes: [SpanEventsEnvelope] = core.events()
+        XCTAssertEqual(envelopes.count, 0, "Sampled-out span must not be uploaded")
+    }
+
+    func testWhenStatsDisabled_eventMapperOnlyRunsOnUploadPath_forSampledInSpan() {
+        let invocations = MapperInvocationCounter()
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockKeepAll(),
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+        )
+        XCTAssertNil(tracer.onSpanFinished)
+
+        tracer.startSpan(operationName: .mockAny()).finish()
+
+        XCTAssertEqual(invocations.count, 1)
+    }
+
+    func testWhenStatsDisabled_eventMapperDoesNotRun_forSampledOutSpan() {
+        let invocations = MapperInvocationCounter()
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockRejectAll(),
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+        )
+        XCTAssertNil(tracer.onSpanFinished)
+
+        tracer.startSpan(operationName: .mockAny()).finish()
+
+        XCTAssertEqual(invocations.count, 0, "Mapper must not run when stats is disabled and span is sampled out")
+    }
+
     func testWhenOnlyMalformedSpanTagsAdded_itSendsSpanWithoutCustomTags() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -292,5 +367,19 @@ class DDSpanTests: XCTestCase {
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
             2
         )
+    }
+}
+
+/// Reference-typed counter used to count `SpanEventMapper` invocations across closure captures.
+/// Tests rely on `PassthroughCoreMock` running synchronously on the calling thread, so no
+/// locking is required.
+private final class MapperInvocationCounter {
+    private(set) var count = 0
+
+    var mapper: SpanEventMapper {
+        return { event in
+            self.count += 1
+            return event
+        }
     }
 }

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -317,4 +317,161 @@ class SpanSnapshotTests: XCTestCase {
 
         XCTAssertNotNil(capturedSnapshot, "Snapshot must be captured regardless of sampling decision")
     }
+
+    // MARK: - EventMapper Consistency
+    //
+    // The user-configured `SpanEventMapper` mutates `resource`, `operationName`, and `tags` on the
+    // `SpanEvent` immediately before upload. Because the stats `SpanSnapshot` is derived from the
+    // post-mapper event, stats and trace uploads agree on every keyed dimension. Without this,
+    // a mapper that rewrites resource names (e.g. to redact PII) would key stats off the
+    // pre-mapper values while traces carry post-mapper values, leading to dashboard inconsistency
+    // and potential cardinality explosions in the stats pipeline.
+
+    func testSnapshotReflectsMappedResourceName() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.resource = "REDACTED"
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(
+            operationName: "network.request",
+            tags: [SpanTags.resource: "GET /users/12345/profile"]
+        )
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.resource, "REDACTED")
+    }
+
+    func testSnapshotReflectsMappedOperationName() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.operationName = "http.request.normalized"
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(operationName: "http.request")
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.operationName, "http.request.normalized")
+    }
+
+    func testSnapshotReflectsMappedPeerTags() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.tags["peer.service"] = "redacted-db"
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(
+            operationName: "db.query",
+            tags: ["peer.service": "postgres-primary"]
+        )
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.peerTags["peer.service"], "redacted-db")
+    }
+
+    func testSnapshotReflectsMapperRemovingPeerTag() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.tags.removeValue(forKey: "peer.service")
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(
+            operationName: "db.query",
+            tags: ["peer.service": "postgres-primary"]
+        )
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertNil(snapshot.peerTags["peer.service"])
+    }
+
+    func testSnapshotReflectsMappedHTTPStatusCode() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.tags[OTTags.httpStatusCode] = "500"
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(
+            operationName: "http.request",
+            tags: [OTTags.httpStatusCode: 200]
+        )
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        XCTAssertEqual(snapshot.httpStatusCode, 500)
+    }
+
+    func testSnapshotMatchesUploadedSpanEvent_whenMapperRewritesResource() throws {
+        // The strongest guarantee: snapshot and uploaded trace agree on resource name post-mapper.
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            spanEventBuilder: .mockWith(eventsMapper: { event in
+                var mapped = event
+                mapped.resource = "GET /users/{id}/profile"
+                return mapped
+            })
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        let span = tracer.startSpan(
+            operationName: "network.request",
+            tags: [SpanTags.resource: "GET /users/12345/profile"]
+        )
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let envelopes: [SpanEventsEnvelope] = core.events()
+        let uploadedSpan = try XCTUnwrap(envelopes.first?.spans.first)
+
+        XCTAssertEqual(snapshot.resource, uploadedSpan.resource)
+        XCTAssertEqual(snapshot.operationName, uploadedSpan.operationName)
+        XCTAssertEqual(snapshot.service, uploadedSpan.serviceName)
+        XCTAssertEqual(snapshot.isError, uploadedSpan.isError)
+    }
 }


### PR DESCRIPTION
### What and why?

The `SpanSnapshot` used for client-side stats was being built **before** the user-configured `SpanEventMapper` ran, while trace uploads carried the **post-mapper** values. This is a correctness gap: a mapper that rewrites resource names (for example, to redact PII, normalize URL paths, or reduce cardinality) would key stats off the pre-mapper values while traces carry the post-mapper values. The result is dashboard inconsistency (stats and traces disagree on `resource.name` for the same span) and potential cardinality explosions in the stats pipeline whenever a mapper merges many request resources into one normalized name.

Caught by Austin on the Android team while preparing the Android equivalent. The same correctness fix will need to land on `dd-sdk-android`.

### How?

Refactored `DDSpan.finish()` to gate on whether the stats hook is registered:

- **Stats enabled** (`ddTracer.onSpanFinished != nil`): build the `SpanEvent` first (which runs the `SpanEventMapper`) and derive the `SpanSnapshot` from it. The same event is reused for the upload when the span is sampled in, so the mapper still runs **at most once per finished span**.
- **Stats disabled**: original flow is preserved. The mapper only runs on the sampled-in upload path, so customers who do not opt into stats see no change in per-span cost.

The snapshot derivation moves into a new `SpanSnapshot.init(from: SpanEvent)` extension that reads every field from the post-mapper event (and its `tags`). This is a single source of truth and replaces the parallel field-extraction logic that previously lived in `DDSpan.createSnapshot(finishTime:)` (now removed). The snapshot type was introduced in [PR #2853 (Add SpanSnapshot type and span finish notification hook)](https://github.com/DataDog/dd-sdk-ios/pull/2853).

### Tests

**`SpanSnapshotTests`** (6 new tests covering mapper consistency):

- `testSnapshotReflectsMappedResourceName`: mapper rewrites `resource`, snapshot carries the new resource.
- `testSnapshotReflectsMappedOperationName`: mapper rewrites `operationName`, snapshot reflects it.
- `testSnapshotReflectsMappedPeerTags`: mapper rewrites `peer.service`, snapshot's `peerTags` reflects the new value.
- `testSnapshotReflectsMapperRemovingPeerTag`: mapper removes a peer tag, snapshot's `peerTags` no longer contains it.
- `testSnapshotReflectsMappedHTTPStatusCode`: mapper rewrites the status tag, snapshot's `httpStatusCode` reflects it.
- `testSnapshotMatchesUploadedSpanEvent_whenMapperRewritesResource`: end-to-end invariant. The snapshot the stats hook receives and the `SpanEvent` written to the upload agree on `resource`, `operationName`, `service`, and `isError`.

**`DDSpanTests`** (4 new tests covering mapper invocation count and sampling interplay):

- `testWhenStatsEnabled_eventMapperRunsExactlyOnce_forSampledInSpan`: with stats on, a sampled-in span invokes the mapper exactly once.
- `testWhenStatsEnabled_eventMapperRunsExactlyOnce_forSampledOutSpan`: with stats on, a sampled-out span still invokes the mapper once (for the snapshot) and produces no upload.
- `testWhenStatsDisabled_eventMapperOnlyRunsOnUploadPath_forSampledInSpan`: with stats off, behavior unchanged.
- `testWhenStatsDisabled_eventMapperDoesNotRun_forSampledOutSpan`: with stats off, sampled-out spans skip the mapper.

All 281 existing tests in the `DatadogTrace` iOS suite continue to pass.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes. N/A (internal, not user-facing)
- [x] Add Objective-C interface for public APIs. N/A (internal to DatadogTrace)
- [x] Run `make api-surface` when adding new APIs. N/A (internal to DatadogTrace)