### PR TITLE
RUM-15945: Sign automatically created commits

### DIFF
--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -96,8 +96,7 @@ push_repo() {
             -T "DataDog/$REPO_NAME" \
             --branch "$DOGFOODING_BRANCH_NAME" \
             --head-sha "$BASE_SHA" \
-            --create-branch \
-            "$(git rev-parse HEAD)"
+            --create-branch
     fi
     cd -
 }

--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -77,6 +77,7 @@ commit_repo() {
     local repo_path="$1"
     echo_subtitle "Commit '$REPO_NAME' repo"
     cd "$repo_path"
+    BASE_SHA=$(git rev-parse HEAD)
     git checkout -b "$DOGFOODING_BRANCH_NAME"
     git add .
     git commit -m "Dogfooding dd-sdk-ios commit: $DOGFOODED_COMMIT"
@@ -89,9 +90,14 @@ push_repo() {
     echo_subtitle "Push '$DOGFOODING_BRANCH_NAME' to '$REPO_NAME' repo"
     cd "$repo_path"
     if [ "$DRY_RUN" = "1" ] || [ "$DRY_RUN" = "true" ]; then
-        echo_warn "Running in DRY RUN mode. Skipping 'git push'."
+        echo_warn "Running in DRY RUN mode. Skipping push."
     else
-        git push -u origin "$DOGFOODING_BRANCH_NAME" --force
+        HEADLESS_TOKEN="$GITHUB_TOKEN" commit-headless push \
+            -T "DataDog/$REPO_NAME" \
+            --branch "$DOGFOODING_BRANCH_NAME" \
+            --head-sha "$BASE_SHA" \
+            --create-branch \
+            "$(git rev-parse HEAD)"
     fi
     cd -
 }


### PR DESCRIPTION
### What and why?

Signing commits that are created in in other repos for dogfooding. Like this one https://github.com/DataDog/datadog-ios/pull/2806

After this change there will be no need to force-push to sign.

Similar change on Android https://github.com/DataDog/dd-sdk-android/pull/3462. See explanation there on how it works.

`commit-headless` tool is installed on MacOS AMI runners https://github.com/DataDog/ci-platform-machine-images/pull/736

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
