### PR TITLE
RUM-16395: Update RUM schema with profiling quota

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		05B9B20299CF44BB97F4A7C8 /* HeatmapIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048E335C84F4B41E3ACA3B91 /* HeatmapIdentifierTests.swift */; };
 		0904F9F42EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
 		0904F9F62EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
+		A1B2C3E52F92000100ABCDEF /* ProfilingContext+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E42F92000100ABCDEF /* ProfilingContext+RUM.swift */; };
+		A1B2C3E72F92000100ABCDEF /* ProfilingContextRUMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E62F92000100ABCDEF /* ProfilingContextRUMTests.swift */; };
 		093AC32A2F56F8AA00267CE1 /* ActiveSpanProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */; };
 		094B553F2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */; };
 		094BB2682F963AB50047C56A /* RUMSessionSamplerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094BB2672F963AB50047C56A /* RUMSessionSamplerProvider.swift */; };
@@ -1797,6 +1799,8 @@
 /* Begin PBXFileReference section */
 		048E335C84F4B41E3ACA3B91 /* HeatmapIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifierTests.swift; sourceTree = "<group>"; };
 		0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
+		A1B2C3E42F92000100ABCDEF /* ProfilingContext+RUM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilingContext+RUM.swift"; sourceTree = "<group>"; };
+		A1B2C3E62F92000100ABCDEF /* ProfilingContextRUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextRUMTests.swift; sourceTree = "<group>"; };
 		093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpanProvider.swift; sourceTree = "<group>"; };
 		094B553E2F76C63100BAB8B5 /* RUMResourceTraceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceTraceIntegrationTests.swift; sourceTree = "<group>"; };
 		094BB2672F963AB50047C56A /* RUMSessionSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionSamplerProvider.swift; sourceTree = "<group>"; };
@@ -4920,6 +4924,7 @@
 			isa = PBXGroup;
 			children = (
 				619F1A262DEF0B3F003954BD /* LaunchReasonResolverTests.swift */,
+				A1B2C3E62F92000100ABCDEF /* ProfilingContextRUMTests.swift */,
 				61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */,
 				117ADDD82EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift */,
 				D253EE982B98B3690010B589 /* ViewCacheTests.swift */,
@@ -4984,6 +4989,7 @@
 		61494B7827F3522C0082BBCC /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				A1B2C3E42F92000100ABCDEF /* ProfilingContext+RUM.swift */,
 				1124D52E2EA6D2370002E053 /* StartupTypeHandler.swift */,
 				619F1A232DEE491D003954BD /* LaunchReasonResolver.swift */,
 				61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */,
@@ -8945,6 +8951,7 @@
 				D29A9F7029DD85BB005C54A4 /* RUMContextProvider.swift in Sources */,
 				61DA6F6C2BB57E32009537E5 /* FatalErrorBuilder.swift in Sources */,
 				619F1A252DEE493F003954BD /* LaunchReasonResolver.swift in Sources */,
+				A1B2C3E52F92000100ABCDEF /* ProfilingContext+RUM.swift in Sources */,
 				D29A9F6029DD85BB005C54A4 /* ViewIdentifier.swift in Sources */,
 				49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */,
 				96F70D522DDDBDA600D3736B /* SwiftUIComponentDetector.swift in Sources */,
@@ -9068,6 +9075,7 @@
 				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BC2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
+				A1B2C3E72F92000100ABCDEF /* ProfilingContextRUMTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,
 				6105C5142D0C584F00C4C5EE /* INVMetricTests.swift in Sources */,

--- a/DatadogInternal/Sources/Models/Profiling/ProfilingContext.swift
+++ b/DatadogInternal/Sources/Models/Profiling/ProfilingContext.swift
@@ -79,10 +79,15 @@ public struct ProfilingContext: AdditionalContext {
     /// The current profiling status.
     public let status: Status
 
+    /// The reason provided by the profiling quota admission API.
+    public let quotaReason: DDProfiling.QuotaReason?
+
     /// Creates a new profiling context with the specified status.
     ///
     /// - Parameter status: The current profiling status to be included in the context.
-    public init(status: Status) {
+    /// - Parameter quotaReason: The reason provided by the profiling quota admission API.
+    public init(status: Status, quotaReason: DDProfiling.QuotaReason? = nil) {
         self.status = status
+        self.quotaReason = quotaReason
     }
 }

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -10,6 +10,133 @@
 
 public protocol RUMDataModel: Codable {}
 
+/// Profiling context
+public struct DDProfiling: Codable {
+    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+    ///
+    /// Possible values:
+    /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+    /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+    /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+    public let errorReason: ErrorReason?
+
+    /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+    ///
+    /// Possible values:
+    /// - `quota_ok`: Quota check passed.
+    /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+    /// - `org_disabled`: The organization has profiling disabled.
+    /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+    /// - `undefined`: The quota reason is undefined.
+    /// - `timeout`: The quota check timed out on the client side.
+    /// - `api-error`: An API error occurred on the client side.
+    public let quotaReason: QuotaReason?
+
+    /// Used to track the status of the RUM Profiler.
+    ///
+    /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+    ///
+    /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+    /// - `running`: The Profiler is running.
+    /// - `stopped`: The Profiler is stopped.
+    /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+    public let status: Status?
+
+    public enum CodingKeys: String, CodingKey {
+        case errorReason = "error_reason"
+        case quotaReason = "quota_reason"
+        case status = "status"
+    }
+
+    /// Profiling context
+    ///
+    /// - Parameters:
+    ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+    ///
+    /// Possible values:
+    /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+    /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+    /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+    ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+    ///
+    /// Possible values:
+    /// - `quota_ok`: Quota check passed.
+    /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+    /// - `org_disabled`: The organization has profiling disabled.
+    /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+    /// - `undefined`: The quota reason is undefined.
+    /// - `timeout`: The quota check timed out on the client side.
+    /// - `api-error`: An API error occurred on the client side.
+    ///   - status: Used to track the status of the RUM Profiler.
+    ///
+    /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+    ///
+    /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+    /// - `running`: The Profiler is running.
+    /// - `stopped`: The Profiler is stopped.
+    /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+    public init(
+        errorReason: ErrorReason? = nil,
+        quotaReason: QuotaReason? = nil,
+        status: Status? = nil
+    ) {
+        self.errorReason = errorReason
+        self.quotaReason = quotaReason
+        self.status = status
+    }
+
+    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+    ///
+    /// Possible values:
+    /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+    /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+    /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+    public enum ErrorReason: String, Codable {
+        case notSupportedByBrowser = "not-supported-by-browser"
+        case failedToLazyLoad = "failed-to-lazy-load"
+        case missingDocumentPolicyHeader = "missing-document-policy-header"
+        case unexpectedException = "unexpected-exception"
+    }
+
+    /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+    ///
+    /// Possible values:
+    /// - `quota_ok`: Quota check passed.
+    /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+    /// - `org_disabled`: The organization has profiling disabled.
+    /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+    /// - `undefined`: The quota reason is undefined.
+    /// - `timeout`: The quota check timed out on the client side.
+    /// - `api-error`: An API error occurred on the client side.
+    public enum QuotaReason: String, Codable {
+        case quotaOk = "quota_ok"
+        case quotaExceeded = "quota_exceeded"
+        case orgDisabled = "org_disabled"
+        case backendUnavailable = "backend_unavailable"
+        case undefined = "undefined"
+        case timeout = "timeout"
+        case apiError = "api-error"
+    }
+
+    /// Used to track the status of the RUM Profiler.
+    ///
+    /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+    ///
+    /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+    /// - `running`: The Profiler is running.
+    /// - `stopped`: The Profiler is stopped.
+    /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+    public enum Status: String, Codable {
+        case starting = "starting"
+        case running = "running"
+        case stopped = "stopped"
+        case error = "error"
+    }
+}
+
 /// Device properties
 public struct Device: Codable {
     /// The CPU architecture of the device that is reporting the error
@@ -549,7 +676,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// Height of the target element (in pixels)
                 public let height: Int64?
 
-                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 public let permanentId: String?
 
                 /// CSS selector path of the target element
@@ -571,7 +698,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// - Parameters:
                 ///   - composedPathSelector: Selector data based on the click event composed path
                 ///   - height: Height of the target element (in pixels)
-                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 ///   - selector: CSS selector path of the target element
                 ///   - width: Width of the target element (in pixels)
                 public init(
@@ -1531,7 +1658,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public let parentSpanId: String?
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// trace sample rate in decimal format
         public let rulePsr: Double?
@@ -1577,7 +1704,7 @@ public struct RUMErrorEvent: RUMDataModel {
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
             parentSpanId: String? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             rulePsr: Double? = nil,
             sdkName: String? = nil,
             session: Session? = nil,
@@ -1633,88 +1760,6 @@ public struct RUMErrorEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -3041,7 +3086,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public let formatVersion: Int64 = 2
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
@@ -3072,7 +3117,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
             discarded: Bool? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
@@ -3122,88 +3167,6 @@ public struct RUMLongTaskEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -5406,7 +5369,7 @@ public struct RUMViewEvent: RUMDataModel {
         public let pageStates: [PageStates]?
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// Debug metadata for Replay Sessions
         public let replayStats: ReplayStats?
@@ -5448,7 +5411,7 @@ public struct RUMViewEvent: RUMDataModel {
             configuration: Configuration? = nil,
             documentVersion: Int64,
             pageStates: [PageStates]? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             replayStats: ReplayStats? = nil,
             sdkName: String? = nil,
             session: Session? = nil
@@ -5565,88 +5528,6 @@ public struct RUMViewEvent: RUMDataModel {
                 case hidden = "hidden"
                 case frozen = "frozen"
                 case terminated = "terminated"
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -9667,7 +9548,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         public let formatVersion: Int64 = 2
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
@@ -9695,7 +9576,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
@@ -9744,88 +9625,6 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -10411,7 +10210,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         public let formatVersion: Int64 = 2
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
@@ -10439,7 +10238,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
@@ -10488,88 +10287,6 @@ public struct RUMVitalDurationEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -11115,7 +10832,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         public let formatVersion: Int64 = 2
 
         /// Profiling context
-        public let profiling: Profiling?
+        public let profiling: DDProfiling?
 
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
@@ -11143,7 +10860,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
-            profiling: Profiling? = nil,
+            profiling: DDProfiling? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
@@ -11192,88 +10909,6 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
-            }
-        }
-
-        /// Profiling context
-        public struct Profiling: Codable {
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public let errorReason: ErrorReason?
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public let status: Status?
-
-            public enum CodingKeys: String, CodingKey {
-                case errorReason = "error_reason"
-                case status = "status"
-            }
-
-            /// Profiling context
-            ///
-            /// - Parameters:
-            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            ///   - status: Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public init(
-                errorReason: ErrorReason? = nil,
-                status: Status? = nil
-            ) {
-                self.errorReason = errorReason
-                self.status = status
-            }
-
-            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-            ///
-            /// Possible values:
-            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
-            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
-            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
-            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-            public enum ErrorReason: String, Codable {
-                case notSupportedByBrowser = "not-supported-by-browser"
-                case failedToLazyLoad = "failed-to-lazy-load"
-                case missingDocumentPolicyHeader = "missing-document-policy-header"
-                case unexpectedException = "unexpected-exception"
-            }
-
-            /// Used to track the status of the RUM Profiler.
-            ///
-            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
-            ///
-            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
-            /// - `running`: The Profiler is running.
-            /// - `stopped`: The Profiler is stopped.
-            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
-            public enum Status: String, Codable {
-                case starting = "starting"
-                case running = "running"
-                case stopped = "stopped"
-                case error = "error"
             }
         }
 
@@ -11768,7 +11403,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -11779,7 +11414,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -12922,7 +12557,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -12933,7 +12568,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -13212,7 +12847,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -13223,7 +12858,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -13538,7 +13173,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -13549,7 +13184,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -14422,4 +14057,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/2e1fe49897be86e72c0c2f0c2ae052c0d5f826eb

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -1487,6 +1487,10 @@ public class objc_RUMErrorEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMErrorEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMErrorEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -1495,7 +1499,7 @@ public class objc_RUMErrorEventDDProfiling: NSObject {
 @objc(DDRUMErrorEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMErrorEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMErrorEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -1505,7 +1509,7 @@ public enum objc_RUMErrorEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMErrorEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -1522,10 +1526,49 @@ public enum objc_RUMErrorEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMErrorEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMErrorEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMErrorEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMErrorEventDDProfilingStatus: Int {
-    internal init(swift: RUMErrorEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -1535,7 +1578,7 @@ public enum objc_RUMErrorEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMErrorEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -3345,6 +3388,10 @@ public class objc_RUMLongTaskEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMLongTaskEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMLongTaskEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -3353,7 +3400,7 @@ public class objc_RUMLongTaskEventDDProfiling: NSObject {
 @objc(DDRUMLongTaskEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMLongTaskEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -3363,7 +3410,7 @@ public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMLongTaskEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -3380,10 +3427,49 @@ public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMLongTaskEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMLongTaskEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMLongTaskEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMLongTaskEventDDProfilingStatus: Int {
-    internal init(swift: RUMLongTaskEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -3393,7 +3479,7 @@ public enum objc_RUMLongTaskEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMLongTaskEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -6340,6 +6426,10 @@ public class objc_RUMViewEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMViewEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMViewEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -6348,7 +6438,7 @@ public class objc_RUMViewEventDDProfiling: NSObject {
 @objc(DDRUMViewEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMViewEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMViewEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -6358,7 +6448,7 @@ public enum objc_RUMViewEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMViewEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -6375,10 +6465,49 @@ public enum objc_RUMViewEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMViewEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMViewEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMViewEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMViewEventDDProfilingStatus: Int {
-    internal init(swift: RUMViewEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -6388,7 +6517,7 @@ public enum objc_RUMViewEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMViewEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -10284,6 +10413,10 @@ public class objc_RUMVitalAppLaunchEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalAppLaunchEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalAppLaunchEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -10292,7 +10425,7 @@ public class objc_RUMVitalAppLaunchEventDDProfiling: NSObject {
 @objc(DDRUMVitalAppLaunchEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMVitalAppLaunchEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -10302,7 +10435,7 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMVitalAppLaunchEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -10319,10 +10452,49 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMVitalAppLaunchEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalAppLaunchEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMVitalAppLaunchEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMVitalAppLaunchEventDDProfilingStatus: Int {
-    internal init(swift: RUMVitalAppLaunchEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -10332,7 +10504,7 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMVitalAppLaunchEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -11397,6 +11569,10 @@ public class objc_RUMVitalDurationEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalDurationEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalDurationEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -11405,7 +11581,7 @@ public class objc_RUMVitalDurationEventDDProfiling: NSObject {
 @objc(DDRUMVitalDurationEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMVitalDurationEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -11415,7 +11591,7 @@ public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMVitalDurationEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -11432,10 +11608,49 @@ public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMVitalDurationEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalDurationEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMVitalDurationEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMVitalDurationEventDDProfilingStatus: Int {
-    internal init(swift: RUMVitalDurationEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -11445,7 +11660,7 @@ public enum objc_RUMVitalDurationEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMVitalDurationEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -12449,6 +12664,10 @@ public class objc_RUMVitalOperationStepEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalOperationStepEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalOperationStepEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -12457,7 +12676,7 @@ public class objc_RUMVitalOperationStepEventDDProfiling: NSObject {
 @objc(DDRUMVitalOperationStepEventDDProfilingErrorReason)
 @_spi(objc)
 public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int {
-    internal init(swift: RUMVitalOperationStepEvent.DD.Profiling.ErrorReason?) {
+    internal init(swift: DDProfiling.ErrorReason?) {
         switch swift {
         case nil: self = .none
         case .notSupportedByBrowser?: self = .notSupportedByBrowser
@@ -12467,7 +12686,7 @@ public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int {
         }
     }
 
-    internal var toSwift: RUMVitalOperationStepEvent.DD.Profiling.ErrorReason? {
+    internal var toSwift: DDProfiling.ErrorReason? {
         switch self {
         case .none: return nil
         case .notSupportedByBrowser: return .notSupportedByBrowser
@@ -12484,10 +12703,49 @@ public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int {
     case unexpectedException
 }
 
+@objc(DDRUMVitalOperationStepEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalOperationStepEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
 @objc(DDRUMVitalOperationStepEventDDProfilingStatus)
 @_spi(objc)
 public enum objc_RUMVitalOperationStepEventDDProfilingStatus: Int {
-    internal init(swift: RUMVitalOperationStepEvent.DD.Profiling.Status?) {
+    internal init(swift: DDProfiling.Status?) {
         switch swift {
         case nil: self = .none
         case .starting?: self = .starting
@@ -12497,7 +12755,7 @@ public enum objc_RUMVitalOperationStepEventDDProfilingStatus: Int {
         }
     }
 
-    internal var toSwift: RUMVitalOperationStepEvent.DD.Profiling.Status? {
+    internal var toSwift: DDProfiling.Status? {
         switch self {
         case .none: return nil
         case .starting: return .starting
@@ -13465,7 +13723,41 @@ public class objc_TelemetryConfigurationEventAction: NSObject {
     }
 
     public var id: String {
-        root.swiftModel.action!.id
+        switch root.swiftModel.action!.id {
+        case .string(let value):
+            return value
+        case .stringsArray(let value):
+            return value.first ?? ""
+        }
+    }
+
+    public var idValue: objc_TelemetryConfigurationEventActionRUMActionID {
+        objc_TelemetryConfigurationEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryConfigurationEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryConfigurationEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryConfigurationEvent
+
+    internal init(root: objc_TelemetryConfigurationEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -14449,7 +14741,41 @@ public class objc_TelemetryDebugEventAction: NSObject {
     }
 
     public var id: String {
-        root.swiftModel.action!.id
+        switch root.swiftModel.action!.id {
+        case .string(let value):
+            return value
+        case .stringsArray(let value):
+            return value.first ?? ""
+        }
+    }
+
+    public var idValue: objc_TelemetryDebugEventActionRUMActionID {
+        objc_TelemetryDebugEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryDebugEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryDebugEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryDebugEvent
+
+    internal init(root: objc_TelemetryDebugEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -14727,7 +15053,41 @@ public class objc_TelemetryErrorEventAction: NSObject {
     }
 
     public var id: String {
-        root.swiftModel.action!.id
+        switch root.swiftModel.action!.id {
+        case .string(let value):
+            return value
+        case .stringsArray(let value):
+            return value.first ?? ""
+        }
+    }
+
+    public var idValue: objc_TelemetryErrorEventActionRUMActionID {
+        objc_TelemetryErrorEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryErrorEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryErrorEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryErrorEvent
+
+    internal init(root: objc_TelemetryErrorEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -14940,4 +15300,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/2e1fe49897be86e72c0c2f0c2ae052c0d5f826eb

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -123,7 +123,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryDebugEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.sampler.samplingRate),
@@ -169,7 +169,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryErrorEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.sampler.samplingRate),
@@ -200,7 +200,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryUsageEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(usage.sampleRate.composed(with: self.sampler.samplingRate)),
@@ -240,7 +240,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryConfigurationEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.configurationExtraSampler.samplingRate.composed(with: self.sampler.samplingRate)),
@@ -284,7 +284,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryDebugEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(effectiveSampleRate),

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -64,10 +64,7 @@ private extension RUMAppLaunchManager {
         self.timeToInitialDisplay = ttid
         let ttidVitalId = dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat
 
-        var profiling: RUMVitalAppLaunchEvent.DD.Profiling?
-        if let profilingContext = context.additionalContext(ofType: ProfilingContext.self) {
-            profiling = .init(errorReason: profilingContext.error, status: profilingContext.profilingStatus)
-        }
+        let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         sendTTIDMessageToProfiler(
             vital: .init(
@@ -180,7 +177,7 @@ private extension RUMAppLaunchManager {
         context: DatadogContext,
         writer: Writer,
         activeView: RUMViewScope?,
-        profiling: RUMVitalAppLaunchEvent.DD.Profiling? = nil
+        profiling: DDProfiling? = nil
     ) {
         let vital = RUMVitalAppLaunchEvent.Vital(
             appLaunchMetric: appLaunchMetric,
@@ -285,44 +282,5 @@ private extension RUMVitalAppLaunchEvent.Vital.AppLaunchMetric {
         case .ttid: return "time_to_initial_display"
         case .ttfd: return "time_to_full_display"
         }
-    }
-}
-
-private extension ProfilingContext {
-    /**
-     * Returns the profiling status reported for app launch.
-     *
-     * Returns:
-     *  - `.running` when the profiler is actively running, or when it was manually stopped or timed out.
-     *  - `.stopped` when the profiler was not started, was sampled out, or the app launch was prewarmed.
-     *  - `.error` when the profiler encountered an error while starting or it is in an unknown status.
-     *
-     * Note: the implementation currently maps `.stopped(.manual)` and `.stopped(.timeout)` to `.running`
-     * because those cases indicate profiling collected enough samples to be associated with the launch.
-     */
-    var profilingStatus: RUMVitalAppLaunchEvent.DD.Profiling.Status {
-        switch self.status {
-        case .running: return .running
-        case .stopped: return .stopped
-        case .error: return .error
-        case .unknown: return .error
-        }
-    }
-
-    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-    ///
-    /// Possible values:
-    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-    var error: RUMVitalAppLaunchEvent.DD.Profiling.ErrorReason? {
-        // RUM-15325: Update RUM schema with the mobile profiler errors
-        if case .error(reason: let reason) = self.status {
-            switch reason {
-            case .memoryAllocationFailed:
-                return .unexpectedException
-            case .alreadyStarted:
-                return nil
-            }
-        }
-        return nil
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -93,10 +93,7 @@ internal class RUMFeatureOperationManager {
             .merging(activeView?.attributes ?? [:]) { $1 }
             .merging(command.attributes) { $1 }
 
-        var profiling: RUMVitalOperationStepEvent.DD.Profiling?
-        if let profilingContext = context.additionalContext(ofType: ProfilingContext.self) {
-            profiling = .init(errorReason: profilingContext.error, status: profilingContext.profilingStatus)
-        }
+        let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         if shouldSendOperationMessage(for: command) {
             let message = OperationMessage(
@@ -234,41 +231,5 @@ internal class RUMFeatureOperationManager {
         } else {
             return "`\(name)`"
         }
-    }
-}
-
-private extension ProfilingContext {
-    /**
-     * Returns the profiling status reported for app launch.
-     *
-     * Returns:
-     *  - `.running` when the profiler is actively running, or when it was manually stopped or timed out.
-     *  - `.stopped` when the profiler was not started, was sampled out, or the app launch was prewarmed.
-     *  - `.error` when the profiler encountered an error while starting or it is in an unknown status.
-     */
-    var profilingStatus: RUMVitalOperationStepEvent.DD.Profiling.Status {
-        switch self.status {
-        case .running: return .running
-        case .stopped: return .stopped
-        case .error: return .error
-        case .unknown: return .error
-        }
-    }
-
-    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-    ///
-    /// Possible values:
-    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-    var error: RUMVitalOperationStepEvent.DD.Profiling.ErrorReason? {
-        // RUM-15325: Update RUM schema with the mobile profiler errors
-        if case .error(reason: let reason) = self.status {
-            switch reason {
-            case .memoryAllocationFailed:
-                return .unexpectedException
-            case .alreadyStarted:
-                return nil
-            }
-        }
-        return nil
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -741,10 +741,7 @@ extension RUMViewScope {
             }
         }
 
-        var profiling: RUMErrorEvent.DD.Profiling?
-        if let profilingContext = context.additionalContext(ofType: ProfilingContext.self) {
-            profiling = .init(errorReason: profilingContext.errorEventErrorReason, status: profilingContext.errorEventProfilingStatus)
-        }
+        let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         let errorEvent = RUMErrorEvent(
             dd: .init(
@@ -848,10 +845,7 @@ extension RUMViewScope {
             .merging(attributes) { $1 }
             .merging(command.attributes) { $1 }
 
-        var profiling: RUMLongTaskEvent.DD.Profiling?
-        if let profilingContext = context.additionalContext(ofType: ProfilingContext.self) {
-            profiling = .init(errorReason: profilingContext.longTaskErrorReason, status: profilingContext.longTaskProfilingStatus)
-        }
+        let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         let longTaskEvent = RUMLongTaskEvent(
             dd: .init(
@@ -982,75 +976,5 @@ private extension Result {
         case .success(let success): return success
         case .failure: return nil
         }
-    }
-}
-
-private extension ProfilingContext {
-    /**
-     * Returns the profiling status reported for app launch.
-     *
-     * Returns:
-     *  - `.running` when the profiler is actively running, or when it was manually stopped or timed out.
-     *  - `.stopped` when the profiler was not started, was sampled out, or the app launch was prewarmed.
-     *  - `.error` when the profiler encountered an error while starting or it is in an unknown status.
-     */
-    var longTaskProfilingStatus: RUMLongTaskEvent.DD.Profiling.Status {
-        switch self.status {
-        case .running: return .running
-        case .stopped: return .stopped
-        case .error: return .error
-        case .unknown: return .error
-        }
-    }
-
-    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-    ///
-    /// Possible values:
-    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-    var longTaskErrorReason: RUMLongTaskEvent.DD.Profiling.ErrorReason? {
-        // RUM-15325: Update RUM schema with the mobile profiler errors
-        if case .error(reason: let reason) = self.status {
-            switch reason {
-            case .memoryAllocationFailed:
-                return .unexpectedException
-            case .alreadyStarted:
-                return nil
-            }
-        }
-        return nil
-    }
-
-    /**
-     * Returns the profiling status reported for app launch.
-     *
-     * Returns:
-     *  - `.running` when the profiler is actively running, or when it was manually stopped or timed out.
-     *  - `.stopped` when the profiler was not started, was sampled out, or the app launch was prewarmed.
-     *  - `.error` when the profiler encountered an error while starting or it is in an unknown status.
-     */
-    var errorEventProfilingStatus: RUMErrorEvent.DD.Profiling.Status {
-        switch self.status {
-        case .running: return .running
-        case .stopped: return .stopped
-        case .error: return .error
-        case .unknown: return .error
-        }
-    }
-
-    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
-    ///
-    /// Possible values:
-    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
-    var errorEventErrorReason: RUMErrorEvent.DD.Profiling.ErrorReason? {
-        // RUM-15325: Update RUM schema with the mobile profiler errors
-        if case .error(reason: let reason) = self.status {
-            switch reason {
-            case .memoryAllocationFailed:
-                return .unexpectedException
-            case .alreadyStarted:
-                return nil
-            }
-        }
-        return nil
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ProfilingContext+RUM.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/Utils/ProfilingContext+RUM.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import DatadogInternal
+
+extension ProfilingContext {
+    /// The profiling info reported as additional context of RUM events.
+    var ddProfiling: DDProfiling {
+        .init(
+            errorReason: errorReason,
+            quotaReason: quotaReason,
+            status: profilingStatus
+        )
+    }
+
+    /// The profiler status reported to the RUM data model.
+    ///
+    /// Returns:
+    /// - `.running` when the profiler is actively running.
+    /// - `.stopped` when the profiler has stopped for any reason.
+    /// - `.error` when the profiler encountered an error or its status could not be determined.
+    private var profilingStatus: DDProfiling.Status {
+        switch status {
+        case .running:
+            return .running
+        case .stopped:
+            return .stopped
+        case .error:
+            return .error
+        case .unknown:
+            return .error
+        }
+    }
+
+    /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+    ///
+    /// Possible values:
+    /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+    private var errorReason: DDProfiling.ErrorReason? {
+        // RUM-15325: Update RUM schema with the mobile profiler errors.
+        guard case .error(reason: let reason) = status else {
+            return nil
+        }
+
+        switch reason {
+        case .memoryAllocationFailed:
+            return .unexpectedException
+        case .alreadyStarted:
+            return nil
+        }
+    }
+}

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -102,7 +102,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.telemetry.telemetryInfo["foo"] as? Int, 42)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
@@ -122,7 +122,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
 
@@ -508,7 +508,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
         let device = try XCTUnwrap(event?.telemetry.device)
         XCTAssertEqual(device.model, deviceMock.model)
@@ -537,7 +537,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, sessionIDOverride)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertNil(event?.telemetry.telemetryInfo[SDKMetricFields.sessionIDOverrideKey], "It should delete `sessionIDOverrideKey` from metric attributes")
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/ProfilingContextRUMTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/Utils/ProfilingContextRUMTests.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+
+final class ProfilingContextRUMTests: XCTestCase {
+    func testDDProfiling_mapsRunningStatus() {
+        let profiling = ProfilingContext(status: .running).ddProfiling
+
+        XCTAssertEqual(profiling.status, .running)
+        XCTAssertNil(profiling.errorReason)
+        XCTAssertNil(profiling.quotaReason)
+    }
+
+    func testDDProfiling_mapsStoppedStatus() throws {
+        let stopReasons: [ProfilingContext.Status.StopReason] = [.manual, .notStarted, .timeout, .prewarmed]
+        let quotaReasons: [DDProfiling.QuotaReason] = [
+            .quotaOk, .quotaExceeded, .orgDisabled, .backendUnavailable, .undefined, .timeout, .apiError
+        ]
+
+        let quotaReason = try XCTUnwrap(quotaReasons.randomElement())
+        let stoppedProfiling = ProfilingContext(
+            status: .stopped(reason: try XCTUnwrap(stopReasons.randomElement())),
+            quotaReason: quotaReason
+        ).ddProfiling
+
+        XCTAssertEqual(stoppedProfiling.status, .stopped)
+        XCTAssertNil(stoppedProfiling.errorReason)
+        XCTAssertEqual(stoppedProfiling.quotaReason, quotaReason)
+    }
+
+    func testDDProfiling_mapsErrorStatus() {
+        let memoryAllocationFailure = ProfilingContext(status: .error(reason: .memoryAllocationFailed)).ddProfiling
+
+        XCTAssertEqual(memoryAllocationFailure.status, .error)
+        XCTAssertEqual(memoryAllocationFailure.errorReason, .unexpectedException)
+        XCTAssertNil(memoryAllocationFailure.quotaReason)
+
+        let alreadyStarted = ProfilingContext(status: .error(reason: .alreadyStarted)).ddProfiling
+
+        XCTAssertEqual(alreadyStarted.status, .error)
+        XCTAssertNil(alreadyStarted.errorReason)
+        XCTAssertNil(alreadyStarted.quotaReason)
+
+        let unknown = ProfilingContext(status: .unknown).ddProfiling
+
+        XCTAssertEqual(unknown.status, .error)
+        XCTAssertNil(unknown.errorReason)
+        XCTAssertNil(unknown.quotaReason)
+    }
+}

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -646,6 +646,7 @@ public class objc_RUMErrorEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMErrorEventDDProfiling: NSObject
     public var errorReason: objc_RUMErrorEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMErrorEventDDProfilingQuotaReason
     public var status: objc_RUMErrorEventDDProfilingStatus
 public enum objc_RUMErrorEventDDProfilingErrorReason: Int
     case none
@@ -653,6 +654,15 @@ public enum objc_RUMErrorEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMErrorEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMErrorEventDDProfilingStatus: Int
     case none
     case starting
@@ -1016,6 +1026,7 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMLongTaskEventDDProfiling: NSObject
     public var errorReason: objc_RUMLongTaskEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMLongTaskEventDDProfilingQuotaReason
     public var status: objc_RUMLongTaskEventDDProfilingStatus
 public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int
     case none
@@ -1023,6 +1034,15 @@ public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMLongTaskEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMLongTaskEventDDProfilingStatus: Int
     case none
     case starting
@@ -1605,6 +1625,7 @@ public enum objc_RUMViewEventDDPageStatesState: Int
     case terminated
 public class objc_RUMViewEventDDProfiling: NSObject
     public var errorReason: objc_RUMViewEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMViewEventDDProfilingQuotaReason
     public var status: objc_RUMViewEventDDProfilingStatus
 public enum objc_RUMViewEventDDProfilingErrorReason: Int
     case none
@@ -1612,6 +1633,15 @@ public enum objc_RUMViewEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMViewEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMViewEventDDProfilingStatus: Int
     case none
     case starting
@@ -2385,6 +2415,7 @@ public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalAppLaunchEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalAppLaunchEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalAppLaunchEventDDProfilingQuotaReason
     public var status: objc_RUMVitalAppLaunchEventDDProfilingStatus
 public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int
     case none
@@ -2392,6 +2423,15 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalAppLaunchEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalAppLaunchEventDDProfilingStatus: Int
     case none
     case starting
@@ -2605,6 +2645,7 @@ public class objc_RUMVitalDurationEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalDurationEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalDurationEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalDurationEventDDProfilingQuotaReason
     public var status: objc_RUMVitalDurationEventDDProfilingStatus
 public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int
     case none
@@ -2612,6 +2653,15 @@ public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalDurationEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalDurationEventDDProfilingStatus: Int
     case none
     case starting
@@ -2814,6 +2864,7 @@ public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalOperationStepEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalOperationStepEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalOperationStepEventDDProfilingQuotaReason
     public var status: objc_RUMVitalOperationStepEventDDProfilingStatus
 public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int
     case none
@@ -2821,6 +2872,15 @@ public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalOperationStepEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalOperationStepEventDDProfilingStatus: Int
     case none
     case starting
@@ -3013,6 +3073,10 @@ public class objc_TelemetryConfigurationEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryConfigurationEventAction: NSObject
     public var id: String
+    public var idValue: objc_TelemetryConfigurationEventActionRUMActionID
+public class objc_TelemetryConfigurationEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryConfigurationEventApplication: NSObject
     public var id: String
 public class objc_TelemetryConfigurationEventSession: NSObject
@@ -3209,6 +3273,10 @@ public class objc_TelemetryDebugEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryDebugEventAction: NSObject
     public var id: String
+    public var idValue: objc_TelemetryDebugEventActionRUMActionID
+public class objc_TelemetryDebugEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryDebugEventApplication: NSObject
     public var id: String
 public class objc_TelemetryDebugEventSession: NSObject
@@ -3264,6 +3332,10 @@ public class objc_TelemetryErrorEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryErrorEventAction: NSObject
     public var id: String
+    public var idValue: objc_TelemetryErrorEventActionRUMActionID
+public class objc_TelemetryErrorEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryErrorEventApplication: NSObject
     public var id: String
 public class objc_TelemetryErrorEventSession: NSObject

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -591,7 +591,7 @@ public protocol CrashReportingPlugin: AnyObject
 
 public enum WebViewTracking
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
-    public static func disable(webView: WKWebView, in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter
         public func send(body: Any, slotId: String? = nil)
@@ -1421,4 +1421,5 @@ public enum Profiling
     public struct Configuration
         public var customEndpoint: URL?
         public var applicationLaunchSampleRate: SampleRate
-        public init(customEndpoint: URL? = nil,applicationLaunchSampleRate: SampleRate = 5)
+        public var continuousSampleRate: SampleRate
+        public init(customEndpoint: URL? = nil,applicationLaunchSampleRate: SampleRate = 5,continuousSampleRate: SampleRate = 5)

--- a/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RUMCodeDecorator.swift
@@ -15,6 +15,7 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
     public init() {
         super.init(
             sharedTypeNames: [
+                "DDProfiling",
                 "RUMConnectivity",
                 "RUMUser",
                 "RUMMethod",
@@ -154,6 +155,10 @@ public class RUMCodeDecorator: SwiftCodeDecorator {
 
         if fixedName == "Graphql" {
             fixedName = "RUMGraphql"
+        }
+
+        if fixedName == "Profiling" {
+            fixedName = "DDProfiling"
         }
 
         return fixedName

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/ObjcInterop/ObjcInteropType+reflection.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/ObjcInterop/ObjcInteropType+reflection.swift
@@ -32,7 +32,8 @@ extension ObjcInteropTransitiveNestedClass: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftStruct.name
+        let parentObjcTypeName = (parentClass as! ObjcInteropReflectable).objcTypeName
+        return parentObjcTypeName + bridgedSwiftStruct.name.removingDuplicatedDDPrefix(after: parentObjcTypeName)
     }
 
     var swiftTypeName: String {
@@ -53,7 +54,8 @@ extension ObjcInteropNestedClass: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftStruct.name
+        let parentObjcTypeName = (parentClass as! ObjcInteropReflectable).objcTypeName
+        return parentObjcTypeName + bridgedSwiftStruct.name.removingDuplicatedDDPrefix(after: parentObjcTypeName)
     }
 
     var swiftTypeName: String {
@@ -71,7 +73,8 @@ extension ObjcInteropNestedEnum: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftEnum.name
+        let parentObjcTypeName = (parentClass as! ObjcInteropReflectable).objcTypeName
+        return parentObjcTypeName + bridgedSwiftEnum.name.removingDuplicatedDDPrefix(after: parentObjcTypeName)
     }
 
     var swiftTypeName: String {
@@ -92,7 +95,8 @@ extension ObjcInteropAssociatedTypeEnum: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftAssociatedTypeEnum.name
+        let parentObjcTypeName = (parentClass as! ObjcInteropReflectable).objcTypeName
+        return parentObjcTypeName + bridgedSwiftAssociatedTypeEnum.name.removingDuplicatedDDPrefix(after: parentObjcTypeName)
     }
 
     var swiftTypeName: String {
@@ -113,6 +117,16 @@ extension ObjcInteropPropertyWrapper {
         } else {
             return swiftPropertyName
         }
+    }
+}
+
+private extension String {
+    func removingDuplicatedDDPrefix(after parentObjcTypeName: String) -> String {
+        guard parentObjcTypeName.hasSuffix("DD"), hasPrefix("DD") else {
+            return self
+        }
+
+        return String(dropFirst(2))
     }
 }
 

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/ObjcInteropPrinter.swift
@@ -6,6 +6,13 @@
 
 import Foundation
 
+private struct AssociatedTypeEnumPropertyIdentity: Hashable {
+    let rootSwiftTypeName: String
+    let ownerObjcTypeName: String
+    let propertyName: String
+    let associatedTypeEnumName: String
+}
+
 /// Generates Swift code for Obj-c interoperability for given `ObjcInteropType` schemas.
 ///
 /// E.g. given `ObjcInteropType` describing Swift struct:
@@ -59,6 +66,27 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
     /// Overrides for generated `@objc(...)` runtime names.
     /// Keys are generated type names (e.g. `objc_RUMErrorEventErrorMeta`), values are runtime names (e.g. `DDRUMErrorEventMeta`).
     private let objcRuntimeNameOverrides: [String: String]
+    /// Overrides for preserving ObjC source compatibility when a schema changes a property into an associated-type enum.
+    private static let legacyStringAccessorWrapperPropertyNames: [AssociatedTypeEnumPropertyIdentity: String] = [
+        .init(
+            rootSwiftTypeName: "TelemetryConfigurationEvent",
+            ownerObjcTypeName: "TelemetryConfigurationEventAction",
+            propertyName: "id",
+            associatedTypeEnumName: "RUMActionID"
+        ): "idValue",
+        .init(
+            rootSwiftTypeName: "TelemetryDebugEvent",
+            ownerObjcTypeName: "TelemetryDebugEventAction",
+            propertyName: "id",
+            associatedTypeEnumName: "RUMActionID"
+        ): "idValue",
+        .init(
+            rootSwiftTypeName: "TelemetryErrorEvent",
+            ownerObjcTypeName: "TelemetryErrorEventAction",
+            propertyName: "id",
+            associatedTypeEnumName: "RUMActionID"
+        ): "idValue"
+    ]
 
     func print(objcInteropTypes: [ObjcInteropType]) throws -> String {
         reset()
@@ -549,6 +577,49 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
     private func printPropertyAccessingNestedAssociatedTypeEnum(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedAssociatedTypeEnum) throws {
         let nestedObjcAssociatedTypeEnum = propertyWrapper.objcNestedAssociatedTypeEnum! // swiftlint:disable:this force_unwrapping
 
+        let swiftProperty = propertyWrapper.bridgedSwiftProperty
+        let objcClassName = objcTypeNamesPrefix + nestedObjcAssociatedTypeEnum.objcTypeName
+
+        if let wrapperPropertyName = legacyStringAccessorWrapperPropertyName(
+            for: propertyWrapper,
+            nestedObjcAssociatedTypeEnum: nestedObjcAssociatedTypeEnum
+        ) {
+            writeLine("public var \(swiftProperty.backtickName): String {")
+            indentRight()
+                writeLine("switch root.swiftModel.\(propertyWrapper.keyPath) {")
+                writeLine("case .string(let value):")
+                    indentRight()
+                    writeLine("return value")
+                    indentLeft()
+                    writeLine("case .stringsArray(let value):")
+                    indentRight()
+                    writeLine("return value.first ?? \"\"")
+                    indentLeft()
+                writeLine("}")
+            indentLeft()
+            writeLine("}")
+
+            writeEmptyLine()
+            try printPropertyAccessingNestedAssociatedTypeEnumWrapper(
+                named: wrapperPropertyName,
+                objcClassName: objcClassName,
+                propertyWrapper: propertyWrapper
+            )
+            return
+        }
+
+        try printPropertyAccessingNestedAssociatedTypeEnumWrapper(
+            named: swiftProperty.backtickName,
+            objcClassName: objcClassName,
+            propertyWrapper: propertyWrapper
+        )
+    }
+
+    private func printPropertyAccessingNestedAssociatedTypeEnumWrapper(
+        named objcPropertyName: String,
+        objcClassName: String,
+        propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedAssociatedTypeEnum
+    ) throws {
         // Generate accessor to the referenced wrapper, e.g.:
         // ```
         // @objc public var bar: DDFooBar? {
@@ -556,9 +627,7 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
         // }
         // ```
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
-        let objcPropertyName = swiftProperty.backtickName
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
-        let objcClassName = objcTypeNamesPrefix + nestedObjcAssociatedTypeEnum.objcTypeName
 
         writeLine("public var \(objcPropertyName): \(objcClassName)\(objcPropertyOptionality) {")
         indentRight()
@@ -577,6 +646,24 @@ public class ObjcInteropPrinter: BasePrinter, CodePrinter {
             }
         indentLeft()
         writeLine("}")
+    }
+
+    private func legacyStringAccessorWrapperPropertyName(
+        for propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedAssociatedTypeEnum,
+        nestedObjcAssociatedTypeEnum: ObjcInteropAssociatedTypeEnum
+    ) -> String? {
+        guard let owner = propertyWrapper.owner as? ObjcInteropReflectable else {
+            return nil
+        }
+
+        let identity = AssociatedTypeEnumPropertyIdentity(
+            rootSwiftTypeName: owner.objcRootClass.bridgedSwiftStruct.name,
+            ownerObjcTypeName: owner.objcTypeName,
+            propertyName: propertyWrapper.bridgedSwiftProperty.name,
+            associatedTypeEnumName: nestedObjcAssociatedTypeEnum.bridgedSwiftAssociatedTypeEnum.name
+        )
+
+        return Self.legacyStringAccessorWrapperPropertyNames[identity]
     }
 
     // MARK: - Generating names

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/ObjcInteropPrinterTests.swift
@@ -2503,6 +2503,224 @@ final class ObjcInteropPrinterTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
+    func testPrintingObjcInteropKeepsLegacyStringAccessorForCompatibleAssociatedTypeEnumProperty() throws {
+        let telemetryEvent = SwiftStruct(
+            name: "TelemetryDebugEvent",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "action",
+                    type: SwiftStruct(
+                        name: "Action",
+                        comment: nil,
+                        properties: [
+                            .mock(
+                                propertyName: "id",
+                                type: SwiftTypeReference(referencedTypeName: "RUMActionID"),
+                                isOptional: false,
+                                mutability: .immutable
+                            )
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    mutability: .immutable
+                )
+            ],
+            conformance: []
+        )
+
+        let rumActionID = SwiftAssociatedTypeEnum(
+            name: "RUMActionID",
+            comment: nil,
+            cases: [
+                SwiftAssociatedTypeEnum.Case(label: "string", associatedType: SwiftPrimitive<String>()),
+                SwiftAssociatedTypeEnum.Case(label: "stringsArray", associatedType: SwiftArray(element: SwiftPrimitive<String>()))
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct TelemetryDebugEvent {
+            public let action: Action?
+
+            ///
+            /// - Parameters:
+            ///   - action:
+            public init(
+                action: Action? = nil
+            ) {
+                self.action = action
+            }
+
+            public struct Action {
+                public let id: RUMActionID
+
+                ///
+                /// - Parameters:
+                ///   - id:
+                public init(
+                    id: RUMActionID
+                ) {
+                    self.id = id
+                }
+            }
+        }
+
+        public enum RUMActionID {
+            case string(value: String)
+            case stringsArray(value: [String])
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc(DDTelemetryDebugEvent)
+        @objcMembers
+        @_spi(objc)
+        public class objc_TelemetryDebugEvent: NSObject {
+            public internal(set) var swiftModel: TelemetryDebugEvent
+            internal var root: objc_TelemetryDebugEvent { self }
+
+            public init(swiftModel: TelemetryDebugEvent) {
+                self.swiftModel = swiftModel
+            }
+
+            public var action: objc_TelemetryDebugEventAction? {
+                root.swiftModel.action != nil ? objc_TelemetryDebugEventAction(root: root) : nil
+            }
+        }
+
+        @objc(DDTelemetryDebugEventAction)
+        @objcMembers
+        @_spi(objc)
+        public class objc_TelemetryDebugEventAction: NSObject {
+            internal let root: objc_TelemetryDebugEvent
+
+            internal init(root: objc_TelemetryDebugEvent) {
+                self.root = root
+            }
+
+            public var id: String {
+                switch root.swiftModel.action!.id {
+                case .string(let value):
+                    return value
+                case .stringsArray(let value):
+                    return value.first ?? ""
+                }
+            }
+
+            public var idValue: objc_TelemetryDebugEventActionRUMActionID {
+                objc_TelemetryDebugEventActionRUMActionID(root: root)
+            }
+        }
+
+        @objc(DDTelemetryDebugEventActionRUMActionID)
+        @objcMembers
+        @_spi(objc)
+        public class objc_TelemetryDebugEventActionRUMActionID: NSObject {
+            internal let root: objc_TelemetryDebugEvent
+
+            internal init(root: objc_TelemetryDebugEvent) {
+                self.root = root
+            }
+
+            public var string: String? {
+                guard case .string(let value) = root.swiftModel.action!.id else {
+                    return nil
+                }
+                return value
+            }
+
+            public var stringsArray: [String]? {
+                guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+                    return nil
+                }
+                return value
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [telemetryEvent, rumActionID])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForReferencedDDTypeRemovesDuplicatedDDPrefixFromWrapperNames() throws {
+        let rumErrorEvent = SwiftStruct(
+            name: "RUMEvent",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "dd",
+                    type: SwiftStruct(
+                        name: "DD",
+                        comment: nil,
+                        properties: [
+                            .mock(
+                                propertyName: "shared",
+                                type: SwiftTypeReference(referencedTypeName: "DDShared"),
+                                isOptional: true,
+                                mutability: .immutable
+                            )
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    mutability: .immutable
+                )
+            ],
+            conformance: []
+        )
+
+        let ddShared = SwiftStruct(
+            name: "DDShared",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "detail",
+                    type: SwiftEnum(
+                        name: "Detail",
+                        comment: nil,
+                        cases: [
+                            SwiftEnum.Case(label: "value1", rawValue: .string(value: "value_1"))
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    mutability: .immutable
+                ),
+                .mock(
+                    propertyName: "status",
+                    type: SwiftEnum(
+                        name: "Status",
+                        comment: nil,
+                        cases: [
+                            SwiftEnum.Case(label: "value2", rawValue: .string(value: "value_2"))
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    mutability: .immutable
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try printSwiftWithObjcInterop(for: [rumErrorEvent, ddShared])
+
+        XCTAssertTrue(actual.contains("public var shared: objc_RUMEventDDShared?"))
+        XCTAssertTrue(actual.contains("@objc(DDRUMEventDDShared)"))
+        XCTAssertTrue(actual.contains("public class objc_RUMEventDDShared: NSObject"))
+        XCTAssertTrue(actual.contains("@objc(DDRUMEventDDSharedDetail)"))
+        XCTAssertTrue(actual.contains("public enum objc_RUMEventDDSharedDetail: Int"))
+        XCTAssertTrue(actual.contains("@objc(DDRUMEventDDSharedStatus)"))
+        XCTAssertTrue(actual.contains("public enum objc_RUMEventDDSharedStatus: Int"))
+        XCTAssertFalse(actual.contains("DDDDShared"))
+    }
+
     func testPrintingObjcInteropForSwiftStructWithAssociatedTypeEnumArrayProperties() throws {
         let associatedTypeEnum1 = SwiftAssociatedTypeEnum(
             name: "Status1",


### PR DESCRIPTION
### What and why?

This PR updates the RUM schema to add profiling quota information to the `dd.profiling` payload of RUM events.
It also centralizes the `DDProfiling` model so it can be reused across RUM events.

### How?

- Updates `RUMDataModels` to include profiling quota information.
- Extends `ProfilingContext` to carry `quotaReason`.
- Exposes a `ddProfiling` computed property to adapt the current profiling additional context into the RUM events.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
