### PR TITLE
RUM-16395: Stop profiling when quota is rejected

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		110DD1B72EEC3E45002F3B8B /* SafeReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DD1B62EEC3E45002F3B8B /* SafeReadTests.swift */; };
 		110DD1BB2EEC3EE7002F3B8B /* safe_read_testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 110DD1B92EEC3EE7002F3B8B /* safe_read_testing.h */; };
 		110DD1BE2EEC7095002F3B8B /* ProfilerFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110DD1BC2EEC708E002F3B8B /* ProfilerFeatureTests.swift */; };
+		11A14A622F9B740000B1C0DE /* ProfilingQuotaChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A14A612F9B740000B1C0DE /* ProfilingQuotaChecker.swift */; };
+		11A14A642F9B740000B1C0DE /* ProfilingQuotaCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A14A632F9B740000B1C0DE /* ProfilingQuotaCheckerTests.swift */; };
 		111201C32E93C13000375DA3 /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111201BF2E93C13000375DA3 /* AppStateManager.swift */; };
 		111201C42E93C13000375DA3 /* AppStateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111201BE2E93C13000375DA3 /* AppStateInfo.swift */; };
 		1121FD002EE319F000297156 /* ProfilingTelemetryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1121FCFE2EE319E600297156 /* ProfilingTelemetryController.swift */; };
@@ -1825,6 +1827,8 @@
 		110DD1B62EEC3E45002F3B8B /* SafeReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeReadTests.swift; sourceTree = "<group>"; };
 		110DD1B92EEC3EE7002F3B8B /* safe_read_testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = safe_read_testing.h; sourceTree = "<group>"; };
 		110DD1BC2EEC708E002F3B8B /* ProfilerFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilerFeatureTests.swift; sourceTree = "<group>"; };
+		11A14A612F9B740000B1C0DE /* ProfilingQuotaChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingQuotaChecker.swift; sourceTree = "<group>"; };
+		11A14A632F9B740000B1C0DE /* ProfilingQuotaCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingQuotaCheckerTests.swift; sourceTree = "<group>"; };
 		111201BE2E93C13000375DA3 /* AppStateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateInfo.swift; sourceTree = "<group>"; };
 		111201BF2E93C13000375DA3 /* AppStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
 		1117AA052D09A39400F86B29 /* RUMAttributesIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAttributesIntegrationTests.swift; sourceTree = "<group>"; };
@@ -6654,6 +6658,7 @@
 				110DD1B02EEB6BB5002F3B8B /* ProfilingConfiguration.swift */,
 				118848592F6C50EC008D2919 /* ProfilingHandler.swift */,
 				1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */,
+				11A14A612F9B740000B1C0DE /* ProfilingQuotaChecker.swift */,
 				1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */,
 				D233E7C32E4625D400E7CFDE /* RequestBuilder.swift */,
 				1126B2512EBAB22600A74226 /* PrivacyInfo.xcprivacy */,
@@ -6683,6 +6688,7 @@
 				1E03E4DD559B4F63BD5A292E /* ProfilingConditionsTests.swift */,
 				110DD1B32EEB7080002F3B8B /* ProfilingConfigurationTests.swift */,
 				BD6D5C2849404C4EAD7FF7E3 /* ProfilingHandlerTests.swift */,
+				11A14A632F9B740000B1C0DE /* ProfilingQuotaCheckerTests.swift */,
 				D233E7DD2E4A109100E7CFDE /* ProfilingTest.swift */,
 				D233E7E32E4A2AFE00E7CFDE /* RequestBuilderTests.swift */,
 				110DD1B62EEC3E45002F3B8B /* SafeReadTests.swift */,
@@ -8537,6 +8543,7 @@
 				D233E7C62E4625D400E7CFDE /* Profiling.swift in Sources */,
 				11C4E5922F571F86002196F4 /* ProfileAttachments.swift in Sources */,
 				1162323E2F87D8FC00F20ABC /* ProfilingContextMessageReceiver.swift in Sources */,
+				11A14A622F9B740000B1C0DE /* ProfilingQuotaChecker.swift in Sources */,
 				116232402F87FA6F00F20ABC /* ProfilingSamplerProvider.swift in Sources */,
 				1121FD022EE33B3400297156 /* ConfigurationMetric.swift in Sources */,
 				D2D0E1F22E3CE59700BA4113 /* dd_profiler.cpp in Sources */,
@@ -9122,6 +9129,7 @@
 				110DD1B52EEB7090002F3B8B /* ProfilingConfigurationTests.swift in Sources */,
 				110DD1BE2EEC7095002F3B8B /* ProfilerFeatureTests.swift in Sources */,
 				0EFAE08216FC46BC84FEDF88 /* ProfilingHandlerTests.swift in Sources */,
+				11A14A642F9B740000B1C0DE /* ProfilingQuotaCheckerTests.swift in Sources */,
 				A6DC5EA853D947FA9FEA4743 /* ProfilingConditionsTests.swift in Sources */,
 				D27465832E7BFEC600C47FE2 /* AppLaunchProfilerTests.swift in Sources */,
 				D2D0E2072E3CEF1200BA4113 /* MachSamplingProfilerTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
@@ -223,22 +223,24 @@ final class ProfilingRUMIntegrationTests: XCTestCase {
 
         // When
         enableRUM(sessionSampleRate: Fixtures.sampledInRUMSessionRate, sessionUUID: sessionUUID)
-        enableProfiling(continuousSampleRate: Fixtures.continuousSampledOutRate)
+        enableProfiling(applicationLaunchSampleRate: 0, continuousSampleRate: Fixtures.continuousSampledOutRate)
 
         startRUMView()
 
         // Then
         waitAndAssertRUMViewEvents()
         waitUntilContinuousProfilingSampled(false)
-        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "continuous profiling is stopped")
 
         startVital(name: vitalName, operationKey: operationKey)
         waitUntilProfilerStatus(DD_PROFILER_STATUS_RUNNING, description: "profiler is running for the custom vital")
+        wait(during: Fixtures.minProfileDuration) {}
 
         finishVital(name: vitalName, operationKey: operationKey)
         waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "profiler is stopped after the custom vital")
 
-        let attachments = try XCTUnwrap(waitForProfileAttachments().last)
+        let profileAttachments = waitForProfileAttachments()
+        XCTAssertEqual(profileAttachments.count, 1)
+        let attachments = try XCTUnwrap(profileAttachments.last)
         let rumVitals = try rumVitals(from: attachments)
         XCTAssertEqual(rumVitals.count, 1)
         XCTAssertEqual(rumVitals.first?["name"] as? String, vitalName)

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -103,7 +103,7 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
                 }
 
                 // Skip Datadog's own intake requests to prevent infinite recursion
-                if self.isDatadogIntakeRequest(currentRequest) {
+                if self.hasDatadogAuthHeader(request: currentRequest) {
                     return
                 }
 
@@ -359,7 +359,7 @@ extension NetworkInstrumentationFeature {
     ///
     /// - Parameter request: The URLRequest to check.
     /// - Returns: `true` if the request is an SDK internal request, `false` otherwise.
-    private func isDatadogIntakeRequest(_ request: URLRequest?) -> Bool {
+    private func hasDatadogAuthHeader(request: URLRequest?) -> Bool {
         // Datadog internal requests authenticate with either `DD-API-KEY` or `DD-CLIENT-TOKEN`.
         // This catches both this SDK's own uploads (preventing recursion) and other Datadog
         // tooling that may run in the same process (e.g. `DatadogSDKTesting`'s CI Visibility

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -360,11 +360,13 @@ extension NetworkInstrumentationFeature {
     /// - Parameter request: The URLRequest to check.
     /// - Returns: `true` if the request is an SDK internal request, `false` otherwise.
     private func isDatadogIntakeRequest(_ request: URLRequest?) -> Bool {
-        // Every Datadog intake request authenticates with `DD-API-KEY`. This catches both this SDK's
-        // own uploads (preventing recursion) and other Datadog tooling that may run in the same
-        // process (e.g. `DatadogSDKTesting`'s CI Visibility uploader, which would otherwise pollute
-        // interception expectations via the global `__NSCFLocalSessionTask.resume` swizzle in tests).
+        // Datadog internal requests authenticate with either `DD-API-KEY` or `DD-CLIENT-TOKEN`.
+        // This catches both this SDK's own uploads (preventing recursion) and other Datadog
+        // tooling that may run in the same process (e.g. `DatadogSDKTesting`'s CI Visibility
+        // uploader, which would otherwise pollute interception expectations via the global
+        // `__NSCFLocalSessionTask.resume` swizzle in tests).
         return request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddAPIKeyHeaderField) != nil
+            || request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddClientTokenHeaderField) != nil
     }
 
     /// Helper structure that optionally contains a trace context and captured state, used to pass this

--- a/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
@@ -20,6 +20,7 @@ public struct URLRequestBuilder {
         public static let contentEncodingHeaderField = "Content-Encoding"
         public static let userAgentHeaderField = "User-Agent"
         public static let ddAPIKeyHeaderField = "DD-API-KEY"
+        public static let ddClientTokenHeaderField = "DD-CLIENT-TOKEN"
         public static let ddEVPOriginHeaderField = "DD-EVP-ORIGIN"
         public static let ddEVPOriginVersionHeaderField = "DD-EVP-ORIGIN-VERSION"
         public static let ddRequestIDHeaderField = "DD-REQUEST-ID"
@@ -81,6 +82,11 @@ public struct URLRequestBuilder {
         /// Datadog request authentication header.
         public static func ddAPIKeyHeader(clientToken: String) -> HTTPHeader {
             return HTTPHeader(field: ddAPIKeyHeaderField, value: { clientToken })
+        }
+
+        /// Datadog client token authentication header.
+        public static func ddClientTokenHeader(clientToken: String) -> HTTPHeader {
+            return HTTPHeader(field: ddClientTokenHeaderField, value: { clientToken })
         }
 
         /// An observability and troubleshooting Datadog header for tracking the origin which is sending the request.

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1803,9 +1803,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             taskCompleted.fulfill()
         }
         task.resume()
+        task.cancel()
 
-        // Wait for task to complete
-        wait(for: [taskCompleted], timeout: 10)
+        // Wait for the cancellation completion.
+        wait(for: [taskCompleted], timeout: 1)
 
         // Then - Verify SDK request with DD-API-KEY was not intercepted
         XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-API-KEY header, even to custom endpoints")
@@ -1823,7 +1824,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         }
 
         // When - Make a request with DD-CLIENT-TOKEN (used by the profiling quota admission API)
-        let quotaURL = URL(string: "https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota?session_id=test")!
+        let quotaURL = URL(string: "http://custom-endpoint.example.com/api/v2/profiling/quota?session_id=test")!
         var request = URLRequest(url: quotaURL)
         request.setValue(.mockRandom(), forHTTPHeaderField: "DD-CLIENT-TOKEN")
 
@@ -1832,8 +1833,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             taskCompleted.fulfill()
         }
         task.resume()
+        task.cancel()
 
-        wait(for: [taskCompleted], timeout: 10)
+        // Wait for the cancellation completion.
+        wait(for: [taskCompleted], timeout: 1)
 
         // Then
         XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-CLIENT-TOKEN header")

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1811,6 +1811,34 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-API-KEY header, even to custom endpoints")
     }
 
+    func testAutomaticMode_doesNotTrackSDKRequestsAuthenticatedWithClientToken() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        let session = URLSession(configuration: .ephemeral)
+
+        var interceptedSDKRequests: [URLSessionTaskInterception] = []
+        handler.onInterceptionDidStart = { interception in
+            interceptedSDKRequests.append(interception)
+        }
+
+        // When - Make a request with DD-CLIENT-TOKEN (used by the profiling quota admission API)
+        let quotaURL = URL(string: "https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota?session_id=test")!
+        var request = URLRequest(url: quotaURL)
+        request.setValue(.mockRandom(), forHTTPHeaderField: "DD-CLIENT-TOKEN")
+
+        let taskCompleted = expectation(description: "Task completed")
+        let task = session.dataTask(with: request) { _, _, _ in
+            taskCompleted.fulfill()
+        }
+        task.resume()
+
+        wait(for: [taskCompleted], timeout: 10)
+
+        // Then
+        XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-CLIENT-TOKEN header")
+    }
+
     func testAutomaticMode_doesNotTrackDatadogSDKTestingRequests() throws {
         // Given - Enable automatic mode
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)

--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -77,10 +77,14 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
             currentServerTimeOffset = message.ttid.serverTimeOffset
             dd_profiler_set_server_time_offset_ns(message.ttid.serverTimeOffset.dd.toInt64Nanoseconds)
 
-            defer { Self.unregisterInstance() }
+            defer {
+                if Self.unregisterInstance(stopProfiler: quotaChecker.isRejectedByQuota) {
+                    updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
+                }
+            }
+
             // Quota is fail-open while pending or unavailable; only an explicit rejection drops app-launch.
             guard !quotaChecker.isRejectedByQuota else {
-                stopProfilerOnQuotaRejectionIfNeeded()
                 telemetryController.sendProfileDropped(
                     for: operation,
                     reason: .quotaRejected(quotaChecker.quotaResult?.reason)
@@ -130,15 +134,6 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
 
         return currentProfile
     }
-
-    private func stopProfilerOnQuotaRejectionIfNeeded() {
-        guard Self.currentPendingInstances <= 1 else {
-            return
-        }
-
-        dd_profiler_stop()
-        updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
-    }
 }
 
 // MARK: - Handle AppLaunchProfiler instances
@@ -153,15 +148,26 @@ private extension AppLaunchProfiler {
     }
 
     /// Decrements the pending instance counter and destroys the profiler when all instances are done.
-    static func unregisterInstance() {
+    @discardableResult
+    static func unregisterInstance(stopProfiler: Bool = false) -> Bool {
         lock.lock()
         defer { lock.unlock() }
 
         pendingInstances -= 1
-        if pendingInstances <= 0 {
-            dd_pprof_destroy(Self.appLaunchProfile)
-            Self.appLaunchProfile = nil
+        guard pendingInstances <= 0 else {
+            return false
         }
+
+        if stopProfiler {
+            dd_profiler_stop()
+            if let profile = dd_profiler_flush_and_get_profile() {
+                dd_pprof_destroy(profile)
+            }
+        }
+
+        dd_pprof_destroy(Self.appLaunchProfile)
+        Self.appLaunchProfile = nil
+        return stopProfiler
     }
 }
 

--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -25,6 +25,7 @@ internal final class AppLaunchProfiler: ProfilingHandler {
     private static let lock = NSLock()
 
     private let profilingSamplerProvider: ProfilingSamplerProvider
+    private let quotaChecker: ProfilingQuotaChecking
 
     let featureScope: FeatureScope
     let telemetryController: ProfilingTelemetryController
@@ -41,6 +42,7 @@ internal final class AppLaunchProfiler: ProfilingHandler {
     init(
         core: DatadogCoreProtocol,
         profilingSamplerProvider: ProfilingSamplerProvider,
+        quotaChecker: ProfilingQuotaChecking,
         telemetryController: ProfilingTelemetryController = .init(),
         encoder: JSONEncoder = JSONEncoder()
     ) {
@@ -48,6 +50,7 @@ internal final class AppLaunchProfiler: ProfilingHandler {
 
         self.featureScope = core.scope(for: ProfilerFeature.self)
         self.profilingSamplerProvider = profilingSamplerProvider
+        self.quotaChecker = quotaChecker
         self.telemetryController = telemetryController
         self.encoder = encoder
     }
@@ -74,6 +77,17 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
             currentServerTimeOffset = message.ttid.serverTimeOffset
             dd_profiler_set_server_time_offset_ns(message.ttid.serverTimeOffset.dd.toInt64Nanoseconds)
 
+            defer { Self.unregisterInstance() }
+            // Quota is fail-open while pending or unavailable; only an explicit rejection drops app-launch.
+            guard !quotaChecker.isRejectedByQuota else {
+                stopProfilerOnQuotaRejectionIfNeeded()
+                telemetryController.sendProfileDropped(
+                    for: operation,
+                    reason: .quotaRejected(quotaChecker.quotaResult?.reason)
+                )
+                return false
+            }
+
             if profilingSamplerProvider.isContinuousProfilingConfigured == false
                 && self.currentRUMVitals.didCompleteOperations() {
                 dd_profiler_stop()
@@ -82,7 +96,6 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
 
             currentRUMVitals[message.ttid.key] = message.ttid
 
-            defer { Self.unregisterInstance() }
             guard let profile = appLaunchProfile() else {
                 telemetryController.sendNoProfile(for: operation)
                 return false
@@ -116,6 +129,15 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
         Self.appLaunchProfile = currentProfile
 
         return currentProfile
+    }
+
+    private func stopProfilerOnQuotaRejectionIfNeeded() {
+        guard Self.currentPendingInstances <= 1 else {
+            return
+        }
+
+        dd_profiler_stop()
+        updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
     }
 }
 

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -123,11 +123,12 @@ internal final class DatadogProfiler: ProfilingHandler {
                 }
 
                 if result?.decision == .quotaKO {
-                    // Quota is evaluated per RUM session. Once rejected, disable continuous/custom profiling,
-                    // but let app-launch profiling keep the shared native profiler briefly if TTID is pending.
-                    cleanUpState(preservingOngoingOperations: false)
+                    // Quota is evaluated per RUM session. Once rejected, disable profiling for
+                    // continuous, custom and app-launch profiles in that session.
+                    cleanUpState()
                     isStoppedByQuota = true
                     updateProfilerState(canProfile: shouldKeepProfilerRunning())
+                    discardCurrentProfile()
                 } else if isStoppedByQuota {
                     // A new session clears the previous quota result before the next check completes.
                     // Restart immediately when profiling is otherwise allowed, matching quota fail-open.
@@ -284,17 +285,15 @@ private extension DatadogProfiler {
             }
             attributes = message.attributes
 
-            // Remove events that were handled by `AppLaunchProfiler`
-            currentRUMVitals = currentRUMVitals.ongoingOperations()
-            hangs.removeAll()
-            longTasks.removeAll()
+            // Remove events that were handled by `AppLaunchProfiler`.
+            cleanUpState()
             updateProfilerState(canProfile: shouldKeepProfilerRunning())
         }
     }
 
     func handleOperation(message: OperationMessage) {
         queue.async { [weak self] in
-            guard let self else {
+            guard let self, !quotaChecker.isRejectedByQuota else {
                 return
             }
             attributes = message.attributes
@@ -324,13 +323,21 @@ private extension DatadogProfiler {
 
     func handleAppHang(message: AppHangMessage) {
         queue.async { [weak self] in
-            self?.hangs.append(message.hang)
+            guard let self, !self.quotaChecker.isRejectedByQuota else {
+                return
+            }
+            attributes = message.attributes
+            hangs.append(message.hang)
         }
     }
 
     func handleLongTask(message: LongTaskMessage) {
         queue.async { [weak self] in
-            self?.longTasks.append(message.longTask)
+            guard let self, !self.quotaChecker.isRejectedByQuota else {
+                return
+            }
+            attributes = message.attributes
+            longTasks.append(message.longTask)
         }
     }
 
@@ -346,7 +353,7 @@ private extension DatadogProfiler {
             if canProfile {
                 dd_profiler_start()
                 previousCustomProfilingStartDate = dateProvider.now
-                updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
+                updateProfilingContext()
                 startTimer()
             }
         case .running:
@@ -357,7 +364,7 @@ private extension DatadogProfiler {
             } else {
                 stopTimer()
                 dd_profiler_stop()
-                updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
+                updateProfilingContext(quotaReason: quotaChecker.isRejectedByQuota ? quotaChecker.quotaResult?.reason : nil)
             }
         default: break
         }
@@ -367,6 +374,7 @@ private extension DatadogProfiler {
         previousCustomProfilingStartDate = dateProvider.now
         guard let profile = dd_profiler_flush_and_get_profile() else {
             telemetryController.sendNoProfile(for: operation)
+            cleanUpState()
             return
         }
 
@@ -379,10 +387,21 @@ private extension DatadogProfiler {
                 longTasks: longTasks
             )
         } else {
-            telemetryController.sendProfileNotWritten(for: operation)
+            telemetryController.sendProfileDropped(for: operation, reason: profileDropReason)
         }
 
-        cleanUpState(preservingOngoingOperations: !quotaChecker.isRejectedByQuota)
+        cleanUpState()
+    }
+
+    func discardCurrentProfile() {
+        guard let profile = dd_profiler_flush_and_get_profile() else {
+            return
+        }
+        dd_pprof_destroy(profile)
+    }
+
+    var profileDropReason: ProfilingSessionMetric.ProfileDropReason {
+        quotaChecker.isRejectedByQuota ? .quotaRejected(quotaChecker.quotaResult?.reason) : .noProfiledEvents
     }
 
     var canWriteProfile: Bool {
@@ -396,7 +415,7 @@ private extension DatadogProfiler {
 
     func shouldKeepProfilerRunning() -> Bool {
         guard !quotaChecker.isRejectedByQuota else {
-            return hasConditionsToProfile && canWaitForAppLaunchVital
+            return false
         }
 
         if profilingSamplerProvider.isContinuousProfilingConfigured {
@@ -414,8 +433,8 @@ private extension DatadogProfiler {
     }
 
     var canWaitForAppLaunchVital: Bool {
-        // App launch profiles share the native profiler but are not gated by quota.
-        // If quota rejects before TTID, keep sampling only until the normal cutoff elapses.
+        // If continuous profiling samples out before TTID, keep the shared native profiler
+        // briefly so AppLaunchProfiler can harvest the launch profile.
         hasReceivedAppLaunchVital == false
             && dateProvider.now.timeIntervalSince(previousCustomProfilingStartDate) < Constants.cutOffTime
     }
@@ -426,14 +445,18 @@ private extension DatadogProfiler {
     }
 
     func canExtendCustomProfiling() -> Bool {
-        currentRUMVitals.ongoingOperations().contains {
+        guard !quotaChecker.isRejectedByQuota else {
+            return false
+        }
+
+        return currentRUMVitals.ongoingOperations().contains {
             dateProvider.now.timeIntervalSince($1.date) < Constants.cutOffTime
         }
     }
 
-    func cleanUpState(preservingOngoingOperations: Bool = true) {
+    func cleanUpState() {
         // Preserve ongoing custom operations across normal flushes; quota rejection discards all RUM references.
-        if preservingOngoingOperations && canExtendCustomProfiling() {
+        if canExtendCustomProfiling() {
             currentRUMVitals = currentRUMVitals.ongoingOperations()
         } else {
             currentRUMVitals.removeAll()

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -23,8 +23,8 @@ internal final class DatadogProfiler: ProfilingHandler {
         static let maxProfileDuration: TimeInterval = 60 // 1 minute profiles
         /// Minimum profile duration during continuous profiling.
         static let minProfileDuration: TimeInterval = 5 // 5 seconds profiles
-        /// Default cut off duration for custom profiling.
-        static let customProfilingCutOffTime: TimeInterval = 60 // 1 minute cutoff
+        /// Maximum time to keep profiling alive while waiting for RUM events.
+        static let cutOffTime: TimeInterval = 60 // 1 minute cutoff
     }
 
     static let defaultQueue = DispatchQueue(
@@ -39,6 +39,7 @@ internal final class DatadogProfiler: ProfilingHandler {
     /// The queue used to synchronize the profiling data and the writes.
     private let queue: DispatchQueue
     private let profilingSamplerProvider: ProfilingSamplerProvider
+    private let quotaChecker: ProfilingQuotaChecking
     private let profilingConditions: ProfilingConditions
     private let profilingInterval: TimeInterval
     private let minProfileDuration: TimeInterval
@@ -67,13 +68,18 @@ internal final class DatadogProfiler: ProfilingHandler {
     // Current profiling mode
     private(set) var operation: ProfilingOperation
     /// Allows continuous profiling to temporarily run while waiting for the first
-    /// RUM-linked sampling decision. The grace is consumed on the first timer cycle
-    /// or when the app backgrounds before a decision is received.
+    /// RUM-linked sampling decision. The grace is consumed when a definitive decision
+    /// arrives, on the first timer cycle, or when the app backgrounds before a decision
+    /// is received.
     private var isContinuousProfilingGraceAvailable: Bool
+    /// Tracks profiler stops caused by quota rejection so a later session quota reset can
+    /// restart profiling without waiting for an unrelated app-state or condition change.
+    private var isStoppedByQuota = false
 
     init?(
         core: DatadogCoreProtocol,
         profilingSamplerProvider: ProfilingSamplerProvider,
+        quotaChecker: ProfilingQuotaChecking,
         queue: DispatchQueue = DatadogProfiler.defaultQueue,
         telemetryController: ProfilingTelemetryController = .init(),
         profilingConditions: ProfilingConditions = .init(),
@@ -94,6 +100,7 @@ internal final class DatadogProfiler: ProfilingHandler {
         self.featureScope = core.scope(for: ProfilerFeature.self)
         self.queue = queue
         self.profilingSamplerProvider = profilingSamplerProvider
+        self.quotaChecker = quotaChecker
         self.telemetryController = telemetryController
         self.profilingConditions = profilingConditions
         self.profilingInterval = profilingInterval
@@ -103,13 +110,40 @@ internal final class DatadogProfiler: ProfilingHandler {
         self.previousCustomProfilingStartDate = dateProvider.now
         self.operation = profilingSamplerProvider.isContinuousProfilingConfigured ? .continuousProfiling : .customProfiling
         self.isContinuousProfilingGraceAvailable = profilingSamplerProvider.isContinuousProfilingConfigured
+            && profilingSamplerProvider.continuousProfilingSampled == nil
 
         if profilingSamplerProvider.isContinuousProfilingConfigured {
             startTimer()
         }
+
+        quotaChecker.onQuotaResultUpdate = { [weak self] result in
+            self?.queue.async { [weak self] in
+                guard let self else {
+                    return
+                }
+
+                if result?.decision == .quotaKO {
+                    // Quota is evaluated per RUM session. Once rejected, disable continuous/custom profiling,
+                    // but let app-launch profiling keep the shared native profiler briefly if TTID is pending.
+                    cleanUpState(preservingOngoingOperations: false)
+                    isStoppedByQuota = true
+                    updateProfilerState(canProfile: shouldKeepProfilerRunning())
+                } else if isStoppedByQuota {
+                    // A new session clears the previous quota result before the next check completes.
+                    // Restart immediately when profiling is otherwise allowed, matching quota fail-open.
+                    let canProfile = shouldKeepProfilerRunning()
+                    isStoppedByQuota = false
+                    updateProfilerState(canProfile: canProfile)
+                    if canProfile && timer == nil {
+                        startTimer()
+                    }
+                }
+            }
+        }
     }
 
     deinit {
+        stopTimer()
         Self.lock.lock()
         Self.hasActiveInstance = false
         Self.lock.unlock()
@@ -195,8 +229,25 @@ private extension DatadogProfiler {
             let currentAppState = context.applicationStateHistory.currentState
             defer { previousAppState = currentAppState }
 
-            if let isContinuousProfiling = profilingSamplerProvider.continuousProfilingSampled {
-                operation = isContinuousProfiling ? .continuousProfiling : .customProfiling
+            switch profilingSamplerProvider.continuousProfilingSampled {
+            case true:
+                operation = .continuousProfiling
+            case false:
+                operation = .customProfiling
+
+                if isContinuousProfilingGraceAvailable {
+                    // The profiler was running optimistically while waiting for the RUM
+                    // sampling decision. If that decision samples out continuous profiling,
+                    // stop the optimistic profiler unless app-launch profiling still needs
+                    // the shared native profiler to harvest TTID.
+                    isContinuousProfilingGraceAvailable = false
+                    let canProfile = shouldKeepProfilerRunning()
+                    if canProfile || !canWaitForAppLaunchVital {
+                        updateProfilerState(canProfile: canProfile)
+                    }
+                    return
+                }
+            case .none: break
             }
 
             if currentAppState == .background {
@@ -226,6 +277,7 @@ private extension DatadogProfiler {
     }
 
     func handleAppLaunch(message: TTIDMessage) {
+        hasReceivedAppLaunchVital = true
         queue.async { [weak self] in
             guard let self else {
                 return
@@ -294,14 +346,18 @@ private extension DatadogProfiler {
             if canProfile {
                 dd_profiler_start()
                 previousCustomProfilingStartDate = dateProvider.now
-                updateProfilingContext()
+                updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
                 startTimer()
             }
         case .running:
-            if canProfile == false {
-                dd_profiler_stop()
-                updateProfilingContext()
+            if canProfile {
+                if timer == nil {
+                    startTimer()
+                }
+            } else {
                 stopTimer()
+                dd_profiler_stop()
+                updateProfilingContext(quotaReason: quotaChecker.quotaResult?.reason)
             }
         default: break
         }
@@ -322,20 +378,27 @@ private extension DatadogProfiler {
                 hangs: hangs,
                 longTasks: longTasks
             )
-            cleanUpState()
         } else {
             telemetryController.sendProfileNotWritten(for: operation)
         }
+
+        cleanUpState(preservingOngoingOperations: !quotaChecker.isRejectedByQuota)
     }
 
     var canWriteProfile: Bool {
-        // At least Custom Profiling is running
-        self.currentRUMVitals.count > 0
-        // Continuous Profiling is sampled in and there are events of interest
-        || (profilingSamplerProvider.continuousProfilingSampled == true && (hangs.count > 0 || longTasks.count > 0))
+        let hasCustomProfilingData = currentRUMVitals.count > 0
+        let hasContinuousProfilingData = profilingSamplerProvider.continuousProfilingSampled == true
+            && (hangs.count > 0 || longTasks.count > 0)
+
+        // Keep quota fail-open while the check is pending. Only explicit rejection prevents writing.
+        return (hasCustomProfilingData || hasContinuousProfilingData) && !quotaChecker.isRejectedByQuota
     }
 
     func shouldKeepProfilerRunning() -> Bool {
+        guard !quotaChecker.isRejectedByQuota else {
+            return hasConditionsToProfile && canWaitForAppLaunchVital
+        }
+
         if profilingSamplerProvider.isContinuousProfilingConfigured {
             switch profilingSamplerProvider.continuousProfilingSampled {
             case .some(true): // It is Continuous Profiling running
@@ -350,6 +413,13 @@ private extension DatadogProfiler {
         }
     }
 
+    var canWaitForAppLaunchVital: Bool {
+        // App launch profiles share the native profiler but are not gated by quota.
+        // If quota rejects before TTID, keep sampling only until the normal cutoff elapses.
+        hasReceivedAppLaunchVital == false
+            && dateProvider.now.timeIntervalSince(previousCustomProfilingStartDate) < Constants.cutOffTime
+    }
+
     var isCustomProfiling: Bool {
         profilingSamplerProvider.isContinuousProfilingConfigured == false
             || profilingSamplerProvider.continuousProfilingSampled == false
@@ -357,16 +427,16 @@ private extension DatadogProfiler {
 
     func canExtendCustomProfiling() -> Bool {
         currentRUMVitals.ongoingOperations().contains {
-            dateProvider.now.timeIntervalSince($1.date) < Constants.customProfilingCutOffTime
+            dateProvider.now.timeIntervalSince($1.date) < Constants.cutOffTime
         }
     }
 
-    func cleanUpState() {
-        // if it is custom profiling and reached the cutoff time
-        if canExtendCustomProfiling() == false {
-            currentRUMVitals.removeAll()
-        } else {
+    func cleanUpState(preservingOngoingOperations: Bool = true) {
+        // Preserve ongoing custom operations across normal flushes; quota rejection discards all RUM references.
+        if preservingOngoingOperations && canExtendCustomProfiling() {
             currentRUMVitals = currentRUMVitals.ongoingOperations()
+        } else {
+            currentRUMVitals.removeAll()
         }
         hangs.removeAll()
         longTasks.removeAll()

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -231,9 +231,9 @@ private extension DatadogProfiler {
             defer { previousAppState = currentAppState }
 
             switch profilingSamplerProvider.continuousProfilingSampled {
-            case true:
+            case true?:
                 operation = .continuousProfiling
-            case false:
+            case false?:
                 operation = .customProfiling
 
                 if isContinuousProfilingGraceAvailable {
@@ -243,7 +243,7 @@ private extension DatadogProfiler {
                     // the shared native profiler to harvest TTID.
                     isContinuousProfilingGraceAvailable = false
                     let canProfile = shouldKeepProfilerRunning()
-                    if canProfile || !canWaitForAppLaunchVital {
+                    if canProfile || !shouldWaitForAppLaunchVital {
                         updateProfilerState(canProfile: canProfile)
                     }
                     return
@@ -432,7 +432,7 @@ private extension DatadogProfiler {
         }
     }
 
-    var canWaitForAppLaunchVital: Bool {
+    var shouldWaitForAppLaunchVital: Bool {
         // If continuous profiling samples out before TTID, keep the shared native profiler
         // briefly so AppLaunchProfiler can harvest the launch profile.
         hasReceivedAppLaunchVital == false

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -60,9 +60,12 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
             AppLaunchProfiler(
                 core: core,
                 profilingSamplerProvider: profilingSamplerProvider,
+                quotaChecker: quotaChecker,
                 telemetryController: telemetryController
             )
         )
+
+        messageReceivers.append(quotaChecker)
 
         if let datadogProfiler = DatadogProfiler(
             core: core,
@@ -71,7 +74,6 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
             telemetryController: telemetryController,
             minProfileDuration: configuration.minProfileDuration
         ) {
-            messageReceivers.append(quotaChecker)
             messageReceivers.append(datadogProfiler)
         }
 

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -43,6 +43,7 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
         configuration: Profiling.Configuration,
         requestBuilder: FeatureRequestBuilder,
         telemetryController: ProfilingTelemetryController,
+        quotaChecker: ProfilingQuotaChecking = ProfilingQuotaChecker(),
         userDefaults: UserDefaults = UserDefaults(suiteName: DD_PROFILING_USER_DEFAULTS_SUITE_NAME) ?? .standard //swiftlint:disable:this required_reason_api_name
     ) {
         self.requestBuilder = requestBuilder
@@ -52,20 +53,25 @@ internal final class ProfilerFeature: DatadogRemoteFeature {
         self.profilingSamplerProvider = ProfilingSamplerProvider(continuousSampleRate: continuousSampleRate)
 
         var messageReceivers: [FeatureMessageReceiver] = [
-            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
+            ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider)
+        ]
+
+        messageReceivers.append(
             AppLaunchProfiler(
                 core: core,
                 profilingSamplerProvider: profilingSamplerProvider,
                 telemetryController: telemetryController
             )
-        ]
+        )
 
         if let datadogProfiler = DatadogProfiler(
             core: core,
             profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker,
             telemetryController: telemetryController,
             minProfileDuration: configuration.minProfileDuration
         ) {
+            messageReceivers.append(quotaChecker)
             messageReceivers.append(datadogProfiler)
         }
 

--- a/DatadogProfiling/Sources/ProfilingHandler.swift
+++ b/DatadogProfiling/Sources/ProfilingHandler.swift
@@ -29,8 +29,8 @@ internal protocol ProfilingHandler {
 
 extension ProfilingHandler {
     @discardableResult
-    func updateProfilingContext() -> ProfilingContext {
-        let profilingContext = ProfilingContext(status: .current)
+    func updateProfilingContext(quotaReason: DDProfiling.QuotaReason? = nil) -> ProfilingContext {
+        let profilingContext = ProfilingContext(status: .current, quotaReason: quotaReason)
         self.featureScope.set(context: profilingContext)
 
         return profilingContext

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -39,7 +39,7 @@ extension ProfilingQuotaChecking {
 /// Checks profiling quota admission for the active RUM session.
 ///
 /// This service owns the quota request lifecycle and session-scoped result cache.
-/// It starts a quota request when a RUM session id is observed with granted
+/// It starts a quota request when a sampled-in RUM session id is observed with granted
 /// tracking consent, ignores stale responses for previous sessions and fails open
 /// on request or decoding errors.
 internal final class ProfilingQuotaChecker: ProfilingQuotaChecking {
@@ -74,7 +74,8 @@ extension ProfilingQuotaChecker: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         guard case let .context(context) = message,
               context.trackingConsent == .granted,
-              let rumContext = context.additionalContext(ofType: RUMCoreContext.self) else {
+              let rumContext = context.additionalContext(ofType: RUMCoreContext.self),
+              rumContext.sessionSampler.isSampled else {
             return false
         }
 

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -234,15 +234,22 @@ private struct QuotaResponse: Decodable {
 }
 
 private extension QuotaResponse.Attributes {
+    /// Converts quota response attributes into the session-scoped upload gate.
+    ///
+    /// `admitted` is the source of truth for quota admission/rejection reasons. This keeps
+    /// the SDK correct if `admitted` and `reason` disagree, or if a new backend rejection
+    /// reason is normalized to `.undefined`. Explicit fail-open reasons keep uploads enabled
+    /// regardless of `admitted`.
     var quotaResult: ProfilingQuotaResult {
+        let decision: ProfilingQuotaResult.Decision
         switch reason {
-        case .backendUnavailable:
-            return .init(decision: .quotaOK, reason: reason)
-        case .timeout, .apiError:
-            return .init(decision: .quotaOK, reason: .apiError)
+        case .backendUnavailable, .timeout, .apiError:
+            decision = .quotaOK
         case .quotaOk, .quotaExceeded, .orgDisabled, .undefined:
-            return .init(decision: admitted ? .quotaOK : .quotaKO, reason: reason)
+            decision = admitted ? .quotaOK : .quotaKO
         }
+
+        return .init(decision: decision, reason: reason)
     }
 }
 

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -1,0 +1,248 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+#if !os(watchOS)
+
+internal struct ProfilingQuotaResult: Equatable {
+    internal enum Decision: Equatable {
+        case quotaOK
+        case quotaKO
+    }
+
+    let decision: Decision
+    let reason: DDProfiling.QuotaReason
+}
+
+internal protocol ProfilingQuotaChecking: AnyObject, FeatureMessageReceiver {
+    var quotaResult: ProfilingQuotaResult? { get }
+
+    /// Called when the active session quota result changes.
+    ///
+    /// The callback emits `nil` when a new session starts and the previous result is cleared,
+    /// then emits the resolved result once the quota request completes.
+    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)? { get set }
+}
+
+extension ProfilingQuotaChecking {
+    // Keep quota fail-open while the check is pending. This avoids losing early profiles on slow quota responses.
+    var isRejectedByQuota: Bool {
+        quotaResult?.decision == .quotaKO
+    }
+}
+
+/// Checks profiling quota admission for the active RUM session.
+///
+/// This service owns the quota request lifecycle and session-scoped result cache.
+/// It starts a quota request when a RUM session id is observed with granted
+/// tracking consent, ignores stale responses for previous sessions and fails open
+/// on request or decoding errors.
+internal final class ProfilingQuotaChecker: ProfilingQuotaChecking {
+    private enum Constants {
+        static let quotaPath = "/api/v2/profiling/quota"
+        static let sessionIDQueryItem = "session_id"
+    }
+
+    private static var urlSession: URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+
+        return URLSession(configuration: configuration)
+    }
+
+    private let urlSession: URLSession
+
+    @ReadWriteLock
+    private var state: State = .idle
+    var quotaResult: ProfilingQuotaResult? { state.quotaResult }
+
+    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)?
+
+    init(urlSession: URLSession = ProfilingQuotaChecker.urlSession) {
+        self.urlSession = urlSession
+    }
+}
+
+extension ProfilingQuotaChecker: FeatureMessageReceiver {
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message,
+              context.trackingConsent == .granted,
+              let rumContext = context.additionalContext(ofType: RUMCoreContext.self) else {
+            return false
+        }
+
+        checkIfNeeded(sessionID: rumContext.sessionID, context: context)
+
+        return false
+    }
+
+    private func checkIfNeeded(sessionID: String, context: DatadogContext) {
+        var shouldStartRequest = false
+
+        _state.mutate {
+            switch $0 {
+            case .idle:
+                $0 = .pending(sessionID: sessionID)
+                shouldStartRequest = true
+            case .pending(let currentSessionID), .resolved(let currentSessionID, _):
+                guard currentSessionID != sessionID else {
+                    return
+                }
+
+                $0 = .pending(sessionID: sessionID)
+                shouldStartRequest = true
+            }
+        }
+
+        guard shouldStartRequest else {
+            return
+        }
+
+        onQuotaResultUpdate?(nil)
+
+        let request = self.request(sessionID: sessionID, context: context)
+        urlSession.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else {
+                return
+            }
+
+            let result = Self.mapResponse(data: data, response: response, error: error)
+
+            if self.storeIfCurrentSession(result: result, sessionID: sessionID) {
+                self.onQuotaResultUpdate?(result)
+            }
+        }
+        .resume()
+    }
+
+    private func request(sessionID: String, context: DatadogContext) -> URLRequest {
+        var request = URLRequest(url: quotaURL(for: context.site, sessionID: sessionID))
+        request.httpMethod = "GET"
+        request.httpShouldHandleCookies = false
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("application/vnd.api+json", forHTTPHeaderField: "Accept")
+        request.setValue(context.clientToken, forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddClientTokenHeaderField)
+
+        return request
+    }
+
+    private func quotaURL(for site: DatadogSite, sessionID: String) -> URL {
+        var components = URLComponents(url: site.endpoint, resolvingAgainstBaseURL: false)
+        let quotaHost = components?.host.map { "quota.\($0)" }
+        components?.host = quotaHost
+        components?.path = Constants.quotaPath
+        components?.queryItems = [URLQueryItem(name: Constants.sessionIDQueryItem, value: sessionID)]
+
+        return components?.url ?? site.endpoint
+    }
+
+    private func storeIfCurrentSession(result: ProfilingQuotaResult, sessionID: String) -> Bool {
+        var didStore = false
+
+        _state.mutate {
+            switch $0 {
+            case .pending(let currentSessionID) where currentSessionID == sessionID,
+                    .resolved(let currentSessionID, _) where currentSessionID == sessionID:
+                $0 = .resolved(sessionID: sessionID, result: result)
+                didStore = true
+            default:
+                return
+            }
+        }
+
+        return didStore
+    }
+}
+
+extension ProfilingQuotaChecker {
+    static func mapResponse(data: Data?, response _: URLResponse?, error: Error?) -> ProfilingQuotaResult {
+        if let error = error as? URLError {
+            if error.code == .timedOut {
+                return .init(decision: .quotaOK, reason: .timeout)
+            }
+
+            return .init(decision: .quotaOK, reason: .apiError)
+        }
+
+        guard let data,
+              let quotaResponse = try? JSONDecoder().decode(QuotaResponse.self, from: data)
+        else {
+            return .init(decision: .quotaOK, reason: .apiError)
+        }
+
+        return quotaResponse.data.attributes.quotaResult
+    }
+}
+
+private extension ProfilingQuotaChecker {
+    enum State {
+        case idle
+        case pending(sessionID: String)
+        case resolved(sessionID: String, result: ProfilingQuotaResult)
+
+        var quotaResult: ProfilingQuotaResult? {
+            guard case let .resolved(_, result) = self else {
+                return nil
+            }
+
+            return result
+        }
+    }
+}
+
+private struct QuotaResponse: Decodable {
+    struct DataContainer: Decodable {
+        let attributes: Attributes
+    }
+
+    struct Attributes: Decodable {
+        let admitted: Bool
+        let reason: DDProfiling.QuotaReason
+
+        enum CodingKeys: String, CodingKey {
+            case admitted
+            case reason
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            admitted = try container.decode(Bool.self, forKey: .admitted)
+
+            let rawReason = try container.decodeIfPresent(String.self, forKey: .reason)
+            reason = Self.normalizedReason(from: rawReason)
+        }
+
+        private static func normalizedReason(from rawValue: String?) -> DDProfiling.QuotaReason {
+            switch rawValue {
+            case DDProfiling.QuotaReason.backendUnavailable.rawValue, "backend_client_not_initialized":
+                return .backendUnavailable
+            case let rawValue:
+                return rawValue.flatMap(DDProfiling.QuotaReason.init(rawValue:)) ?? .undefined
+            }
+        }
+    }
+
+    let data: DataContainer
+}
+
+private extension QuotaResponse.Attributes {
+    var quotaResult: ProfilingQuotaResult {
+        switch reason {
+        case .backendUnavailable:
+            return .init(decision: .quotaOK, reason: reason)
+        case .timeout, .apiError:
+            return .init(decision: .quotaOK, reason: .apiError)
+        case .quotaOk, .quotaExceeded, .orgDisabled, .undefined:
+            return .init(decision: admitted ? .quotaOK : .quotaKO, reason: reason)
+        }
+    }
+}
+
+#endif

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
@@ -20,13 +20,31 @@ internal final class ProfilingSessionMetric {
         static let sessionKey = "profiling_session"
         static let noProfileErrorMessage = "No profile was stored."
         static let noDataErrorMessage = "Error serializing the profile."
-        static let profileNotWrittenErrorMessage = "Profile was not written because no profiled events were collected."
+        static let noProfiledEventsErrorMessage = "Profile was not written because no profiled events were collected."
+        static let quotaErrorMessage = "Profile was not written because profiling quota rejected the session."
     }
 
     enum StartReason: String {
         case applicationLaunch = "application_launch"
         case continuous = "continuous"
         case rumOperation = "rum_operation"
+    }
+
+    enum ProfileDropReason: Equatable {
+        case noProfiledEvents
+        case quotaRejected(DDProfiling.QuotaReason?)
+
+        var errorMessage: String {
+            switch self {
+            case .noProfiledEvents:
+                return Constants.noProfiledEventsErrorMessage
+            case .quotaRejected(let reason):
+                guard let reason else {
+                    return Constants.quotaErrorMessage
+                }
+                return "\(Constants.quotaErrorMessage) Quota reason: \(reason.rawValue)."
+            }
+        }
     }
 
     var metricName: String { Constants.name }
@@ -138,16 +156,17 @@ extension ProfilingSessionMetric {
         )
     }
 
-    static func profileNotWritten(
+    static func profileDropped(
         startReason: StartReason,
         status: ProfilingContext.Status,
+        reason: ProfileDropReason = .noProfiledEvents,
         cycleIndex: Int? = nil,
         appStartInfo: String? = nil
     ) -> ProfilingSessionMetric {
         .init(
             startReason: startReason,
             status: status,
-            errorMessage: Constants.profileNotWrittenErrorMessage,
+            errorMessage: reason.errorMessage,
             cycleIndex: cycleIndex,
             appStartInfo: appStartInfo
         )

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
@@ -90,12 +90,16 @@ internal final class ProfilingTelemetryController {
         )
     }
 
-    /// Sends a metric for a profile that was captured but intentionally not written.
-    func sendProfileNotWritten(for operation: ProfilingOperation) {
+    /// Sends a metric for a profile that was intentionally dropped.
+    func sendProfileDropped(
+        for operation: ProfilingOperation,
+        reason: ProfilingSessionMetric.ProfileDropReason = .noProfiledEvents
+    ) {
         send(
-            .profileNotWritten(
+            .profileDropped(
                 startReason: operation.startReason,
                 status: .current,
+                reason: reason,
                 cycleIndex: cycleIndex(for: operation),
                 appStartInfo: operation == .appLaunch ? appStartInfo : nil
             )

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -612,6 +612,7 @@ extension AppLaunchProfilerTests {
 
         XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.05)
+        let rejectedLaunchProfile = try XCTUnwrap(dd_profiler_get_profile())
 
         // When
         _ = profiler.receive(message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: appLaunchVital)), from: core)
@@ -621,6 +622,7 @@ extension AppLaunchProfilerTests {
         XCTAssertTrue(core.metadata.isEmpty)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         XCTAssertEqual(AppLaunchProfiler.currentPendingInstances, 0)
+        XCTAssertNotEqual(dd_profiler_get_profile(), rejectedLaunchProfile)
 
         let profilingContext = try XCTUnwrap(core.context.additionalContext(ofType: ProfilingContext.self))
         XCTAssertEqual(profilingContext.quotaReason, .quotaExceeded)

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -478,6 +478,45 @@ final class AppLaunchProfilerTests: XCTestCase {
         XCTAssertEqual(sampleCount, 0, "Profile should have no samples after all instances received")
     }
 
+    func testMultipleInstances_whenFirstInstanceIsRejectedByQuota_keepsProfileForOtherInstances() {
+        // Given
+        let rejectedCore = PassthroughCoreMock()
+        let admittedCore = PassthroughCoreMock()
+
+        let rejectedQuotaChecker = ProfilingQuotaCheckerMock()
+        rejectedQuotaChecker.quotaResult = .init(decision: .quotaKO, reason: .quotaExceeded)
+        let admittedQuotaChecker = ProfilingQuotaCheckerMock()
+        admittedQuotaChecker.quotaResult = .init(decision: .quotaOK, reason: .quotaOk)
+
+        let rejectedProfiler = appLaunchProfiler(core: rejectedCore, quotaChecker: rejectedQuotaChecker)
+        let admittedProfiler = appLaunchProfiler(core: admittedCore, quotaChecker: admittedQuotaChecker)
+
+        XCTAssertEqual(dd_profiler_start(), 1)
+        Thread.sleep(forTimeInterval: 0.05)
+        XCTAssertEqual(AppLaunchProfiler.currentPendingInstances, 2)
+
+        // When
+        _ = rejectedProfiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: appLaunchVital)),
+            from: rejectedCore
+        )
+
+        // Then
+        XCTAssertTrue(rejectedCore.events.isEmpty)
+        XCTAssertEqual(AppLaunchProfiler.currentPendingInstances, 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        // When
+        _ = admittedProfiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: appLaunchVital)),
+            from: admittedCore
+        )
+
+        // Then
+        XCTAssertEqual(admittedCore.events.count, 1)
+        XCTAssertEqual(AppLaunchProfiler.currentPendingInstances, 0)
+    }
+
     func testConcurrentRegistration_isThreadSafe() {
         // Given
         let iterations = 100
@@ -555,6 +594,47 @@ extension AppLaunchProfilerTests {
         XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfileErrorMessage)
         XCTAssertNotNil(metric.errorCode)
     }
+
+    func testReceive_whenQuotaIsRejected_dropsProfileAndSendsProfileDroppedMetric() throws {
+        // Given
+        let telemetry = TelemetryMock()
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.quotaResult = .init(decision: .quotaKO, reason: .quotaExceeded)
+        let core = PassthroughCoreMock(context: .mockWith(
+            launchInfo: .mockWith(launchReason: .userLaunch)
+        ))
+        let profiler = appLaunchProfiler(
+            core: core,
+            quotaChecker: quotaChecker,
+            telemetryController: ProfilingTelemetryController(telemetry: telemetry)
+        )
+        _ = profiler.receive(message: .context(core.context), from: core)
+
+        XCTAssertEqual(dd_profiler_start(), 1)
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // When
+        _ = profiler.receive(message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: appLaunchVital)), from: core)
+
+        // Then
+        XCTAssertTrue(core.events.isEmpty)
+        XCTAssertTrue(core.metadata.isEmpty)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(AppLaunchProfiler.currentPendingInstances, 0)
+
+        let profilingContext = try XCTUnwrap(core.context.additionalContext(ofType: ProfilingContext.self))
+        XCTAssertEqual(profilingContext.quotaReason, .quotaExceeded)
+
+        let metric = try lastProfilingSessionMetric(from: telemetry)
+        XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
+        XCTAssertEqual(metric.appStartInfo, "user_launch")
+        XCTAssertNil(metric.duration)
+        XCTAssertNil(metric.fileSize)
+        XCTAssertEqual(
+            metric.errorMessage,
+            "\(ProfilingSessionMetric.Constants.quotaErrorMessage) Quota reason: quota_exceeded."
+        )
+    }
 }
 
 // MARK: - Private
@@ -567,6 +647,7 @@ private extension AppLaunchProfilerTests {
     func appLaunchProfiler(
         core: DatadogCoreProtocol = PassthroughCoreMock(),
         isContinuousProfiling: Bool = false,
+        quotaChecker: ProfilingQuotaChecking = ProfilingQuotaCheckerMock(),
         telemetryController: ProfilingTelemetryController = .init()
     ) -> AppLaunchProfiler {
         let profilingSamplerProvider = ProfilingSamplerProvider(
@@ -576,6 +657,7 @@ private extension AppLaunchProfilerTests {
         return AppLaunchProfiler(
             core: core,
             profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker,
             telemetryController: telemetryController
         )
     }

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -28,6 +28,8 @@ final class DatadogProfilerTests: XCTestCase {
     }
 
     override func tearDown() {
+        profilerQueue.sync {}
+        core.messageReceiver = NOPFeatureMessageReceiver()
         DatadogProfiler.resetActiveInstance()
         dd_profiler_stop()
         dd_profiler_destroy()
@@ -416,28 +418,123 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testReceiveContextWhenContinuousProfilingSamplesOut_andVitalIsOngoing() {
+    func testReceiveContext_startsContinuousProfiler_whenSessionIsSampledIn() {
         // Given
         core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
         connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
-        let startOperation = Vital.mockWith(stepType: .start)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+
+        // When
         core.context = .mockWith(
             applicationStateHistory: .mockAppInForeground(),
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
         )
         flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_stopsContinuousProfiler_whenSessionIsSampledOut() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider
+        )
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground()
+        )
+        flushQueue()
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
         _ = profiler.receive(
-            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
             from: core
         )
+        flushQueue()
 
         // When
         core.context = .mockWith(
             applicationStateHistory: .mockAppInForeground(),
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_keepsNativeProfilerRunning_whenSessionIsSampledOutBeforeAppLaunchVital() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        // When - the RUM session samples out before AppLaunchProfiler can harvest TTID.
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+
+        // Then - app-launch profiling keeps the shared native profiler alive.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        // When - TTID is processed.
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+
+        // Then - the sampled-out continuous profiler can stop after app-launch harvesting.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveOperationStart_afterContinuousProfilingSamplesOut_startsCustomProfiling() {
+        // Given
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider
+        )
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+
+        let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
+
+        // When
+        _ = profiler.receive(
+            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)),
+            from: core
         )
         flushQueue()
 
@@ -448,14 +545,20 @@ extension DatadogProfilerTests {
 
     func testReceiveOperationStartWhenContinuousProfilingSamplesOut_andVitalStarts() {
         // Given
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        let dateProvider = DateProviderMock()
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
         profilingSamplerProvider.updateWith(
             deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: 0)
         )
-        let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider)
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_CREATED)
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider
+        )
+        shareCurrentContext(with: profiler)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
-        let startOperation = Vital.mockWith(stepType: .start)
+        let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
 
         // When
         _ = profiler.receive(
@@ -484,9 +587,12 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
         flushQueue()
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
-        waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
+        }
 
         // Then
+        XCTAssertTrue(core.metadata.isEmpty)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
     }
@@ -564,11 +670,12 @@ extension DatadogProfilerTests {
         )
 
         // When - operations complete, sampled-out continuous profiling should use the custom timer path.
-        waitForProfileWrite {
-            _ = profiler.receive(
-                message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)),
-                from: core
-            )
+        _ = profiler.receive(
+            message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)),
+            from: core
+        )
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED && core.metadata.isEmpty == false
         }
 
         // Then
@@ -933,8 +1040,9 @@ extension DatadogProfilerTests {
         let endOp: Vital = .mockWith(name: startOp.name, operationKey: startOp.operationKey, stepType: .end)
 
         // When - operations complete, profiler stops and writes via timer (no background notification needed)
-        waitForProfileWrite {
-            _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOp)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOp)), from: core)
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED && core.metadata.isEmpty == false
         }
 
         // Then
@@ -961,8 +1069,9 @@ extension DatadogProfilerTests {
         let endOp = Vital.mockWith(id: "end-id", name: startOp.name, operationKey: startOp.operationKey, stepType: .end)
 
         // When
-        waitForProfileWrite {
-            _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOp)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOp)), from: core)
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED && core.metadata.isEmpty == false
         }
 
         // Then
@@ -1044,8 +1153,8 @@ extension DatadogProfilerTests {
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
 
-        // Advance past customProfilingCutOffTime
-        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.customProfilingCutOffTime + 1)
+        // Advance past the RUM event cutoff.
+        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.cutOffTime + 1)
 
         // When - app launch vital received after cutoff
         let launchVital = Vital.mockWith()
@@ -1204,7 +1313,8 @@ extension DatadogProfilerTests {
         // When
         let second = DatadogProfiler(
             core: core,
-            profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true)
+            profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true),
+            quotaChecker: quotaChecker()
         )
         XCTAssertNil(second)
 
@@ -1245,7 +1355,8 @@ extension DatadogProfilerTests {
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
             let profiler = DatadogProfiler(
                 core: core,
-                profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true)
+                profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: true),
+                quotaChecker: quotaChecker()
             )
             lock.lock()
             profilers.append(profiler)
@@ -1310,19 +1421,27 @@ extension DatadogProfilerTests {
         // Given
         let telemetry = TelemetryMock()
         let telemetryController = ProfilingTelemetryController(telemetry: telemetry)
+        let dateProvider = DateProviderMock()
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
         profilingSamplerProvider.updateWith(
             deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
         )
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
-            profilingInterval: 0.05,
-            telemetryController: telemetryController
+            telemetryController: telemetryController,
+            dateProvider: dateProvider
         )
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When
-        waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite(expectingWrite: false) {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
 
         // Then
         let metric = try firstProfilingSessionMetric(from: telemetry)
@@ -1359,8 +1478,9 @@ extension DatadogProfilerTests {
         )
 
         // When
-        waitForProfileWrite {
-            _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: endOperation)), from: core)
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED && core.metadata.isEmpty == false
         }
 
         // Then
@@ -1372,6 +1492,405 @@ extension DatadogProfilerTests {
         XCTAssertEqual(metric.stoppedReason, ProfilingContext.Status.StopReason.manual.rawValue)
         XCTAssertNil(metric.errorCode)
         XCTAssertNil(metric.errorMessage)
+        withExtendedLifetime(profiler) {}
+    }
+}
+
+// MARK: - Profiling Quota
+
+extension DatadogProfilerTests {
+    func testQuotaIsCheckedAsSoonAsContextIsShared() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        let sessionID: UUID = .mockAny()
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionID: sessionID, sessionSampleRate: .maxSampleRate)]
+        )
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+
+        // Then
+        XCTAssertEqual(
+            quotaChecker.receivedContexts.compactMap { $0.additionalContext(ofType: RUMCoreContext.self)?.sessionID },
+            [sessionID.uuidString.lowercased()]
+        )
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaRejection_stopsAndDoesNotWriteContinuousProfile() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
+        }
+
+        let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
+        flushQueue()
+
+        // When
+        waitForProfileWrite(expectingWrite: false, timeout: 0.15) {}
+
+        // Then
+        XCTAssertTrue(core.metadata.isEmpty)
+        XCTAssertEqual(quotaChecker.receivedContexts.count, 1)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaRejectionBeforeAppLaunchVital_keepsNativeProfilerRunningUntilAppLaunchIsProcessed() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+
+        // When - quota rejects before TTID has been harvested.
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+
+        // Then - continuous/custom profiling is disabled, but app launch keeps the native profiler alive.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        // When - TTID is processed.
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+
+        // Then - quota can stop the shared native profiler after AppLaunchProfiler had a chance to harvest it.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaRejectionBeforeAppLaunchVital_doesNotRestartNativeProfiler_whenAppIsBackgrounded() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider,
+            quotaChecker: quotaChecker
+        )
+        let rumContext = RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(since: dateProvider.now.addingTimeInterval(-1)),
+            additionalContext: [rumContext]
+        )
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        // When - the app backgrounds while quota is still pending.
+        core.context = .mockWith(
+            applicationStateHistory: .mockWith(
+                initialState: .active,
+                date: dateProvider.now.addingTimeInterval(-1),
+                transitions: [(state: .background, date: dateProvider.now)]
+            ),
+            additionalContext: [rumContext]
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+
+        // When - quota rejects before TTID is harvested.
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+        _ = core.messageReceiver.receive(message: .context(core.context), from: core)
+        flushQueue()
+
+        // Then - app-launch preservation does not override background profiling conditions.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaRejectionBeforeAppLaunchVital_stopsNativeProfilerOnNextTimerCycle_whenAppLaunchVitalIsNotReceived() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            profilingInterval: 0.05,
+            dateProvider: dateProvider,
+            quotaChecker: quotaChecker
+        )
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+
+        // When - quota rejects before TTID and no TTID message is ever received.
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.cutOffTime + 1)
+
+        // Then - the next profiling timer cycle prevents quota-rejected profiling from sampling indefinitely.
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
+        }
+        XCTAssertTrue(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaResultReset_restartsContinuousProfile_whenAppStateIsUnchanged() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let firstSessionID: UUID = .mockAny()
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionID: firstSessionID, sessionSampleRate: .maxSampleRate)]
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
+        }
+
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaOK, reason: .quotaOk)
+        }
+        let secondSessionID: UUID = .mockAny()
+
+        // When - RUM rotates session while the app stays active.
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionID: secondSessionID, sessionSampleRate: .maxSampleRate)]
+        )
+
+        // Then
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_RUNNING
+        }
+        XCTAssertEqual(
+            quotaChecker.receivedContexts.compactMap { $0.additionalContext(ofType: RUMCoreContext.self)?.sessionID },
+            [firstSessionID.uuidString.lowercased(), secondSessionID.uuidString.lowercased()]
+        )
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testQuotaRejection_discardsRejectedRUMEventsBeforeNextAdmittedProfile() throws {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.quotaResult = .init(decision: .quotaKO, reason: .quotaExceeded)
+        let dateProvider = DateProviderMock()
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        profilingSamplerProvider.updateWith(
+            deterministicSampler: DeterministicSampler(uuid: .mockRandom(), samplingRate: .maxSampleRate)
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            dateProvider: dateProvider,
+            quotaChecker: quotaChecker
+        )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+
+        let rejectedLongTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        _ = profiler.receive(
+            message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: rejectedLongTask)),
+            from: core
+        )
+        flushQueue()
+
+        // When - a flushed profile is rejected by quota.
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite(expectingWrite: false) {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then - the rejected profile is not written.
+        XCTAssertTrue(core.metadata.isEmpty)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+
+        // When - a later session is admitted and writes a profile.
+        quotaChecker.quotaResult = .init(decision: .quotaOK, reason: .quotaOk)
+        dateProvider.now = dateProvider.now.addingTimeInterval(1)
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .background,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .inactive, date: dateProvider.now)]
+        ))
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+
+        let admittedLongTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
+        _ = profiler.receive(
+            message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: admittedLongTask)),
+            from: core
+        )
+        flushQueue()
+
+        dateProvider.now = dateProvider.now.addingTimeInterval(1)
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then - only the admitted session RUM event is attached.
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let rumEvents = try typedRUMEvents(from: metadata)
+        XCTAssertEqual(eventIDs(ofType: "long_task", in: rumEvents), [admittedLongTask.id])
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testCustomProfiler_stopsAndDoesNotWriteProfile_whenQuotaIsRejected() throws {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        let initialDate = Date().addingTimeInterval(-(DatadogProfiler.Constants.minProfileDuration + 3))
+        let dateProvider = DateProviderMock(now: initialDate)
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: false)
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            profilingInterval: 0.05,
+            dateProvider: dateProvider,
+            quotaChecker: quotaChecker
+        )
+        connectMessageReceiver(
+            to: profiler,
+            profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker
+        )
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
+            from: core
+        )
+        flushQueue()
+
+        let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaKO, reason: .quotaExceeded)
+        }
+
+        // When
+        core.context = core.context
+        waitUntil(timeout: 1.0) {
+            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
+        }
+
+        // Then
+        XCTAssertTrue(core.metadata.isEmpty)
+        XCTAssertEqual(quotaChecker.receivedContexts.count, 2)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        let profilingContext = try XCTUnwrap(core.context.additionalContext(ofType: ProfilingContext.self))
+        XCTAssertEqual(profilingContext.quotaReason, .quotaExceeded)
         withExtendedLifetime(profiler) {}
     }
 }
@@ -1415,11 +1934,13 @@ private extension DatadogProfilerTests {
         profilingConditions: ProfilingConditions = ProfilingConditions(),
         profilingInterval: TimeInterval = .infinity,
         telemetryController: ProfilingTelemetryController = .init(),
-        dateProvider: DateProvider = DateProviderMock()
+        dateProvider: DateProvider = DateProviderMock(),
+        quotaChecker: ProfilingQuotaChecking = ProfilingQuotaCheckerMock()
     ) -> DatadogProfiler {
-        DatadogProfiler(
+        return DatadogProfiler(
             core: core,
             profilingSamplerProvider: profilingSamplerProvider,
+            quotaChecker: quotaChecker,
             queue: profilerQueue,
             telemetryController: telemetryController,
             profilingConditions: profilingConditions,
@@ -1432,11 +1953,13 @@ private extension DatadogProfilerTests {
         profilingConditions: ProfilingConditions = ProfilingConditions(),
         profilingInterval: TimeInterval = .infinity,
         telemetryController: ProfilingTelemetryController = .init(),
-        dateProvider: DateProvider = DateProviderMock()
+        dateProvider: DateProvider = DateProviderMock(),
+        quotaChecker: ProfilingQuotaChecking = ProfilingQuotaCheckerMock()
     ) -> DatadogProfiler {
         DatadogProfiler(
             core: core,
             profilingSamplerProvider: profilingSamplerProvider(isContinuousProfiling: false),
+            quotaChecker: quotaChecker,
             queue: profilerQueue,
             telemetryController: telemetryController,
             profilingConditions: profilingConditions,
@@ -1447,6 +1970,14 @@ private extension DatadogProfilerTests {
 
     func profilingSamplerProvider(isContinuousProfiling: Bool) -> ProfilingSamplerProvider {
         ProfilingSamplerProvider(continuousSampleRate: isContinuousProfiling ? .maxSampleRate : 0)
+    }
+
+    func quotaChecker() -> ProfilingQuotaCheckerMock {
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        quotaChecker.receiveHandler = { _ in
+            .init(decision: .quotaOK, reason: .quotaOk)
+        }
+        return quotaChecker
     }
 
     func shareCurrentContext(with profiler: DatadogProfiler) {
@@ -1466,15 +1997,41 @@ private extension DatadogProfilerTests {
 
     func connectMessageReceiver(
         to profiler: DatadogProfiler,
-        profilingSamplerProvider: ProfilingSamplerProvider
+        profilingSamplerProvider: ProfilingSamplerProvider,
+        quotaChecker: ProfilingQuotaChecking? = nil
     ) {
-        let messageReceiver = CombinedFeatureMessageReceiver(
+        var receivers: [FeatureMessageReceiver] = [
             ProfilingContextMessageReceiver(profilingSamplerProvider: profilingSamplerProvider),
             profiler
-        )
+        ]
+        if let quotaChecker {
+            receivers.append(quotaChecker)
+        }
+
+        let messageReceiver = CombinedFeatureMessageReceiver(receivers)
         core.messageReceiver = messageReceiver
         _ = messageReceiver.receive(message: .context(core.context), from: core)
         flushQueue()
+    }
+
+    func waitUntil(
+        timeout: TimeInterval,
+        pollInterval: TimeInterval = 0.01,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: () -> Bool
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+
+            Thread.sleep(forTimeInterval: pollInterval)
+        }
+
+        XCTFail("Condition was not met within \(timeout) seconds.", file: file, line: line)
     }
 }
 #endif // !os(watchOS)

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -115,7 +115,7 @@ final class DatadogProfilerTests: XCTestCase {
             operationKey: completedOperationStart.operationKey,
             stepType: .end
         )
-        let ongoingOperationStart = Vital.mockWith(name: "ongoing-operation", stepType: .start)
+        let ongoingOperationStart = Vital.mockWith(name: "ongoing-operation", stepType: .start, date: dateProvider.now)
         let hang = DurationEvent(id: "hang-id", type: .error, start: 0, duration: 500)
         let longTask = DurationEvent(id: "long-task-id", type: .longTask, start: 0, duration: 100)
         let launchVital: Vital = .mockWith(stepType: nil)
@@ -321,8 +321,12 @@ extension DatadogProfilerTests {
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
+        let attributes: [AttributeKey: AttributeValue] = [
+            RUMCoreContext.IDs.sessionID: "long-task-session-id",
+            RUMCoreContext.IDs.viewID: "long-task-view-id"
+        ]
         let longTask = DurationEvent(id: .mockRandom(), type: .longTask, start: 0, duration: 100)
-        _ = profiler.receive(message: .payload(LongTaskMessage(attributes: mockRandomAttributes(), longTask: longTask)), from: core)
+        _ = profiler.receive(message: .payload(LongTaskMessage(attributes: attributes, longTask: longTask)), from: core)
         flushQueue()
 
         // When
@@ -339,6 +343,9 @@ extension DatadogProfilerTests {
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
         let rumEvents = try typedRUMEvents(from: metadata)
         XCTAssertEqual(eventIDs(ofType: "long_task", in: rumEvents), [longTask.id])
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        XCTAssertEqual(event.additionalAttributes?[RUMCoreContext.IDs.sessionID] as? String, "long-task-session-id")
+        XCTAssertEqual(event.additionalAttributes?[RUMCoreContext.IDs.viewID] as? String, "long-task-view-id")
         withExtendedLifetime(profiler) {}
     }
 
@@ -352,8 +359,12 @@ extension DatadogProfilerTests {
         let profiler = continuousProfiler(profilingSamplerProvider: profilingSamplerProvider, dateProvider: dateProvider)
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
+        let attributes: [AttributeKey: AttributeValue] = [
+            RUMCoreContext.IDs.sessionID: "app-hang-session-id",
+            RUMCoreContext.IDs.viewID: "app-hang-view-id"
+        ]
         let hang = DurationEvent(id: .mockRandom(), type: .error, start: 0, duration: 500)
-        XCTAssertTrue(profiler.receive(message: .payload(AppHangMessage(attributes: mockRandomAttributes(), hang: hang)), from: core))
+        XCTAssertTrue(profiler.receive(message: .payload(AppHangMessage(attributes: attributes, hang: hang)), from: core))
 
         // When
         core.context = .mockWith(applicationStateHistory: .mockWith(
@@ -369,6 +380,9 @@ extension DatadogProfilerTests {
         let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
         let rumEvents = try typedRUMEvents(from: metadata)
         XCTAssertEqual(eventIDs(ofType: "error", in: rumEvents), [hang.id])
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        XCTAssertEqual(event.additionalAttributes?[RUMCoreContext.IDs.sessionID] as? String, "app-hang-session-id")
+        XCTAssertEqual(event.additionalAttributes?[RUMCoreContext.IDs.viewID] as? String, "app-hang-view-id")
         withExtendedLifetime(profiler) {}
     }
 }
@@ -1417,7 +1431,7 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testContinuousProfiler_sendsProfilingSessionMetric_whenProfileIsNotWritten() throws {
+    func testContinuousProfiler_sendsProfilingSessionMetric_whenProfileIsDropped() throws {
         // Given
         let telemetry = TelemetryMock()
         let telemetryController = ProfilingTelemetryController(telemetry: telemetry)
@@ -1449,7 +1463,7 @@ extension DatadogProfilerTests {
         XCTAssertEqual(metric.cycleIndex, 0)
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
-        XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.profileNotWrittenErrorMessage)
+        XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfiledEventsErrorMessage)
         XCTAssertNil(metric.errorCode)
         XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
@@ -1545,7 +1559,13 @@ extension DatadogProfilerTests {
             applicationStateHistory: .mockAppInForeground(),
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, Int64.max, 0)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        let rejectedTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        rejectedTrace.pointee = .mockWith(tid: 1, addresses: [0x100001000])
+        dd_pprof_add_samples(dd_profiler_get_profile(), rejectedTrace, 1)
+        dd_free(rejectedTrace)
+        XCTAssertGreaterThan(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
         _ = profiler.receive(
             message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
             from: core
@@ -1572,11 +1592,12 @@ extension DatadogProfilerTests {
         XCTAssertTrue(core.metadata.isEmpty)
         XCTAssertEqual(quotaChecker.receivedContexts.count, 1)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
 
         withExtendedLifetime(profiler) {}
     }
 
-    func testQuotaRejectionBeforeAppLaunchVital_keepsNativeProfilerRunningUntilAppLaunchIsProcessed() {
+    func testQuotaRejectionBeforeAppLaunchVital_stopsNativeProfilerImmediately() {
         // Given
         let quotaChecker = ProfilingQuotaCheckerMock()
         quotaChecker.receiveHandler = { _ in
@@ -1603,8 +1624,8 @@ extension DatadogProfilerTests {
             quotaChecker: quotaChecker
         )
 
-        // Then - continuous/custom profiling is disabled, but app launch keeps the native profiler alive.
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        // Then - continuous, custom and app-launch profiling are disabled for the rejected session.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
 
         // When - TTID is processed.
         _ = profiler.receive(
@@ -1613,7 +1634,7 @@ extension DatadogProfilerTests {
         )
         flushQueue()
 
-        // Then - quota can stop the shared native profiler after AppLaunchProfiler had a chance to harvest it.
+        // Then - app launch does not restart profiling after quota rejection.
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
     }
@@ -1667,7 +1688,7 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testQuotaRejectionBeforeAppLaunchVital_stopsNativeProfilerOnNextTimerCycle_whenAppLaunchVitalIsNotReceived() {
+    func testQuotaRejectionBeforeAppLaunchVital_stopsNativeProfilerImmediately_whenAppLaunchVitalIsNotReceived() {
         // Given
         let quotaChecker = ProfilingQuotaCheckerMock()
         quotaChecker.receiveHandler = { _ in
@@ -1680,7 +1701,6 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock()
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
-            profilingInterval: 0.05,
             dateProvider: dateProvider,
             quotaChecker: quotaChecker
         )
@@ -1697,13 +1717,9 @@ extension DatadogProfilerTests {
             quotaChecker: quotaChecker
         )
         flushQueue()
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
-        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.cutOffTime + 1)
 
-        // Then - the next profiling timer cycle prevents quota-rejected profiling from sampling indefinitely.
-        waitUntil(timeout: 1.0) {
-            dd_profiler_get_status() == DD_PROFILER_STATUS_STOPPED
-        }
+        // Then - quota rejection is enough to stop the native profiler; no app-launch fallback timer is needed.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
@@ -1757,6 +1773,9 @@ extension DatadogProfilerTests {
         waitUntil(timeout: 1.0) {
             dd_profiler_get_status() == DD_PROFILER_STATUS_RUNNING
         }
+        let runningProfilingContext = core.context.additionalContext(ofType: ProfilingContext.self)
+        XCTAssertEqual(runningProfilingContext?.status, .running)
+        XCTAssertNil(runningProfilingContext?.quotaReason)
         XCTAssertEqual(
             quotaChecker.receivedContexts.compactMap { $0.additionalContext(ofType: RUMCoreContext.self)?.sessionID },
             [firstSessionID.uuidString.lowercased(), secondSessionID.uuidString.lowercased()]
@@ -1766,6 +1785,8 @@ extension DatadogProfilerTests {
 
     func testQuotaRejection_discardsRejectedRUMEventsBeforeNextAdmittedProfile() throws {
         // Given
+        let telemetry = TelemetryMock()
+        let telemetryController = ProfilingTelemetryController(telemetry: telemetry)
         let quotaChecker = ProfilingQuotaCheckerMock()
         quotaChecker.quotaResult = .init(decision: .quotaKO, reason: .quotaExceeded)
         let dateProvider = DateProviderMock()
@@ -1775,10 +1796,10 @@ extension DatadogProfilerTests {
         )
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
+            telemetryController: telemetryController,
             dateProvider: dateProvider,
             quotaChecker: quotaChecker
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         _ = profiler.receive(
             message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
             from: core
@@ -1792,7 +1813,7 @@ extension DatadogProfilerTests {
         )
         flushQueue()
 
-        // When - a flushed profile is rejected by quota.
+        // When - the stopped profiler has no native profile to flush for the rejected session.
         core.context = .mockWith(applicationStateHistory: .mockWith(
             initialState: .active,
             date: dateProvider.now.addingTimeInterval(-1),
@@ -1802,9 +1823,13 @@ extension DatadogProfilerTests {
             _ = profiler.receive(message: .context(core.context), from: core)
         }
 
-        // Then - the rejected profile is not written.
+        // Then - the rejected profile is not written, and the rejected RUM event is discarded.
         XCTAssertTrue(core.metadata.isEmpty)
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        let noProfileMetric = try firstProfilingSessionMetric(from: telemetry)
+        XCTAssertEqual(
+            noProfileMetric.errorMessage,
+            ProfilingSessionMetric.Constants.noProfileErrorMessage
+        )
 
         // When - a later session is admitted and writes a profile.
         quotaChecker.quotaResult = .init(decision: .quotaOK, reason: .quotaOk)

--- a/DatadogProfiling/Tests/ProfilerFeatureTests.swift
+++ b/DatadogProfiling/Tests/ProfilerFeatureTests.swift
@@ -22,6 +22,9 @@ final class ProfilerFeatureTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        DatadogProfiler.resetActiveInstance()
+        dd_profiler_stop()
+        dd_profiler_destroy()
         userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
     }
@@ -29,6 +32,9 @@ final class ProfilerFeatureTests: XCTestCase {
     override func tearDown() {
         userDefaults.removePersistentDomain(forName: suiteName)
         userDefaults = nil
+        DatadogProfiler.resetActiveInstance()
+        dd_profiler_stop()
+        dd_profiler_destroy()
         super.tearDown()
     }
 
@@ -107,6 +113,62 @@ final class ProfilerFeatureTests: XCTestCase {
 
         // Then
         XCTAssertEqual(userDefaults.value(forKey: DD_PROFILING_APP_LAUNCH_SAMPLE_RATE_KEY) as? SampleRate, previousSampleRate)
+    }
+
+    func testMessageReceiver_checksQuota_whenCustomEndpointIsConfigured() {
+        // Given
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        let feature = ProfilerFeature(
+            core: core,
+            configuration: .init(customEndpoint: .mockRandom()),
+            requestBuilder: requestBuilder,
+            telemetryController: telemetryController,
+            quotaChecker: quotaChecker,
+            userDefaults: userDefaults
+        )
+        let context: DatadogContext = .mockWith(
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+
+        // When
+        _ = feature.messageReceiver.receive(message: .context(context), from: core)
+
+        // Then
+        XCTAssertEqual(quotaChecker.receivedContexts.count, 1)
+    }
+
+    func testMessageReceiver_doesNotCheckQuota_whenDatadogProfilerIsNotCreated() {
+        // Given
+        let firstFeature = ProfilerFeature(
+            core: PassthroughCoreMock(),
+            configuration: .init(),
+            requestBuilder: requestBuilder,
+            telemetryController: telemetryController,
+            userDefaults: userDefaults
+        )
+        let quotaChecker = ProfilingQuotaCheckerMock()
+        let secondCore = PassthroughCoreMock()
+        let secondFeature = ProfilerFeature(
+            core: secondCore,
+            configuration: .init(),
+            requestBuilder: requestBuilder,
+            telemetryController: telemetryController,
+            quotaChecker: quotaChecker,
+            userDefaults: userDefaults
+        )
+        let context: DatadogContext = .mockWith(
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+
+        // When
+        _ = secondFeature.messageReceiver.receive(message: .context(context), from: secondCore)
+
+        // Then
+        XCTAssertTrue(quotaChecker.receivedContexts.isEmpty)
+        withExtendedLifetime(firstFeature) {}
+        withExtendedLifetime(secondFeature) {}
     }
 
     func testProfilingSamplerProvider_isDeterministicForSameSessionID() {

--- a/DatadogProfiling/Tests/ProfilerFeatureTests.swift
+++ b/DatadogProfiling/Tests/ProfilerFeatureTests.swift
@@ -138,7 +138,7 @@ final class ProfilerFeatureTests: XCTestCase {
         XCTAssertEqual(quotaChecker.receivedContexts.count, 1)
     }
 
-    func testMessageReceiver_doesNotCheckQuota_whenDatadogProfilerIsNotCreated() {
+    func testMessageReceiver_checksQuotaForAppLaunchProfiler_whenDatadogProfilerIsNotCreated() {
         // Given
         let firstFeature = ProfilerFeature(
             core: PassthroughCoreMock(),
@@ -166,7 +166,7 @@ final class ProfilerFeatureTests: XCTestCase {
         _ = secondFeature.messageReceiver.receive(message: .context(context), from: secondCore)
 
         // Then
-        XCTAssertTrue(quotaChecker.receivedContexts.isEmpty)
+        XCTAssertEqual(quotaChecker.receivedContexts.count, 1)
         withExtendedLifetime(firstFeature) {}
         withExtendedLifetime(secondFeature) {}
     }

--- a/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
@@ -91,6 +91,28 @@ final class ProfilingQuotaCheckerTests: XCTestCase {
         XCTAssertNil(checker.quotaResult)
     }
 
+    func testDoesNothingWhenRUMSessionIsSampledOut() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let context = DatadogContext.mockWith(
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(context), from: PassthroughCoreMock())
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 0, timeout: 0.1).count, 0)
+        XCTAssertNil(checker.quotaResult)
+    }
+
     func testStartsQuotaRequestWhenTrackingConsentBecomesGranted() {
         // Given
         let server = ServerMock(

--- a/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
@@ -1,0 +1,335 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if !os(watchOS)
+
+import XCTest
+import DatadogInternal
+import TestUtilities
+
+@testable import DatadogProfiling
+
+final class ProfilingQuotaCheckerTests: XCTestCase {
+    func testBuildsQuotaURLAndHeaders() throws {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let sessionID: UUID = .mockAny()
+        let context = DatadogContext.mockWith(
+            site: .us1,
+            clientToken: "test-client-token",
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionID: sessionID, sessionSampleRate: .maxSampleRate)]
+        )
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(context), from: PassthroughCoreMock())
+        let request = try XCTUnwrap(server.waitAndReturnRequests(count: 1).first)
+
+        // Then
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota?session_id=\(sessionID.uuidString.lowercased())"
+        )
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "DD-CLIENT-TOKEN"), "test-client-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/vnd.api+json")
+        XCTAssertFalse(request.httpShouldHandleCookies)
+    }
+
+    func testDoesNothingWhenContextHasNoRUMSession() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+
+        // When
+        _ = checker.receive(
+            message: FeatureMessage.context(DatadogContext.mockWith(trackingConsent: .granted, additionalContext: [])),
+            from: PassthroughCoreMock()
+        )
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 0, timeout: 0.1).count, 0)
+        XCTAssertNil(checker.quotaResult)
+    }
+
+    func testDoesNothingWhenTrackingConsentIsNotGranted() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+
+        // When
+        [TrackingConsent.pending, .notGranted].forEach { trackingConsent in
+            let context = DatadogContext.mockWith(
+                trackingConsent: trackingConsent,
+                additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+            )
+
+            _ = checker.receive(message: FeatureMessage.context(context), from: PassthroughCoreMock())
+        }
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 0, timeout: 0.1).count, 0)
+        XCTAssertNil(checker.quotaResult)
+    }
+
+    func testStartsQuotaRequestWhenTrackingConsentBecomesGranted() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let rumContext = RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)
+        let pendingConsentContext = DatadogContext.mockWith(
+            trackingConsent: .pending,
+            additionalContext: [rumContext]
+        )
+        let grantedConsentContext = DatadogContext.mockWith(
+            trackingConsent: .granted,
+            additionalContext: [rumContext]
+        )
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(pendingConsentContext), from: PassthroughCoreMock())
+        _ = checker.receive(message: FeatureMessage.context(grantedConsentContext), from: PassthroughCoreMock())
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 1).count, 1)
+    }
+
+    func testMapResponse_returnsQuotaKO_forQuotaExceeded() {
+        // Given
+        let response = quotaResponse(admitted: false, reason: .quotaExceeded)
+
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: response,
+            response: HTTPURLResponse.mockResponseWith(statusCode: 200),
+            error: nil
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaKO, reason: .quotaExceeded))
+    }
+
+    func testMapResponse_returnsQuotaOK_forBackendUnavailable() {
+        // Given
+        let response = quotaResponse(admitted: false, reason: .backendUnavailable)
+
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: response,
+            response: HTTPURLResponse.mockResponseWith(statusCode: 200),
+            error: nil
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaOK, reason: .backendUnavailable))
+    }
+
+    func testMapResponse_normalizesUnknownReason_toUndefined() {
+        // Given
+        let response = quotaResponse(admitted: true, rawReason: .mockAny())
+
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: response,
+            response: HTTPURLResponse.mockResponseWith(statusCode: 200),
+            error: nil
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaOK, reason: .undefined))
+    }
+
+    func testMapResponse_returnsQuotaKO_whenNotAdmittedWithUnknownReason() {
+        // Given
+        let response = quotaResponse(admitted: false, rawReason: .mockAny())
+
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: response,
+            response: HTTPURLResponse.mockResponseWith(statusCode: 200),
+            error: nil
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaKO, reason: .undefined))
+    }
+
+    func testMapResponse_returnsTimeout_whenRequestTimesOut() {
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: nil,
+            response: nil,
+            error: URLError(.timedOut)
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaOK, reason: .timeout))
+    }
+
+    func testMapResponse_returnsAPIError_whenPayloadIsInvalid() {
+        // When
+        let result = ProfilingQuotaChecker.mapResponse(
+            data: Data("invalid".utf8),
+            response: HTTPURLResponse.mockResponseWith(statusCode: 200),
+            error: nil
+        )
+
+        // Then
+        XCTAssertEqual(result, .init(decision: .quotaOK, reason: .apiError))
+    }
+
+    func testDeduplicatesRepeatedContexts_forSameSession() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let context = DatadogContext.mockWith(
+            site: .us1,
+            clientToken: "test-client-token",
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(context), from: PassthroughCoreMock())
+        _ = checker.receive(message: FeatureMessage.context(context), from: PassthroughCoreMock())
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 1).count, 1)
+    }
+
+    func testStartsNewRequest_whenSessionChanges() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let firstContext = DatadogContext.mockWith(
+            site: .us1,
+            clientToken: "test-client-token",
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionID: .mockAny(), sessionSampleRate: .maxSampleRate)]
+        )
+        let secondContext = DatadogContext.mockWith(
+            site: .us1,
+            clientToken: "test-client-token",
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionID: .mockAny(), sessionSampleRate: .maxSampleRate)]
+        )
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(firstContext), from: PassthroughCoreMock())
+        _ = checker.receive(message: FeatureMessage.context(secondContext), from: PassthroughCoreMock())
+
+        // Then
+        XCTAssertEqual(server.waitAndReturnRequests(count: 2).count, 2)
+    }
+
+    func testNotifiesQuotaResultUpdate() {
+        // Given
+        let server = ServerMock(
+            delivery: .success(
+                response: .mockResponseWith(statusCode: 200),
+                data: quotaResponse(admitted: true, reason: .quotaOk)
+            )
+        )
+        let checker = ProfilingQuotaChecker(urlSession: server.getInterceptedURLSession())
+        let core = PassthroughCoreMock()
+        let context = DatadogContext.mockWith(
+            trackingConsent: .granted,
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
+        )
+        let expectation = expectation(description: "quota update")
+        checker.onQuotaResultUpdate = { result in
+            guard result?.reason == .quotaOk else {
+                return
+            }
+
+            expectation.fulfill()
+        }
+
+        // When
+        _ = checker.receive(message: FeatureMessage.context(context), from: core)
+        _ = server.waitAndReturnRequests(count: 1)
+
+        // Then
+        waitForExpectations(timeout: 1.0)
+    }
+}
+
+private extension ProfilingQuotaCheckerTests {
+    private func quotaResponse(admitted: Bool, reason: DDProfiling.QuotaReason) -> Data {
+        quotaResponse(admitted: admitted, rawReason: reason.rawValue)
+    }
+
+    private func quotaResponse(admitted: Bool, rawReason: String) -> Data {
+        Data(
+            """
+            {"data":{"id":"quota","type":"profiling-quota","attributes":{"admitted":\(admitted),"reason":"\(rawReason)"}}}
+            """.utf8
+        )
+    }
+}
+
+final class ProfilingQuotaCheckerMock: ProfilingQuotaChecking {
+    private(set) var receivedContexts: [DatadogContext] = []
+    var quotaResult: ProfilingQuotaResult?
+    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)?
+    var receiveHandler: ((DatadogContext) -> ProfilingQuotaResult?)?
+    private var currentSessionID: String?
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message,
+              let rumContext = context.additionalContext(ofType: RUMCoreContext.self) else {
+            return false
+        }
+
+        receivedContexts.append(context)
+
+        if currentSessionID != rumContext.sessionID {
+            currentSessionID = rumContext.sessionID
+            quotaResult = nil
+            onQuotaResultUpdate?(nil)
+        }
+
+        if let result = receiveHandler?(context) {
+            quotaResult = result
+            onQuotaResultUpdate?(result)
+        }
+
+        return false
+    }
+}
+
+#endif

--- a/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
+++ b/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
@@ -163,12 +163,12 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
     }
 
-    func testTrackingProfilingSessionMetric_whenProfileIsNotWritten() throws {
+    func testTrackingProfilingSessionMetric_whenProfileIsDropped() throws {
         // Given
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
         // When
-        controller.sendProfileNotWritten(for: .customProfiling)
+        controller.sendProfileDropped(for: .customProfiling)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
@@ -176,7 +176,29 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
         XCTAssertNil(metric.errorCode)
-        XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.profileNotWrittenErrorMessage)
+        XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfiledEventsErrorMessage)
+
+        let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
+        XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
+    }
+
+    func testTrackingProfilingSessionMetric_whenProfileIsDroppedBecauseQuotaRejected() throws {
+        // Given
+        let controller = ProfilingTelemetryController(telemetry: telemetry)
+
+        // When
+        controller.sendProfileDropped(for: .customProfiling, reason: .quotaRejected(.quotaExceeded))
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
+        XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.rumOperation.rawValue)
+        XCTAssertNil(metric.duration)
+        XCTAssertNil(metric.fileSize)
+        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(
+            metric.errorMessage,
+            "\(ProfilingSessionMetric.Constants.quotaErrorMessage) Quota reason: quota_exceeded."
+        )
 
         let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
         XCTAssertEqual(metricTelemetry.sampleRate, 20.0)
@@ -189,7 +211,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
 
         // When
         controller.sendProfile(durationNs: 1, fileSize: 2, for: .continuousProfiling)
-        controller.sendProfileNotWritten(for: .customProfiling)
+        controller.sendProfileDropped(for: .customProfiling)
 
         // Then
         let diagnostics = telemetry.messages.compactMap { message in

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -45,8 +45,10 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         // Given
         let command = RUMOperationStepVitalCommand.mockRandom()
         let view: RUMViewScope = .mockAny()
+        let quotaReason: DDProfiling.QuotaReason = .mockRandom()
 
         // When
+        mockContext.set(additionalContext: ProfilingContext(status: .running, quotaReason: quotaReason))
         manager.process(
             command,
             context: mockContext,
@@ -90,6 +92,10 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         XCTAssertEqual(vital.stepType, command.stepType)
         XCTAssertEqual(vital.failureReason, command.failureReason)
         XCTAssertNil(vital.vitalDescription)
+
+        // Profiling Status
+        XCTAssertEqual(event.dd.profiling?.status, .running)
+        XCTAssertEqual(event.dd.profiling?.quotaReason, quotaReason)
     }
 
     func testFeatureOperationCommand_sendsOperationMessageWithServerTimeOffset() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -51,11 +51,13 @@ final class RUMAppLaunchManagerTests: XCTestCase {
     func testTTIDCommand_createsAppLaunchVitalEvent() throws {
         // Given
         let ttid = 2.0
+        let quotaReason: DDProfiling.QuotaReason = .mockRandom()
         let command: RUMTimeToInitialDisplayCommand = .mockWith(
             time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttid)
         )
 
         // When
+        mockContext.set(additionalContext: ProfilingContext(status: .running, quotaReason: quotaReason))
         manager.process(command, context: mockContext, writer: mockWriter)
 
         // Then
@@ -90,6 +92,10 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertNil(event.synthetics)
         XCTAssertNil(event.usr)
         XCTAssertNotNil(event.version)
+
+        // Profiling Status
+        XCTAssertEqual(event.dd.profiling?.status, .running)
+        XCTAssertEqual(event.dd.profiling?.quotaReason, quotaReason)
     }
 
     func testTTIDCommand_appliesServerTimeOffsetToAppLaunchEventAndProfilerMessage() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2058,8 +2058,10 @@ class RUMViewScopeTests: XCTestCase {
         let completionExpectation = expectation(description: "Error processing completion")
 
         let hasReplay: Bool = .mockRandom()
+        let quotaReason: DDProfiling.QuotaReason = .mockRandom()
         var context = self.context
         context.set(additionalContext: SessionReplayCoreContext.HasReplay(value: hasReplay))
+        context.set(additionalContext: ProfilingContext(status: .running, quotaReason: quotaReason))
 
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
@@ -2137,6 +2139,10 @@ class RUMViewScopeTests: XCTestCase {
 
         let viewUpdate = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(viewUpdate.view.error.count, 1)
+
+        // Profiling Status
+        XCTAssertEqual(error.dd.profiling?.status, .running)
+        XCTAssertEqual(error.dd.profiling?.quotaReason, quotaReason)
     }
 
     func testWhenViewErrorIsAddedWithConfiguredSource_itSendsErrorEventWithCorrectSource() throws {
@@ -2915,8 +2921,10 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenLongTaskIsAdded_itSendsLongTaskEventAndViewUpdateEvent() throws {
         let hasReplay: Bool = .mockRandom()
+        let quotaReason: DDProfiling.QuotaReason = .mockRandom()
         var context = self.context
         context.set(additionalContext: SessionReplayCoreContext.HasReplay(value: hasReplay))
+        context.set(additionalContext: ProfilingContext(status: .running, quotaReason: quotaReason))
 
         let startViewDate: Date = .mockDecember15th2019At10AMUTC()
 
@@ -2984,6 +2992,10 @@ class RUMViewScopeTests: XCTestCase {
 
         let viewUpdate = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(viewUpdate.view.longTask?.count, 1)
+
+        // Profiling Status
+        XCTAssertEqual(event.dd.profiling?.status, .running)
+        XCTAssertEqual(event.dd.profiling?.quotaReason, quotaReason)
     }
 
     func testGivenStartedView_whenLongTaskWithAttributesIsAdded_itDoesNotUpdateViewAttributes() throws {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -891,3 +891,17 @@ extension RUMVitalOperationStepEvent.Vital.StepType: AnyMockable, RandomMockable
         return RUMVitalOperationStepEvent.Vital.StepType.allCases.randomElement()!
     }
 }
+
+extension DDProfiling.QuotaReason: RandomMockable {
+    public static func mockRandom() -> Self {
+        return [
+            .quotaOk,
+            .quotaExceeded,
+            .orgDisabled,
+            .backendUnavailable,
+            .undefined,
+            .timeout,
+            .apiError
+        ].randomElement()!
+    }
+}


### PR DESCRIPTION
### What and why?

This PR adds Profiling quota admission support on iOS, aligned with the [Browser SDK behavior](https://github.com/DataDog/browser-sdk/pull/4514). Profiling starts optimistically to avoid losing early data but quota is checked as soon as a RUM session id is available and enforced when profiles are about to be written.

The quota decision gates both continuous and custom profiling uploads (app launch profiling is ignored). If the active session is rejected by quota, the profiler stops on the next profiling decision point. 
The quota reason is also propagated into RUM events through `dd.profiling.quota_reason` giving visibility into whether profiling was admitted, rejected or failed.

### How?

- Adds `ProfilingQuotaChecker`, a session-scoped service that listens for RUM context, calls the profiling quota endpoint with the RUM session id, caches the result per session, ignores stale responses and fails on timeout, network or parsing errors.
- Wires the quota checker into `ProfilerFeature` and `DatadogProfiler`, keeping profiling startup optimistic while gating profile writes by both sampling and quota.
- Stops continuous/custom profiling when quota returns `.quotaKO` for the current session.
- Marks quota requests using `DD-CLIENT-TOKEN` as internal Datadog requests so they are not instrumented.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
