### PR TITLE
[RUM-16633] Add wildcard host pattern matching to WebView tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [FIX] Expose RUM operation options to Objective-C from `DatadogRUM`. See [#2969][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 - [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
-- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. Patterns like `"*.example.com"` and `"preview-*.shopist.io"` are matched in Browser SDK using plain string operations. See [#2959][]
+- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
 
 # 3.11.1 / 28-05-2026
 
@@ -1173,6 +1173,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2952]: https://github.com/DataDog/dd-sdk-ios/pull/2952
 [#2968]: https://github.com/DataDog/dd-sdk-ios/pull/2968
 [#2969]: https://github.com/DataDog/dd-sdk-ios/pull/2969
+[#2963]: https://github.com/DataDog/dd-sdk-ios/pull/2963
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [FIX] Expose RUM operation options to Objective-C from `DatadogRUM`. See [#2969][]
+- [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
+- [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
+- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. Patterns like `"*.example.com"` and `"preview-*.shopist.io"` are matched in Browser SDK using plain string operations. See [#2959][]
 
 # 3.11.1 / 28-05-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
+
 # 3.12.0 / 04-06-2026
 
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
@@ -9,9 +11,6 @@
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [FIX] Expose RUM operation options to Objective-C from `DatadogRUM`. See [#2969][]
-- [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
-- [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
-- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
 
 # 3.11.1 / 28-05-2026
 

--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -38,6 +38,27 @@ public final class objc_WebViewTracking: NSObject {
         )
     }
 
+    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session,
+    /// using wildcard host patterns for matching.
+    ///
+    /// - Parameters:
+    ///   - webView: The web-view to track.
+    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
+    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
+    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
+    @objc
+    public static func enable(
+        webView: WKWebView,
+        hostPatterns: [String],
+        logsSampleRate: SampleRate = .maxSampleRate
+    ) {
+        WebViewTracking.enable(
+            webView: webView,
+            hostPatterns: hostPatterns,
+            logsSampleRate: logsSampleRate
+        )
+    }
+
     /// Disables Datadog iOS SDK and Datadog Browser SDK integration.
     ///
     /// Removes Datadog's ScriptMessageHandler and UserScript from the caller.

--- a/DatadogWebViewTracking/Sources/WebViewSessionRolloverHandler.swift
+++ b/DatadogWebViewTracking/Sources/WebViewSessionRolloverHandler.swift
@@ -190,12 +190,18 @@ internal final class WebViewTrackingElements: Sendable {
     /// the JavaScript bridge.
     let allowedWebViewHostsString: String
 
+    /// Wildcard host patterns provided by the user, concatenated as a JSON-ready string.
+    /// Non-nil only when the customer used `enable(webView:hostPatterns:)`.
+    let hostPatternsString: String?
+
     /// Creates a new `WebViewTrackingElements`.
     ///
     /// - Parameters:
     ///   - allowedWebViewHostsString: The hosts provided by the user, after being sanitized, and concatenated
     ///   on a string ready to be injected in the JavaScript bridge.
-    init(allowedWebViewHostsString: String) {
+    ///   - hostPatternsString: Wildcard host patterns ready to be injected in the JavaScript bridge.
+    init(allowedWebViewHostsString: String, hostPatternsString: String? = nil) {
         self.allowedWebViewHostsString = allowedWebViewHostsString
+        self.hostPatternsString = hostPatternsString
     }
 }

--- a/DatadogWebViewTracking/Sources/WebViewSessionRolloverHandler.swift
+++ b/DatadogWebViewTracking/Sources/WebViewSessionRolloverHandler.swift
@@ -186,22 +186,16 @@ internal final class WebViewTrackingElements: Sendable {
      Implementation note: this needs to be a class since it's a requirement for NSMapTable.
      */
 
-    /// The hosts provided by the user, after being sanitized, and concatenated on a string ready to be injected in
-    /// the JavaScript bridge.
+    /// The hosts or wildcard patterns provided by the user, after being sanitized, and concatenated on a string
+    /// ready to be injected in the JavaScript bridge.
     let allowedWebViewHostsString: String
-
-    /// Wildcard host patterns provided by the user, concatenated as a JSON-ready string.
-    /// Non-nil only when the customer used `enable(webView:hostPatterns:)`.
-    let hostPatternsString: String?
 
     /// Creates a new `WebViewTrackingElements`.
     ///
     /// - Parameters:
-    ///   - allowedWebViewHostsString: The hosts provided by the user, after being sanitized, and concatenated
-    ///   on a string ready to be injected in the JavaScript bridge.
-    ///   - hostPatternsString: Wildcard host patterns ready to be injected in the JavaScript bridge.
-    init(allowedWebViewHostsString: String, hostPatternsString: String? = nil) {
+    ///   - allowedWebViewHostsString: The hosts or wildcard patterns provided by the user, after being sanitized,
+    ///   and concatenated on a string ready to be injected in the JavaScript bridge.
+    init(allowedWebViewHostsString: String) {
         self.allowedWebViewHostsString = allowedWebViewHostsString
-        self.hostPatternsString = hostPatternsString
     }
 }

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -60,9 +60,8 @@ public enum WebViewTracking {
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session,
     /// using wildcard host patterns for matching.
     ///
-    /// If the content loaded in WebView uses Datadog Browser SDK with `getAllowedWebViewHostPatterns`
-    /// support and its hostname matches one of the specified patterns, web events will be correlated
-    /// with the RUM session from native SDK.
+    /// If the content loaded in WebView uses Datadog Browser SDK and its hostname matches one of the
+    /// specified patterns, web events will be correlated with the RUM session from native SDK.
     ///
     /// Patterns support a single `*` wildcard: `"*.example.com"`, `"preview-*.shopist.io"`, `"shopist.io"`.
     /// Patterns with more than one `*` are dropped with a warning.
@@ -210,18 +209,11 @@ public enum WebViewTracking {
             return pattern.lowercased()
         }
 
-        if validPatterns.contains(where: { $0.contains("*") }) {
-            consolePrint(
-                "WebView host patterns with wildcards require Browser SDK with `getAllowedWebViewHostPatterns` support. Older Browser SDK versions will only match exact host entries.",
-                .warn
-            )
-        }
-
-        let hostPatternsString = validPatterns
+        let allowedWebViewHostsString = validPatterns
             .map { "\"\($0)\"" }
             .joined(separator: ",")
 
-        let elements = WebViewTrackingElements(allowedWebViewHostsString: "", hostPatternsString: hostPatternsString)
+        let elements = WebViewTrackingElements(allowedWebViewHostsString: allowedWebViewHostsString)
         let isTraceSampled = WebViewTracking.isTraceSampledStringValue(for: core)
 
         try WebViewSessionRolloverHandler.register(webView: webView, in: core, using: elements)
@@ -266,13 +258,6 @@ public enum WebViewTracking {
         // Share native capabilities with Browser SDK
         let capabilities = sessionReplay != nil ? "\"records\"" : ""
 
-        let hostPatternsMethodBlock: String
-        if let patternsString = elements.hostPatternsString {
-            hostPatternsMethodBlock = "\n    getAllowedWebViewHostPatterns() {\n        return '[\(patternsString)]'\n    },"
-        } else {
-            hostPatternsMethodBlock = ""
-        }
-
         let js = """
         \(Self.jsCodePrefix)
         window.\(bridgeName) = {
@@ -281,7 +266,7 @@ public enum WebViewTracking {
             },
             getAllowedWebViewHosts() {
                 return '[\(elements.allowedWebViewHostsString)]'
-            },\(hostPatternsMethodBlock)
+            },
             getCapabilities() {
                 return '[\(capabilities)]'
             },

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -57,6 +57,42 @@ public enum WebViewTracking {
         }
     }
 
+    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session,
+    /// using wildcard host patterns for matching.
+    ///
+    /// If the content loaded in WebView uses Datadog Browser SDK with `getAllowedWebViewHostPatterns`
+    /// support and its hostname matches one of the specified patterns, web events will be correlated
+    /// with the RUM session from native SDK.
+    ///
+    /// Patterns support a single `*` wildcard: `"*.example.com"`, `"preview-*.shopist.io"`, `"shopist.io"`.
+    /// Patterns with more than one `*` are dropped with a warning.
+    ///
+    /// - Parameters:
+    ///   - webView: The web-view to track.
+    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
+    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
+    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
+    ///   - core: Datadog SDK core to use for tracking.
+    public static func enable(
+        webView: WKWebView,
+        hostPatterns: [String],
+        logsSampleRate: SampleRate = .maxSampleRate,
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
+        do {
+            try runOnMainThreadSync {
+                try enableOrThrow(
+                    tracking: webView,
+                    hostPatterns: hostPatterns,
+                    logsSampleRate: logsSampleRate,
+                    in: core
+                )
+            }
+        } catch let error {
+            consolePrint("\(error)", .error)
+        }
+    }
+
     /// Disables Datadog iOS SDK and Datadog Browser SDK integration.
     ///
     /// Removes Datadog's ScriptMessageHandler and UserScript from the caller.
@@ -133,6 +169,68 @@ public enum WebViewTracking {
         core.telemetry.usage(event: .trackWebView)
     }
 
+    @MainActor
+    static func enableOrThrow(
+        tracking webView: WKWebView,
+        hostPatterns: [String],
+        logsSampleRate: Float,
+        in core: DatadogCoreProtocol
+    ) throws {
+        guard !(core is NOPDatadogCore) else {
+            throw ProgrammerError(
+                description: "Datadog SDK must be initialized before calling `WebViewTracking.enable(webView:)`."
+            )
+        }
+
+        let controller = webView.configuration.userContentController
+        let isTracking = controller.userScripts.contains { $0.source.starts(with: Self.jsCodePrefix) }
+        guard !isTracking else {
+            DD.logger.warn("`startTrackingDatadogEvents(core:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
+            return
+        }
+
+        let bridgeName = DDScriptMessageHandler.name
+
+        let messageHandler = DDScriptMessageHandler(
+            emitter: MessageEmitter(
+                logsSampler: Sampler(samplingRate: logsSampleRate),
+                core: core
+            )
+        )
+
+        controller.removeScriptMessageHandler(forName: bridgeName)
+        controller.add(messageHandler, name: bridgeName)
+
+        let validPatterns: [String] = hostPatterns.compactMap { pattern in
+            let wildcardCount = pattern.filter { $0 == "*" }.count
+            if wildcardCount > 1 {
+                consolePrint("WebView host pattern \"\(pattern)\" contains more than one wildcard and will be ignored.", .warn)
+                return nil
+            }
+            return pattern.lowercased()
+        }
+
+        if validPatterns.contains(where: { $0.contains("*") }) {
+            consolePrint(
+                "WebView host patterns with wildcards require Browser SDK with `getAllowedWebViewHostPatterns` support. Older Browser SDK versions will only match exact host entries.",
+                .warn
+            )
+        }
+
+        let hostPatternsString = validPatterns
+            .map { "\"\($0)\"" }
+            .joined(separator: ",")
+
+        let elements = WebViewTrackingElements(allowedWebViewHostsString: "", hostPatternsString: hostPatternsString)
+        let isTraceSampled = WebViewTracking.isTraceSampledStringValue(for: core)
+
+        try WebViewSessionRolloverHandler.register(webView: webView, in: core, using: elements)
+
+        injectUserScript(on: webView, in: core, using: elements, isTraceSampled: isTraceSampled)
+
+        core.telemetry.usage(event: .trackWebView)
+    }
+
     /// Injects the Javascript bridge code in the WebView user scripts.
     ///
     /// - Important: This function does not check if the script is already there and should be called *only* when
@@ -168,6 +266,13 @@ public enum WebViewTracking {
         // Share native capabilities with Browser SDK
         let capabilities = sessionReplay != nil ? "\"records\"" : ""
 
+        let hostPatternsMethodBlock: String
+        if let patternsString = elements.hostPatternsString {
+            hostPatternsMethodBlock = "\n    getAllowedWebViewHostPatterns() {\n        return '[\(patternsString)]'\n    },"
+        } else {
+            hostPatternsMethodBlock = ""
+        }
+
         let js = """
         \(Self.jsCodePrefix)
         window.\(bridgeName) = {
@@ -176,7 +281,7 @@ public enum WebViewTracking {
             },
             getAllowedWebViewHosts() {
                 return '[\(elements.allowedWebViewHostsString)]'
-            },
+            },\(hostPatternsMethodBlock)
             getCapabilities() {
                 return '[\(capabilities)]'
             },

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -122,31 +122,9 @@ public enum WebViewTracking {
         logsSampleRate: Float,
         in core: DatadogCoreProtocol
     ) throws {
-        guard !(core is NOPDatadogCore) else {
-            throw ProgrammerError(
-                description: "Datadog SDK must be initialized before calling `WebViewTracking.enable(webView:)`."
-            )
-        }
-
-        let controller = webView.configuration.userContentController
-        let isTracking = controller.userScripts.contains { $0.source.starts(with: Self.jsCodePrefix) }
-        guard !isTracking else {
-            DD.logger.warn("`startTrackingDatadogEvents(core:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
+        guard try prepareWebView(webView, logsSampleRate: logsSampleRate, callerName: "WebViewTracking.enable(webView:hosts:)", in: core) else {
             return
         }
-
-        let bridgeName = DDScriptMessageHandler.name
-
-        let messageHandler = DDScriptMessageHandler(
-            emitter: MessageEmitter(
-                logsSampler: Sampler(samplingRate: logsSampleRate),
-                core: core
-            )
-        )
-
-        // Prevent fatal error: `Attempt to add script message handler with name 'DatadogEventBridge' when one already exists.`
-        controller.removeScriptMessageHandler(forName: bridgeName)
-        controller.add(messageHandler, name: bridgeName)
 
         // `WKScriptMessageHandlerWithReply` returns `Promise` and `browser-sdk` expects immediate values.
         // We inject a user script to return `allowedWebViewHosts` instead of using `WKScriptMessageHandlerWithReply`
@@ -175,30 +153,9 @@ public enum WebViewTracking {
         logsSampleRate: Float,
         in core: DatadogCoreProtocol
     ) throws {
-        guard !(core is NOPDatadogCore) else {
-            throw ProgrammerError(
-                description: "Datadog SDK must be initialized before calling `WebViewTracking.enable(webView:)`."
-            )
-        }
-
-        let controller = webView.configuration.userContentController
-        let isTracking = controller.userScripts.contains { $0.source.starts(with: Self.jsCodePrefix) }
-        guard !isTracking else {
-            DD.logger.warn("`startTrackingDatadogEvents(core:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
+        guard try prepareWebView(webView, logsSampleRate: logsSampleRate, callerName: "WebViewTracking.enable(webView:hostPatterns:)", in: core) else {
             return
         }
-
-        let bridgeName = DDScriptMessageHandler.name
-
-        let messageHandler = DDScriptMessageHandler(
-            emitter: MessageEmitter(
-                logsSampler: Sampler(samplingRate: logsSampleRate),
-                core: core
-            )
-        )
-
-        controller.removeScriptMessageHandler(forName: bridgeName)
-        controller.add(messageHandler, name: bridgeName)
 
         let validPatterns: [String] = hostPatterns.compactMap { pattern in
             let lowercased = pattern.lowercased()
@@ -227,6 +184,40 @@ public enum WebViewTracking {
         injectUserScript(on: webView, in: core, using: elements, isTraceSampled: isTraceSampled)
 
         core.telemetry.usage(event: .trackWebView)
+    }
+
+    @MainActor
+    private static func prepareWebView(
+        _ webView: WKWebView,
+        logsSampleRate: Float,
+        callerName: String,
+        in core: DatadogCoreProtocol
+    ) throws -> Bool {
+        guard !(core is NOPDatadogCore) else {
+            throw ProgrammerError(
+                description: "Datadog SDK must be initialized before calling `WebViewTracking.enable(webView:)`."
+            )
+        }
+
+        let controller = webView.configuration.userContentController
+        let isTracking = controller.userScripts.contains { $0.source.starts(with: Self.jsCodePrefix) }
+        guard !isTracking else {
+            DD.logger.warn("`\(callerName)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
+            return false
+        }
+
+        let bridgeName = DDScriptMessageHandler.name
+        let messageHandler = DDScriptMessageHandler(
+            emitter: MessageEmitter(
+                logsSampler: Sampler(samplingRate: logsSampleRate),
+                core: core
+            )
+        )
+        // Prevent fatal error: `Attempt to add script message handler with name 'DatadogEventBridge' when one already exists.`
+        controller.removeScriptMessageHandler(forName: bridgeName)
+        controller.add(messageHandler, name: bridgeName)
+
+        return true
     }
 
     /// Injects the Javascript bridge code in the WebView user scripts.

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -201,12 +201,18 @@ public enum WebViewTracking {
         controller.add(messageHandler, name: bridgeName)
 
         let validPatterns: [String] = hostPatterns.compactMap { pattern in
-            let wildcardCount = pattern.filter { $0 == "*" }.count
-            if wildcardCount > 1 {
-                consolePrint("WebView host pattern \"\(pattern)\" contains more than one wildcard and will be ignored.", .warn)
+            let lowercased = pattern.lowercased()
+            let allowedCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789.-*")
+            if lowercased.unicodeScalars.contains(where: { !allowedCharacters.contains($0) }) {
+                DD.logger.warn("WebView host pattern \"\(pattern)\" contains invalid characters and will be ignored.")
                 return nil
             }
-            return pattern.lowercased()
+            let wildcardCount = lowercased.filter { $0 == "*" }.count
+            if wildcardCount > 1 {
+                DD.logger.warn("WebView host pattern \"\(pattern)\" contains more than one wildcard and will be ignored.")
+                return nil
+            }
+            return lowercased
         }
 
         let allowedWebViewHostsString = validPatterns

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -867,6 +867,102 @@ class WebViewTrackingTests: XCTestCase {
         // Then - disable clears user scripts so the duplicate guard passes again on re-enable
         XCTAssertEqual(trackWebViewUsageCount, 2)
     }
+
+    // MARK: - Wildcard host patterns
+
+    func testItAddsUserScriptWithHostPatterns() throws {
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hostPatterns: ["*.shopist.io", "preview-*.example.com"],
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertEqual(script.source, """
+        /* DatadogEventBridge */
+        window.DatadogEventBridge = {
+            send(msg) {
+                window.webkit.messageHandlers.DatadogEventBridge.postMessage(msg)
+            },
+            getAllowedWebViewHosts() {
+                return '[]'
+            },
+            getAllowedWebViewHostPatterns() {
+                return '["*.shopist.io","preview-*.example.com"]'
+            },
+            getCapabilities() {
+                return '[]'
+            },
+            getPrivacyLevel() {
+                return 'mask'
+            },
+            getIsTraceSampled() {
+                return 'null'
+            }
+        }
+        """)
+    }
+
+    func testLegacyPathDoesNotEmitHostPatternsMethod() throws {
+        let mockSanitizer = HostsSanitizerMock()
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hosts: ["shopist.io"],
+            hostsSanitizer: mockSanitizer,
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertFalse(script.source.contains("getAllowedWebViewHostPatterns"))
+    }
+
+    func testItDropsPatternWithMoreThanOneWildcard() throws {
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hostPatterns: ["*.foo.*.bar", "shopist.io"],
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertTrue(script.source.contains("\"shopist.io\""))
+        XCTAssertFalse(script.source.contains("*.foo.*.bar"))
+    }
+
+    func testItLowercasesHostPatterns() throws {
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hostPatterns: ["*.SHOPIST.IO", "Preview-*.Example.COM"],
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertTrue(script.source.contains("\"*.shopist.io\""))
+        XCTAssertTrue(script.source.contains("\"preview-*.example.com\""))
+    }
 }
 
 #endif

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -891,9 +891,6 @@ class WebViewTrackingTests: XCTestCase {
                 window.webkit.messageHandlers.DatadogEventBridge.postMessage(msg)
             },
             getAllowedWebViewHosts() {
-                return '[]'
-            },
-            getAllowedWebViewHostPatterns() {
                 return '["*.shopist.io","preview-*.example.com"]'
             },
             getCapabilities() {
@@ -907,25 +904,6 @@ class WebViewTrackingTests: XCTestCase {
             }
         }
         """)
-    }
-
-    func testLegacyPathDoesNotEmitHostPatternsMethod() throws {
-        let mockSanitizer = HostsSanitizerMock()
-        let config = WKWebViewConfiguration()
-        let controller = DDUserContentController()
-        config.userContentController = controller
-        let webView = WKWebView(frame: .zero, configuration: config)
-
-        try WebViewTracking.enableOrThrow(
-            tracking: webView,
-            hosts: ["shopist.io"],
-            hostsSanitizer: mockSanitizer,
-            logsSampleRate: 100,
-            in: PassthroughCoreMock()
-        )
-
-        let script = try XCTUnwrap(controller.userScripts.last)
-        XCTAssertFalse(script.source.contains("getAllowedWebViewHostPatterns"))
     }
 
     func testItDropsPatternWithMoreThanOneWildcard() throws {

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -941,6 +941,25 @@ class WebViewTrackingTests: XCTestCase {
         XCTAssertTrue(script.source.contains("\"*.shopist.io\""))
         XCTAssertTrue(script.source.contains("\"preview-*.example.com\""))
     }
+
+    func testItDropsPatternsWithInvalidCharacters() throws {
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hostPatterns: ["foo'bar.com", "back\\slash.com", "shopist.io"],
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertTrue(script.source.contains("\"shopist.io\""))
+        XCTAssertFalse(script.source.contains("foo'bar.com"))
+        XCTAssertFalse(script.source.contains("back\\\\slash.com"))
+    }
 }
 
 #endif

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -500,7 +500,7 @@ class WebViewTrackingTests: XCTestCase {
 
         XCTAssertEqual(
             dd.logger.warnLogs.map({ $0.message }),
-            Array(repeating: "`startTrackingDatadogEvents(core:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.", count: multipleTimes - 1)
+            Array(repeating: "`WebViewTracking.enable(webView:hosts:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.", count: multipleTimes - 1)
         )
     }
 
@@ -959,6 +959,37 @@ class WebViewTrackingTests: XCTestCase {
         XCTAssertTrue(script.source.contains("\"shopist.io\""))
         XCTAssertFalse(script.source.contains("foo'bar.com"))
         XCTAssertFalse(script.source.contains("back\\\\slash.com"))
+    }
+
+    func testSerializationEdgeCases() throws {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        let config = WKWebViewConfiguration()
+        let controller = DDUserContentController()
+        config.userContentController = controller
+        let webView = WKWebView(frame: .zero, configuration: config)
+
+        try WebViewTracking.enableOrThrow(
+            tracking: webView,
+            hostPatterns: [
+                "*",
+                "",
+                "https://foo.com",
+                "shopist.io",
+            ],
+            logsSampleRate: 100,
+            in: PassthroughCoreMock()
+        )
+
+        let script = try XCTUnwrap(controller.userScripts.last)
+        XCTAssertTrue(script.source.contains("\"*\""))
+        XCTAssertTrue(script.source.contains("\"\""))
+        XCTAssertTrue(script.source.contains("\"shopist.io\""))
+        XCTAssertFalse(script.source.contains("https://foo.com"))
+        XCTAssertEqual(dd.logger.warnLogs.map(\.message), [
+            "WebView host pattern \"https://foo.com\" contains invalid characters and will be ignored."
+        ])
     }
 }
 

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3501,6 +3501,7 @@ public class objc_RUMMonitor: NSObject
 
 public final class objc_WebViewTracking: NSObject
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
+    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate)
     public static func disable(webView: WKWebView)
 
 # ----------------------------------

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -588,6 +588,7 @@ public protocol CrashReportingPlugin: AnyObject
 
 public enum WebViewTracking
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter


### PR DESCRIPTION
### What and why?

Adds a new `WebViewTracking.enable(webView:hostPatterns:[String])` overload that accepts wildcard pattern strings like `"*.example.com"` or `"preview-*.shopist.io"`. Customers currently cannot configure WebView tracking for dynamic hostnames (ephemeral preview URLs, multi-tenant subdomain fleets) — the existing `hosts:` API only supports exact matches and subdomain-suffix matching.

This is the iOS side of [RUM-15826](https://datadoghq.atlassian.net/browse/RUM-15826). Browser SDK counterpart: https://github.com/DataDog/browser-sdk/pull/4703

### How?

A new optional `getAllowedWebViewHostPatterns?()` method is injected into the bridge alongside the existing `getAllowedWebViewHosts()`, which keeps its current shape forever. Browser SDK detects the new method via `typeof === 'function'` and evaluates patterns using plain string operations — no regex engine involved on any platform.

Patterns with more than one `*` are dropped with a console warning. Patterns are lowercased. The existing `enable(webView:hosts:)` path is byte-for-byte unchanged.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

[RUM-15826]: https://datadoghq.atlassian.net/browse/RUM-15826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ