### PR TITLE
fix: Account for cpu_ticks rollover.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FIX] Prevent a crash from `VitalCPUReader` when `cpu_ticks.0` rolls over. 
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
@@ -10,9 +10,10 @@ import DatadogInternal
 
 class VitalCPUReaderTest: XCTestCase {
     let testNotificationCenter = NotificationCenter()
-    lazy var cpuReader = VitalCPUReader(notificationCenter: testNotificationCenter)
 
     func testWhenCPUUnderHeavyLoadItMeasuresHigherCPUTicks() throws {
+        let cpuReader = VitalCPUReader(notificationCenter: testNotificationCenter)
+        testNotificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
         let repetitions = 3
 
         // The CPU ticks consumed during heavy processing are not always greater than those during light processing.
@@ -20,9 +21,9 @@ class VitalCPUReaderTest: XCTestCase {
         // To minimize false positives, an average is calculated over n repetitions.
         let utilizationArray: [(highUtilization: Double, sleepUtilization: Double)] = try (0..<repetitions).map { _ in
             // calculates the utilization under heavy processing
-            let highLoadResult = try utilizationAndDuration(heavyLoad)
+            let highLoadResult = try utilizationAndDuration(cpuReader: cpuReader, heavyLoad)
 
-            let sleepResult = try utilizationAndDuration {
+            let sleepResult = try utilizationAndDuration(cpuReader: cpuReader) {
                 // The sleep duration should be the same as the heavy load duration
                 Thread.sleep(forTimeInterval: highLoadResult.duration)
             }
@@ -39,6 +40,9 @@ class VitalCPUReaderTest: XCTestCase {
 
     #if !os(watchOS)
     func testWhenInactiveAppStateItIgnoresCPUTicks() throws {
+        let cpuReader = VitalCPUReader(notificationCenter: testNotificationCenter)
+
+        testNotificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
         let baseline = try XCTUnwrap(cpuReader.readVitalData())
         testNotificationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
         heavyLoad()
@@ -54,7 +58,29 @@ class VitalCPUReaderTest: XCTestCase {
     }
     #endif
 
-    private func utilizationAndDuration(_ block: () -> Void) throws -> (utilization: Double, duration: Double) {
+    func testTickCounterOverflowAccumulatesCorrectly() {
+        // Simulate a UInt32 tick counter that wraps from near UInt32.max back to 0.
+        // Without overflow handling the subtraction would underflow, producing a wildly wrong result.
+        let reader = ControllableVitalCPUReader(notificationCenter: testNotificationCenter)
+
+        // Given:
+        // App becomes active just as counter is about to roll over. The third read does result
+        // in an active rollover.
+        let startTick = UInt64(UInt32.max) - 10
+        reader.mockTicks = [startTick, startTick + 5, 20]
+        testNotificationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+
+        // When:
+        let firstRead = reader.readVitalData()
+        let secondRead = reader.readVitalData()
+
+        // First interval: startTick + 5 = 5
+        XCTAssertEqual(firstRead, 5.0)
+        // Overflow interval: 20 + 10 ticks from rollover = 30
+        XCTAssertEqual(secondRead, 30.0)
+    }
+
+    private func utilizationAndDuration(cpuReader: VitalCPUReader, _ block: () -> Void) throws -> (utilization: Double, duration: Double) {
         let startTime = CFAbsoluteTimeGetCurrent()
         let startUtilization = try XCTUnwrap(cpuReader.readVitalData())
 
@@ -66,6 +92,14 @@ class VitalCPUReaderTest: XCTestCase {
         let utilizedTicks = endUtilization - startUtilization
 
         return (utilizedTicks / duration, duration)
+    }
+}
+
+private class ControllableVitalCPUReader: VitalCPUReader {
+    var mockTicks: [UInt64] = []
+
+    override func readUtilizedTicks() -> UInt64? {
+        mockTicks.isEmpty ? nil : mockTicks.removeFirst()
     }
 }
 

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import TestUtilities
+import DatadogInternal
 @testable import DatadogRUM
 
 class VitalInfoSamplerTests: XCTestCase {
@@ -114,7 +115,17 @@ class VitalInfoSamplerTests: XCTestCase {
             )
         }
 
+        // Application must be active for CPU samples to be registered
+        NotificationCenter.default.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+
         let samplingExpectation = expectation(description: "sampling expectation")
+
+        // Do some work to push up CPU usage
+        for _ in 0...100_000 {
+            let random = Double.random(in: Double.leastNonzeroMagnitude...Double.greatestFiniteMagnitude)
+            _ = tan(random).squareRoot()
+        }
+
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
             samplingExpectation.fulfill()
         }
@@ -122,6 +133,7 @@ class VitalInfoSamplerTests: XCTestCase {
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertGreaterThan(sampler.cpu.meanValue!, 0.0)
             XCTAssertGreaterThan(sampler.cpu.sampleCount, 1)
+            XCTAssertGreaterThan(sampler.cpu.greatestDiff!, 0.0)
             XCTAssertGreaterThan(sampler.memory.meanValue!, 0.0)
             XCTAssertGreaterThan(sampler.memory.sampleCount, 1)
             XCTAssertGreaterThan(sampler.refreshRate.meanValue!, 0.0)

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -113,19 +113,18 @@ class VitalInfoSamplerTests: XCTestCase {
                 refreshRateReader: refreshRateReader,
                 frequency: 0.1
             )
+            sampler.takeSample()
         }
 
-        // Application must be active for CPU samples to be registered
-        NotificationCenter.default.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+        _ = Date()
+        DispatchQueue.concurrentPerform(iterations: 100) { iteration in
+            for _ in 1...10_000 {
+                let random = Double.random(in: Double.leastNonzeroMagnitude...Double.greatestFiniteMagnitude)
+                _ = tan(random).squareRoot()
+            }
+        }
 
         let samplingExpectation = expectation(description: "sampling expectation")
-
-        // Do some work to push up CPU usage
-        for _ in 0...100_000 {
-            let random = Double.random(in: Double.leastNonzeroMagnitude...Double.greatestFiniteMagnitude)
-            _ = tan(random).squareRoot()
-        }
-
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
             samplingExpectation.fulfill()
         }

--- a/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
@@ -24,6 +24,7 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
         self.telemetry = telemetry
         notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: ApplicationNotifications.willResignActive, object: nil)
         notificationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: ApplicationNotifications.didBecomeActive, object: nil)
+        lastReadActiveTicks = readUtilizedTicks()
     }
 
     func readVitalData() -> Double? {

--- a/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
@@ -11,8 +11,9 @@ import DatadogInternal
 internal class VitalCPUReader: SamplingBasedVitalReader {
     /// host_cpu_load_info_count is 4 (tested in iOS 14.4)
     private static let host_cpu_load_info_count = MemoryLayout<host_cpu_load_info>.stride / MemoryLayout<integer_t>.stride
-    private var totalInactiveTicks: UInt64 = 0
-    private var utilizedTicksWhenResigningActive: UInt64? = nil
+    private var totalActiveTicks: UInt64? = nil
+    private var lastReadActiveTicks: UInt64? = nil
+
     /// Telemetry interface.
     private let telemetry: Telemetry
 
@@ -26,12 +27,34 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
     }
 
     func readVitalData() -> Double? {
-        if let ticks = readUtilizedTicks() {
-            let ongoingInactiveTicks = ticks - (utilizedTicksWhenResigningActive ?? ticks)
-            let inactiveTicks = totalInactiveTicks + ongoingInactiveTicks
-            return Double(ticks - inactiveTicks)
+        addActiveTicks()
+        if let totalActiveTicks {
+            return Double(totalActiveTicks)
         }
         return nil
+    }
+
+    private func addActiveTicks() {
+        // If lastReadActiveTicks isn't set, we're currently not the active application.
+        guard let lastActiveTicks = lastReadActiveTicks else {
+            return
+        }
+
+        if let ticks = readUtilizedTicks() {
+            var activeTicks: UInt64 = totalActiveTicks ?? 0
+
+            if ticks < lastActiveTicks {
+                // Ticks overflowed back to 0. The number of elapsed active ticks is the current number of ticks
+                // plus the number of ticks since the last read to a UInt32 overflow
+                activeTicks &+= ticks + (UInt64(UInt32.max) - lastActiveTicks)
+            } else {
+                let elapsedTicks = ticks - lastActiveTicks
+                activeTicks &+= elapsedTicks
+            }
+
+            totalActiveTicks = activeTicks
+            lastReadActiveTicks = ticks
+        }
     }
 
     // TODO: RUMM-1276 appWillResignActive&appDidBecomeActive are called in main thread
@@ -39,18 +62,17 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
 
     @objc
     private func appWillResignActive() {
-        utilizedTicksWhenResigningActive = readUtilizedTicks()
-    }
-    @objc
-    private func appDidBecomeActive() {
-        if let previouslyReadTicks = utilizedTicksWhenResigningActive,
-           let currentTicks = readUtilizedTicks() {
-            utilizedTicksWhenResigningActive = nil
-            totalInactiveTicks += currentTicks - previouslyReadTicks
-        }
+        // Before resigning active, log the current active ticks
+        addActiveTicks()
+        lastReadActiveTicks = nil
     }
 
-    private func readUtilizedTicks() -> UInt64? {
+    @objc
+    private func appDidBecomeActive() {
+        lastReadActiveTicks = readUtilizedTicks()
+    }
+
+    internal func readUtilizedTicks() -> UInt64? {
         // it must be set to host_cpu_load_info_count_size >= host_cpu_load_info_count
         // implementation: https://github.com/opensource-apple/xnu/blob/master/osfmk/kern/host.c#L425
         var host_cpu_load_info_count_size = mach_msg_type_number_t(Self.host_cpu_load_info_count)

--- a/DatadogRUM/Sources/RUMVitals/VitalInfoSampler.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalInfoSampler.swift
@@ -88,7 +88,8 @@ internal final class VitalInfoSampler {
         refreshRateReader.unregister(refreshRatePublisher)
     }
 
-    private func takeSample() {
+    // Note: This is internal for use in testing. Do not call this in regular usage.
+    internal func takeSample() {
         if let newCPUSample = cpuReader.readVitalData() {
             cpuPublisher.mutateAsync { cpuInfo in
                 cpuInfo.addSample(newCPUSample)


### PR DESCRIPTION
### What and why?

VitalCPUReader assumes that the value returned from `cpu_ticks.0` is always increasing, which is not true, as it is a 32-bit integer of the number of CPU Ticks used by User applications since device boot. For a device that has been online for a while, or has seen in heavy use by user applications, this can cause the value to overflow.

In these cases, the VitalCPUReader could crash with an overflow exception when it attempted to subtract out the inactive ticks from the active ones.

### How?

To avoid the overflow and to simplify the logic I've removed tracking "inactive" ticks and changed it to tracking "active" ticks  VitalCPUReader will always return an increasing number of ticks since the first `appDidBecomeActive` notification from NotificationCenter.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
