### PR TITLE
Fix wrong types in the `objc_LogEventDevice` properties definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
+- [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
 - [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
 
@@ -1160,6 +1161,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2859]: https://github.com/DataDog/dd-sdk-ios/pull/2859
 [#2948]: https://github.com/DataDog/dd-sdk-ios/pull/2948
 [#2956]: https://github.com/DataDog/dd-sdk-ios/pull/2956
+[#2966]: https://github.com/DataDog/dd-sdk-ios/pull/2966
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogLogs/Sources/LogsDataModels+objc.swift
+++ b/DatadogLogs/Sources/LogsDataModels+objc.swift
@@ -383,20 +383,20 @@ public class objc_LogEventDevice: NSObject {
         root.swiftModel.device.architecture
     }
 
-    public var batteryLevel: Double? {
-        root.swiftModel.device.batteryLevel
+    public var batteryLevel: NSNumber? {
+        root.swiftModel.device.batteryLevel as NSNumber?
     }
 
     public var brand: String? {
         root.swiftModel.device.brand
     }
 
-    public var brightnessLevel: Double? {
-        root.swiftModel.device.brightnessLevel
+    public var brightnessLevel: NSNumber? {
+        root.swiftModel.device.brightnessLevel as NSNumber?
     }
 
-    public var isLowRam: Bool? {
-        root.swiftModel.device.isLowRam
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device.isLowRam as NSNumber?
     }
 
     public var locale: String? {
@@ -407,8 +407,8 @@ public class objc_LogEventDevice: NSObject {
         root.swiftModel.device.locales
     }
 
-    public var logicalCpuCount: Double? {
-        root.swiftModel.device.logicalCpuCount
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device.logicalCpuCount as NSNumber?
     }
 
     public var model: String? {
@@ -419,16 +419,16 @@ public class objc_LogEventDevice: NSObject {
         root.swiftModel.device.name
     }
 
-    public var powerSavingMode: Bool? {
-        root.swiftModel.device.powerSavingMode
+    public var powerSavingMode: NSNumber? {
+        root.swiftModel.device.powerSavingMode as NSNumber?
     }
 
     public var timeZone: String? {
         root.swiftModel.device.timeZone
     }
 
-    public var totalRam: Double? {
-        root.swiftModel.device.totalRam
+    public var totalRam: NSNumber? {
+        root.swiftModel.device.totalRam as NSNumber?
     }
 
     public var type: objc_LogEventDeviceDeviceType {

--- a/DatadogLogs/Tests/LogsDataModels+objcTests.swift
+++ b/DatadogLogs/Tests/LogsDataModels+objcTests.swift
@@ -30,18 +30,18 @@ class LogsDataModels_objcTests: XCTestCase {
 
         // Then
         XCTAssertEqual(swiftDevice.architecture, objcDevice.architecture)
-        XCTAssertEqual(swiftDevice.batteryLevel, objcDevice.batteryLevel)
+        XCTAssertEqual(swiftDevice.batteryLevel, objcDevice.batteryLevel?.doubleValue)
         XCTAssertEqual(swiftDevice.brand, objcDevice.brand)
-        XCTAssertEqual(swiftDevice.brightnessLevel, objcDevice.brightnessLevel)
-        XCTAssertEqual(swiftDevice.isLowRam, objcDevice.isLowRam)
+        XCTAssertEqual(swiftDevice.brightnessLevel, objcDevice.brightnessLevel?.doubleValue)
+        XCTAssertEqual(swiftDevice.isLowRam, objcDevice.isLowRam?.boolValue)
         XCTAssertEqual(swiftDevice.locale, objcDevice.locale)
         XCTAssertEqual(swiftDevice.locales, objcDevice.locales)
-        XCTAssertEqual(swiftDevice.logicalCpuCount, objcDevice.logicalCpuCount)
+        XCTAssertEqual(swiftDevice.logicalCpuCount, objcDevice.logicalCpuCount?.doubleValue)
         XCTAssertEqual(swiftDevice.model, objcDevice.model)
         XCTAssertEqual(swiftDevice.name, objcDevice.name)
-        XCTAssertEqual(swiftDevice.powerSavingMode, objcDevice.powerSavingMode)
+        XCTAssertEqual(swiftDevice.powerSavingMode, objcDevice.powerSavingMode?.boolValue)
         XCTAssertEqual(swiftDevice.timeZone, objcDevice.timeZone)
-        XCTAssertEqual(swiftDevice.totalRam, objcDevice.totalRam)
+        XCTAssertEqual(swiftDevice.totalRam, objcDevice.totalRam?.doubleValue)
         XCTAssertEqual(swiftDevice.type, objcDevice.type.toSwift)
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -201,18 +201,18 @@ public class objc_LogEventDDDevice: NSObject
     public var architecture: String
 public class objc_LogEventDevice: NSObject
     public var architecture: String?
-    public var batteryLevel: Double?
+    public var batteryLevel: NSNumber?
     public var brand: String?
-    public var brightnessLevel: Double?
-    public var isLowRam: Bool?
+    public var brightnessLevel: NSNumber?
+    public var isLowRam: NSNumber?
     public var locale: String?
     public var locales: [String]?
-    public var logicalCpuCount: Double?
+    public var logicalCpuCount: NSNumber?
     public var model: String?
     public var name: String?
-    public var powerSavingMode: Bool?
+    public var powerSavingMode: NSNumber?
     public var timeZone: String?
-    public var totalRam: Double?
+    public var totalRam: NSNumber?
     public var type: objc_LogEventDeviceDeviceType
 public enum objc_LogEventDeviceDeviceType: Int
     case none


### PR DESCRIPTION
### What and why?

`Bool?` and `Double?` cannot be used in the Objective-C API.

The properties `isLowRam: Bool?`, `logicalCpuCount: Double?`, etc. are Swift optional value types. With `@objcMembers`, the Swift compiler silently drops any property that can't be represented in ObjC — and `Bool?`/`Double?` can't be (ObjC `BOOL`/`double` are non-nullable primitives)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
