### PR TITLE
fix: Fix CPU vital tick rollover crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FIX] Prevent a crash from `VitalCPUReader` when the CPU tick counter rolls over. See [#2968][]
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
 - [IMPROVEMENT] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2949][]
@@ -1166,6 +1167,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2966]: https://github.com/DataDog/dd-sdk-ios/pull/2966
 [#2949]: https://github.com/DataDog/dd-sdk-ios/pull/2949
 [#2952]: https://github.com/DataDog/dd-sdk-ios/pull/2952
+[#2968]: https://github.com/DataDog/dd-sdk-ios/pull/2968
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
@@ -54,6 +54,40 @@ class VitalCPUReaderTest: XCTestCase {
     }
     #endif
 
+    func testWhenCPUCounterRollsOverWhileAppIsInactiveItDoesNotCrash() throws {
+        let tickWhenResigningActive = UInt32.max - 10
+        let tickAfterRollover: UInt32 = 20
+        let cpuReader = VitalCPUReaderMock(
+            notificationCenter: testNotificationCenter,
+            mockTicks: [
+                tickWhenResigningActive,
+                tickAfterRollover
+            ]
+        )
+
+        testNotificationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
+
+        let measurementWhenInactive = try XCTUnwrap(cpuReader.readVitalData())
+        XCTAssertEqual(measurementWhenInactive, Double(tickWhenResigningActive))
+    }
+
+    func testWhenCPUCounterRollsOverWhileAppIsActiveItAccumulatesElapsedTicks() throws {
+        let tickBeforeRollover = UInt32.max - 10
+        let tickAfterRollover: UInt32 = 20
+        let cpuReader = VitalCPUReaderMock(
+            notificationCenter: testNotificationCenter,
+            mockTicks: [
+                tickBeforeRollover,
+                tickAfterRollover
+            ]
+        )
+
+        let measurementBeforeRollover = try XCTUnwrap(cpuReader.readVitalData())
+        let measurementAfterRollover = try XCTUnwrap(cpuReader.readVitalData())
+
+        XCTAssertEqual(measurementAfterRollover - measurementBeforeRollover, 31.0)
+    }
+
     private func utilizationAndDuration(_ block: () -> Void) throws -> (utilization: Double, duration: Double) {
         let startTime = CFAbsoluteTimeGetCurrent()
         let startUtilization = try XCTUnwrap(cpuReader.readVitalData())
@@ -66,6 +100,21 @@ class VitalCPUReaderTest: XCTestCase {
         let utilizedTicks = endUtilization - startUtilization
 
         return (utilizedTicks / duration, duration)
+    }
+}
+
+// Overrides only the OS counter read.
+// Rollover normalization and lifecycle accounting stay in VitalCPUReader.
+private class VitalCPUReaderMock: VitalCPUReader {
+    private var mockTicks: [UInt32]
+
+    init(notificationCenter: NotificationCenter, mockTicks: [UInt32]) {
+        self.mockTicks = mockTicks
+        super.init(notificationCenter: notificationCenter)
+    }
+
+    override func readRawUtilizedTicks() -> UInt32? {
+        mockTicks.isEmpty ? nil : mockTicks.removeFirst()
     }
 }
 

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -112,6 +112,14 @@ class VitalInfoSamplerTests: XCTestCase {
                 refreshRateReader: refreshRateReader,
                 frequency: 0.1
             )
+            sampler.takeSample()
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            for _ in 1...10_000 {
+                let random = Double.random(in: Double.leastNonzeroMagnitude...Double.greatestFiniteMagnitude)
+                _ = tan(random).squareRoot()
+            }
         }
 
         let samplingExpectation = expectation(description: "sampling expectation")
@@ -122,6 +130,7 @@ class VitalInfoSamplerTests: XCTestCase {
         waitForExpectations(timeout: 1.0) { _ in
             XCTAssertGreaterThan(sampler.cpu.meanValue!, 0.0)
             XCTAssertGreaterThan(sampler.cpu.sampleCount, 1)
+            XCTAssertGreaterThan(sampler.cpu.greatestDiff!, 0.0)
             XCTAssertGreaterThan(sampler.memory.meanValue!, 0.0)
             XCTAssertGreaterThan(sampler.memory.sampleCount, 1)
             XCTAssertGreaterThan(sampler.refreshRate.meanValue!, 0.0)

--- a/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
@@ -11,8 +11,11 @@ import DatadogInternal
 internal class VitalCPUReader: SamplingBasedVitalReader {
     /// host_cpu_load_info_count is 4 (tested in iOS 14.4)
     private static let host_cpu_load_info_count = MemoryLayout<host_cpu_load_info>.stride / MemoryLayout<integer_t>.stride
+    private static let cpuTicksCounterRange = UInt64(UInt32.max) + 1
     private var totalInactiveTicks: UInt64 = 0
     private var utilizedTicksWhenResigningActive: UInt64? = nil
+    private var utilizedTicksRolloverOffset: UInt64 = 0
+    private var lastRawUtilizedTicks: UInt32? = nil
     /// Telemetry interface.
     private let telemetry: Telemetry
 
@@ -51,6 +54,26 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
     }
 
     private func readUtilizedTicks() -> UInt64? {
+        guard let rawTicks = readRawUtilizedTicks() else {
+            return nil
+        }
+
+        // cpu_ticks is a UInt32 counter; unwrap it so callers can safely subtract monotonic values.
+        if let lastRawUtilizedTicks, rawTicks < lastRawUtilizedTicks {
+            let (newRolloverOffset, didOverflow) = utilizedTicksRolloverOffset.addingReportingOverflow(Self.cpuTicksCounterRange)
+            guard didOverflow == false else {
+                telemetry.error("CPU Vital rollover offset overflowed.")
+                return nil
+            }
+            utilizedTicksRolloverOffset = newRolloverOffset
+        }
+
+        lastRawUtilizedTicks = rawTicks
+        let ticks = UInt64(rawTicks)
+        return utilizedTicksRolloverOffset + ticks
+    }
+
+    internal func readRawUtilizedTicks() -> UInt32? {
         // it must be set to host_cpu_load_info_count_size >= host_cpu_load_info_count
         // implementation: https://github.com/opensource-apple/xnu/blob/master/osfmk/kern/host.c#L425
         var host_cpu_load_info_count_size = mach_msg_type_number_t(Self.host_cpu_load_info_count)
@@ -88,6 +111,6 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
          therefore even at the worst-case, precision isn't lost during this conversion below.
          */
         let userTicks = cpuLoadInfo.cpu_ticks.0
-        return UInt64(userTicks)
+        return userTicks
     }
 }

--- a/DatadogRUM/Sources/RUMVitals/VitalInfoSampler.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalInfoSampler.swift
@@ -88,7 +88,8 @@ internal final class VitalInfoSampler {
         refreshRateReader.unregister(refreshRatePublisher)
     }
 
-    private func takeSample() {
+    // Note: This is internal for use in testing. Do not call this in regular usage.
+    internal func takeSample() {
         if let newCPUSample = cpuReader.readVitalData() {
             cpuPublisher.mutateAsync { cpuInfo in
                 cpuInfo.addSample(newCPUSample)


### PR DESCRIPTION
> [!NOTE]
> This PR simplifies the solution proposed in https://github.com/DataDog/dd-sdk-ios/pull/2964.

### What and why?

This PR fixes a crash in `VitalCPUReader` when the underlying 32-bit CPU tick counter rolls over. 
The change keeps the existing active/inactive CPU accounting behavior intact and only addresses the counter rollover edge case.

### How?

`readUtilizedTicks()` now normalizes the raw `UInt32` CPU tick value into a monotonic `UInt64` by tracking rollover offset when the raw counter decreases.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
