### PR TITLE
[PANA-7592] Add layer image snapshotting

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -700,6 +700,16 @@
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
 		6482FB0E2EE885C60042234B /* FlagsClientInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */; };
 		6AF71E3149694FD0972B41C5 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */; };
+		759200022FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200012FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift */; };
+		759200042FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200032FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift */; };
+		759200062FD2000100000001 /* ImageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200052FD2000100000001 /* ImageSnapshot.swift */; };
+		759200082FD2000100000001 /* ImageSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200072FD2000100000001 /* ImageSnapshotCache.swift */; };
+		7592000A2FD2000100000001 /* ImageSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200092FD2000100000001 /* ImageSnapshotter.swift */; };
+		7592000C2FD2000100000001 /* ImageSnapshotterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7592000B2FD2000100000001 /* ImageSnapshotterTests.swift */; };
+		7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7592000D2FD2000100000001 /* ImageSnapshotCacheTests.swift */; };
+		759200102FD2000100000001 /* ImageSnapshotRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7592000F2FD2000100000001 /* ImageSnapshotRequest.swift */; };
+		759200122FD2000100000001 /* ImageSnapshotRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */; };
+		759200142FD2000100000001 /* CALayerChangesetMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200132FD2000100000001 /* CALayerChangesetMock.swift */; };
 		770E0BF093842AF7D350E888 /* EvaluationLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC44AD2847746ED69201F65 /* EvaluationLoggingTests.swift */; };
 		86092FDE2DEDC6830075D63B /* AccessibilityValuesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */; };
 		861FD6862DF2EAED00F59823 /* LocaleInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */; };
@@ -2567,6 +2577,16 @@
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
 		6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientInternal.swift; sourceTree = "<group>"; };
 		6FE4202BC457504AC37A51D6 /* HeatmapIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifier.swift; sourceTree = "<group>"; };
+		759200012FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotImageSnapshotRequestTests.swift; sourceTree = "<group>"; };
+		759200032FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayerSnapshot+ImageSnapshot.swift"; sourceTree = "<group>"; };
+		759200052FD2000100000001 /* ImageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshot.swift; sourceTree = "<group>"; };
+		759200072FD2000100000001 /* ImageSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotCache.swift; sourceTree = "<group>"; };
+		759200092FD2000100000001 /* ImageSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotter.swift; sourceTree = "<group>"; };
+		7592000B2FD2000100000001 /* ImageSnapshotterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotterTests.swift; sourceTree = "<group>"; };
+		7592000D2FD2000100000001 /* ImageSnapshotCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotCacheTests.swift; sourceTree = "<group>"; };
+		7592000F2FD2000100000001 /* ImageSnapshotRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotRequest.swift; sourceTree = "<group>"; };
+		759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotRequestTests.swift; sourceTree = "<group>"; };
+		759200132FD2000100000001 /* CALayerChangesetMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerChangesetMock.swift; sourceTree = "<group>"; };
 		7C61BC8C730F46F1A8EF112E /* OcclusionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OcclusionMap.swift; sourceTree = "<group>"; };
 		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityValuesMock.swift; sourceTree = "<group>"; };
@@ -3898,9 +3918,14 @@
 			isa = PBXGroup;
 			children = (
 				5BF2BC6B2FC2B2F7000E999C /* CALayerReplayIDTests.swift */,
+				759200132FD2000100000001 /* CALayerChangesetMock.swift */,
 				5BB09C9E2FC89F04003DB9FF /* CATransform3DAxisAlignedTests.swift */,
 				5BF2BC702FC46A00000E999C /* CALayerSnapshotContextMock.swift */,
 				5BF2BC722FC46F4A000E999C /* CALayerSnapshotFilterTests.swift */,
+				759200012FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift */,
+				7592000D2FD2000100000001 /* ImageSnapshotCacheTests.swift */,
+				759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */,
+				7592000B2FD2000100000001 /* ImageSnapshotterTests.swift */,
 				AB7890CD1234EF567890ABCD /* CALayerSnapshotOcclusionTests.swift */,
 				DE5432ABCD901234FEDCBA98 /* NSObject+CAFilter.swift */,
 				5BF2BC6D2FC42A00000E999C /* CALayerSnapshotSemanticObservationTests.swift */,
@@ -5965,8 +5990,13 @@
 				5BF2BC692FC085DB000E999C /* CALayerSnapshot+Context.swift */,
 				5BF2BAA22FBF3529000E999C /* CALayerSnapshot+CornerRadii.swift */,
 				5BF2BAA42FBF39AF000E999C /* CALayerSnapshot+Filter.swift */,
+				759200032FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift */,
 				CD3456EF7890AB123456CDEF /* CALayerSnapshot+Occlusion.swift */,
 				5BF2BA9C2FBDC047000E999C /* CALayerSnapshot+SemanticObservation.swift */,
+				759200052FD2000100000001 /* ImageSnapshot.swift */,
+				759200072FD2000100000001 /* ImageSnapshotCache.swift */,
+				7592000F2FD2000100000001 /* ImageSnapshotRequest.swift */,
+				759200092FD2000100000001 /* ImageSnapshotter.swift */,
 				5BF2BC762FC4D8E0000E999C /* LayerProvider.swift */,
 				B73450112F9F200100000001 /* LayerRecording.swift */,
 				B73450122F9F200100000001 /* LayerTreeRecordingCoordinator.swift */,
@@ -8260,9 +8290,11 @@
 				B73450222F9F200100000001 /* LayerTreeRecordingCoordinator.swift in Sources */,
 				B73450232F9F200100000001 /* LayerRecorder.swift in Sources */,
 				5BF2BC792FC4D8E0000E999C /* LayerTreeSnapshotBuilder.swift in Sources */,
+				7592000A2FD2000100000001 /* ImageSnapshotter.swift in Sources */,
 				CC33CC1DDED24454BB35E631 /* OcclusionMap.swift in Sources */,
 				AB1234CD5678EF901234ABCD /* CALayerSnapshot+Occlusion.swift in Sources */,
 				61054E8B2A6EE10A00AAA894 /* SessionReplayFeature.swift in Sources */,
+				759200062FD2000100000001 /* ImageSnapshot.swift in Sources */,
 				61054E992A6EE10A00AAA894 /* WireframesBuilder.swift in Sources */,
 				61054E892A6EE10A00AAA894 /* NodeIDGenerator.swift in Sources */,
 				5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */,
@@ -8274,6 +8306,7 @@
 				61054E982A6EE10A00AAA894 /* RecordsBuilder.swift in Sources */,
 				5B9CB9E52E41FD60005485E6 /* Drawing.swift in Sources */,
 				61054E7C2A6EE10A00AAA894 /* UINavigationBarRecorder.swift in Sources */,
+				759200102FD2000100000001 /* ImageSnapshotRequest.swift in Sources */,
 				5B7448442EFBBF07003E622C /* ScreenChangeScheduler.swift in Sources */,
 				96E414142C2AF56F005A6119 /* UIProgressViewRecorder.swift in Sources */,
 				962C41A72CA431370050B747 /* SessionReplayPrivacyOverrides.swift in Sources */,
@@ -8291,6 +8324,7 @@
 				61054E9F2A6EE10B00AAA894 /* Errors.swift in Sources */,
 				5BF7B51F2E44F7D300E0B772 /* ShapeResource.swift in Sources */,
 				5BF2BA9B2FBDBF89000E999C /* CALayerSnapshot.swift in Sources */,
+				759200082FD2000100000001 /* ImageSnapshotCache.swift in Sources */,
 				5BF2BA9D2FBDC052000E999C /* CALayerSnapshot+SemanticObservation.swift in Sources */,
 				D29A470D2D2ED49F0092BC79 /* Xoshiro.swift in Sources */,
 				61054E642A6EE10A00AAA894 /* SessionReplay.swift in Sources */,
@@ -8301,6 +8335,7 @@
 				61054E742A6EE10A00AAA894 /* ViewTreeSnapshotProducer.swift in Sources */,
 				61054E7E2A6EE10A00AAA894 /* NodeRecorder.swift in Sources */,
 				5BF2BAA52FBF39C0000E999C /* CALayerSnapshot+Filter.swift in Sources */,
+				759200042FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift in Sources */,
 				962D72BC2CF6436700F86EF0 /* GraphicsImage.swift in Sources */,
 				61054E6F2A6EE10A00AAA894 /* UIApplicationSwizzler.swift in Sources */,
 				61054E6D2A6EE10A00AAA894 /* CGRect+SessionReplay.swift in Sources */,
@@ -8397,12 +8432,17 @@
 				5BF2BC6C2FC2B2F7000E999C /* CALayerReplayIDTests.swift in Sources */,
 				5BF2BC712FC46A00000E999C /* CALayerSnapshotContextMock.swift in Sources */,
 				5BF2BC732FC46F4A000E999C /* CALayerSnapshotFilterTests.swift in Sources */,
+				759200022FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift in Sources */,
 				5BF2BC6E2FC42A00000E999C /* CALayerSnapshotSemanticObservationTests.swift in Sources */,
 				5BF2BC672FC10001000E999C /* CALayerSnapshotTests.swift in Sources */,
 				5BF2BC752FC4D520000E999C /* LayerTreeSnapshotBuilderTests.swift in Sources */,
 				17EFC9D8185942399E05BDB4 /* OcclusionMapTests.swift in Sources */,
 				EF5678AB9012CD345678EFAB /* CALayerSnapshotOcclusionTests.swift in Sources */,
 				BC9876FA1234CDEF56789ABC /* NSObject+CAFilter.swift in Sources */,
+				7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */,
+				759200122FD2000100000001 /* ImageSnapshotRequestTests.swift in Sources */,
+				7592000C2FD2000100000001 /* ImageSnapshotterTests.swift in Sources */,
+				759200142FD2000100000001 /* CALayerChangesetMock.swift in Sources */,
 				61054FB82A6EE1BA00AAA894 /* UIDatePickerRecorderTests.swift in Sources */,
 				962D72C52CF7806300F86EF0 /* GraphicsImageReflectionTests.swift in Sources */,
 				61054FA32A6EE1BA00AAA894 /* Diff+SRWireframesTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		5B7448312EFAB819003E622C /* CALayerChangeAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B74482A2EFAB819003E622C /* CALayerChangeAggregator.swift */; };
 		5B7448322EFAB819003E622C /* ScreenChangeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B74482C2EFAB819003E622C /* ScreenChangeMonitor.swift */; };
 		5B7448332EFAB819003E622C /* CALayerChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B74482B2EFAB819003E622C /* CALayerChangeset.swift */; };
+		7592001B2FD3000100000001 /* ScreenChangeFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7592001A2FD3000100000001 /* ScreenChangeFilter.swift */; };
 		5B7448372EFAED99003E622C /* CALayerSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7448362EFAED91003E622C /* CALayerSwizzlerTests.swift */; };
 		5B74483C2EFAEFC3003E622C /* CALayerObserverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B74483B2EFAEFC3003E622C /* CALayerObserverMock.swift */; };
 		5B7448402EFB0F7E003E622C /* CALayerChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B74483F2EFB0F7A003E622C /* CALayerChangeAggregatorTests.swift */; };
@@ -2083,6 +2084,7 @@
 		5B74482A2EFAB819003E622C /* CALayerChangeAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerChangeAggregator.swift; sourceTree = "<group>"; };
 		5B74482B2EFAB819003E622C /* CALayerChangeset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerChangeset.swift; sourceTree = "<group>"; };
 		5B74482C2EFAB819003E622C /* ScreenChangeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenChangeMonitor.swift; sourceTree = "<group>"; };
+		7592001A2FD3000100000001 /* ScreenChangeFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenChangeFilter.swift; sourceTree = "<group>"; };
 		5B7448362EFAED91003E622C /* CALayerSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSwizzlerTests.swift; sourceTree = "<group>"; };
 		5B74483B2EFAEFC3003E622C /* CALayerObserverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerObserverMock.swift; sourceTree = "<group>"; };
 		5B74483F2EFB0F7A003E622C /* CALayerChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerChangeAggregatorTests.swift; sourceTree = "<group>"; };
@@ -3833,6 +3835,7 @@
 				5B7448292EFAB819003E622C /* CALayerChange.swift */,
 				5B74482A2EFAB819003E622C /* CALayerChangeAggregator.swift */,
 				5B74482B2EFAB819003E622C /* CALayerChangeset.swift */,
+				7592001A2FD3000100000001 /* ScreenChangeFilter.swift */,
 				5B74482C2EFAB819003E622C /* ScreenChangeMonitor.swift */,
 			);
 			path = ScreenChangeMonitor;
@@ -8372,6 +8375,7 @@
 				5B7448302EFAB819003E622C /* CALayerChange.swift in Sources */,
 				B73450522F9F240000000001 /* CALayerReference.swift in Sources */,
 				5B7448312EFAB819003E622C /* CALayerChangeAggregator.swift in Sources */,
+				7592001B2FD3000100000001 /* ScreenChangeFilter.swift in Sources */,
 				5B7448322EFAB819003E622C /* ScreenChangeMonitor.swift in Sources */,
 				5B7448332EFAB819003E622C /* CALayerChangeset.swift in Sources */,
 			);

--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -111,7 +111,8 @@ internal struct RecordingComponents {
         let layerRecorder = LayerRecorder(
             snapshotBuilder: LayerTreeSnapshotBuilder(layerProvider: keyWindowObserver),
             uiApplicationSwizzler: try UIApplicationSwizzler(handler: touchSnapshotProducer),
-            touchSnapshotProducer: touchSnapshotProducer
+            touchSnapshotProducer: touchSnapshotProducer,
+            imageSnapshotter: ImageSnapshotter(telemetry: telemetry)
         )
         let screenChangeMonitor = try ScreenChangeMonitor(minimumDeliveryInterval: 0.1)
         let recordingCoordinator = LayerTreeRecordingCoordinator(

--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -108,13 +108,20 @@ internal struct RecordingComponents {
 
         let keyWindowObserver = KeyWindowObserver()
         let touchSnapshotProducer = WindowTouchSnapshotProducer(windowObserver: keyWindowObserver)
+        let screenChangeFilter = ScreenChangeFilter()
         let layerRecorder = LayerRecorder(
             snapshotBuilder: LayerTreeSnapshotBuilder(layerProvider: keyWindowObserver),
             uiApplicationSwizzler: try UIApplicationSwizzler(handler: touchSnapshotProducer),
             touchSnapshotProducer: touchSnapshotProducer,
-            imageSnapshotter: ImageSnapshotter(telemetry: telemetry)
+            imageSnapshotter: ImageSnapshotter(
+                screenChangeFilter: screenChangeFilter,
+                telemetry: telemetry
+            )
         )
-        let screenChangeMonitor = try ScreenChangeMonitor(minimumDeliveryInterval: 0.1)
+        let screenChangeMonitor = try ScreenChangeMonitor(
+            minimumDeliveryInterval: 0.1,
+            screenChangeFilter: screenChangeFilter
+        )
         let recordingCoordinator = LayerTreeRecordingCoordinator(
             screenChangeMonitor: screenChangeMonitor,
             textAndInputPrivacy: configuration.textAndInputPrivacyLevel,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -117,9 +117,9 @@ extension CALayerSnapshot.SemanticObservation {
             return true
         case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isBundled:
             return true
-        case .text(let text) where textAndInputPrivacyLevel == .maskSensitiveInputs && !text.isSecureTextEntry:
+        case .text(let text) where textAndInputPrivacyLevel == .maskSensitiveInputs && !text.isSensitiveText:
             return true
-        case .textField(let textField) where textAndInputPrivacyLevel == .maskSensitiveInputs && !textField.isSecureTextEntry:
+        case .textField(let textField) where textAndInputPrivacyLevel == .maskSensitiveInputs && !textField.isSensitiveText:
             return true
         case .layer, .activityIndicator, .progress, .stepper, .switchControl:
             return true

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -115,7 +115,7 @@ extension CALayerSnapshot.SemanticObservation {
         switch semantics {
         case .image where imagePrivacyLevel == .maskNone:
             return true
-        case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isBundled:
+        case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isContextual:
             return true
         case .text(let text) where textAndInputPrivacyLevel == .maskSensitiveInputs && !text.isSensitiveText:
             return true
@@ -131,11 +131,11 @@ extension CALayerSnapshot.SemanticObservation {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.ImageSemantics {
-    fileprivate var isBundled: Bool {
+    fileprivate var isContextual: Bool {
         guard let resolvedImage else {
             return false
         }
-        return resolvedImage.description.contains("named(")
+        return resolvedImage.isContextual
     }
 
     private var resolvedImage: UIImage? {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -7,6 +7,7 @@
 #if os(iOS)
 import Foundation
 import QuartzCore
+import UIKit
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
@@ -62,12 +63,10 @@ extension CALayerSnapshot {
             return false
         }
 
-        switch observation.semantics {
-        case .layer, .activityIndicator, .image, .progress, .stepper, .text, .textField, .switchControl:
-            return true
-        case .label, .webView:
-            return false
-        }
+        return observation.allowsImageSnapshot(
+            textAndInputPrivacyLevel: textAndInputPrivacyLevel,
+            imagePrivacyLevel: imagePrivacyLevel
+        )
     }
 }
 
@@ -104,6 +103,43 @@ extension ImageSnapshotRequest {
             imagePrivacyLevel: layerSnapshot.imagePrivacyLevel,
             previousSnapshotData: previousSnapshotData
         )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.SemanticObservation {
+    fileprivate func allowsImageSnapshot(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
+        imagePrivacyLevel: ImagePrivacyLevel
+    ) -> Bool {
+        switch semantics {
+        case .image where imagePrivacyLevel == .maskNone:
+            return true
+        case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isBundled:
+            return true
+        case .text(let text) where textAndInputPrivacyLevel == .maskSensitiveInputs && !text.isSecureTextEntry:
+            return true
+        case .textField(let textField) where textAndInputPrivacyLevel == .maskSensitiveInputs && !textField.isSecureTextEntry:
+            return true
+        case .layer, .activityIndicator, .progress, .stepper, .switchControl:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.SemanticObservation.ImageSemantics {
+    fileprivate var isBundled: Bool {
+        guard let resolvedImage else {
+            return false
+        }
+        return resolvedImage.description.contains("named(")
+    }
+
+    private var resolvedImage: UIImage? {
+        isHighlighted ? highlightedImage ?? image : image
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import QuartzCore
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot {
+    /// Returns the image snapshot requests needed to represent this layer tree.
+    func imageSnapshotRequests(for changeset: CALayerChangeset, cache: ImageSnapshotCache) -> [ImageSnapshotRequest] {
+        var requests: [ImageSnapshotRequest] = []
+
+        collectImageSnapshotRequests(
+            clipRect: absoluteFrame,
+            changeset: changeset,
+            cache: cache,
+            in: &requests
+        )
+
+        return requests
+    }
+
+    private func collectImageSnapshotRequests(
+        clipRect: CGRect,
+        changeset: CALayerChangeset,
+        cache: ImageSnapshotCache,
+        in requests: inout [ImageSnapshotRequest]
+    ) {
+        let visibleFrame = absoluteFrame.intersection(clipRect)
+
+        guard !visibleFrame.isNull, !visibleFrame.isEmpty else {
+            return
+        }
+
+        let request = ImageSnapshotRequest(
+            layerSnapshot: self,
+            visibleFrame: visibleFrame,
+            hasContentChanges: changeset.hasContentChanges(for: layer),
+            previousSnapshotData: cache.snapshotData(forReplayID: replayID)
+        )
+
+        if let request, observation.ignoreSublayers || sublayers.isEmpty {
+            requests.append(request)
+        } else {
+            for sublayer in sublayers {
+                sublayer.collectImageSnapshotRequests(
+                    clipRect: masksToBounds ? visibleFrame : clipRect,
+                    changeset: changeset,
+                    cache: cache,
+                    in: &requests
+                )
+            }
+        }
+    }
+
+    fileprivate var allowsImageSnapshot: Bool {
+        guard !isPrivate else {
+            return false
+        }
+
+        switch observation.semantics {
+        case .layer, .activityIndicator, .image, .progress, .stepper, .text, .textField, .switchControl:
+            return true
+        case .label, .webView:
+            return false
+        }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotRequest {
+    fileprivate init?(
+        layerSnapshot: CALayerSnapshot,
+        visibleFrame: CGRect,
+        hasContentChanges: Bool,
+        previousSnapshotData: ImageSnapshotData?
+    ) {
+        guard layerSnapshot.allowsImageSnapshot else {
+            return nil
+        }
+
+        if layerSnapshot.layerClass == CALayer.self,
+           layerSnapshot.contentsClass == nil,
+           !hasContentChanges,
+           previousSnapshotData == nil {
+            return nil
+        }
+
+        self.init(
+            replayID: layerSnapshot.replayID,
+            layer: layerSnapshot.layer,
+            layerClass: layerSnapshot.layerClass,
+            bounds: layerSnapshot.bounds,
+            absoluteFrame: layerSnapshot.absoluteFrame,
+            visibleFrame: visibleFrame,
+            isOpaque: layerSnapshot.isOpaque,
+            hasContents: layerSnapshot.contentsClass != nil,
+            hasContentChanges: hasContentChanges,
+            textAndInputPrivacyLevel: layerSnapshot.textAndInputPrivacyLevel,
+            imagePrivacyLevel: layerSnapshot.imagePrivacyLevel,
+            previousSnapshotData: previousSnapshotData
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
@@ -12,7 +12,7 @@ import QuartzCore
 extension CALayerSnapshot {
     /// A Boolean value indicating whether the layer draws any content.
     var drawsContent: Bool {
-        observation.ignoreSubtree
+        observation.ignoreSublayers
             || layerClass != CALayer.self
             || contentsClass != nil
             || hasBackgroundColor

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -12,12 +12,12 @@ import WebKit
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
-    /// Semantic meaning captured for a layer, plus the traversal decision for its descendants.
+    /// Semantic meaning captured for a layer, plus the traversal decision for its sublayers.
     struct SemanticObservation: Sendable, Equatable {
         var semantics: Semantics
 
-        /// When `true`, the semantic payload owns how this layer is represented and descendants are not captured.
-        var ignoreSubtree: Bool = false
+        /// When `true`, the semantic payload owns how this layer is represented and sublayers are not captured.
+        var ignoreSublayers: Bool = false
     }
 }
 
@@ -43,7 +43,7 @@ extension CALayerSnapshot.SemanticObservation {
     init(layer: CALayer, context: CALayerSnapshot.Context) {
         switch layer.delegate {
         case _ as UIActivityIndicatorView:
-            self.init(semantics: .activityIndicator, ignoreSubtree: true)
+            self.init(semantics: .activityIndicator, ignoreSublayers: true)
         case let label as UILabel where !label.hasAttributedText:
             // Attributed text falls through to layer semantics and will be rendered from the layer image.
             self.init(label: label)
@@ -93,7 +93,7 @@ extension CALayerSnapshot.SemanticObservation {
                     lineBreakMode: label.lineBreakMode
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -148,7 +148,7 @@ extension CALayerSnapshot.SemanticObservation {
                     tintColor: imageView.tintColor
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -164,7 +164,7 @@ extension CALayerSnapshot.SemanticObservation {
     fileprivate init(progressView: UIProgressView) {
         self.init(
             semantics: .progress(.init(progress: progressView.progress)),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -180,7 +180,7 @@ extension CALayerSnapshot.SemanticObservation {
     fileprivate init(stepper: UIStepper) {
         self.init(
             semantics: .stepper(.init(value: stepper.value)),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -204,7 +204,7 @@ extension CALayerSnapshot.SemanticObservation {
                     isSecureTextEntry: textView.isSecureTextEntry
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -243,7 +243,7 @@ extension CALayerSnapshot.SemanticObservation {
     fileprivate init(switchControl: UISwitch) {
         self.init(
             semantics: .switchControl(.init(isOn: switchControl.isOn)),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }
@@ -259,7 +259,7 @@ extension CALayerSnapshot.SemanticObservation {
     fileprivate init(webView: WKWebView) {
         self.init(
             semantics: .webView(.init(slotID: webView.hash)),
-            ignoreSubtree: true
+            ignoreSublayers: true
         )
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -192,7 +192,7 @@ extension CALayerSnapshot.SemanticObservation {
     struct TextSemantics: Sendable, Equatable {
         let text: String?
         let isEditable: Bool
-        let isSecureTextEntry: Bool
+        let isSensitiveText: Bool
     }
 
     fileprivate init(textView: UITextView) {
@@ -201,7 +201,7 @@ extension CALayerSnapshot.SemanticObservation {
                 .init(
                     text: textView.text,
                     isEditable: textView.isEditable,
-                    isSecureTextEntry: textView.isSecureTextEntry
+                    isSensitiveText: textView.dd.isSensitiveText
                 )
             ),
             ignoreSublayers: true
@@ -216,7 +216,7 @@ extension CALayerSnapshot.SemanticObservation {
     struct TextFieldSemantics: Sendable, Equatable {
         let text: String?
         let placeholder: String?
-        let isSecureTextEntry: Bool
+        let isSensitiveText: Bool
     }
 
     fileprivate init(textField: UITextField) {
@@ -225,7 +225,7 @@ extension CALayerSnapshot.SemanticObservation {
                 .init(
                     text: textField.text,
                     placeholder: textField.placeholder,
-                    isSecureTextEntry: textField.isSecureTextEntry
+                    isSensitiveText: textField.dd.isSensitiveText
                 )
             )
         )

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -108,14 +108,14 @@ extension CALayerSnapshot {
 
         let privacy = privacy.applying(layer.privacyOverrides)
         let observation = privacy.isPrivate
-            ? SemanticObservation(semantics: .layer, ignoreSubtree: true)
+            ? SemanticObservation(semantics: .layer, ignoreSublayers: true)
             : SemanticObservation(layer: layer, context: context)
 
         let childVisibleBounds = layer.masksToBounds
             ? absoluteFrame.intersection(visibleBounds)
             : visibleBounds
 
-        let sublayers = observation.ignoreSubtree || childVisibleBounds.isEmpty
+        let sublayers = observation.ignoreSublayers || childVisibleBounds.isEmpty
             ? []
             : layer.sublayers?.compactMap {
                 CALayerSnapshot(

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
@@ -14,7 +14,10 @@ import UIKit
 @available(iOS 13.0, tvOS 13.0, *)
 internal final class ImageSnapshot: Sendable {
     let image: UIImage
+
+    /// The image frame in the root layer coordinate space.
     let frame: CGRect
+
     let textAndInputPrivacyLevel: TextAndInputPrivacyLevel
     let imagePrivacyLevel: ImagePrivacyLevel
 
@@ -35,7 +38,11 @@ internal final class ImageSnapshot: Sendable {
 @available(iOS 13.0, tvOS 13.0, *)
 internal struct ImageSnapshotData: Sendable {
     let snapshot: ImageSnapshot
+
+    /// The rendered rect in the source layer coordinate space.
     let localRect: CGRect
+
+    /// The source layer bounds captured when the image was rendered.
     let bounds: CGRect
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import UIKit
+
+@preconcurrency import DatadogInternal
+
+/// Rendered image for one layer snapshot.
+@available(iOS 13.0, tvOS 13.0, *)
+internal final class ImageSnapshot: Sendable {
+    let image: UIImage
+    let frame: CGRect
+    let textAndInputPrivacyLevel: TextAndInputPrivacyLevel
+    let imagePrivacyLevel: ImagePrivacyLevel
+
+    init(
+        image: UIImage,
+        frame: CGRect,
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
+        imagePrivacyLevel: ImagePrivacyLevel
+    ) {
+        self.image = image
+        self.frame = frame
+        self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
+        self.imagePrivacyLevel = imagePrivacyLevel
+    }
+}
+
+/// An image snapshot and the geometry used to render it.
+@available(iOS 13.0, tvOS 13.0, *)
+internal struct ImageSnapshotData: Sendable {
+    let snapshot: ImageSnapshot
+    let localRect: CGRect
+    let bounds: CGRect
+}
+
+/// Failure reason for a layer image snapshot.
+@available(iOS 13.0, tvOS 13.0, *)
+internal enum ImageSnapshotError: Error, Equatable {
+    /// The recorder exhausted its time budget before rendering this image.
+    case timedOut
+
+    /// The image could not be rendered and should be ignored for this frame.
+    case discarded
+}
+
+/// Result of rendering one layer image snapshot.
+@available(iOS 13.0, tvOS 13.0, *)
+internal typealias ImageSnapshotResult = Result<ImageSnapshot, ImageSnapshotError>
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -91,7 +91,7 @@ internal final class ImageSnapshotCache {
         imageSnapshots.removeObject(forKey: replayID as NSNumber)
     }
 
-    func removeSnapshotData(forReplayIDs replayIDs: Set<Int64>) {
+    func removeSnapshotData<ReplayIDs: Sequence>(forReplayIDs replayIDs: ReplayIDs) where ReplayIDs.Element == Int64 {
         for replayID in replayIDs {
             removeSnapshotData(forReplayID: replayID)
         }
@@ -103,7 +103,7 @@ internal final class ImageSnapshotCache {
         }
         .prefix(policy.maximumRemovals)
 
-        removeSnapshotData(forReplayIDs: Set(expiredReplayIDs))
+        removeSnapshotData(forReplayIDs: expiredReplayIDs)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -91,15 +91,19 @@ internal final class ImageSnapshotCache {
         imageSnapshots.removeObject(forKey: replayID as NSNumber)
     }
 
+    func removeSnapshotData(forReplayIDs replayIDs: Set<Int64>) {
+        for replayID in replayIDs {
+            removeSnapshotData(forReplayID: replayID)
+        }
+    }
+
     private func removeExpiredSnapshots() {
         let expiredReplayIDs = metadata.compactMap { replayID, entry in
             frameNumber - entry.lastFrameNumber > policy.expirationFrameCount ? replayID : nil
         }
         .prefix(policy.maximumRemovals)
 
-        for replayID in expiredReplayIDs {
-            removeSnapshotData(forReplayID: replayID)
-        }
+        removeSnapshotData(forReplayIDs: Set(expiredReplayIDs))
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+
+/// Cache of layer image snapshots.
+///
+/// Stores rendered snapshots across image snapshot passes and keeps the render
+/// metadata needed to decide when a cached snapshot can be reused.
+@available(iOS 13.0, tvOS 13.0, *)
+internal final class ImageSnapshotCache {
+    struct Policy {
+        let expirationFrameCount: UInt64
+        let removalIntervalFrameCount: UInt64
+        let maximumRemovals: Int
+
+        static let `default` = Self(
+            expirationFrameCount: 300,
+            removalIntervalFrameCount: 10,
+            maximumRemovals: 128
+        )
+    }
+
+    private struct Metadata {
+        let localRect: CGRect
+        let bounds: CGRect
+        var lastFrameNumber: UInt64
+    }
+
+    private let policy: Policy
+    private let imageSnapshots: NSCache<NSNumber, ImageSnapshot>
+    private var frameNumber: UInt64 = 0
+    private var metadata: [Int64: Metadata] = [:]
+
+    init(
+        policy: Policy = .default,
+        imageSnapshots: NSCache<NSNumber, ImageSnapshot> = NSCache()
+    ) {
+        self.policy = .init(
+            expirationFrameCount: policy.expirationFrameCount,
+            removalIntervalFrameCount: max(1, policy.removalIntervalFrameCount),
+            maximumRemovals: max(1, policy.maximumRemovals)
+        )
+        self.imageSnapshots = imageSnapshots
+    }
+
+    func updateFrameNumber(for replayIDs: [Int64]) {
+        frameNumber &+= 1
+
+        for replayID in replayIDs {
+            metadata[replayID]?.lastFrameNumber = frameNumber
+        }
+
+        if frameNumber.isMultiple(of: policy.removalIntervalFrameCount) {
+            removeExpiredSnapshots()
+        }
+    }
+
+    func snapshotData(forReplayID replayID: Int64) -> ImageSnapshotData? {
+        guard let metadata = metadata[replayID] else {
+            return nil
+        }
+
+        guard let snapshot = imageSnapshots.object(forKey: replayID as NSNumber) else {
+            self.metadata.removeValue(forKey: replayID)
+            return nil
+        }
+
+        return .init(
+            snapshot: snapshot,
+            localRect: metadata.localRect,
+            bounds: metadata.bounds
+        )
+    }
+
+    func setSnapshotData(_ snapshotData: ImageSnapshotData, forReplayID replayID: Int64) {
+        imageSnapshots.setObject(snapshotData.snapshot, forKey: replayID as NSNumber)
+        metadata[replayID] = .init(
+            localRect: snapshotData.localRect,
+            bounds: snapshotData.bounds,
+            lastFrameNumber: frameNumber
+        )
+    }
+
+    func removeSnapshotData(forReplayID replayID: Int64) {
+        metadata.removeValue(forKey: replayID)
+        imageSnapshots.removeObject(forKey: replayID as NSNumber)
+    }
+
+    private func removeExpiredSnapshots() {
+        let expiredReplayIDs = metadata.compactMap { replayID, entry in
+            frameNumber - entry.lastFrameNumber > policy.expirationFrameCount ? replayID : nil
+        }
+        .prefix(policy.maximumRemovals)
+
+        for replayID in expiredReplayIDs {
+            removeSnapshotData(forReplayID: replayID)
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -99,11 +99,12 @@ extension ImageSnapshotRequest {
         }
 
         let localRect = snapshotWillBePartial ? visibleLocalRect : bounds
+        let frame = snapshotWillBePartial ? visibleFrame : absoluteFrame
 
         return .init(
             layer: layer,
             localRect: localRect,
-            frame: layer.convert(localRect, to: rootLayer),
+            frame: frame,
             needsSnapshot: needsSnapshot
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -1,0 +1,140 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import QuartzCore
+
+@preconcurrency import DatadogInternal
+
+/// Request to render one `CALayerSnapshot` as an image.
+@available(iOS 13.0, tvOS 13.0, *)
+internal struct ImageSnapshotRequest: Sendable {
+    let replayID: Int64
+    let layer: CALayerReference
+    let layerClass: AnyClass
+    let bounds: CGRect
+    let absoluteFrame: CGRect
+    let visibleFrame: CGRect
+    let isOpaque: Bool
+    let hasContents: Bool
+    let hasContentChanges: Bool
+    let textAndInputPrivacyLevel: TextAndInputPrivacyLevel
+    let imagePrivacyLevel: ImagePrivacyLevel
+    let previousSnapshotData: ImageSnapshotData?
+
+    init(
+        replayID: Int64,
+        layer: CALayerReference,
+        layerClass: AnyClass,
+        bounds: CGRect,
+        absoluteFrame: CGRect,
+        visibleFrame: CGRect,
+        isOpaque: Bool,
+        hasContents: Bool,
+        hasContentChanges: Bool,
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
+        imagePrivacyLevel: ImagePrivacyLevel,
+        previousSnapshotData: ImageSnapshotData?
+    ) {
+        self.replayID = replayID
+        self.layer = layer
+        self.layerClass = layerClass
+        self.bounds = bounds
+        self.absoluteFrame = absoluteFrame
+        self.visibleFrame = visibleFrame
+        self.isOpaque = isOpaque
+        self.hasContents = hasContents
+        self.hasContentChanges = hasContentChanges
+        self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
+        self.imagePrivacyLevel = imagePrivacyLevel
+        self.previousSnapshotData = previousSnapshotData
+    }
+}
+
+/// An image snapshot request resolved against the current layer tree.
+@available(iOS 13.0, tvOS 13.0, *)
+internal struct ResolvedImageSnapshotRequest {
+    let layer: CALayer
+    let localRect: CGRect
+    let frame: CGRect
+    let needsSnapshot: Bool
+}
+
+/// Failure reason for resolving an image snapshot request.
+@available(iOS 13.0, tvOS 13.0, *)
+internal enum ImageSnapshotRequestResolutionError: Error {
+    case missingLayer
+    case invalidRect
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotRequest {
+    @MainActor
+    func resolved(relativeTo rootLayer: CALayer) throws -> ResolvedImageSnapshotRequest {
+        guard let layer = layer.resolve() else {
+            throw ImageSnapshotRequestResolutionError.missingLayer
+        }
+
+        let visibleLocalRect = layer.convert(visibleFrame, from: rootLayer)
+
+        guard !visibleLocalRect.isNull, !visibleLocalRect.isEmpty else {
+            throw ImageSnapshotRequestResolutionError.invalidRect
+        }
+
+        let isNew = previousSnapshotData == nil
+        let lastSnapshotWasPartial = previousSnapshotData.map { !$0.bounds.equalTo($0.localRect) } ?? false
+        let snapshotWillBePartial = bounds.sizeExceeds(rootLayer.bounds)
+        let snapshotRectDidChange = (lastSnapshotWasPartial || snapshotWillBePartial) &&
+            !(previousSnapshotData?.localRect.equalTo(visibleLocalRect) ?? false)
+
+        let needsSnapshot = if layerClass == CALayer.self {
+            (hasContents && isNew) || hasContentChanges || snapshotRectDidChange
+        } else {
+            isNew || hasContentChanges || layer.hasVisualAnimation || snapshotRectDidChange
+        }
+
+        let localRect = snapshotWillBePartial ? visibleLocalRect : bounds
+
+        return .init(
+            layer: layer,
+            localRect: localRect,
+            frame: layer.convert(localRect, to: rootLayer),
+            needsSnapshot: needsSnapshot
+        )
+    }
+}
+
+extension CALayer {
+    private enum Constants {
+        static let geometryKeys: Set<String> = [
+            "position",
+            "position.x",
+            "position.y",
+            "zPosition",
+            "anchorPoint",
+            "anchorPoint.x",
+            "anchorPoint.y"
+        ]
+    }
+
+    fileprivate var hasVisualAnimation: Bool {
+        guard let animationKeys = animationKeys(), !animationKeys.isEmpty else {
+            return false
+        }
+
+        return animationKeys.contains {
+            !Constants.geometryKeys.contains($0)
+        }
+    }
+}
+
+extension CGRect {
+    fileprivate func sizeExceeds(_ other: CGRect) -> Bool {
+        width > other.width || height > other.height
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -95,7 +95,7 @@ extension ImageSnapshotRequest {
         let needsSnapshot = if layerClass == CALayer.self {
             (hasContents && isNew) || hasContentChanges || snapshotRectDidChange || snapshotBoundsDidChange
         } else {
-            isNew || hasContentChanges || layer.hasVisualAnimation || snapshotRectDidChange || snapshotBoundsDidChange
+            isNew || hasContentChanges || snapshotRectDidChange || snapshotBoundsDidChange
         }
 
         let localRect = snapshotWillBePartial ? visibleLocalRect : bounds
@@ -106,30 +106,6 @@ extension ImageSnapshotRequest {
             frame: layer.convert(localRect, to: rootLayer),
             needsSnapshot: needsSnapshot
         )
-    }
-}
-
-extension CALayer {
-    private enum Constants {
-        static let geometryKeys: Set<String> = [
-            "position",
-            "position.x",
-            "position.y",
-            "zPosition",
-            "anchorPoint",
-            "anchorPoint.x",
-            "anchorPoint.y"
-        ]
-    }
-
-    fileprivate var hasVisualAnimation: Bool {
-        guard let animationKeys = animationKeys(), !animationKeys.isEmpty else {
-            return false
-        }
-
-        return animationKeys.contains {
-            !Constants.geometryKeys.contains($0)
-        }
     }
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -90,11 +90,12 @@ extension ImageSnapshotRequest {
         let snapshotWillBePartial = bounds.sizeExceeds(rootLayer.bounds)
         let snapshotRectDidChange = (lastSnapshotWasPartial || snapshotWillBePartial) &&
             !(previousSnapshotData?.localRect.equalTo(visibleLocalRect) ?? false)
+        let snapshotBoundsDidChange = previousSnapshotData.map { !$0.bounds.equalTo(bounds) } ?? false
 
         let needsSnapshot = if layerClass == CALayer.self {
-            (hasContents && isNew) || hasContentChanges || snapshotRectDidChange
+            (hasContents && isNew) || hasContentChanges || snapshotRectDidChange || snapshotBoundsDidChange
         } else {
-            isNew || hasContentChanges || layer.hasVisualAnimation || snapshotRectDidChange
+            isNew || hasContentChanges || layer.hasVisualAnimation || snapshotRectDidChange || snapshotBoundsDidChange
         }
 
         let localRect = snapshotWillBePartial ? visibleLocalRect : bounds

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -179,7 +179,7 @@ extension ImageSnapshotCache {
         let contentChangeReplayIDs = changeset.contentChanges.compactMap {
             $0.layer.resolve()?.replayID
         }
-        removeSnapshotData(forReplayIDs: Set(contentChangeReplayIDs))
+        removeSnapshotData(forReplayIDs: contentChangeReplayIDs)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -54,6 +54,11 @@ internal final class ImageSnapshotter: ImageSnapshotting {
         changeset: CALayerChangeset,
         timeout: TimeInterval
     ) async -> [Int64: ImageSnapshotResult] {
+        // Invalidate content changes before request extraction. Occlusion pruning can
+        // remove changed layers from the snapshot tree, but their cached images must not
+        // be reused if they become visible again later.
+        cache.removeSnapshotDataForContentChanges(in: changeset)
+
         let requests = root.imageSnapshotRequests(for: changeset, cache: cache)
         cache.updateFrameNumber(for: requests.map(\.replayID))
 
@@ -166,6 +171,17 @@ internal final class ImageSnapshotter: ImageSnapshotting {
                 }
             }
         }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotCache {
+    @MainActor
+    fileprivate func removeSnapshotDataForContentChanges(in changeset: CALayerChangeset) {
+        let contentChangeReplayIDs = changeset.contentChanges.compactMap {
+            $0.layer.resolve()?.replayID
+        }
+        removeSnapshotData(forReplayIDs: Set(contentChangeReplayIDs))
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -30,17 +30,20 @@ internal final class ImageSnapshotter: ImageSnapshotting {
     }
 
     private let cache: ImageSnapshotCache
+    private let screenChangeFilter: ScreenChangeFilter
     private let scale: CGFloat?
     private let timeSource: any TimeSource
     private let telemetry: any Telemetry
 
     init(
         cache: ImageSnapshotCache = ImageSnapshotCache(),
+        screenChangeFilter: ScreenChangeFilter = ScreenChangeFilter(),
         scale: CGFloat? = nil,
         timeSource: any TimeSource = MediaTimeSource(),
         telemetry: any Telemetry = NOPTelemetry()
     ) {
         self.cache = cache
+        self.screenChangeFilter = screenChangeFilter
         self.scale = scale
         self.timeSource = timeSource
         self.telemetry = telemetry
@@ -155,10 +158,12 @@ internal final class ImageSnapshotter: ImageSnapshotting {
         format.opaque = opaque
 
         let renderer = UIGraphicsImageRenderer(size: rect.size, format: format)
-        return try objc_rethrow {
-            renderer.image { context in
-                context.cgContext.translateBy(x: -rect.origin.x, y: -rect.origin.y)
-                layer.render(in: context.cgContext)
+        return try screenChangeFilter.ignoringChanges {
+            try objc_rethrow {
+                renderer.image { context in
+                    context.cgContext.translateBy(x: -rect.origin.x, y: -rect.origin.y)
+                    layer.render(in: context.cgContext)
+                }
             }
         }
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -1,0 +1,163 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import Foundation
+import QuartzCore
+import UIKit
+
+/// Captures rendered image snapshots from layer snapshot requests.
+@available(iOS 13.0, tvOS 13.0, *)
+internal protocol ImageSnapshotting: AnyObject {
+    /// Renders images for the optimized layer tree within the given time budget.
+    @MainActor
+    func takeImageSnapshots(
+        for root: CALayerSnapshot,
+        changeset: CALayerChangeset,
+        timeout: TimeInterval
+    ) async -> [Int64: ImageSnapshotResult]
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@MainActor
+internal final class ImageSnapshotter: ImageSnapshotting {
+    private enum Constants {
+        static let yieldThreshold: TimeInterval = 0.008
+    }
+
+    private let cache: ImageSnapshotCache
+    private let scale: CGFloat?
+    private let timeSource: any TimeSource
+    private let telemetry: any Telemetry
+
+    init(
+        cache: ImageSnapshotCache = ImageSnapshotCache(),
+        scale: CGFloat? = nil,
+        timeSource: any TimeSource = MediaTimeSource(),
+        telemetry: any Telemetry = NOPTelemetry()
+    ) {
+        self.cache = cache
+        self.scale = scale
+        self.timeSource = timeSource
+        self.telemetry = telemetry
+    }
+
+    func takeImageSnapshots(
+        for root: CALayerSnapshot,
+        changeset: CALayerChangeset,
+        timeout: TimeInterval
+    ) async -> [Int64: ImageSnapshotResult] {
+        let requests = root.imageSnapshotRequests(for: changeset, cache: cache)
+        cache.updateFrameNumber(for: requests.map(\.replayID))
+
+        guard let rootLayer = root.layer.resolve(), !requests.isEmpty else {
+            return [:]
+        }
+
+        let startTime = timeSource.now
+        var lastYieldTime = startTime
+        var results: [Int64: ImageSnapshotResult] = [:]
+
+        results.reserveCapacity(requests.count)
+
+        var firstUnprocessedIndex = requests.endIndex
+
+        for index in requests.indices {
+            let now = timeSource.now
+
+            if Task.isCancelled || (now - startTime) >= timeout {
+                firstUnprocessedIndex = index
+                break
+            }
+
+            let request = requests[index]
+            results[request.replayID] = takeImageSnapshot(for: request, rootLayer: rootLayer)
+
+            if now - lastYieldTime >= Constants.yieldThreshold {
+                await Task.yield()
+                lastYieldTime = timeSource.now
+            }
+        }
+
+        if firstUnprocessedIndex < requests.endIndex {
+            for request in requests[firstUnprocessedIndex...] {
+                results[request.replayID] = .failure(.timedOut)
+            }
+        }
+
+        return results
+    }
+
+    private func takeImageSnapshot(
+        for request: ImageSnapshotRequest,
+        rootLayer: CALayer
+    ) -> ImageSnapshotResult {
+        do {
+            let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+            let snapshot: ImageSnapshot
+
+            if !resolvedRequest.needsSnapshot, let cachedSnapshot = request.previousSnapshotData?.snapshot {
+                snapshot = cachedSnapshot.frame.equalTo(resolvedRequest.frame)
+                    ? cachedSnapshot
+                    : ImageSnapshot(
+                        image: cachedSnapshot.image,
+                        frame: resolvedRequest.frame,
+                        textAndInputPrivacyLevel: request.textAndInputPrivacyLevel,
+                        imagePrivacyLevel: request.imagePrivacyLevel
+                    )
+            } else {
+                snapshot = ImageSnapshot(
+                    image: try renderImage(
+                        for: resolvedRequest.layer,
+                        in: resolvedRequest.localRect,
+                        opaque: request.isOpaque
+                    ),
+                    frame: resolvedRequest.frame,
+                    textAndInputPrivacyLevel: request.textAndInputPrivacyLevel,
+                    imagePrivacyLevel: request.imagePrivacyLevel
+                )
+            }
+
+            cache.setSnapshotData(
+                .init(
+                    snapshot: snapshot,
+                    localRect: resolvedRequest.localRect,
+                    bounds: request.bounds
+                ),
+                forReplayID: request.replayID
+            )
+            return .success(snapshot)
+        } catch ImageSnapshotRequestResolutionError.missingLayer {
+            cache.removeSnapshotData(forReplayID: request.replayID)
+            return .failure(.discarded)
+        } catch let objc as ObjcException {
+            telemetry.error(
+                "[SR] Failed to capture layer image snapshot due to Objective-C runtime exception",
+                error: objc.error
+            )
+            cache.removeSnapshotData(forReplayID: request.replayID)
+            return .failure(.discarded)
+        } catch {
+            return .failure(.discarded)
+        }
+    }
+
+    private func renderImage(for layer: CALayer, in rect: CGRect, opaque: Bool) throws -> UIImage {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = scale ?? layer.contentsScale
+        format.opaque = opaque
+
+        let renderer = UIGraphicsImageRenderer(size: rect.size, format: format)
+        return try objc_rethrow {
+            renderer.image { context in
+                context.cgContext.translateBy(x: -rect.origin.x, y: -rect.origin.y)
+                layer.render(in: context.cgContext)
+            }
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -85,6 +85,9 @@ internal final class ImageSnapshotter: ImageSnapshotting {
 
         if firstUnprocessedIndex < requests.endIndex {
             for request in requests[firstUnprocessedIndex...] {
+                if request.hasContentChanges {
+                    cache.removeSnapshotData(forReplayID: request.replayID)
+                }
                 results[request.replayID] = .failure(.timedOut)
             }
         }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -112,14 +112,12 @@ internal final class ImageSnapshotter: ImageSnapshotting {
             let snapshot: ImageSnapshot
 
             if !resolvedRequest.needsSnapshot, let cachedSnapshot = request.previousSnapshotData?.snapshot {
-                snapshot = cachedSnapshot.frame.equalTo(resolvedRequest.frame)
-                    ? cachedSnapshot
-                    : ImageSnapshot(
-                        image: cachedSnapshot.image,
-                        frame: resolvedRequest.frame,
-                        textAndInputPrivacyLevel: request.textAndInputPrivacyLevel,
-                        imagePrivacyLevel: request.imagePrivacyLevel
-                    )
+                snapshot = ImageSnapshot(
+                    image: cachedSnapshot.image,
+                    frame: resolvedRequest.frame,
+                    textAndInputPrivacyLevel: request.textAndInputPrivacyLevel,
+                    imagePrivacyLevel: request.imagePrivacyLevel
+                )
             } else {
                 snapshot = ImageSnapshot(
                     image: try renderImage(

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
@@ -17,17 +17,26 @@ internal actor LayerRecorder: LayerRecording {
     private let snapshotBuilder: any LayerTreeSnapshotBuilding
     private let uiApplicationSwizzler: UIApplicationSwizzler
     private let touchSnapshotProducer: any TouchSnapshotProducer
+    private let imageSnapshotter: any ImageSnapshotting
+    private let timeoutInterval: TimeInterval
+    private let timeSource: any TimeSource
 
     private var recordTask: Task<Void, Never>?
 
     init(
         snapshotBuilder: any LayerTreeSnapshotBuilding,
         uiApplicationSwizzler: UIApplicationSwizzler,
-        touchSnapshotProducer: any TouchSnapshotProducer
+        touchSnapshotProducer: any TouchSnapshotProducer,
+        imageSnapshotter: any ImageSnapshotting,
+        timeoutInterval: TimeInterval = 0.09,
+        timeSource: any TimeSource = MediaTimeSource()
     ) {
         self.snapshotBuilder = snapshotBuilder
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.touchSnapshotProducer = touchSnapshotProducer
+        self.imageSnapshotter = imageSnapshotter
+        self.timeoutInterval = timeoutInterval
+        self.timeSource = timeSource
 
         uiApplicationSwizzler.swizzle()
     }
@@ -47,7 +56,8 @@ internal actor LayerRecorder: LayerRecording {
         }
     }
 
-    private func record(_: CALayerChangeset, context: LayerRecordingContext) async {
+    private func record(_ changeset: CALayerChangeset, context: LayerRecordingContext) async {
+        let startTime = timeSource.now
         let (layerTreeSnapshot, touchSnapshot) = await takeSnapshot(context: context)
 
         guard
@@ -57,8 +67,15 @@ internal actor LayerRecorder: LayerRecording {
             return
         }
 
-        _ = (root, touchSnapshot)
-        // TODO: PANA-7550 Process optimized layer tree and touch snapshots
+        let remainingTime = max(0, timeoutInterval - (timeSource.now - startTime))
+        let imageSnapshots = await imageSnapshotter.takeImageSnapshots(
+            for: root,
+            changeset: changeset,
+            timeout: remainingTime
+        )
+
+        _ = (root, touchSnapshot, imageSnapshots)
+        // TODO: PANA-7592 Process optimized layer tree, image snapshots, and touch snapshots
     }
 
     private func takeSnapshot(context: LayerRecordingContext) async -> (LayerTreeSnapshot?, TouchSnapshot?) {

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeAggregator.swift
@@ -16,6 +16,7 @@ internal final class CALayerChangeAggregator {
 
     private let minimumDeliveryInterval: TimeInterval
     private let timerScheduler: any TimerScheduler
+    private let screenChangeFilter: ScreenChangeFilter
 
     private var isRunning = false
     private var isDeliveringChanges = false
@@ -26,10 +27,12 @@ internal final class CALayerChangeAggregator {
     init(
         minimumDeliveryInterval: TimeInterval,
         timerScheduler: any TimerScheduler,
+        screenChangeFilter: ScreenChangeFilter = ScreenChangeFilter(),
         handler: ((CALayerChangeset) -> Void)? = nil
     ) {
         self.minimumDeliveryInterval = minimumDeliveryInterval
         self.timerScheduler = timerScheduler
+        self.screenChangeFilter = screenChangeFilter
         self.handler = handler
     }
 
@@ -58,8 +61,12 @@ internal final class CALayerChangeAggregator {
     }
 
     private func record(_ layer: CALayer, aspect: CALayerChange.Aspect.Set) {
-        // Only record on the main thread and ignore changes triggered in the delivery handler
-        guard Thread.isMainThread, isRunning, !isDeliveringChanges else {
+        // Only record on the main thread and ignore changes triggered by SDK work.
+        guard Thread.isMainThread else {
+            return
+        }
+
+        guard isRunning, !isDeliveringChanges, screenChangeFilter.acceptsChanges else {
             return
         }
 

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeset.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeset.swift
@@ -16,6 +16,12 @@ internal struct CALayerChangeset: Sendable, Equatable {
         changes.isEmpty
     }
 
+    var contentChanges: [CALayerChange] {
+        changes.values.filter { change in
+            change.aspects.contains(.display) || change.aspects.contains(.draw)
+        }
+    }
+
     private let changes: [ObjectIdentifier: CALayerChange]
 
     init(_ changes: [ObjectIdentifier: CALayerChange] = [:]) {

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/ScreenChangeFilter.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/ScreenChangeFilter.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import DatadogInternal
+
+/// Controls when observed layer callbacks become screen changes.
+internal final class ScreenChangeFilter {
+    private var ignoredScopesCount = 0
+
+    var acceptsChanges: Bool {
+        dd_assert(Thread.isMainThread, "ScreenChangeFilter must be used from the main thread")
+        return ignoredScopesCount == 0
+    }
+
+    func ignoringChanges<T>(_ operation: () throws -> T) rethrows -> T {
+        dd_assert(Thread.isMainThread, "ScreenChangeFilter must be used from the main thread")
+
+        ignoredScopesCount += 1
+        defer {
+            ignoredScopesCount -= 1
+        }
+
+        return try operation()
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/ScreenChangeMonitor.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/ScreenChangeMonitor.swift
@@ -24,11 +24,13 @@ internal final class ScreenChangeMonitor {
     init(
         minimumDeliveryInterval: TimeInterval,
         timerScheduler: any TimerScheduler = .dispatchSource,
+        screenChangeFilter: ScreenChangeFilter = ScreenChangeFilter(),
         handler: ((CALayerChangeset) -> Void)? = nil
     ) throws {
         self.layerChangeAggregator = CALayerChangeAggregator(
             minimumDeliveryInterval: minimumDeliveryInterval,
             timerScheduler: timerScheduler,
+            screenChangeFilter: screenChangeFilter,
             handler: handler
         )
         self.layerSwizzler = try CALayerSwizzler(observer: layerChangeAggregator)

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/TimeSource.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/TimeSource.swift
@@ -6,9 +6,17 @@
 
 #if os(iOS)
 import Foundation
+import QuartzCore
 
-/// Provides the current time used by screen change monitoring.
+/// Provides the current time used by recording components.
 internal protocol TimeSource {
     var now: TimeInterval { get }
+}
+
+/// Time source backed by Core Animation's monotonic media time.
+internal struct MediaTimeSource: TimeSource {
+    var now: TimeInterval {
+        CACurrentMediaTime()
+    }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -131,4 +131,23 @@ extension DatadogExtension where ExtendedType: UIImage {
     }
 }
 
+extension UIImage {
+    @available(iOS 13.0, *)
+    var isContextual: Bool {
+        return isSymbolImage || isBundled || isAlwaysTemplate
+    }
+
+    @available(iOS 13.0, *)
+    var isTinted: Bool {
+        return isSymbolImage || isAlwaysTemplate
+    }
+
+    private var isBundled: Bool {
+        return description.contains("named(")
+    }
+
+    private var isAlwaysTemplate: Bool {
+        return renderingMode == .alwaysTemplate
+    }
+}
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -141,26 +141,6 @@ internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
     }
 }
 
-fileprivate extension UIImage {
-    @available(iOS 13.0, *)
-    var isContextual: Bool {
-        return isSymbolImage || isBundled || isAlwaysTemplate
-    }
-
-    @available(iOS 13.0, *)
-    var isTinted: Bool {
-        return isSymbolImage || isAlwaysTemplate
-    }
-
-    private var isBundled: Bool {
-        return description.contains("named(")
-    }
-
-    private var isAlwaysTemplate: Bool {
-        return renderingMode == .alwaysTemplate
-    }
-}
-
 fileprivate extension UIImageView {
     var isSystemControlBackground: Bool {
         return isButtonBackground || isBarBackground

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerChangesetMock.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerChangesetMock.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import QuartzCore
+
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerChangeset {
+    static func mockChange(for layer: CALayer, aspects: CALayerChange.Aspect.Set) -> CALayerChangeset {
+        CALayerChangeset(
+            [ObjectIdentifier(layer): CALayerChange(layer: .init(layer), aspects: aspects)]
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -278,6 +278,25 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips sensitive semantic text layer when text privacy masks sensitive inputs")
+    func skipsSensitiveSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "hello@datadoghq.com"
+        textView.textContentType = .emailAddress
+        textView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips web view layer")
     func skipsWebViewLayer() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -465,7 +465,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
     }
 
-    private final class BundledImageMock: UIImage {
+    private final class BundledImageMock: UIImage, @unchecked Sendable {
         override var description: String {
             "named(mock-bundled-image)"
         }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -1,0 +1,315 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import QuartzCore
+import Testing
+import UIKit
+import WebKit
+
+@testable import DatadogSessionReplay
+
+@MainActor
+struct CALayerSnapshotImageSnapshotRequestTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for plain layer with contents")
+    func createsRequestForPlainLayerWithContents() throws {
+        // Given
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        layer.contents = NSObject()
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.replayID == snapshot.replayID)
+        #expect(request.layer == snapshot.layer)
+        #expect(request.visibleFrame == snapshot.absoluteFrame)
+        #expect(request.hasContentChanges == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for plain layer with content changes")
+    func createsRequestForPlainLayerWithContentChanges() throws {
+        // Given
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let changeset = CALayerChangeset.mockChange(for: layer, aspects: .display)
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer == snapshot.layer)
+        #expect(request.hasContentChanges)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for plain layer with cached snapshot data")
+    func createsRequestForPlainLayerWithCachedSnapshotData() throws {
+        // Given
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+
+        let imageSnapshot = Self.mockImageSnapshot()
+        let snapshotData = Self.mockSnapshotData(snapshot: imageSnapshot)
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(snapshotData, forReplayID: snapshot.replayID)
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer == snapshot.layer)
+        #expect(request.previousSnapshotData?.snapshot === imageSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips plain layer without contents, content changes, or cache")
+    func skipsPlainLayerWithoutContentsChangesOrCachedSnapshotData() throws {
+        // Given
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for layer subclass without contents")
+    func createsRequestForLayerSubclassWithoutContents() throws {
+        // Given
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.replayID == snapshot.replayID)
+        #expect(request.layerClass == CATextLayer.self)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for semantic image layer")
+    func createsRequestForSemanticImageLayer() throws {
+        // Given
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        imageView.layer.addSublayer(child)
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.replayID == snapshot.replayID)
+        #expect(request.layer.matches(imageView.layer))
+        #expect(request.hasContents)
+        #expect(!requests.contains { $0.layer.matches(child) })
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips web view layer")
+    func skipsWebViewLayer() throws {
+        // Given
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        webView.layer.contents = NSObject()
+        let snapshot = try #require(CALayerSnapshot(from: webView.layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips private layer")
+    func skipsPrivateLayer() throws {
+        // Given
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        view.dd.sessionReplayPrivacyOverrides.hide = true
+        view.layer.contents = NSObject()
+        let snapshot = try #require(CALayerSnapshot(from: view.layer, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Clips request visible frame to masking ancestor")
+    func clipsRequestVisibleFrameToMaskingAncestor() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let clippingLayer = CALayer()
+        clippingLayer.frame = CGRect(x: 10, y: 10, width: 40, height: 40)
+        clippingLayer.masksToBounds = true
+        root.addSublayer(clippingLayer)
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 20, y: 20, width: 40, height: 40)
+        clippingLayer.addSublayer(child)
+
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(child))
+        #expect(request.visibleFrame == CGRect(x: 30, y: 30, width: 20, height: 20))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Does not clip request visible frame to non-masking ancestor")
+    func doesNotClipRequestVisibleFrameToNonMaskingAncestor() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let container = CALayer()
+        container.frame = CGRect(x: 10, y: 10, width: 40, height: 40)
+        container.masksToBounds = false
+        root.addSublayer(container)
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 20, y: 20, width: 90, height: 90)
+        container.addSublayer(child)
+
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(child))
+        #expect(request.visibleFrame == CGRect(x: 30, y: 30, width: 70, height: 70))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Keeps traversing image-capable container")
+    func keepsTraversingImageCapableContainer() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let parent = CALayer()
+        parent.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        parent.contents = NSObject()
+        root.addSublayer(parent)
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        parent.addSublayer(child)
+
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(child))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Keeps traversing when container image would include web view")
+    func keepsTraversingWhenContainerImageWouldIncludeWebView() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let parent = CALayer()
+        parent.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        parent.contents = NSObject()
+        root.addSublayer(parent)
+
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+        parent.addSublayer(webView.layer)
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 50, y: 50, width: 20, height: 20)
+        parent.addSublayer(child)
+
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.contains { $0.layer.matches(child) })
+        #expect(!requests.contains { $0.layer.matches(parent) })
+        #expect(!requests.contains { $0.layer.matches(webView.layer) })
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    private static func mockImageSnapshot() -> ImageSnapshot {
+        ImageSnapshot(
+            image: UIImage(),
+            frame: .zero,
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    private static func mockSnapshotData(
+        snapshot: ImageSnapshot,
+        localRect: CGRect = .zero,
+        bounds: CGRect = .zero
+    ) -> ImageSnapshotData {
+        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
+    }
+}
+
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -116,8 +116,8 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Creates request for semantic image layer")
-    func createsRequestForSemanticImageLayer() throws {
+    @Test("Creates request for semantic image layer when image privacy masks none")
+    func createsRequestForSemanticImageLayerWhenImagePrivacyMasksNone() throws {
         // Given
         let imageView = UIImageView(image: UIImage())
         imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
@@ -127,7 +127,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         child.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
         imageView.layer.addSublayer(child)
 
-        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny()))
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
         let cache = ImageSnapshotCache()
 
         // When
@@ -140,6 +140,141 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.layer.matches(imageView.layer))
         #expect(request.hasContents)
         #expect(!requests.contains { $0.layer.matches(child) })
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips semantic image layer when image privacy masks all")
+    func skipsSemanticImageLayerWhenImagePrivacyMasksAll() throws {
+        // Given
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskAll)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips semantic image layer when image privacy masks non-bundled images")
+    func skipsSemanticImageLayerWhenImagePrivacyMasksNonBundledImages() throws {
+        // Given
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNonBundledOnly)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for highlighted semantic image layer when highlighted image is bundled")
+    func createsRequestForHighlightedSemanticImageLayerWhenHighlightedImageIsBundled() throws {
+        // Given
+        let imageView = UIImageView(image: UIImage(), highlightedImage: BundledImageMock())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.isHighlighted = true
+        imageView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNonBundledOnly)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(imageView.layer))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for highlighted semantic image layer when fallback image is bundled")
+    func createsRequestForHighlightedSemanticImageLayerWhenFallbackImageIsBundled() throws {
+        // Given
+        let imageView = UIImageView(image: BundledImageMock())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.isHighlighted = true
+        imageView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNonBundledOnly)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(imageView.layer))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips semantic text layer when text privacy masks all")
+    func skipsSemanticTextLayerWhenTextPrivacyMasksAll() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+        textView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskAll)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for semantic text layer when text privacy masks sensitive inputs")
+    func createsRequestForSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+        textView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(textView.layer))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips secure semantic text layer when text privacy masks sensitive inputs")
+    func skipsSecureSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+        textView.isSecureTextEntry = true
+        textView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -309,6 +444,12 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         bounds: CGRect = .zero
     ) -> ImageSnapshotData {
         ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
+    }
+
+    private final class BundledImageMock: UIImage {
+        override var description: String {
+            "named(mock-bundled-image)"
+        }
     }
 }
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -29,8 +29,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records activity indicator semantics and ignores subtree")
-    func recordsActivityIndicatorSemanticsAndIgnoresSubtree() {
+    @Test("Records activity indicator semantics and ignores sublayers")
+    func recordsActivityIndicatorSemanticsAndIgnoresSublayers() {
         // Given
         let activityIndicator = UIActivityIndicatorView(style: .medium)
 
@@ -38,12 +38,12 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: activityIndicator.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .activityIndicator, ignoreSubtree: true))
+        #expect(observation == .init(semantics: .activityIndicator, ignoreSublayers: true))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records label semantics and ignores subtree")
-    func recordsLabelSemanticsAndIgnoresSubtree() {
+    @Test("Records label semantics and ignores sublayers")
+    func recordsLabelSemanticsAndIgnoresSublayers() {
         // Given
         let font = UIFont.boldSystemFont(ofSize: 14)
         let label = UILabel()
@@ -69,7 +69,7 @@ struct CALayerSnapshotSemanticObservationTests {
                     lineBreakMode: .byTruncatingMiddle
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         ))
     }
 
@@ -101,7 +101,7 @@ struct CALayerSnapshotSemanticObservationTests {
                     lineBreakMode: label.lineBreakMode
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         ))
     }
 
@@ -123,8 +123,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records image semantics and ignores subtree")
-    func recordsImageSemanticsAndIgnoresSubtree() {
+    @Test("Records image semantics and ignores sublayers")
+    func recordsImageSemanticsAndIgnoresSublayers() {
         // Given
         let image = UIImage()
         let highlightedImage = UIImage()
@@ -145,13 +145,13 @@ struct CALayerSnapshotSemanticObservationTests {
                     tintColor: .green
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records progress semantics and ignores subtree")
-    func recordsProgressSemanticsAndIgnoresSubtree() {
+    @Test("Records progress semantics and ignores sublayers")
+    func recordsProgressSemanticsAndIgnoresSublayers() {
         // Given
         let progressView = UIProgressView()
         progressView.progress = 0.75
@@ -160,12 +160,12 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: progressView.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .progress(.init(progress: 0.75)), ignoreSubtree: true))
+        #expect(observation == .init(semantics: .progress(.init(progress: 0.75)), ignoreSublayers: true))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records stepper semantics and ignores subtree")
-    func recordsStepperSemanticsAndIgnoresSubtree() {
+    @Test("Records stepper semantics and ignores sublayers")
+    func recordsStepperSemanticsAndIgnoresSublayers() {
         // Given
         let stepper = UIStepper()
         stepper.value = 7
@@ -174,12 +174,12 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: stepper.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .stepper(.init(value: 7)), ignoreSubtree: true))
+        #expect(observation == .init(semantics: .stepper(.init(value: 7)), ignoreSublayers: true))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text view semantics and ignores subtree")
-    func recordsTextViewSemanticsAndIgnoresSubtree() {
+    @Test("Records text view semantics and ignores sublayers")
+    func recordsTextViewSemanticsAndIgnoresSublayers() {
         // Given
         let textView = UITextView()
         textView.text = "Body"
@@ -198,13 +198,13 @@ struct CALayerSnapshotSemanticObservationTests {
                     isSecureTextEntry: true
                 )
             ),
-            ignoreSubtree: true
+            ignoreSublayers: true
         ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text field semantics and keeps subtree")
-    func recordsTextFieldSemanticsAndKeepsSubtree() {
+    @Test("Records text field semantics and keeps sublayers")
+    func recordsTextFieldSemanticsAndKeepsSublayers() {
         // Given
         let textField = UITextField()
         textField.text = "Value"
@@ -227,8 +227,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records switch semantics and ignores subtree")
-    func recordsSwitchSemanticsAndIgnoresSubtree() {
+    @Test("Records switch semantics and ignores sublayers")
+    func recordsSwitchSemanticsAndIgnoresSublayers() {
         // Given
         let switchControl = UISwitch()
         switchControl.isOn = true
@@ -237,7 +237,7 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: switchControl.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .switchControl(.init(isOn: true)), ignoreSubtree: true))
+        #expect(observation == .init(semantics: .switchControl(.init(isOn: true)), ignoreSublayers: true))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -252,7 +252,7 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: webView.layer, context: context)
 
         // Then
-        #expect(observation == .init(semantics: .webView(.init(slotID: webView.hash)), ignoreSubtree: true))
+        #expect(observation == .init(semantics: .webView(.init(slotID: webView.hash)), ignoreSublayers: true))
         #expect(webViewCache.allObjects.first === webView)
     }
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -195,7 +195,7 @@ struct CALayerSnapshotSemanticObservationTests {
                 .init(
                     text: "Body",
                     isEditable: false,
-                    isSecureTextEntry: true
+                    isSensitiveText: true
                 )
             ),
             ignoreSublayers: true
@@ -220,7 +220,7 @@ struct CALayerSnapshotSemanticObservationTests {
                 .init(
                     text: "Value",
                     placeholder: "Placeholder",
-                    isSecureTextEntry: true
+                    isSensitiveText: true
                 )
             )
         ))

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -1,0 +1,117 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import Testing
+import UIKit
+
+@testable import DatadogSessionReplay
+
+struct ImageSnapshotCacheTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Returns stored snapshot data")
+    func returnsStoredSnapshotData() throws {
+        // Given
+        let cache = ImageSnapshotCache()
+        let snapshot = ImageSnapshot.mockAny()
+        let snapshotData = ImageSnapshotData.mockAny(
+            snapshot: snapshot,
+            localRect: CGRect(x: 1, y: 2, width: 3, height: 4),
+            bounds: CGRect(x: 5, y: 6, width: 7, height: 8)
+        )
+
+        // When
+        cache.setSnapshotData(snapshotData, forReplayID: 1)
+        let cachedSnapshotData = try #require(cache.snapshotData(forReplayID: 1))
+
+        // Then
+        #expect(cachedSnapshotData.snapshot === snapshot)
+        #expect(cachedSnapshotData.localRect == snapshotData.localRect)
+        #expect(cachedSnapshotData.bounds == snapshotData.bounds)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Removes stored snapshot data")
+    func removesStoredSnapshotData() {
+        // Given
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(.mockAny(), forReplayID: 1)
+
+        // When
+        cache.removeSnapshotData(forReplayID: 1)
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: 1) == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Drops snapshot data when cached image is evicted")
+    func dropsSnapshotDataWhenCachedImageIsEvicted() {
+        // Given
+        let imageSnapshots = NSCache<NSNumber, ImageSnapshot>()
+        let cache = ImageSnapshotCache(imageSnapshots: imageSnapshots)
+        cache.setSnapshotData(.mockAny(), forReplayID: 1)
+
+        // When
+        imageSnapshots.removeAllObjects()
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: 1) == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Expires snapshot data after unobserved frames")
+    func expiresSnapshotDataAfterUnobservedFrames() throws {
+        // Given
+        let policy = ImageSnapshotCache.Policy(
+            expirationFrameCount: 1,
+            removalIntervalFrameCount: 1,
+            maximumRemovals: 1
+        )
+        let cache = ImageSnapshotCache(policy: policy)
+        let snapshot = ImageSnapshot.mockAny()
+        cache.setSnapshotData(.mockAny(snapshot: snapshot), forReplayID: 1)
+
+        // When
+        cache.updateFrameNumber(for: [1])
+        cache.updateFrameNumber(for: [])
+
+        // Then
+        let cachedSnapshot = try #require(cache.snapshotData(forReplayID: 1)?.snapshot)
+        #expect(cachedSnapshot === snapshot)
+
+        // When
+        cache.updateFrameNumber(for: [])
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: 1) == nil)
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshot {
+    fileprivate static func mockAny() -> ImageSnapshot {
+        ImageSnapshot(
+            image: UIImage(),
+            frame: .zero,
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotData {
+    fileprivate static func mockAny(
+        snapshot: ImageSnapshot = .mockAny(),
+        localRect: CGRect = .zero,
+        bounds: CGRect = .zero
+    ) -> ImageSnapshotData {
+        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -1,0 +1,303 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import QuartzCore
+import Testing
+import UIKit
+
+@testable import DatadogSessionReplay
+
+@MainActor
+struct ImageSnapshotRequestTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Throws when layer reference is deallocated")
+    func throwsWhenLayerReferenceIsDeallocated() {
+        // Given
+        let rootLayer = CALayer()
+        let request: ImageSnapshotRequest = {
+            var layer: CALayer? = CALayer()
+            let request = ImageSnapshotRequest.mockAny(layer: layer!)
+            layer = nil
+            return request
+        }()
+
+        // When / Then
+        #expect(throws: ImageSnapshotRequestResolutionError.missingLayer) {
+            _ = try request.resolved(relativeTo: rootLayer)
+        }
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Throws when visible frame resolves to empty rect")
+    func throwsWhenVisibleFrameResolvesToEmptyRect() {
+        // Given
+        let rootLayer = CALayer()
+        let layer = CALayer()
+        rootLayer.addSublayer(layer)
+        let request = ImageSnapshotRequest.mockAny(layer: layer, visibleFrame: .zero)
+
+        // When / Then
+        #expect(throws: ImageSnapshotRequestResolutionError.invalidRect) {
+            _ = try request.resolved(relativeTo: rootLayer)
+        }
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("New plain layer with contents needs snapshot")
+    func newPlainLayerWithContentsNeedsSnapshot() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(layer: layer, hasContents: true)
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.layer === layer)
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Plain layer with contents does not need snapshot after first appearance")
+    func plainLayerWithContentsDoesNotNeedSnapshotAfterFirstAppearance() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            hasContents: true,
+            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Layer with content changes needs snapshot")
+    func layerWithContentChangesNeedsSnapshot() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            hasContentChanges: true,
+            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Layer subclass without changes does not need snapshot after first appearance")
+    func layerSubclassWithoutChangesDoesNotNeedSnapshotAfterFirstAppearance() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Layer subclass with visual animation needs snapshot")
+    func layerSubclassWithVisualAnimationNeedsSnapshot() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        layer.add(CABasicAnimation(keyPath: "opacity"), forKey: "opacity")
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Layer subclass with geometry animation does not need snapshot")
+    func layerSubclassWithGeometryAnimationDoesNotNeedSnapshot() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        layer.add(CABasicAnimation(keyPath: "position"), forKey: "position")
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Partial snapshot needs snapshot when visible frame changes")
+    func partialSnapshotNeedsSnapshotWhenVisibleFrameChanges() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 400, height: 120)
+        layer.position = CGPoint(x: 200, y: 60)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            visibleFrame: CGRect(x: 180, y: 0, width: 20, height: 100),
+            previousSnapshotData: .mockAny(
+                localRect: CGRect(x: 0, y: 0, width: 10, height: 100),
+                bounds: layer.bounds
+            )
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == CGRect(x: 180, y: 0, width: 20, height: 100))
+        #expect(resolvedRequest.frame == CGRect(x: 180, y: 0, width: 20, height: 100))
+        #expect(resolvedRequest.needsSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Partial snapshot does not need snapshot when visible frame is unchanged")
+    func partialSnapshotDoesNotNeedSnapshotWhenVisibleFrameIsUnchanged() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 400, height: 120)
+        layer.position = CGPoint(x: 200, y: 60)
+        rootLayer.addSublayer(layer)
+
+        let visibleFrame = CGRect(x: 180, y: 0, width: 20, height: 100)
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            visibleFrame: visibleFrame,
+            previousSnapshotData: .mockAny(
+                localRect: visibleFrame,
+                bounds: layer.bounds
+            )
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == visibleFrame)
+        #expect(resolvedRequest.frame == visibleFrame)
+        #expect(resolvedRequest.needsSnapshot == false)
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotRequest {
+    @MainActor
+    fileprivate static func mockAny(
+        layer: CALayer,
+        visibleFrame: CGRect? = nil,
+        hasContents: Bool = false,
+        hasContentChanges: Bool = false,
+        previousSnapshotData: ImageSnapshotData? = nil
+    ) -> ImageSnapshotRequest {
+        ImageSnapshotRequest(
+            replayID: layer.replayID,
+            layer: CALayerReference(layer),
+            layerClass: type(of: layer),
+            bounds: layer.bounds,
+            absoluteFrame: layer.frame,
+            visibleFrame: visibleFrame ?? layer.frame,
+            isOpaque: layer.isOpaque,
+            hasContents: hasContents,
+            hasContentChanges: hasContentChanges,
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll,
+            previousSnapshotData: previousSnapshotData
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotData {
+    fileprivate static func mockAny(
+        localRect: CGRect,
+        bounds: CGRect
+    ) -> ImageSnapshotData {
+        ImageSnapshotData(
+            snapshot: ImageSnapshot(
+                image: UIImage(),
+                frame: .zero,
+                textAndInputPrivacyLevel: .maskAll,
+                imagePrivacyLevel: .maskAll
+            ),
+            localRect: localRect,
+            bounds: bounds
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -194,6 +194,29 @@ struct ImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Uses captured frame when live layer moves before resolution")
+    func usesCapturedFrameWhenLiveLayerMovesBeforeResolution() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let capturedFrame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        let layer = CALayer()
+        layer.frame = capturedFrame
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(layer: layer)
+
+        layer.frame = CGRect(x: 30, y: 40, width: 100, height: 40)
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.frame == capturedFrame)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Partial snapshot needs snapshot when visible frame changes")
     func partialSnapshotNeedsSnapshotWhenVisibleFrameChanges() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -169,31 +169,6 @@ struct ImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Layer subclass with visual animation needs snapshot")
-    func layerSubclassWithVisualAnimationNeedsSnapshot() throws {
-        // Given
-        let rootLayer = CALayer()
-        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
-
-        let layer = CATextLayer()
-        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
-        layer.add(CABasicAnimation(keyPath: "opacity"), forKey: "opacity")
-        rootLayer.addSublayer(layer)
-
-        let request = ImageSnapshotRequest.mockAny(
-            layer: layer,
-            previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
-        )
-
-        // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
-
-        // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
-        #expect(resolvedRequest.needsSnapshot)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer subclass with geometry animation does not need snapshot")
     func layerSubclassWithGeometryAnimationDoesNotNeedSnapshot() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -144,6 +144,31 @@ struct ImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Layer subclass needs snapshot when bounds change")
+    func layerSubclassNeedsSnapshotWhenBoundsChange() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let previousBounds = CGRect(x: 0, y: 0, width: 80, height: 40)
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 120, height: 80)
+        rootLayer.addSublayer(layer)
+
+        let request = ImageSnapshotRequest.mockAny(
+            layer: layer,
+            previousSnapshotData: .mockAny(localRect: previousBounds, bounds: previousBounds)
+        )
+
+        // When
+        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+
+        // Then
+        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.needsSnapshot)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer subclass with visual animation needs snapshot")
     func layerSubclassWithVisualAnimationNeedsSnapshot() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -124,6 +124,47 @@ struct ImageSnapshotterTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Refreshes privacy metadata when cached image is reused")
+    func refreshesPrivacyMetadataWhenCachedImageIsReused() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(
+            CALayerSnapshot(
+                from: rootLayer,
+                in: .mockAny(textAndInputPrivacyLevel: .maskAll, imagePrivacyLevel: .maskNone)
+            )
+        )
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        // When
+        let secondRoot = try #require(
+            CALayerSnapshot(
+                from: rootLayer,
+                in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs, imagePrivacyLevel: .maskAll)
+            )
+        )
+        let secondResults = await snapshotter.takeImageSnapshots(for: secondRoot, changeset: .init(), timeout: 1)
+
+        // Then
+        let secondResult = try #require(secondResults[layer.replayID])
+        let secondImageSnapshot = try secondResult.get()
+        #expect(firstImageSnapshot.image === secondImageSnapshot.image)
+        #expect(secondImageSnapshot.textAndInputPrivacyLevel == .maskSensitiveInputs)
+        #expect(secondImageSnapshot.imagePrivacyLevel == .maskAll)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders new image when content changes")
     func rendersNewImageWhenContentChanges() async throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -1,0 +1,176 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import QuartzCore
+import Testing
+import UIKit
+
+@testable import DatadogSessionReplay
+
+@MainActor
+struct ImageSnapshotterTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Renders image snapshot for layer subclass")
+    func rendersImageSnapshotForLayerSubclass() async throws {
+        // Given
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        let root = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let snapshotter = ImageSnapshotter()
+
+        // When
+        let results = await snapshotter.takeImageSnapshots(for: root, changeset: .init(), timeout: 1)
+
+        // Then
+        let result = try #require(results[root.replayID])
+        let imageSnapshot = try result.get()
+        #expect(imageSnapshot.frame == root.absoluteFrame)
+        #expect(imageSnapshot.image.size == root.bounds.size)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Times out unprocessed image requests")
+    func timesOutUnprocessedImageRequests() async throws {
+        // Given
+        let layer = CATextLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
+        let root = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+        let snapshotter = ImageSnapshotter()
+
+        // When
+        let results = await snapshotter.takeImageSnapshots(for: root, changeset: .init(), timeout: 0)
+
+        // Then
+        let result = try #require(results[root.replayID])
+        #expect(throws: ImageSnapshotError.timedOut) {
+            try result.get()
+        }
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Reuses cached image when only frame changes")
+    func reusesCachedImageWhenOnlyFrameChanges() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        // When
+        layer.frame = CGRect(x: 20, y: 15, width: 100, height: 40)
+        let secondRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let secondResults = await snapshotter.takeImageSnapshots(for: secondRoot, changeset: .init(), timeout: 1)
+
+        // Then
+        let secondResult = try #require(secondResults[layer.replayID])
+        let secondImageSnapshot = try secondResult.get()
+        #expect(firstImageSnapshot.image === secondImageSnapshot.image)
+        #expect(secondImageSnapshot.frame == CGRect(x: 20, y: 15, width: 100, height: 40))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Renders new image when content changes")
+    func rendersNewImageWhenContentChanges() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        // When
+        layer.backgroundColor = UIColor.blue.cgColor
+        let secondRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let changeset = CALayerChangeset.mockChange(for: layer, aspects: .display)
+        let secondResults = await snapshotter.takeImageSnapshots(for: secondRoot, changeset: changeset, timeout: 1)
+
+        // Then
+        let secondResult = try #require(secondResults[layer.replayID])
+        let secondImageSnapshot = try secondResult.get()
+        #expect(firstImageSnapshot.image !== secondImageSnapshot.image)
+        #expect(secondImageSnapshot.frame == layer.frame)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Renders full layer image when clipped by ancestor")
+    func rendersFullLayerImageWhenClippedByAncestor() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let clippingLayer = CALayer()
+        clippingLayer.frame = CGRect(x: 10, y: 10, width: 40, height: 40)
+        clippingLayer.masksToBounds = true
+        rootLayer.addSublayer(clippingLayer)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 20, y: 20, width: 40, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        clippingLayer.addSublayer(layer)
+
+        let root = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let snapshotter = ImageSnapshotter()
+
+        // When
+        let results = await snapshotter.takeImageSnapshots(for: root, changeset: .init(), timeout: 1)
+
+        // Then
+        let result = try #require(results[layer.replayID])
+        let imageSnapshot = try result.get()
+        #expect(imageSnapshot.frame == CGRect(x: 30, y: 30, width: 40, height: 40))
+        #expect(imageSnapshot.image.size == CGSize(width: 40, height: 40))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Renders visible rect for oversized layer")
+    func rendersVisibleRectForOversizedLayer() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let root = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let snapshotter = ImageSnapshotter()
+
+        // When
+        let results = await snapshotter.takeImageSnapshots(for: root, changeset: .init(), timeout: 1)
+
+        // Then
+        let result = try #require(results[layer.replayID])
+        let imageSnapshot = try result.get()
+        #expect(imageSnapshot.frame == CGRect(x: 0, y: 0, width: 100, height: 100))
+        #expect(imageSnapshot.image.size == CGSize(width: 100, height: 100))
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -54,6 +54,45 @@ struct ImageSnapshotterTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Removes cached image when changed request times out")
+    func removesCachedImageWhenChangedRequestTimesOut() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        layer.backgroundColor = UIColor.blue.cgColor
+        let changedRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let changeset = CALayerChangeset.mockChange(for: layer, aspects: .display)
+
+        // When
+        let timedOutResults = await snapshotter.takeImageSnapshots(for: changedRoot, changeset: changeset, timeout: 0)
+        let timedOutResult = try #require(timedOutResults[layer.replayID])
+
+        // Then
+        #expect(throws: ImageSnapshotError.timedOut) {
+            try timedOutResult.get()
+        }
+
+        let nextRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let nextResults = await snapshotter.takeImageSnapshots(for: nextRoot, changeset: .init(), timeout: 1)
+        let nextResult = try #require(nextResults[layer.replayID])
+        let nextImageSnapshot = try nextResult.get()
+        #expect(firstImageSnapshot.image !== nextImageSnapshot.image)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Reuses cached image when only frame changes")
     func reusesCachedImageWhenOnlyFrameChanges() async throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -156,6 +156,53 @@ struct ImageSnapshotterTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Invalidates cached image when occluded layer content changes")
+    func invalidatesCachedImageWhenOccludedLayerContentChanges() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CATextLayer()
+        layer.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.contentsScale = 1
+        rootLayer.addSublayer(layer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        layer.backgroundColor = UIColor.blue.cgColor
+
+        let occluder = CALayer()
+        occluder.frame = rootLayer.bounds
+        occluder.backgroundColor = UIColor.white.cgColor
+        occluder.zPosition = 1
+        rootLayer.addSublayer(occluder)
+
+        let occludedRootSnapshot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let occludedRoot = try #require(occludedRootSnapshot.removingOccluded())
+        let changeset = CALayerChangeset.mockChange(for: layer, aspects: .display)
+
+        // When
+        let occludedResults = await snapshotter.takeImageSnapshots(for: occludedRoot, changeset: changeset, timeout: 1)
+
+        // Then
+        #expect(!occludedRoot.sublayers.contains { $0.layer.matches(layer) })
+        #expect(occludedResults[layer.replayID] == nil)
+
+        occluder.removeFromSuperlayer()
+
+        let revealedRoot = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let revealedResults = await snapshotter.takeImageSnapshots(for: revealedRoot, changeset: .init(), timeout: 1)
+        let revealedResult = try #require(revealedResults[layer.replayID])
+        let revealedImageSnapshot = try revealedResult.get()
+        #expect(firstImageSnapshot.image !== revealedImageSnapshot.image)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders full layer image when clipped by ancestor")
     func rendersFullLayerImageWhenClippedByAncestor() async throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
@@ -120,7 +120,7 @@ struct LayerTreeSnapshotBuilderTests {
         #expect(snapshot.root.sublayers.count == 1)
         #expect(snapshot.root.sublayers[0].observation == .init(
             semantics: .webView(.init(slotID: webView.hash)),
-            ignoreSubtree: true
+            ignoreSublayers: true
         ))
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangeAggregatorTests.swift
@@ -15,14 +15,18 @@ final class CALayerChangeAggregatorTests: XCTestCase {
     private let testTimerScheduler = TestTimerScheduler(now: 0)
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var layerChangeAggregator: CALayerChangeAggregator!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var screenChangeFilter: ScreenChangeFilter!
     private var changesets: [CALayerChangeset] = []
 
     override func setUp() {
         super.setUp()
 
+        screenChangeFilter = ScreenChangeFilter()
         layerChangeAggregator = CALayerChangeAggregator(
             minimumDeliveryInterval: 0.1,
-            timerScheduler: testTimerScheduler
+            timerScheduler: testTimerScheduler,
+            screenChangeFilter: screenChangeFilter
         ) { [weak self] changeset in
             self?.changesets.append(changeset)
         }
@@ -179,6 +183,42 @@ final class CALayerChangeAggregatorTests: XCTestCase {
 
         // then
         XCTAssertEqual(changesets.count, 1, "Should ignore changes triggered while delivering")
+    }
+
+    func testIgnoresChangesWhileScreenChangeFilterIgnoresChanges() {
+        // given
+        let ignoredLayer = CALayer()
+        let acceptedLayer = CALayer()
+
+        // when
+        layerChangeAggregator.start()
+
+        testTimerScheduler.advance(to: 0.02)
+        screenChangeFilter.ignoringChanges {
+            screenChangeFilter.ignoringChanges {
+                layerChangeAggregator.layerDidDisplay(ignoredLayer)
+            }
+            layerChangeAggregator.layerDidLayoutSublayers(ignoredLayer)
+        }
+
+        testTimerScheduler.advance(to: 1.0)
+
+        // then
+        XCTAssertTrue(changesets.isEmpty)
+
+        // when
+        layerChangeAggregator.layerDidDisplay(acceptedLayer)
+        testTimerScheduler.advance(to: 1.0)
+
+        // then
+        XCTAssertEqual(
+            changesets,
+            [
+                .init(
+                    [ObjectIdentifier(acceptedLayer): CALayerChange(layer: .init(acceptedLayer), aspects: .display)]
+                )
+            ]
+        )
     }
 
     func testMergesChangesForMultipleLayersIndependently() {


### PR DESCRIPTION
### What and why?

This is the next PR in the series integrating the Core Animation recording pipeline. It adds the image snapshotting step to the Core Animation based Session Replay recorder.

### How?

The recorder now collects image snapshot requests from the captured layer tree, renders the selected layers, and caches rendered images across frames.

The implementation also adds tests for request selection, request resolution, cache behavior, and image snapshot rendering.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
