### PR TITLE
Merge `release/3.12.0` to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Unreleased
 
+# 3.12.0 / 04-06-2026
+
+- [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
+- [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
+- [IMPROVEMENT] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2952][]
 - [FIX] Prevent a crash from `VitalCPUReader` when the CPU tick counter rolls over. See [#2968][]
 - [FIX] Prevent crash misattribution when an inactive RUM view emits a terminal event after `stopResource()`. See [#2948][]
 - [FIX] Fix wrong types in the `objc_LogEventDevice` properties definition. See [#2966][]
-- [IMPROVEMENT] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2949][]
-- [FIX] Add `logger` case to `RUMErrorSource` (Swift) and `DDRUMErrorSource` (Obj-C) for cross-platform parity. See [#2952][]
 - [FIX] Expose RUM operation options to Objective-C from `DatadogRUM`. See [#2969][]
-- [FEATURE] Instrumented Web Views now have their tracing decision consistent with the native SDK. See [#2859][]
-- [IMPROVEMENT] Align public RUM session IDs with event formatting. See [#2956][]
 
 # 3.11.1 / 28-05-2026
 
@@ -1166,7 +1167,6 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2948]: https://github.com/DataDog/dd-sdk-ios/pull/2948
 [#2956]: https://github.com/DataDog/dd-sdk-ios/pull/2956
 [#2966]: https://github.com/DataDog/dd-sdk-ios/pull/2966
-[#2949]: https://github.com/DataDog/dd-sdk-ios/pull/2949
 [#2952]: https://github.com/DataDog/dd-sdk-ios/pull/2952
 [#2968]: https://github.com/DataDog/dd-sdk-ios/pull/2968
 [#2969]: https://github.com/DataDog/dd-sdk-ios/pull/2969

--- a/DatadogCore.podspec
+++ b/DatadogCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCore"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogCore/Sources/Versioning.swift
+++ b/DatadogCore/Sources/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "3.11.1"
+internal let __sdkVersion = "3.12.0"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCrashReporting"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogFlags.podspec
+++ b/DatadogFlags.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogFlags"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Official Datadog Feature Flags module of the Swift SDK."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogInternal"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog Internal Package. This module is not for public use."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogLogs"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog Logs Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogProfiling.podspec
+++ b/DatadogProfiling.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogProfiling"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Official Datadog Profiling module of the Swift SDK."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogRUM"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog Real User Monitoring Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-06-01
-sdk_version: 3.11.0
-verified_against_commit: d3b6c039d
+last_updated: 2026-06-03
+sdk_version: 3.12.0
+verified_against_commit: a0fb31f68
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift
@@ -169,9 +169,11 @@ RUM.enable(
         // Default: false
         collectAccessibility: false,
         
-        // Experimental feature flags (currently no active flags for RUM)
-        // Default: [:]
-        featureFlags: [:]
+        // RUM feature flags
+        // Default: .defaults ([.trackScrollAndSwipeActions: true])
+        // Set [.trackScrollAndSwipeActions: false] to disable automatic
+        // scroll/swipe action tracking and INV attribution for those gestures
+        featureFlags: .defaults
     )
 )
 
@@ -189,6 +191,11 @@ monitor.startView(key: "ProductList", name: "Product List Screen")
 
 // Add custom error
 monitor.addError(message: "Failed to load products", source: .network)
+
+// Read the active sampled-in session ID, matching emitted RUM event `session.id`
+monitor.currentSessionID { sessionId in
+    print("Current RUM session: \(sessionId ?? "none")")
+}
 
 // Stop the view
 monitor.stopView(key: "ProductList")
@@ -210,10 +217,10 @@ monitor.stopView(key: "ProductList")
 - **`DatadogRUM/Sources/RUMMonitor.swift`** - Access point for manual RUM tracking via `RUMMonitor.shared()`
 - **`DatadogRUM/Sources/RUMMonitorProtocol.swift`** - Full API for manual RUM instrumentation
   - Views: `startView()`, `stopView()`
-  - Errors: `addError()`
+  - Errors: `addError()`; sources are `.source`, `.network`, `.webview`, `.console`, `.logger`, and `.custom`
   - Resources: `startResource()`, `stopResource()`
   - Actions: `addAction()`, `startAction()`, `stopAction()`
-  - Custom attributes, timings, and feature flags
+  - Current session ID, custom attributes, timings, and feature flags
 
 ### Implementation
 - **`DatadogRUM/Sources/Feature/RUMFeature.swift`** - Internal feature implementation. Shows how configuration translates to behavior.
@@ -247,16 +254,23 @@ Event mappers allow modifying or dropping events before upload:
 
 **Note**: To filter views, use view predicates instead of the mapper.
 
+### Feature Flags
+- `featureFlags` defaults to `.defaults`, currently `[.trackScrollAndSwipeActions: true]`.
+- `.trackScrollAndSwipeActions`: when set to `false`, disables automatic scroll and swipe action tracking done through `UIScrollView.delegate` swizzling. It has no effect unless `uiKitActionsPredicate` is configured. Disabling it also prevents scroll/swipe gestures from being considered for INV (Interaction-to-Next-View) attribution.
+- `.none`: no-op feature flag case kept in the public enum.
+
 ## Common Troubleshooting Patterns
 
 ### "No RUM data appearing"
 1. Check `Datadog.initialize()` and `RUM.enable()` were called
 2. Verify session wasn't sampled out (check `sessionSampleRate`)
+3. `currentSessionID(completion:)` returns `nil` when there is no active session or the active session is sampled out
 
 ### "Views or actions not tracked"
 1. Check if predicates are configured in RUMConfiguration
 2. For UIKit: `uiKitViewsPredicate` and `uiKitActionsPredicate` must be set
 3. For SwiftUI: `swiftUIViewsPredicate` and `swiftUIActionsPredicate` must be set, as well as UIKit predicates
+4. If scroll/swipe actions are missing while taps still appear, check `featureFlags[.trackScrollAndSwipeActions]`; setting it to `false` disables those automatic actions and their INV attribution
 
 ### "Network requests not tracked"
 1. Verify `urlSessionTracking` is configured in RUMConfiguration (RUM.enable() handles URLSessionInstrumentation internally)

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSessionReplay"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Official Datadog Session Replay SDK for iOS."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogTrace"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog Trace Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogTrace/TRACE_FEATURE.md
+++ b/DatadogTrace/TRACE_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-06-02
-sdk_version: 3.11.0
-verified_against_commit: f3a6d91c1
+last_updated: 2026-06-03
+sdk_version: 3.12.0
+verified_against_commit: a0fb31f68
 tracked_files:
   - DatadogTrace/Sources/Trace.swift
   - DatadogTrace/Sources/TraceConfiguration.swift
@@ -231,6 +231,7 @@ Set `urlSessionTracking` to connect Trace to the shared automatic `URLSession` n
 - **Injection strategy**: `traceControlInjection` — `.sampled` (default) only injects context on sampled first-party requests; `.all` injects context, including drop decisions, on every matching first-party request.
 - **Status-code redaction**: `redactedStatusCodes` (default `[404]`) replaces the `resource.name` tag with the status code string for matching responses. Pass an empty set to disable.
 - **Duration breakdown**: For DNS / SSL / TTFB timing, also call `URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: YourURLSessionDelegate.self))` after `Trace.enable()`.
+- **Duration sanitation**: automatic URLSession spans clamp their finish time so it is never earlier than their start time before computing foreground/background tags or finishing the span.
 
 > Note: Automatic `URLSession` network instrumentation involves swizzling `URLSession` and `URLSessionTask` methods.
 
@@ -294,3 +295,4 @@ Returned when `Datadog.initialize()` was not called or `Trace.enable()` was not 
 - The default tracer's `sampleRate` decides which spans are kept; manual `keepTrace()` / `dropTrace()` overrides that decision for the whole trace, and should be called on the root span right after creation so that propagation carries the correct sampling priority.
 - For the OpenTelemetry tracer provider, `instrumentationName`, `instrumentationVersion`, `schemaUrl` and `attributes` parameters are accepted for API compatibility but ignored — configure tags via `Trace.Configuration.tags`.
 - Automatic `URLSession` network instrumentation relies on swizzling; if your app already swizzles `URLSession` itself, validate behavior in integration tests.
+- Automatic URLSession spans sanitize inconsistent task timing by using `max(startTime, endTime)` for finish time, foreground duration ranges, and background-state lookup.

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogWebViewTracking"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog WebView Tracking Module."
 
   s.homepage     = "https://www.datadoghq.com"

--- a/TestUtilities.podspec
+++ b/TestUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TestUtilities"
-  s.version      = "3.11.1"
+  s.version      = "3.12.0"
   s.summary      = "Datadog Testing Utilities. This module is for internal testing and should not be published."
 
   s.homepage     = "https://www.datadoghq.com"


### PR DESCRIPTION
### What and why?

Merges `release/3.12.0` to develop;
git counterpart of https://github.com/DataDog/dd-sdk-ios/pull/2972
