### PR TITLE
[PANA-7586] Generate Session Replay composition tree models

### DIFF
--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -13,6 +13,544 @@ import DatadogInternal
 
 internal protocol SRDataModel: Codable {}
 
+/// A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+@_spi(Internal)
+public struct SRCompositionLayer: Codable {
+    /// Ordered back-to-front references to child wireframes or child layers.
+    public let children: [SRCompositionLayerChild]
+
+    /// Operation used when compositing the rendered group into its parent.
+    public let compositeOperation: CompositeOperation?
+
+    /// The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+    public let height: Int64
+
+    /// Stable layer identifier, persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// Ordered list of rendering modifiers applied to the composed layer output in array order.
+    public let modifiers: [SRCompositionLayerModifier]?
+
+    /// The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+    public let width: Int64
+
+    /// The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public let x: Int64
+
+    /// The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public let y: Int64
+
+    public enum CodingKeys: String, CodingKey {
+        case children = "children"
+        case compositeOperation = "compositeOperation"
+        case height = "height"
+        case id = "id"
+        case modifiers = "modifiers"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    }
+
+    /// A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+    ///
+    /// - Parameters:
+    ///   - children: Ordered back-to-front references to child wireframes or child layers.
+    ///   - compositeOperation: Operation used when compositing the rendered group into its parent.
+    ///   - height: The height in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+    ///   - id: Stable layer identifier, persistent throughout the view lifetime.
+    ///   - modifiers: Ordered list of rendering modifiers applied to the composed layer output in array order.
+    ///   - width: The width in pixels of the layer. Uses the same coordinate space as mobile wireframes.
+    ///   - x: The position in pixels on the X axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    ///   - y: The position in pixels on the Y axis of the layer in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public init(
+        children: [SRCompositionLayerChild],
+        compositeOperation: CompositeOperation? = nil,
+        height: Int64,
+        id: Int64,
+        modifiers: [SRCompositionLayerModifier]? = nil,
+        width: Int64,
+        x: Int64,
+        y: Int64
+    ) {
+        self.children = children
+        self.compositeOperation = compositeOperation
+        self.height = height
+        self.id = id
+        self.modifiers = modifiers
+        self.width = width
+        self.x = x
+        self.y = y
+    }
+
+    /// Operation used when compositing the rendered group into its parent.
+    @_spi(Internal)
+    public enum CompositeOperation: String, Codable {
+        case sourceOver = "sourceOver"
+        case destinationIn = "destinationIn"
+        case plusDarker = "plusDarker"
+    }
+}
+
+/// Represents a platform background material effect captured as layer rendering state.
+@_spi(Internal)
+public struct SRCompositionLayerBackgroundMaterialModifier: Codable {
+    /// Material kind.
+    public let kind: Kind
+
+    /// The type of the modifier.
+    public let type: String = "backgroundMaterial"
+
+    public enum CodingKeys: String, CodingKey {
+        case kind = "kind"
+        case type = "type"
+    }
+
+    /// Represents a platform background material effect captured as layer rendering state.
+    ///
+    /// - Parameters:
+    ///   - kind: Material kind.
+    public init(
+        kind: Kind
+    ) {
+        self.kind = kind
+    }
+
+    /// Material kind.
+    @_spi(Internal)
+    public enum Kind: String, Codable {
+        case glass = "glass"
+    }
+}
+
+/// Adds a signed brightness bias to the rendered layer contents.
+@_spi(Internal)
+public struct SRCompositionLayerBrightnessBiasModifier: Codable {
+    /// The type of the modifier.
+    public let type: String = "brightnessBias"
+
+    /// Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+    public let value: Double
+
+    public enum CodingKeys: String, CodingKey {
+        case type = "type"
+        case value = "value"
+    }
+
+    /// Adds a signed brightness bias to the rendered layer contents.
+    ///
+    /// - Parameters:
+    ///   - value: Brightness bias from -1 to 1 added to each normalized RGB channel (alpha is unchanged). 0 leaves content unchanged. Positive values brighten; negative values darken. Each channel is clamped to [0, 1] after the bias is applied.
+    public init(
+        value: Double
+    ) {
+        self.value = value
+    }
+}
+
+/// A reference to a child wireframe or child layer in a composition layer.
+@_spi(Internal)
+public struct SRCompositionLayerChild: Codable {
+    /// The id of the referenced wireframe or layer.
+    public let id: Int64
+
+    /// The type of the child reference.
+    public let type: SRCompositionLayerChildType
+
+    public enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case type = "type"
+    }
+
+    /// A reference to a child wireframe or child layer in a composition layer.
+    ///
+    /// - Parameters:
+    ///   - id: The id of the referenced wireframe or layer.
+    ///   - type: The type of the child reference.
+    public init(
+        id: Int64,
+        type: SRCompositionLayerChildType
+    ) {
+        self.id = id
+        self.type = type
+    }
+}
+
+/// The type of the child reference.
+@_spi(Internal)
+public enum SRCompositionLayerChildType: String, Codable {
+    case wireframe = "wireframe"
+    case layer = "layer"
+}
+
+/// Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+@_spi(Internal)
+public struct SRCompositionLayerClipModifier: Codable {
+    /// Path fill rule. Defaults to 'nonzero'.
+    public let fillRule: FillRule?
+
+    /// SVG path string defining the clip region, in coordinates local to the layer rectangle.
+    public let path: String
+
+    /// The type of the modifier.
+    public let type: String = "clip"
+
+    public enum CodingKeys: String, CodingKey {
+        case fillRule = "fillRule"
+        case path = "path"
+        case type = "type"
+    }
+
+    /// Geometric clipping applied to the composed layer output, in coordinates local to the layer rectangle.
+    ///
+    /// - Parameters:
+    ///   - fillRule: Path fill rule. Defaults to 'nonzero'.
+    ///   - path: SVG path string defining the clip region, in coordinates local to the layer rectangle.
+    public init(
+        fillRule: FillRule? = nil,
+        path: String
+    ) {
+        self.fillRule = fillRule
+        self.path = path
+    }
+
+    /// Path fill rule. Defaults to 'nonzero'.
+    @_spi(Internal)
+    public enum FillRule: String, Codable {
+        case nonzero = "nonzero"
+        case evenodd = "evenodd"
+    }
+}
+
+/// Color transformation using a 4x5 matrix applied to the composed layer output.
+@_spi(Internal)
+public struct SRCompositionLayerColorMatrixModifier: Codable {
+    /// 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+    public let matrix: [Double]
+
+    /// The type of the modifier.
+    public let type: String = "colorMatrix"
+
+    public enum CodingKeys: String, CodingKey {
+        case matrix = "matrix"
+        case type = "type"
+    }
+
+    /// Color transformation using a 4x5 matrix applied to the composed layer output.
+    ///
+    /// - Parameters:
+    ///   - matrix: 4x5 color matrix encoded as 20 numbers in row-major order. Input and output color channels are normalized to [0, 1]. The transform for each output channel is: R' = m[0]*R + m[1]*G + m[2]*B + m[3]*A + m[4], G' = m[5]*R + m[6]*G + m[7]*B + m[8]*A + m[9], B' = m[10]*R + m[11]*G + m[12]*B + m[13]*A + m[14], A' = m[15]*R + m[16]*G + m[17]*B + m[18]*A + m[19]. Each output channel is clamped to [0, 1] after evaluation.
+    public init(
+        matrix: [Double]
+    ) {
+        self.matrix = matrix
+    }
+}
+
+/// Gaussian blur applied to the composed layer output.
+@_spi(Internal)
+public struct SRCompositionLayerGaussianBlurModifier: Codable {
+    /// Gaussian blur radius.
+    public let radius: Double
+
+    /// The type of the modifier.
+    public let type: String = "gaussianBlur"
+
+    public enum CodingKeys: String, CodingKey {
+        case radius = "radius"
+        case type = "type"
+    }
+
+    /// Gaussian blur applied to the composed layer output.
+    ///
+    /// - Parameters:
+    ///   - radius: Gaussian blur radius.
+    public init(
+        radius: Double
+    ) {
+        self.radius = radius
+    }
+}
+
+/// A rendering modifier applied to the composed layer output.
+@_spi(Internal)
+public enum SRCompositionLayerModifier: Codable {
+    case compositionLayerClipModifier(value: SRCompositionLayerClipModifier)
+    case compositionLayerOpacityModifier(value: SRCompositionLayerOpacityModifier)
+    case compositionLayerColorMatrixModifier(value: SRCompositionLayerColorMatrixModifier)
+    case compositionLayerGaussianBlurModifier(value: SRCompositionLayerGaussianBlurModifier)
+    case compositionLayerBrightnessBiasModifier(value: SRCompositionLayerBrightnessBiasModifier)
+    case compositionLayerSaturateModifier(value: SRCompositionLayerSaturateModifier)
+    case compositionLayerBackgroundMaterialModifier(value: SRCompositionLayerBackgroundMaterialModifier)
+
+    // MARK: - Codable
+
+    public func encode(to encoder: Encoder) throws {
+        // Encode only the associated value, without encoding enum case
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .compositionLayerClipModifier(let value):
+            try container.encode(value)
+        case .compositionLayerOpacityModifier(let value):
+            try container.encode(value)
+        case .compositionLayerColorMatrixModifier(let value):
+            try container.encode(value)
+        case .compositionLayerGaussianBlurModifier(let value):
+            try container.encode(value)
+        case .compositionLayerBrightnessBiasModifier(let value):
+            try container.encode(value)
+        case .compositionLayerSaturateModifier(let value):
+            try container.encode(value)
+        case .compositionLayerBackgroundMaterialModifier(let value):
+            try container.encode(value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode enum case from associated value
+        let container = try decoder.singleValueContainer()
+
+        if let value = try? container.decode(SRCompositionLayerClipModifier.self) {
+            self = .compositionLayerClipModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerOpacityModifier.self) {
+            self = .compositionLayerOpacityModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerColorMatrixModifier.self) {
+            self = .compositionLayerColorMatrixModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerGaussianBlurModifier.self) {
+            self = .compositionLayerGaussianBlurModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerBrightnessBiasModifier.self) {
+            self = .compositionLayerBrightnessBiasModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerSaturateModifier.self) {
+            self = .compositionLayerSaturateModifier(value: value)
+            return
+        }
+        if let value = try? container.decode(SRCompositionLayerBackgroundMaterialModifier.self) {
+            self = .compositionLayerBackgroundMaterialModifier(value: value)
+            return
+        }
+        let error = DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: """
+            Failed to decode `SRCompositionLayerModifier`.
+            Ran out of possibilities when trying to decode the value of associated type.
+            """
+        )
+        throw DecodingError.typeMismatch(SRCompositionLayerModifier.self, error)
+    }
+}
+
+/// Opacity applied to the composed layer output at this point in the modifier order.
+@_spi(Internal)
+public struct SRCompositionLayerOpacityModifier: Codable {
+    /// The type of the modifier.
+    public let type: String = "opacity"
+
+    /// Opacity value from 0 to 1.
+    public let value: Double
+
+    public enum CodingKeys: String, CodingKey {
+        case type = "type"
+        case value = "value"
+    }
+
+    /// Opacity applied to the composed layer output at this point in the modifier order.
+    ///
+    /// - Parameters:
+    ///   - value: Opacity value from 0 to 1.
+    public init(
+        value: Double
+    ) {
+        self.value = value
+    }
+}
+
+/// Applies a saturation adjustment to the rendered layer contents.
+@_spi(Internal)
+public struct SRCompositionLayerSaturateModifier: Codable {
+    /// The type of the modifier.
+    public let type: String = "saturate"
+
+    /// Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+    public let value: Double
+
+    public enum CodingKeys: String, CodingKey {
+        case type = "type"
+        case value = "value"
+    }
+
+    /// Applies a saturation adjustment to the rendered layer contents.
+    ///
+    /// - Parameters:
+    ///   - value: Saturation multiplier. 1 leaves content unchanged. 0 removes saturation.
+    public init(
+        value: Double
+    ) {
+        self.value = value
+    }
+}
+
+/// Sparse update for a composition layer. Omitted fields are unchanged.
+@_spi(Internal)
+public struct SRCompositionLayerUpdate: Codable {
+    /// When present, replaces the full child list for this layer.
+    public let children: [SRCompositionLayerChild]?
+
+    /// Updated composite operation for this layer.
+    public let compositeOperation: CompositeOperation?
+
+    /// Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+    public let height: Int64?
+
+    /// The id of the layer to update.
+    public let id: Int64
+
+    /// When present, replaces the full modifier list for this layer.
+    public let modifiers: [SRCompositionLayerModifier]?
+
+    /// Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+    public let width: Int64?
+
+    /// Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public let x: Int64?
+
+    /// Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public let y: Int64?
+
+    public enum CodingKeys: String, CodingKey {
+        case children = "children"
+        case compositeOperation = "compositeOperation"
+        case height = "height"
+        case id = "id"
+        case modifiers = "modifiers"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    }
+
+    /// Sparse update for a composition layer. Omitted fields are unchanged.
+    ///
+    /// - Parameters:
+    ///   - children: When present, replaces the full child list for this layer.
+    ///   - compositeOperation: Updated composite operation for this layer.
+    ///   - height: Updated height in pixels. Uses the same coordinate space as mobile wireframes.
+    ///   - id: The id of the layer to update.
+    ///   - modifiers: When present, replaces the full modifier list for this layer.
+    ///   - width: Updated width in pixels. Uses the same coordinate space as mobile wireframes.
+    ///   - x: Updated X position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    ///   - y: Updated Y position in absolute coordinates. Uses the same coordinate space as mobile wireframes.
+    public init(
+        children: [SRCompositionLayerChild]? = nil,
+        compositeOperation: CompositeOperation? = nil,
+        height: Int64? = nil,
+        id: Int64,
+        modifiers: [SRCompositionLayerModifier]? = nil,
+        width: Int64? = nil,
+        x: Int64? = nil,
+        y: Int64? = nil
+    ) {
+        self.children = children
+        self.compositeOperation = compositeOperation
+        self.height = height
+        self.id = id
+        self.modifiers = modifiers
+        self.width = width
+        self.x = x
+        self.y = y
+    }
+
+    /// Updated composite operation for this layer.
+    @_spi(Internal)
+    public enum CompositeOperation: String, Codable {
+        case sourceOver = "sourceOver"
+        case destinationIn = "destinationIn"
+        case plusDarker = "plusDarker"
+    }
+}
+
+/// Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+@_spi(Internal)
+public struct SRCompositionTree: Codable {
+    /// Non-root composition layers referenced by the tree.
+    public let layers: [SRCompositionLayer]?
+
+    /// A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+    public let root: SRCompositionLayer
+
+    public enum CodingKeys: String, CodingKey {
+        case layers = "layers"
+        case root = "root"
+    }
+
+    /// Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+    ///
+    /// - Parameters:
+    ///   - layers: Non-root composition layers referenced by the tree.
+    ///   - root: A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+    public init(
+        layers: [SRCompositionLayer]? = nil,
+        root: SRCompositionLayer
+    ) {
+        self.layers = layers
+        self.root = root
+    }
+}
+
+/// Mobile-specific. Incremental data carrying composition tree layer mutations.
+@_spi(Internal)
+public struct SRCompositionTreeMutationData: Codable {
+    /// Full layer definitions for newly added layers.
+    public let adds: [SRCompositionLayer]?
+
+    /// Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
+    public let removes: [Int64]?
+
+    /// A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+    public let root: SRCompositionLayer?
+
+    /// The source of this type of incremental data.
+    public let source: Int64 = 10
+
+    /// Sparse updates for existing layers.
+    public let updates: [SRCompositionLayerUpdate]?
+
+    public enum CodingKeys: String, CodingKey {
+        case adds = "adds"
+        case removes = "removes"
+        case root = "root"
+        case source = "source"
+        case updates = "updates"
+    }
+
+    /// Mobile-specific. Incremental data carrying composition tree layer mutations.
+    ///
+    /// - Parameters:
+    ///   - adds: Full layer definitions for newly added layers.
+    ///   - removes: Ids of layer definitions to remove. Removing a referenced layer also requires updating the parent or root child list.
+    ///   - root: A rendering group that groups child wireframes and child layers. Does not draw pixels itself. Ordered rendering modifiers and compositing are applied to its composed output.
+    ///   - updates: Sparse updates for existing layers.
+    public init(
+        adds: [SRCompositionLayer]? = nil,
+        removes: [Int64]? = nil,
+        root: SRCompositionLayer? = nil,
+        updates: [SRCompositionLayerUpdate]? = nil
+    ) {
+        self.adds = adds
+        self.removes = removes
+        self.root = root
+        self.updates = updates
+    }
+}
+
 /// Schema of clipping information for a Wireframe.
 @_spi(Internal)
 public struct SRContentClip: Codable, Hashable {
@@ -144,19 +682,26 @@ public struct SRFullSnapshotRecord: Codable {
 
     @_spi(Internal)
     public struct Data: Codable {
+        /// Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
+        public let compositionTree: SRCompositionTree?
+
         /// The Wireframes contained by this Record.
         public let wireframes: [SRWireframe]
 
         public enum CodingKeys: String, CodingKey {
+            case compositionTree = "compositionTree"
             case wireframes = "wireframes"
         }
 
         ///
         /// - Parameters:
+        ///   - compositionTree: Optional composition tree describing the rendering hierarchy. When present, the player uses this tree for rendering order and group operations.
         ///   - wireframes: The Wireframes contained by this Record.
         public init(
+            compositionTree: SRCompositionTree? = nil,
             wireframes: [SRWireframe]
         ) {
+            self.compositionTree = compositionTree
             self.wireframes = wireframes
         }
     }
@@ -186,7 +731,7 @@ public struct SRImageWireframe: Codable, Hashable {
     /// MIME type of the image file
     public var mimeType: String?
 
-    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     public let permanentId: String?
 
     /// Unique identifier of the image resource
@@ -234,7 +779,7 @@ public struct SRImageWireframe: Codable, Hashable {
     ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
     ///   - isEmpty: Flag describing an image wireframe that should render an empty state placeholder
     ///   - mimeType: MIME type of the image file
-    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     ///   - resourceId: Unique identifier of the image resource
     ///   - shapeStyle: The style of this wireframe.
     ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
@@ -309,6 +854,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
         case touchData(value: TouchData)
         case viewportResizeData(value: ViewportResizeData)
         case pointerInteractionData(value: PointerInteractionData)
+        case compositionTreeMutationData(value: SRCompositionTreeMutationData)
 
         // MARK: - Codable
 
@@ -324,6 +870,8 @@ public struct SRIncrementalSnapshotRecord: Codable {
             case .viewportResizeData(let value):
                 try container.encode(value)
             case .pointerInteractionData(let value):
+                try container.encode(value)
+            case .compositionTreeMutationData(let value):
                 try container.encode(value)
             }
         }
@@ -346,6 +894,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
             }
             if let value = try? container.decode(PointerInteractionData.self) {
                 self = .pointerInteractionData(value: value)
+                return
+            }
+            if let value = try? container.decode(SRCompositionTreeMutationData.self) {
+                self = .compositionTreeMutationData(value: value)
                 return
             }
             let error = DecodingError.Context(
@@ -1189,7 +1741,7 @@ public struct SRPlaceholderWireframe: Codable, Hashable {
     /// Label of the placeholder
     public var label: String?
 
-    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     public let permanentId: String?
 
     /// The type of the wireframe.
@@ -1223,7 +1775,7 @@ public struct SRPlaceholderWireframe: Codable, Hashable {
     ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
     ///   - label: Label of the placeholder
-    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
     ///   - x: The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
     ///   - y: The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
@@ -1452,6 +2004,7 @@ public struct SRSegment: SRDataModel {
         case flutter = "flutter"
         case reactNative = "react-native"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case maui = "maui"
     }
 
     /// View properties
@@ -1554,7 +2107,7 @@ public struct SRShapeWireframe: Codable, Hashable {
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
     public let id: Int64
 
-    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     public let permanentId: String?
 
     /// The style of this wireframe.
@@ -1592,7 +2145,7 @@ public struct SRShapeWireframe: Codable, Hashable {
     ///   - clip: Schema of clipping information for a Wireframe.
     ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     ///   - shapeStyle: The style of this wireframe.
     ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
     ///   - x: The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
@@ -1794,7 +2347,7 @@ public struct SRTextWireframe: Codable, Hashable {
     /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
     public let id: Int64
 
-    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     public let permanentId: String?
 
     /// The style of this wireframe.
@@ -1844,7 +2397,7 @@ public struct SRTextWireframe: Codable, Hashable {
     ///   - clip: Schema of clipping information for a Wireframe.
     ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
-    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     ///   - shapeStyle: The style of this wireframe.
     ///   - text: The text value of the wireframe.
     ///   - textPosition: Schema of all properties of a TextPosition.
@@ -2023,7 +2576,7 @@ public struct SRWebviewWireframe: Codable, Hashable {
     /// Whether this webview is visible or not.
     public let isVisible: Bool?
 
-    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     public let permanentId: String?
 
     /// The style of this wireframe.
@@ -2067,7 +2620,7 @@ public struct SRWebviewWireframe: Codable, Hashable {
     ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
     ///   - isVisible: Whether this webview is visible or not.
-    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate wireframes with RUM action events.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
     ///   - shapeStyle: The style of this wireframe.
     ///   - slotId: Unique Id of the slot containing this webview.
     ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
@@ -2164,4 +2717,4 @@ public enum SRWireframe: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/79d6285a53f07fe507952081fef124dbc3bdeaf2
+// Generated from https://github.com/DataDog/rum-events-format/tree/dacedf0e5a6034a47967c142cfb9f4fe3c10464a

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -282,6 +282,10 @@ public enum SRCompositionLayerModifier: Codable {
     case compositionLayerSaturateModifier(value: SRCompositionLayerSaturateModifier)
     case compositionLayerBackgroundMaterialModifier(value: SRCompositionLayerBackgroundMaterialModifier)
 
+    private enum DiscriminatorCodingKeys: String, CodingKey {
+        case discriminator = "type"
+    }
+
     // MARK: - Codable
 
     public func encode(to encoder: Encoder) throws {
@@ -307,45 +311,42 @@ public enum SRCompositionLayerModifier: Codable {
     }
 
     public init(from decoder: Decoder) throws {
-        // Decode enum case from associated value
+        // Decode enum case from discriminator
         let container = try decoder.singleValueContainer()
+        let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
 
-        if let value = try? container.decode(SRCompositionLayerClipModifier.self) {
-            self = .compositionLayerClipModifier(value: value)
+        switch try discriminatorContainer.decode(String.self, forKey: .discriminator) {
+        case "clip":
+            self = .compositionLayerClipModifier(value: try container.decode(SRCompositionLayerClipModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerOpacityModifier.self) {
-            self = .compositionLayerOpacityModifier(value: value)
+        case "opacity":
+            self = .compositionLayerOpacityModifier(value: try container.decode(SRCompositionLayerOpacityModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerColorMatrixModifier.self) {
-            self = .compositionLayerColorMatrixModifier(value: value)
+        case "colorMatrix":
+            self = .compositionLayerColorMatrixModifier(value: try container.decode(SRCompositionLayerColorMatrixModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerGaussianBlurModifier.self) {
-            self = .compositionLayerGaussianBlurModifier(value: value)
+        case "gaussianBlur":
+            self = .compositionLayerGaussianBlurModifier(value: try container.decode(SRCompositionLayerGaussianBlurModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerBrightnessBiasModifier.self) {
-            self = .compositionLayerBrightnessBiasModifier(value: value)
+        case "brightnessBias":
+            self = .compositionLayerBrightnessBiasModifier(value: try container.decode(SRCompositionLayerBrightnessBiasModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerSaturateModifier.self) {
-            self = .compositionLayerSaturateModifier(value: value)
+        case "saturate":
+            self = .compositionLayerSaturateModifier(value: try container.decode(SRCompositionLayerSaturateModifier.self))
             return
-        }
-        if let value = try? container.decode(SRCompositionLayerBackgroundMaterialModifier.self) {
-            self = .compositionLayerBackgroundMaterialModifier(value: value)
+        case "backgroundMaterial":
+            self = .compositionLayerBackgroundMaterialModifier(value: try container.decode(SRCompositionLayerBackgroundMaterialModifier.self))
             return
+        default:
+            let error = DecodingError.Context(
+                codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],
+                debugDescription: """
+                Failed to decode `SRCompositionLayerModifier`.
+                Discriminator `type` did not match any known case.
+                """
+            )
+            throw DecodingError.dataCorrupted(error)
         }
-        let error = DecodingError.Context(
-            codingPath: container.codingPath,
-            debugDescription: """
-            Failed to decode `SRCompositionLayerModifier`.
-            Ran out of possibilities when trying to decode the value of associated type.
-            """
-        )
-        throw DecodingError.typeMismatch(SRCompositionLayerModifier.self, error)
     }
 }
 
@@ -856,6 +857,10 @@ public struct SRIncrementalSnapshotRecord: Codable {
         case pointerInteractionData(value: PointerInteractionData)
         case compositionTreeMutationData(value: SRCompositionTreeMutationData)
 
+        private enum DiscriminatorCodingKeys: String, CodingKey {
+            case discriminator = "source"
+        }
+
         // MARK: - Codable
 
         public func encode(to encoder: Encoder) throws {
@@ -877,37 +882,36 @@ public struct SRIncrementalSnapshotRecord: Codable {
         }
 
         public init(from decoder: Decoder) throws {
-            // Decode enum case from associated value
+            // Decode enum case from discriminator
             let container = try decoder.singleValueContainer()
+            let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
 
-            if let value = try? container.decode(MutationData.self) {
-                self = .mutationData(value: value)
+            switch try discriminatorContainer.decode(Int64.self, forKey: .discriminator) {
+            case 0:
+                self = .mutationData(value: try container.decode(MutationData.self))
                 return
-            }
-            if let value = try? container.decode(TouchData.self) {
-                self = .touchData(value: value)
+            case 2:
+                self = .touchData(value: try container.decode(TouchData.self))
                 return
-            }
-            if let value = try? container.decode(ViewportResizeData.self) {
-                self = .viewportResizeData(value: value)
+            case 4:
+                self = .viewportResizeData(value: try container.decode(ViewportResizeData.self))
                 return
-            }
-            if let value = try? container.decode(PointerInteractionData.self) {
-                self = .pointerInteractionData(value: value)
+            case 9:
+                self = .pointerInteractionData(value: try container.decode(PointerInteractionData.self))
                 return
-            }
-            if let value = try? container.decode(SRCompositionTreeMutationData.self) {
-                self = .compositionTreeMutationData(value: value)
+            case 10:
+                self = .compositionTreeMutationData(value: try container.decode(SRCompositionTreeMutationData.self))
                 return
+            default:
+                let error = DecodingError.Context(
+                    codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],
+                    debugDescription: """
+                    Failed to decode `Data`.
+                    Discriminator `source` did not match any known case.
+                    """
+                )
+                throw DecodingError.dataCorrupted(error)
             }
-            let error = DecodingError.Context(
-                codingPath: container.codingPath,
-                debugDescription: """
-                Failed to decode `Data`.
-                Ran out of possibilities when trying to decode the value of associated type.
-                """
-            )
-            throw DecodingError.typeMismatch(Data.self, error)
         }
 
         /// Mobile-specific. Schema of a MutationData.

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -600,6 +600,148 @@ public enum WebViewTracking
 
 [?] extension SRTextPosition.Alignment
     public init(systemTextAlignment: NSTextAlignment,vertical: SRTextPosition.Alignment.Vertical = .center)
+public struct SRCompositionLayer: Codable
+    public let children: [SRCompositionLayerChild]
+    public let compositeOperation: CompositeOperation?
+    public let height: Int64
+    public let id: Int64
+    public let modifiers: [SRCompositionLayerModifier]?
+    public let width: Int64
+    public let x: Int64
+    public let y: Int64
+    public enum CodingKeys: String, CodingKey
+        case children = "children"
+        case compositeOperation = "compositeOperation"
+        case height = "height"
+        case id = "id"
+        case modifiers = "modifiers"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    public init(children: [SRCompositionLayerChild],compositeOperation: CompositeOperation? = nil,height: Int64,id: Int64,modifiers: [SRCompositionLayerModifier]? = nil,width: Int64,x: Int64,y: Int64)
+    public enum CompositeOperation: String, Codable
+        case sourceOver = "sourceOver"
+        case destinationIn = "destinationIn"
+        case plusDarker = "plusDarker"
+public struct SRCompositionLayerBackgroundMaterialModifier: Codable
+    public let kind: Kind
+    public let type: String = "backgroundMaterial"
+    public enum CodingKeys: String, CodingKey
+        case kind = "kind"
+        case type = "type"
+    public init(kind: Kind)
+    public enum Kind: String, Codable
+        case glass = "glass"
+public struct SRCompositionLayerBrightnessBiasModifier: Codable
+    public let type: String = "brightnessBias"
+    public let value: Double
+    public enum CodingKeys: String, CodingKey
+        case type = "type"
+        case value = "value"
+    public init(value: Double)
+public struct SRCompositionLayerChild: Codable
+    public let id: Int64
+    public let type: SRCompositionLayerChildType
+    public enum CodingKeys: String, CodingKey
+        case id = "id"
+        case type = "type"
+    public init(id: Int64,type: SRCompositionLayerChildType)
+public enum SRCompositionLayerChildType: String, Codable
+    case wireframe = "wireframe"
+    case layer = "layer"
+public struct SRCompositionLayerClipModifier: Codable
+    public let fillRule: FillRule?
+    public let path: String
+    public let type: String = "clip"
+    public enum CodingKeys: String, CodingKey
+        case fillRule = "fillRule"
+        case path = "path"
+        case type = "type"
+    public init(fillRule: FillRule? = nil,path: String)
+    public enum FillRule: String, Codable
+        case nonzero = "nonzero"
+        case evenodd = "evenodd"
+public struct SRCompositionLayerColorMatrixModifier: Codable
+    public let matrix: [Double]
+    public let type: String = "colorMatrix"
+    public enum CodingKeys: String, CodingKey
+        case matrix = "matrix"
+        case type = "type"
+    public init(matrix: [Double])
+public struct SRCompositionLayerGaussianBlurModifier: Codable
+    public let radius: Double
+    public let type: String = "gaussianBlur"
+    public enum CodingKeys: String, CodingKey
+        case radius = "radius"
+        case type = "type"
+    public init(radius: Double)
+public enum SRCompositionLayerModifier: Codable
+    case compositionLayerClipModifier(value: SRCompositionLayerClipModifier)
+    case compositionLayerOpacityModifier(value: SRCompositionLayerOpacityModifier)
+    case compositionLayerColorMatrixModifier(value: SRCompositionLayerColorMatrixModifier)
+    case compositionLayerGaussianBlurModifier(value: SRCompositionLayerGaussianBlurModifier)
+    case compositionLayerBrightnessBiasModifier(value: SRCompositionLayerBrightnessBiasModifier)
+    case compositionLayerSaturateModifier(value: SRCompositionLayerSaturateModifier)
+    case compositionLayerBackgroundMaterialModifier(value: SRCompositionLayerBackgroundMaterialModifier)
+    public func encode(to encoder: Encoder) throws
+    public init(from decoder: Decoder) throws
+public struct SRCompositionLayerOpacityModifier: Codable
+    public let type: String = "opacity"
+    public let value: Double
+    public enum CodingKeys: String, CodingKey
+        case type = "type"
+        case value = "value"
+    public init(value: Double)
+public struct SRCompositionLayerSaturateModifier: Codable
+    public let type: String = "saturate"
+    public let value: Double
+    public enum CodingKeys: String, CodingKey
+        case type = "type"
+        case value = "value"
+    public init(value: Double)
+public struct SRCompositionLayerUpdate: Codable
+    public let children: [SRCompositionLayerChild]?
+    public let compositeOperation: CompositeOperation?
+    public let height: Int64?
+    public let id: Int64
+    public let modifiers: [SRCompositionLayerModifier]?
+    public let width: Int64?
+    public let x: Int64?
+    public let y: Int64?
+    public enum CodingKeys: String, CodingKey
+        case children = "children"
+        case compositeOperation = "compositeOperation"
+        case height = "height"
+        case id = "id"
+        case modifiers = "modifiers"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    public init(children: [SRCompositionLayerChild]? = nil,compositeOperation: CompositeOperation? = nil,height: Int64? = nil,id: Int64,modifiers: [SRCompositionLayerModifier]? = nil,width: Int64? = nil,x: Int64? = nil,y: Int64? = nil)
+    public enum CompositeOperation: String, Codable
+        case sourceOver = "sourceOver"
+        case destinationIn = "destinationIn"
+        case plusDarker = "plusDarker"
+public struct SRCompositionTree: Codable
+    public let layers: [SRCompositionLayer]?
+    public let root: SRCompositionLayer
+    public enum CodingKeys: String, CodingKey
+        case layers = "layers"
+        case root = "root"
+    public init(layers: [SRCompositionLayer]? = nil,root: SRCompositionLayer)
+public struct SRCompositionTreeMutationData: Codable
+    public let adds: [SRCompositionLayer]?
+    public let removes: [Int64]?
+    public let root: SRCompositionLayer?
+    public let source: Int64 = 10
+    public let updates: [SRCompositionLayerUpdate]?
+    public enum CodingKeys: String, CodingKey
+        case adds = "adds"
+        case removes = "removes"
+        case root = "root"
+        case source = "source"
+        case updates = "updates"
+    public init(adds: [SRCompositionLayer]? = nil,removes: [Int64]? = nil,root: SRCompositionLayer? = nil,updates: [SRCompositionLayerUpdate]? = nil)
 public struct SRContentClip: Codable, Hashable
     public let bottom: Int64?
     public let left: Int64?
@@ -637,10 +779,12 @@ public struct SRFullSnapshotRecord: Codable
         case type = "type"
     public init(data: Data,timestamp: Int64)
     public struct Data: Codable
+        public let compositionTree: SRCompositionTree?
         public let wireframes: [SRWireframe]
         public enum CodingKeys: String, CodingKey
+            case compositionTree = "compositionTree"
             case wireframes = "wireframes"
-        public init(wireframes: [SRWireframe])
+        public init(compositionTree: SRCompositionTree? = nil,wireframes: [SRWireframe])
 public struct SRImageWireframe: Codable, Hashable
     public var base64: String?
     public let border: SRShapeBorder?
@@ -686,6 +830,7 @@ public struct SRIncrementalSnapshotRecord: Codable
         case touchData(value: TouchData)
         case viewportResizeData(value: ViewportResizeData)
         case pointerInteractionData(value: PointerInteractionData)
+        case compositionTreeMutationData(value: SRCompositionTreeMutationData)
         public func encode(to encoder: Encoder) throws
         public init(from decoder: Decoder) throws
         public struct MutationData: Codable
@@ -979,6 +1124,7 @@ public struct SRSegment: SRDataModel
         case flutter = "flutter"
         case reactNative = "react-native"
         case kotlinMultiplatform = "kotlin-multiplatform"
+        case maui = "maui"
     public struct View: Codable
         public let id: String
         public enum CodingKeys: String, CodingKey

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -88,6 +88,23 @@ public class SRCodeDecorator: SwiftCodeDecorator {
         return `struct`
     }
 
+    override public func transform(associatedTypeEnum: SwiftAssociatedTypeEnum) throws -> SwiftAssociatedTypeEnum {
+        var transformed = try super.transform(associatedTypeEnum: associatedTypeEnum)
+
+        if transformed.name == "SRCompositionLayerModifier" {
+            transformed = addDiscriminator("type", to: transformed, basedOn: associatedTypeEnum)
+        }
+
+        let parentIncrementalSnapshotRecord = context.predecessorStruct(
+            matching: { $0.name.lowercased() == "mobileincrementalsnapshotrecord" }
+        )
+        if associatedTypeEnum.name.lowercased() == "data" && parentIncrementalSnapshotRecord != nil {
+            transformed = addDiscriminator("source", to: transformed, basedOn: associatedTypeEnum)
+        }
+
+        return transformed
+    }
+
     override public func format(structName: String) -> String {
         super.format(
             structName: structName
@@ -178,6 +195,36 @@ public class SRCodeDecorator: SwiftCodeDecorator {
         }
 
         return fixedName
+    }
+
+    private func addDiscriminator(
+        _ codingKey: String,
+        to associatedTypeEnum: SwiftAssociatedTypeEnum,
+        basedOn originalAssociatedTypeEnum: SwiftAssociatedTypeEnum
+    ) -> SwiftAssociatedTypeEnum {
+        var associatedTypeEnum = associatedTypeEnum
+        associatedTypeEnum.discriminatorCodingKey = codingKey
+        associatedTypeEnum.cases = zip(originalAssociatedTypeEnum.cases, associatedTypeEnum.cases).map { originalCase, transformedCase in
+            var transformedCase = transformedCase
+            transformedCase.discriminatorValue = discriminatorValue(for: codingKey, in: originalCase.associatedType)
+            if codingKey == "source", let value = transformedCase.discriminatorValue as? Int {
+                transformedCase.discriminatorValue = Int64(value)
+            }
+            return transformedCase
+        }
+        return associatedTypeEnum
+    }
+
+    private func discriminatorValue(for codingKey: String, in swiftType: SwiftType) -> SwiftPropertyDefaultValue? {
+        guard let `struct` = swiftType as? SwiftStruct else {
+            return nil
+        }
+        return `struct`.properties.first {
+            guard case .static(let value) = $0.codingKey else {
+                return false
+            }
+            return value == codingKey
+        }?.defaultValue
     }
 }
 

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -204,6 +204,8 @@ public class SRCodeDecorator: SwiftCodeDecorator {
     ) -> SwiftAssociatedTypeEnum {
         var associatedTypeEnum = associatedTypeEnum
         associatedTypeEnum.discriminatorCodingKey = codingKey
+        // `super.transform` keeps case order while renaming cases and associated types.
+        // Keep this in mind if the base transformer starts reordering cases.
         associatedTypeEnum.cases = zip(originalAssociatedTypeEnum.cases, associatedTypeEnum.cases).map { originalCase, transformedCase in
             var transformedCase = transformedCase
             transformedCase.discriminatorValue = discriminatorValue(for: codingKey, in: originalCase.associatedType)

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -41,6 +41,21 @@ public class SRCodeDecorator: SwiftCodeDecorator {
                 "SRShapeStyle",
                 "SRTextPosition",
                 "SRTextStyle",
+                // Detach composition tree types to shared, root-level definitions:
+                "SRCompositionTree",
+                "SRCompositionLayer",
+                "SRCompositionLayerChild",
+                "SRCompositionLayerChildType",
+                "SRCompositionLayerModifier",
+                "SRCompositionLayerClipModifier",
+                "SRCompositionLayerOpacityModifier",
+                "SRCompositionLayerColorMatrixModifier",
+                "SRCompositionLayerGaussianBlurModifier",
+                "SRCompositionLayerBrightnessBiasModifier",
+                "SRCompositionLayerSaturateModifier",
+                "SRCompositionLayerBackgroundMaterialModifier",
+                "SRCompositionLayerUpdate",
+                "SRCompositionTreeMutationData",
             ]
         )
     }
@@ -123,6 +138,32 @@ public class SRCodeDecorator: SwiftCodeDecorator {
         }
         if parentWireframe != nil && fixedName == "TextStyle" {
             fixedName = "SRTextStyle"
+        }
+
+        // Detach composition tree types to shared, root-level definitions.
+        let parentCompositionTree = context.predecessorStruct(matching: { $0.name.lowercased() == "compositiontree" })
+        let parentCompositionTreeMutationData = context.predecessorStruct(
+            matching: { $0.name.lowercased() == "compositiontreemutationdata" }
+        )
+        let isNestedInCompositionTree = parentCompositionTree != nil || parentCompositionTreeMutationData != nil
+
+        if parentCompositionTree != nil && (fixedName == "Layers" || fixedName == "Root") {
+            fixedName = "SRCompositionLayer"
+        }
+        if parentCompositionTreeMutationData != nil && (fixedName == "Adds" || fixedName == "Root") {
+            fixedName = "SRCompositionLayer"
+        }
+        if parentCompositionTreeMutationData != nil && fixedName == "Updates" {
+            fixedName = "SRCompositionLayerUpdate"
+        }
+        if isNestedInCompositionTree && fixedName == "Children" {
+            fixedName = "SRCompositionLayerChild"
+        }
+        if isNestedInCompositionTree && fixedName == "ChildrenType" {
+            fixedName = "SRCompositionLayerChildType"
+        }
+        if isNestedInCompositionTree && fixedName == "Modifiers" {
+            fixedName = "SRCompositionLayerModifier"
         }
 
         // Ensure all root types have `SR` prefix:

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/Transformers/Swift/SwiftType.swift
@@ -65,12 +65,14 @@ public struct SwiftAssociatedTypeEnum: SwiftType {
     public struct Case: SwiftType, SwiftPropertyDefaultValue {
         public var label: String
         public var associatedType: SwiftType
+        public var discriminatorValue: SwiftPropertyDefaultValue? = nil
     }
 
     public var name: String
     public var comment: String?
     public var cases: [Case]
     public var conformance: [SwiftProtocol]
+    public var discriminatorCodingKey: String? = nil
 }
 
 public struct SwiftStruct: SwiftType {

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
@@ -393,6 +393,54 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
     }
 
     private func printAssociatedTypeEnum(_ enumeration: SwiftAssociatedTypeEnum) throws {
+        struct DiscriminatorCase {
+            let enumCase: SwiftAssociatedTypeEnum.Case
+            let associatedTypeDeclaration: String
+            let valueLiteral: String
+            let valueType: String
+        }
+
+        func discriminatorValueDeclaration(_ value: SwiftPropertyDefaultValue) throws -> (type: String, literal: String) {
+            switch value {
+            case let stringValue as String:
+                let escaped = stringValue
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "\"", with: "\\\"")
+                return ("String", "\"\(escaped)\"")
+            case let integerValue as Int:
+                return ("Int", "\(integerValue)")
+            case let integerValue as Int64:
+                return ("Int64", "\(integerValue)")
+            default:
+                throw Exception.unimplemented("Discriminator value `\(value)` is not supported")
+            }
+        }
+
+        func discriminatorCases() throws -> [DiscriminatorCase]? {
+            guard let discriminatorCodingKey = enumeration.discriminatorCodingKey else {
+                return nil
+            }
+
+            let cases: [DiscriminatorCase] = try enumeration.cases.map { `case` in
+                let discriminatorValue = try `case`.discriminatorValue.unwrapOrThrow(
+                    .illegal("Missing discriminator value for `\(enumeration.name).\(`case`.label)` using `\(discriminatorCodingKey)`")
+                )
+                let valueDeclaration = try discriminatorValueDeclaration(discriminatorValue)
+                return try DiscriminatorCase(
+                    enumCase: `case`,
+                    associatedTypeDeclaration: typeDeclaration(`case`.associatedType),
+                    valueLiteral: valueDeclaration.literal,
+                    valueType: valueDeclaration.type
+                )
+            }
+
+            if let first = cases.first, cases.contains(where: { $0.valueType != first.valueType }) {
+                throw Exception.illegal("Discriminator `\(discriminatorCodingKey)` mixes value types in `\(enumeration.name)`")
+            }
+
+            return cases
+        }
+
         func printEncodingImplemenation() {
             writeLine("\(configuration.accessLevel) func encode(to encoder: Encoder) throws {")
             indentRight()
@@ -413,39 +461,97 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
             writeLine("}")
         }
 
-        func printDecodingImplemenation() throws {
-            writeLine("\(configuration.accessLevel) init(from decoder: Decoder) throws {")
+        func printShapeBasedDecodingImplementation() throws {
+            writeLine("// Decode enum case from associated value")
+            writeLine("let container = try decoder.singleValueContainer()")
+            writeEmptyLine()
+
+            try enumeration.cases.forEach { `case` in
+                writeLine("if let value = try? container.decode(\(try typeDeclaration(`case`.associatedType)).self) {")
+                indentRight()
+                    writeLine("self = .\(`case`.backtickLabel)(value: value)")
+                    writeLine("return")
+                indentLeft()
+                writeLine("}")
+            }
+
+            writeLine("let error = DecodingError.Context(")
             indentRight()
-                writeLine("// Decode enum case from associated value")
-                writeLine("let container = try decoder.singleValueContainer()")
-                writeEmptyLine()
+                writeLine("codingPath: container.codingPath,")
+                writeLine("debugDescription: \"\"\"")
+                writeLine("Failed to decode `\(enumeration.name)`.")
+                writeLine("Ran out of possibilities when trying to decode the value of associated type.")
+                writeLine("\"\"\"")
+            indentLeft()
+            writeLine(")")
+            writeLine("throw DecodingError.typeMismatch(\(enumeration.name).self, error)")
+        }
 
-                try enumeration.cases.forEach { `case` in
-                    writeLine("if let value = try? container.decode(\(try typeDeclaration(`case`.associatedType)).self) {")
-                    indentRight()
-                        writeLine("self = .\(`case`.backtickLabel)(value: value)")
-                        writeLine("return")
-                    indentLeft()
-                    writeLine("}")
-                }
+        func printDiscriminatorBasedDecodingImplementation(cases: [DiscriminatorCase]) throws {
+            let discriminatorCodingKey = try enumeration.discriminatorCodingKey.unwrapOrThrow(
+                .inconsistency("Discriminator cases require a discriminator coding key")
+            )
+            let valueType = try (cases.first?.valueType).unwrapOrThrow(
+                .illegal("Discriminator `\(discriminatorCodingKey)` in `\(enumeration.name)` has no cases")
+            )
 
+            writeLine("// Decode enum case from discriminator")
+            writeLine("let container = try decoder.singleValueContainer()")
+            writeLine("let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)")
+            writeEmptyLine()
+            writeLine("switch try discriminatorContainer.decode(\(valueType).self, forKey: .discriminator) {")
+            cases.forEach { `case` in
+                let decodedValue = "try container.decode(\(`case`.associatedTypeDeclaration).self)"
+                writeLine("case \(`case`.valueLiteral):")
+                indentRight()
+                    writeLine("self = .\(`case`.enumCase.backtickLabel)(value: \(decodedValue))")
+                    writeLine("return")
+                indentLeft()
+            }
+            writeLine("default:")
+            indentRight()
                 writeLine("let error = DecodingError.Context(")
                 indentRight()
-                    writeLine("codingPath: container.codingPath,")
+                    writeLine("codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],")
                     writeLine("debugDescription: \"\"\"")
                     writeLine("Failed to decode `\(enumeration.name)`.")
-                    writeLine("Ran out of possibilities when trying to decode the value of associated type.")
+                    writeLine("Discriminator `\(discriminatorCodingKey)` did not match any known case.")
                     writeLine("\"\"\"")
                 indentLeft()
                 writeLine(")")
-                writeLine("throw DecodingError.typeMismatch(\(enumeration.name).self, error)")
+                writeLine("throw DecodingError.dataCorrupted(error)")
+            indentLeft()
+            writeLine("}")
+        }
 
+        func printDecodingImplemenation(discriminatorCases: [DiscriminatorCase]?) throws {
+            writeLine("\(configuration.accessLevel) init(from decoder: Decoder) throws {")
+            indentRight()
+                if let discriminatorCases {
+                    try printDiscriminatorBasedDecodingImplementation(cases: discriminatorCases)
+                } else {
+                    try printShapeBasedDecodingImplementation()
+                }
+            indentLeft()
+            writeLine("}")
+        }
+
+        func printDiscriminatorCodingKeys() throws {
+            guard let discriminatorCodingKey = enumeration.discriminatorCodingKey else {
+                return
+            }
+
+            writeEmptyLine()
+            writeLine("private enum DiscriminatorCodingKeys: String, CodingKey {")
+            indentRight()
+                writeLine("case discriminator = \"\(discriminatorCodingKey)\"")
             indentLeft()
             writeLine("}")
         }
 
         let implementedProtocols = enumeration.conformance.map { $0.name }
         let conformance = implementedProtocols.isEmpty ? "" : ": \(implementedProtocols.joined(separator: ", "))"
+        let discriminatorCases = try discriminatorCases()
 
         printComment(enumeration.comment)
         if let attribute = configuration.accessLevel.attribute {
@@ -458,13 +564,17 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
             writeLine("case \(`case`.backtickLabel)(value: \(associatedTypeDeclaration))")
         }
 
+        if discriminatorCases != nil {
+            try printDiscriminatorCodingKeys()
+        }
+
         if enumeration.conforms(to: codableProtocol) {
             writeEmptyLine()
             writeLine("// MARK: - Codable")
             writeEmptyLine()
             printEncodingImplemenation()
             writeEmptyLine()
-            try printDecodingImplemenation()
+            try printDecodingImplemenation(discriminatorCases: discriminatorCases)
         }
 
         try printNestedTypes(in: enumeration)

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
@@ -657,6 +657,83 @@ final class SwiftPrinterTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
+    func testPrintingSwiftAssociatedTypeEnumWithDiscriminator() throws {
+        let enumeration = SwiftAssociatedTypeEnum(
+            name: "Modifier",
+            comment: nil,
+            cases: [
+                SwiftAssociatedTypeEnum.Case(
+                    label: "opacityModifier",
+                    associatedType: SwiftTypeReference(referencedTypeName: "OpacityModifier"),
+                    discriminatorValue: "opacity"
+                ),
+                SwiftAssociatedTypeEnum.Case(
+                    label: "saturateModifier",
+                    associatedType: SwiftTypeReference(referencedTypeName: "SaturateModifier"),
+                    discriminatorValue: "saturate"
+                )
+            ],
+            conformance: [codableProtocol],
+            discriminatorCodingKey: "type"
+        )
+
+        let printer = SwiftPrinter()
+        let actual = try printer.print(swiftTypes: [enumeration])
+
+        let expected = """
+
+        public enum Modifier: Codable {
+            case opacityModifier(value: OpacityModifier)
+            case saturateModifier(value: SaturateModifier)
+
+            private enum DiscriminatorCodingKeys: String, CodingKey {
+                case discriminator = "type"
+            }
+
+            // MARK: - Codable
+
+            public func encode(to encoder: Encoder) throws {
+                // Encode only the associated value, without encoding enum case
+                var container = encoder.singleValueContainer()
+
+                switch self {
+                case .opacityModifier(let value):
+                    try container.encode(value)
+                case .saturateModifier(let value):
+                    try container.encode(value)
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                // Decode enum case from discriminator
+                let container = try decoder.singleValueContainer()
+                let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
+
+                switch try discriminatorContainer.decode(String.self, forKey: .discriminator) {
+                case "opacity":
+                    self = .opacityModifier(value: try container.decode(OpacityModifier.self))
+                    return
+                case "saturate":
+                    self = .saturateModifier(value: try container.decode(SaturateModifier.self))
+                    return
+                default:
+                    let error = DecodingError.Context(
+                        codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],
+                        debugDescription: \"\"\"
+                        Failed to decode `Modifier`.
+                        Discriminator `type` did not match any known case.
+                        \"\"\"
+                    )
+                    throw DecodingError.dataCorrupted(error)
+                }
+            }
+        }
+
+        """
+
+        XCTAssertEqual(expected, actual)
+    }
+
     func testPrintingSwiftStructAndEnumWithAttribute() throws {
         let `struct` = SwiftStruct(
             name: "Foo",

--- a/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
@@ -1,0 +1,189 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import CodeGeneration
+@testable import CodeDecoration
+
+final class SRCodeDecoratorTests: XCTestCase {
+    func testDecoratingCompositionTreeSharedTypes() throws {
+        let fullSnapshotRecord = SwiftStruct(
+            name: "MobileFullSnapshotRecord",
+            comment: nil,
+            properties: [
+                Self.property(
+                    named: "data",
+                    type: SwiftStruct(
+                        name: "data",
+                        comment: nil,
+                        properties: [
+                            Self.property(
+                                named: "compositionTree",
+                                type: SwiftStruct(
+                                    name: "compositionTree",
+                                    comment: nil,
+                                    properties: [
+                                        Self.property(
+                                            named: "layers",
+                                            type: SwiftArray(element: Self.compositionLayer(named: "layers")),
+                                            isOptional: true
+                                        ),
+                                        Self.property(named: "root", type: Self.compositionLayer(named: "root"))
+                                    ],
+                                    conformance: []
+                                ),
+                                isOptional: true
+                            )
+                        ],
+                        conformance: []
+                    )
+                )
+            ],
+            conformance: []
+        )
+        let incrementalSnapshotRecord = SwiftStruct(
+            name: "MobileIncrementalSnapshotRecord",
+            comment: nil,
+            properties: [
+                Self.property(
+                    named: "data",
+                    type: SwiftAssociatedTypeEnum(
+                        name: "data",
+                        comment: nil,
+                        cases: [
+                            SwiftAssociatedTypeEnum.Case(
+                                label: "CompositionTreeMutationData",
+                                associatedType: SwiftStruct(
+                                    name: "CompositionTreeMutationData",
+                                    comment: nil,
+                                    properties: [
+                                        Self.property(
+                                            named: "adds",
+                                            type: SwiftArray(element: Self.compositionLayer(named: "adds")),
+                                            isOptional: true
+                                        ),
+                                        Self.property(named: "root", type: Self.compositionLayer(named: "root"), isOptional: true),
+                                        Self.property(
+                                            named: "updates",
+                                            type: SwiftArray(element: Self.compositionLayerUpdate(named: "updates")),
+                                            isOptional: true
+                                        )
+                                    ],
+                                    conformance: []
+                                )
+                            )
+                        ],
+                        conformance: []
+                    )
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try SRCodeDecorator()
+            .decorate(code: GeneratedCode(swiftTypes: [fullSnapshotRecord, incrementalSnapshotRecord]))
+
+        let typeNames = actual.swiftTypes.compactMap { $0.typeName }
+        XCTAssertTrue(typeNames.contains("SRCompositionTree"))
+        XCTAssertTrue(typeNames.contains("SRCompositionLayer"))
+        XCTAssertTrue(typeNames.contains("SRCompositionLayerChild"))
+        XCTAssertTrue(typeNames.contains("SRCompositionLayerModifier"))
+        XCTAssertTrue(typeNames.contains("SRCompositionLayerUpdate"))
+        XCTAssertTrue(typeNames.contains("SRCompositionTreeMutationData"))
+        XCTAssertFalse(typeNames.contains("Layers"))
+        XCTAssertFalse(typeNames.contains("Root"))
+        XCTAssertFalse(typeNames.contains("Adds"))
+        XCTAssertFalse(typeNames.contains("Updates"))
+
+        let compositionTree = try XCTUnwrap(actual.swiftTypes.first { $0.typeName == "SRCompositionTree" } as? SwiftStruct)
+        let layers: SwiftStruct.Property = try XCTUnwrap(compositionTree.properties.first { $0.name == "layers" })
+        XCTAssertEqual("SRCompositionLayer", ((layers.type as? SwiftArray)?.element as? SwiftTypeReference)?.referencedTypeName)
+
+        let root: SwiftStruct.Property = try XCTUnwrap(compositionTree.properties.first { $0.name == "root" })
+        XCTAssertEqual("SRCompositionLayer", (root.type as? SwiftTypeReference)?.referencedTypeName)
+
+        let mutationData = try XCTUnwrap(actual.swiftTypes.first { $0.typeName == "SRCompositionTreeMutationData" } as? SwiftStruct)
+        let adds: SwiftStruct.Property = try XCTUnwrap(mutationData.properties.first { $0.name == "adds" })
+        XCTAssertEqual("SRCompositionLayer", ((adds.type as? SwiftArray)?.element as? SwiftTypeReference)?.referencedTypeName)
+
+        let mutationRoot: SwiftStruct.Property = try XCTUnwrap(mutationData.properties.first { $0.name == "root" })
+        XCTAssertEqual("SRCompositionLayer", (mutationRoot.type as? SwiftTypeReference)?.referencedTypeName)
+
+        let updates: SwiftStruct.Property = try XCTUnwrap(mutationData.properties.first { $0.name == "updates" })
+        XCTAssertEqual("SRCompositionLayerUpdate", ((updates.type as? SwiftArray)?.element as? SwiftTypeReference)?.referencedTypeName)
+    }
+
+    private static func property(
+        named name: String,
+        type: SwiftType,
+        isOptional: Bool = false
+    ) -> SwiftStruct.Property {
+        SwiftStruct.Property(
+            name: name,
+            comment: nil,
+            type: type,
+            isOptional: isOptional,
+            mutability: .immutable,
+            defaultValue: nil,
+            codingKey: .static(value: name)
+        )
+    }
+
+    private static func compositionLayer(named name: String) -> SwiftStruct {
+        SwiftStruct(
+            name: name,
+            comment: nil,
+            properties: [
+                property(named: "children", type: SwiftArray(element: compositionLayerChild(named: "children"))),
+                property(named: "compositeOperation", type: compositeOperation(named: "compositeOperation"), isOptional: true),
+                property(named: "modifiers", type: SwiftArray(element: compositionLayerModifier(named: "modifiers")), isOptional: true)
+            ],
+            conformance: []
+        )
+    }
+
+    private static func compositionLayerUpdate(named name: String) -> SwiftStruct {
+        SwiftStruct(
+            name: name,
+            comment: nil,
+            properties: [
+                property(named: "children", type: SwiftArray(element: compositionLayerChild(named: "children")), isOptional: true),
+                property(named: "compositeOperation", type: compositeOperation(named: "compositeOperation"), isOptional: true),
+                property(named: "modifiers", type: SwiftArray(element: compositionLayerModifier(named: "modifiers")), isOptional: true)
+            ],
+            conformance: []
+        )
+    }
+
+    private static func compositionLayerChild(named name: String) -> SwiftStruct {
+        SwiftStruct(
+            name: name,
+            comment: nil,
+            properties: [
+                property(named: "type", type: SwiftEnum(name: "type", comment: nil, cases: [], conformance: []))
+            ],
+            conformance: []
+        )
+    }
+
+    private static func compositionLayerModifier(named name: String) -> SwiftAssociatedTypeEnum {
+        SwiftAssociatedTypeEnum(
+            name: name,
+            comment: nil,
+            cases: [
+                SwiftAssociatedTypeEnum.Case(
+                    label: "CompositionLayerClipModifier",
+                    associatedType: SwiftStruct(name: "CompositionLayerClipModifier", comment: nil, properties: [], conformance: [])
+                )
+            ],
+            conformance: []
+        )
+    }
+
+    private static func compositeOperation(named name: String) -> SwiftEnum {
+        SwiftEnum(name: name, comment: nil, cases: [], conformance: [])
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
@@ -67,6 +67,11 @@ final class SRCodeDecoratorTests: XCTestCase {
                                         ),
                                         Self.property(named: "root", type: Self.compositionLayer(named: "root"), isOptional: true),
                                         Self.property(
+                                            named: "source",
+                                            type: SwiftPrimitive<Int>(),
+                                            defaultValue: 10
+                                        ),
+                                        Self.property(
                                             named: "updates",
                                             type: SwiftArray(element: Self.compositionLayerUpdate(named: "updates")),
                                             isOptional: true
@@ -114,12 +119,26 @@ final class SRCodeDecoratorTests: XCTestCase {
 
         let updates: SwiftStruct.Property = try XCTUnwrap(mutationData.properties.first { $0.name == "updates" })
         XCTAssertEqual("SRCompositionLayerUpdate", ((updates.type as? SwiftArray)?.element as? SwiftTypeReference)?.referencedTypeName)
+
+        let transformedIncrementalSnapshotRecord = try XCTUnwrap(
+            actual.swiftTypes.first { $0.typeName == "SRIncrementalSnapshotRecord" } as? SwiftStruct
+        )
+        let incrementalData = try XCTUnwrap(
+            transformedIncrementalSnapshotRecord.properties.first { $0.name == "data" }?.type as? SwiftAssociatedTypeEnum
+        )
+        XCTAssertEqual("source", incrementalData.discriminatorCodingKey)
+        XCTAssertEqual(Int64(10), incrementalData.cases.first?.discriminatorValue as? Int64)
+
+        let modifier = try XCTUnwrap(actual.swiftTypes.first { $0.typeName == "SRCompositionLayerModifier" } as? SwiftAssociatedTypeEnum)
+        XCTAssertEqual("type", modifier.discriminatorCodingKey)
+        XCTAssertEqual("clip", modifier.cases.first?.discriminatorValue as? String)
     }
 
     private static func property(
         named name: String,
         type: SwiftType,
-        isOptional: Bool = false
+        isOptional: Bool = false,
+        defaultValue: SwiftPropertyDefaultValue? = nil
     ) -> SwiftStruct.Property {
         SwiftStruct.Property(
             name: name,
@@ -127,7 +146,7 @@ final class SRCodeDecoratorTests: XCTestCase {
             type: type,
             isOptional: isOptional,
             mutability: .immutable,
-            defaultValue: nil,
+            defaultValue: defaultValue,
             codingKey: .static(value: name)
         )
     }
@@ -176,7 +195,18 @@ final class SRCodeDecoratorTests: XCTestCase {
             cases: [
                 SwiftAssociatedTypeEnum.Case(
                     label: "CompositionLayerClipModifier",
-                    associatedType: SwiftStruct(name: "CompositionLayerClipModifier", comment: nil, properties: [], conformance: [])
+                    associatedType: SwiftStruct(
+                        name: "CompositionLayerClipModifier",
+                        comment: nil,
+                        properties: [
+                            property(
+                                named: "type",
+                                type: SwiftPrimitive<String>(),
+                                defaultValue: "clip"
+                            )
+                        ],
+                        conformance: []
+                    )
                 )
             ],
             conformance: []


### PR DESCRIPTION
### What and why?

This PR updates the generated Session Replay models with the schema changes from [DataDog/rum-events-format#390](https://github.com/DataDog/rum-events-format/pull/390).

These models add the composition tree payloads needed by the Core Animation recording pipeline. This is schema/model work only; it does not change runtime capture behavior.

Related RFCs (internal):
- [Core Animation recording pipeline](https://datadoghq.atlassian.net/wiki/x/v4AXjAE)
- [Session Replay schema changes](https://datadoghq.atlassian.net/wiki/x/tIVXkQE)

### How?

- Regenerated `SRDataModels.swift`.
- Added generator decoration so composition tree types use stable SDK names like `SRCompositionTree`, `SRCompositionLayer`, and `SRCompositionLayerModifier`.
- Added opt-in discriminator decoding for generated SR unions that need it:
  - `SRCompositionLayerModifier` uses `type`.
  - `SRIncrementalSnapshotRecord.Data` uses `source`.
- Kept existing generated union decoding behavior unchanged unless a discriminator is explicitly configured.
- Added generator tests for the new Session Replay type decoration and discriminator decoding output.
- Updated the Swift API surface.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
