### PR TITLE
[PANA-7550] Preserve layer subclass content during occlusion pruning

### DIFF
--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
@@ -5,14 +5,19 @@
  */
 
 #if os(iOS)
-import CoreGraphics
 import Foundation
+import QuartzCore
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// A Boolean value indicating whether the layer draws any content.
     var drawsContent: Bool {
-        observation.ignoreSubtree || contentsClass != nil || hasBackgroundColor || hasBorder || hasVisibleShadow
+        observation.ignoreSubtree
+            || layerClass != CALayer.self
+            || contentsClass != nil
+            || hasBackgroundColor
+            || hasBorder
+            || hasVisibleShadow
     }
 
     /// A Boolean value indicating whether the layer paints its frame as an opaque rectangle.

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotOcclusionTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotOcclusionTests.swift
@@ -75,6 +75,22 @@ struct CALayerSnapshotOcclusionTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Draws content when the layer subclass has unmodeled drawing state")
+    func drawsContentWhenLayerSubclassHasUnmodeledDrawingState() throws {
+        // Given
+        let layer = CAShapeLayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 10, height: 10)
+        layer.path = UIBezierPath(rect: layer.bounds).cgPath
+        layer.fillColor = UIColor.red.cgColor
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+
+        // Then
+        #expect(snapshot.drawsContent)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is an occluder when fully opaque with a solid background")
     func isOccluderWhenFullyOpaqueWithSolidBackground() throws {
         // Given
@@ -309,6 +325,27 @@ struct CALayerSnapshotOcclusionTests {
                 CGRect(x: 0, y: 0, width: 40, height: 40)
             ]
         )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Keeps a layer subclass with unmodeled drawing state")
+    func keepsLayerSubclassWithUnmodeledDrawingState() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let shape = CAShapeLayer()
+        shape.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        shape.path = UIBezierPath(rect: shape.bounds).cgPath
+        shape.fillColor = UIColor.red.cgColor
+        root.addSublayer(shape)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let result = try #require(snapshot.removingOccluded())
+
+        // Then
+        #expect(result.sublayers.map(\.absoluteFrame) == [CGRect(x: 10, y: 10, width: 20, height: 20)])
     }
 
     @available(iOS 13.0, tvOS 13.0, *)


### PR DESCRIPTION
### What and why?

This PR fixes the layer tree optimization step so it does not remove visible Core Animation subclass layers.

SwiftUI can use layer subclasses, such as shape layers, that draw content through subclass-specific state instead of `contents`, background, border, or shadow.

### How?

`CALayerSnapshot.drawsContent` now treats non-`CALayer` subclasses as content-bearing.

This keeps pruning conservative for custom or framework-owned layers, while still allowing empty plain `CALayer` containers to be removed.

Added focused occlusion tests for `CAShapeLayer`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
