### PR TITLE
[PANA-7681] Track dependencies for collapsed layer image snapshots

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		759200102FD2000100000001 /* ImageSnapshotRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7592000F2FD2000100000001 /* ImageSnapshotRequest.swift */; };
 		759200122FD2000100000001 /* ImageSnapshotRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */; };
 		759200142FD2000100000001 /* CALayerChangesetMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200132FD2000100000001 /* CALayerChangesetMock.swift */; };
+		759200162FD2000100000001 /* ImageSnapshotMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759200152FD2000100000001 /* ImageSnapshotMocks.swift */; };
 		770E0BF093842AF7D350E888 /* EvaluationLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC44AD2847746ED69201F65 /* EvaluationLoggingTests.swift */; };
 		86092FDE2DEDC6830075D63B /* AccessibilityValuesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */; };
 		861FD6862DF2EAED00F59823 /* LocaleInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861FD6842DF2EAED00F59823 /* LocaleInfoPublisherTests.swift */; };
@@ -2589,6 +2590,7 @@
 		7592000F2FD2000100000001 /* ImageSnapshotRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotRequest.swift; sourceTree = "<group>"; };
 		759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotRequestTests.swift; sourceTree = "<group>"; };
 		759200132FD2000100000001 /* CALayerChangesetMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerChangesetMock.swift; sourceTree = "<group>"; };
+		759200152FD2000100000001 /* ImageSnapshotMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotMocks.swift; sourceTree = "<group>"; };
 		7C61BC8C730F46F1A8EF112E /* OcclusionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OcclusionMap.swift; sourceTree = "<group>"; };
 		7D0DE1D82F8B4F7FA24BD2C9 /* RecordingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
 		86092FDC2DEDC6830075D63B /* AccessibilityValuesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityValuesMock.swift; sourceTree = "<group>"; };
@@ -3927,6 +3929,7 @@
 				5BF2BC722FC46F4A000E999C /* CALayerSnapshotFilterTests.swift */,
 				759200012FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift */,
 				7592000D2FD2000100000001 /* ImageSnapshotCacheTests.swift */,
+				759200152FD2000100000001 /* ImageSnapshotMocks.swift */,
 				759200112FD2000100000001 /* ImageSnapshotRequestTests.swift */,
 				7592000B2FD2000100000001 /* ImageSnapshotterTests.swift */,
 				AB7890CD1234EF567890ABCD /* CALayerSnapshotOcclusionTests.swift */,
@@ -8444,6 +8447,7 @@
 				EF5678AB9012CD345678EFAB /* CALayerSnapshotOcclusionTests.swift in Sources */,
 				BC9876FA1234CDEF56789ABC /* NSObject+CAFilter.swift in Sources */,
 				7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */,
+				759200162FD2000100000001 /* ImageSnapshotMocks.swift in Sources */,
 				759200122FD2000100000001 /* ImageSnapshotRequestTests.swift in Sources */,
 				7592000C2FD2000100000001 /* ImageSnapshotterTests.swift in Sources */,
 				759200142FD2000100000001 /* CALayerChangesetMock.swift in Sources */,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -40,7 +40,7 @@ extension CALayerSnapshot {
         let request = ImageSnapshotRequest(
             layerSnapshot: self,
             visibleFrame: visibleFrame,
-            hasContentChanges: changeset.hasContentChanges(for: layer),
+            hasChanges: changeset.hasContentChanges(for: layer) || changeset.hasChanges(for: dependencies),
             previousSnapshotData: cache.snapshotData(forReplayID: replayID)
         )
 
@@ -75,7 +75,7 @@ extension ImageSnapshotRequest {
     fileprivate init?(
         layerSnapshot: CALayerSnapshot,
         visibleFrame: CGRect,
-        hasContentChanges: Bool,
+        hasChanges: Bool,
         previousSnapshotData: ImageSnapshotData?
     ) {
         guard layerSnapshot.allowsImageSnapshot else {
@@ -84,7 +84,8 @@ extension ImageSnapshotRequest {
 
         if layerSnapshot.layerClass == CALayer.self,
            layerSnapshot.contentsClass == nil,
-           !hasContentChanges,
+           layerSnapshot.dependencies.isEmpty,
+           !hasChanges,
            previousSnapshotData == nil {
             return nil
         }
@@ -98,7 +99,8 @@ extension ImageSnapshotRequest {
             visibleFrame: visibleFrame,
             isOpaque: layerSnapshot.isOpaque,
             hasContents: layerSnapshot.contentsClass != nil,
-            hasContentChanges: hasContentChanges,
+            dependencies: layerSnapshot.dependencies,
+            hasChanges: hasChanges,
             textAndInputPrivacyLevel: layerSnapshot.textAndInputPrivacyLevel,
             imagePrivacyLevel: layerSnapshot.imagePrivacyLevel,
             previousSnapshotData: previousSnapshotData

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -37,11 +37,16 @@ extension CALayerSnapshot {
             return
         }
 
+        let previousSnapshotData = cache.snapshotData(forReplayID: replayID)
+        let hasChanges = changeset.hasContentChanges(for: layer)
+            || changeset.hasChanges(for: dependencies)
+            || (previousSnapshotData.map { $0.dependencies != dependencies } ?? false)
+
         let request = ImageSnapshotRequest(
             layerSnapshot: self,
             visibleFrame: visibleFrame,
-            hasChanges: changeset.hasContentChanges(for: layer) || changeset.hasChanges(for: dependencies),
-            previousSnapshotData: cache.snapshotData(forReplayID: replayID)
+            hasChanges: hasChanges,
+            previousSnapshotData: previousSnapshotData
         )
 
         if let request, observation.ignoreSublayers || sublayers.isEmpty {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -227,7 +227,8 @@ extension CALayerSnapshot.SemanticObservation {
                     placeholder: textField.placeholder,
                     isSensitiveText: textField.dd.isSensitiveText
                 )
-            )
+            ),
+            ignoreSublayers: true
         )
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -41,6 +41,8 @@ internal struct CALayerSnapshot: Sendable {
     let absoluteFrame: CGRect
 
     var sublayers: [CALayerSnapshot]
+    /// Live descendant layers omitted from `sublayers` but captured when this layer is rendered as an image.
+    let dependencies: [CALayerReference]
     let sublayerTransform: CATransform3D
 
     let mask: CALayerReference?
@@ -115,9 +117,10 @@ extension CALayerSnapshot {
             ? absoluteFrame.intersection(visibleBounds)
             : visibleBounds
 
-        let sublayers = observation.ignoreSublayers || childVisibleBounds.isEmpty
-            ? []
-            : layer.sublayers?.compactMap {
+        let sublayers = if observation.ignoreSublayers || childVisibleBounds.isEmpty {
+            [CALayerSnapshot]()
+        } else {
+            layer.sublayers?.compactMap {
                 CALayerSnapshot(
                     from: $0,
                     rootLayer: rootLayer,
@@ -126,6 +129,19 @@ extension CALayerSnapshot {
                     context: context
                 )
             } ?? []
+        }
+
+        let dependencies = if observation.ignoreSublayers && !childVisibleBounds.isEmpty {
+            layer.sublayers?.flatMap {
+                $0.visibleDependencies(
+                    rootLayer: rootLayer,
+                    visibleBounds: childVisibleBounds
+                )
+                .map(CALayerReference.init)
+            } ?? []
+        } else {
+            [CALayerReference]()
+        }
 
         var cornerRadii = CornerRadii()
 
@@ -157,6 +173,7 @@ extension CALayerSnapshot {
             transform: layer.transform,
             absoluteFrame: absoluteFrame,
             sublayers: sublayers,
+            dependencies: dependencies,
             sublayerTransform: layer.sublayerTransform,
             mask: layer.mask.map(CALayerReference.init),
             masksToBounds: layer.masksToBounds,
@@ -206,6 +223,39 @@ extension CALayerSnapshot {
 extension CALayer {
     @MainActor fileprivate var privacyOverrides: SessionReplayPrivacyOverrides? {
         (delegate as? UIView)?.dd._privacyOverrides
+    }
+
+    @MainActor
+    fileprivate func visibleDependencies(rootLayer: CALayer, visibleBounds: CGRect) -> [CALayer] {
+        guard !isHidden, opacity > 0 else {
+            return []
+        }
+
+        let absoluteFrame = convert(bounds, to: rootLayer)
+
+        guard
+            !(absoluteFrame.isEmpty && masksToBounds),
+            absoluteFrame.intersects(visibleBounds)
+        else {
+            return []
+        }
+
+        let childVisibleBounds = masksToBounds
+            ? absoluteFrame.intersection(visibleBounds)
+            : visibleBounds
+
+        let sublayerDependencies = if childVisibleBounds.isEmpty {
+            [CALayer]()
+        } else {
+            sublayers?.flatMap {
+                $0.visibleDependencies(
+                    rootLayer: rootLayer,
+                    visibleBounds: childVisibleBounds
+                )
+            } ?? []
+        }
+
+        return CollectionOfOne(self) + sublayerDependencies
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshot.swift
@@ -44,6 +44,9 @@ internal struct ImageSnapshotData: Sendable {
 
     /// The source layer bounds captured when the image was rendered.
     let bounds: CGRect
+
+    /// Layer dependencies captured when the image was rendered.
+    let dependencies: [CALayerReference]
 }
 
 /// Failure reason for a layer image snapshot.

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -74,20 +74,20 @@ internal final class ImageSnapshotCache {
         return .init(
             snapshot: snapshot,
             localRect: metadata.localRect,
-            bounds: metadata.bounds
+            bounds: metadata.bounds,
+            dependencies: metadata.dependencies
         )
     }
 
     func setSnapshotData(
         _ snapshotData: ImageSnapshotData,
-        forReplayID replayID: Int64,
-        dependencies: [CALayerReference] = []
+        forReplayID replayID: Int64
     ) {
         imageSnapshots.setObject(snapshotData.snapshot, forKey: replayID as NSNumber)
         metadata[replayID] = .init(
             localRect: snapshotData.localRect,
             bounds: snapshotData.bounds,
-            dependencies: dependencies,
+            dependencies: snapshotData.dependencies,
             lastFrameNumber: frameNumber
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -28,6 +28,7 @@ internal final class ImageSnapshotCache {
     private struct Metadata {
         let localRect: CGRect
         let bounds: CGRect
+        let dependencies: [CALayerReference]
         var lastFrameNumber: UInt64
     }
 
@@ -77,13 +78,35 @@ internal final class ImageSnapshotCache {
         )
     }
 
-    func setSnapshotData(_ snapshotData: ImageSnapshotData, forReplayID replayID: Int64) {
+    func setSnapshotData(
+        _ snapshotData: ImageSnapshotData,
+        forReplayID replayID: Int64,
+        dependencies: [CALayerReference] = []
+    ) {
         imageSnapshots.setObject(snapshotData.snapshot, forKey: replayID as NSNumber)
         metadata[replayID] = .init(
             localRect: snapshotData.localRect,
             bounds: snapshotData.bounds,
+            dependencies: dependencies,
             lastFrameNumber: frameNumber
         )
+    }
+
+    @MainActor
+    func removeSnapshotDataForChanges(in changeset: CALayerChangeset) {
+        var replayIDs = Set<Int64>()
+
+        for change in changeset.contentChanges {
+            if let replayID = change.layer.resolve()?.replayID {
+                replayIDs.insert(replayID)
+            }
+        }
+
+        for (replayID, metadata) in metadata where changeset.hasChanges(for: metadata.dependencies) {
+            replayIDs.insert(replayID)
+        }
+
+        removeSnapshotData(forReplayIDs: replayIDs)
     }
 
     func removeSnapshotData(forReplayID replayID: Int64) {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -21,7 +21,8 @@ internal struct ImageSnapshotRequest: Sendable {
     let visibleFrame: CGRect
     let isOpaque: Bool
     let hasContents: Bool
-    let hasContentChanges: Bool
+    let dependencies: [CALayerReference]
+    let hasChanges: Bool
     let textAndInputPrivacyLevel: TextAndInputPrivacyLevel
     let imagePrivacyLevel: ImagePrivacyLevel
     let previousSnapshotData: ImageSnapshotData?
@@ -35,7 +36,8 @@ internal struct ImageSnapshotRequest: Sendable {
         visibleFrame: CGRect,
         isOpaque: Bool,
         hasContents: Bool,
-        hasContentChanges: Bool,
+        dependencies: [CALayerReference],
+        hasChanges: Bool,
         textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
         imagePrivacyLevel: ImagePrivacyLevel,
         previousSnapshotData: ImageSnapshotData?
@@ -48,7 +50,8 @@ internal struct ImageSnapshotRequest: Sendable {
         self.visibleFrame = visibleFrame
         self.isOpaque = isOpaque
         self.hasContents = hasContents
-        self.hasContentChanges = hasContentChanges
+        self.dependencies = dependencies
+        self.hasChanges = hasChanges
         self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
         self.imagePrivacyLevel = imagePrivacyLevel
         self.previousSnapshotData = previousSnapshotData
@@ -85,21 +88,32 @@ extension ImageSnapshotRequest {
             throw ImageSnapshotRequestResolutionError.invalidRect
         }
 
-        let isNew = previousSnapshotData == nil
-        let lastSnapshotWasPartial = previousSnapshotData.map { !$0.bounds.equalTo($0.localRect) } ?? false
-        let snapshotWillBePartial = bounds.sizeExceeds(rootLayer.bounds)
-        let snapshotRectDidChange = (lastSnapshotWasPartial || snapshotWillBePartial) &&
-            !(previousSnapshotData?.localRect.equalTo(visibleLocalRect) ?? false)
+        let isNewSnapshot = previousSnapshotData == nil
+
+        // Oversized layers are rendered only in their visible area
+        let requiresPartialSnapshot = self.requiresPartialSnapshot(relativeTo: rootLayer)
+
+        // Full snapshots can be moved without re-rendering, but partial snapshots depend on the visible slice
+        let partialSnapshotHasChanges = self.hasPartialSnapshotChanges(
+            visibleLocalRect: visibleLocalRect,
+            requiresPartialSnapshot: requiresPartialSnapshot
+        )
+
+        // Bounds changes invalidate the bitmap coordinate space
         let snapshotBoundsDidChange = previousSnapshotData.map { !$0.bounds.equalTo(bounds) } ?? false
 
-        let needsSnapshot = if layerClass == CALayer.self {
-            (hasContents && isNew) || hasContentChanges || snapshotRectDidChange || snapshotBoundsDidChange
-        } else {
-            isNew || hasContentChanges || snapshotRectDidChange || snapshotBoundsDidChange
-        }
+        // Plain layers need contents or collapsed dependencies to produce pixels on first capture
+        let shouldCaptureInitialSnapshot = layerClass != CALayer.self || hasContents || !dependencies.isEmpty
 
-        let localRect = snapshotWillBePartial ? visibleLocalRect : bounds
-        let frame = snapshotWillBePartial ? visibleFrame : absoluteFrame
+        // Render when there is no reusable snapshot or when tracked inputs changed
+        let needsSnapshot = (isNewSnapshot && shouldCaptureInitialSnapshot) ||
+            hasChanges ||
+            partialSnapshotHasChanges ||
+            snapshotBoundsDidChange
+
+        // Full snapshots capture the layer bounds while partial snapshots capture only the visible slice
+        let localRect = requiresPartialSnapshot ? visibleLocalRect : bounds
+        let frame = requiresPartialSnapshot ? visibleFrame : absoluteFrame
 
         return .init(
             layer: layer,
@@ -108,11 +122,31 @@ extension ImageSnapshotRequest {
             needsSnapshot: needsSnapshot
         )
     }
+
+    private func requiresPartialSnapshot(relativeTo rootLayer: CALayer) -> Bool {
+        bounds.width > rootLayer.bounds.width || bounds.height > rootLayer.bounds.height
+    }
+
+    private func hasPartialSnapshotChanges(
+        visibleLocalRect: CGRect,
+        requiresPartialSnapshot: Bool
+    ) -> Bool {
+        guard previousSnapshotData?.isPartial == true || requiresPartialSnapshot else {
+            return false
+        }
+
+        guard let previousSnapshotData else {
+            return true
+        }
+
+        return !previousSnapshotData.localRect.equalTo(visibleLocalRect)
+    }
 }
 
-extension CGRect {
-    fileprivate func sizeExceeds(_ other: CGRect) -> Bool {
-        width > other.width || height > other.height
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotData {
+    fileprivate var isPartial: Bool {
+        !bounds.equalTo(localRect)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -135,10 +135,10 @@ internal final class ImageSnapshotter: ImageSnapshotting {
                 .init(
                     snapshot: snapshot,
                     localRect: resolvedRequest.localRect,
-                    bounds: request.bounds
+                    bounds: request.bounds,
+                    dependencies: request.dependencies
                 ),
-                forReplayID: request.replayID,
-                dependencies: request.dependencies
+                forReplayID: request.replayID
             )
             return .success(snapshot)
         } catch ImageSnapshotRequestResolutionError.missingLayer {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -54,10 +54,10 @@ internal final class ImageSnapshotter: ImageSnapshotting {
         changeset: CALayerChangeset,
         timeout: TimeInterval
     ) async -> [Int64: ImageSnapshotResult] {
-        // Invalidate content changes before request extraction. Occlusion pruning can
+        // Invalidate changed layers before request extraction. Occlusion pruning can
         // remove changed layers from the snapshot tree, but their cached images must not
         // be reused if they become visible again later.
-        cache.removeSnapshotDataForContentChanges(in: changeset)
+        cache.removeSnapshotDataForChanges(in: changeset)
 
         let requests = root.imageSnapshotRequests(for: changeset, cache: cache)
         cache.updateFrameNumber(for: requests.map(\.replayID))
@@ -93,7 +93,7 @@ internal final class ImageSnapshotter: ImageSnapshotting {
 
         if firstUnprocessedIndex < requests.endIndex {
             for request in requests[firstUnprocessedIndex...] {
-                if request.hasContentChanges {
+                if request.hasChanges {
                     cache.removeSnapshotData(forReplayID: request.replayID)
                 }
                 results[request.replayID] = .failure(.timedOut)
@@ -137,7 +137,8 @@ internal final class ImageSnapshotter: ImageSnapshotting {
                     localRect: resolvedRequest.localRect,
                     bounds: request.bounds
                 ),
-                forReplayID: request.replayID
+                forReplayID: request.replayID,
+                dependencies: request.dependencies
             )
             return .success(snapshot)
         } catch ImageSnapshotRequestResolutionError.missingLayer {
@@ -169,17 +170,6 @@ internal final class ImageSnapshotter: ImageSnapshotting {
                 }
             }
         }
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension ImageSnapshotCache {
-    @MainActor
-    fileprivate func removeSnapshotDataForContentChanges(in changeset: CALayerChangeset) {
-        let contentChangeReplayIDs = changeset.contentChanges.compactMap {
-            $0.layer.resolve()?.replayID
-        }
-        removeSnapshotData(forReplayIDs: contentChangeReplayIDs)
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeset.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerChangeset.swift
@@ -45,6 +45,14 @@ internal struct CALayerChangeset: Sendable, Equatable {
         }
         return aspects.contains(.display) || aspects.contains(.draw)
     }
+
+    func hasChanges(for layer: CALayerReference) -> Bool {
+        aspects(for: layer) != nil
+    }
+
+    func hasChanges<S: Sequence>(for layers: S) -> Bool where S.Element == CALayerReference {
+        layers.contains { hasChanges(for: $0) }
+    }
 }
 
 extension CALayerChangeset: CustomStringConvertible {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -34,7 +34,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.replayID == snapshot.replayID)
         #expect(request.layer == snapshot.layer)
         #expect(request.visibleFrame == snapshot.absoluteFrame)
-        #expect(request.hasContentChanges == false)
+        #expect(request.hasChanges == false)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -54,7 +54,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.count == 1)
         let request = try #require(requests.first)
         #expect(request.layer == snapshot.layer)
-        #expect(request.hasContentChanges)
+        #expect(request.hasChanges)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -246,7 +246,9 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         textView.text = "Hello"
         textView.layer.contents = NSObject()
 
-        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let snapshot = try #require(
+            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
         let cache = ImageSnapshotCache()
 
         // When
@@ -256,6 +258,89 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.count == 1)
         let request = try #require(requests.first)
         #expect(request.layer.matches(textView.layer))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for semantic text layer when ignored sublayer changes")
+    func createsRequestForSemanticTextLayerWhenIgnoredSublayerChanges() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+
+        let ignoredSublayer = CALayer()
+        ignoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        textView.layer.addSublayer(ignoredSublayer)
+
+        let snapshot = try #require(
+            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .display)
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(snapshot.sublayers.isEmpty)
+        #expect(snapshot.dependencies.contains { $0.matches(ignoredSublayer) })
+        #expect(request.layer.matches(textView.layer))
+        #expect(request.dependencies.contains { $0.matches(ignoredSublayer) })
+        #expect(request.hasChanges)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for semantic text layer when ignored sublayer lays out")
+    func createsRequestForSemanticTextLayerWhenIgnoredSublayerLaysOut() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+
+        let ignoredSublayer = CALayer()
+        ignoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        textView.layer.addSublayer(ignoredSublayer)
+
+        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .layout)
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(textView.layer))
+        #expect(request.hasChanges)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Does not mark semantic text layer changed when owner only lays out")
+    func doesNotMarkSemanticTextLayerChangedWhenOwnerOnlyLaysOut() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+        textView.layer.contents = NSObject()
+
+        let snapshot = try #require(
+            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(
+            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot()),
+            forReplayID: snapshot.replayID
+        )
+        let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(textView.layer))
+        #expect(!request.hasChanges)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -65,8 +65,8 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 40)
         let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
 
-        let imageSnapshot = Self.mockImageSnapshot()
-        let snapshotData = Self.mockSnapshotData(snapshot: imageSnapshot)
+        let imageSnapshot = ImageSnapshot.mockAny()
+        let snapshotData = ImageSnapshotData.mockAny(snapshot: imageSnapshot)
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(snapshotData, forReplayID: snapshot.replayID)
 
@@ -339,7 +339,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         )
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
-            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot(), dependencies: previousSnapshot.dependencies),
+            .mockAny(dependencies: previousSnapshot.dependencies),
             forReplayID: snapshot.replayID
         )
         let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
@@ -368,7 +368,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         )
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
-            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot(), dependencies: snapshot.dependencies),
+            .mockAny(dependencies: snapshot.dependencies),
             forReplayID: snapshot.replayID
         )
         let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
@@ -569,26 +569,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.contains { $0.layer.matches(child) })
         #expect(!requests.contains { $0.layer.matches(parent) })
         #expect(!requests.contains { $0.layer.matches(webView.layer) })
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    private static func mockImageSnapshot() -> ImageSnapshot {
-        ImageSnapshot(
-            image: UIImage(),
-            frame: .zero,
-            textAndInputPrivacyLevel: .maskAll,
-            imagePrivacyLevel: .maskAll
-        )
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    private static func mockSnapshotData(
-        snapshot: ImageSnapshot,
-        localRect: CGRect = .zero,
-        bounds: CGRect = .zero,
-        dependencies: [CALayerReference] = []
-    ) -> ImageSnapshotData {
-        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
     }
 
     private final class BundledImageMock: UIImage, @unchecked Sendable {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -316,6 +316,46 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for semantic text layer when ignored sublayer is replaced")
+    func createsRequestForSemanticTextLayerWhenIgnoredSublayerIsReplaced() throws {
+        // Given
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        textView.text = "Hello"
+
+        let previousIgnoredSublayer = CALayer()
+        previousIgnoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        textView.layer.addSublayer(previousIgnoredSublayer)
+        let previousSnapshot = try #require(
+            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+
+        previousIgnoredSublayer.removeFromSuperlayer()
+        let currentIgnoredSublayer = CALayer()
+        currentIgnoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
+        textView.layer.addSublayer(currentIgnoredSublayer)
+
+        let snapshot = try #require(
+            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(
+            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot(), dependencies: previousSnapshot.dependencies),
+            forReplayID: snapshot.replayID
+        )
+        let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(textView.layer))
+        #expect(request.dependencies.contains { $0.matches(currentIgnoredSublayer) })
+        #expect(request.hasChanges)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not mark semantic text layer changed when owner only lays out")
     func doesNotMarkSemanticTextLayerChangedWhenOwnerOnlyLaysOut() throws {
         // Given
@@ -328,7 +368,7 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         )
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
-            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot()),
+            Self.mockSnapshotData(snapshot: Self.mockImageSnapshot(), dependencies: snapshot.dependencies),
             forReplayID: snapshot.replayID
         )
         let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
@@ -545,9 +585,10 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     private static func mockSnapshotData(
         snapshot: ImageSnapshot,
         localRect: CGRect = .zero,
-        bounds: CGRect = .zero
+        bounds: CGRect = .zero,
+        dependencies: [CALayerReference] = []
     ) -> ImageSnapshotData {
-        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
+        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
     }
 
     private final class BundledImageMock: UIImage, @unchecked Sendable {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -203,8 +203,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text field semantics and keeps sublayers")
-    func recordsTextFieldSemanticsAndKeepsSublayers() {
+    @Test("Records text field semantics and ignores sublayers")
+    func recordsTextFieldSemanticsAndIgnoresSublayers() {
         // Given
         let textField = UITextField()
         textField.text = "Value"
@@ -222,7 +222,8 @@ struct CALayerSnapshotSemanticObservationTests {
                     placeholder: "Placeholder",
                     isSensitiveText: true
                 )
-            )
+            ),
+            ignoreSublayers: true
         ))
     }
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -11,6 +11,7 @@ import UIKit
 
 @testable import DatadogSessionReplay
 
+@MainActor
 struct ImageSnapshotCacheTests {
     @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns stored snapshot data")
@@ -61,6 +62,64 @@ struct ImageSnapshotCacheTests {
 
         // Then
         #expect(cache.snapshotData(forReplayID: 1) == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Removes stored snapshot data for direct content changes")
+    func removesStoredSnapshotDataForDirectContentChanges() {
+        // Given
+        let layer = CALayer()
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(.mockAny(), forReplayID: layer.replayID)
+        let changeset = CALayerChangeset.mockChange(for: layer, aspects: .display)
+
+        // When
+        cache.removeSnapshotDataForChanges(in: changeset)
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: layer.replayID) == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Removes stored snapshot data when dependency changes")
+    func removesStoredSnapshotDataWhenDependencyChanges() {
+        // Given
+        let owner = CALayer()
+        let dependency = CALayer()
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(
+            .mockAny(),
+            forReplayID: owner.replayID,
+            dependencies: [.init(dependency)]
+        )
+        let changeset = CALayerChangeset.mockChange(for: dependency, aspects: .layout)
+
+        // When
+        cache.removeSnapshotDataForChanges(in: changeset)
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: owner.replayID) == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Keeps stored snapshot data when owner only lays out")
+    func keepsStoredSnapshotDataWhenOwnerOnlyLaysOut() {
+        // Given
+        let owner = CALayer()
+        let dependency = CALayer()
+        let cache = ImageSnapshotCache()
+        cache.setSnapshotData(
+            .mockAny(),
+            forReplayID: owner.replayID,
+            dependencies: [.init(dependency)]
+        )
+        let changeset = CALayerChangeset.mockChange(for: owner, aspects: .layout)
+
+        // When
+        cache.removeSnapshotDataForChanges(in: changeset)
+
+        // Then
+        #expect(cache.snapshotData(forReplayID: owner.replayID) != nil)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -5,7 +5,6 @@
  */
 
 #if os(iOS)
-import DatadogInternal
 import Testing
 import UIKit
 
@@ -150,27 +149,4 @@ struct ImageSnapshotCacheTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
-extension ImageSnapshot {
-    fileprivate static func mockAny() -> ImageSnapshot {
-        ImageSnapshot(
-            image: UIImage(),
-            frame: .zero,
-            textAndInputPrivacyLevel: .maskAll,
-            imagePrivacyLevel: .maskAll
-        )
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension ImageSnapshotData {
-    fileprivate static func mockAny(
-        snapshot: ImageSnapshot = .mockAny(),
-        localRect: CGRect = .zero,
-        bounds: CGRect = .zero,
-        dependencies: [CALayerReference] = []
-    ) -> ImageSnapshotData {
-        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
-    }
-}
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -33,6 +33,7 @@ struct ImageSnapshotCacheTests {
         #expect(cachedSnapshotData.snapshot === snapshot)
         #expect(cachedSnapshotData.localRect == snapshotData.localRect)
         #expect(cachedSnapshotData.bounds == snapshotData.bounds)
+        #expect(cachedSnapshotData.dependencies == snapshotData.dependencies)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -88,9 +89,8 @@ struct ImageSnapshotCacheTests {
         let dependency = CALayer()
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
-            .mockAny(),
-            forReplayID: owner.replayID,
-            dependencies: [.init(dependency)]
+            .mockAny(dependencies: [.init(dependency)]),
+            forReplayID: owner.replayID
         )
         let changeset = CALayerChangeset.mockChange(for: dependency, aspects: .layout)
 
@@ -109,9 +109,8 @@ struct ImageSnapshotCacheTests {
         let dependency = CALayer()
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
-            .mockAny(),
-            forReplayID: owner.replayID,
-            dependencies: [.init(dependency)]
+            .mockAny(dependencies: [.init(dependency)]),
+            forReplayID: owner.replayID
         )
         let changeset = CALayerChangeset.mockChange(for: owner, aspects: .layout)
 
@@ -168,9 +167,10 @@ extension ImageSnapshotData {
     fileprivate static func mockAny(
         snapshot: ImageSnapshot = .mockAny(),
         localRect: CGRect = .zero,
-        bounds: CGRect = .zero
+        bounds: CGRect = .zero,
+        dependencies: [CALayerReference] = []
     ) -> ImageSnapshotData {
-        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds)
+        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import UIKit
+
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshot {
+    static func mockAny() -> ImageSnapshot {
+        ImageSnapshot(
+            image: UIImage(),
+            frame: .zero,
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ImageSnapshotData {
+    static func mockAny(
+        snapshot: ImageSnapshot = .mockAny(),
+        localRect: CGRect = .zero,
+        bounds: CGRect = .zero,
+        dependencies: [CALayerReference] = []
+    ) -> ImageSnapshotData {
+        ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -107,7 +107,7 @@ struct ImageSnapshotRequestTests {
 
         let request = ImageSnapshotRequest.mockAny(
             layer: layer,
-            hasContentChanges: true,
+            hasChanges: true,
             previousSnapshotData: .mockAny(localRect: layer.bounds, bounds: layer.bounds)
         )
 
@@ -285,7 +285,8 @@ extension ImageSnapshotRequest {
         layer: CALayer,
         visibleFrame: CGRect? = nil,
         hasContents: Bool = false,
-        hasContentChanges: Bool = false,
+        dependencies: [CALayerReference] = [],
+        hasChanges: Bool = false,
         previousSnapshotData: ImageSnapshotData? = nil
     ) -> ImageSnapshotRequest {
         ImageSnapshotRequest(
@@ -297,7 +298,8 @@ extension ImageSnapshotRequest {
             visibleFrame: visibleFrame ?? layer.frame,
             isOpaque: layer.isOpaque,
             hasContents: hasContents,
-            hasContentChanges: hasContentChanges,
+            dependencies: dependencies,
+            hasChanges: hasChanges,
             textAndInputPrivacyLevel: .maskAll,
             imagePrivacyLevel: .maskAll,
             previousSnapshotData: previousSnapshotData

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -307,24 +307,4 @@ extension ImageSnapshotRequest {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
-extension ImageSnapshotData {
-    fileprivate static func mockAny(
-        localRect: CGRect,
-        bounds: CGRect,
-        dependencies: [CALayerReference] = []
-    ) -> ImageSnapshotData {
-        ImageSnapshotData(
-            snapshot: ImageSnapshot(
-                image: UIImage(),
-                frame: .zero,
-                textAndInputPrivacyLevel: .maskAll,
-                imagePrivacyLevel: .maskAll
-            ),
-            localRect: localRect,
-            bounds: bounds,
-            dependencies: dependencies
-        )
-    }
-}
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRequestTests.swift
@@ -311,7 +311,8 @@ extension ImageSnapshotRequest {
 extension ImageSnapshotData {
     fileprivate static func mockAny(
         localRect: CGRect,
-        bounds: CGRect
+        bounds: CGRect,
+        dependencies: [CALayerReference] = []
     ) -> ImageSnapshotData {
         ImageSnapshotData(
             snapshot: ImageSnapshot(
@@ -321,7 +322,8 @@ extension ImageSnapshotData {
                 imagePrivacyLevel: .maskAll
             ),
             localRect: localRect,
-            bounds: bounds
+            bounds: bounds,
+            dependencies: dependencies
         )
     }
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -244,6 +244,63 @@ struct ImageSnapshotterTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Invalidates cached image when occluded ignored sublayer changes")
+    func invalidatesCachedImageWhenOccludedIgnoredSublayerChanges() async throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let textView = UITextView(frame: CGRect(x: 10, y: 10, width: 100, height: 40))
+        textView.text = "Hello"
+        textView.layer.contentsScale = 1
+        rootLayer.addSublayer(textView.layer)
+
+        let ignoredSublayer = CALayer()
+        ignoredSublayer.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        ignoredSublayer.backgroundColor = UIColor.red.cgColor
+        textView.layer.addSublayer(ignoredSublayer)
+
+        let snapshotter = ImageSnapshotter()
+        let firstRoot = try #require(
+            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
+        let firstResult = try #require(firstResults[textView.layer.replayID])
+        let firstImageSnapshot = try firstResult.get()
+
+        ignoredSublayer.backgroundColor = UIColor.blue.cgColor
+
+        let occluder = CALayer()
+        occluder.frame = rootLayer.bounds
+        occluder.backgroundColor = UIColor.white.cgColor
+        occluder.zPosition = 1
+        rootLayer.addSublayer(occluder)
+
+        let occludedRootSnapshot = try #require(
+            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let occludedRoot = try #require(occludedRootSnapshot.removingOccluded())
+        let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .display)
+
+        // When
+        let occludedResults = await snapshotter.takeImageSnapshots(for: occludedRoot, changeset: changeset, timeout: 1)
+
+        // Then
+        #expect(!occludedRoot.sublayers.contains { $0.layer.matches(textView.layer) })
+        #expect(occludedResults[textView.layer.replayID] == nil)
+
+        occluder.removeFromSuperlayer()
+
+        let revealedRoot = try #require(
+            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+        )
+        let revealedResults = await snapshotter.takeImageSnapshots(for: revealedRoot, changeset: .init(), timeout: 1)
+        let revealedResult = try #require(revealedResults[textView.layer.replayID])
+        let revealedImageSnapshot = try revealedResult.get()
+        #expect(firstImageSnapshot.image !== revealedImageSnapshot.image)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders full layer image when clipped by ancestor")
     func rendersFullLayerImageWhenClippedByAncestor() async throws {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangesetTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangesetTests.swift
@@ -34,6 +34,30 @@ struct CALayerChangesetTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Display, draw, and layout changes are tracked changes")
+    func hasChanges() {
+        // Given
+        let displayLayer = CALayer()
+        let drawLayer = CALayer()
+        let layoutLayer = CALayer()
+        let unchangedLayer = CALayer()
+
+        let changeset = CALayerChangeset(
+            [
+                ObjectIdentifier(displayLayer): CALayerChange(layer: .init(displayLayer), aspects: .display),
+                ObjectIdentifier(drawLayer): CALayerChange(layer: .init(drawLayer), aspects: .draw),
+                ObjectIdentifier(layoutLayer): CALayerChange(layer: .init(layoutLayer), aspects: .layout)
+            ]
+        )
+
+        // Then
+        #expect(changeset.hasChanges(for: .init(displayLayer)))
+        #expect(changeset.hasChanges(for: .init(drawLayer)))
+        #expect(changeset.hasChanges(for: .init(layoutLayer)))
+        #expect(!changeset.hasChanges(for: .init(unchangedLayer)))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Deallocated layers do not return stale aspects")
     func deallocatedLayerDoesNotReturnStaleAspects() {
         // Given


### PR DESCRIPTION
### What and why?

This PR fixes image snapshot caching for semantic layers that ignore their sublayers.

Some layers, like `UITextView` and `UITextField`, are captured as one parent image snapshot while their sublayers are omitted from the snapshot tree. This PR tracks those omitted live sublayers as dependencies, so changes inside the collapsed subtree invalidate the cached parent image.

This work is part of the new Core Animation recording pipeline and remains behind the internal feature flag.

### How?

- Adds `CALayerSnapshot.dependencies` for visible descendant layers omitted from `sublayers`.
- Uses those dependencies when creating image snapshot requests and invalidating `ImageSnapshotCache`.
- Extends `CALayerChangeset` with helpers for checking any tracked layer change.
- Makes `UITextField` semantics ignore sublayers like `UITextView`.
- Adds focused tests for dependency tracking, cache invalidation, request resolution, and text field semantics.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
