### PR TITLE
[RUM-11641] Speed up api-surface generation and run it on PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,8 +132,10 @@ Lint:
 API Surface Verify:
   stage: lint
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)\/.*/'
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
   script:
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --iOS
     - make clean repo-setup ENV=ci
     - make api-surface-verify
 

--- a/Makefile
+++ b/Makefile
@@ -384,45 +384,28 @@ endif
 # Define the list of Datadog modules for API surface generation
 DATADOG_MODULES := DatadogCore DatadogLogs DatadogTrace DatadogRUM DatadogCrashReporting DatadogWebViewTracking DatadogSessionReplay DatadogFlags DatadogProfiling
 
-# Generate api-surface files for Datadog APIs
+# Generate api-surface files for Datadog APIs.
+# Builds and parses each module once, emitting both the Swift and ObjC surfaces in a single run.
 api-surface:
 	@$(ECHO_TITLE) "make api-surface"
-	@echo "Generating api-surface-swift"
+	@echo "Generating api-surface (swift + objc)"
 	@cd tools/api-surface && \
 		swift run api-surface generate \
 		--path ../../ \
-		--language swift \
 		$(foreach module,$(DATADOG_MODULES),--library-name $(module)) \
-		--output-file ../../$(SWIFT_OUTPUT_PATH)
+		--language swift --output-file ../../$(SWIFT_OUTPUT_PATH) \
+		--language objc --output-file ../../$(OBJC_OUTPUT_PATH)
 
-	@echo "Generating api-surface-objc"
-	@cd tools/api-surface && \
-		swift run api-surface generate \
-		--path ../../ \
-		--language objc \
-		$(foreach module,$(DATADOG_MODULES),--library-name $(module)) \
-		--output-file ../../$(OBJC_OUTPUT_PATH)
-
-# Verify API surface files for Datadog APIs
+# Verify API surface files for Datadog APIs (Swift + ObjC) in a single run.
 api-surface-verify:
 	@$(ECHO_TITLE) "make api-surface-verify"
-	@echo "Verifying api-surface-swift"
+	@echo "Verifying api-surface (swift + objc)"
 	@cd tools/api-surface && \
 		swift run api-surface verify \
 		--path ../../ \
-		--language swift \
 		$(foreach module,$(DATADOG_MODULES),--library-name $(module)) \
-		--output-file /tmp/api-surface-swift-generated \
-		../../api-surface-swift
-
-	@echo "Verifying api-surface-objc"
-	@cd tools/api-surface && \
-		swift run api-surface verify \
-		--path ../../ \
-		--language objc \
-		$(foreach module,$(DATADOG_MODULES),--library-name $(module)) \
-		--output-file /tmp/api-surface-objc-generated \
-		../../api-surface-objc
+		--language swift --output-file /tmp/api-surface-swift-generated --reference-file ../../api-surface-swift \
+		--language objc --output-file /tmp/api-surface-objc-generated --reference-file ../../api-surface-objc
 
 # Verify feature doc files are up to date
 feature-docs-verify:

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -106,7 +106,7 @@ public final class objc_LogsConfiguration: NSObject
     public func setEventMapper(_ mapper: @escaping (objc_LogEvent) -> objc_LogEvent?)
 public final class objc_Logs: NSObject
     public static func enable(with configuration: objc_LogsConfiguration = .init())
-    public static func enable(with configuration: objc_LogsConfiguration,instanceName: String?)
+    public static func enable(with configuration: objc_LogsConfiguration, instanceName: String?)
     public static func addAttribute(forKey key: String, value: Any)
     public static func addAttribute(forKey key: String, value: Any, instanceName: String?)
     public static func removeAttribute(forKey key: String)
@@ -148,7 +148,7 @@ public final class objc_Logger: NSObject
     public func add(tag: String)
     public func remove(tag: String)
     public static func create(with configuration: objc_LoggerConfiguration = .init()) -> objc_Logger
-    public static func create(with configuration: objc_LoggerConfiguration,instanceName: String?) -> objc_Logger
+    public static func create(with configuration: objc_LoggerConfiguration, instanceName: String?) -> objc_Logger
 [?] extension objc_Logger
     public func _internal_sync_critical(message: String,error: Error?,attributes: [String: Any])
 public class objc_LogEvent: NSObject

--- a/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
@@ -65,7 +65,7 @@ public struct APISurface {
 /// This is created inside a `parse-module` child process (one per module, each with its own sourcekitd), which is
 /// the only safe way to parallelize parsing: the in-process SourceKit daemon silently drops results when hit from
 /// multiple threads in the same process.
-struct ParsedAPISurface {
+internal struct ParsedAPISurface {
     private let docs: [SwiftDocs]
 
     /// Reconstructs the module from its name and compiler arguments and parses it. No build is performed here; it
@@ -85,7 +85,7 @@ struct ParsedAPISurface {
 
 /// Holds a temporary patched package workspace used to run `xcodebuild` and
 /// automatically removes it when no longer referenced.
-final class PatchedPackageWorkspace {
+internal final class PatchedPackageWorkspace {
     let path: String
 
     init(originalPath: String) throws {

--- a/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
@@ -62,9 +62,10 @@ public struct APISurface {
 
 /// The parsed SourceKit documentation for a single module, ready to print for any language.
 ///
-/// This is created inside a `parse-module` child process (one per module, each with its own sourcekitd), which is
-/// the only safe way to parallelize parsing: the in-process SourceKit daemon silently drops results when hit from
-/// multiple threads in the same process.
+/// Created inside a `parse-module` child process (one per module). Parsing is isolated per process rather than
+/// parallelized across threads in a single process because, in our own testing, parsing modules concurrently on
+/// multiple threads produced incomplete output: declarations were silently dropped (e.g. the ObjC surface shrank
+/// from 3566 to 1204 lines). A fresh SourceKit state per child process avoids that.
 internal struct ParsedAPISurface {
     private let docs: [SwiftDocs]
 

--- a/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
@@ -11,53 +11,81 @@ public struct APISurfaceError: Error, CustomStringConvertible {
     public let description: String
 }
 
+/// Builds a module interface for an SPM library.
+///
+/// Building is split from parsing so that all modules can be compiled serially into a single, shared derived data
+/// path (so common dependencies such as `DatadogInternal` compile only once and each leaf module compiles once),
+/// keeping the expensive SourceKit parsing as a separate, clearly-bounded step.
 public struct APISurface {
+    /// The name of the SPM library this surface was generated for.
+    public let libraryName: String
     private let module: Module
-    private let language: Language
-    private let patchedPackageWorkspace: PatchedPackageWorkspace
-    private let generator = Generator()
-    private let printer = Printer()
 
     // MARK: - Initialization
 
-    /// Creates API surface for an SPM library.
+    /// Builds the module interface for an SPM library.
+    ///
     /// - Parameters:
     ///   - libraryName: the name of Swift library for generating API surface.
-    ///   - path: the path to a folder containing `Package.swift`.
-    ///   - language: the language of the API surface.
-    public init(spmLibraryName libraryName: String, inPath path: String, language: Language) throws {
-        // Create patch folder:
-        let patchedPackageWorkspace = try PatchedPackageWorkspace(originalPath: path)
-
+    ///   - workspace: the shared, patched package workspace to run `xcodebuild` from.
+    ///   - derivedDataPath: the shared derived data path so `xcodebuild` reuses build artifacts across modules.
+    init(spmLibraryName libraryName: String, workspace: PatchedPackageWorkspace, derivedDataPath: String) throws {
         let module = Module(
             xcodeBuildArguments: [
                 "-scheme", libraryName,
                 "-destination", "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest",
                 "-sdk", "iphonesimulator",
+                "-derivedDataPath", derivedDataPath,
             ],
-            inPath: patchedPackageWorkspace.path
+            inPath: workspace.path
         )
 
         guard let module = module else {
             throw APISurfaceError(description: "Failed to generate module interface with `SourceKittenFramework`.")
         }
 
+        self.libraryName = libraryName
         self.module = module
-        self.language = language
-        self.patchedPackageWorkspace = patchedPackageWorkspace
     }
 
-    // MARK: - Output
+    // MARK: - Parsing inputs
 
-    public func print() throws -> String {
-        let items = try generator.generateSurfaceItems(for: module, language: language)
-        return printer.print(items: items)
+    /// The module name as resolved by `xcodebuild`/SourceKitten (used to reconstruct the module for parsing).
+    var moduleName: String { module.name }
+
+    /// The compiler arguments SourceKit needs to parse this module.
+    ///
+    /// These are captured once from the build above and can be handed to a separate `parse-module` process so the
+    /// expensive SourceKit parsing runs in parallel without rebuilding (each process gets its own sourcekitd).
+    var compilerArguments: [String] { module.compilerArguments }
+}
+
+/// The parsed SourceKit documentation for a single module, ready to print for any language.
+///
+/// This is created inside a `parse-module` child process (one per module, each with its own sourcekitd), which is
+/// the only safe way to parallelize parsing: the in-process SourceKit daemon silently drops results when hit from
+/// multiple threads in the same process.
+struct ParsedAPISurface {
+    private let docs: [SwiftDocs]
+
+    /// Reconstructs the module from its name and compiler arguments and parses it. No build is performed here; it
+    /// relies on the build artifacts already produced into the shared derived data path by the parent process.
+    init(moduleName: String, compilerArguments: [String]) {
+        let module = Module(name: moduleName, compilerArguments: compilerArguments)
+        self.docs = module.docs
+    }
+
+    /// Prints the API surface for the given language from the already-parsed module documentation.
+    func print(language: Language) throws -> String {
+        // A fresh `Generator` per call keeps this method free of shared mutable state.
+        let items = try Generator().generateSurfaceItems(docs: docs, language: language)
+        return Printer().print(items: items)
     }
 }
 
 /// Holds a temporary patched package workspace used to run `xcodebuild` and
 /// automatically removes it when no longer referenced.
-private final class PatchedPackageWorkspace {
+final class PatchedPackageWorkspace {
     let path: String
 
     init(originalPath: String) throws {

--- a/tools/api-surface/Sources/APISurfaceCore/Commands.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Commands.swift
@@ -135,7 +135,7 @@ public struct VerifyCommand: ParsableCommand {
 }
 
 /// A single output to produce: a language paired with the file it should be written to.
-struct APISurfaceOutput {
+internal struct APISurfaceOutput {
     let language: Language
     let outputFile: String
 }
@@ -264,7 +264,9 @@ private func parseModulesInParallel(
     languages: [Language],
     executablePath: String
 ) throws -> [[Language: String]] {
-    guard !surfaces.isEmpty else { return [] }
+    guard !surfaces.isEmpty else {
+        return []
+    }
 
     let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("com.datadoghq.api-surface-parse-\(UUID().uuidString)", isDirectory: true)

--- a/tools/api-surface/Sources/APISurfaceCore/Commands.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Commands.swift
@@ -8,6 +8,46 @@ import Foundation
 import ArgumentParser
 import SourceKittenFramework
 
+/// Internal worker command: parses a single, already-built module and writes its surface body per language.
+///
+/// `generate` fans out one of these per module so that parsing runs in parallel across processes (each with its own
+/// sourcekitd). It is not meant to be called directly; it relies on build artifacts produced by the parent process.
+public struct ParseModuleCommand: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "parse-module",
+        abstract: "Parse a single pre-built module and write its API surface body per language.",
+        shouldDisplay: false
+    )
+
+    @Option(help: "The module name to parse.")
+    var name: String
+
+    @Option(help: "Path to a JSON file containing the module's compiler arguments.")
+    var compilerArgsFile: String
+
+    @Option(help: "The file to which the parsed surface body should be written (paired with `--language`).")
+    var outputFile: [String]
+
+    @Option(help: "The language of the surface body to print (paired with `--output-file`).")
+    var language: [Language]
+
+    public init() {}
+
+    public func run() throws {
+        let outputs = try zipLanguagesAndFiles(languages: language, outputFiles: outputFile)
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: compilerArgsFile))
+        let compilerArguments = try JSONDecoder().decode([String].self, from: data)
+
+        let parsed = ParsedAPISurface(moduleName: name, compilerArguments: compilerArguments)
+
+        for output in outputs {
+            let body = try parsed.print(language: output.language)
+            try body.write(toFile: output.outputFile, atomically: true, encoding: .utf8)
+        }
+    }
+}
+
 public struct GenerateCommand: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "generate",
@@ -20,21 +60,17 @@ public struct GenerateCommand: ParsableCommand {
     @Option(help: "The path to the folder containing `Package.swift`.")
     var path: String
 
-    @Option(help: "The file to which the generated API surface should be written.")
-    var outputFile: String
+    @Option(help: "The file to which the generated API surface should be written (use once per language, paired with `--language`).")
+    var outputFile: [String]
 
-    @Option(help: "The language of the API surface to print.")
-    var language: Language
+    @Option(help: "The language of the API surface to print (use once per output file, paired with `--output-file`).")
+    var language: [Language]
 
     public init() {}
 
     public func run() throws {
-        try generateAPISurface(
-            libraryName: libraryName,
-            path: path,
-            outputFile: outputFile,
-            language: language
-        )
+        let outputs = try zipLanguagesAndFiles(languages: language, outputFiles: outputFile)
+        try generateAPISurface(libraryName: libraryName, path: path, outputs: outputs)
     }
 }
 
@@ -50,29 +86,37 @@ public struct VerifyCommand: ParsableCommand {
     @Option(help: "The path to the folder containing `Package.swift`.")
     var path: String
 
-    @Option(help: "The temporary file to which the generated API surface should be written.")
-    var outputFile: String
+    @Option(help: "The temporary file to which the generated API surface should be written (use once per language, paired with `--language`).")
+    var outputFile: [String]
 
-    @Option(help: "The language of the API surface to verify.")
-    var language: Language
+    @Option(help: "The language of the API surface to verify (use once per output file, paired with `--output-file`).")
+    var language: [Language]
 
-    @Argument(help: "Path to the reference API surface file to compare against.")
-    var referencePath: String
+    @Option(help: "Path to the reference API surface file to compare against (use once per language, paired with `--output-file`).")
+    var referenceFile: [String]
 
     public init() {}
 
     public func run() throws {
-        try generateAPISurface(
-            libraryName: libraryName,
-            path: path,
-            outputFile: outputFile,
-            language: language
-        )
+        let outputs = try zipLanguagesAndFiles(languages: language, outputFiles: outputFile)
+
+        guard referenceFile.count == outputs.count else {
+            throw ValidationError("The number of `--reference-file` options must match the number of `--output-file` options.")
+        }
+
+        try generateAPISurface(libraryName: libraryName, path: path, outputs: outputs)
 
         // Compare the generated files with the reference files
-        let diff = try compareFiles(reference: referencePath, generated: outputFile)
+        var hasMismatch = false
+        for (output, reference) in zip(outputs, referenceFile) {
+            let diff = try compareFiles(reference: reference, generated: output.outputFile)
+            if !diff.isEmpty {
+                hasMismatch = true
+                print("❌ API surface mismatch for \(output.language.rawValue): \(reference)")
+            }
+        }
 
-        if !diff.isEmpty {
+        if hasMismatch {
             throw ValidationError("""
                 ❌ API surface mismatch detected!
                 Run `make api-surface` locally to update reference files and commit the changes.
@@ -90,45 +134,241 @@ public struct VerifyCommand: ParsableCommand {
     }
 }
 
+/// A single output to produce: a language paired with the file it should be written to.
+struct APISurfaceOutput {
+    let language: Language
+    let outputFile: String
+}
+
+/// Pairs `--language` options with `--output-file` options by position, validating that the counts match.
+private func zipLanguagesAndFiles(languages: [Language], outputFiles: [String]) throws -> [APISurfaceOutput] {
+    guard languages.count == outputFiles.count else {
+        throw ValidationError("The number of `--language` options must match the number of `--output-file` options.")
+    }
+    guard !languages.isEmpty else {
+        throw ValidationError("At least one `--language` / `--output-file` pair must be provided.")
+    }
+    return zip(languages, outputFiles).map { APISurfaceOutput(language: $0, outputFile: $1) }
+}
+
+/// Builds and parses every library exactly once, then writes the requested language outputs.
+///
+/// The pipeline runs in three phases:
+/// 1. Build every module serially into one shared derived data path (so dependencies compile only once).
+/// 2. Parse each module concurrently, one `parse-module` child process per module (each with its own sourcekitd).
+/// 3. Print every requested language output from the parsed surfaces.
 private func generateAPISurface(
     libraryName: [String],
     path: String,
-    outputFile: String,
-    language: Language
+    outputs: [APISurfaceOutput]
 ) throws {
-    var output = ""
-    var printSeparator = false
+    // Shared workspace and derived data path so common dependencies compile once and are reused across modules.
+    let workspace = try PatchedPackageWorkspace(originalPath: path)
+    let derivedDataPath = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("com.datadoghq.api-surface-dd-\(UUID().uuidString)", isDirectory: true)
+        .path
+    defer { try? FileManager.default.removeItem(atPath: derivedDataPath) }
 
+    // Phase 1 - Build each module serially into the shared derived data path.
+    let buildStart = Date()
+    var surfaces: [APISurface] = []
     for library in libraryName {
         do {
-            let surface = try APISurface(spmLibraryName: library, inPath: path, language: language)
-            if printSeparator {
-                output.append("\n")
-            }
-
-            output.append("""
-            # ----------------------------------
-            # API surface for \(library):
-            # ----------------------------------
-
-            """)
-
-            output.append("\n")
-            output.append(try surface.print() + "\n")
-
-            printSeparator = true
+            let surface = try APISurface(
+                spmLibraryName: library,
+                workspace: workspace,
+                derivedDataPath: derivedDataPath
+            )
+            surfaces.append(surface)
         } catch {
             print("❌ Error generating API surface for library \(library): \(error)")
             throw error
         }
     }
+    logDuration("build", since: buildStart)
 
-    // Write the output to the specified file
-    do {
-        try output.write(toFile: outputFile, atomically: true, encoding: .utf8)
-        print("✅ API surface written to \(outputFile)")
-    } catch {
-        print("❌ Error writing API surface to \(outputFile): \(error)")
-        throw error
+    // Phase 2 - Parse each module (in parallel via child processes when possible).
+    let parseStart = Date()
+    let languages = outputs.map(\.language)
+    let bodiesByModule = try parseModules(surfaces: surfaces, languages: languages)
+    logDuration("parse", since: parseStart)
+
+    // Phase 3 - Print every requested language output from the parsed surfaces.
+    for output in outputs {
+        var content = ""
+        var printSeparator = false
+
+        for (index, surface) in surfaces.enumerated() {
+            if printSeparator {
+                content.append("\n")
+            }
+
+            content.append("""
+            # ----------------------------------
+            # API surface for \(surface.libraryName):
+            # ----------------------------------
+
+            """)
+
+            content.append("\n")
+            content.append((bodiesByModule[index][output.language] ?? "") + "\n")
+
+            printSeparator = true
+        }
+
+        do {
+            try content.write(toFile: output.outputFile, atomically: true, encoding: .utf8)
+            print("✅ API surface written to \(output.outputFile)")
+        } catch {
+            print("❌ Error writing API surface to \(output.outputFile): \(error)")
+            throw error
+        }
     }
+}
+
+/// Parses every built module, returning per module (in input order) a map of language to its printed surface body.
+///
+/// Parsing runs in parallel via one `parse-module` child process per module when the running tool can re-invoke
+/// itself (i.e. when launched as the `api-surface` executable). Otherwise — for example under `swift test`, where the
+/// host executable is the test runner — it falls back to serial, in-process parsing. Serial in-process parsing is the
+/// only safe single-process option: SourceKit's in-process daemon (sourcekitd) silently drops results under
+/// concurrent requests from multiple threads.
+private func parseModules(
+    surfaces: [APISurface],
+    languages: [Language]
+) throws -> [[Language: String]] {
+    if let executablePath = resolvedWorkerExecutablePath() {
+        return try parseModulesInParallel(surfaces: surfaces, languages: languages, executablePath: executablePath)
+    }
+    return try parseModulesSerially(surfaces: surfaces, languages: languages)
+}
+
+/// Serial, in-process fallback for parsing modules (used when child processes can't be spawned, e.g. under tests).
+private func parseModulesSerially(
+    surfaces: [APISurface],
+    languages: [Language]
+) throws -> [[Language: String]] {
+    try surfaces.map { surface in
+        let parsed = ParsedAPISurface(moduleName: surface.moduleName, compilerArguments: surface.compilerArguments)
+        var bodies: [Language: String] = [:]
+        for language in languages where bodies[language] == nil {
+            bodies[language] = try parsed.print(language: language)
+        }
+        return bodies
+    }
+}
+
+/// Parses every built module concurrently, one `parse-module` child process per module.
+private func parseModulesInParallel(
+    surfaces: [APISurface],
+    languages: [Language],
+    executablePath: String
+) throws -> [[Language: String]] {
+    guard !surfaces.isEmpty else { return [] }
+
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("com.datadoghq.api-surface-parse-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    var results = [[Language: String]?](repeating: nil, count: surfaces.count)
+    var firstError: Error?
+    let lock = NSLock()
+    let group = DispatchGroup()
+    let maxConcurrent = max(1, min(surfaces.count, ProcessInfo.processInfo.activeProcessorCount))
+    let semaphore = DispatchSemaphore(value: maxConcurrent)
+    let queue = DispatchQueue(label: "com.datadoghq.api-surface.parse", attributes: .concurrent)
+
+    for (index, surface) in surfaces.enumerated() {
+        semaphore.wait()
+        group.enter()
+        queue.async {
+            defer {
+                semaphore.signal()
+                group.leave()
+            }
+            do {
+                let bodies = try runParseModuleChild(
+                    executablePath: executablePath,
+                    surface: surface,
+                    languages: languages,
+                    tempDir: tempDir,
+                    index: index
+                )
+                lock.lock()
+                results[index] = bodies
+                lock.unlock()
+            } catch {
+                lock.lock()
+                if firstError == nil { firstError = error }
+                lock.unlock()
+            }
+        }
+    }
+
+    group.wait()
+
+    if let firstError = firstError {
+        throw firstError
+    }
+
+    return results.map { $0 ?? [:] }
+}
+
+/// Runs a single `parse-module` child process for one module and returns its printed body per language.
+private func runParseModuleChild(
+    executablePath: String,
+    surface: APISurface,
+    languages: [Language],
+    tempDir: URL,
+    index: Int
+) throws -> [Language: String] {
+    let argsFile = tempDir.appendingPathComponent("args-\(index).json")
+    try JSONEncoder().encode(surface.compilerArguments).write(to: argsFile)
+
+    var arguments = [
+        "parse-module",
+        "--name", surface.moduleName,
+        "--compiler-args-file", argsFile.path,
+    ]
+
+    var outputFiles: [Language: URL] = [:]
+    for language in languages where outputFiles[language] == nil {
+        let outputFile = tempDir.appendingPathComponent("body-\(index)-\(language.rawValue)")
+        outputFiles[language] = outputFile
+        arguments.append(contentsOf: ["--language", language.rawValue, "--output-file", outputFile.path])
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executablePath)
+    process.arguments = arguments
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+        throw APISurfaceError(
+            description: "Parsing module `\(surface.moduleName)` failed (exit code \(process.terminationStatus))."
+        )
+    }
+
+    var bodies: [Language: String] = [:]
+    for (language, outputFile) in outputFiles {
+        bodies[language] = try String(contentsOf: outputFile, encoding: .utf8)
+    }
+    return bodies
+}
+
+/// Resolves the path to the running `api-surface` executable so it can be re-invoked as a `parse-module` child.
+///
+/// Returns `nil` when the host executable is not the tool itself (e.g. the `xctest` runner under `swift test`), in
+/// which case parsing falls back to the serial, in-process path.
+private func resolvedWorkerExecutablePath() -> String? {
+    let path = Bundle.main.executablePath ?? CommandLine.arguments[0]
+    return URL(fileURLWithPath: path).lastPathComponent == "api-surface" ? path : nil
+}
+
+/// Logs a phase duration to stderr, useful for profiling the build vs. parse split in CI.
+private func logDuration(_ label: String, since start: Date) {
+    let seconds = Date().timeIntervalSince(start)
+    fputs(String(format: "⏱ api-surface %@ phase: %.1fs\n", label, seconds), stderr)
 }

--- a/tools/api-surface/Sources/APISurfaceCore/Commands.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Commands.swift
@@ -229,10 +229,11 @@ private func generateAPISurface(
 /// Parses every built module, returning per module (in input order) a map of language to its printed surface body.
 ///
 /// Parsing runs in parallel via one `parse-module` child process per module when the running tool can re-invoke
-/// itself (i.e. when launched as the `api-surface` executable). Otherwise — for example under `swift test`, where the
-/// host executable is the test runner — it falls back to serial, in-process parsing. Serial in-process parsing is the
-/// only safe single-process option: SourceKit's in-process daemon (sourcekitd) silently drops results under
-/// concurrent requests from multiple threads.
+/// itself (i.e. when launched as the `api-surface` executable). Otherwise, for example under `swift test` where the
+/// host executable is the test runner, it falls back to serial, in-process parsing. We use child processes rather
+/// than threads because, in our own testing, parsing modules concurrently on multiple threads in a single process
+/// produced incomplete output (declarations were silently dropped); serial in-process parsing is the safe
+/// single-process fallback.
 private func parseModules(
     surfaces: [APISurface],
     languages: [Language]

--- a/tools/api-surface/Sources/APISurfaceCore/Generator.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Generator.swift
@@ -37,9 +37,9 @@ internal class Generator {
     /// Tracks currently traversed items.
     private var items: [SurfaceItem] = []
 
-    func generateSurfaceItems(for module: Module, language: Language) throws -> [SurfaceItem] {
+    func generateSurfaceItems(docs moduleDocs: [SwiftDocs], language: Language) throws -> [SurfaceItem] {
         items = []
-        for docs in module.docs {
+        for docs in moduleDocs {
             guard let path = docs.file.path,
                   language.shouldParse(path: path) else {
                 continue

--- a/tools/api-surface/Sources/api-surface/main.swift
+++ b/tools/api-surface/Sources/api-surface/main.swift
@@ -12,7 +12,8 @@ private struct RootCommand: ParsableCommand {
         abstract: "A tool to manage API surface files.",
         subcommands: [
             GenerateCommand.self,
-            VerifyCommand.self
+            VerifyCommand.self,
+            ParseModuleCommand.self
         ],
         defaultSubcommand: GenerateCommand.self
     )

--- a/tools/api-surface/Tests/APISurfaceCoreTests/IntegrationTests.swift
+++ b/tools/api-surface/Tests/APISurfaceCoreTests/IntegrationTests.swift
@@ -111,7 +111,7 @@ class IntegrationTests: XCTestCase {
             "--path", fixturesPackageFolder().path,
             "--language", "swift",
             "--output-file", generatedFile,
-            referenceFile
+            "--reference-file", referenceFile
         ])
         try verifyCommand.run()
     }
@@ -149,7 +149,7 @@ class IntegrationTests: XCTestCase {
             "--path", fixturesPackageFolder().path,
             "--language", "swift",
             "--output-file", generatedFile,
-            referenceFile
+            "--reference-file", referenceFile
         ])
 
         XCTAssertThrowsError(try verifyCommand.run()) { error in


### PR DESCRIPTION
### What and why?
`make api-surface` was too slow (~8 min locally, ~3 min in CI) to run on every PR, so it only ran on release branches. As a result the committed API surface references drifted from the actual public API. This makes generation about 5x faster so the check can run on every PR and stay accurate.

### How?
- Build each module once into a shared workspace and derived data path, so shared dependencies (like DatadogInternal) compile only once instead of once per module per language.
- Parse each module once and write both the Swift and ObjC surfaces in a single run, instead of two full passes.
- Parse modules in parallel using one `parse-module` child process per module, each with its own sourcekitd. In-process thread parallelism is unsafe (sourcekitd silently drops results), so it falls back to serial in-process parsing under `swift test`.
- Enable the `API Surface Verify` job on PRs.

Local timing went from 478s to ~95s. Output is byte for byte identical to the previous implementation.

### Review checklist
- [x] Tests updated (api-surface tool integration tests)
- [x] PR mentions the JIRA reference (RUM-11641)
- [ ] CHANGELOG entry: N/A, tooling and CI only
- [ ] Objective-C interface: N/A
- [x] Ran make api-surface-verify (passes)