### PR TITLE
[PANA-7699] Simplify Core Animation layer semantics

### DIFF
--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -68,9 +68,7 @@ extension CALayerSnapshot {
             return false
         }
 
-        return observation.allowsImageSnapshot(
-            imagePrivacyLevel: imagePrivacyLevel
-        )
+        return observation.allowsImageSnapshot(imagePrivacyLevel: imagePrivacyLevel)
     }
 }
 
@@ -114,9 +112,7 @@ extension ImageSnapshotRequest {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
-    fileprivate func allowsImageSnapshot(
-        imagePrivacyLevel: ImagePrivacyLevel
-    ) -> Bool {
+    fileprivate func allowsImageSnapshot(imagePrivacyLevel: ImagePrivacyLevel) -> Bool {
         switch semantics {
         case .image where imagePrivacyLevel == .maskNone:
             return true

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -69,7 +69,6 @@ extension CALayerSnapshot {
         }
 
         return observation.allowsImageSnapshot(
-            textAndInputPrivacyLevel: textAndInputPrivacyLevel,
             imagePrivacyLevel: imagePrivacyLevel
         )
     }
@@ -116,7 +115,6 @@ extension ImageSnapshotRequest {
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     fileprivate func allowsImageSnapshot(
-        textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
         imagePrivacyLevel: ImagePrivacyLevel
     ) -> Bool {
         switch semantics {
@@ -124,11 +122,7 @@ extension CALayerSnapshot.SemanticObservation {
             return true
         case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isContextual:
             return true
-        case .text(let text) where textAndInputPrivacyLevel == .maskSensitiveInputs && !text.isSensitiveText:
-            return true
-        case .textField(let textField) where textAndInputPrivacyLevel == .maskSensitiveInputs && !textField.isSensitiveText:
-            return true
-        case .layer, .activityIndicator, .progress, .stepper, .switchControl:
+        case .layer, .activityIndicator, .stepper, .switchControl:
             return true
         default:
             return false

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -50,10 +50,6 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(label: label)
         case let imageView as UIImageView:
             self.init(imageView: imageView)
-        case _ as UIProgressView:
-            self.init(semantics: .layer, ignoresImagePrivacy: true)
-        case _ as UISlider:
-            self.init(semantics: .layer, ignoresImagePrivacy: true)
         case let stepper as UIStepper:
             self.init(stepper: stepper)
         case let textView as UITextView:
@@ -67,6 +63,10 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(webView: webView)
         default:
             self.init(semantics: .layer)
+        }
+
+        if layer.delegate is UIControl || layer.delegate is UIProgressView {
+            ignoresImagePrivacy = true
         }
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -18,6 +18,9 @@ extension CALayerSnapshot {
 
         /// When `true`, the semantic payload owns how this layer is represented and sublayers are not captured.
         var ignoreSublayers: Bool = false
+
+        /// When `true`, image privacy does not apply to image snapshots captured from this layer or its sublayers.
+        var ignoresImagePrivacy: Bool = false
     }
 }
 
@@ -47,6 +50,10 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(label: label)
         case let imageView as UIImageView:
             self.init(imageView: imageView)
+        case _ as UIProgressView:
+            self.init(semantics: .layer, ignoresImagePrivacy: true)
+        case _ as UISlider:
+            self.init(semantics: .layer, ignoresImagePrivacy: true)
         case let stepper as UIStepper:
             self.init(stepper: stepper)
         case let textView as UITextView:

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -181,7 +181,7 @@ extension CALayerSnapshot.SemanticObservation {
                 .init(
                     isSensitiveText: textView.dd.isSensitiveText,
                     isEditable: textView.isEditable,
-                    isEmpty: textView.text.isEmpty
+                    isEmpty: textView.text?.isEmpty ?? true
                 )
             )
         )

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -29,6 +29,7 @@ extension CALayerSnapshot.SemanticObservation {
         case label(LabelSemantics)
         case image(ImageSemantics)
         case stepper(StepperSemantics)
+        case textInput(TextInputSemantics)
         case switchControl(SwitchControlSemantics)
         case webView(WebViewSemantics)
     }
@@ -48,6 +49,10 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(imageView: imageView)
         case let stepper as UIStepper:
             self.init(stepper: stepper)
+        case let textView as UITextView:
+            self.init(textView: textView)
+        case let textField as UITextField:
+            self.init(textField: textField)
         case let switchControl as UISwitch:
             self.init(switchControl: switchControl)
         case let webView as WKWebView:
@@ -156,6 +161,41 @@ extension CALayerSnapshot.SemanticObservation {
         self.init(
             semantics: .stepper(.init(value: stepper.value)),
             ignoreSublayers: true
+        )
+    }
+}
+
+// MARK: - TextInputSemantics
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.SemanticObservation {
+    struct TextInputSemantics: Sendable, Equatable {
+        let isSensitiveText: Bool
+        let isEditable: Bool
+        let isEmpty: Bool
+    }
+
+    fileprivate init(textView: UITextView) {
+        self.init(
+            semantics: .textInput(
+                .init(
+                    isSensitiveText: textView.dd.isSensitiveText,
+                    isEditable: textView.isEditable,
+                    isEmpty: textView.text.isEmpty
+                )
+            )
+        )
+    }
+
+    fileprivate init(textField: UITextField) {
+        self.init(
+            semantics: .textInput(
+                .init(
+                    isSensitiveText: textField.dd.isSensitiveText,
+                    isEditable: true,
+                    isEmpty: textField.text?.isEmpty ?? true
+                )
+            )
         )
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -28,10 +28,7 @@ extension CALayerSnapshot.SemanticObservation {
         case activityIndicator
         case label(LabelSemantics)
         case image(ImageSemantics)
-        case progress(ProgressSemantics)
         case stepper(StepperSemantics)
-        case text(TextSemantics)
-        case textField(TextFieldSemantics)
         case switchControl(SwitchControlSemantics)
         case webView(WebViewSemantics)
     }
@@ -49,14 +46,8 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(label: label)
         case let imageView as UIImageView:
             self.init(imageView: imageView)
-        case let progressView as UIProgressView:
-            self.init(progressView: progressView)
         case let stepper as UIStepper:
             self.init(stepper: stepper)
-        case let textView as UITextView:
-            self.init(textView: textView)
-        case let textField as UITextField:
-            self.init(textField: textField)
         case let switchControl as UISwitch:
             self.init(switchControl: switchControl)
         case let webView as WKWebView:
@@ -153,22 +144,6 @@ extension CALayerSnapshot.SemanticObservation {
     }
 }
 
-// MARK: - ProgressSemantics
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension CALayerSnapshot.SemanticObservation {
-    struct ProgressSemantics: Sendable, Equatable {
-        let progress: Float
-    }
-
-    fileprivate init(progressView: UIProgressView) {
-        self.init(
-            semantics: .progress(.init(progress: progressView.progress)),
-            ignoreSublayers: true
-        )
-    }
-}
-
 // MARK: - StepperSemantics
 
 @available(iOS 13.0, tvOS 13.0, *)
@@ -180,54 +155,6 @@ extension CALayerSnapshot.SemanticObservation {
     fileprivate init(stepper: UIStepper) {
         self.init(
             semantics: .stepper(.init(value: stepper.value)),
-            ignoreSublayers: true
-        )
-    }
-}
-
-// MARK: - TextSemantics
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension CALayerSnapshot.SemanticObservation {
-    struct TextSemantics: Sendable, Equatable {
-        let text: String?
-        let isEditable: Bool
-        let isSensitiveText: Bool
-    }
-
-    fileprivate init(textView: UITextView) {
-        self.init(
-            semantics: .text(
-                .init(
-                    text: textView.text,
-                    isEditable: textView.isEditable,
-                    isSensitiveText: textView.dd.isSensitiveText
-                )
-            ),
-            ignoreSublayers: true
-        )
-    }
-}
-
-// MARK: - TextFieldSemantics
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension CALayerSnapshot.SemanticObservation {
-    struct TextFieldSemantics: Sendable, Equatable {
-        let text: String?
-        let placeholder: String?
-        let isSensitiveText: Bool
-    }
-
-    fileprivate init(textField: UITextField) {
-        self.init(
-            semantics: .textField(
-                .init(
-                    text: textField.text,
-                    placeholder: textField.placeholder,
-                    isSensitiveText: textField.dd.isSensitiveText
-                )
-            ),
             ignoreSublayers: true
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -114,7 +114,7 @@ extension CALayerSnapshot {
             ? SemanticObservation(semantics: .layer, ignoreSublayers: true)
             : SemanticObservation(layer: layer, context: context)
 
-        if observation.ignoresImagePrivacy {
+        if observation.ignoresImagePrivacy, layer.privacyOverrides?.imagePrivacy == nil {
             privacy.imagePrivacyLevel = .maskNone
         }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -108,10 +108,15 @@ extension CALayerSnapshot {
             return nil
         }
 
-        let privacy = privacy.applying(layer.privacyOverrides)
+        var privacy = privacy.applying(layer.privacyOverrides)
+
         let observation = privacy.isPrivate
             ? SemanticObservation(semantics: .layer, ignoreSublayers: true)
             : SemanticObservation(layer: layer, context: context)
+
+        if observation.ignoresImagePrivacy {
+            privacy.imagePrivacyLevel = .maskNone
+        }
 
         let childVisibleBounds = layer.masksToBounds
             ? absoluteFrame.intersection(visibleBounds)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -161,6 +161,52 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for progress view image sublayer when image privacy masks all")
+    func createsRequestForProgressViewImageSublayerWhenImagePrivacyMasksAll() throws {
+        // Given
+        let progressView = UIProgressView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+        imageView.layer.contents = NSObject()
+        progressView.addSubview(imageView)
+
+        let snapshot = try #require(CALayerSnapshot(from: progressView.layer, in: .mockAny(imagePrivacyLevel: .maskAll)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(imageView.layer))
+        #expect(request.imagePrivacyLevel == .maskNone)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for slider image sublayer when image privacy masks all")
+    func createsRequestForSliderImageSublayerWhenImagePrivacyMasksAll() throws {
+        // Given
+        let slider = UISlider(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+        imageView.layer.contents = NSObject()
+        slider.addSubview(imageView)
+
+        let snapshot = try #require(CALayerSnapshot(from: slider.layer, in: .mockAny(imagePrivacyLevel: .maskAll)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(imageView.layer))
+        #expect(request.imagePrivacyLevel == .maskNone)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks non-bundled images")
     func skipsSemanticImageLayerWhenImagePrivacyMasksNonBundledImages() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -230,6 +230,28 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips button image sublayer when button image privacy override masks all")
+    func skipsButtonImageSublayerWhenButtonImagePrivacyOverrideMasksAll() throws {
+        // Given
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        button.dd.sessionReplayPrivacyOverrides.imagePrivacy = .maskAll
+
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+        imageView.layer.contents = NSObject()
+        button.addSubview(imageView)
+
+        let snapshot = try #require(CALayerSnapshot(from: button.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks non-bundled images")
     func skipsSemanticImageLayerWhenImagePrivacyMasksNonBundledImages() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -207,6 +207,29 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates request for button image sublayer when image privacy masks all")
+    func createsRequestForButtonImageSublayerWhenImagePrivacyMasksAll() throws {
+        // Given
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 40, height: 40)
+        imageView.layer.contents = NSObject()
+        button.addSubview(imageView)
+
+        let snapshot = try #require(CALayerSnapshot(from: button.layer, in: .mockAny(imagePrivacyLevel: .maskAll)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.layer.matches(imageView.layer))
+        #expect(request.imagePrivacyLevel == .maskNone)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks non-bundled images")
     func skipsSemanticImageLayerWhenImagePrivacyMasksNonBundledImages() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -221,58 +221,19 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Skips semantic text layer when text privacy masks all")
-    func skipsSemanticTextLayerWhenTextPrivacyMasksAll() throws {
+    @Test("Creates request for semantic image layer when ignored sublayer changes")
+    func createsRequestForSemanticImageLayerWhenIgnoredSublayerChanges() throws {
         // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
-        textView.layer.contents = NSObject()
-
-        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskAll)))
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.isEmpty)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Creates request for semantic text layer when text privacy masks sensitive inputs")
-    func createsRequestForSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
-        // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
-        textView.layer.contents = NSObject()
-
-        let snapshot = try #require(
-            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
-        )
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.count == 1)
-        let request = try #require(requests.first)
-        #expect(request.layer.matches(textView.layer))
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Creates request for semantic text layer when ignored sublayer changes")
-    func createsRequestForSemanticTextLayerWhenIgnoredSublayerChanges() throws {
-        // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
 
         let ignoredSublayer = CALayer()
         ignoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
-        textView.layer.addSublayer(ignoredSublayer)
+        imageView.layer.addSublayer(ignoredSublayer)
 
         let snapshot = try #require(
-            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .display)
         let cache = ImageSnapshotCache()
@@ -285,23 +246,24 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         let request = try #require(requests.first)
         #expect(snapshot.sublayers.isEmpty)
         #expect(snapshot.dependencies.contains { $0.matches(ignoredSublayer) })
-        #expect(request.layer.matches(textView.layer))
+        #expect(request.layer.matches(imageView.layer))
         #expect(request.dependencies.contains { $0.matches(ignoredSublayer) })
         #expect(request.hasChanges)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Creates request for semantic text layer when ignored sublayer lays out")
-    func createsRequestForSemanticTextLayerWhenIgnoredSublayerLaysOut() throws {
+    @Test("Creates request for semantic image layer when ignored sublayer lays out")
+    func createsRequestForSemanticImageLayerWhenIgnoredSublayerLaysOut() throws {
         // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
 
         let ignoredSublayer = CALayer()
         ignoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
-        textView.layer.addSublayer(ignoredSublayer)
+        imageView.layer.addSublayer(ignoredSublayer)
 
-        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
         let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .layout)
         let cache = ImageSnapshotCache()
 
@@ -311,38 +273,39 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         // Then
         #expect(requests.count == 1)
         let request = try #require(requests.first)
-        #expect(request.layer.matches(textView.layer))
+        #expect(request.layer.matches(imageView.layer))
         #expect(request.hasChanges)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Creates request for semantic text layer when ignored sublayer is replaced")
-    func createsRequestForSemanticTextLayerWhenIgnoredSublayerIsReplaced() throws {
+    @Test("Creates request for semantic image layer when ignored sublayer is replaced")
+    func createsRequestForSemanticImageLayerWhenIgnoredSublayerIsReplaced() throws {
         // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
 
         let previousIgnoredSublayer = CALayer()
         previousIgnoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
-        textView.layer.addSublayer(previousIgnoredSublayer)
+        imageView.layer.addSublayer(previousIgnoredSublayer)
         let previousSnapshot = try #require(
-            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
 
         previousIgnoredSublayer.removeFromSuperlayer()
         let currentIgnoredSublayer = CALayer()
         currentIgnoredSublayer.frame = CGRect(x: 10, y: 10, width: 20, height: 20)
-        textView.layer.addSublayer(currentIgnoredSublayer)
+        imageView.layer.addSublayer(currentIgnoredSublayer)
 
         let snapshot = try #require(
-            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
             .mockAny(dependencies: previousSnapshot.dependencies),
             forReplayID: snapshot.replayID
         )
-        let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
+        let changeset = CALayerChangeset.mockChange(for: imageView.layer, aspects: .layout)
 
         // When
         let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
@@ -350,28 +313,28 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         // Then
         #expect(requests.count == 1)
         let request = try #require(requests.first)
-        #expect(request.layer.matches(textView.layer))
+        #expect(request.layer.matches(imageView.layer))
         #expect(request.dependencies.contains { $0.matches(currentIgnoredSublayer) })
         #expect(request.hasChanges)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Does not mark semantic text layer changed when owner only lays out")
-    func doesNotMarkSemanticTextLayerChangedWhenOwnerOnlyLaysOut() throws {
+    @Test("Does not mark semantic image layer changed when owner only lays out")
+    func doesNotMarkSemanticImageLayerChangedWhenOwnerOnlyLaysOut() throws {
         // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
-        textView.layer.contents = NSObject()
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        imageView.layer.contents = NSObject()
 
         let snapshot = try #require(
-            CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let cache = ImageSnapshotCache()
         cache.setSnapshotData(
             .mockAny(dependencies: snapshot.dependencies),
             forReplayID: snapshot.replayID
         )
-        let changeset = CALayerChangeset.mockChange(for: textView.layer, aspects: .layout)
+        let changeset = CALayerChangeset.mockChange(for: imageView.layer, aspects: .layout)
 
         // When
         let requests = snapshot.imageSnapshotRequests(for: changeset, cache: cache)
@@ -379,46 +342,8 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         // Then
         #expect(requests.count == 1)
         let request = try #require(requests.first)
-        #expect(request.layer.matches(textView.layer))
+        #expect(request.layer.matches(imageView.layer))
         #expect(!request.hasChanges)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Skips secure semantic text layer when text privacy masks sensitive inputs")
-    func skipsSecureSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
-        // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "Hello"
-        textView.isSecureTextEntry = true
-        textView.layer.contents = NSObject()
-
-        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.isEmpty)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Skips sensitive semantic text layer when text privacy masks sensitive inputs")
-    func skipsSensitiveSemanticTextLayerWhenTextPrivacyMasksSensitiveInputs() throws {
-        // Given
-        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-        textView.text = "hello@datadoghq.com"
-        textView.textContentType = .emailAddress
-        textView.layer.contents = NSObject()
-
-        let snapshot = try #require(CALayerSnapshot(from: textView.layer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)))
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.isEmpty)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -150,8 +150,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records progress semantics and ignores sublayers")
-    func recordsProgressSemanticsAndIgnoresSublayers() {
+    @Test("Records progress view as layer semantics")
+    func recordsProgressViewAsLayerSemantics() {
         // Given
         let progressView = UIProgressView()
         progressView.progress = 0.75
@@ -160,7 +160,7 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: progressView.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .progress(.init(progress: 0.75)), ignoreSublayers: true))
+        #expect(observation == .init(semantics: .layer))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -178,8 +178,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text view semantics and ignores sublayers")
-    func recordsTextViewSemanticsAndIgnoresSublayers() {
+    @Test("Records text view as layer semantics")
+    func recordsTextViewAsLayerSemantics() {
         // Given
         let textView = UITextView()
         textView.text = "Body"
@@ -190,21 +190,12 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textView.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(
-            semantics: .text(
-                .init(
-                    text: "Body",
-                    isEditable: false,
-                    isSensitiveText: true
-                )
-            ),
-            ignoreSublayers: true
-        ))
+        #expect(observation == .init(semantics: .layer))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text field semantics and ignores sublayers")
-    func recordsTextFieldSemanticsAndIgnoresSublayers() {
+    @Test("Records text field as layer semantics")
+    func recordsTextFieldAsLayerSemantics() {
         // Given
         let textField = UITextField()
         textField.text = "Value"
@@ -215,16 +206,7 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textField.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(
-            semantics: .textField(
-                .init(
-                    text: "Value",
-                    placeholder: "Placeholder",
-                    isSensitiveText: true
-                )
-            ),
-            ignoreSublayers: true
-        ))
+        #expect(observation == .init(semantics: .layer))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -219,6 +219,26 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Records nil text view input semantics")
+    func recordsNilTextViewInputSemantics() {
+        // Given
+        let textView = UITextView()
+        textView.text = nil
+
+        // When
+        let observation = CALayerSnapshot.SemanticObservation(layer: textView.layer, context: .mockAny())
+
+        // Then
+        #expect(observation == .init(semantics: .textInput(
+            .init(
+                isSensitiveText: false,
+                isEditable: true,
+                isEmpty: true
+            )
+        )))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records text field input semantics and records sublayers")
     func recordsTextFieldInputSemanticsAndRecordsSublayers() {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -150,8 +150,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records progress view as layer semantics")
-    func recordsProgressViewAsLayerSemantics() {
+    @Test("Records progress view as layer semantics ignoring image privacy")
+    func recordsProgressViewAsLayerSemanticsIgnoringImagePrivacy() {
         // Given
         let progressView = UIProgressView()
         progressView.progress = 0.75
@@ -160,7 +160,20 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: progressView.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .layer))
+        #expect(observation == .init(semantics: .layer, ignoresImagePrivacy: true))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Records slider as layer semantics ignoring image privacy")
+    func recordsSliderAsLayerSemanticsIgnoringImagePrivacy() {
+        // Given
+        let slider = UISlider()
+
+        // When
+        let observation = CALayerSnapshot.SemanticObservation(layer: slider.layer, context: .mockAny())
+
+        // Then
+        #expect(observation == .init(semantics: .layer, ignoresImagePrivacy: true))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -177,6 +177,19 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Records button as layer semantics ignoring image privacy")
+    func recordsButtonAsLayerSemanticsIgnoringImagePrivacy() {
+        // Given
+        let button = UIButton()
+
+        // When
+        let observation = CALayerSnapshot.SemanticObservation(layer: button.layer, context: .mockAny())
+
+        // Then
+        #expect(observation == .init(semantics: .layer, ignoresImagePrivacy: true))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records stepper semantics and ignores sublayers")
     func recordsStepperSemanticsAndIgnoresSublayers() {
         // Given
@@ -187,7 +200,11 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: stepper.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .stepper(.init(value: 7)), ignoreSublayers: true))
+        #expect(observation == .init(
+            semantics: .stepper(.init(value: 7)),
+            ignoreSublayers: true,
+            ignoresImagePrivacy: true
+        ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -264,13 +281,16 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textField.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .textInput(
-            .init(
-                isSensitiveText: true,
-                isEditable: true,
-                isEmpty: false
-            )
-        )))
+        #expect(observation == .init(
+            semantics: .textInput(
+                .init(
+                    isSensitiveText: true,
+                    isEditable: true,
+                    isEmpty: false
+                )
+            ),
+            ignoresImagePrivacy: true
+        ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -284,13 +304,16 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textField.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .textInput(
-            .init(
-                isSensitiveText: false,
-                isEditable: true,
-                isEmpty: true
-            )
-        )))
+        #expect(observation == .init(
+            semantics: .textInput(
+                .init(
+                    isSensitiveText: false,
+                    isEditable: true,
+                    isEmpty: true
+                )
+            ),
+            ignoresImagePrivacy: true
+        ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -304,7 +327,11 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: switchControl.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .switchControl(.init(isOn: true)), ignoreSublayers: true))
+        #expect(observation == .init(
+            semantics: .switchControl(.init(isOn: true)),
+            ignoreSublayers: true,
+            ignoresImagePrivacy: true
+        ))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -178,8 +178,8 @@ struct CALayerSnapshotSemanticObservationTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text view as layer semantics")
-    func recordsTextViewAsLayerSemantics() {
+    @Test("Records text view input semantics and records sublayers")
+    func recordsTextViewInputSemanticsAndRecordsSublayers() {
         // Given
         let textView = UITextView()
         textView.text = "Body"
@@ -190,12 +190,37 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textView.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .layer))
+        #expect(observation == .init(semantics: .textInput(
+            .init(
+                isSensitiveText: true,
+                isEditable: false,
+                isEmpty: false
+            )
+        )))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Records text field as layer semantics")
-    func recordsTextFieldAsLayerSemantics() {
+    @Test("Records empty text view input semantics")
+    func recordsEmptyTextViewInputSemantics() {
+        // Given
+        let textView = UITextView()
+
+        // When
+        let observation = CALayerSnapshot.SemanticObservation(layer: textView.layer, context: .mockAny())
+
+        // Then
+        #expect(observation == .init(semantics: .textInput(
+            .init(
+                isSensitiveText: false,
+                isEditable: true,
+                isEmpty: true
+            )
+        )))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Records text field input semantics and records sublayers")
+    func recordsTextFieldInputSemanticsAndRecordsSublayers() {
         // Given
         let textField = UITextField()
         textField.text = "Value"
@@ -206,7 +231,33 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: textField.layer, context: .mockAny())
 
         // Then
-        #expect(observation == .init(semantics: .layer))
+        #expect(observation == .init(semantics: .textInput(
+            .init(
+                isSensitiveText: true,
+                isEditable: true,
+                isEmpty: false
+            )
+        )))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Records empty text field input semantics")
+    func recordsEmptyTextFieldInputSemantics() {
+        // Given
+        let textField = UITextField()
+        textField.placeholder = "Placeholder"
+
+        // When
+        let observation = CALayerSnapshot.SemanticObservation(layer: textField.layer, context: .mockAny())
+
+        // Then
+        #expect(observation == .init(semantics: .textInput(
+            .init(
+                isSensitiveText: false,
+                isEditable: true,
+                isEmpty: true
+            )
+        )))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -250,22 +250,22 @@ struct ImageSnapshotterTests {
         let rootLayer = CALayer()
         rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
 
-        let textView = UITextView(frame: CGRect(x: 10, y: 10, width: 100, height: 40))
-        textView.text = "Hello"
-        textView.layer.contentsScale = 1
-        rootLayer.addSublayer(textView.layer)
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 10, y: 10, width: 100, height: 40)
+        imageView.layer.contentsScale = 1
+        rootLayer.addSublayer(imageView.layer)
 
         let ignoredSublayer = CALayer()
         ignoredSublayer.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
         ignoredSublayer.backgroundColor = UIColor.red.cgColor
-        textView.layer.addSublayer(ignoredSublayer)
+        imageView.layer.addSublayer(ignoredSublayer)
 
         let snapshotter = ImageSnapshotter()
         let firstRoot = try #require(
-            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: rootLayer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let firstResults = await snapshotter.takeImageSnapshots(for: firstRoot, changeset: .init(), timeout: 1)
-        let firstResult = try #require(firstResults[textView.layer.replayID])
+        let firstResult = try #require(firstResults[imageView.layer.replayID])
         let firstImageSnapshot = try firstResult.get()
 
         ignoredSublayer.backgroundColor = UIColor.blue.cgColor
@@ -277,7 +277,7 @@ struct ImageSnapshotterTests {
         rootLayer.addSublayer(occluder)
 
         let occludedRootSnapshot = try #require(
-            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: rootLayer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let occludedRoot = try #require(occludedRootSnapshot.removingOccluded())
         let changeset = CALayerChangeset.mockChange(for: ignoredSublayer, aspects: .display)
@@ -286,16 +286,16 @@ struct ImageSnapshotterTests {
         let occludedResults = await snapshotter.takeImageSnapshots(for: occludedRoot, changeset: changeset, timeout: 1)
 
         // Then
-        #expect(!occludedRoot.sublayers.contains { $0.layer.matches(textView.layer) })
-        #expect(occludedResults[textView.layer.replayID] == nil)
+        #expect(!occludedRoot.sublayers.contains { $0.layer.matches(imageView.layer) })
+        #expect(occludedResults[imageView.layer.replayID] == nil)
 
         occluder.removeFromSuperlayer()
 
         let revealedRoot = try #require(
-            CALayerSnapshot(from: rootLayer, in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs))
+            CALayerSnapshot(from: rootLayer, in: .mockAny(imagePrivacyLevel: .maskNone))
         )
         let revealedResults = await snapshotter.takeImageSnapshots(for: revealedRoot, changeset: .init(), timeout: 1)
-        let revealedResult = try #require(revealedResults[textView.layer.replayID])
+        let revealedResult = try #require(revealedResults[imageView.layer.replayID])
         let revealedImageSnapshot = try revealedResult.get()
         #expect(firstImageSnapshot.image !== revealedImageSnapshot.image)
     }


### PR DESCRIPTION
### What and why?

This PR simplifies the semantic model for the new Core Animation recording pipeline.

`UIProgressView` now falls back to normal layer-tree capture instead of using a dedicated semantic case. This better matches how it is rendered: progress views are built from image-like sublayers.

`UITextView` and `UITextField` no longer use dedicated text payloads or own their full subtree. They now keep a small `textInput` semantic hint while still recording their layer subtree. This lets the later redaction step run in the background with the input state it needs, without reading UIKit state off the main thread.

This does not remove privacy masking. The layer snapshot still carries the resolved privacy levels, privacy overrides, layer class, delegate class, contents class, and text input hints needed by the redaction step.

### How?

- Removes the `.progress`, `.text`, and `.textField` semantic cases.
- Lets `UIProgressView` use `.layer` semantics.
- Adds a lightweight `.textInput` semantic for `UITextView` and `UITextField`.
- Captures whether text inputs are sensitive, editable, and empty.
- Removes the old text-specific image snapshot eligibility.
- Updates semantic observation and image snapshot tests.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
