### PR TITLE
Add FFE SDK owners to flag module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,7 @@
 /docs/ @DataDog/documentation @DataDog/rum-mobile 
 *README.md @DataDog/documentation @DataDog/rum-mobile
 *MIGRATION.md @DataDog/documentation
+
+## Feature Flags
+
+/DatadogFlags/ @DataDog/rum-mobile @DataDog/rum-mobile-ios @DataDog/feature-flags-sdks

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 
 ## Feature Flags
 
-/DatadogFlags/ @DataDog/rum-mobile @DataDog/rum-mobile-ios @DataDog/feature-flags-sdks
+/DatadogFlags/ @DataDog/rum-mobile @DataDog/rum-mobile-ios @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
## Motivation
FFE SDK engineers should be requested on changes to the iOS feature flag SDK module.

## Changes
- Add `@DataDog/feature-flagging-and-experimentation-sdk` as a CODEOWNER for `/DatadogFlags/`.
- Keep the existing RUM mobile and iOS mobile owners on that module.

## Decisions
- Targeted `develop` because this repository does not have a `main` branch.
- No runtime tests were run; this is a CODEOWNERS-only change. Validated with `git diff --check`.