### PR TITLE
FFL-2510: Add allocationKey to FlagDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FEATURE] Expose `allocationKey` as a top-level property on `FlagDetails` for callers using `getDetails(key:defaultValue:)`. See [#2989][]
 - [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
 - [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -252,7 +252,8 @@ extension FlagsClient: FlagsClientProtocol {
             key: key,
             value: value,
             variant: flagAssignment.variationKey,
-            reason: flagAssignment.reason
+            reason: flagAssignment.reason,
+            allocationKey: flagAssignment.allocationKey.isEmpty ? nil : flagAssignment.allocationKey
         )
 
         trackEvaluation(key: key, assignment: flagAssignment, context: context)

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -101,5 +101,4 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
         self.error = error
         self.allocationKey = allocationKey
     }
-
 }

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -102,23 +102,4 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
         self.allocationKey = allocationKey
     }
 
-    /// Creates detailed flag evaluation information.
-    ///
-    /// This overload preserves binary compatibility with prior SDK versions that did not include `allocationKey`.
-    ///
-    /// - Parameters:
-    ///   - key: The feature flag key.
-    ///   - value: The evaluated or default value.
-    ///   - variant: The variant key served, if any.
-    ///   - reason: The evaluation reason, if available.
-    ///   - error: Any error that occurred during evaluation.
-    public init(
-        key: String,
-        value: T,
-        variant: String? = nil,
-        reason: String? = nil,
-        error: FlagEvaluationError? = nil
-    ) {
-        self.init(key: key, value: value, variant: variant, reason: reason, error: error, allocationKey: nil)
-    }
 }

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -101,4 +101,24 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
         self.error = error
         self.allocationKey = allocationKey
     }
+
+    /// Creates detailed flag evaluation information.
+    ///
+    /// This overload preserves binary compatibility with prior SDK versions that did not include `allocationKey`.
+    ///
+    /// - Parameters:
+    ///   - key: The feature flag key.
+    ///   - value: The evaluated or default value.
+    ///   - variant: The variant key served, if any.
+    ///   - reason: The evaluation reason, if available.
+    ///   - error: Any error that occurred during evaluation.
+    public init(
+        key: String,
+        value: T,
+        variant: String? = nil,
+        reason: String? = nil,
+        error: FlagEvaluationError? = nil
+    ) {
+        self.init(key: key, value: value, variant: variant, reason: reason, error: error, allocationKey: nil)
+    }
 }

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -71,6 +71,12 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
     /// value is from a successful evaluation or a fallback to the default value.
     public var error: FlagEvaluationError?
 
+    /// The allocation key associated with this flag evaluation.
+    ///
+    /// Identifies the allocation bucket used when evaluating the flag. `nil` if the flag
+    /// was not found, evaluation failed, or no allocation was associated with this evaluation.
+    public var allocationKey: String?
+
     /// Creates detailed flag evaluation information.
     ///
     /// - Parameters:
@@ -79,17 +85,20 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
     ///   - variant: The variant key served, if any.
     ///   - reason: The evaluation reason, if available.
     ///   - error: Any error that occurred during evaluation.
+    ///   - allocationKey: The allocation key for the evaluation, or `nil` if not available.
     public init(
         key: String,
         value: T,
         variant: String? = nil,
         reason: String? = nil,
-        error: FlagEvaluationError? = nil
+        error: FlagEvaluationError? = nil,
+        allocationKey: String? = nil
     ) {
         self.key = key
         self.value = value
         self.variant = variant
         self.reason = reason
         self.error = error
+        self.allocationKey = allocationKey
     }
 }

--- a/DatadogFlags/Tests/Client/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientTests.swift
@@ -232,7 +232,8 @@ final class FlagsClientTests: XCTestCase {
                 key: "boolean-flag",
                 value: true,
                 variant: "variation-124",
-                reason: "TARGETING_MATCH"
+                reason: "TARGETING_MATCH",
+                allocationKey: "allocation-124"
             )
         )
         XCTAssertEqual(
@@ -477,6 +478,52 @@ final class FlagsClientTests: XCTestCase {
             )
         )
         XCTAssertNil(flagAssignments["missing-flag"])
+    }
+
+    func testGetDetails_errorPathsHaveEmptyAllocationKey() {
+        // Given — a client with no context (providerNotReady) and one string flag (for typeMismatch)
+        let providerNotReadyClient = FlagsClient(
+            repository: FlagsRepositoryMock(),
+            exposureLogger: ExposureLoggerMock(),
+            evaluationLogger: EvaluationLoggerMock(),
+            rumFlagEvaluationReporter: RUMFlagEvaluationReporterMock()
+        )
+
+        let clientWithFlags = FlagsClient(
+            repository: FlagsRepositoryMock(
+                flagsData: .init(
+                    flags: [
+                        "string-flag": .init(
+                            allocationKey: "allocation-123",
+                            variationKey: "variation-123",
+                            variation: .string("red"),
+                            reason: "TARGETING_MATCH",
+                            doLog: false
+                        )
+                    ],
+                    context: .mockAny(),
+                    date: .mockAny()
+                )
+            ),
+            exposureLogger: ExposureLoggerMock(),
+            evaluationLogger: EvaluationLoggerMock(),
+            rumFlagEvaluationReporter: RUMFlagEvaluationReporterMock()
+        )
+
+        // When
+        let providerNotReadyDetails = providerNotReadyClient.getDetails(key: "any-flag", defaultValue: false)
+        let flagNotFoundDetails = clientWithFlags.getDetails(key: "missing-flag", defaultValue: false)
+        let typeMismatchDetails = clientWithFlags.getDetails(key: "string-flag", defaultValue: false)
+
+        // Then — all error paths return nil allocationKey
+        XCTAssertEqual(providerNotReadyDetails.error, .providerNotReady)
+        XCTAssertNil(providerNotReadyDetails.allocationKey)
+
+        XCTAssertEqual(flagNotFoundDetails.error, .flagNotFound)
+        XCTAssertNil(flagNotFoundDetails.allocationKey)
+
+        XCTAssertEqual(typeMismatchDetails.error, .typeMismatch)
+        XCTAssertNil(typeMismatchDetails.allocationKey)
     }
 
     func testSendFlagEvaluation() {

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1546,7 +1546,6 @@ public struct FlagDetails<T>: Equatable where T: Equatable
     public var error: FlagEvaluationError?
     public var allocationKey: String?
     public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil,allocationKey: String? = nil)
-    public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil)
 public protocol FlagValue: Encodable
 public enum FlagsError: Error
     case networkError(Error)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1546,6 +1546,7 @@ public struct FlagDetails<T>: Equatable where T: Equatable
     public var error: FlagEvaluationError?
     public var allocationKey: String?
     public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil,allocationKey: String? = nil)
+    public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil)
 public protocol FlagValue: Encodable
 public enum FlagsError: Error
     case networkError(Error)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1531,7 +1531,7 @@ public struct FlagAssignment: Equatable
     public var variation: Variation
     public var reason: String
     public var doLog: Bool
-    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool)
+    public init(allocationKey: String,variationKey: String,variation: Variation,reason: String,doLog: Bool)
     public init(from decoder: any Decoder) throws
     public func encode(to encoder: any Encoder) throws
 public enum FlagEvaluationError: Error
@@ -1544,7 +1544,8 @@ public struct FlagDetails<T>: Equatable where T: Equatable
     public var variant: String?
     public var reason: String?
     public var error: FlagEvaluationError?
-    public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil)
+    public var allocationKey: String?
+    public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil,allocationKey: String? = nil)
 public protocol FlagValue: Encodable
 public enum FlagsError: Error
     case networkError(Error)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1531,7 +1531,7 @@ public struct FlagAssignment: Equatable
     public var variation: Variation
     public var reason: String
     public var doLog: Bool
-    public init(allocationKey: String,variationKey: String,variation: Variation,reason: String,doLog: Bool)
+    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool)
     public init(from decoder: any Decoder) throws
     public func encode(to encoder: any Encoder) throws
 public enum FlagEvaluationError: Error


### PR DESCRIPTION
### What and why?

FFL-2510 — \`FlagDetails\` lacked a top-level \`allocationKey\` field, making the allocation key from the Precomputed Flags response inaccessible to callers using \`getDetails\`.

### How?

- \`FlagDetails.swift\`: Added \`public var allocationKey: String?\` (default \`nil\`). \`nil\` means no allocation was associated with the evaluation — never empty string.
- \`FlagsClient.getDetails\`: populates \`allocationKey\` from the typed assignment field on success; error paths return \`nil\`
- API surface regenerated

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run \`make api-surface\` when adding new APIs