### PR TITLE
Rename memory_max to memory_footprint in timeseries schema

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -5591,26 +5591,26 @@ public struct RUMTimeseriesMemoryEvent: RUMDataModel {
             /// Memory measurements for this sample
             public struct DataPoint: Codable {
                 /// Physical memory footprint of the process in bytes
-                public let memoryMax: Double
+                public let memoryFootprint: Double
 
                 /// Memory footprint as a percentage of total device RAM
                 public let memoryPercent: Double
 
                 public enum CodingKeys: String, CodingKey {
-                    case memoryMax = "memory_max"
+                    case memoryFootprint = "memory_footprint"
                     case memoryPercent = "memory_percent"
                 }
 
                 /// Memory measurements for this sample
                 ///
                 /// - Parameters:
-                ///   - memoryMax: Physical memory footprint of the process in bytes
+                ///   - memoryFootprint: Physical memory footprint of the process in bytes
                 ///   - memoryPercent: Memory footprint as a percentage of total device RAM
                 public init(
-                    memoryMax: Double,
+                    memoryFootprint: Double,
                     memoryPercent: Double
                 ) {
-                    self.memoryMax = memoryMax
+                    self.memoryFootprint = memoryFootprint
                     self.memoryPercent = memoryPercent
                 }
             }
@@ -14933,4 +14933,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1
+// Generated from https://github.com/DataDog/rum-events-format/tree/eb33e481c74c6d84bbf29b6417acb5f0f3bb3b02

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -6551,8 +6551,8 @@ public class objc_RUMTimeseriesMemoryEventTimeseriesDataDataPoint: NSObject {
         self.root = root
     }
 
-    public var memoryMax: NSNumber {
-        root.swiftModel.dataPoint.memoryMax as NSNumber
+    public var memoryFootprint: NSNumber {
+        root.swiftModel.dataPoint.memoryFootprint as NSNumber
     }
 
     public var memoryPercent: NSNumber {
@@ -15458,4 +15458,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/41a1741091c4690633728ca86dee85fa12ef3fe1
+// Generated from https://github.com/DataDog/rum-events-format/tree/eb33e481c74c6d84bbf29b6417acb5f0f3bb3b02

--- a/DatadogRUM/Sources/Timeseries/DeltaEncoder.swift
+++ b/DatadogRUM/Sources/Timeseries/DeltaEncoder.swift
@@ -24,7 +24,7 @@ internal enum DeltaEncoder {
     /// {
     ///   "precision": 4,
     ///   "ts": [absoluteNs, delta1, delta2, ...],
-    ///   "memory_max": [scaledInt64, delta1, delta2, ...],
+    ///   "memory_footprint": [scaledInt64, delta1, delta2, ...],
     ///   "memory_percent": [scaledInt64, delta1, ...]
     /// }
     /// ```
@@ -34,22 +34,22 @@ internal enum DeltaEncoder {
         }
 
         var ts: [Int64] = []
-        var memoryMax: [Int64] = []
+        var memoryFootprint: [Int64] = []
         var memoryPercent: [Int64] = []
 
         for (index, sample) in batch.enumerated() {
             if index == 0 {
                 ts.append(sample.timestamp)
-                memoryMax.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryMax * scale))
+                memoryFootprint.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryFootprint * scale))
                 memoryPercent.append(Int64.ddWithNoOverflow(sample.dataPoint.memoryPercent * scale))
             } else {
                 let prev = batch[index - 1]
                 let (tsDelta, _) = sample.timestamp.subtractingReportingOverflow(prev.timestamp)
                 ts.append(tsDelta)
-                let curMax = Int64.ddWithNoOverflow(sample.dataPoint.memoryMax * scale)
-                let prevMax = Int64.ddWithNoOverflow(prev.dataPoint.memoryMax * scale)
+                let curMax = Int64.ddWithNoOverflow(sample.dataPoint.memoryFootprint * scale)
+                let prevMax = Int64.ddWithNoOverflow(prev.dataPoint.memoryFootprint * scale)
                 let (maxDelta, _) = curMax.subtractingReportingOverflow(prevMax)
-                memoryMax.append(maxDelta)
+                memoryFootprint.append(maxDelta)
                 let curPct = Int64.ddWithNoOverflow(sample.dataPoint.memoryPercent * scale)
                 let prevPct = Int64.ddWithNoOverflow(prev.dataPoint.memoryPercent * scale)
                 let (pctDelta, _) = curPct.subtractingReportingOverflow(prevPct)
@@ -61,7 +61,7 @@ internal enum DeltaEncoder {
             "precision": precision,
             "resolution": "ns",
             "ts": ts,
-            "memory_max": memoryMax,
+            "memory_footprint": memoryFootprint,
             "memory_percent": memoryPercent
         ]
     }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -186,7 +186,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         if let bytes = memoryReader.readVitalData() {
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
             let dataPoint = RUMTimeseriesMemoryEvent.Timeseries.Data(
-                dataPoint: .init(memoryMax: bytes, memoryPercent: memoryPercent),
+                dataPoint: .init(memoryFootprint: bytes, memoryPercent: memoryPercent),
                 timestamp: now
             )
             memoryBuffer.append(dataPoint)

--- a/DatadogRUM/Tests/Timeseries/DeltaEncoderTests.swift
+++ b/DatadogRUM/Tests/Timeseries/DeltaEncoderTests.swift
@@ -18,7 +18,7 @@ class DeltaEncoderTests: XCTestCase {
 
     func testEncodeMemory_returnsNilForSingleSample() {
         let sample = RUMTimeseriesMemoryEvent.Timeseries.Data(
-            dataPoint: .init(memoryMax: 100.0, memoryPercent: 10.0),
+            dataPoint: .init(memoryFootprint: 100.0, memoryPercent: 10.0),
             timestamp: 1_000_000_000
         )
         XCTAssertNil(DeltaEncoder.encodeMemory([sample]))
@@ -27,9 +27,9 @@ class DeltaEncoderTests: XCTestCase {
     func testEncodeMemory_correctDeltaEncoding() throws {
         // Given
         let samples: [RUMTimeseriesMemoryEvent.Timeseries.Data] = [
-            .init(dataPoint: .init(memoryMax: 100.0, memoryPercent: 10.0), timestamp: 1_000_000_000),
-            .init(dataPoint: .init(memoryMax: 200.5, memoryPercent: 20.0), timestamp: 2_000_000_000),
-            .init(dataPoint: .init(memoryMax: 200.5, memoryPercent: 20.5), timestamp: 3_000_000_000)
+            .init(dataPoint: .init(memoryFootprint: 100.0, memoryPercent: 10.0), timestamp: 1_000_000_000),
+            .init(dataPoint: .init(memoryFootprint: 200.5, memoryPercent: 20.0), timestamp: 2_000_000_000),
+            .init(dataPoint: .init(memoryFootprint: 200.5, memoryPercent: 20.5), timestamp: 3_000_000_000)
         ]
 
         // When
@@ -42,9 +42,9 @@ class DeltaEncoderTests: XCTestCase {
         let ts = try XCTUnwrap(result["ts"] as? [Int64])
         XCTAssertEqual(ts, [1_000_000_000, 1_000_000_000, 1_000_000_000])
 
-        // memory_max: 100*10000=1_000_000, (200.5-100)*10000=1_005_000, 0
-        let memoryMax = try XCTUnwrap(result["memory_max"] as? [Int64])
-        XCTAssertEqual(memoryMax, [1_000_000, 1_005_000, 0])
+        // memory_footprint: 100*10000=1_000_000, (200.5-100)*10000=1_005_000, 0
+        let memoryFootprint = try XCTUnwrap(result["memory_footprint"] as? [Int64])
+        XCTAssertEqual(memoryFootprint, [1_000_000, 1_005_000, 0])
 
         // memory_percent: 10*10000=100_000, (20-10)*10000=100_000, (20.5-20)*10000=5_000
         let memoryPercent = try XCTUnwrap(result["memory_percent"] as? [Int64])
@@ -55,12 +55,12 @@ class DeltaEncoderTests: XCTestCase {
         // Values scaled to near Int64.max / Int64.min to exercise subtractingReportingOverflow
         let hugeBytes = Double(Int64.max) / 10_000.0
         let samples: [RUMTimeseriesMemoryEvent.Timeseries.Data] = [
-            .init(dataPoint: .init(memoryMax: hugeBytes, memoryPercent: 100.0), timestamp: Int64.max),
-            .init(dataPoint: .init(memoryMax: 0.0, memoryPercent: 0.0), timestamp: 0)
+            .init(dataPoint: .init(memoryFootprint: hugeBytes, memoryPercent: 100.0), timestamp: Int64.max),
+            .init(dataPoint: .init(memoryFootprint: 0.0, memoryPercent: 0.0), timestamp: 0)
         ]
         // Should not crash
         let result = try XCTUnwrap(DeltaEncoder.encodeMemory(samples))
-        XCTAssertNotNil(result["memory_max"] as? [Int64])
+        XCTAssertNotNil(result["memory_footprint"] as? [Int64])
     }
 
     // MARK: - CPU encoding

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -50,7 +50,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.source, .ios)
         XCTAssertEqual(event.timeseries.name, "memory")
         XCTAssertEqual(event.timeseries.data.count, 2)
-        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryMax, 1_000_000)
+        XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryFootprint, 1_000_000)
         XCTAssertEqual(event.timeseries.data[0].dataPoint.memoryPercent, 0.025, accuracy: 0.001)
     }
 
@@ -114,7 +114,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // Then
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events")
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events")
-        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)[0].timeseries.data[0].dataPoint.memoryMax, 2_000_000)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)[0].timeseries.data[0].dataPoint.memoryFootprint, 2_000_000)
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)[0].timeseries.data[0].dataPoint.cpuUsage, 75.0)
     }
 
@@ -380,7 +380,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let dataDict = try XCTUnwrap(tsDict["data"] as? [String: Any])
         XCTAssertEqual(dataDict["resolution"] as? String, "ns")
         XCTAssertNotNil(dataDict["ts"])
-        XCTAssertNotNil(dataDict["memory_max"])
+        XCTAssertNotNil(dataDict["memory_footprint"])
         XCTAssertNotNil(dataDict["memory_percent"])
     }
 


### PR DESCRIPTION
### What and why?

Renames the `memory_max` field to `memory_footprint` in the timeseries memory schema to better reflect what is measured. Regenerates the iOS RUM data models accordingly and updates all usages.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs