### PR TITLE
[RUM-16711] Add foreground refresh to RemoteConfigurationProvider

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -56,8 +56,7 @@ internal final class DatadogCore {
     let bus = MessageBus()
 
     /// The remote configuration provider, if configured.
-    @ReadWriteLock
-    var remoteConfigurationProvider: RemoteConfigurationProvider?
+    let remoteConfigurationProvider: RemoteConfigurationProvider?
 
     /// The last successfully fetched remote configuration, if any.
     @ReadWriteLock

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -56,7 +56,8 @@ internal final class DatadogCore {
     let bus = MessageBus()
 
     /// The remote configuration provider, if configured.
-    var remoteConfigurationProvider: RemoteConfigurationProvider?
+    @ReadWriteLock
+    var remoteConfigurationProvider: RemoteConfigurationProvider? = nil
 
     /// The last successfully fetched remote configuration, if any.
     var remoteConfiguration: RemoteConfiguration? {
@@ -99,9 +100,9 @@ internal final class DatadogCore {
         directory: CoreDirectory,
         dateProvider: DateProvider,
         initialConsent: TrackingConsent,
-    	performance: PerformancePreset,
-    	httpClient: HTTPClient,
-    	encryption: DataEncryption?,
+        performance: PerformancePreset,
+        httpClient: HTTPClient,
+        encryption: DataEncryption?,
         contextProvider: DatadogContextProvider,
         applicationVersion: String,
         maxBatchesPerUpload: Int,
@@ -327,6 +328,7 @@ internal final class DatadogCore {
     /// Stops all processes for this instance of the Datadog core by
     /// deallocating all Features and their storage & upload units.
     func stop() {
+        remoteConfigurationProvider?.stop()
         stores = [:]
         features = [:]
     }

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -57,12 +57,11 @@ internal final class DatadogCore {
 
     /// The remote configuration provider, if configured.
     @ReadWriteLock
-    var remoteConfigurationProvider: RemoteConfigurationProvider? = nil
+    var remoteConfigurationProvider: RemoteConfigurationProvider?
 
     /// The last successfully fetched remote configuration, if any.
-    var remoteConfiguration: RemoteConfiguration? {
-        remoteConfigurationProvider?.remoteConfiguration
-    }
+    @ReadWriteLock
+    var remoteConfiguration: RemoteConfiguration?
 
     /// Registry for Features.
     @ReadWriteLock
@@ -133,6 +132,15 @@ internal final class DatadogCore {
         // forward any context change on the message-bus
         self.contextProvider.publish { [weak self] context in
             self?.send(message: .context(context))
+        }
+
+        self.remoteConfigurationProvider?.start { [weak self] result in
+            switch result {
+            case .success(let remoteConfiguration):
+                self?.remoteConfiguration = remoteConfiguration
+            case .failure(let error):
+                self?.telemetry.error("[RemoteConfig] Sync failed", error: error)
+            }
         }
     }
 

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -7,22 +7,22 @@
 import Foundation
 import DatadogInternal
 
-/// Provides the last successfully fetched remote configuration and refreshes its cache.
-///
-/// TODO: Also trigger `sync()` on every app foreground transition so remote config
-/// is refreshed while the app is in use, not only at SDK init (RFC §Caching Strategy).
+/// Provides the last successfully fetched remote configuration.
+/// Refreshes when started and when the app enters foreground.
 internal final class RemoteConfigurationProvider {
     let id: String
     let site: DatadogSite
     let directory: Directory
     let httpClient: HTTPClient
-    private let telemetry: Telemetry
+    private let notificationCenter: NotificationCenter
+    @ReadWriteLock
+    private var foregroundObserver: NSObjectProtocol?
 
     /// The result of the last cache read or CDN fetch.
     /// `.success(remoteConfiguration)` — remote configuration is available.
     /// `.failure` — no cache yet, or a read/write error.
     @ReadWriteLock
-    private(set) var cache: Result<RemoteConfiguration, RemoteConfigurationError>
+    private(set) var cache: Result<RemoteConfiguration, RemoteConfigurationError> = .failure(.diskError)
 
     var remoteConfiguration: RemoteConfiguration? {
         try? cache.get()
@@ -33,38 +33,68 @@ internal final class RemoteConfigurationProvider {
         site: DatadogSite,
         directory: Directory,
         httpClient: HTTPClient,
-        telemetry: Telemetry = NOPTelemetry()
+        notificationCenter: NotificationCenter
     ) {
         self.id = id
         self.site = site
         self.directory = directory
         self.httpClient = httpClient
-        self.telemetry = telemetry
+        self.notificationCenter = notificationCenter
+    }
+
+    func start(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         // Synchronous read on the caller's thread (main thread during SDK init).
         // Acceptable because the file is small (a single JSON document) and only
         // present after a previous successful fetch — absent on first launch.
-        self._cache = ReadWriteLock(wrappedValue: Self.readCache(id: id, from: directory, telemetry: telemetry))
+        let cached = Self.readCache(id: id, from: directory)
+        if let cached {
+            cache = cached
+            completionHandler(cached)
+        }
+
+        #if canImport(UIKit)
+        foregroundObserver = notificationCenter.addObserver(
+            forName: ApplicationNotifications.willEnterForeground,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.sync { _ in }
+        }
+        #endif
+
+        sync(cached == nil ? completionHandler : { _ in })
+    }
+
+    func stop() {
+        #if canImport(UIKit)
+        var observer: NSObjectProtocol?
+        _foregroundObserver.mutate {
+            observer = $0
+            $0 = nil
+        }
+
+        if let observer {
+            notificationCenter.removeObserver(observer)
+        }
+        #endif
     }
 
     // MARK: - Private
 
     private static func readCache(
         id: String,
-        from directory: Directory,
-        telemetry: Telemetry
-    ) -> Result<RemoteConfiguration, RemoteConfigurationError> {
+        from directory: Directory
+    ) -> Result<RemoteConfiguration, RemoteConfigurationError>? {
         let fileName = "\(id).json"
         guard directory.hasFile(named: fileName) else {
-            return .failure(.diskError)
+            return nil
         }
 
         let data: Data
         do {
             data = try directory.file(named: fileName).read()
         } catch {
-            let error = RemoteConfigurationError.diskError
-            telemetry.error("[RemoteConfig] Cache read failed", error: error)
-            return .failure(error)
+            return .failure(.diskError)
         }
 
         return decode(data)
@@ -78,12 +108,8 @@ internal final class RemoteConfigurationProvider {
         }
     }
 
-    // MARK: - Internal
-
     /// Fires an async CDN fetch and updates the cache on success.
-    ///
-    /// - Parameter completionHandler: Called with the fetch result when the operation (and any cache write) is done.
-    func sync(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
+    private func sync(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         // Build request with conditional ETag header if a previous ETag is stored.
         // Only send If-None-Match when the cache is usable — if cache is .failure,
         // a 304 response would leave us with no data to serve.
@@ -98,14 +124,18 @@ internal final class RemoteConfigurationProvider {
             request.setValue(etag, forHTTPHeaderField: "If-None-Match")
         }
 
-        httpClient.send(request: request, delegate: nil) { result in
+        httpClient.send(request: request, delegate: nil) { [weak self] result in
+            guard let self else {
+                return
+            }
+
             switch result {
             case .failure(let error):
                 completionHandler(.failure(.networkError(error)))
 
             case .success(let (http, data)):
                 // 1. Not Modified — existing cache is still valid
-                if http.statusCode == 304 {
+                if http.statusCode == 304, case .success = self.cache {
                     completionHandler(self.cache)
                     return
                 }
@@ -136,7 +166,8 @@ internal final class RemoteConfigurationProvider {
                 // all-or-nothing: the existing file is never left in a truncated state.
                 do {
                     try File(url: self.directory.url.appendingPathComponent("\(self.id).json")).write(data: data)
-                    self.cache = .success(remoteConfiguration)
+                    let result: Result<RemoteConfiguration, RemoteConfigurationError> = .success(remoteConfiguration)
+                    self.cache = result
 
                     // Store ETag for conditional requests on the next sync.
                     // If the response has no ETag, delete any stale validator so we
@@ -151,8 +182,7 @@ internal final class RemoteConfigurationProvider {
                         // try? silently handles the case where the file does not exist
                         try? self.directory.file(named: etagFileName).delete()
                     }
-
-                    completionHandler(.success(remoteConfiguration))
+                    completionHandler(result)
                 } catch {
                     completionHandler(.failure(.diskError))
                 }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -7,8 +7,7 @@
 import Foundation
 import DatadogInternal
 
-/// Provides the last successfully fetched remote configuration.
-/// Refreshes when started and when the app enters foreground.
+/// Fetches remote configuration when started and when the app enters foreground.
 internal final class RemoteConfigurationProvider {
     let id: String
     let site: DatadogSite
@@ -17,16 +16,6 @@ internal final class RemoteConfigurationProvider {
     private let notificationCenter: NotificationCenter
     @ReadWriteLock
     private var foregroundObserver: NSObjectProtocol?
-
-    /// The result of the last cache read or CDN fetch.
-    /// `.success(remoteConfiguration)` — remote configuration is available.
-    /// `.failure` — no cache yet, or a read/write error.
-    @ReadWriteLock
-    private(set) var cache: Result<RemoteConfiguration, RemoteConfigurationError> = .failure(.diskError)
-
-    var remoteConfiguration: RemoteConfiguration? {
-        try? cache.get()
-    }
 
     init(
         id: String,
@@ -48,35 +37,25 @@ internal final class RemoteConfigurationProvider {
         // present after a previous successful fetch — absent on first launch.
         let cached = Self.readCache(id: id, from: directory)
         if let cached {
-            cache = cached
             completionHandler(cached)
         }
 
-        #if canImport(UIKit)
         foregroundObserver = notificationCenter.addObserver(
             forName: ApplicationNotifications.willEnterForeground,
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.sync { _ in }
+            self?.sync(completionHandler)
         }
-        #endif
 
-        sync(cached == nil ? completionHandler : { _ in })
+        sync(completionHandler)
     }
 
     func stop() {
-        #if canImport(UIKit)
-        var observer: NSObjectProtocol?
-        _foregroundObserver.mutate {
-            observer = $0
-            $0 = nil
+        _foregroundObserver.mutate { observer in
+            observer.map { notificationCenter.removeObserver($0) }
+            observer = nil
         }
-
-        if let observer {
-            notificationCenter.removeObserver(observer)
-        }
-        #endif
     }
 
     // MARK: - Private
@@ -108,17 +87,15 @@ internal final class RemoteConfigurationProvider {
         }
     }
 
-    /// Fires an async CDN fetch and updates the cache on success.
+    /// Fires an async CDN fetch and persists the configuration on success.
     private func sync(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         // Build request with conditional ETag header if a previous ETag is stored.
-        // Only send If-None-Match when the cache is usable — if cache is .failure,
-        // a 304 response would leave us with no data to serve.
         var request = URLRequest(url: site.remoteConfigurationEndpoint
             .appendingPathComponent("v1")
             .appendingPathComponent(id)
             .appendingPathExtension("json"))
 
-        if case .success = cache,
+        if directory.hasFile(named: "\(id).json"),
            let data = try? directory.file(named: "\(id).etag").read(),
            let etag = String(data: data, encoding: .utf8) {
             request.setValue(etag, forHTTPHeaderField: "If-None-Match")
@@ -134,9 +111,13 @@ internal final class RemoteConfigurationProvider {
                 completionHandler(.failure(.networkError(error)))
 
             case .success(let (http, data)):
-                // 1. Not Modified — existing cache is still valid
-                if http.statusCode == 304, case .success = self.cache {
-                    completionHandler(self.cache)
+                // 1. Not Modified — existing persisted configuration is still valid.
+                if http.statusCode == 304 {
+                    if let cached = Self.readCache(id: self.id, from: self.directory), case .success = cached {
+                        completionHandler(cached)
+                    } else {
+                        completionHandler(.failure(.httpError(http.statusCode)))
+                    }
                     return
                 }
 
@@ -161,14 +142,11 @@ internal final class RemoteConfigurationProvider {
                     return
                 }
 
-                // All checks passed — persist to disk and update in-memory cache.
+                // All checks passed — persist to disk.
                 // File.write uses .atomic (write to temp, then rename), so the update is
                 // all-or-nothing: the existing file is never left in a truncated state.
                 do {
                     try File(url: self.directory.url.appendingPathComponent("\(self.id).json")).write(data: data)
-                    let result: Result<RemoteConfiguration, RemoteConfigurationError> = .success(remoteConfiguration)
-                    self.cache = result
-
                     // Store ETag for conditional requests on the next sync.
                     // If the response has no ETag, delete any stale validator so we
                     // never send If-None-Match for a different representation.
@@ -182,7 +160,7 @@ internal final class RemoteConfigurationProvider {
                         // try? silently handles the case where the file does not exist
                         try? self.directory.file(named: etagFileName).delete()
                     }
-                    completionHandler(result)
+                    completionHandler(.success(remoteConfiguration))
                 } catch {
                     completionHandler(.failure(.diskError))
                 }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -40,6 +40,7 @@ internal final class RemoteConfigurationProvider {
             completionHandler(cached)
         }
 
+#if canImport(UIKit)
         foregroundObserver = notificationCenter.addObserver(
             forName: ApplicationNotifications.willEnterForeground,
             object: nil,
@@ -47,13 +48,16 @@ internal final class RemoteConfigurationProvider {
         ) { [weak self] _ in
             self?.sync(completionHandler)
         }
+#endif
 
         sync(completionHandler)
     }
 
     func stop() {
         _foregroundObserver.mutate { observer in
+#if canImport(UIKit)
             observer.map { notificationCenter.removeObserver($0) }
+#endif
             observer = nil
         }
     }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -35,8 +35,7 @@ internal final class RemoteConfigurationProvider {
         // Synchronous read on the caller's thread (main thread during SDK init).
         // Acceptable because the file is small (a single JSON document) and only
         // present after a previous successful fetch — absent on first launch.
-        let cached = Self.readCache(id: id, from: directory)
-        if let cached {
+        if let cached = Self.readCache(id: id, from: directory) {
             completionHandler(cached)
         }
 
@@ -117,11 +116,6 @@ internal final class RemoteConfigurationProvider {
             case .success(let (http, data)):
                 // 1. Not Modified — existing persisted configuration is still valid.
                 if http.statusCode == 304 {
-                    if let cached = Self.readCache(id: self.id, from: self.directory), case .success = cached {
-                        completionHandler(cached)
-                    } else {
-                        completionHandler(.failure(.httpError(http.statusCode)))
-                    }
                     return
                 }
 

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -471,13 +471,12 @@ extension DatadogCore {
                 site: configuration.site,
                 directory: directory.coreDirectory,
                 httpClient: httpClient,
-                telemetry: self.telemetry
+                notificationCenter: configuration.notificationCenter
             )
             self.remoteConfigurationProvider = remoteConfigurationProvider
-
-            remoteConfigurationProvider.sync { [weak self] result in
+            remoteConfigurationProvider.start { [weak self] result in
                 if case .failure(let error) = result {
-                    self?.telemetry.error("[RemoteConfig] Sync failed", error: error)
+                    self?.telemetry.error("[RemoteConfig] Load failed", error: error)
                 }
             }
         }

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -424,6 +424,16 @@ extension DatadogCore {
         )
 
         let httpClient = configuration.httpClientFactory(configuration.proxyConfiguration)
+        let remoteConfigurationProvider = configuration.remoteConfigurationID.map {
+            RemoteConfigurationProvider(
+                id: $0,
+                site: configuration.site,
+                directory: directory.coreDirectory,
+                httpClient: httpClient,
+                notificationCenter: configuration.notificationCenter
+            )
+        }
+
         self.init(
             directory: directory,
             dateProvider: configuration.dateProvider,
@@ -462,24 +472,9 @@ extension DatadogCore {
             applicationVersion: applicationVersion,
             maxBatchesPerUpload: configuration.batchProcessingLevel.maxBatchesPerUpload,
             backgroundTasksEnabled: configuration.backgroundTasksEnabled,
-            isRunFromExtension: isRunFromExtension
+            isRunFromExtension: isRunFromExtension,
+            remoteConfigurationProvider: remoteConfigurationProvider
         )
-
-        if let remoteConfigurationID = configuration.remoteConfigurationID {
-            let remoteConfigurationProvider = RemoteConfigurationProvider(
-                id: remoteConfigurationID,
-                site: configuration.site,
-                directory: directory.coreDirectory,
-                httpClient: httpClient,
-                notificationCenter: configuration.notificationCenter
-            )
-            self.remoteConfigurationProvider = remoteConfigurationProvider
-            remoteConfigurationProvider.start { [weak self] result in
-                if case .failure(let error) = result {
-                    self?.telemetry.error("[RemoteConfig] Load failed", error: error)
-                }
-            }
-        }
 
         telemetry.configuration(
             backgroundTasksEnabled: configuration.backgroundTasksEnabled,

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -492,47 +492,47 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
-    func test304ResponseReturnsPersistedConfiguration() throws {
+    func test304ResponsePreservesCache() throws {
         // Given — pre-populate persisted configuration
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
-        let requestExpectation = expectation(description: "request completes")
-        let completionExpectation = expectation(description: "cached remote configuration is returned")
-        completionExpectation.expectedFulfillmentCount = 2
 
+        let requestExpectation = expectation(description: "CDN request is sent")
         MockURLProtocol.requestHandler = { request in
             requestExpectation.fulfill()
             return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil as Data?)
         }
+
+        // completion is called once synchronously from cache; NOT again after CDN 304
+        let cacheExpectation = expectation(description: "cached config returned once from start")
         let rc = makeProvider(start: false)
         rc.start { result in
-            if case .success(let remoteConfiguration) = result,
-               remoteConfiguration.rum?.applicationId == "existing-application-id" {
-                completionExpectation.fulfill()
+            if case .success(let config) = result, config.rum?.applicationId == "existing-application-id" {
+                cacheExpectation.fulfill()
             }
         }
 
-        wait(for: [requestExpectation], timeout: 2)
-        wait(for: [completionExpectation], timeout: 2)
-
+        wait(for: [requestExpectation, cacheExpectation], timeout: 2)
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "File must be unchanged after 304")
         withExtendedLifetime(rc) {}
     }
 
-    func test304ResponseWithoutCacheReturnsHTTPError() {
+    func test304ResponseWithoutCacheDoesNotCallCompletion() {
+        // Given — no persisted configuration, CDN returns 304 (unusual server-side scenario)
         let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
 
-        let expectation = expectation(description: "sync returns http error")
-        rc.start { result in
-            if case .failure(.httpError(304)) = result {
-                expectation.fulfill()
-            }
+        // No cache → no synchronous completion. CDN 304 → no completion either.
+        let unexpectedCompletion = expectation(description: "completion should not be called")
+        unexpectedCompletion.isInverted = true
+        rc.start { _ in
+            unexpectedCompletion.fulfill()
         }
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 0.5)
 
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        withExtendedLifetime(rc) {}
     }
 
 #if canImport(UIKit)

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -41,6 +41,14 @@ private func mockSession() -> URLSession {
     return URLSession(configuration: config)
 }
 
+private final class NeverHTTPClient: HTTPClient {
+    func send(
+        request: URLRequest,
+        delegate: URLSessionTaskDelegate?,
+        completion: @escaping (Result<(HTTPURLResponse, Data?), Error>) -> Void
+    ) {}
+}
+
 // MARK: - Tests
 
 class RemoteConfigurationTests: XCTestCase {
@@ -64,19 +72,48 @@ class RemoteConfigurationTests: XCTestCase {
 
     private func makeProvider(
         id: String = "test-id",
-        telemetry: Telemetry = NOPTelemetry()
+        httpClient: HTTPClient? = nil,
+        notificationCenter: NotificationCenter = NotificationCenter(),
+        start: Bool = true
     ) -> RemoteConfigurationProvider {
-        RemoteConfigurationProvider(
+        let provider = RemoteConfigurationProvider(
             id: id,
             site: .us1,
             directory: coreDir.coreDirectory,
-            httpClient: httpClient,
-            telemetry: telemetry
+            httpClient: httpClient ?? self.httpClient,
+            notificationCenter: notificationCenter
         )
+        if start {
+            provider.start { _ in }
+        }
+        return provider
     }
 
     private func remoteConfigurationData(applicationID: String = "application-id") -> Data {
         Data("{\"rum\":{\"applicationId\":\"\(applicationID)\"}}".utf8)
+    }
+
+    private func waitForCache(
+        in provider: RemoteConfigurationProvider,
+        applicationID: String,
+        fileData: Data? = nil,
+        fileName: String = "test-id.json"
+    ) {
+        let expectation = expectation(description: "remote configuration cache is updated")
+        wait(until: {
+            let cachedApplicationID = try? provider.cache.get().rum?.applicationId
+            guard cachedApplicationID == applicationID else {
+                return false
+            }
+
+            guard let fileData else {
+                return true
+            }
+
+            let fileURL = self.coreDir.coreDirectory.url.appendingPathComponent(fileName)
+            return (try? Data(contentsOf: fileURL)) == fileData
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
     }
 
     // MARK: endpoint URL construction
@@ -116,8 +153,8 @@ class RemoteConfigurationTests: XCTestCase {
     // MARK: Init
 
     func testInitCacheIsEmptyOnFirstLaunch() {
-        let rc = makeProvider()
-        guard case .failure = rc.cache else {
+        let rc = makeProvider(httpClient: NeverHTTPClient())
+        guard case .failure(.diskError) = rc.cache else {
             return XCTFail("Expected cache to be .failure on first launch")
         }
     }
@@ -127,28 +164,49 @@ class RemoteConfigurationTests: XCTestCase {
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try payload.write(to: fileURL, options: .atomic)
 
-        let rc = makeProvider()
+        let rc = makeProvider(httpClient: NeverHTTPClient())
         XCTAssertEqual(try rc.cache.get().rum?.applicationId, "cached-application-id")
     }
 
     func testInitCacheIsFailureWhenNoFileExists() {
         // No .json file on disk — cache must be .failure (first launch)
-        let rc = makeProvider()
-        guard case .failure = rc.cache else {
+        let rc = makeProvider(httpClient: NeverHTTPClient())
+        guard case .failure(.diskError) = rc.cache else {
             return XCTFail("Expected cache to be .failure when no file exists on disk")
         }
     }
 
-    func testInitCacheDiskReadFailureReportsTelemetry() throws {
+    func testInitCacheIsFailureWhenFileCannotBeRead() throws {
         try FileManager.default.createDirectory(
             at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             withIntermediateDirectories: false
         )
+
+        let rc = makeProvider(httpClient: NeverHTTPClient())
+
+        guard case .failure(.diskError) = rc.cache else {
+            return XCTFail("Expected cache to be .failure when cached file cannot be read")
+        }
+    }
+
+    func testStartCacheReadFailureCanBeReportedToTelemetryByCaller() throws {
+        try FileManager.default.createDirectory(
+            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
+            withIntermediateDirectories: false
+        )
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let telemetry = TelemetryMock()
 
-        let rc = makeProvider(telemetry: telemetry)
+        let expectation = expectation(description: "cache read failure is returned")
+        rc.start { result in
+            if case .failure(let error) = result {
+                telemetry.error("[RemoteConfig] Load failed", error: error)
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 2)
 
-        XCTAssertTrue(telemetry.messages.firstError()?.message.hasPrefix("[RemoteConfig] Cache read failed") == true)
+        XCTAssertTrue(telemetry.messages.firstError()?.message.hasPrefix("[RemoteConfig] Load failed") == true)
         guard case .failure(.diskError) = rc.cache else {
             return XCTFail("Expected cache to be .failure when cached file cannot be read")
         }
@@ -160,135 +218,114 @@ class RemoteConfigurationTests: XCTestCase {
             options: .atomic
         )
 
-        let rc = makeProvider()
+        let rc = makeProvider(httpClient: NeverHTTPClient())
         guard case .failure(.decodingError) = rc.cache else {
             return XCTFail("Expected cache to be .failure when file cannot be decoded")
         }
     }
 
-    // MARK: sync()
+    // MARK: Initial sync
 
-    func testSyncReturnsSuccessAndPopulatesCache() {
+    func testInitSyncReturnsSuccessAndPopulatesCache() {
         let payload = remoteConfigurationData(applicationID: "fetched-application-id")
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
         let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
 
-        rc.sync { result in
-            XCTAssertEqual(try? result.get().rum?.applicationId, "fetched-application-id")
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 2)
-
-        XCTAssertEqual(try? rc.cache.get().rum?.applicationId, "fetched-application-id")
-        XCTAssertEqual(try? Data(contentsOf: coreDir.coreDirectory.url.appendingPathComponent("test-id.json")), payload)
+        waitForCache(in: rc, applicationID: "fetched-application-id", fileData: payload)
     }
 
-    func testSyncPersistsCacheAcrossInstances() throws {
+    func testInitSyncPersistsCacheAcrossInstances() throws {
         let payload = remoteConfigurationData(applicationID: "persisted-application-id")
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
         let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-        rc.sync { _ in expectation.fulfill() }
-        wait(for: [expectation], timeout: 2)
+        waitForCache(in: rc, applicationID: "persisted-application-id", fileData: payload)
 
-        XCTAssertEqual(try? makeProvider().cache.get().rum?.applicationId, "persisted-application-id")
+        XCTAssertEqual(
+            try? makeProvider(httpClient: NeverHTTPClient()).cache.get().rum?.applicationId,
+            "persisted-application-id"
+        )
     }
 
-    func testSyncNetworkErrorReturnsFailureAndLeavesCache() {
+    func testInitSyncNetworkErrorReturnsFailureAndLeavesCache() {
         let error = URLError(.networkConnectionLost)
         let rc = RemoteConfigurationProvider(
             id: "test-id",
             site: .us1,
             directory: coreDir.coreDirectory,
-            httpClient: HTTPClientMock(error: error)
+            httpClient: HTTPClientMock(error: error),
+            notificationCenter: NotificationCenter()
         )
-        let expectation = expectation(description: "sync completes")
 
-        rc.sync { result in
-            guard case .failure(.networkError(let receivedError as URLError)) = result else {
-                return XCTFail("Expected failure on network error")
+        let expectation = expectation(description: "sync fails")
+        rc.start { result in
+            if case .failure(.networkError) = result {
+                expectation.fulfill()
             }
-            XCTAssertEqual(receivedError.code, error.code)
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        waitForExpectations(timeout: 2)
 
         guard case .failure = rc.cache else {
             return XCTFail("Cache must remain .failure after network error")
         }
     }
 
-    func testSyncNon2xxReturnsFailureAndPreservesCache() throws {
+    func testInitSyncNon2xxReturnsFailureAndPreservesCache() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
+        let requestExpectation = expectation(description: "request completes")
 
         MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, nil)
+            requestExpectation.fulfill()
+            return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, nil as Data?)
         }
         let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { result in
-            guard case .failure = result else {
-                return XCTFail("Expected failure on non-2xx")
-            }
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 2)
+        wait(for: [requestExpectation], timeout: 2)
 
         XCTAssertEqual(
-            try? makeProvider().cache.get().rum?.applicationId,
+            try? rc.cache.get().rum?.applicationId,
             "existing-application-id",
             "Existing cache must be preserved after non-2xx"
         )
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after non-2xx")
     }
 
-    func testSyncEmptyBodyReturnsFailureAndLeavesCache() {
+    func testInitSyncEmptyBodyReturnsFailureAndLeavesCache() {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
         }
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
+        let rc = makeProvider(start: false)
 
-        rc.sync { result in
-            guard case .failure = result else {
-                return XCTFail("Expected failure on empty body")
+        let expectation = expectation(description: "sync fails")
+        rc.start { result in
+            if case .failure(.emptyBody) = result {
+                expectation.fulfill()
             }
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        waitForExpectations(timeout: 2)
 
         guard case .failure = rc.cache else {
             return XCTFail("Cache must remain .failure after empty body response")
         }
     }
 
-    func testSyncInvalidJSONBodyReturnsFailureAndPreservesCache() throws {
+    func testInitSyncInvalidJSONBodyReturnsFailureAndPreservesCache() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
+        let requestExpectation = expectation(description: "request completes")
 
         let nonJSON = Data("this is not json".utf8)
         MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, nonJSON)
+            requestExpectation.fulfill()
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, nonJSON)
         }
         let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { result in
-            guard case .failure(.decodingError) = result else {
-                return XCTFail("Expected decoding failure")
-            }
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 2)
+        wait(for: [requestExpectation], timeout: 2)
 
         XCTAssertEqual(
             try? rc.cache.get().rum?.applicationId,
@@ -298,7 +335,7 @@ class RemoteConfigurationTests: XCTestCase {
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after decoding error")
     }
 
-    func testSyncDiskWriteFailureReturnsFailure() {
+    func testInitSyncDiskWriteFailureReturnsFailure() {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
         }
@@ -307,41 +344,44 @@ class RemoteConfigurationTests: XCTestCase {
             id: "test-id",
             site: .us1,
             directory: missingDir,
-            httpClient: httpClient
+            httpClient: httpClient,
+            notificationCenter: NotificationCenter()
         )
-        let expectation = expectation(description: "sync completes")
 
-        rc.sync { result in
-            guard case .failure = result else {
-                return XCTFail("Expected failure on disk write error")
+        let expectation = expectation(description: "sync fails")
+        rc.start { result in
+            if case .failure(.diskError) = result {
+                expectation.fulfill()
             }
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        waitForExpectations(timeout: 2)
 
-        guard case .failure = rc.cache else {
+        guard case .failure(.diskError) = rc.cache else {
             return XCTFail("Cache must remain .failure after disk write error")
         }
     }
 
     // MARK: ETag
 
-    func testSyncStoresETagAfterSuccessfulFetch() {
+    func testInitSyncStoresETagAfterSuccessfulFetch() {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["ETag": "abc123"])!, Data("{}".utf8))
         }
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
+        let provider = makeProvider()
 
-        rc.sync { _ in expectation.fulfill() }
-        wait(for: [expectation], timeout: 2)
-
+        let expectation = expectation(description: "etag is stored")
         let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
+        wait(until: {
+            (try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8)) == "abc123"
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
+
         let storedETag = try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8)
         XCTAssertEqual(storedETag, "abc123")
+        withExtendedLifetime(provider) {}
     }
 
-    func testSyncDeletesStaleETagWhenResponseHasNoETag() throws {
+    func testInitSyncDeletesStaleETagWhenResponseHasNoETag() throws {
         // Given — a stale ETag file from a previous fetch
         try Data("old-etag".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
@@ -352,20 +392,24 @@ class RemoteConfigurationTests: XCTestCase {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
         }
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-        rc.sync { _ in expectation.fulfill() }
-        wait(for: [expectation], timeout: 2)
+        let provider = makeProvider()
 
         // Then — stale ETag file must be deleted so it is never sent as If-None-Match
+        let expectation = expectation(description: "stale etag is deleted")
         let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
+        wait(until: {
+            !FileManager.default.fileExists(atPath: etagFileURL.path)
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
+
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: etagFileURL.path),
             "Stale ETag must be deleted when 200 response carries no ETag"
         )
+        withExtendedLifetime(provider) {}
     }
 
-    func testSyncDoesNotSendIfNoneMatchWhenCacheIsFailure() throws {
+    func testInitSyncDoesNotSendIfNoneMatchWhenCacheIsFailure() throws {
         // Given — ETag file exists but JSON cache is unreadable (cache is .failure)
         try Data("abc123".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
@@ -379,19 +423,21 @@ class RemoteConfigurationTests: XCTestCase {
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
         }
 
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { _ in expectation.fulfill() }
-        wait(for: [expectation], timeout: 2)
+        let provider = makeProvider()
+        let expectation = expectation(description: "request is sent")
+        wait(until: {
+            capturedRequest != nil
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
 
         XCTAssertNil(
             capturedRequest?.value(forHTTPHeaderField: "If-None-Match"),
             "Must not send If-None-Match when cache is .failure — a 304 would leave us with no data"
         )
+        withExtendedLifetime(provider) {}
     }
 
-    func testSyncSendsIfNoneMatchHeaderWhenETagStored() throws {
+    func testInitSyncSendsIfNoneMatchHeaderWhenETagStored() throws {
         // Given — store an ETag from a previous fetch
         try Data("abc123".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
@@ -410,55 +456,111 @@ class RemoteConfigurationTests: XCTestCase {
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
         }
 
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { _ in expectation.fulfill() }
-        wait(for: [expectation], timeout: 2)
+        let provider = makeProvider()
+        let expectation = expectation(description: "request is sent")
+        wait(until: {
+            capturedRequest != nil
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
 
         XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "If-None-Match"), "abc123")
+        withExtendedLifetime(provider) {}
     }
 
-    func test304ResponsePreservesCacheAndReportsSuccess() throws {
+    func test304ResponsePreservesCache() throws {
         // Given — pre-populate cache
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
+        let requestExpectation = expectation(description: "request completes")
 
         MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil)
+            requestExpectation.fulfill()
+            return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil as Data?)
         }
         let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { result in
-            XCTAssertEqual(try? result.get().rum?.applicationId, "existing-application-id", "304 must return existing cached configuration")
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 2)
+        wait(for: [requestExpectation], timeout: 2)
 
         XCTAssertEqual(try? rc.cache.get().rum?.applicationId, "existing-application-id", "Cache must be unchanged after 304")
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "File must be unchanged after 304")
     }
 
-    func test304ResponseCallsCompletionEvenWhenCacheIsFailure() {
-        // Given — no .json file, so cache is .failure
+    func test304ResponseWithoutCacheReturnsHTTPError() {
+        let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
 
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil)
-        }
-        let rc = makeProvider()
-        let expectation = expectation(description: "sync completes")
-
-        rc.sync { result in
-            // completionHandler must always be called — even when 304 + cache is .failure
-            guard case .failure = result else {
-                return XCTFail("Expected .failure when 304 + unreadable cache")
+        let expectation = expectation(description: "sync returns http error")
+        rc.start { result in
+            if case .failure(.httpError(304)) = result {
+                expectation.fulfill()
             }
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        waitForExpectations(timeout: 2)
+
+        guard case .failure(.diskError) = rc.cache else {
+            return XCTFail("Cache must remain .failure when 304 is returned without existing cache")
+        }
     }
+
+#if canImport(UIKit)
+    func testWillEnterForegroundSyncsRemoteConfiguration() {
+        let notificationCenter = NotificationCenter()
+        let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
+        let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            let payload = requestCount == 1 ? initialPayload : foregroundPayload
+            requestLock.unlock()
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+        }
+        let rc = makeProvider(notificationCenter: notificationCenter)
+        waitForCache(in: rc, applicationID: "initial-application-id", fileData: initialPayload)
+
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+
+        waitForCache(in: rc, applicationID: "foreground-application-id", fileData: foregroundPayload)
+    }
+
+    func testWillEnterForegroundDoesNotCallStartCompletionAgain() {
+        let notificationCenter = NotificationCenter()
+        let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
+        let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            let payload = requestCount == 1 ? initialPayload : foregroundPayload
+            requestLock.unlock()
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+        }
+
+        let completionLock = NSLock()
+        var completionCount = 0
+        let startCompletion = expectation(description: "start completion is called")
+        let rc = makeProvider(notificationCenter: notificationCenter, start: false)
+        rc.start { _ in
+            completionLock.lock()
+            completionCount += 1
+            let count = completionCount
+            completionLock.unlock()
+
+            if count == 1 {
+                startCompletion.fulfill()
+            }
+        }
+        wait(for: [startCompletion], timeout: 2)
+        waitForCache(in: rc, applicationID: "initial-application-id", fileData: initialPayload)
+
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+        waitForCache(in: rc, applicationID: "foreground-application-id", fileData: foregroundPayload)
+
+        XCTAssertEqual(completionLock.withLock { completionCount }, 1)
+    }
+
+#endif
 
     func testDifferentIDsUseDifferentFiles() throws {
         let payload1 = remoteConfigurationData(applicationID: "application-id-one")
@@ -468,19 +570,15 @@ class RemoteConfigurationTests: XCTestCase {
             (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload1)
         }
         let rc1 = makeProvider(id: "id-one")
-        let exp1 = expectation(description: "sync 1 completes")
-        rc1.sync { _ in exp1.fulfill() }
-        wait(for: [exp1], timeout: 2)
+        waitForCache(in: rc1, applicationID: "application-id-one", fileData: payload1, fileName: "id-one.json")
 
         MockURLProtocol.requestHandler = { _ in
             (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload2)
         }
         let rc2 = makeProvider(id: "id-two")
-        let exp2 = expectation(description: "sync 2 completes")
-        rc2.sync { _ in exp2.fulfill() }
-        wait(for: [exp2], timeout: 2)
+        waitForCache(in: rc2, applicationID: "application-id-two", fileData: payload2, fileName: "id-two.json")
 
-        XCTAssertEqual(try? makeProvider(id: "id-one").cache.get().rum?.applicationId, "application-id-one")
-        XCTAssertEqual(try? makeProvider(id: "id-two").cache.get().rum?.applicationId, "application-id-two")
+        XCTAssertEqual(try? makeProvider(id: "id-one", httpClient: NeverHTTPClient()).cache.get().rum?.applicationId, "application-id-one")
+        XCTAssertEqual(try? makeProvider(id: "id-two", httpClient: NeverHTTPClient()).cache.get().rum?.applicationId, "application-id-two")
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -93,16 +93,16 @@ class RemoteConfigurationTests: XCTestCase {
         Data("{\"rum\":{\"applicationId\":\"\(applicationID)\"}}".utf8)
     }
 
-    private func waitForCache(
-        in provider: RemoteConfigurationProvider,
+    private func waitForPersistedConfiguration(
         applicationID: String,
         fileData: Data? = nil,
         fileName: String = "test-id.json"
     ) {
-        let expectation = expectation(description: "remote configuration cache is updated")
+        let expectation = expectation(description: "remote configuration is persisted")
         wait(until: {
-            let cachedApplicationID = try? provider.cache.get().rum?.applicationId
-            guard cachedApplicationID == applicationID else {
+            let fileURL = self.coreDir.coreDirectory.url.appendingPathComponent(fileName)
+            guard let persistedData = try? Data(contentsOf: fileURL),
+                  (try? JSONDecoder().decode(RemoteConfiguration.self, from: persistedData).rum?.applicationId) == applicationID else {
                 return false
             }
 
@@ -110,10 +110,9 @@ class RemoteConfigurationTests: XCTestCase {
                 return true
             }
 
-            let fileURL = self.coreDir.coreDirectory.url.appendingPathComponent(fileName)
-            return (try? Data(contentsOf: fileURL)) == fileData
+            return persistedData == fileData
         }, andThenFulfill: expectation)
-        waitForExpectations(timeout: 2)
+        wait(for: [expectation], timeout: 2)
     }
 
     // MARK: endpoint URL construction
@@ -152,41 +151,68 @@ class RemoteConfigurationTests: XCTestCase {
 
     // MARK: Init
 
-    func testInitCacheIsEmptyOnFirstLaunch() {
-        let rc = makeProvider(httpClient: NeverHTTPClient())
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Expected cache to be .failure on first launch")
+    func testStartDoesNotReadCacheOnFirstLaunch() {
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "completion is not called without cache or network response")
+        expectation.isInverted = true
+
+        rc.start { _ in
+            expectation.fulfill()
         }
+        waitForExpectations(timeout: 0.1)
+
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitReadsCacheFromPreviousLaunch() throws {
+    func testStartReadsCacheFromPreviousLaunch() throws {
         let payload = remoteConfigurationData(applicationID: "cached-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try payload.write(to: fileURL, options: .atomic)
 
-        let rc = makeProvider(httpClient: NeverHTTPClient())
-        XCTAssertEqual(try rc.cache.get().rum?.applicationId, "cached-application-id")
-    }
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "cached remote configuration is returned")
 
-    func testInitCacheIsFailureWhenNoFileExists() {
-        // No .json file on disk — cache must be .failure (first launch)
-        let rc = makeProvider(httpClient: NeverHTTPClient())
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Expected cache to be .failure when no file exists on disk")
+        rc.start { result in
+            if case .success(let remoteConfiguration) = result,
+               remoteConfiguration.rum?.applicationId == "cached-application-id" {
+                expectation.fulfill()
+            }
         }
+        waitForExpectations(timeout: 2)
+
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitCacheIsFailureWhenFileCannotBeRead() throws {
+    func testStartDoesNotCallCompletionWhenNoFileExists() {
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "completion is not called when no cache exists")
+        expectation.isInverted = true
+
+        rc.start { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 0.1)
+
+        withExtendedLifetime(rc) {}
+    }
+
+    func testStartReturnsFailureWhenFileCannotBeRead() throws {
         try FileManager.default.createDirectory(
             at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             withIntermediateDirectories: false
         )
 
-        let rc = makeProvider(httpClient: NeverHTTPClient())
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "cache read failure is returned")
 
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Expected cache to be .failure when cached file cannot be read")
+        rc.start { result in
+            if case .failure(.diskError) = result {
+                expectation.fulfill()
+            }
         }
+        waitForExpectations(timeout: 2)
+
+        withExtendedLifetime(rc) {}
     }
 
     func testStartCacheReadFailureCanBeReportedToTelemetryByCaller() throws {
@@ -207,50 +233,63 @@ class RemoteConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 2)
 
         XCTAssertTrue(telemetry.messages.firstError()?.message.hasPrefix("[RemoteConfig] Load failed") == true)
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Expected cache to be .failure when cached file cannot be read")
-        }
     }
 
-    func testInitCacheIsFailureWhenFileCannotBeDecoded() throws {
+    func testStartReturnsFailureWhenFileCannotBeDecoded() throws {
         try Data("this is not json".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
         )
 
-        let rc = makeProvider(httpClient: NeverHTTPClient())
-        guard case .failure(.decodingError) = rc.cache else {
-            return XCTFail("Expected cache to be .failure when file cannot be decoded")
+        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "cache decoding failure is returned")
+
+        rc.start { result in
+            if case .failure(.decodingError) = result {
+                expectation.fulfill()
+            }
         }
+        waitForExpectations(timeout: 2)
+
+        withExtendedLifetime(rc) {}
     }
 
     // MARK: Initial sync
 
-    func testInitSyncReturnsSuccessAndPopulatesCache() {
+    func testInitSyncReturnsSuccessAndPersistsConfiguration() {
         let payload = remoteConfigurationData(applicationID: "fetched-application-id")
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
         let rc = makeProvider()
 
-        waitForCache(in: rc, applicationID: "fetched-application-id", fileData: payload)
+        waitForPersistedConfiguration(applicationID: "fetched-application-id", fileData: payload)
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncPersistsCacheAcrossInstances() throws {
+    func testInitSyncPersistsConfigurationAcrossInstances() throws {
         let payload = remoteConfigurationData(applicationID: "persisted-application-id")
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
         let rc = makeProvider()
-        waitForCache(in: rc, applicationID: "persisted-application-id", fileData: payload)
+        waitForPersistedConfiguration(applicationID: "persisted-application-id", fileData: payload)
 
-        XCTAssertEqual(
-            try? makeProvider(httpClient: NeverHTTPClient()).cache.get().rum?.applicationId,
-            "persisted-application-id"
-        )
+        let cachedProvider = makeProvider(httpClient: NeverHTTPClient(), start: false)
+        let expectation = expectation(description: "persisted remote configuration is returned")
+        cachedProvider.start { result in
+            if case .success(let remoteConfiguration) = result,
+               remoteConfiguration.rum?.applicationId == "persisted-application-id" {
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 2)
+
+        withExtendedLifetime(rc) {}
+        withExtendedLifetime(cachedProvider) {}
     }
 
-    func testInitSyncNetworkErrorReturnsFailureAndLeavesCache() {
+    func testInitSyncNetworkErrorReturnsFailureAndLeavesNoPersistedConfiguration() {
         let error = URLError(.networkConnectionLost)
         let rc = RemoteConfigurationProvider(
             id: "test-id",
@@ -268,12 +307,11 @@ class RemoteConfigurationTests: XCTestCase {
         }
         waitForExpectations(timeout: 2)
 
-        guard case .failure = rc.cache else {
-            return XCTFail("Cache must remain .failure after network error")
-        }
+        let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
-    func testInitSyncNon2xxReturnsFailureAndPreservesCache() throws {
+    func testInitSyncNon2xxReturnsFailureAndPreservesPersistedConfiguration() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
@@ -286,15 +324,11 @@ class RemoteConfigurationTests: XCTestCase {
         let rc = makeProvider()
         wait(for: [requestExpectation], timeout: 2)
 
-        XCTAssertEqual(
-            try? rc.cache.get().rum?.applicationId,
-            "existing-application-id",
-            "Existing cache must be preserved after non-2xx"
-        )
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after non-2xx")
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncEmptyBodyReturnsFailureAndLeavesCache() {
+    func testInitSyncEmptyBodyReturnsFailureAndLeavesNoPersistedConfiguration() {
         MockURLProtocol.requestHandler = { request in
             (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
         }
@@ -308,12 +342,11 @@ class RemoteConfigurationTests: XCTestCase {
         }
         waitForExpectations(timeout: 2)
 
-        guard case .failure = rc.cache else {
-            return XCTFail("Cache must remain .failure after empty body response")
-        }
+        let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
-    func testInitSyncInvalidJSONBodyReturnsFailureAndPreservesCache() throws {
+    func testInitSyncInvalidJSONBodyReturnsFailureAndPreservesPersistedConfiguration() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
@@ -327,12 +360,8 @@ class RemoteConfigurationTests: XCTestCase {
         let rc = makeProvider()
         wait(for: [requestExpectation], timeout: 2)
 
-        XCTAssertEqual(
-            try? rc.cache.get().rum?.applicationId,
-            "existing-application-id",
-            "Existing cache must be preserved after decoding error"
-        )
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after decoding error")
+        withExtendedLifetime(rc) {}
     }
 
     func testInitSyncDiskWriteFailureReturnsFailure() {
@@ -355,10 +384,6 @@ class RemoteConfigurationTests: XCTestCase {
             }
         }
         waitForExpectations(timeout: 2)
-
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Cache must remain .failure after disk write error")
-        }
     }
 
     // MARK: ETag
@@ -409,13 +434,13 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
-    func testInitSyncDoesNotSendIfNoneMatchWhenCacheIsFailure() throws {
-        // Given — ETag file exists but JSON cache is unreadable (cache is .failure)
+    func testInitSyncDoesNotSendIfNoneMatchWhenPersistedConfigurationIsMissing() throws {
+        // Given — ETag file exists but JSON configuration is missing.
         try Data("abc123".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
             options: .atomic
         )
-        // No .json file → cache will be .failure after init
+        // No .json file means a 304 response would leave the caller with no configuration.
 
         var capturedRequest: URLRequest?
         MockURLProtocol.requestHandler = { request in
@@ -432,7 +457,7 @@ class RemoteConfigurationTests: XCTestCase {
 
         XCTAssertNil(
             capturedRequest?.value(forHTTPHeaderField: "If-None-Match"),
-            "Must not send If-None-Match when cache is .failure — a 304 would leave us with no data"
+            "Must not send If-None-Match when persisted configuration is missing — a 304 would leave us with no data"
         )
         withExtendedLifetime(provider) {}
     }
@@ -444,7 +469,7 @@ class RemoteConfigurationTests: XCTestCase {
             options: .atomic
         )
 
-        // Pre-populate .json so cache is .success (required to send If-None-Match)
+        // Pre-populate .json so persisted configuration is available (required to send If-None-Match)
         try Data("{}".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
@@ -467,22 +492,32 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
-    func test304ResponsePreservesCache() throws {
-        // Given — pre-populate cache
+    func test304ResponseReturnsPersistedConfiguration() throws {
+        // Given — pre-populate persisted configuration
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
         let requestExpectation = expectation(description: "request completes")
+        let completionExpectation = expectation(description: "cached remote configuration is returned")
+        completionExpectation.expectedFulfillmentCount = 2
 
         MockURLProtocol.requestHandler = { request in
             requestExpectation.fulfill()
             return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil as Data?)
         }
-        let rc = makeProvider()
-        wait(for: [requestExpectation], timeout: 2)
+        let rc = makeProvider(start: false)
+        rc.start { result in
+            if case .success(let remoteConfiguration) = result,
+               remoteConfiguration.rum?.applicationId == "existing-application-id" {
+                completionExpectation.fulfill()
+            }
+        }
 
-        XCTAssertEqual(try? rc.cache.get().rum?.applicationId, "existing-application-id", "Cache must be unchanged after 304")
+        wait(for: [requestExpectation], timeout: 2)
+        wait(for: [completionExpectation], timeout: 2)
+
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "File must be unchanged after 304")
+        withExtendedLifetime(rc) {}
     }
 
     func test304ResponseWithoutCacheReturnsHTTPError() {
@@ -496,9 +531,8 @@ class RemoteConfigurationTests: XCTestCase {
         }
         waitForExpectations(timeout: 2)
 
-        guard case .failure(.diskError) = rc.cache else {
-            return XCTFail("Cache must remain .failure when 304 is returned without existing cache")
-        }
+        let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
 #if canImport(UIKit)
@@ -516,14 +550,15 @@ class RemoteConfigurationTests: XCTestCase {
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
         let rc = makeProvider(notificationCenter: notificationCenter)
-        waitForCache(in: rc, applicationID: "initial-application-id", fileData: initialPayload)
+        waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
 
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
 
-        waitForCache(in: rc, applicationID: "foreground-application-id", fileData: foregroundPayload)
+        waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
+        withExtendedLifetime(rc) {}
     }
 
-    func testWillEnterForegroundDoesNotCallStartCompletionAgain() {
+    func testWillEnterForegroundCallsCompletionAgain() {
         let notificationCenter = NotificationCenter()
         let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
@@ -539,25 +574,28 @@ class RemoteConfigurationTests: XCTestCase {
 
         let completionLock = NSLock()
         var completionCount = 0
-        let startCompletion = expectation(description: "start completion is called")
+        let completionExpectation = expectation(description: "completion is called for each sync")
+        completionExpectation.expectedFulfillmentCount = 2
         let rc = makeProvider(notificationCenter: notificationCenter, start: false)
-        rc.start { _ in
+        rc.start { result in
+            guard case .success = result else {
+                return
+            }
+
             completionLock.lock()
             completionCount += 1
-            let count = completionCount
             completionLock.unlock()
 
-            if count == 1 {
-                startCompletion.fulfill()
-            }
+            completionExpectation.fulfill()
         }
-        wait(for: [startCompletion], timeout: 2)
-        waitForCache(in: rc, applicationID: "initial-application-id", fileData: initialPayload)
+        waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
 
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
-        waitForCache(in: rc, applicationID: "foreground-application-id", fileData: foregroundPayload)
+        waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
 
-        XCTAssertEqual(completionLock.withLock { completionCount }, 1)
+        wait(for: [completionExpectation], timeout: 2)
+        XCTAssertEqual(completionLock.withLock { completionCount }, 2)
+        withExtendedLifetime(rc) {}
     }
 
 #endif
@@ -570,15 +608,36 @@ class RemoteConfigurationTests: XCTestCase {
             (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload1)
         }
         let rc1 = makeProvider(id: "id-one")
-        waitForCache(in: rc1, applicationID: "application-id-one", fileData: payload1, fileName: "id-one.json")
+        waitForPersistedConfiguration(applicationID: "application-id-one", fileData: payload1, fileName: "id-one.json")
 
         MockURLProtocol.requestHandler = { _ in
             (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload2)
         }
         let rc2 = makeProvider(id: "id-two")
-        waitForCache(in: rc2, applicationID: "application-id-two", fileData: payload2, fileName: "id-two.json")
+        waitForPersistedConfiguration(applicationID: "application-id-two", fileData: payload2, fileName: "id-two.json")
 
-        XCTAssertEqual(try? makeProvider(id: "id-one", httpClient: NeverHTTPClient()).cache.get().rum?.applicationId, "application-id-one")
-        XCTAssertEqual(try? makeProvider(id: "id-two", httpClient: NeverHTTPClient()).cache.get().rum?.applicationId, "application-id-two")
+        let cachedProvider1 = makeProvider(id: "id-one", httpClient: NeverHTTPClient(), start: false)
+        let cachedProvider2 = makeProvider(id: "id-two", httpClient: NeverHTTPClient(), start: false)
+        let expectation1 = expectation(description: "first cached configuration is returned")
+        let expectation2 = expectation(description: "second cached configuration is returned")
+
+        cachedProvider1.start { result in
+            if case .success(let remoteConfiguration) = result,
+               remoteConfiguration.rum?.applicationId == "application-id-one" {
+                expectation1.fulfill()
+            }
+        }
+        cachedProvider2.start { result in
+            if case .success(let remoteConfiguration) = result,
+               remoteConfiguration.rum?.applicationId == "application-id-two" {
+                expectation2.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 2)
+
+        withExtendedLifetime(rc1) {}
+        withExtendedLifetime(rc2) {}
+        withExtendedLifetime(cachedProvider1) {}
+        withExtendedLifetime(cachedProvider2) {}
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -22,6 +22,31 @@ private struct FeatureMock: DatadogRemoteFeature {
     var performanceOverride: PerformancePresetOverride? = nil
 }
 
+private final class PendingHTTPClientMock: HTTPClient {
+    private typealias Completion = (Result<(HTTPURLResponse, Data?), any Error>) -> Void
+
+    private let queue = DispatchQueue(label: "com.datadoghq.PendingHTTPClientMock-\(UUID().uuidString)")
+    private var requests: [URLRequest] = []
+    private var completions: [Completion] = []
+
+    func send(
+        request: URLRequest,
+        delegate: URLSessionTaskDelegate?,
+        completion: @escaping (Result<(HTTPURLResponse, Data?), any Error>) -> Void
+    ) {
+        queue.sync {
+            requests.append(request)
+            completions.append(completion)
+        }
+    }
+
+    func requestsSent() -> [URLRequest] {
+        queue.sync {
+            requests
+        }
+    }
+}
+
 class DatadogCoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -43,8 +68,10 @@ class DatadogCoreTests: XCTestCase {
             id: "test-id",
             site: .us1,
             directory: temporaryCoreDirectory.coreDirectory,
-            httpClient: HTTPClientMock()
+            httpClient: PendingHTTPClientMock(),
+            notificationCenter: NotificationCenter()
         )
+        remoteConfigurationProvider.start { _ in }
 
         let core = DatadogCore(
             directory: temporaryCoreDirectory,
@@ -384,6 +411,53 @@ class DatadogCoreTests: XCTestCase {
         core.flush()
         XCTAssertEqual(requestBuilderSpy.requestParameters.count, 0, "It should not send any request")
     }
+
+#if canImport(UIKit)
+    func testWhenStoppingInstance_itStopsRemoteConfigurationProvider() throws {
+        // Given
+        let notificationCenter = NotificationCenter()
+        let httpClient = PendingHTTPClientMock()
+        weak var weakProvider: RemoteConfigurationProvider?
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            initialConsent: .granted,
+            performance: .mockRandom(),
+            httpClient: HTTPClientMock(),
+            encryption: nil,
+            contextProvider: .mockAny(),
+            applicationVersion: .mockAny(),
+            maxBatchesPerUpload: .mockAny(),
+            backgroundTasksEnabled: .mockAny(),
+            remoteConfigurationProvider: {
+                let provider = RemoteConfigurationProvider(
+                    id: "test-id",
+                    site: .us1,
+                    directory: temporaryCoreDirectory.coreDirectory,
+                    httpClient: httpClient,
+                    notificationCenter: notificationCenter
+                )
+                weakProvider = provider
+                provider.start { _ in }
+                return provider
+            }()
+        )
+
+        XCTAssertEqual(httpClient.requestsSent().count, 1)
+
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+        XCTAssertEqual(httpClient.requestsSent().count, 2)
+
+        // When
+        core.stop()
+
+        // Then
+        XCTAssertNotNil(core.remoteConfigurationProvider)
+        XCTAssertNotNil(weakProvider)
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+        XCTAssertEqual(httpClient.requestsSent().count, 2)
+    }
+#endif
 
     func testItAppendsUserDataIfAnonymousIdentifierExists() {
         let core = DatadogCore(

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -71,8 +71,6 @@ class DatadogCoreTests: XCTestCase {
             httpClient: PendingHTTPClientMock(),
             notificationCenter: NotificationCenter()
         )
-        remoteConfigurationProvider.start { _ in }
-
         let core = DatadogCore(
             directory: temporaryCoreDirectory,
             dateProvider: SystemDateProvider(),
@@ -412,7 +410,6 @@ class DatadogCoreTests: XCTestCase {
         XCTAssertEqual(requestBuilderSpy.requestParameters.count, 0, "It should not send any request")
     }
 
-#if canImport(UIKit)
     func testWhenStoppingInstance_itStopsRemoteConfigurationProvider() throws {
         // Given
         let notificationCenter = NotificationCenter()
@@ -438,7 +435,6 @@ class DatadogCoreTests: XCTestCase {
                     notificationCenter: notificationCenter
                 )
                 weakProvider = provider
-                provider.start { _ in }
                 return provider
             }()
         )
@@ -457,7 +453,6 @@ class DatadogCoreTests: XCTestCase {
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
         XCTAssertEqual(httpClient.requestsSent().count, 2)
     }
-#endif
 
     func testItAppendsUserDataIfAnonymousIdentifierExists() {
         let core = DatadogCore(


### PR DESCRIPTION
### What and why?

Adds foreground refresh to RemoteConfigurationProvider so remote configuration stays fresh while the app is in use, not only at SDK initialization.

When the app returns to the foreground, the provider re-syncs with the CDN. If the configuration has changed, the new document is fetched, decoded, persisted to disk, and the in-memory cache is updated. If nothing has changed, the server returns 304 and no work is done thanks to the ETag conditional request mechanism.

### How?

- RemoteConfigurationProvider observes ApplicationNotifications.willEnterForeground via NotificationCenter, registered in init and removed in deinit.
- The observer is only registered on platforms that support UIKit (#if canImport(UIKit)).
- notificationCenter is injected in the RemoteConfigurationProvider init and passed from Datagdog.swift via configuration.notificationCenter.
- sync() is now private — the provider is fully autonomous: it syncs on init and on every foreground transition without any external orchestration.
- Telemetry errors are reported internally via an injected Telemetry instance (NOPTelemetry() by default for tests).


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs


Note: TTL-based suppression (skip the CDN request if last sync was recent) is intentionally out of scope and will be tracked in a separate ticket.
