### PR TITLE
RUM-16755: Fix loading of misaligned data.

### DIFF
--- a/DatadogCore/Sources/Core/DataStore/DataStoreFileReader.swift
+++ b/DatadogCore/Sources/Core/DataStore/DataStoreFileReader.swift
@@ -46,6 +46,6 @@ internal struct DataStoreFileReader {
             throw DataStoreFileReadingError.insufficientVersionBytes
         }
 
-        return data.withUnsafeBytes { $0.load(as: T.self) }
+        return data.withUnsafeBytes { $0.loadUnaligned(as: T.self) }
     }
 }

--- a/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
+++ b/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
@@ -128,13 +128,13 @@ internal final class TLVBlockReader<BlockType> where BlockType: RawRepresentable
     /// Reads a block type.
     private func readType() throws -> BlockType.RawValue {
         let data = try read(length: MemoryLayout<BlockType.RawValue>.size)
-        return data.withUnsafeBytes { $0.load(as: BlockType.RawValue.self) }
+        return data.withUnsafeBytes { $0.loadUnaligned(as: BlockType.RawValue.self) }
     }
 
     /// Reads block data.
     private func readData() throws -> Data {
         let data = try read(length: MemoryLayout<TLVBlockSize>.size)
-        let size = data.withUnsafeBytes { $0.load(as: TLVBlockSize.self) }
+        let size = data.withUnsafeBytes { $0.loadUnaligned(as: TLVBlockSize.self) }
 
         // even if `Int` is able to represent all `TLVBlockSize` on 64 bit
         // arch, we make sure to avoid overflow and get the exact data

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpanId+Datadog.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpanId+Datadog.swift
@@ -14,7 +14,7 @@ extension OpenTelemetryApi.SpanId {
     func toDatadog() -> SpanID {
         var data = Data(count: 8)
         self.copyBytesTo(dest: &data, destOffset: 0)
-        let integerLiteral = UInt64(bigEndian: data.withUnsafeBytes { $0.load(as: UInt64.self) })
+        let integerLiteral = UInt64(bigEndian: data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) })
         return .init(integerLiteral: integerLiteral)
     }
 }


### PR DESCRIPTION
### What and why?

Fixes crash reported in #2994. Data loaded in the corrected functions is not guaranteed to be aligned as the loaded type expects, since they may be local (stack) copies of single bytes (Inline Data representations) the compiler may store on any address. Although this has not been a problem so far, Xcode 27 compiler aligns data differently and causes crashes.

### How?

Since we cannot assume data is aligned, `load` calls were replaced by `loadUnaligned`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
