### PR TITLE
[RUM-16774] Encode and upload client-side stats via MessagePack

### DIFF
--- a/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
@@ -27,12 +27,14 @@ public struct URLRequestBuilder {
 
         public enum ContentType {
             case applicationJSON
+            case applicationMsgPack
             case textPlainUTF8
             case multipartFormData(boundary: String)
 
             public var toString: String {
                 switch self {
                 case .applicationJSON: return "application/json"
+                case .applicationMsgPack: return "application/msgpack"
                 case .textPlainUTF8: return "text/plain;charset=UTF-8"
                 case .multipartFormData(let boundary): return "multipart/form-data; boundary=\(boundary)"
                 }

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -35,7 +35,9 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
     ) {
         self.requestBuilder = StatsRequestBuilder(
             customIntakeURL: configuration.customStatsEndpoint,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            runtimeID: UUID().uuidString,
+            sequenceNumberProvider: StatsSequenceNumberProvider()
         )
         self.messageReceiver = NOPFeatureMessageReceiver()
         self.performanceOverride = nil

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -88,14 +88,17 @@ internal final class StatsBucket {
 // MARK: - Exportable Bucket
 
 /// A flushed bucket ready for serialization and upload.
-internal struct ExportedBucket: Encodable, Sendable {
+///
+/// Conforms to `Codable` so it can be written to the feature's storage as JSON and later
+/// decoded back by `StatsRequestBuilder` for encoding into the MessagePack wire payload.
+internal struct ExportedBucket: Codable, Sendable {
     let start: UInt64
     let duration: UInt64
     let stats: [ExportedGroupedStats]
 }
 
 /// A single grouped stats entry ready for serialization.
-internal struct ExportedGroupedStats: Encodable, Sendable {
+internal struct ExportedGroupedStats: Codable, Sendable {
     let service: String
     let name: String
     let resource: String

--- a/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
@@ -7,21 +7,76 @@
 import Foundation
 import DatadogInternal
 
+/// Provides monotonically increasing sequence numbers for uploaded stats payloads.
+///
+/// The sequence number lets the intake order and uniquely identify the payloads sent by a
+/// single tracer (`runtimeID`). It is incremented once per built request; retries of the same
+/// batch therefore get distinct sequence numbers, which is acceptable because the value is used
+/// for identification, not for stats aggregation.
+internal final class StatsSequenceNumberProvider {
+    @ReadWriteLock private var value: UInt64 = 0
+
+    /// Returns the next sequence number, starting at `1` for the first call.
+    func next() -> UInt64 {
+        var next: UInt64 = 0
+        _value.mutate {
+            $0 += 1
+            next = $0
+        }
+        return next
+    }
+}
+
 /// Builds HTTP requests for uploading client-side stats to the `/api/v0.2/stats` intake.
+///
+/// Decodes the `ExportedBucket`s persisted by `ClientStatsFeature`, maps them onto the
+/// wire-format `StatsPayload`, encodes that to MessagePack, and uploads it deflate-compressed.
 internal struct StatsRequestBuilder: FeatureRequestBuilder {
+    /// Custom stats intake URL, overriding the site default when set.
     let customIntakeURL: URL?
+    /// Sends telemetry through the SDK core.
     let telemetry: Telemetry
+    /// Identifies the tracer instance uniquely across the payloads it sends.
+    let runtimeID: String
+    /// Supplies the per-payload sequence number.
+    let sequenceNumberProvider: StatsSequenceNumberProvider
+
+    private let encoder = MsgPackEncoder()
+    private let decoder = JSONDecoder()
 
     func request(
         for events: [Event],
         with context: DatadogContext,
         execution: ExecutionContext
-    ) -> URLRequest {
+    ) throws -> URLRequest {
+        guard !events.isEmpty else {
+            throw InternalError(description: "[Trace] Client stats batch must not be empty.")
+        }
+
+        // If a stored bucket cannot be decoded there is no way to recover it, so we throw
+        // and let the core drop the batch rather than uploading a partial payload.
+        let buckets = try events
+            .map { try decoder.decode(ExportedBucket.self, from: $0.data) }
+            .map(ClientStatsBucket.init)
+
+        let clientStats = ClientStatsPayload(
+            hostname: "",
+            env: context.env,
+            version: context.version,
+            service: context.service,
+            tracerVersion: context.sdkVersion,
+            runtimeID: runtimeID,
+            sequenceNumber: sequenceNumberProvider.next(),
+            stats: buckets
+        )
+        let payload = StatsPayload(clientStats: [clientStats], splitPayload: false)
+        let body = try encoder.encode(payload)
+
         let builder = URLRequestBuilder(
             url: url(with: context),
             queryItems: [],
             headers: [
-                .contentTypeHeader(contentType: .applicationJSON),
+                .contentTypeHeader(contentType: .applicationMsgPack),
                 .userAgentHeader(
                     appName: context.applicationName,
                     appVersion: context.version,
@@ -36,8 +91,7 @@ internal struct StatsRequestBuilder: FeatureRequestBuilder {
             telemetry: telemetry
         )
 
-        let data = events.reduce(Data()) { $0 + $1.data }
-        return builder.uploadRequest(with: data)
+        return builder.uploadRequest(with: body)
     }
 
     func url(with context: DatadogContext) -> URL {

--- a/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
@@ -61,6 +61,10 @@ internal struct StatsRequestBuilder: FeatureRequestBuilder {
             .map(ClientStatsBucket.init)
 
         let clientStats = ClientStatsPayload(
+            // Always empty on mobile: there is no stable, meaningful device hostname
+            // (and reporting one would be a privacy concern), so `DatadogContext` exposes
+            // none. `Hostname` is a server-tracer field in the protobuf model; the intake
+            // accepts it empty. Matches the Android SDK.
             hostname: "",
             env: context.env,
             version: context.version,

--- a/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
+++ b/DatadogTrace/Sources/Feature/StatsRequestBuilder.swift
@@ -14,7 +14,8 @@ import DatadogInternal
 /// batch therefore get distinct sequence numbers, which is acceptable because the value is used
 /// for identification, not for stats aggregation.
 internal final class StatsSequenceNumberProvider {
-    @ReadWriteLock private var value: UInt64 = 0
+    @ReadWriteLock
+    private var value: UInt64 = 0
 
     /// Returns the next sequence number, starting at `1` for the first call.
     func next() -> UInt64 {

--- a/DatadogTrace/Sources/Stats/ClientStatsPayload.swift
+++ b/DatadogTrace/Sources/Stats/ClientStatsPayload.swift
@@ -170,3 +170,41 @@ internal struct ClientGroupedStats: Encodable {
         self.serviceSource = serviceSource
     }
 }
+
+// MARK: - Mapping from the concentrator's exported types
+
+extension ClientStatsBucket {
+    /// Maps a `StatsConcentrator`-exported bucket into the wire-format bucket.
+    init(_ exported: ExportedBucket) {
+        self.init(
+            start: exported.start,
+            duration: exported.duration,
+            stats: exported.stats.map(ClientGroupedStats.init)
+        )
+    }
+}
+
+extension ClientGroupedStats {
+    /// Maps a `StatsConcentrator`-exported grouped-stats entry into the wire-format entry.
+    /// `ExportedGroupedStats.synthetics` is dropped because the wire model hardcodes
+    /// `Synthetics` to `false` (the mobile SDK has no synthetic-test concept).
+    init(_ exported: ExportedGroupedStats) {
+        self.init(
+            service: exported.service,
+            name: exported.name,
+            resource: exported.resource,
+            httpStatusCode: exported.httpStatusCode,
+            type: exported.type,
+            spanKind: exported.spanKind,
+            isTraceRoot: exported.isTraceRoot,
+            hits: exported.hits,
+            errors: exported.errors,
+            duration: exported.duration,
+            topLevelHits: exported.topLevelHits,
+            okSummary: exported.okSummary,
+            errorSummary: exported.errorSummary,
+            peerTags: exported.peerTags,
+            serviceSource: exported.serviceSource
+        )
+    }
+}

--- a/DatadogTrace/Sources/Stats/Trilean.swift
+++ b/DatadogTrace/Sources/Stats/Trilean.swift
@@ -25,3 +25,14 @@ extension Trilean: Encodable {
         try container.encode(Int32(rawValue))
     }
 }
+
+extension Trilean: Decodable {
+    /// Decodes from the `Int32` raw value written by `encode(to:)`. Required so
+    /// `ExportedGroupedStats` can round-trip through the feature's JSON storage before
+    /// being mapped to the wire payload. Unknown raw values fall back to `notSet`.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Int32.self)
+        self = Trilean(rawValue: Int(rawValue)) ?? .notSet
+    }
+}

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -288,6 +288,36 @@ class ClientStatsFeatureTests: XCTestCase {
         XCTAssertEqual(provider.next(), 3)
     }
 
+    func testSequenceNumberProviderSupportsConcurrentAccess() {
+        // Given
+        let provider = StatsSequenceNumberProvider()
+        let threadCount = 16
+        let iterationsPerThread = 1_000
+        let total = threadCount * iterationsPerThread
+
+        var perThread = [[UInt64]](repeating: [], count: threadCount)
+        let lock = NSLock()
+
+        // When: every thread hammers `next()` concurrently.
+        DispatchQueue.concurrentPerform(iterations: threadCount) { thread in
+            var local: [UInt64] = []
+            local.reserveCapacity(iterationsPerThread)
+            for _ in 0..<iterationsPerThread {
+                local.append(provider.next())
+            }
+            lock.lock()
+            perThread[thread] = local
+            lock.unlock()
+        }
+
+        // Then: no value is dropped or handed out twice, and the counter is left consistent.
+        let all = perThread.flatMap { $0 }
+        XCTAssertEqual(all.count, total)
+        XCTAssertEqual(Set(all).count, total, "Concurrent next() calls must each return a unique value")
+        XCTAssertEqual(all.max(), UInt64(total))
+        XCTAssertEqual(provider.next(), UInt64(total) + 1)
+    }
+
     func testSequenceNumberIncrementsAcrossRequests() throws {
         // Given
         let builder = makeRequestBuilder()

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -138,6 +138,251 @@ class ClientStatsFeatureTests: XCTestCase {
 
         XCTAssertTrue(core.exportedBuckets.isEmpty)
     }
+
+    // MARK: - Request Builder - Encoding
+
+    func testWhenBuildingRequest_itTargetsStatsIntakeWithMsgPackContentType() throws {
+        // Given
+        let context: DatadogContext = .mockWith(clientToken: "client-token", source: "ios", ciAppOrigin: nil)
+        let builder = makeRequestBuilder()
+
+        // When
+        let request = try builder.request(
+            for: [makeEvent(from: makeExportedBucket())],
+            with: context,
+            execution: .init(previousResponseCode: nil, attempt: 0)
+        )
+
+        // Then
+        XCTAssertEqual(request.url, context.site.endpoint.appendingPathComponent("api/v0.2/stats"))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/msgpack")
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], "client-token")
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], "ios")
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], context.sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
+    }
+
+    func testWhenBuildingRequest_itCompressesBodyWithDeflate() throws {
+        // Given: a payload large and repetitive enough that deflate shrinks it.
+        let builder = makeRequestBuilder()
+
+        // When
+        let request = try builder.request(
+            for: [makeEvent(from: makeExportedBucket(groupCount: 20))],
+            with: .mockAny(),
+            execution: .init(previousResponseCode: nil, attempt: 0)
+        )
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
+        XCTAssertNotNil(try request.decompressed().httpBody)
+    }
+
+    func testWhenBuildingRequest_itEncodesEnvelopeFromContext() throws {
+        // Given
+        let context: DatadogContext = .mockWith(
+            service: "ios-app",
+            env: "staging",
+            version: "1.2.3",
+            sdkVersion: "2.0.0"
+        )
+        let builder = makeRequestBuilder(runtimeID: "runtime-id")
+
+        // When
+        let request = try builder.request(
+            for: [makeEvent(from: makeExportedBucket())],
+            with: context,
+            execution: .init(previousResponseCode: nil, attempt: 0)
+        )
+
+        // Then
+        let clientStats = try firstClientStatsPayload(in: request)
+        XCTAssertEqual(clientStats["Hostname"] as? String, "")
+        XCTAssertEqual(clientStats["Env"] as? String, "staging")
+        XCTAssertEqual(clientStats["Version"] as? String, "1.2.3")
+        XCTAssertEqual(clientStats["Service"] as? String, "ios-app")
+        XCTAssertEqual(clientStats["TracerVersion"] as? String, "2.0.0")
+        XCTAssertEqual(clientStats["Lang"] as? String, "ios")
+        XCTAssertEqual(clientStats["RuntimeID"] as? String, "runtime-id")
+        XCTAssertEqual(clientStats["Sequence"] as? Int64, 1)
+    }
+
+    func testWhenBuildingRequest_itMapsExportedBucketsOntoWirePayload() throws {
+        // Given
+        let bucket = makeExportedBucket(start: 1_000, duration: 10_000_000_000, groupCount: 1)
+        let builder = makeRequestBuilder()
+
+        // When
+        let request = try builder.request(
+            for: [makeEvent(from: bucket)],
+            with: .mockAny(),
+            execution: .init(previousResponseCode: nil, attempt: 0)
+        )
+
+        // Then
+        let clientStats = try firstClientStatsPayload(in: request)
+        let buckets = try XCTUnwrap(clientStats["Stats"] as? [Any?])
+        XCTAssertEqual(buckets.count, 1)
+
+        let bucketFields = try mapFields(buckets[0])
+        XCTAssertEqual(bucketFields["Start"] as? Int64, 1_000)
+        XCTAssertEqual(bucketFields["Duration"] as? Int64, 10_000_000_000)
+
+        let groups = try XCTUnwrap(bucketFields["Stats"] as? [Any?])
+        let group = try mapFields(groups[0])
+        XCTAssertEqual(group["Service"] as? String, "service-0")
+        XCTAssertEqual(group["Name"] as? String, "operation")
+        XCTAssertEqual(group["Resource"] as? String, "GET /resource")
+        XCTAssertEqual(group["HTTPStatusCode"] as? Int64, 200)
+        XCTAssertEqual(group["Hits"] as? Int64, 10)
+        XCTAssertEqual(group["Errors"] as? Int64, 2)
+        XCTAssertEqual(group["IsTraceRoot"] as? Int64, Int64(Trilean.true.rawValue))
+        XCTAssertEqual(group["Synthetics"] as? Bool, false)
+        XCTAssertEqual(group["OkSummary"] as? Data, Data(repeating: 0x1, count: 64))
+
+        let peerTags = try XCTUnwrap(group["PeerTags"] as? [Any?])
+        XCTAssertEqual(peerTags.compactMap { $0 as? String }, ["peer.service:db"])
+    }
+
+    func testWhenBuildingRequestFromMultipleEvents_itEncodesAllBuckets() throws {
+        // Given
+        let events = [
+            makeEvent(from: makeExportedBucket(start: 1_000)),
+            makeEvent(from: makeExportedBucket(start: 2_000)),
+        ]
+        let builder = makeRequestBuilder()
+
+        // When
+        let request = try builder.request(
+            for: events,
+            with: .mockAny(),
+            execution: .init(previousResponseCode: nil, attempt: 0)
+        )
+
+        // Then: all buckets land under a single ClientStatsPayload (one tracer).
+        let envelope = try decodeEnvelope(in: request)
+        let clientStatsArray = try XCTUnwrap(envelope["Stats"] as? [Any?])
+        XCTAssertEqual(clientStatsArray.count, 1)
+
+        let clientStats = try mapFields(clientStatsArray[0])
+        let buckets = try XCTUnwrap(clientStats["Stats"] as? [Any?])
+        XCTAssertEqual(buckets.count, 2)
+    }
+
+    func testWhenEventsAreEmpty_itThrows() {
+        let builder = makeRequestBuilder()
+        XCTAssertThrowsError(
+            try builder.request(
+                for: [],
+                with: .mockAny(),
+                execution: .init(previousResponseCode: nil, attempt: 0)
+            )
+        )
+    }
+
+    func testSequenceNumberProviderIncrementsMonotonically() {
+        let provider = StatsSequenceNumberProvider()
+        XCTAssertEqual(provider.next(), 1)
+        XCTAssertEqual(provider.next(), 2)
+        XCTAssertEqual(provider.next(), 3)
+    }
+
+    func testSequenceNumberIncrementsAcrossRequests() throws {
+        // Given
+        let builder = makeRequestBuilder()
+        let execution = ExecutionContext(previousResponseCode: nil, attempt: 0)
+
+        // When
+        let first = try builder.request(
+            for: [makeEvent(from: makeExportedBucket())],
+            with: .mockAny(),
+            execution: execution
+        )
+        let second = try builder.request(
+            for: [makeEvent(from: makeExportedBucket())],
+            with: .mockAny(),
+            execution: execution
+        )
+
+        // Then
+        XCTAssertEqual(try firstClientStatsPayload(in: first)["Sequence"] as? Int64, 1)
+        XCTAssertEqual(try firstClientStatsPayload(in: second)["Sequence"] as? Int64, 2)
+    }
+
+    func testCustomStatsEndpointOverridesURL() {
+        let customURL: URL = .mockRandom()
+        let builder = makeRequestBuilder(customIntakeURL: customURL)
+        XCTAssertEqual(builder.url(with: .mockAny()), customURL)
+    }
+
+    // MARK: - Request Builder - Helpers
+
+    private func makeRequestBuilder(
+        customIntakeURL: URL? = nil,
+        runtimeID: String = "runtime-id",
+        sequenceNumberProvider: StatsSequenceNumberProvider = StatsSequenceNumberProvider()
+    ) -> StatsRequestBuilder {
+        StatsRequestBuilder(
+            customIntakeURL: customIntakeURL,
+            telemetry: NOPTelemetry(),
+            runtimeID: runtimeID,
+            sequenceNumberProvider: sequenceNumberProvider
+        )
+    }
+
+    /// Encodes an `ExportedBucket` the same way the feature storage does (JSON), producing a
+    /// stored `Event` for the request builder to decode.
+    private func makeEvent(from bucket: ExportedBucket) -> Event {
+        // swiftlint:disable:next force_try
+        let data = try! JSONEncoder.dd.default().encode(bucket)
+        return Event(data: data)
+    }
+
+    private func makeExportedBucket(
+        start: UInt64 = 1_000,
+        duration: UInt64 = 10_000_000_000,
+        groupCount: Int = 1
+    ) -> ExportedBucket {
+        let stats = (0..<groupCount).map { index in
+            ExportedGroupedStats(
+                service: "service-\(index)",
+                name: "operation",
+                resource: "GET /resource",
+                httpStatusCode: 200,
+                type: "web",
+                spanKind: "server",
+                isTraceRoot: .true,
+                synthetics: false,
+                hits: 10,
+                errors: 2,
+                duration: 5_000,
+                topLevelHits: 10,
+                okSummary: Data(repeating: 0x1, count: 64),
+                errorSummary: Data(repeating: 0x2, count: 64),
+                peerTags: ["peer.service:db"],
+                serviceSource: "src"
+            )
+        }
+        return ExportedBucket(start: start, duration: duration, stats: stats)
+    }
+
+    private func decodeEnvelope(in request: URLRequest) throws -> [String: Any?] {
+        let body = try XCTUnwrap(request.decompressed().httpBody)
+        var decoder = MsgPackTestDecoder(data: body)
+        return Dictionary(uniqueKeysWithValues: try decoder.readMap())
+    }
+
+    private func firstClientStatsPayload(in request: URLRequest) throws -> [String: Any?] {
+        let envelope = try decodeEnvelope(in: request)
+        let clientStatsArray = try XCTUnwrap(envelope["Stats"] as? [Any?])
+        return try mapFields(clientStatsArray[0])
+    }
+
+    private func mapFields(_ value: Any?) throws -> [String: Any?] {
+        let entries = try XCTUnwrap(value as? [(String, Any?)])
+        return Dictionary(uniqueKeysWithValues: entries.map { ($0.0, $0.1) })
+    }
 }
 
 private final class FeatureRegistrationPassthroughCoreMock: DatadogCoreProtocol, FeatureScope {

--- a/E2ETests/Runner/Scenarios/OpenTelemetryTrace/OpenTelemetryTraceScenario.swift
+++ b/E2ETests/Runner/Scenarios/OpenTelemetryTrace/OpenTelemetryTraceScenario.swift
@@ -27,7 +27,10 @@ struct TraceScenario: Scenario {
                         sampleRate: 100,
                         traceControlInjection: .all
                     )
-                )
+                ),
+                // Exercise the client-side stats upload pipeline (MessagePack + deflate to
+                // `/api/v0.2/stats`) end to end so Synthetics validates real intake acceptance.
+                statsComputationEnabled: true
             )
         )
 


### PR DESCRIPTION
### What and why?

Wires the client-side stats pipeline end to end. Building on [RUM-16605](https://github.com/DataDog/dd-sdk-ios/pull/2971), this replaces the `StatsRequestBuilder`
stub - which emitted raw JSON - with the real upload path: the `ExportedBucket`s
persisted by `ClientStatsFeature` are decoded, mapped onto the wire-format
`StatsPayload`, MessagePack-encoded, and uploaded deflate-compressed to the
`/api/v0.2/stats` intake.

### How?

- **Content type**: add `URLRequestBuilder.HTTPHeader.ContentType.applicationMsgPack`
  (`application/msgpack`).
- **Storage round-trip**: make `ExportedBucket` / `ExportedGroupedStats` `Codable`
  and `Trilean` `Decodable` so stored events decode back out of feature storage.
- **Mapping**: add `ExportedBucket -> ClientStatsBucket` and
  `ExportedGroupedStats -> ClientGroupedStats` initializers (kept in the trace
  module, no SDK-context coupling).
- **Envelope**: `StatsRequestBuilder` now assembles `ClientStatsPayload` with
  `hostname` empty, `env` / `version` / `service` / `tracerVersion` from
  `DatadogContext`, a per-process `runtimeID` (UUID), and a monotonic
  `sequenceNumber` from a thread-safe `StatsSequenceNumberProvider`. The builder
  throws on an empty batch or undecodable events so the core drops them rather
  than uploading a partial payload.
- **Wiring**: `ClientStatsFeature` owns the `runtimeID` and sequence provider,
  injecting both into the request builder.
- **E2E**: enable `statsComputationEnabled` in the dogfood trace scenario so the
  Synthetics run validates real intake acceptance of the deflate + MessagePack
  envelope.

The `application/msgpack` case is on `URLRequestBuilder` (public but not part of
the tracked api-surface), so the public API surface is unchanged.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes (n/a - internal feature, not yet public)
- [ ] Add Objective-C interface for public APIs (n/a - no new public Swift API)
- [x] Run \`make api-surface\` when adding new APIs (n/a - api-surface unchanged)

[RUM-16605]: https://datadoghq.atlassian.net/browse/RUM-16605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ